### PR TITLE
fix: replace deprecated appbuilder.app with current_app

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -295,7 +295,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         #
         # Setup regular views
         #
-        app_root = appbuilder.app.config["APPLICATION_ROOT"]
+        app_root = current_app.config["APPLICATION_ROOT"]
         if app_root.endswith("/"):
             app_root = app_root.rstrip("/")
 
@@ -347,7 +347,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=_("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
+                current_app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 
@@ -357,7 +357,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             label=_("User Registrations"),
             category="Security",
             category_label=_("Security"),
-            menu_cond=lambda: bool(appbuilder.app.config["AUTH_USER_REGISTRATION"]),
+            menu_cond=lambda: bool(current_app.config["AUTH_USER_REGISTRATION"]),
         )
 
         appbuilder.add_view(
@@ -367,7 +367,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=_("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
+                current_app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 
@@ -378,7 +378,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=_("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
+                current_app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 

--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -17,7 +17,7 @@
   {% import 'appbuilder/general/lib.html' as lib %}
   {% from 'superset/partials/asset_bundle.html' import css_bundle, js_bundle with context %}
   {% import "superset/macros.html" as macros %}
-  {% set favicons = appbuilder.app.config['FAVICONS'] %}
+  {% set favicons = config['FAVICONS'] %}
 
   <head>
     <title>

--- a/tests/unit_tests/extension_tests.py
+++ b/tests/unit_tests/extension_tests.py
@@ -96,11 +96,11 @@ def test_spa_template_standalone_body_has_min_height():
     )
 
     appbuilder = Mock()
-    appbuilder.app.config = {"FAVICONS": []}
 
     def render(standalone_mode: bool) -> str:
         return env.get_template("spa.html").render(
             appbuilder=appbuilder,
+            config={"FAVICONS": []},
             assets_prefix="",
             bootstrap_data="{}",
             entry="spa",


### PR DESCRIPTION
## Summary

`AppBuilder.app` was deprecated by Flask-AppBuilder in favor of Flask's `current_app`. This PR removes all remaining usages.

**Commit 1 — `superset/initialization/__init__.py`**
Replaces 5 usages of `appbuilder.app.config[...]` with `current_app.config[...]`. `current_app` was already imported on line 28.

**Commit 2 — `superset/templates/superset/spa.html` + test**
Replaces `appbuilder.app.config['FAVICONS']` with `config['FAVICONS']` in the SPA template.
`config` is registered as a Jinja2 env global by Flask (`rv.globals.update(config=self.config, ...)`) and is available in every Flask-rendered template — no `appbuilder.app` needed.
Updates the corresponding unit test to pass `config={"FAVICONS": []}` directly to the Jinja2 render call (that test uses raw Jinja2, not Flask's renderer, so it must inject `config` explicitly).

No behavior change in either commit.

## Test plan

- [ ] Boot Superset and verify the deprecation warning no longer appears in logs
- [ ] Confirm Security menu items (Roles, Users, Groups, User Registrations) still render correctly based on config flags
- [ ] Confirm favicon `<link>` tags still render correctly from `FAVICONS` config
- [ ] `pytest tests/unit_tests/extension_tests.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)