### PR TITLE
fix(translation): update german translation for slider range

### DIFF
--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -3324,7 +3324,7 @@ msgstr "Wählen Sie die Benachrichtigungsmethode und die Empfänger."
 
 #, fuzzy, python-format
 msgid "Choose numbers between %(min)s and %(max)s"
-msgstr "Die Breite des Bildes muss zwischen %(min)spx und %(max)spx liegen."
+msgstr "Die Werte müssen zwischen %(min)s und %(max)s liegen."
 
 msgid "Choose one of the available databases from the panel on the left."
 msgstr ""


### PR DESCRIPTION
german translation for slider range was misleading with "width of image must be betweeen min px and max px"

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Add slider range in filters and check german translation.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
