### PR TITLE
feat(websocket): add backpressure handling for slow consumers

### DIFF
--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -269,6 +269,80 @@ describe('server', () => {
     });
   });
 
+  describe('backpressure', () => {
+    const fakeEvent = {
+      id: '1615426152415-0',
+      channel_id: channelId,
+      job_id: 'c9b99965-8f1e-4ce5-aa43-d6fc94d6a510',
+      status: 'done',
+    };
+
+    afterEach(() => {
+      server.opts.maxSocketBufferBytes = 0;
+    });
+
+    test('does not terminate when cap disabled (0)', () => {
+      server.opts.maxSocketBufferBytes = 0;
+      const ws = new wsMock('localhost');
+      // simulate a large outbound buffer
+      (ws as unknown as { bufferedAmount: number }).bufferedAmount = 10_000_000;
+      const terminateMock = jest.spyOn(ws, 'terminate');
+      const sendMock = jest.spyOn(ws, 'send');
+      server.trackClient(channelId, {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+
+      server.sendToChannel(channelId, fakeEvent);
+
+      expect(terminateMock).not.toHaveBeenCalled();
+      expect(sendMock).toHaveBeenCalled();
+    });
+
+    test('terminates a slow client whose buffer exceeds the cap', () => {
+      server.opts.maxSocketBufferBytes = 1024;
+      const ws = new wsMock('localhost');
+      (ws as unknown as { bufferedAmount: number }).bufferedAmount = 2048;
+      const terminateMock = jest.spyOn(ws, 'terminate');
+      const sendMock = jest.spyOn(ws, 'send');
+      const cleanChannelMock = jest.spyOn(server, 'cleanChannel');
+      server.trackClient(channelId, {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+
+      server.sendToChannel(channelId, fakeEvent);
+
+      expect(terminateMock).toHaveBeenCalled();
+      expect(sendMock).not.toHaveBeenCalled();
+      expect(statsdIncrementMock).toHaveBeenCalledWith(
+        'ws_client_backpressure_disconnect',
+      );
+      expect(cleanChannelMock).toHaveBeenCalledWith(channelId);
+      cleanChannelMock.mockRestore();
+    });
+
+    test('keeps sending to a client within the cap', () => {
+      server.opts.maxSocketBufferBytes = 1024;
+      const ws = new wsMock('localhost');
+      (ws as unknown as { bufferedAmount: number }).bufferedAmount = 16;
+      const terminateMock = jest.spyOn(ws, 'terminate');
+      const sendMock = jest.spyOn(ws, 'send');
+      server.trackClient(channelId, {
+        ws,
+        channel: channelId,
+        pongTs: Date.now(),
+      });
+
+      server.sendToChannel(channelId, fakeEvent);
+
+      expect(terminateMock).not.toHaveBeenCalled();
+      expect(sendMock).toHaveBeenCalled();
+    });
+  });
+
   describe('fetchRangeFromStream', () => {
     beforeEach(() => {
       mockRedisXrange.mockClear();

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -279,6 +279,9 @@ describe('server', () => {
 
     afterEach(() => {
       server.opts.maxSocketBufferBytes = 0;
+      // Restore any spies (e.g. on server.cleanChannel) so they don't leak
+      // across tests and cause order-dependent failures.
+      jest.restoreAllMocks();
     });
 
     test('does not terminate when cap disabled (0)', () => {
@@ -321,7 +324,6 @@ describe('server', () => {
         'ws_client_backpressure_disconnect',
       );
       expect(cleanChannelMock).toHaveBeenCalledWith(channelId);
-      cleanChannelMock.mockRestore();
     });
 
     test('keeps sending to a client within the cap', () => {

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -102,6 +102,21 @@ function configFromFile(): Partial<ConfigType> {
 
 const isPresent = (s: string) => /\S+/.test(s);
 const toNumber = Number;
+
+// Parse a non-negative numeric env override, ignoring malformed input.
+// Returns the fallback (and logs a warning) when the value is not a finite
+// number >= 0, so a misconfiguration can't silently disable the feature.
+function toNonNegativeNumber(val: string, fallback: number): number {
+  const parsed = Number(val);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.warn(
+      `Invalid numeric config value "${val}"; expected a non-negative ` +
+        `number. Falling back to ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
 const toBoolean = (s: string) => s.toLowerCase() === 'true';
 const toStringArray = (s: string) => s.split(',');
 
@@ -125,7 +140,10 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
     GC_CHANNELS_INTERVAL_MS: val =>
       (config.gcChannelsIntervalMs = toNumber(val)),
     MAX_SOCKET_BUFFER_BYTES: val =>
-      (config.maxSocketBufferBytes = toNumber(val)),
+      (config.maxSocketBufferBytes = toNonNegativeNumber(
+        val,
+        config.maxSocketBufferBytes,
+      )),
     REDIS_HOST: val => (config.redis.host = val),
     REDIS_PORT: val => (config.redis.port = toNumber(val)),
     REDIS_PASSWORD: val => (config.redis.password = val),

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -50,6 +50,7 @@ type ConfigType = {
   socketResponseTimeoutMs: number;
   pingSocketsIntervalMs: number;
   gcChannelsIntervalMs: number;
+  maxSocketBufferBytes: number;
 };
 
 function defaultConfig(): ConfigType {
@@ -68,6 +69,9 @@ function defaultConfig(): ConfigType {
     socketResponseTimeoutMs: 60 * 1000,
     pingSocketsIntervalMs: 20 * 1000,
     gcChannelsIntervalMs: 120 * 1000,
+    // 0 disables the per-socket send-buffer cap; set a positive byte value to
+    // opt in to terminating clients whose outbound buffer grows beyond it.
+    maxSocketBufferBytes: 0,
     statsd: {
       host: '127.0.0.1',
       port: 8125,
@@ -120,6 +124,8 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
       (config.pingSocketsIntervalMs = toNumber(val)),
     GC_CHANNELS_INTERVAL_MS: val =>
       (config.gcChannelsIntervalMs = toNumber(val)),
+    MAX_SOCKET_BUFFER_BYTES: val =>
+      (config.maxSocketBufferBytes = toNumber(val)),
     REDIS_HOST: val => (config.redis.host = val),
     REDIS_PORT: val => (config.redis.port = toNumber(val)),
     REDIS_PASSWORD: val => (config.redis.password = val),

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -209,6 +209,10 @@ export const sendToChannel = (channel: string, value: EventValue): void => {
           `configured limit (${maxSocketBufferBytes} bytes)`,
       );
       socketInstance.ws.terminate();
+      // Drop the terminated socket from the global registry immediately
+      // rather than waiting for the next checkSockets sweep, so a burst of
+      // slow clients doesn't leave dead entries resident between pings.
+      delete sockets[socketId];
       cleanChannel(channel);
       return;
     }

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -194,6 +194,24 @@ export const sendToChannel = (channel: string, value: EventValue): void => {
   channels[channel].sockets.forEach(socketId => {
     const socketInstance: SocketInstance = sockets[socketId];
     if (!socketInstance) return cleanChannel(channel);
+    // Backpressure: if a slow or stalled client has let its outbound buffer
+    // grow past the configured cap, terminate it rather than buffering
+    // unbounded data in server memory. Opt-in: a cap of 0 disables the check.
+    const { maxSocketBufferBytes } = opts;
+    if (
+      maxSocketBufferBytes > 0 &&
+      socketInstance.ws.bufferedAmount > maxSocketBufferBytes
+    ) {
+      statsd.increment('ws_client_backpressure_disconnect');
+      logger.warn(
+        `Terminating socket on channel ${channel}: send buffer ` +
+          `(${socketInstance.ws.bufferedAmount} bytes) exceeded the ` +
+          `configured limit (${maxSocketBufferBytes} bytes)`,
+      );
+      socketInstance.ws.terminate();
+      cleanChannel(channel);
+      return;
+    }
     try {
       socketInstance.ws.send(strData);
     } catch (err) {


### PR DESCRIPTION
### SUMMARY

When broadcasting events, `sendToChannel` called `ws.send()` unconditionally. A slow or stalled client that stops reading its socket would cause the server's per-connection outbound buffer to grow without bound, consuming server memory and degrading service for everyone on the sidecar.

This adds an **opt-in** per-socket send-buffer cap:

| Config | Env var | Default |
|--------|---------|---------|
| `maxSocketBufferBytes` | `MAX_SOCKET_BUFFER_BYTES` | `0` (disabled) |

It defaults to `0`, which disables the check — **existing deployments are unaffected**. When a positive value is configured, a socket whose `bufferedAmount` exceeds the cap is terminated and cleaned up before the next send, and a `ws_client_backpressure_disconnect` statsd counter is emitted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — sidecar behavior, config-gated.

### TESTING INSTRUCTIONS

```
cd superset-websocket
npm ci
npm test
```

New tests cover: cap disabled by default (no termination), a client over the cap terminated + counted + channel cleaned, and a client within the cap still receiving sends.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)