### PR TITLE
fix(matrixify): Set singular metric field for pie and other single-me…

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.test.ts
@@ -72,6 +72,7 @@ test('should generate a 2x2 grid for metrics mode', () => {
     createAdhocMetric('Revenue'),
     createSqlMetric('Q1', 'SUM(CASE WHEN quarter = 1 THEN value END)'),
   ]);
+  expect(firstCell!.formData.metric).toEqual(createAdhocMetric('Revenue'));
 });
 
 test('should generate grid for dimensions mode', () => {
@@ -213,6 +214,9 @@ test('should skip missing column metrics when generating cell form data', () => 
   expect(grid!.cells[0][0]!.formData.metrics).toEqual([
     createAdhocMetric('Revenue'),
   ]);
+  expect(grid!.cells[0][0]!.formData.metric).toEqual(
+    createAdhocMetric('Revenue'),
+  );
 });
 
 test('should not escape HTML entities in cell titles', () => {
@@ -469,6 +473,51 @@ test('should handle metrics without labels', () => {
   // Metrics without labels show empty string
   expect(grid!.rowHeaders).toEqual(['']);
   expect(grid!.colHeaders).toEqual(['count']);
+});
+
+test('should set singular metric for singular-metric chart types like Pie', () => {
+  const rowMetricFormData: TestFormData = {
+    viz_type: 'pie',
+    datasource: '1__table',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'metrics',
+    matrixify_rows: [createAdhocMetric('Revenue'), createAdhocMetric('Profit')],
+  };
+
+  const grid = generateMatrixifyGrid(rowMetricFormData);
+
+  expect(grid).not.toBeNull();
+  expect(grid!.cells[0][0]!.formData.metrics).toEqual([
+    createAdhocMetric('Revenue'),
+  ]);
+  expect(grid!.cells[0][0]!.formData.metric).toEqual(
+    createAdhocMetric('Revenue'),
+  );
+  expect(grid!.cells[1][0]!.formData.metrics).toEqual([
+    createAdhocMetric('Profit'),
+  ]);
+  expect(grid!.cells[1][0]!.formData.metric).toEqual(
+    createAdhocMetric('Profit'),
+  );
+});
+
+test('should not overwrite singular metric in dimension-only mode', () => {
+  const dimensionFormData: TestFormData = {
+    viz_type: 'pie',
+    datasource: '1__table',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions',
+    matrixify_dimension_rows: {
+      dimension: 'country',
+      values: ['USA', 'Canada'],
+    },
+    metric: 'existing_metric',
+  };
+
+  const grid = generateMatrixifyGrid(dimensionFormData);
+
+  expect(grid).not.toBeNull();
+  expect(grid!.cells[0][0]!.formData.metric).toBe('existing_metric');
 });
 
 test('should preserve slice_id and dashboardId for embedded dashboard permissions', () => {

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.ts
@@ -197,6 +197,7 @@ function generateCellFormData(
   // If we have metrics from the matrix, use them; otherwise keep original
   if (metrics.length > 0) {
     cellFormData.metrics = metrics;
+    cellFormData.metric = metrics[0];
   }
 
   return cellFormData;


### PR DESCRIPTION
### SUMMARY

- Pie charts (and 11 other singular-metric chart types) all render the same metric when using Matrixify's "split by metric" feature
- Root cause: `MatrixifyGridGenerator` sets `cellFormData.metrics` (plural array), but Pie/Gauge/Funnel/BigNumber/etc. read `formData.metric` (singular string) — which is never set, so all panels fall back to the default empty metric
- Fix: also set `cellFormData.metric = metrics[0]` when assigning per-cell metrics, so singular-metric charts pick up the correct value

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
