### PR TITLE
fix(explore): require Update Chart for Matrixify dimension changes

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/matrixifyControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/matrixifyControls.tsx
@@ -118,7 +118,6 @@ const matrixifyControls: Record<string, SharedControlConfig<any>> = {};
     description: t(`Select dimension and values`),
     default: { dimension: '', values: [] },
     validators: [], // No validation - rely on visibility
-    renderTrigger: true,
     tabOverride: 'matrixify',
     shouldMapStateToProps: (prevState, state) => {
       // Recalculate when any relevant form_data field changes


### PR DESCRIPTION
### SUMMARY

#### Problem

In Matrixify, changing the dimension dropdown immediately triggers queries against the database — up to 25 simultaneous queries when "All dimensions" is selected. If a user accidentally selects a high-cardinality dimension (e.g. email), the database takes a significant and unintended hit. This is inconsistent with the rest of Superset, where data-affecting controls require clicking "Update Chart" before queries execute.

#### Root Cause

The `matrixify_dimension_{axis}` control had `renderTrigger: true`, which causes the chart to auto-re-render on any value change. Since each Matrixify grid cell is a `StatefulChart` that independently fetches data, a grid restructure (new dimension → new cells) triggers a DB query per cell without user confirmation.

#### Solution

Removed `renderTrigger: true` from the `matrixify_dimension_{axis}` control definition. Without this flag, dimension changes mark the chart as stale and activate the "Update Chart" button — matching the standard pattern used by other data-affecting controls like `dndGroupByControl`. The chart continues displaying old data until the user explicitly clicks "Update Chart".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
