### PR TITLE
feat(mcp): log successful JWT authentication events

### DIFF
--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -560,11 +560,15 @@ class DetailedJWTVerifier(MCPJWTVerifier):
 
             # All validations passed. Log the successful authentication with
             # safe metadata only — never the token contents or any secret.
+            # Coerce scope entries to strings before sorting so a malformed
+            # (non-orderable) scope claim can never turn this audit log into a
+            # TypeError that would mask a successful auth as a failure.
+            scopes_for_log = sorted(str(scope) for scope in scopes)
             logger.info(
                 "JWT authentication succeeded: client_id='%s', scopes=%s, "
                 "auth_method='bearer_jwt'",
                 _sanitize_for_log(client_id),
-                _sanitize_for_log(" ".join(sorted(scopes)) or "(none)"),
+                _sanitize_for_log(" ".join(scopes_for_log) or "(none)"),
             )
             return AccessToken(
                 token=token,

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -298,6 +298,43 @@ async def test_valid_token_logs_success(hs256_verifier, caplog):
 
 
 @pytest.mark.asyncio
+async def test_success_log_tolerates_non_orderable_scopes(hs256_verifier, caplog):
+    """The success audit log must never raise on a non-orderable scope claim.
+
+    Scope entries are coerced to strings before sorting, so a malformed scopes
+    list like ``["read", 1]`` cannot raise ``TypeError`` inside the audit log and
+    mask an otherwise-valid token as a generic ``"Token validation failed"``.
+    """
+    future_exp = int(time.time()) + 3600
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": future_exp,
+    }
+
+    with caplog.at_level(logging.INFO, logger="superset.mcp_service.jwt_verifier"):
+        with (
+            patch.object(hs256_verifier.jwt, "decode", return_value=claims),
+            patch.object(hs256_verifier, "_extract_scopes", return_value=["read", 1]),
+        ):
+            await hs256_verifier.load_access_token(token)
+
+    # The success audit log is reached and emitted without raising. Before the
+    # str-coercion fix, ``sorted(["read", 1])`` would raise ``TypeError`` *before*
+    # this record was emitted, so its presence proves the logging path is safe.
+    assert any(
+        "JWT authentication succeeded" in record.message
+        and record.levelno == logging.INFO
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
 async def test_token_without_expiration_rejected(hs256_verifier):
     """Token without an exp claim must be rejected (exp is required)."""
     token = _make_token(

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -271,6 +271,33 @@ async def test_valid_token(hs256_verifier):
 
 
 @pytest.mark.asyncio
+async def test_valid_token_logs_success(hs256_verifier, caplog):
+    """A successful authentication should leave an INFO-level audit entry."""
+    future_exp = int(time.time()) + 3600
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": future_exp,
+    }
+
+    with caplog.at_level(logging.INFO, logger="superset.mcp_service.jwt_verifier"):
+        with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+            result = await hs256_verifier.load_access_token(token)
+
+    assert result is not None
+    assert any(
+        "JWT authentication succeeded" in record.message
+        and record.levelno == logging.INFO
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
 async def test_token_without_expiration_rejected(hs256_verifier):
     """Token without an exp claim must be rejected (exp is required)."""
     token = _make_token(


### PR DESCRIPTION
### SUMMARY

The MCP JWT verifier (`superset/mcp_service/jwt_verifier.py`) logs authentication *failures* at WARNING, but a *successful* authentication produced no log entry — so there was no audit trail for successful MCP access.

This adds an `INFO`-level log on the success path of `load_access_token()`, right before the `AccessToken` is returned, recording the client id and the granted scopes. No token value or raw claim values are logged (consistent with the verifier's existing logging discipline).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — server-side logging.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/test_jwt_verifier.py
```

A new test asserts an INFO record is emitted on a successful token load.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)