### PR TITLE
ci: make Docker-build npm ci resilient to transient network blips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ WORKDIR /app/superset-frontend
 RUN mkdir -p /app/superset/static/assets \
              /app/superset/translations
 
+# Harden `npm ci` against transient npm-registry network blips (e.g. ECONNRESET),
+# which otherwise fail the entire multi-platform image build with no retry.
+ENV npm_config_fetch_retries=5 \
+    npm_config_fetch_retry_mintimeout=20000 \
+    npm_config_fetch_retry_maxtimeout=120000 \
+    npm_config_fetch_timeout=600000
+
 # Mount package files and install dependencies if not in dev mode
 # NOTE: we mount packages and plugins as they are referenced in package.json as workspaces
 # ideally we'd COPY only their package.json. Here npm ci will be cached as long

--- a/superset-websocket/Dockerfile
+++ b/superset-websocket/Dockerfile
@@ -14,6 +14,13 @@
 # limitations under the License.
 FROM node:22-alpine AS build
 
+# Harden `npm ci` against transient npm-registry network blips (e.g. ECONNRESET),
+# which otherwise fail the image build with no retry.
+ENV npm_config_fetch_retries=5 \
+    npm_config_fetch_retry_mintimeout=20000 \
+    npm_config_fetch_retry_maxtimeout=120000 \
+    npm_config_fetch_timeout=600000
+
 WORKDIR /home/superset-websocket
 
 COPY . ./
@@ -24,7 +31,12 @@ RUN npm ci && \
 
 FROM node:22-alpine
 
-ENV NODE_ENV=production
+# Retry npm-registry fetches so a transient blip doesn't fail the build.
+ENV NODE_ENV=production \
+    npm_config_fetch_retries=5 \
+    npm_config_fetch_retry_mintimeout=20000 \
+    npm_config_fetch_retry_maxtimeout=120000 \
+    npm_config_fetch_timeout=600000
 WORKDIR /home/superset-websocket
 
 COPY --from=build /home/superset-websocket/dist ./dist


### PR DESCRIPTION
### SUMMARY

The `docker-build` job is the single biggest source of `master` CI flakiness — it failed **~25% of runs (8/32)** over the last few days, recurring across multiple days. Almost every failure is the same transient:

```
#15 [linux/arm64 build 4/4] RUN npm ci && npm run build
#15 49.22 npm error code ECONNRESET
#15 49.23 npm error network read ECONNRESET
#15 ERROR: process "/bin/sh -c npm ci && npm run build" did not complete successfully: exit code: 152
```

`npm ci` runs with npm's default fetch-retry settings and no wrapper, so a single dropped connection to the npm registry fails the entire multi-platform build.

This PR sets npm's fetch-retry configuration via environment variables immediately before `npm ci` in both Dockerfiles (`Dockerfile`, and `superset-websocket/Dockerfile` build + prod stages):

- `npm_config_fetch_retries=5` (default 2)
- `npm_config_fetch_retry_mintimeout=20000` (default 10000)
- `npm_config_fetch_retry_maxtimeout=120000` (default 60000)
- `npm_config_fetch_timeout=600000` (default 300000)

These are no-ops on the happy path and only engage when the registry blips. Verified the env-var mapping is honored: `npm_config_fetch_retries=5 npm config get fetch-retries` → `5`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI/build resilience change.

### TESTING INSTRUCTIONS
The image build is exercised by the existing `docker-build` matrix in CI. No behavior change to the produced image; only npm's retry/backoff during dependency install.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)