### PR TITLE
fix(jinja): apply consistent value handling to url_param across input sources

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -288,11 +288,16 @@ class ExtraCache:
         from superset.views.utils import get_form_data
 
         if has_request_context() and request.args.get(param):
-            return request.args.get(param, default)
+            result = request.args.get(param, default)
+        else:
+            form_data, _ = get_form_data()
+            url_params = form_data.get("url_params") or {}
+            result = url_params.get(param, default)
 
-        form_data, _ = get_form_data()
-        url_params = form_data.get("url_params") or {}
-        result = url_params.get(param, default)
+        # Apply the same handling to every input source. Values read from
+        # request.args must go through the dialect-specific quoting below just
+        # like values sourced from form_data, so the result is consistent
+        # regardless of where the parameter originated.
         if result and escape_result and self.dialect:
             # use the dialect specific quoting logic to escape string
             result = String().literal_processor(dialect=self.dialect)(value=result)[

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -438,6 +438,26 @@ def test_url_param_unescaped_default_form_data() -> None:
         assert cache.url_param("bar", "O'Malley", escape_result=False) == "O'Malley"
 
 
+def test_url_param_escaped_query() -> None:
+    """
+    Test that a ``url_param`` value read from the request query string is
+    handled the same way as one sourced from ``form_data`` -- i.e. it goes
+    through the dialect-specific quoting instead of being returned raw.
+    """
+    with current_app.test_request_context(query_string={"foo": "O'Brien"}):
+        cache = ExtraCache(dialect=dialect())
+        assert cache.url_param("foo") == "O''Brien"
+
+
+def test_url_param_unescaped_query() -> None:
+    """
+    Test that ``escape_result=False`` returns the raw query-string value.
+    """
+    with current_app.test_request_context(query_string={"foo": "O'Brien"}):
+        cache = ExtraCache(dialect=dialect())
+        assert cache.url_param("foo", escape_result=False) == "O'Brien"
+
+
 def test_safe_proxy_primitive() -> None:
     """
     Test the ``safe_proxy`` helper with a function returning a ``str``.


### PR DESCRIPTION
### SUMMARY

`ExtraCache.url_param()` reads a parameter from either the request query string (`request.args`) or from `form_data['url_params']`. The two sources were not handled consistently: when the value came from `request.args` the function returned it through an early `return`, **skipping** the dialect-specific quoting and the cache-key wrapping that the `form_data` path applies a few lines below.

This change funnels both input sources through the same tail so the result is processed identically regardless of where the parameter originated:

- the `request.args` and `form_data` branches now only *select* the raw value;
- the existing `escape_result`/dialect quoting and `add_to_cache_keys` handling then runs once for both.

No change for the `form_data` path. For the query-string path the value is now quoted via the same dialect logic (and included in the cache key) instead of being returned verbatim. `escape_result=False` still returns the raw value, matching the documented behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend behavior consistency.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/jinja_context_test.py -k url_param
```

New tests assert the query-string path is quoted the same way as the `form_data` path, and that `escape_result=False` returns the raw value.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)