### PR TITLE
fix(urls): preserve repeated query parameters

### DIFF
--- a/superset/utils/urls.py
+++ b/superset/utils/urls.py
@@ -60,12 +60,12 @@ def modify_url_query(url: str, **kwargs: Any) -> str:
             v = [v]
         params[k] = v
 
-    query_parts = []
-    for k, values in params.items():
-        query_parts.extend(
-            f"{k}={urllib.parse.quote(str(value))}" for value in values
-        )
-    parts[3] = "&".join(query_parts)
+    parts[3] = urllib.parse.urlencode(
+        params,
+        doseq=True,
+        quote_via=urllib.parse.quote,
+        safe="/",
+    )
     return urllib.parse.urlunsplit(parts)
 
 

--- a/superset/utils/urls.py
+++ b/superset/utils/urls.py
@@ -60,9 +60,12 @@ def modify_url_query(url: str, **kwargs: Any) -> str:
             v = [v]
         params[k] = v
 
-    parts[3] = "&".join(
-        f"{k}={urllib.parse.quote(str(v[0]))}" for k, v in params.items()
-    )
+    query_parts = []
+    for k, values in params.items():
+        query_parts.extend(
+            f"{k}={urllib.parse.quote(str(value))}" for value in values
+        )
+    parts[3] = "&".join(query_parts)
     return urllib.parse.urlunsplit(parts)
 
 

--- a/tests/unit_tests/utils/urls_tests.py
+++ b/tests/unit_tests/utils/urls_tests.py
@@ -38,3 +38,25 @@ def test_convert_dashboard_link() -> None:
 def test_convert_dashboard_link_with_integer() -> None:
     test_url = modify_url_query(EXPLORE_DASHBOARD_LINK, standalone=0)
     assert test_url == "http://localhost:9000/superset/dashboard/3/?standalone=0"
+
+
+def test_modify_url_query_preserves_repeated_existing_parameters() -> None:
+    test_url = modify_url_query(
+        "http://localhost:9000/explore/?filter=a&filter=b",
+        standalone="1",
+    )
+
+    assert test_url == "http://localhost:9000/explore/?filter=a&filter=b&standalone=1"
+
+
+def test_modify_url_query_adds_list_values_as_repeated_parameters() -> None:
+    test_url = modify_url_query(
+        "http://localhost:9000/explore/?existing=ok",
+        tag=["alpha value", "beta/value"],
+    )
+
+    assert (
+        test_url
+        == "http://localhost:9000/explore/?existing=ok"
+        "&tag=alpha%20value&tag=beta/value"
+    )

--- a/tests/unit_tests/utils/urls_tests.py
+++ b/tests/unit_tests/utils/urls_tests.py
@@ -56,7 +56,6 @@ def test_modify_url_query_adds_list_values_as_repeated_parameters() -> None:
     )
 
     assert (
-        test_url
-        == "http://localhost:9000/explore/?existing=ok"
+        test_url == "http://localhost:9000/explore/?existing=ok"
         "&tag=alpha%20value&tag=beta/value"
     )


### PR DESCRIPTION
# Preserve Repeated Query Parameters

## SUMMARY

This PR fixes `modify_url_query` so repeated query parameters are preserved when
updating or adding URL parameters.

Previously, `modify_url_query` parsed query parameters into lists using
`parse_qs`, but rebuilt the query string manually by taking only the first value
of each parameter. As a result, URLs containing repeated parameters such as:

```text
/explore/?filter=a&filter=b
```

could be incorrectly serialized, after adding another parameter, as:

```text
/explore/?filter=a&standalone=1
```

This change replaces the manual query string serialization with
`urllib.parse.urlencode(..., doseq=True)`, allowing multiple values for the same
query parameter to be correctly expanded and preserved.

The implementation keeps the existing URL encoding behavior by using
`quote_via=urllib.parse.quote` and `safe="/"`, ensuring spaces are encoded as
`%20` and path-like values containing `/` remain readable.

Additional unit tests were added to cover:

- preserving repeated query parameters already present in the URL;
- adding list values as repeated query parameters.

Existing tests continue to cover scalar query parameter replacement.


## TESTING INSTRUCTIONS

Run:

```bash
python -m pytest -q tests/unit_tests/utils/urls_tests.py
```

Or run only the tests related to this change:

```bash
python -m pytest -q \
  tests/unit_tests/utils/urls_tests.py::test_modify_url_query_preserves_repeated_existing_parameters \
  tests/unit_tests/utils/urls_tests.py::test_modify_url_query_adds_list_values_as_repeated_parameters
```

## ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
