### PR TITLE
fix(explore): drop inherit/custom time shifts when switching to a viz that can't honor them

### DIFF
--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -402,6 +402,22 @@ describe('should collect control values and create SFD', () => {
     expect(formData.time_compare).toBeNull();
   });
 
+  test('strips a scalar time shift after getControlsState coerces it to an array', () => {
+    // Table/Big Number store `time_compare` as a scalar string; getControlsState
+    // coerces it to an array before the strip runs, so a lone unsupported marker
+    // must still serialize to null on the target viz (SC-99170).
+    const store = {
+      ...sourceMockStore,
+      form_data: {
+        ...sourceMockFormData,
+        time_compare: 'inherit',
+      },
+    };
+    const sfd = new StandardizedFormData(store.form_data);
+    const { formData } = sfd.transform('target_viz', store);
+    expect(formData.time_compare).toBeNull();
+  });
+
   test('should inherit standardizedFormData and memorizedFormData is LIFO', () => {
     // from source_viz to target_viz
     const sfd = new StandardizedFormData(sourceMockFormData);

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -344,6 +344,47 @@ describe('should collect control values and create SFD', () => {
     ]);
   });
 
+  test('strips inherit/custom time shifts when target viz does not support them', () => {
+    // Table/Big Number period-over-period offer "inherit" and "custom" time
+    // shifts; the timeseries advanced-analytics target (target_viz) does not.
+    // Carrying them over leaves un-removable tags on the new chart (SC-99170).
+    const store = {
+      ...sourceMockStore,
+      form_data: {
+        ...sourceMockFormData,
+        time_compare: ['1 year ago', 'inherit', 'custom'],
+      },
+    };
+    const sfd = new StandardizedFormData(store.form_data);
+    const { formData } = sfd.transform('target_viz', store);
+    // the free-form delta survives, the special markers are dropped
+    expect(formData.time_compare).toEqual(['1 year ago']);
+  });
+
+  test('preserves inherit/custom time shifts when target viz supports them', () => {
+    getChartControlPanelRegistry().registerValue('target_viz_inherit', {
+      controlPanelSections: [
+        sections.timeComparisonControls({}),
+        {
+          label: 'transform controls',
+          controlSetRows: publicControls
+            .filter(c => c !== 'dashboardId' && c !== 'time_compare')
+            .map(control => [control]),
+        },
+      ],
+    });
+    const store = {
+      ...sourceMockStore,
+      form_data: {
+        ...sourceMockFormData,
+        time_compare: ['1 year ago', 'inherit'],
+      },
+    };
+    const sfd = new StandardizedFormData(store.form_data);
+    const { formData } = sfd.transform('target_viz_inherit', store);
+    expect(formData.time_compare).toEqual(['1 year ago', 'inherit']);
+  });
+
   test('should inherit standardizedFormData and memorizedFormData is LIFO', () => {
     // from source_viz to target_viz
     const sfd = new StandardizedFormData(sourceMockFormData);

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -276,6 +276,18 @@ describe('should collect control values and create SFD', () => {
         metrics: formData.standardizedFormData.controls.metrics,
       }),
     });
+    // a target viz whose "Time shift" control offers inherit/custom choices
+    getChartControlPanelRegistry().registerValue('target_viz_inherit', {
+      controlPanelSections: [
+        sections.timeComparisonControls({}),
+        {
+          label: 'transform controls',
+          controlSetRows: publicControlFields
+            .filter(c => c !== 'time_compare')
+            .map(control => [control]),
+        },
+      ],
+    });
   });
 
   test('should avoid to overlap', () => {
@@ -362,17 +374,6 @@ describe('should collect control values and create SFD', () => {
   });
 
   test('preserves inherit/custom time shifts when target viz supports them', () => {
-    getChartControlPanelRegistry().registerValue('target_viz_inherit', {
-      controlPanelSections: [
-        sections.timeComparisonControls({}),
-        {
-          label: 'transform controls',
-          controlSetRows: publicControls
-            .filter(c => c !== 'dashboardId' && c !== 'time_compare')
-            .map(control => [control]),
-        },
-      ],
-    });
     const store = {
       ...sourceMockStore,
       form_data: {
@@ -383,6 +384,22 @@ describe('should collect control values and create SFD', () => {
     const sfd = new StandardizedFormData(store.form_data);
     const { formData } = sfd.transform('target_viz_inherit', store);
     expect(formData.time_compare).toEqual(['1 year ago', 'inherit']);
+  });
+
+  test('clears time_compare to null when every shift is unsupported', () => {
+    // When only special markers carry over and none survive, the control value
+    // must serialize to null (not an empty array) so the target chart shows an
+    // empty "Time shift" rather than a stray tag (SC-99170).
+    const store = {
+      ...sourceMockStore,
+      form_data: {
+        ...sourceMockFormData,
+        time_compare: ['inherit', 'custom'],
+      },
+    };
+    const sfd = new StandardizedFormData(store.form_data);
+    const { formData } = sfd.transform('target_viz', store);
+    expect(formData.time_compare).toBeNull();
   });
 
   test('should inherit standardizedFormData and memorizedFormData is LIFO', () => {

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -156,6 +156,36 @@ export class StandardizedFormData {
     return controls;
   }
 
+  // Time shifts only meaningful for viz types whose "Time shift" control offers
+  // them (Big Number / Table period-over-period). Other viz types reuse the same
+  // `time_compare` key without these choices.
+  private static specialTimeShifts = ['inherit', 'custom'];
+
+  // Drop `time_compare` markers the target viz can't honor so they don't carry
+  // over as un-removable tags when switching chart types.
+  static dropUnsupportedTimeShifts(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    controlsState: Record<string, any>,
+  ): void {
+    const control = controlsState?.time_compare;
+    if (!control || !Array.isArray(control.value)) {
+      return;
+    }
+    const supportedChoices = new Set(
+      ensureIsArray(control.choices).map(
+        (choice: [string, string]) => choice[0],
+      ),
+    );
+    const filtered = control.value.filter(
+      (shift: string) =>
+        !StandardizedFormData.specialTimeShifts.includes(shift) ||
+        supportedChoices.has(shift),
+    );
+    if (filtered.length !== control.value.length) {
+      control.value = filtered.length ? filtered : null;
+    }
+  }
+
   private getLatestFormData(vizType: string): QueryFormData {
     if (this.has(vizType)) {
       return this.get(vizType);
@@ -215,6 +245,7 @@ export class StandardizedFormData {
       ...publicFormData,
       viz_type: targetVizType,
     });
+    StandardizedFormData.dropUnsupportedTimeShifts(targetControlsState);
     const targetFormData = {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...getFormDataFromControls(targetControlsState as any),

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -164,20 +164,25 @@ export class StandardizedFormData {
   // Drop `time_compare` markers the target viz can't honor so they don't carry
   // over as un-removable tags when switching chart types.
   static dropUnsupportedTimeShifts(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    controlsState: Record<string, any>,
+    controlsState: Record<string, unknown>,
   ): void {
-    const control = controlsState?.time_compare;
+    const control = controlsState?.time_compare as
+      | { value?: unknown; choices?: unknown }
+      | undefined;
     if (!control || !Array.isArray(control.value)) {
       return;
     }
     const supportedChoices = new Set(
-      ensureIsArray(control.choices).map(
-        (choice: [string, string]) => choice[0],
-      ),
+      ensureIsArray(control.choices)
+        .filter(
+          (choice): choice is [string, string] =>
+            Array.isArray(choice) && typeof choice[0] === 'string',
+        )
+        .map(choice => choice[0]),
     );
     const filtered = control.value.filter(
-      (shift: string) =>
+      (shift: unknown) =>
+        typeof shift !== 'string' ||
         !StandardizedFormData.specialTimeShifts.includes(shift) ||
         supportedChoices.has(shift),
     );


### PR DESCRIPTION
### SUMMARY

When you convert a chart from **Big Number with Time Comparison** or **Table** (both offer the "Inherit range from time filter" and "Custom" time shifts) into a timeseries chart such as Line or Bar, the `inherit`/`custom` value was carried over into the new chart's **Time shift** control. The timeseries Advanced Analytics "Time shift" reuses the same `time_compare` form-data key but does not offer those options, and because the control is free-form the value was accepted and left as a stray tag the user had to delete by hand on every edit.

`StandardizedFormData.transform` preserves shared controls across viz-type switches. It now drops `inherit`/`custom` from `time_compare` when the target viz type's Time shift control does not list them as choices. Portable relative shifts (e.g. "1 year ago") are still carried over, and `inherit`/`custom` are preserved when switching between viz types that both support them (e.g. Table to Big Number).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After converting a Big Number (Time Comparison) chart with Time shift = "Inherit" into a Line chart:

| Before | After |
| :---: | :---: |
| ![before](https://files.catbox.moe/ejiec0.png) | ![after](https://files.catbox.moe/thj9na.png) |

### TESTING INSTRUCTIONS

1. Create a **Big Number with Time Comparison** (or **Table**) chart.
2. In **Time Comparison**, set **Time shift** to **Inherit range from time filter**.
3. Switch the visualization type to **Line Chart** (or Bar).
4. Open **Advanced Analytics → Time Comparison**.
5. The **Time shift** field is empty; previously it showed a lingering `inherit` tag.

Unit tests in `standardizedFormData.test.ts` cover both stripping (target viz without inherit/custom) and preservation (target viz that supports them).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
