### PR TITLE
fix(mcp): handle JWKS fetch network errors during token verification

### DIFF
--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -454,7 +454,11 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                 # letting the network error propagate as an unexpected exception.
                 reason = "JWKS verification key unavailable"
                 _jwt_failure_reason.set(reason)
-                logger.warning("Could not fetch JWKS verification key: %s", e)
+                # WARNING carries only the generic category (per the module's
+                # logging contract); the sanitized exception detail, which may
+                # include the JWKS endpoint host, is reserved for DEBUG.
+                logger.warning("Could not fetch JWKS verification key")
+                logger.debug("JWKS fetch error detail: %s", _sanitize_for_log(e))
                 return None
             except ValueError as e:
                 reason = "Failed to get verification key"

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -33,6 +33,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
+import httpx
 from authlib.jose.errors import (
     BadSignatureError,
     DecodeError,
@@ -447,6 +448,14 @@ class DetailedJWTVerifier(MCPJWTVerifier):
             # Step 2: Get verification key (static or JWKS)
             try:
                 verification_key = await self._get_verification_key(token)
+            except (httpx.HTTPError, OSError, TimeoutError) as e:
+                # Transient failure reaching or reading the JWKS endpoint.
+                # Treat it as an authentication failure (return None) instead of
+                # letting the network error propagate as an unexpected exception.
+                reason = "JWKS verification key unavailable"
+                _jwt_failure_reason.set(reason)
+                logger.warning("Could not fetch JWKS verification key: %s", e)
+                return None
             except ValueError as e:
                 reason = "Failed to get verification key"
                 _jwt_failure_reason.set(reason)

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -93,6 +93,27 @@ async def test_malformed_token_header(hs256_verifier):
 
 
 @pytest.mark.asyncio
+async def test_jwks_network_error_is_handled(hs256_verifier):
+    """A network error fetching the JWKS key is handled, not propagated."""
+    import httpx
+
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+
+    with patch.object(
+        hs256_verifier,
+        "_get_verification_key",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    assert _jwt_failure_reason.get() == "JWKS verification key unavailable"
+
+
+@pytest.mark.asyncio
 async def test_signature_verification_failed(hs256_verifier):
     """Token with bad signature should report signature failure."""
     token = _make_token(


### PR DESCRIPTION
### SUMMARY

In `DetailedJWTVerifier.load_access_token()`, the step that fetches the verification key only caught `ValueError`. When a deployment uses JWKS, that key is fetched over the network (httpx), so a connection/timeout/DNS error would raise an exception type the function didn't handle — it propagated out as an unexpected error rather than being treated as a (transient) verification failure.

This catches `httpx.HTTPError`, `OSError` and `TimeoutError` from the key fetch explicitly: it records a generic failure reason, logs a `warning`, and returns `None` so the request is handled as a normal authentication failure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend error handling.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/test_jwt_verifier.py
```

A new test patches the key fetch to raise `httpx.ConnectError` and asserts the call returns `None` with a generic failure reason instead of propagating.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)