### PR TITLE
feat(uploads): add optional max file size for data uploads

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -67,6 +67,10 @@ Operators can tune or disable the policy via config:
 - `FAB_PASSWORD_COMPLEXITY_VALIDATOR` — replace with your own callable for custom rules.
 - `FAB_PASSWORD_COMPLEXITY_ENABLED = False` — disable enforcement entirely.
 
+### Data uploads bounded by UPLOAD_MAX_FILE_SIZE_BYTES
+
+Single data-file uploads (CSV, Excel, columnar) are now bounded by the `UPLOAD_MAX_FILE_SIZE_BYTES` config option, which defaults to `100 * 1024 * 1024` (100 MB). Files larger than this are rejected with a `413` before their contents are buffered into memory. Set `UPLOAD_MAX_FILE_SIZE_BYTES = None` to disable the check and restore unbounded uploads.
+
 ### Duration formatter precision
 
 The `DURATION` number formatter now uses `Intl.DurationFormat` for locale-aware output. By default, sub-second fields are omitted, so values that previously displayed fractional seconds with `pretty-ms`, such as `10500` milliseconds rendering as `10.5s`, now render as `10s`.

--- a/superset/commands/database/exceptions.py
+++ b/superset/commands/database/exceptions.py
@@ -118,6 +118,11 @@ class DatabaseUploadFailed(CommandException):
     message = _("Database upload file failed")
 
 
+class DatabaseUploadFileTooLarge(CommandException):
+    status = 413
+    message = _("Database upload file exceeds the maximum allowed size.")
+
+
 class DatabaseUploadSaveMetadataFailed(CommandException):
     status = 500
     message = _("Database upload file failed, while saving metadata")

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import Any, Optional, TypedDict
 
 import pandas as pd
+from flask import current_app
 from flask_babel import lazy_gettext as _
 from werkzeug.datastructures import FileStorage
 
@@ -29,6 +30,7 @@ from superset.commands.database.exceptions import (
     DatabaseNotFoundError,
     DatabaseSchemaUploadNotAllowed,
     DatabaseUploadFailed,
+    DatabaseUploadFileTooLarge,
     DatabaseUploadNotSupported,
     DatabaseUploadSaveMetadataFailed,
 )
@@ -188,6 +190,16 @@ class UploadCommand(BaseCommand):
 
         sqla_table.fetch_metadata()
 
+    @staticmethod
+    def _file_size_bytes(file: Any) -> int:
+        """Return the size of an uploaded file without consuming its stream."""
+        stream = getattr(file, "stream", file)
+        position = stream.tell()
+        stream.seek(0, 2)  # seek to end
+        size = stream.tell()
+        stream.seek(position)  # restore the original position
+        return size
+
     def validate(self) -> None:
         self._model = DatabaseDAO.find_by_id(self._model_id)
         if not self._model:
@@ -196,3 +208,11 @@ class UploadCommand(BaseCommand):
             raise DatabaseSchemaUploadNotAllowed()
         if not self._model.db_engine_spec.supports_file_upload:
             raise DatabaseUploadNotSupported()
+
+        max_file_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
+        if (
+            max_file_size is not None
+            and self._file is not None
+            and self._file_size_bytes(self._file) > max_file_size
+        ):
+            raise DatabaseUploadFileTooLarge()

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -200,6 +200,25 @@ class UploadCommand(BaseCommand):
         stream.seek(position)  # restore the original position
         return size
 
+    @classmethod
+    def validate_file_size(cls, file: Any) -> None:
+        """
+        Reject a file whose size exceeds ``UPLOAD_MAX_FILE_SIZE_BYTES``.
+
+        Shared by the upload command and the metadata endpoint so oversized
+        files are rejected before their contents are read into memory,
+        regardless of which path is used.
+
+        :raises DatabaseUploadFileTooLarge: if the file is larger than the limit
+        """
+        max_file_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
+        if (
+            max_file_size is not None
+            and file is not None
+            and cls._file_size_bytes(file) > max_file_size
+        ):
+            raise DatabaseUploadFileTooLarge()
+
     def validate(self) -> None:
         self._model = DatabaseDAO.find_by_id(self._model_id)
         if not self._model:
@@ -209,10 +228,4 @@ class UploadCommand(BaseCommand):
         if not self._model.db_engine_spec.supports_file_upload:
             raise DatabaseUploadNotSupported()
 
-        max_file_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
-        if (
-            max_file_size is not None
-            and self._file is not None
-            and self._file_size_bytes(self._file) > max_file_size
-        ):
-            raise DatabaseUploadFileTooLarge()
+        self.validate_file_size(self._file)

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -191,13 +191,22 @@ class UploadCommand(BaseCommand):
         sqla_table.fetch_metadata()
 
     @staticmethod
-    def _file_size_bytes(file: Any) -> int:
-        """Return the size of an uploaded file without consuming its stream."""
+    def _file_size_bytes(file: Any) -> Optional[int]:
+        """
+        Return the size of an uploaded file without consuming its stream.
+
+        Returns ``None`` when the stream is not seekable, in which case the
+        size cannot be determined cheaply and the size check is skipped in
+        favour of downstream guards.
+        """
         stream = getattr(file, "stream", file)
-        position = stream.tell()
-        stream.seek(0, 2)  # seek to end
-        size = stream.tell()
-        stream.seek(position)  # restore the original position
+        try:
+            position = stream.tell()
+            stream.seek(0, 2)  # seek to end
+            size = stream.tell()
+            stream.seek(position)  # restore the original position
+        except (AttributeError, OSError):
+            return None
         return size
 
     @classmethod
@@ -212,11 +221,10 @@ class UploadCommand(BaseCommand):
         :raises DatabaseUploadFileTooLarge: if the file is larger than the limit
         """
         max_file_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
-        if (
-            max_file_size is not None
-            and file is not None
-            and cls._file_size_bytes(file) > max_file_size
-        ):
+        if max_file_size is None or file is None:
+            return
+        size = cls._file_size_bytes(file)
+        if size is not None and size > max_file_size:
             raise DatabaseUploadFileTooLarge()
 
     def validate(self) -> None:

--- a/superset/commands/database/uploaders/columnar_reader.py
+++ b/superset/commands/database/uploaders/columnar_reader.py
@@ -23,7 +23,6 @@ from zipfile import BadZipfile, is_zipfile, ZipFile
 
 import pandas as pd
 import pyarrow.parquet as pq
-from flask import current_app
 from flask_babel import lazy_gettext as _
 from pyarrow.lib import ArrowException
 from werkzeug.datastructures import FileStorage
@@ -38,41 +37,6 @@ from superset.exceptions import SupersetException
 from superset.utils.core import check_is_safe_zip
 
 logger = logging.getLogger(__name__)
-
-
-def _check_file_size(file: FileStorage) -> None:
-    """
-    Reject an uploaded file whose raw (on-the-wire) size exceeds the configured
-    limit before its contents are buffered into memory.
-
-    This is complementary to the ZIP decompression-ratio guard: it bounds the
-    raw bytes accepted regardless of whether the payload is compressed.
-
-    :param file: The uploaded file to check.
-    :throws DatabaseUploadFailed: if the file exceeds the configured limit.
-    """
-    max_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
-    if not max_size:
-        return
-    stream = file.stream
-    try:
-        current_position = stream.tell()
-        stream.seek(0, 2)  # seek to end
-        size = stream.tell()
-        stream.seek(current_position)
-    except (AttributeError, OSError):
-        # If the stream is not seekable we cannot determine the size cheaply;
-        # skip the check and rely on downstream guards.
-        return
-    if size > max_size:
-        raise DatabaseUploadFailed(
-            _(
-                "File size %(size)s bytes exceeds the maximum allowed "
-                "upload size of %(max_size)s bytes",
-                size=size,
-                max_size=max_size,
-            )
-        )
 
 
 class ColumnarReaderOptions(ReaderOptions, total=False):
@@ -118,7 +82,6 @@ class ColumnarReader(BaseDataReader):
         :param file: The file to yield files from.
         :return: A generator that yields files.
         """
-        _check_file_size(file)
         file_suffix = Path(file.filename).suffix
         if not file_suffix:
             raise DatabaseUploadFailed(_("Unexpected no file extension found"))

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1727,6 +1727,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             parameters = UploadFileMetadataPostSchema().load(request_form)
         except ValidationError as error:
             return self.response_400(message=error.messages)
+        UploadCommand.validate_file_size(parameters["file"])
         if parameters["type"] == UploadFileType.CSV.value:
             metadata = CSVReader(parameters).file_metadata(parameters["file"])
         elif parameters["type"] == UploadFileType.EXCEL.value:

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1718,6 +1718,15 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/401'
             404:
               $ref: '#/components/responses/404'
+            413:
+              description: Payload too large, file exceeds the maximum allowed size
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
             500:
               $ref: '#/components/responses/500'
         """
@@ -1778,6 +1787,15 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/401'
             404:
               $ref: '#/components/responses/404'
+            413:
+              description: Payload too large, file exceeds the maximum allowed size
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
             422:
               $ref: '#/components/responses/422'
             500:

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-07-14 15:10+0300\n"
 "Last-Translator: Abdalrahim G. Fakhouri <abdilra7eem@yahoo.com>\n"
 "Language: ar\n"
@@ -4661,6 +4661,9 @@ msgstr "تم تحديث إعدادات قاعدة البيانات"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "قاعدة البيانات لا تدعم الاستعلامات الفرعية"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18307,10 +18310,6 @@ msgstr "قيمة تصاعدية"
 
 msgid "value descending"
 msgstr "قيمة تنازلي"
-
-#, fuzzy
-msgid "valuename"
-msgstr "اسم الجدول"
 
 msgid "var"
 msgstr "VAR"

--- a/superset/translations/ca/LC_MESSAGES/messages.po
+++ b/superset/translations/ca/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2025-06-27 12:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -4654,6 +4654,9 @@ msgstr "Configuració de base de dades actualitzada"
 
 msgid "Database type does not support file uploads."
 msgstr "El tipus de base de dades no suporta pujades de fitxers."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "La pujada de fitxer de base de dades ha fallat"
@@ -18303,10 +18306,6 @@ msgstr "valor ascendent"
 
 msgid "value descending"
 msgstr "valor descendent"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nom de taula"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/cs/LC_MESSAGES/messages.po
+++ b/superset/translations/cs/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2016-05-02 08:49-0700\n"
 "Last-Translator: Jan Šmejkal <jan.smejkal@orgis.cz>\n"
 "Language: cs\n"
@@ -4632,6 +4632,9 @@ msgstr "Nastavení databáze aktualizováno"
 
 msgid "Database type does not support file uploads."
 msgstr "Typ databáze nepodporuje nahrávání souborů."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Nahrání souboru do databáze selhalo"
@@ -18244,10 +18247,6 @@ msgstr "hodnota vzestupně"
 
 msgid "value descending"
 msgstr "hodnota sestupně"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Název tabulky"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2023-04-07 19:45+0200\n"
 "Last-Translator: Holger Bruch <holger.bruch@wattbewerb.de>\n"
 "Language: de\n"
@@ -4722,6 +4722,9 @@ msgstr "Datenbankeinstellungen aktualisiert"
 
 msgid "Database type does not support file uploads."
 msgstr "Der Datenbanktyp unterstützt keine Datei-Uploads."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Datenbank-Upload fehlgeschlagen"
@@ -18685,10 +18688,6 @@ msgstr "Wert aufsteigend"
 
 msgid "value descending"
 msgstr "Wert absteigend"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Tabellenname"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2016-05-02 08:49-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -4199,6 +4199,9 @@ msgid "Database settings updated"
 msgstr ""
 
 msgid "Database type does not support file uploads."
+msgstr ""
+
+msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
 
 msgid "Database upload file failed"
@@ -16445,9 +16448,6 @@ msgid "value ascending"
 msgstr ""
 
 msgid "value descending"
-msgstr ""
-
-msgid "valuename"
 msgstr ""
 
 msgid "var"

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2016-05-02 08:49-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -4817,6 +4817,9 @@ msgstr "Configuración de la base de datos actualizada"
 
 msgid "Database type does not support file uploads."
 msgstr "El tipo de base de datos no admite subidas de archivos."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "La subida de la base de datos ha fallado"
@@ -19024,10 +19027,6 @@ msgstr "valor ascendente"
 
 msgid "value descending"
 msgstr "valor descendente"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nombre de la tabla"
 
 msgid "var"
 msgstr "var."

--- a/superset/translations/fa/LC_MESSAGES/messages.po
+++ b/superset/translations/fa/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-10-20 00:07+0330\n"
 "Last-Translator: Emad Rad <codewithemad@gmail.com>\n"
 "Language: fa\n"
@@ -4599,6 +4599,9 @@ msgstr "تنظیمات پایگاه داده به‌روزرسانی شدند"
 
 msgid "Database type does not support file uploads."
 msgstr "نوع پایگاه داده از بارگذاری فایل پشتیبانی نمی‌کند."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "بارگذاری فایل پایگاه داده ناموفق بود"
@@ -18232,10 +18235,6 @@ msgstr "مقدار صعودی"
 
 msgid "value descending"
 msgstr "مقدار نزولی"
-
-#, fuzzy
-msgid "valuename"
-msgstr "نام جدول"
 
 msgid "var"
 msgstr "متغیر"

--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fi\n"
@@ -8151,6 +8151,9 @@ msgstr "Tietokannan asetukset päivitetty"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "Tietokantityyppi ei tue tiedostojen lataamista."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ru, sk, sl, uk]
@@ -32065,12 +32068,6 @@ msgstr "arvo nouseva"
 #, fuzzy
 msgid "value descending"
 msgstr "arvo laskeva"
-
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, es,
-# fr, ja, lv, mi, ru, sk, uk]
-#, fuzzy
-msgid "valuename"
-msgstr "Taulukon nimi"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ru, sk, sl, uk]

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2025-06-26 15:34+0200\n"
 "Last-Translator: \n"
 "Language: fr\n"
@@ -4654,6 +4654,9 @@ msgstr "Mise à jour des paramètres de la base de données"
 
 msgid "Database type does not support file uploads."
 msgstr "La base de données ne prend pas en charge le chargement de fichiers"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Le chargement de fichier dans la base a échoué"
@@ -18861,10 +18864,6 @@ msgstr "valeurs croissantes"
 #, fuzzy
 msgid "value descending"
 msgstr "valeurs décroissantes"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nom du tableau"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2018-02-11 22:26+0200\n"
 "Last-Translator: Raffaele Spangaro <raffa@raffaelespangaro.it>\n"
 "Language: it\n"
@@ -4562,6 +4562,9 @@ msgstr "La tua query non può essere salvata"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "Sorgente dati e tipo di grafico"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -17931,10 +17934,6 @@ msgstr "Importa"
 #, fuzzy
 msgid "value descending"
 msgstr "Importa"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Database"
 
 msgid "var"
 msgstr ""

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-05-14 13:30+0900\n"
 "Last-Translator: Yuri Umezaki <bungoume@gmail.com>\n"
 "Language: ja\n"
@@ -4297,6 +4297,9 @@ msgstr "データベース設定を更新しました"
 
 msgid "Database type does not support file uploads."
 msgstr "このデータベース種類はファイルアップロードをサポートしていません。"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "データベースへのファイルアップロードに失敗しました"
@@ -16820,10 +16823,6 @@ msgstr "値の昇順"
 
 msgid "value descending"
 msgstr "値の降順"
-
-#, fuzzy
-msgid "valuename"
-msgstr "テーブル名"
 
 msgid "var"
 msgstr "分散"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2019-02-02 22:28+0900\n"
 "Last-Translator: \n"
 "Language: ko\n"
@@ -4540,6 +4540,9 @@ msgid "Database settings updated"
 msgstr "데이터베이스를 업데이트할 수 없습니다."
 
 msgid "Database type does not support file uploads."
+msgstr ""
+
+msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
 
 msgid "Database upload file failed"
@@ -17765,10 +17768,6 @@ msgstr ""
 
 msgid "value descending"
 msgstr ""
-
-#, fuzzy
-msgid "valuename"
-msgstr "테이블 명"
 
 msgid "var"
 msgstr ""

--- a/superset/translations/lv/LC_MESSAGES/messages.po
+++ b/superset/translations/lv/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2026-03-27 14:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: lv\n"
@@ -4571,6 +4571,9 @@ msgstr "Datubāzes iestatījumi atjaunināti"
 
 msgid "Database type does not support file uploads."
 msgstr "Datubāzes tips neatbalsta failu augšupielādi."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Datubāzes faila augšupielāde neizdevās"
@@ -17864,10 +17867,6 @@ msgstr "vērtība augošā secībā"
 
 msgid "value descending"
 msgstr "vērtība dilstošā secībā"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Tabulas nosaukums"
 
 msgid "var"
 msgstr "dispersija"

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4201,6 +4201,9 @@ msgid "Database settings updated"
 msgstr ""
 
 msgid "Database type does not support file uploads."
+msgstr ""
+
+msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
 
 msgid "Database upload file failed"
@@ -16420,9 +16423,6 @@ msgid "value ascending"
 msgstr ""
 
 msgid "value descending"
-msgstr ""
-
-msgid "valuename"
 msgstr ""
 
 msgid "var"

--- a/superset/translations/mi/LC_MESSAGES/messages.po
+++ b/superset/translations/mi/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2026-01-25 16:09+1300\n"
 "Last-Translator: karo.co.nz\n"
 "Language: mi\n"
@@ -4583,6 +4583,9 @@ msgstr "Kua whakahouhia ngā tautuhinga pātengi raraunga"
 
 msgid "Database type does not support file uploads."
 msgstr "Karekau e tautoko te momo pātengi raraunga i ngā tukuake kōnae."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "I rahua te tukuake kōnae pātengi raraunga"
@@ -18223,10 +18226,6 @@ msgstr "uara piki"
 
 msgid "value descending"
 msgstr "uara heke"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Ingoa ripanga"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  superset-ds\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-05-08 14:41+0000\n"
 "Last-Translator: \n"
 "Language: nl\n"
@@ -4687,6 +4687,9 @@ msgstr "Database instellingen bijgewerkt"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "Database ondersteunt geen subquery’s"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18510,10 +18513,6 @@ msgstr "waarde oplopend"
 
 msgid "value descending"
 msgstr "waarde aflopend"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Tabel Naam"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2021-11-16 17:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -4796,6 +4796,9 @@ msgstr "Ustawienia bazy danych zaktualizowane"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "Typ bazy danych nie obsługuje przesyłania plików."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -19160,10 +19163,6 @@ msgstr "wartości rosnące"
 #, fuzzy
 msgid "value descending"
 msgstr "wartości malejące"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nazwa tabeli"
 
 #, fuzzy
 msgid "var"

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2018-03-12 16:24+0000\n"
 "Last-Translator: Nuno Heli Beires <nuno.beires@douroeci.com>\n"
 "Language: pt\n"
@@ -4627,6 +4627,9 @@ msgstr "Não foi possível gravar a sua query"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "Origem de dados %(name)s já existe"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18174,10 +18177,6 @@ msgstr "Ordenar decrescente"
 #, fuzzy
 msgid "value descending"
 msgstr "Ordenar decrescente"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nome da Tabela"
 
 msgid "var"
 msgstr ""

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2023-05-22 08:04-0400\n"
 "Last-Translator: \n"
 "Language: pt_BR\n"
@@ -4789,6 +4789,9 @@ msgstr "Configurações do banco de dados atualizadas"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "O banco de dados não é compatível com subconsultas"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18753,10 +18756,6 @@ msgstr "valor crescente"
 
 msgid "value descending"
 msgstr "valor decrescente"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Nome da Tabela"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2025-11-05 14:37+0300\n"
 "Last-Translator: innovark\n"
 "Language: ru\n"
@@ -4552,6 +4552,9 @@ msgstr "Настройки базы данных обновлены"
 
 msgid "Database type does not support file uploads."
 msgstr "База данных не поддерживает загрузку файлов"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Произошла ошибка при загрузке файла в базу данных"
@@ -17861,10 +17864,6 @@ msgstr "по возрастанию значения"
 
 msgid "value descending"
 msgstr "по убыванию значения"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Имя таблицы"
 
 msgid "var"
 msgstr "дисперсия"

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2026-05-18 15:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: sk\n"
@@ -4632,6 +4632,9 @@ msgstr "Nastavenie databáza aktualizované"
 
 msgid "Database type does not support file uploads."
 msgstr "Typ databáza nepodporuje nahrávanie súborov."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Nahranie súboru do databáza zlyhalo"
@@ -18267,10 +18270,6 @@ msgstr "hodnota vzestupne"
 
 msgid "value descending"
 msgstr "hodnota sestupne"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Názov tabuľky"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Superset\n"
 "Report-Msgid-Bugs-To: dkrat7 @github.com\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-10-05 23:46+0200\n"
 "Last-Translator: dkrat7 <dkrat7 @github.com>\n"
 "Language: sl_SI\n"
@@ -4653,6 +4653,9 @@ msgstr "Nastavitve podatkovne baze posodobljene"
 
 msgid "Database type does not support file uploads."
 msgstr "Tip podatkovne baze ne podpira nalaganje datotek."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Nalaganje datoteke v podatkovno bazo ni uspelo"
@@ -18286,10 +18289,6 @@ msgstr "0 - 9"
 
 msgid "value descending"
 msgstr "9 - 0"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Ime tabele"
 
 msgid "var"
 msgstr "var"

--- a/superset/translations/th/LC_MESSAGES/messages.po
+++ b/superset/translations/th/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: th\n"
@@ -8011,6 +8011,9 @@ msgstr "อัปเดตการตั้งค่าฐานข้อมู
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "ประเภทฐานข้อมูลนี้ไม่รองรับการอัปโหลดไฟล์"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ru, sk, sl, uk]
@@ -31703,12 +31706,6 @@ msgstr "ค่าจากน้อยไปมาก"
 #, fuzzy
 msgid "value descending"
 msgstr "ค่าจากมากไปน้อย"
-
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, es,
-# fr, ja, lv, mi, ru, sk, uk]
-#, fuzzy
-msgid "valuename"
-msgstr "ชื่อตาราง"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ru, sk, sl, uk]

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Superset VERSION\n"
 "Report-Msgid-Bugs-To: avsarcoteli@gmail.com\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2024-02-25 14:00+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: tr\n"
@@ -4358,6 +4358,9 @@ msgid "Database settings updated"
 msgstr "Veritabanı ayarları güncellendi"
 
 msgid "Database type does not support file uploads."
+msgstr ""
+
+msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
 
 #, fuzzy
@@ -17092,10 +17095,6 @@ msgstr ""
 
 msgid "value descending"
 msgstr ""
-
-#, fuzzy
-msgid "valuename"
-msgstr "Tablo ismi"
 
 msgid "var"
 msgstr ""

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: ted.korostiled@gmail.com\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2026-04-30 22:04+0300\n"
 "Last-Translator: Danylo Korostil\n"
 "Language: uk\n"
@@ -4542,6 +4542,9 @@ msgstr "Параметри бази даних оновлено"
 
 msgid "Database type does not support file uploads."
 msgstr "База даних не підтримує підвантаження файлів."
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 msgid "Database upload file failed"
 msgstr "Не вдалося вивантажити файл до бази даних"
@@ -17818,10 +17821,6 @@ msgstr "значення за зростанням"
 
 msgid "value descending"
 msgstr "значення за спаданням"
-
-#, fuzzy
-msgid "valuename"
-msgstr "Назва таблиці"
 
 msgid "var"
 msgstr "дисперсія"

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Apache Superset 0.22.1\n"
 "Report-Msgid-Bugs-To: zhouyao94@qq.com\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2019-01-04 22:19+0800\n"
 "Last-Translator: cdmikechen \n"
 "Language: zh\n"
@@ -4603,6 +4603,9 @@ msgstr "数据库设置已更新"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "数据库不支持子查询"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18143,10 +18146,6 @@ msgstr "升序"
 
 msgid "value descending"
 msgstr "降序"
-
-#, fuzzy
-msgid "valuename"
-msgstr "表名"
 
 #, fuzzy
 msgid "var"

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Apache Superset 0.22.1\n"
 "Report-Msgid-Bugs-To: bestlong168@gmail.com\n"
-"POT-Creation-Date: 2026-06-05 12:59+0300\n"
+"POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2019-01-04 22:19+0800\n"
 "Last-Translator: Shao Yu-Lung <bestlong168@gmail.com>\n"
 "Language: zh_TW\n"
@@ -4605,6 +4605,9 @@ msgstr "資料庫設定已更新"
 #, fuzzy
 msgid "Database type does not support file uploads."
 msgstr "資料庫不支持子查詢"
+
+msgid "Database upload file exceeds the maximum allowed size."
+msgstr ""
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -18155,10 +18158,6 @@ msgstr "升序"
 
 msgid "value descending"
 msgstr "降序"
-
-#, fuzzy
-msgid "valuename"
-msgstr "表名"
 
 #, fuzzy
 msgid "var"

--- a/tests/unit_tests/commands/databases/columnar_reader_test.py
+++ b/tests/unit_tests/commands/databases/columnar_reader_test.py
@@ -17,12 +17,10 @@
 import io
 import tempfile
 from typing import Any
-from unittest.mock import patch
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import numpy as np
 import pytest
-from flask import current_app
 from werkzeug.datastructures import FileStorage
 
 from superset.commands.database.exceptions import DatabaseUploadFailed
@@ -264,53 +262,6 @@ def test_columnar_reader_unsafe_zip_rejected_in_metadata():
     with pytest.raises(DatabaseUploadFailed) as ex:
         reader.file_metadata(FileStorage(unsafe_zip, "test.zip"))
     assert "compress ratio above allowed threshold" in str(ex.value)
-
-
-def test_columnar_reader_oversize_file_rejected():
-    reader = ColumnarReader(
-        options=ColumnarReaderOptions(),
-    )
-    file = create_columnar_file(COLUMNAR_DATA)
-    file.stream.seek(0, 2)
-    file_size = file.stream.tell()
-    file.stream.seek(0)
-    with patch.dict(
-        current_app.config,
-        {"UPLOAD_MAX_FILE_SIZE_BYTES": file_size - 1},
-    ):
-        with pytest.raises(DatabaseUploadFailed) as ex:
-            reader.file_to_dataframe(file)
-    assert "exceeds the maximum allowed upload size" in str(ex.value)
-
-
-def test_columnar_reader_oversize_file_rejected_in_metadata():
-    reader = ColumnarReader(
-        options=ColumnarReaderOptions(),
-    )
-    file = create_columnar_file(COLUMNAR_DATA)
-    file.stream.seek(0, 2)
-    file_size = file.stream.tell()
-    file.stream.seek(0)
-    with patch.dict(
-        current_app.config,
-        {"UPLOAD_MAX_FILE_SIZE_BYTES": file_size - 1},
-    ):
-        with pytest.raises(DatabaseUploadFailed) as ex:
-            reader.file_metadata(file)
-    assert "exceeds the maximum allowed upload size" in str(ex.value)
-
-
-def test_columnar_reader_under_limit_accepted():
-    reader = ColumnarReader(
-        options=ColumnarReaderOptions(),
-    )
-    file = create_columnar_file(COLUMNAR_DATA)
-    with patch.dict(
-        current_app.config,
-        {"UPLOAD_MAX_FILE_SIZE_BYTES": 100 * 1024 * 1024},
-    ):
-        df = reader.file_to_dataframe(file)
-    assert len(df) == 3
 
 
 def test_columnar_reader_metadata():

--- a/tests/unit_tests/commands/databases/upload_command_test.py
+++ b/tests/unit_tests/commands/databases/upload_command_test.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+from werkzeug.datastructures import FileStorage
+
+from superset.commands.database.exceptions import DatabaseUploadFileTooLarge
+from superset.commands.database.uploaders.base import UploadCommand
+
+
+def _file(contents: bytes) -> FileStorage:
+    return FileStorage(stream=io.BytesIO(contents), filename="data.bin")
+
+
+def test_file_size_bytes_does_not_consume_stream() -> None:
+    file = _file(b"abcdefghij")  # 10 bytes
+    assert UploadCommand._file_size_bytes(file) == 10
+    # the stream is left at its original position so processing still works
+    assert file.stream.read() == b"abcdefghij"
+
+
+def _command(file: FileStorage) -> UploadCommand:
+    # the reader is not exercised by validate(); a stub is sufficient
+    return UploadCommand(
+        model_id=1,
+        table_name="t",
+        file=file,
+        schema=None,
+        reader=MagicMock(),
+    )
+
+
+def _stub_passing_checks(mocker: MockerFixture) -> None:
+    model = mocker.MagicMock()
+    model.db_engine_spec.supports_file_upload = True
+    mocker.patch(
+        "superset.commands.database.uploaders.base.DatabaseDAO.find_by_id",
+        return_value=model,
+    )
+    mocker.patch(
+        "superset.commands.database.uploaders.base.schema_allows_file_upload",
+        return_value=True,
+    )
+
+
+def test_validate_rejects_file_over_limit(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    _stub_passing_checks(mocker)
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 4},
+    )
+    command = _command(_file(b"too many bytes"))
+    with pytest.raises(DatabaseUploadFileTooLarge):
+        command.validate()
+
+
+def test_validate_allows_file_within_limit(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    _stub_passing_checks(mocker)
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 1024},
+    )
+    command = _command(_file(b"small"))
+    command.validate()  # should not raise
+
+
+def test_validate_no_limit_when_unset(app_context: None, mocker: MockerFixture) -> None:
+    _stub_passing_checks(mocker)
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": None},
+    )
+    command = _command(_file(b"x" * 10_000))
+    command.validate()  # no limit configured -> no rejection

--- a/tests/unit_tests/commands/databases/upload_command_test.py
+++ b/tests/unit_tests/commands/databases/upload_command_test.py
@@ -85,11 +85,35 @@ def test_validate_allows_file_within_limit(
     command.validate()  # should not raise
 
 
-def test_validate_no_limit_when_unset(app_context: None, mocker: MockerFixture) -> None:
+def test_validate_no_limit_when_disabled(
+    app_context: None, mocker: MockerFixture
+) -> None:
     _stub_passing_checks(mocker)
     mocker.patch.dict(
         "superset.commands.database.uploaders.base.current_app.config",
         {"UPLOAD_MAX_FILE_SIZE_BYTES": None},
     )
     command = _command(_file(b"x" * 10_000))
-    command.validate()  # no limit configured -> no rejection
+    command.validate()  # limit explicitly disabled (None) -> no rejection
+
+
+def test_validate_file_size_rejects_over_limit(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    # the shared helper is used by both the upload and metadata paths
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 4},
+    )
+    with pytest.raises(DatabaseUploadFileTooLarge):
+        UploadCommand.validate_file_size(_file(b"too many bytes"))
+
+
+def test_validate_file_size_allows_within_limit(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 1024},
+    )
+    UploadCommand.validate_file_size(_file(b"small"))  # should not raise

--- a/tests/unit_tests/commands/databases/upload_command_test.py
+++ b/tests/unit_tests/commands/databases/upload_command_test.py
@@ -117,3 +117,31 @@ def test_validate_file_size_allows_within_limit(
         {"UPLOAD_MAX_FILE_SIZE_BYTES": 1024},
     )
     UploadCommand.validate_file_size(_file(b"small"))  # should not raise
+
+
+class _NonSeekableStream(io.RawIOBase):
+    def seekable(self) -> bool:
+        return False
+
+    def tell(self) -> int:
+        raise OSError("not seekable")
+
+
+def _non_seekable_file() -> FileStorage:
+    return FileStorage(stream=_NonSeekableStream(), filename="data.bin")
+
+
+def test_file_size_bytes_returns_none_when_not_seekable() -> None:
+    # a non-seekable stream raises on seek/tell; the size is unknown
+    assert UploadCommand._file_size_bytes(_non_seekable_file()) is None
+
+
+def test_validate_file_size_skips_when_not_seekable(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(
+        "superset.commands.database.uploaders.base.current_app.config",
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 4},
+    )
+    # size can't be determined cheaply -> skip rather than raising a 500
+    UploadCommand.validate_file_size(_non_seekable_file())

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -1858,6 +1858,43 @@ def test_columnar_metadata_validation(
     assert response.json == {"message": {"file": ["Field may not be null."]}}
 
 
+def test_metadata_file_too_large(
+    mocker: MockerFixture, client: Any, full_api_access: None
+) -> None:
+    """
+    The metadata endpoint rejects an oversized file with a 413 before the
+    reader parses it, so the size limit cannot be bypassed by hitting
+    ``upload_metadata`` instead of ``upload``.
+    """
+    file_metadata = mocker.patch.object(CSVReader, "file_metadata")
+    mocker.patch.dict(current_app.config, {"UPLOAD_MAX_FILE_SIZE_BYTES": 4})
+    response = client.post(
+        "/api/v1/database/upload_metadata/",
+        data={"type": "csv", "file": create_csv_file()},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 413
+    assert (
+        response.json["errors"][0]["message"]
+        == "Database upload file exceeds the maximum allowed size."
+    )
+    file_metadata.assert_not_called()
+
+
+def test_metadata_within_size_limit(
+    mocker: MockerFixture, client: Any, full_api_access: None
+) -> None:
+    """A file under ``UPLOAD_MAX_FILE_SIZE_BYTES`` passes the metadata endpoint."""
+    _ = mocker.patch.object(CSVReader, "file_metadata")
+    mocker.patch.dict(current_app.config, {"UPLOAD_MAX_FILE_SIZE_BYTES": 1024 * 1024})
+    response = client.post(
+        "/api/v1/database/upload_metadata/",
+        data={"type": "csv", "file": create_csv_file()},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 200
+
+
 def test_table_metadata_happy_path(
     mocker: MockerFixture,
     client: Any,


### PR DESCRIPTION
### SUMMARY

`UploadCommand.validate()` (used by the CSV / Excel / columnar upload flows) validated database and schema permissions but never checked the **size** of the uploaded file at that layer. A large file would be read fully into memory (BytesIO buffers, then a pandas DataFrame) before any bound was applied.

This adds a size limit:

| Config | Default |
|--------|---------|
| `UPLOAD_MAX_FILE_SIZE_BYTES` | `100 * 1024 * 1024` (100 MB) |

It defaults to 100 MB (the same knob introduced in #40637), and a file larger than the limit is rejected in `validate()` with a `413` (`DatabaseUploadFileTooLarge`) before its contents are read. The size is measured by seeking the upload stream and restoring its position, so it does not consume the file. Set `UPLOAD_MAX_FILE_SIZE_BYTES = None` to disable the check entirely.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend validation, config-gated.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/commands/databases/upload_command_test.py
```

New tests: size helper does not consume the stream; a file over the limit is rejected; a file within the limit passes; a non-seekable stream skips the check rather than 500-ing; the metadata endpoint enforces the limit too.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
