### PR TITLE
perf(filters): cache column-values endpoint to skip DB on repeat requests

### DIFF
--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -134,10 +134,20 @@ class DatasourceRestApi(BaseSupersetApi):
 
         # Cache distinct column-value results so a dashboard with many filters
         # backed by the same (often heavy) virtual dataset doesn't re-execute
-        # the wrapping query per filter (#39342). The cache key includes the
-        # user id so RLS-filtered datasources can't leak values across users,
-        # and the dataset's ``changed_on`` so an edit to the underlying SQL
-        # busts cached entries on the next request.
+        # the wrapping query per filter (#39342).
+        #
+        # Key fields:
+        # - ``user`` — baseline per-user isolation. ``get_user_id()`` returns
+        #   ``None`` for guest/anonymous sessions, so this field alone is not
+        #   sufficient for RLS safety.
+        # - ``rls`` — full RLS fingerprint via
+        #   ``security_manager.get_rls_cache_key`` (the canonical helper used
+        #   by viz.py and query_context_processor.py). Covers both regular
+        #   RLS policy changes and guest-token RLS, so embedded sessions
+        #   with different guest tokens never share cached values even when
+        #   ``get_user_id()`` is ``None`` for both.
+        # - ``changed_on`` — auto-busts cached entries when the dataset's
+        #   underlying SQL is edited.
         force = parse_boolean_string(request.args.get("force"))
         cache_key = (
             "col_values:"
@@ -149,6 +159,7 @@ class DatasourceRestApi(BaseSupersetApi):
                         "limit": row_limit,
                         "denorm": denormalize_column,
                         "user": get_user_id(),
+                        "rls": security_manager.get_rls_cache_key(datasource),
                         "changed_on": str(getattr(datasource, "changed_on", "")),
                     },
                     sort_keys=True,

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -31,7 +31,13 @@ from superset.exceptions import SupersetSecurityException
 from superset.extensions import cache_manager
 from superset.superset_typing import FlaskResponse
 from superset.utils import json
-from superset.utils.core import apply_max_row_limit, DatasourceType, SqlExpressionType
+from superset.utils.core import (
+    apply_max_row_limit,
+    DatasourceType,
+    get_user_id,
+    parse_boolean_string,
+    SqlExpressionType,
+)
 from superset.views.base_api import BaseSupersetApi, statsd_metrics
 
 logger = logging.getLogger(__name__)
@@ -51,8 +57,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_column_values",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_column_values"
+        ),
         log_to_statsd=False,
     )
     def get_column_values(
@@ -124,13 +131,48 @@ class DatasourceRestApi(BaseSupersetApi):
 
         row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
         denormalize_column = not datasource.normalize_columns
+
+        # Cache distinct column-value results so a dashboard with many filters
+        # backed by the same (often heavy) virtual dataset doesn't re-execute
+        # the wrapping query per filter (#39342). The cache key includes the
+        # user id so RLS-filtered datasources can't leak values across users,
+        # and the dataset's ``changed_on`` so an edit to the underlying SQL
+        # busts cached entries on the next request.
+        force = parse_boolean_string(request.args.get("force"))
+        cache_key = (
+            "col_values:"
+            + hashlib.sha256(
+                json.dumps(
+                    {
+                        "uid": datasource.uid,
+                        "col": column_name,
+                        "limit": row_limit,
+                        "denorm": denormalize_column,
+                        "user": get_user_id(),
+                        "changed_on": str(getattr(datasource, "changed_on", "")),
+                    },
+                    sort_keys=True,
+                ).encode()
+            ).hexdigest()
+        )
+
+        if (
+            not force
+            and (cached := cache_manager.data_cache.get(cache_key)) is not None
+        ):
+            logger.debug(
+                "column-values cache HIT: uid=%s col=%s", datasource.uid, column_name
+            )
+            response = self.response(200, result=cached)
+            response.headers["X-Cache-Status"] = "HIT"
+            return response
+
         try:
             payload = datasource.values_for_column(
                 column_name=column_name,
                 limit=row_limit,
                 denormalize_column=denormalize_column,
             )
-            return self.response(200, result=payload)
         except KeyError:
             return self.response(
                 400, message=f"Column name {column_name} does not exist"
@@ -144,6 +186,31 @@ class DatasourceRestApi(BaseSupersetApi):
                 ),
             )
 
+        # Warn before caching very large payloads (high-cardinality columns)
+        # so operators can spot cache-memory pressure before Redis OOMs.
+        # Threshold is operator-tunable; defaults to 100k rows.
+        warn_threshold = app.config.get("FILTER_VALUES_CACHE_WARN_THRESHOLD", 100_000)
+        if (payload_size := len(payload)) > warn_threshold:
+            logger.warning(
+                "column-values payload exceeds cache-warn threshold: "
+                "uid=%s col=%s rows=%d threshold=%d",
+                datasource.uid,
+                column_name,
+                payload_size,
+                warn_threshold,
+            )
+
+        timeout = datasource.cache_timeout or app.config.get(
+            "CACHE_DEFAULT_TIMEOUT", 300
+        )
+        cache_manager.data_cache.set(cache_key, payload, timeout=timeout)
+        logger.debug(
+            "column-values cache MISS: uid=%s col=%s", datasource.uid, column_name
+        )
+        response = self.response(200, result=payload)
+        response.headers["X-Cache-Status"] = "MISS"
+        return response
+
     @expose(
         "/<datasource_type>/<int:datasource_id>/validate_expression/",
         methods=("POST",),
@@ -152,8 +219,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".validate_expression",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.validate_expression"
+        ),
         log_to_statsd=False,
     )
     def validate_expression(

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -34,7 +34,6 @@ from superset.utils import json
 from superset.utils.core import (
     apply_max_row_limit,
     DatasourceType,
-    get_user_id,
     parse_boolean_string,
     SqlExpressionType,
 )
@@ -137,17 +136,22 @@ class DatasourceRestApi(BaseSupersetApi):
         # the wrapping query per filter (#39342).
         #
         # Key fields:
-        # - ``user`` — baseline per-user isolation. ``get_user_id()`` returns
-        #   ``None`` for guest/anonymous sessions, so this field alone is not
-        #   sufficient for RLS safety.
         # - ``rls`` — full RLS fingerprint via
         #   ``security_manager.get_rls_cache_key`` (the canonical helper used
-        #   by viz.py and query_context_processor.py). Covers both regular
-        #   RLS policy changes and guest-token RLS, so embedded sessions
-        #   with different guest tokens never share cached values even when
-        #   ``get_user_id()`` is ``None`` for both.
+        #   by viz.py and query_context_processor.py). This is the sole
+        #   security-isolation field — two users with identical effective
+        #   RLS share a cache entry (intentional: they would see identical
+        #   filtered values anyway), while users with different RLS, guest
+        #   sessions with different guest-token RLS, and anonymous sessions
+        #   with no RLS each get their own partition. We deliberately do
+        #   NOT include the raw user id; doing so would defeat the
+        #   intended cross-user cache sharing without adding any real
+        #   security boundary beyond what the RLS fingerprint already
+        #   provides.
         # - ``changed_on`` — auto-busts cached entries when the dataset's
         #   underlying SQL is edited.
+        # - ``uid`` / ``col`` / ``limit`` / ``denorm`` — basic query-shape
+        #   isolation so different inputs never collide.
         force = parse_boolean_string(request.args.get("force"))
         cache_key = (
             "col_values:"
@@ -158,7 +162,6 @@ class DatasourceRestApi(BaseSupersetApi):
                         "col": column_name,
                         "limit": row_limit,
                         "denorm": denormalize_column,
-                        "user": get_user_id(),
                         "rls": security_manager.get_rls_cache_key(datasource),
                         "changed_on": str(getattr(datasource, "changed_on", "")),
                     },

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -31,6 +31,14 @@ from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
 
 
 class TestDatasourceApi(SupersetTestCase):
+    def setUp(self):
+        # Clear the column-values cache before every test so that
+        # ``get_column_values`` always re-runs ``values_for_column`` rather
+        # than returning a payload populated by a previous test. Prevents
+        # order-dependent flakes now that the endpoint caches its result.
+        super().setUp()
+        cache_manager.data_cache.clear()
+
     def get_virtual_dataset(self):
         return (
             db.session.query(SqlaTable)
@@ -257,30 +265,6 @@ class TestDatasourceApi(SupersetTestCase):
 
         self.client.get(f"api/v1/datasource/table/{table.id}/column/col1/values/")
         self.client.get(f"api/v1/datasource/table/{table.id}/column/col2/values/")
-
-        assert values_for_column_mock.call_count == 2
-
-    @pytest.mark.usefixtures("app_context", "virtual_dataset")
-    @patch("superset.datasource.api.get_user_id")
-    @patch("superset.models.helpers.ExploreMixin.values_for_column")
-    def test_get_column_values_cache_isolated_per_user(
-        self, values_for_column_mock, get_user_id_mock
-    ):
-        """Per-user cache isolation: two distinct users hitting the same
-        column must each populate their own cache entry. Patching
-        ``get_user_id`` directly avoids the login-flow side effects (which
-        would also trip the datasource-access check before the cache code
-        is reached)."""
-        cache_manager.data_cache.clear()
-        values_for_column_mock.return_value = ["v"]
-        self.login(ADMIN_USERNAME)
-        table = self.get_virtual_dataset()
-        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
-
-        get_user_id_mock.return_value = 1
-        self.client.get(url)
-        get_user_id_mock.return_value = 2
-        self.client.get(url)
 
         assert values_for_column_mock.call_count == 2
 

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -306,6 +306,29 @@ class TestDatasourceApi(SupersetTestCase):
         assert values_for_column_mock.call_count == 2
 
     @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.datasource.api.security_manager.get_rls_cache_key")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_cache_isolated_per_rls_context(
+        self, values_for_column_mock, get_rls_cache_key_mock
+    ):
+        """RLS safety for guest/embedded sessions. ``get_user_id()`` returns
+        ``None`` for guest users, so two embedded dashboards with different
+        guest-token RLS would otherwise collide on ``user=None``. Including
+        the RLS fingerprint in the cache key keeps them separate."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["v"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        get_rls_cache_key_mock.return_value = ["dept='A'"]
+        self.client.get(url)
+        get_rls_cache_key_mock.return_value = ["dept='B'"]
+        self.client.get(url)
+
+        assert values_for_column_mock.call_count == 2
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
     @patch("superset.models.helpers.ExploreMixin.values_for_column")
     def test_get_column_values_response_advertises_cache_status(
         self, values_for_column_mock

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
 from unittest.mock import ANY, patch
 
 import pytest
@@ -23,6 +24,7 @@ from sqlalchemy.sql.elements import TextClause
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.exceptions import DatasourceTypeNotSupportedError
+from superset.extensions import cache_manager
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
@@ -204,6 +206,124 @@ class TestDatasourceApi(SupersetTestCase):
             assert rv.status_code == 200
             response = json.loads(rv.data.decode("utf-8"))
             assert response["result"] == []
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_cache_hit_skips_query(self, values_for_column_mock):
+        """Regression test for #39342.
+
+        Two identical requests for the same column on the same datasource
+        should hit ``values_for_column`` exactly once — the second request
+        returns the cached payload.
+        """
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["a", "b", "c"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        rv1 = self.client.get(url)
+        rv2 = self.client.get(url)
+
+        assert rv1.status_code == 200
+        assert rv2.status_code == 200
+        assert json.loads(rv2.data.decode("utf-8"))["result"] == ["a", "b", "c"]
+        assert values_for_column_mock.call_count == 1
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_force_bypasses_cache(self, values_for_column_mock):
+        """``?force=true`` should bypass the cache and re-query the source."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["a", "b"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        self.client.get(url)
+        self.client.get(f"{url}?force=true")
+
+        assert values_for_column_mock.call_count == 2
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_cache_isolated_per_column(self, values_for_column_mock):
+        """Different columns on the same datasource must not share a cache
+        entry — otherwise filter values would be silently swapped."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["x"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+
+        self.client.get(f"api/v1/datasource/table/{table.id}/column/col1/values/")
+        self.client.get(f"api/v1/datasource/table/{table.id}/column/col2/values/")
+
+        assert values_for_column_mock.call_count == 2
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_cache_isolated_per_user(self, values_for_column_mock):
+        """RLS safety: two users hitting the same column must each populate
+        their own cache entry. Without this isolation, user A's
+        RLS-restricted values could leak to user B."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["v"]
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        self.login(ADMIN_USERNAME)
+        self.client.get(url)
+        self.logout()
+        self.login(GAMMA_USERNAME)
+        # Grant gamma the permission so the request reaches the cache path.
+        perm = security_manager.find_permission_view_menu(
+            "can_get_column_values", "Datasource"
+        )
+        security_manager.add_permission_role(security_manager.find_role("Gamma"), perm)
+        self.client.get(url)
+
+        assert values_for_column_mock.call_count == 2
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_cache_busts_on_changed_on(self, values_for_column_mock):
+        """Editing the underlying virtual dataset SQL bumps ``changed_on``,
+        which is part of the cache key — so the next request must miss the
+        cache and re-run the query."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["v"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        self.client.get(url)
+        # Simulate an edit to the dataset; ``changed_on`` is what the cache
+        # key reads, so any new value forces a miss.
+        table.changed_on = datetime(2030, 1, 1)
+        db.session.flush()
+        self.client.get(url)
+
+        assert values_for_column_mock.call_count == 2
+
+    @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.models.helpers.ExploreMixin.values_for_column")
+    def test_get_column_values_response_advertises_cache_status(
+        self, values_for_column_mock
+    ):
+        """The ``X-Cache-Status`` response header should advertise MISS on
+        the populating request and HIT on the next identical request, so
+        operators can debug cache behavior from logs or browser devtools."""
+        cache_manager.data_cache.clear()
+        values_for_column_mock.return_value = ["v"]
+        self.login(ADMIN_USERNAME)
+        table = self.get_virtual_dataset()
+        url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
+
+        rv_miss = self.client.get(url)
+        rv_hit = self.client.get(url)
+
+        assert rv_miss.headers.get("X-Cache-Status") == "MISS"
+        assert rv_hit.headers.get("X-Cache-Status") == "HIT"
 
     @patch("superset.datasource.api.security_manager.can_access")
     @patch("superset.datasource.api.GetCombinedDatasourceListCommand.run")

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -261,25 +261,25 @@ class TestDatasourceApi(SupersetTestCase):
         assert values_for_column_mock.call_count == 2
 
     @pytest.mark.usefixtures("app_context", "virtual_dataset")
+    @patch("superset.datasource.api.get_user_id")
     @patch("superset.models.helpers.ExploreMixin.values_for_column")
-    def test_get_column_values_cache_isolated_per_user(self, values_for_column_mock):
-        """RLS safety: two users hitting the same column must each populate
-        their own cache entry. Without this isolation, user A's
-        RLS-restricted values could leak to user B."""
+    def test_get_column_values_cache_isolated_per_user(
+        self, values_for_column_mock, get_user_id_mock
+    ):
+        """Per-user cache isolation: two distinct users hitting the same
+        column must each populate their own cache entry. Patching
+        ``get_user_id`` directly avoids the login-flow side effects (which
+        would also trip the datasource-access check before the cache code
+        is reached)."""
         cache_manager.data_cache.clear()
         values_for_column_mock.return_value = ["v"]
+        self.login(ADMIN_USERNAME)
         table = self.get_virtual_dataset()
         url = f"api/v1/datasource/table/{table.id}/column/col2/values/"
 
-        self.login(ADMIN_USERNAME)
+        get_user_id_mock.return_value = 1
         self.client.get(url)
-        self.logout()
-        self.login(GAMMA_USERNAME)
-        # Grant gamma the permission so the request reaches the cache path.
-        perm = security_manager.find_permission_view_menu(
-            "can_get_column_values", "Datasource"
-        )
-        security_manager.add_permission_role(security_manager.find_role("Gamma"), perm)
+        get_user_id_mock.return_value = 2
         self.client.get(url)
 
         assert values_for_column_mock.call_count == 2


### PR DESCRIPTION
### SUMMARY

**Related to #39342 (partial — addresses the repeat-load case only, see scope note below).**

The `/api/v1/datasource/<type>/<id>/column/<column>/values/` endpoint had **no caching**. When a dashboard has multiple native filters backed by the same virtual dataset, each filter fires its own HTTP request to this endpoint, and each request re-executes the wrapping query:

```sql
SELECT DISTINCT <column>
FROM (<virtual_dataset_SQL>)  -- heavy CTE re-runs every time
```

If the virtual dataset has joins or aggregations that take a few seconds, every additional filter multiplied the cost — and even a simple page reload re-ran every filter query from scratch.

This PR adds a result cache around the call to `datasource.values_for_column(...)`, mirroring the exact pattern already in use at `superset/datasource/api.py:417` for the `get_compatible_metrics` endpoint.

### Scope vs #39342 — read this first

This PR is a **caching improvement**, not the architectural fix #39342 originally asks for. The two are complementary, not equivalent:

| | #39342 asks for | This PR delivers |
|---|---|---|
| Strategy | Execute the wrapping query **once** and project all filter columns from it (e.g., one CTE with multiple `SELECT DISTINCT` projections) | Cache the per-column distinct values across requests |
| First-load behavior | 1 query for N filters | Still N queries (one per column, cache miss on first hit) |
| Repeat-load behavior | 1 query for N filters | 0 queries — all cache hits |
| Implementation footprint | New bulk endpoint + frontend coordination to call it | Single cache wrapper in existing endpoint |
| Frontend changes required | Yes | No |

**Leaving #39342 open** so the single-execution / bulk-endpoint path can be tracked separately as a follow-up. This PR is best understood as a foundation that reduces repeat DB pressure today without precluding the bigger refactor later.

### What this delivers

- ✅ Repeated requests for the same column → cache hit (no DB query)
- ✅ Dashboard reload → all filter values cached → instant
- ✅ Two users on the same dashboard with same RLS → second user gets cached values
- ✅ Editing the virtual dataset SQL auto-busts the cache (via `changed_on` in the cache key)
- ✅ `?force=true` query param bypasses the cache
- ✅ `X-Cache-Status: HIT` / `MISS` response header for operator debugging
- ✅ Warning log when a single column produces a payload larger than `FILTER_VALUES_CACHE_WARN_THRESHOLD` (defaults to 100k rows) — early signal for cache-memory pressure

### Cache key

```python
cache_key = "col_values:" + sha256({
    "uid": datasource.uid,             # which dataset
    "col": column_name,                # which column
    "limit": row_limit,                # respects FILTER_SELECT_ROW_LIMIT
    "denorm": denormalize_column,      # respects per-dataset normalize_columns
    "rls": security_manager.get_rls_cache_key(datasource),  # RLS isolation
    "changed_on": str(datasource.changed_on),  # auto-bust on dataset edit
})
```

**Security note:** The `rls` field uses `security_manager.get_rls_cache_key()` — the canonical RLS fingerprint helper already used by `viz.py:479` and `query_context_processor.py:239`. This covers both regular RLS policy changes and guest-token RLS, so embedded sessions with different guest tokens never share cached values, and users with different RLS policies are partitioned correctly.

**Correctness note:** `changed_on` busts the cache when someone edits the underlying virtual dataset SQL — no manual invalidation needed.

### TTL

Uses the same logic as the existing `get_compatible_metrics` endpoint at api.py:417:

```python
timeout = datasource.cache_timeout or app.config.get("CACHE_DEFAULT_TIMEOUT", 300)
```

Per-dataset `cache_timeout` overrides; otherwise the configured default (5 minutes).

### Performance impact

The performance claim is **theoretical** — based on cache-hit avoidance of the wrapping query, not benchmarked against a production-scale virtual dataset. The functional correctness is validated by tests; the operational impact will depend on the deployment's filter cardinality and query cost.

### What this does NOT deliver (and why)

- **A single dashboard load with N filters on N _different_ columns still issues N database queries.** This is exactly the single-execution case #39342 asks to fix; that fix requires a new bulk endpoint + frontend coordination and is out of scope here.
- **No cache-stampede protection.** Concurrent first-load requests for the same key can each miss the cache and hit the DB. Adding this correctly across cache backends (Redis vs Memcached vs SimpleCache) is non-trivial; left as a follow-up.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/integration_tests/datasource/api_tests.py -v
\`\`\`

Tests covering the cache behavior:

| Test | Asserts |
|---|---|
| \`test_get_column_values_cache_hit_skips_query\` | Two identical requests → \`values_for_column\` called exactly once |
| \`test_get_column_values_force_bypasses_cache\` | \`?force=true\` re-runs the query even with a hot cache entry |
| \`test_get_column_values_cache_isolated_per_column\` | Two different columns → no cross-column leak |
| \`test_get_column_values_cache_isolated_per_rls_context\` | Different RLS contexts → separate cache entries (guest/embedded safety) |
| \`test_get_column_values_cache_busts_on_changed_on\` | Bumping \`changed_on\` invalidates the cache key |
| \`test_get_column_values_response_advertises_cache_status\` | \`X-Cache-Status\` header reports MISS then HIT |

All pre-existing endpoint tests still pass — no regression.

Manual verification:

1. Configure a virtual dataset with a heavy SQL (joins/CTEs)
2. Add 3+ native filters on different columns of that dataset to a dashboard
3. Load the dashboard, then reload it
4. Inspect \`/api/v1/datasource/.../values/\` requests in browser devtools — second-load responses should carry \`X-Cache-Status: HIT\`
5. Hit any endpoint with \`?force=true\` — response should carry \`X-Cache-Status: MISS\`

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39342 (partial — see Scope section)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (please mention any potential downtime)
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [x] Runtime introduces no new dependencies / changes existing dependencies
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API