### PR TITLE
ci: authenticate Docker Hub pulls for service containers

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -83,6 +83,11 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        # Authenticated pulls use our higher Docker Hub rate limit. Empty on
+        # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -90,6 +95,9 @@ jobs:
           - 15432:5432
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:
@@ -193,6 +201,11 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        # Authenticated pulls use our higher Docker Hub rate limit. Empty on
+        # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -200,6 +213,9 @@ jobs:
           - 15432:5432
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -51,6 +51,9 @@ jobs:
         image: mysql:8.0
         # Authenticated pulls use our higher Docker Hub rate limit. Empty on
         # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -62,6 +65,9 @@ jobs:
           --health-retries=5
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         options: --entrypoint redis-server
         ports:
           - 16379:6379
@@ -139,6 +145,9 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -148,6 +157,9 @@ jobs:
           - 15432:5432
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:
@@ -198,6 +210,9 @@ jobs:
     services:
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -50,6 +50,11 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        # Authenticated pulls use our higher Docker Hub rate limit. Empty on
+        # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -59,6 +64,9 @@ jobs:
           - 15432:5432
       presto:
         image: starburstdata/presto:350-e.6
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -68,6 +76,9 @@ jobs:
           - 15433:8080
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:
@@ -114,6 +125,11 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        # Authenticated pulls use our higher Docker Hub rate limit. Empty on
+        # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -123,6 +139,9 @@ jobs:
           - 15432:5432
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:


### PR DESCRIPTION
### SUMMARY

A scan of recent `master` CI runs showed that nearly all non-build failures trace to **anonymous Docker Hub pulls of service containers** timing out or 502-ing — Docker Hub rate-limits anonymous pulls per shared runner IP. Examples from `master`:

- **E2E** (`cypress-matrix`): `docker pull postgres:17-alpine` → *Docker pull failed*, retries exhausted, job fails.
- **Python-Integration** (`test-postgres`): `registry-1.docker.io/v2/` → *net/http: request canceled (Client.Timeout exceeded)*.
- **Python Presto/Hive**: `bde2020/hive-metastore-postgresql` → *HTTP 502 Bad Gateway*.

The integration workflow already documents the intended fix in a comment —

```yaml
# Authenticated pulls use our higher Docker Hub rate limit. Empty on
# fork PRs (secrets unavailable) -> runner falls back to anonymous.
```

— but the corresponding `credentials:` block was never actually present on the service definitions, so every pull is anonymous.

This PR adds `credentials:` (using the existing `DOCKERHUB_USER` / `DOCKERHUB_TOKEN` secrets already used by the `docker-build` workflow) to every Docker Hub service container across the three affected workflows:

- `superset-python-integrationtest.yml` — mysql, redis, postgres
- `superset-e2e.yml` — postgres, redis
- `superset-python-presto-hive.yml` — postgres, presto, redis

### Fork-PR behavior

On fork PRs the secrets evaluate to empty and the runner falls back to anonymous pulls, so **fork behavior is unchanged**. Only push / same-repo PR builds (where the flakes were observed) gain the higher authenticated rate limit. This matches the contract the existing in-repo comment already describes.

> Note: this covers service containers declared in `services:`. The `bde2020` hive metastore pulled via `docker compose` in the Presto/Hive job is a separate follow-up (it'd need `docker login` before `docker compose up`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI reliability change.

### TESTING INSTRUCTIONS
Exercised by the existing integration / E2E / Presto-Hive workflows. No change to test behavior; only how the service images are pulled.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)