### PR TITLE
docs(jinja): show a safe filter example in get_filters docstring

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -354,6 +354,12 @@ class ExtraCache:
             - you want to have the ability for filter inside the main query for speed
             purposes
 
+        .. warning::
+            Do not hand-escape filter values into SQL strings (for example with
+            ``replace("'", "''")``). Such patterns are incomplete and easy to get
+            wrong. Render list values through the ``where_in`` filter, and prefer
+            the ``IN`` operator over building literals by hand.
+
         Usage example::
 
 
@@ -374,10 +380,6 @@ class ExtraCache:
                 {%- if filter.get('op') == 'IN' -%}
                     AND
                     full_name IN {{ filter.get('val')|where_in }}
-                {%- endif -%}
-                {%- if filter.get('op') == 'LIKE' -%}
-                    AND
-                    full_name LIKE '{{ filter.get('val') | replace("'", "''") }}'
                 {%- endif -%}
                 {%- endfor -%}
                 UNION ALL


### PR DESCRIPTION
### SUMMARY

The `get_filters` docstring in `superset/jinja_context.py` included a usage example that built a `LIKE` clause by hand-escaping the filter value with `replace("'", "''")`. Hand-rolled escaping like that is incomplete and easy to get wrong, and the docstring is a pattern users copy.

This updates the documentation only:
- removes the hand-escaped `LIKE` branch from the example;
- keeps the `where_in`-based `IN` example (the recommended approach);
- adds a `.. warning::` advising against hand-escaping filter values into SQL and pointing to `where_in` / the `IN` operator.

No code behavior changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — docstring only.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/jinja_context_test.py -k get_filters
```

(`get_filters` behavior is unchanged; existing tests pass.)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)