### PR TITLE
feat(websocket): improve operational logging and crash safety

### DIFF
--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -43,7 +43,7 @@ const mockRedisXrange = jest.fn() as jest.MockedFunction<MockedRedisXrange>;
 jest.mock('ws');
 jest.mock('ioredis', () => {
   return jest.fn().mockImplementation(() => {
-    return { xrange: mockRedisXrange };
+    return { xrange: mockRedisXrange, on: jest.fn() };
   });
 });
 
@@ -526,6 +526,8 @@ describe('server', () => {
       server.httpUpgrade(request, socket, Buffer.alloc(5));
       expect(socketDestroySpy).toHaveBeenCalled();
       expect(wssUpgradeSpy).not.toHaveBeenCalled();
+      // rejected upgrades are counted for auditability
+      expect(statsdIncrementMock).toHaveBeenCalledWith('ws_upgrade_rejected');
     });
 
     test('valid JWT, no channel', async () => {

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -18,6 +18,7 @@
  */
 import * as http from 'http';
 import * as net from 'net';
+import { inspect } from 'util';
 import WebSocket, { WebSocketServer } from 'ws';
 import { randomUUID } from 'crypto';
 import jwt, { Algorithm } from 'jsonwebtoken';
@@ -528,10 +529,17 @@ if (startServer) {
   // configured logger instead of printing a default trace (or, for an
   // unhandled rejection, terminating the process on newer Node versions).
   process.on('unhandledRejection', (reason: unknown) => {
-    logger.error(`Unhandled promise rejection: ${reason}`);
+    // Normalize the reason defensively: a raw template interpolation throws on
+    // a Symbol (or other exotic value), which would crash this last-resort
+    // handler. `inspect` safely stringifies any value.
+    logger.error(`Unhandled promise rejection: ${inspect(reason)}`);
   });
-  process.on('uncaughtException', (err: Error) => {
-    logger.error(`Uncaught exception: ${err.stack ?? err.message}`);
+  process.on('uncaughtException', (err: unknown) => {
+    // JavaScript can throw non-Error values (including null), so guard the
+    // shape before dereferencing instead of assuming an Error is present.
+    const detail =
+      err instanceof Error ? (err.stack ?? err.message) : inspect(err);
+    logger.error(`Uncaught exception: ${detail}`);
   });
 
   // init server event listeners

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -96,15 +96,15 @@ export const statsd = new StatsD({
 
 // enforce JWT secret length
 if (startServer && opts.jwtSecret.length < 32) {
-  console.error('ERROR: Please provide a JWT secret at least 32 bytes long');
+  logger.error('Please provide a JWT secret at least 32 bytes long');
   process.exit(1);
 }
 
 if (startServer && opts.jwtSecret.startsWith('CHANGE-ME')) {
-  console.warn(
-    'WARNING: it appears your secret in your config.json is insecure',
+  logger.warn(
+    'It appears your secret in your config.json is insecure. ' +
+      'DO NOT USE IN PRODUCTION',
   );
-  console.warn('DO NOT USE IN PRODUCTION');
 }
 
 export const buildRedisOpts = (baseConfig: RedisConfig) => {
@@ -140,6 +140,9 @@ export const buildRedisOpts = (baseConfig: RedisConfig) => {
 
 // initialize servers
 const redis = new Redis(buildRedisOpts(opts.redis));
+redis.on('error', (err: Error) => {
+  logger.error(`Redis connection error: ${err.message}`);
+});
 const httpServer = http.createServer();
 export const wss = new WebSocketServer({
   noServer: true,
@@ -267,7 +270,9 @@ export const subscribeToGlobalStream = async (
  * Callback function to process events received from a Redis Stream
  */
 export const processStreamResults = (results: StreamResult[]): void => {
-  logger.debug(`events received: ${results}`);
+  // Log only the batch size, not the raw payloads, which carry user and
+  // job identifiers.
+  logger.debug(`events received: count=${results.length}`);
   results.forEach(item => {
     try {
       const id = item[0];
@@ -437,8 +442,14 @@ export const httpUpgrade = (
   try {
     readChannelId(request);
   } catch (err) {
-    // JWT invalid, do not establish a WebSocket connection
-    logger.error(err);
+    // Token invalid/absent: do not establish a WebSocket connection. Record a
+    // structured warning (with the request's remote address) so rejected
+    // upgrade attempts are auditable, without logging the token itself.
+    statsd.increment('ws_upgrade_rejected');
+    logger.warn(
+      `Rejected WebSocket upgrade from ${request.socket.remoteAddress ?? 'unknown'}: ` +
+        `${(err as Error).message}`,
+    );
     socket.destroy();
     return;
   }
@@ -513,9 +524,21 @@ export const cleanChannel = (channel: string) => {
 // server startup
 
 if (startServer) {
+  // Last-resort handlers so an unhandled async error is recorded through the
+  // configured logger instead of printing a default trace (or, for an
+  // unhandled rejection, terminating the process on newer Node versions).
+  process.on('unhandledRejection', (reason: unknown) => {
+    logger.error(`Unhandled promise rejection: ${reason}`);
+  });
+  process.on('uncaughtException', (err: Error) => {
+    logger.error(`Uncaught exception: ${err.stack ?? err.message}`);
+  });
+
   // init server event listeners
   wss.on('connection', function (ws: WebSocket) {
-    ws.on('error', console.error);
+    ws.on('error', (err: Error) =>
+      logger.error(`socket error: ${err.message}`),
+    );
   });
   wss.on('connection', wsConnection);
   httpServer.on('request', httpRequest);

--- a/superset-websocket/src/logger.ts
+++ b/superset-websocket/src/logger.ts
@@ -43,6 +43,7 @@ export function createLogger(opts: LoggingOptionsType) {
     level: opts.logLevel,
     transports: logTransports,
     format: winston.format.combine(
+      winston.format.timestamp(),
       winston.format.errors({ stack: true }),
       winston.format.json(),
     ),


### PR DESCRIPTION
### SUMMARY

A cluster of small observability/robustness improvements to the websocket sidecar:

- **Timestamps** — add `winston.format.timestamp()` so every log line carries a timestamp.
- **Consistent logging** — route the startup secret warnings and the per-socket `error` handler through the configured logger instead of `console.*`, so they honor the configured level and JSON format.
- **Leaner debug logs** — when debug-logging received events, log only the batch size rather than the raw event payloads (which carry user/job identifiers).
- **Auditable upgrade rejections** — when a WebSocket upgrade is rejected for an invalid/absent channel token, record a structured warning (with the request's remote address) and a `ws_upgrade_rejected` statsd counter, instead of a bare error.
- **Redis error context** — attach a Redis `error` handler so connection errors are logged with context.
- **Crash safety** — add process-level `unhandledRejection`/`uncaughtException` handlers that log through the configured logger (and avoid a silent termination on newer Node versions).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — sidecar logging/robustness.

### TESTING INSTRUCTIONS

```
cd superset-websocket
npm ci
npm test
```

Existing suite passes; a new assertion verifies the `ws_upgrade_rejected` counter on a rejected upgrade.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)