### PR TITLE
docs(footer): render social icons as uniform white

### DIFF
--- a/docs/src/styles/main.css
+++ b/docs/src/styles/main.css
@@ -291,6 +291,12 @@ a > span > svg {
 .footer__social-links img {
   height: 24px;
   width: 24px;
+  /* The brand SVGs ship in their native colors (e.g. Slack's dark aubergine,
+     X's near-black), which disappear on the dark footer. Render them all as
+     uniform white silhouettes. The icons are single-path glyphs whose
+     counters (the LinkedIn "in", Slack gaps, Reddit face) are transparent
+     cut-outs, so they stay legible against the footer background. */
+  filter: brightness(0) invert(1);
 }
 
 .footer__ci-services {


### PR DESCRIPTION
### SUMMARY

Follow-up to #38108, which added social media badges to the website footer.
The badges use each brand's **native fill** — Slack `#4A154B` (dark aubergine),
X `#484848` (near-black), LinkedIn/Bluesky blue, Reddit orange. Against the dark
footer background (`#173036`), **Slack is effectively invisible and X is very
low-contrast**:

| icon | fill | on `#173036` footer |
|---|---|---|
| slack | `#4A154B` | ❌ nearly invisible |
| x | `#484848` | ⚠️ low contrast |
| linkedin / bluesky / reddit | blue / blue / orange | ok |

All five are single-path SVG glyphs whose interior details (the LinkedIn "in",
the Slack gaps, the Reddit face) are **transparent cut-outs**, so a one-line
CSS filter renders them as clean, uniform **white** logos that stay legible —
the cut-outs simply show the dark footer through them. This avoids shipping
five separate recolored white SVGs and keeps the brand-colored source assets
intact for any other use.

```css
.footer__social-links img {
  ...
  filter: brightness(0) invert(1);
}
```

### BEFORE/AFTER

Before: Slack mark blends into the footer (barely visible). After: all five
icons render as consistent white silhouettes.

### TESTING INSTRUCTIONS

Build the docs (`cd docs && yarn build && yarn serve`) and check the footer —
all five social icons render white and legible on the dark background.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)