### PR TITLE
feat(websocket): add configurable per-channel and total connection limits

### DIFF
--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -717,6 +717,59 @@ describe('server', () => {
       expect(server.connectionLimitReason(channelId)).toBeNull();
     });
 
+    test('isSocketActive reflects the socket readyState', () => {
+      const ws = new wsMock('localhost');
+      setReadyState(ws, WebSocket.OPEN);
+      const socketId = server.trackClient(channelId, {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+      expect(server.isSocketActive(socketId)).toBe(true);
+      setReadyState(ws, WebSocket.CLOSED);
+      expect(server.isSocketActive(socketId)).toBe(false);
+      // unknown socket ids are never active
+      expect(server.isSocketActive('does-not-exist')).toBe(false);
+    });
+
+    test('activeSocketCount counts only active sockets', () => {
+      const openWs = new wsMock('localhost');
+      setReadyState(openWs, WebSocket.OPEN);
+      server.trackClient(channelId, {
+        ws: openWs,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+      const closedWs = new wsMock('localhost');
+      setReadyState(closedWs, WebSocket.CLOSED);
+      server.trackClient(channelId, {
+        ws: closedWs,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+      expect(server.activeSocketCount()).toBe(1);
+    });
+
+    test('activeChannelSocketCount counts only active sockets on the channel', () => {
+      const openWs = new wsMock('localhost');
+      setReadyState(openWs, WebSocket.OPEN);
+      server.trackClient(channelId, {
+        ws: openWs,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+      const closedWs = new wsMock('localhost');
+      setReadyState(closedWs, WebSocket.CLOSED);
+      server.trackClient(channelId, {
+        ws: closedWs,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+      expect(server.activeChannelSocketCount(channelId)).toBe(1);
+      // unknown channels report zero active sockets
+      expect(server.activeChannelSocketCount('no-such-channel')).toBe(0);
+    });
+
     test('wsConnection refuses over-limit connection without tracking', () => {
       server.opts.maxConnectionsPerChannel = 1;
       const existingWs = new wsMock('localhost');

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -726,6 +726,9 @@ describe('server', () => {
         pongTs: Date.now(),
       });
       expect(server.isSocketActive(socketId)).toBe(true);
+      // CONNECTING is also considered active (see SOCKET_ACTIVE_STATES)
+      setReadyState(ws, WebSocket.CONNECTING);
+      expect(server.isSocketActive(socketId)).toBe(true);
       setReadyState(ws, WebSocket.CLOSED);
       expect(server.isSocketActive(socketId)).toBe(false);
       // unknown socket ids are never active

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -661,8 +661,10 @@ describe('server', () => {
 
     test('total connection limit reached', () => {
       server.opts.maxTotalConnections = 1;
+      const ws = new wsMock('localhost');
+      setReadyState(ws, WebSocket.OPEN);
       const socketInstance = {
-        ws: new wsMock('localhost'),
+        ws,
         channel: channelId,
         pongTs: Date.now(),
       };
@@ -674,8 +676,10 @@ describe('server', () => {
 
     test('per-channel connection limit reached', () => {
       server.opts.maxConnectionsPerChannel = 1;
+      const ws = new wsMock('localhost');
+      setReadyState(ws, WebSocket.OPEN);
       const socketInstance = {
-        ws: new wsMock('localhost'),
+        ws,
         channel: channelId,
         pongTs: Date.now(),
       };
@@ -685,10 +689,40 @@ describe('server', () => {
       );
     });
 
+    test('stale closed socket does not count toward total limit', () => {
+      server.opts.maxTotalConnections = 1;
+      const ws = new wsMock('localhost');
+      const socketInstance = {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, socketInstance);
+      // simulate the socket having closed but not yet been GC'd
+      setReadyState(ws, WebSocket.CLOSED);
+      expect(server.connectionLimitReason('some-other-channel')).toBeNull();
+    });
+
+    test('stale closed socket does not count toward per-channel limit', () => {
+      server.opts.maxConnectionsPerChannel = 1;
+      const ws = new wsMock('localhost');
+      const socketInstance = {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, socketInstance);
+      // simulate the socket having closed but not yet been GC'd
+      setReadyState(ws, WebSocket.CLOSED);
+      expect(server.connectionLimitReason(channelId)).toBeNull();
+    });
+
     test('wsConnection refuses over-limit connection without tracking', () => {
       server.opts.maxConnectionsPerChannel = 1;
+      const existingWs = new wsMock('localhost');
+      setReadyState(existingWs, WebSocket.OPEN);
       const existing = {
-        ws: new wsMock('localhost'),
+        ws: existingWs,
         channel: channelId,
         pongTs: Date.now(),
       };

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -632,6 +632,82 @@ describe('server', () => {
     });
   });
 
+  describe('connection limits', () => {
+    const getRequest = (token: string, url: string): http.IncomingMessage => {
+      const request = new http.IncomingMessage(new net.Socket());
+      request.method = 'GET';
+      request.headers = { cookie: `${config.jwtCookieName}=${token}` };
+      request.url = url;
+      return request;
+    };
+
+    afterEach(() => {
+      // restore opt-in limits to their disabled default
+      server.opts.maxTotalConnections = 0;
+      server.opts.maxConnectionsPerChannel = 0;
+    });
+
+    test('no limit when disabled (0)', () => {
+      server.opts.maxTotalConnections = 0;
+      server.opts.maxConnectionsPerChannel = 0;
+      const socketInstance = {
+        ws: new wsMock('localhost'),
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, socketInstance);
+      expect(server.connectionLimitReason(channelId)).toBeNull();
+    });
+
+    test('total connection limit reached', () => {
+      server.opts.maxTotalConnections = 1;
+      const socketInstance = {
+        ws: new wsMock('localhost'),
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, socketInstance);
+      expect(server.connectionLimitReason('some-other-channel')).toMatch(
+        /total connection limit/,
+      );
+    });
+
+    test('per-channel connection limit reached', () => {
+      server.opts.maxConnectionsPerChannel = 1;
+      const socketInstance = {
+        ws: new wsMock('localhost'),
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, socketInstance);
+      expect(server.connectionLimitReason(channelId)).toMatch(
+        /per-channel connection limit/,
+      );
+    });
+
+    test('wsConnection refuses over-limit connection without tracking', () => {
+      server.opts.maxConnectionsPerChannel = 1;
+      const existing = {
+        ws: new wsMock('localhost'),
+        channel: channelId,
+        pongTs: Date.now(),
+      };
+      server.trackClient(channelId, existing);
+
+      const trackClientSpy = jest.spyOn(server, 'trackClient');
+      const ws = new wsMock('localhost');
+      const validToken = jwt.sign({ channel: channelId }, config.jwtSecret);
+      server.wsConnection(ws, getRequest(validToken, 'http://localhost'));
+
+      expect(ws.close).toHaveBeenCalledWith(
+        1013,
+        expect.stringMatching(/limit/),
+      );
+      expect(trackClientSpy).not.toHaveBeenCalled();
+      trackClientSpy.mockRestore();
+    });
+  });
+
   describe('httpUpgrade', () => {
     let socket: net.Socket;
     let socketDestroySpy: jest.SpiedFunction<typeof socket.destroy>;

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -53,6 +53,8 @@ type ConfigType = {
   gcChannelsIntervalMs: number;
   maxSocketBufferBytes: number;
   eventYieldBatchSize: number;
+  maxConnectionsPerChannel: number;
+  maxTotalConnections: number;
 };
 
 function defaultConfig(): ConfigType {
@@ -78,6 +80,9 @@ function defaultConfig(): ConfigType {
     // Number of stream events to process before yielding to the event loop.
     // 0 disables yielding (process the whole batch synchronously).
     eventYieldBatchSize: 100,
+    // 0 disables the limit (unlimited); set a positive value to opt in.
+    maxConnectionsPerChannel: 0,
+    maxTotalConnections: 0,
     statsd: {
       host: '127.0.0.1',
       port: 8125,
@@ -160,6 +165,9 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
         val,
         config.eventYieldBatchSize,
       )),
+    MAX_CONNECTIONS_PER_CHANNEL: val =>
+      (config.maxConnectionsPerChannel = toNumber(val)),
+    MAX_TOTAL_CONNECTIONS: val => (config.maxTotalConnections = toNumber(val)),
     REDIS_HOST: val => (config.redis.host = val),
     REDIS_PORT: val => (config.redis.port = toNumber(val)),
     REDIS_PASSWORD: val => (config.redis.password = val),

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -175,7 +175,7 @@ const CONNECTION_LIMIT_CLOSE_CODE = 1013;
  * `checkSockets`/`cleanChannel` GC routines), so connection-limit checks must
  * filter on live socket state rather than trusting the raw registry sizes.
  */
-const isSocketActive = (socketId: string): boolean => {
+export const isSocketActive = (socketId: string): boolean => {
   const socketInstance = sockets[socketId];
   return (
     !!socketInstance &&
@@ -186,13 +186,13 @@ const isSocketActive = (socketId: string): boolean => {
 /**
  * Counts the sockets in the global registry that are still active.
  */
-const activeSocketCount = (): number =>
+export const activeSocketCount = (): number =>
   Object.keys(sockets).filter(isSocketActive).length;
 
 /**
  * Counts the active sockets currently registered on the given channel.
  */
-const activeChannelSocketCount = (channel: string): number =>
+export const activeChannelSocketCount = (channel: string): number =>
   channels[channel]?.sockets.filter(isSocketActive).length ?? 0;
 
 /**

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -163,6 +163,37 @@ export const setLastFirehoseId = (id: string): void => {
   lastFirehoseId = id;
 };
 
+// WebSocket close code used when a connection is refused because a configured
+// connection limit has been reached (1013 = "Try Again Later").
+const CONNECTION_LIMIT_CLOSE_CODE = 1013;
+
+/**
+ * Determines whether accepting a new connection on the given channel would
+ * exceed a configured connection limit. Returns a human-readable reason when a
+ * limit is reached, or `null` when the connection is within limits.
+ *
+ * Both limits are opt-in: a value of `0` (the default) disables the check.
+ */
+export const connectionLimitReason = (channel: string): string | null => {
+  const { maxTotalConnections, maxConnectionsPerChannel } = opts;
+
+  if (
+    maxTotalConnections > 0 &&
+    Object.keys(sockets).length >= maxTotalConnections
+  ) {
+    return `total connection limit (${maxTotalConnections}) reached`;
+  }
+
+  if (maxConnectionsPerChannel > 0) {
+    const channelSize = channels[channel]?.sockets.length ?? 0;
+    if (channelSize >= maxConnectionsPerChannel) {
+      return `per-channel connection limit (${maxConnectionsPerChannel}) reached`;
+    }
+  }
+
+  return null;
+};
+
 /**
  * Adds the passed channel and socket instance to the internal registries.
  */
@@ -379,6 +410,17 @@ export const incrementId = (id: string): string => {
  */
 export const wsConnection = (ws: WebSocket, request: http.IncomingMessage) => {
   const channel: string = readChannelId(request);
+
+  // Refuse the connection if a configured connection limit has been reached,
+  // before tracking it against the internal registries.
+  const limitReason = connectionLimitReason(channel);
+  if (limitReason) {
+    statsd.increment('ws_connection_rejected');
+    logger.warn(`Refusing connection on channel ${channel}: ${limitReason}`);
+    ws.close(CONNECTION_LIMIT_CLOSE_CODE, limitReason);
+    return;
+  }
+
   const socketInstance: SocketInstance = { ws, channel, pongTs: Date.now() };
 
   // add this ws instance to the internal registry

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -168,27 +168,57 @@ export const setLastFirehoseId = (id: string): void => {
 const CONNECTION_LIMIT_CLOSE_CODE = 1013;
 
 /**
+ * Returns whether the socket with the given id is currently active, i.e. it is
+ * still registered and its underlying connection is in an active readyState.
+ *
+ * Closed sockets are only removed from the registries asynchronously (via the
+ * `checkSockets`/`cleanChannel` GC routines), so connection-limit checks must
+ * filter on live socket state rather than trusting the raw registry sizes.
+ */
+const isSocketActive = (socketId: string): boolean => {
+  const socketInstance = sockets[socketId];
+  return (
+    !!socketInstance &&
+    SOCKET_ACTIVE_STATES.includes(socketInstance.ws.readyState)
+  );
+};
+
+/**
+ * Counts the sockets in the global registry that are still active.
+ */
+const activeSocketCount = (): number =>
+  Object.keys(sockets).filter(isSocketActive).length;
+
+/**
+ * Counts the active sockets currently registered on the given channel.
+ */
+const activeChannelSocketCount = (channel: string): number =>
+  channels[channel]?.sockets.filter(isSocketActive).length ?? 0;
+
+/**
  * Determines whether accepting a new connection on the given channel would
  * exceed a configured connection limit. Returns a human-readable reason when a
  * limit is reached, or `null` when the connection is within limits.
  *
  * Both limits are opt-in: a value of `0` (the default) disables the check.
+ *
+ * Counts are derived from active socket state rather than raw registry sizes:
+ * recently closed sockets linger in the registries until the next GC pass, so
+ * counting them would spuriously reject new connections even when no active
+ * connection is consuming capacity.
  */
 export const connectionLimitReason = (channel: string): string | null => {
   const { maxTotalConnections, maxConnectionsPerChannel } = opts;
 
-  if (
-    maxTotalConnections > 0 &&
-    Object.keys(sockets).length >= maxTotalConnections
-  ) {
+  if (maxTotalConnections > 0 && activeSocketCount() >= maxTotalConnections) {
     return `total connection limit (${maxTotalConnections}) reached`;
   }
 
-  if (maxConnectionsPerChannel > 0) {
-    const channelSize = channels[channel]?.sockets.length ?? 0;
-    if (channelSize >= maxConnectionsPerChannel) {
-      return `per-channel connection limit (${maxConnectionsPerChannel}) reached`;
-    }
+  if (
+    maxConnectionsPerChannel > 0 &&
+    activeChannelSocketCount(channel) >= maxConnectionsPerChannel
+  ) {
+    return `per-channel connection limit (${maxConnectionsPerChannel}) reached`;
   }
 
   return null;


### PR DESCRIPTION
### SUMMARY

The websocket sidecar's `trackClient` accepted every incoming connection unconditionally, with no cap on how many sockets a single channel — or the server overall — could hold.

This adds two **opt-in** connection limits:

| Config | Env var | Default |
|--------|---------|---------|
| `maxConnectionsPerChannel` | `MAX_CONNECTIONS_PER_CHANNEL` | `0` (disabled) |
| `maxTotalConnections` | `MAX_TOTAL_CONNECTIONS` | `0` (disabled) |

Both default to `0`, which disables the check — so **existing deployments behave exactly as before** until an operator sets a positive value based on their capacity planning. When a configured limit is reached, `wsConnection` refuses the new socket with WebSocket close code `1013` ("Try Again Later") **before** it is tracked, and emits a `ws_connection_rejected` statsd counter for observability.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — sidecar behavior, config-gated.

### TESTING INSTRUCTIONS

```
cd superset-websocket
npm ci
npm test
```

New tests cover: limits disabled by default, per-channel limit reached, total limit reached, and `wsConnection` closing an over-limit socket (code 1013) without tracking it.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)