### PR TITLE
fix(mcp): make search_tools query optional to fix null content on tool discovery

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -648,7 +648,7 @@ def _create_search_transform(  # noqa: C901
 ) -> Any:
     """Create the configured search transform with tool-permission filtering."""
     from fastmcp.server.context import Context
-    from fastmcp.tools.base import Tool
+    from fastmcp.tools.tool import Tool
 
     def _make_optional_query_search_tool(transform: Any) -> Any:
         """Create search tool with optional query — returns all tools when omitted."""
@@ -691,6 +691,7 @@ def _create_search_transform(  # noqa: C901
                 return make_normalizing_call_tool(self)
 
             def _make_search_tool(self) -> Any:
+                """Build the optional-query ``search_tools`` for regex search."""
                 return _make_optional_query_search_tool(self)
 
         return _FixedRegexSearchTransform(**kwargs)
@@ -710,6 +711,7 @@ def _create_search_transform(  # noqa: C901
             return make_normalizing_call_tool(self)
 
         def _make_search_tool(self) -> Any:
+            """Build the optional-query ``search_tools`` for BM25 search."""
             return _make_optional_query_search_tool(self)
 
     return _FixedBM25SearchTransform(**kwargs)

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -509,6 +509,27 @@ def _fix_call_tool_arguments(tool: Any) -> Any:
     return tool
 
 
+def _fix_search_tool_query(tool: Any) -> Any:
+    """Fix anyOf schema in search_tools ``query`` for MCP bridge compatibility.
+
+    The optional ``query: str | None`` parameter emits an ``anyOf`` JSON
+    Schema with no top-level ``type``. Some MCP bridges (mcp-remote,
+    Claude Desktop) don't handle ``anyOf`` and strip it, leaving the field
+    typeless — the same failure mode ``_fix_call_tool_arguments`` guards
+    against. Replaces the ``anyOf`` with a flat ``type: string``.
+
+    Only the advertised schema changes; FastMCP validates calls against
+    the function signature, so omitting ``query`` remains valid.
+    """
+    if "query" in (props := (tool.parameters or {}).get("properties", {})):
+        props["query"] = {
+            "default": None,
+            "description": "Natural language query. Omit to list all available tools.",
+            "type": "string",
+        }
+    return tool
+
+
 def _normalize_call_tool_arguments(
     arguments: dict[str, Any] | None,
     tool_schema: dict[str, Any] | None,
@@ -651,7 +672,8 @@ def _create_search_transform(  # noqa: C901
                 results = await transform._search(hidden, query)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=transform._search_tool_name)
+        tool = Tool.from_function(fn=search_tools, name=transform._search_tool_name)
+        return _fix_search_tool_query(tool)
 
     if strategy == "regex":
         from fastmcp.server.transforms.search import RegexSearchTransform

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -619,7 +619,7 @@ def _apply_tool_search_transform(mcp_instance: Any, config: dict[str, Any]) -> N
     )
 
 
-def _create_search_transform(
+def _create_search_transform(  # noqa: C901
     *,
     strategy: str,
     kwargs: dict[str, Any],
@@ -627,6 +627,31 @@ def _create_search_transform(
 ) -> Any:
     """Create the configured search transform with tool-permission filtering."""
     from fastmcp.server.context import Context
+    from fastmcp.tools.base import Tool
+
+    def _make_optional_query_search_tool(transform: Any) -> Any:
+        """Create search tool with optional query — returns all tools when omitted."""
+
+        async def search_tools(
+            query: Annotated[
+                str | None,
+                "Natural language query. Omit to list all available tools.",
+            ] = None,
+            ctx: Context = None,
+        ) -> str | list[dict[str, Any]]:
+            """Search for tools using natural language.
+
+            Returns matching tool definitions ranked by relevance.
+            If no query is provided, returns all available tools.
+            """
+            hidden = await transform._get_visible_tools(ctx)
+            if not query:
+                results = hidden
+            else:
+                results = await transform._search(hidden, query)
+            return await transform._render_results(results)
+
+        return Tool.from_function(fn=search_tools, name=transform._search_tool_name)
 
     if strategy == "regex":
         from fastmcp.server.transforms.search import RegexSearchTransform
@@ -643,6 +668,9 @@ def _create_search_transform(
                 """Build the normalized ``call_tool`` proxy for regex search."""
                 return make_normalizing_call_tool(self)
 
+            def _make_search_tool(self) -> Any:
+                return _make_optional_query_search_tool(self)
+
         return _FixedRegexSearchTransform(**kwargs)
 
     from fastmcp.server.transforms.search import BM25SearchTransform
@@ -658,6 +686,9 @@ def _create_search_transform(
         def _make_call_tool(self) -> Any:
             """Build the normalized ``call_tool`` proxy for BM25 search."""
             return make_normalizing_call_tool(self)
+
+        def _make_search_tool(self) -> Any:
+            return _make_optional_query_search_tool(self)
 
     return _FixedBM25SearchTransform(**kwargs)
 

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -1226,3 +1226,84 @@ def test_create_serializer_include_schemas_true_with_compact():
     assert result[0]["inputSchema"]["properties"]["filters"]["items"] == {
         "type": "object"
     }
+
+
+# -- search_tools optional query tests --
+
+
+def test_search_tool_query_is_optional_in_schema():
+    """search_tools parameters schema marks query as optional (not required)."""
+    mock_mcp = MagicMock()
+    config = {
+        "strategy": "bm25",
+        "max_results": 5,
+        "always_visible": [],
+        "search_tool_name": "search_tools",
+        "call_tool_name": "call_tool",
+    }
+    _apply_tool_search_transform(mock_mcp, config)
+    transform = mock_mcp.add_transform.call_args[0][0]
+    search_tool = transform._make_search_tool()
+
+    params = search_tool.parameters
+    assert "query" not in params.get("required", [])
+
+
+def test_search_tool_with_no_query_returns_all_visible_tools():
+    """search_tools returns all visible tools when called with no arguments."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    mock_mcp = MagicMock()
+    config = {
+        "strategy": "bm25",
+        "max_results": 5,
+        "always_visible": [],
+        "search_tool_name": "search_tools",
+        "call_tool_name": "call_tool",
+    }
+    _apply_tool_search_transform(mock_mcp, config)
+    transform = mock_mcp.add_transform.call_args[0][0]
+
+    tool_a = MagicMock()
+    tool_b = MagicMock()
+    all_tools = [tool_a, tool_b]
+
+    async def run():
+        transform._get_visible_tools = AsyncMock(return_value=all_tools)
+        transform._render_results = AsyncMock(return_value=[{"name": "tool_a"}])
+        search_tool = transform._make_search_tool()
+        await search_tool.run({})  # must not raise ValidationError
+        return transform._render_results.call_args[0][0]
+
+    rendered_with = asyncio.run(run())
+    assert rendered_with == all_tools
+
+
+def test_search_tool_regex_with_no_query_returns_all_visible_tools():
+    """Regex strategy returns all visible tools when called with no arguments."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    mock_mcp = MagicMock()
+    config = {
+        "strategy": "regex",
+        "max_results": 5,
+        "always_visible": [],
+        "search_tool_name": "search_tools",
+        "call_tool_name": "call_tool",
+    }
+    _apply_tool_search_transform(mock_mcp, config)
+    transform = mock_mcp.add_transform.call_args[0][0]
+
+    all_tools = [MagicMock(), MagicMock()]
+
+    async def run():
+        transform._get_visible_tools = AsyncMock(return_value=all_tools)
+        transform._render_results = AsyncMock(return_value=[])
+        search_tool = transform._make_search_tool()
+        await search_tool.run({})
+        return transform._render_results.call_args[0][0]
+
+    rendered_with = asyncio.run(run())
+    assert rendered_with == all_tools

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -1231,7 +1231,7 @@ def test_create_serializer_include_schemas_true_with_compact():
 # -- search_tools optional query tests --
 
 
-def test_search_tool_query_is_optional_in_schema():
+def test_search_tool_query_is_optional_in_schema() -> None:
     """search_tools schema marks query optional with a flat concrete type.
 
     The query schema must not use ``anyOf`` — MCP bridges (mcp-remote,
@@ -1257,7 +1257,7 @@ def test_search_tool_query_is_optional_in_schema():
     assert "anyOf" not in query_schema
 
 
-def test_search_tool_with_no_query_returns_all_visible_tools():
+def test_search_tool_with_no_query_returns_all_visible_tools() -> None:
     """search_tools returns all visible tools when called with no arguments."""
     import asyncio
     from unittest.mock import AsyncMock
@@ -1277,7 +1277,7 @@ def test_search_tool_with_no_query_returns_all_visible_tools():
     tool_b = MagicMock()
     all_tools = [tool_a, tool_b]
 
-    async def run():
+    async def run() -> list[MagicMock]:
         transform._get_visible_tools = AsyncMock(return_value=all_tools)
         transform._render_results = AsyncMock(return_value=[{"name": "tool_a"}])
         search_tool = transform._make_search_tool()
@@ -1288,7 +1288,44 @@ def test_search_tool_with_no_query_returns_all_visible_tools():
     assert rendered_with == all_tools
 
 
-def test_search_tool_regex_with_no_query_returns_all_visible_tools():
+def test_search_tool_empty_string_query_returns_all_visible_tools() -> None:
+    """An explicitly empty query is treated like an omitted one (fail open).
+
+    BM25/regex search with no search terms would rank nothing and return
+    an empty catalog — the same discovery footgun as the required-query
+    bug. Clients sending ``{"query": ""}`` to mean "list everything" get
+    the full visible catalog instead.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    mock_mcp = MagicMock()
+    config = {
+        "strategy": "bm25",
+        "max_results": 5,
+        "always_visible": [],
+        "search_tool_name": "search_tools",
+        "call_tool_name": "call_tool",
+    }
+    _apply_tool_search_transform(mock_mcp, config)
+    transform = mock_mcp.add_transform.call_args[0][0]
+
+    all_tools = [MagicMock(), MagicMock()]
+
+    async def run() -> list[MagicMock]:
+        transform._get_visible_tools = AsyncMock(return_value=all_tools)
+        transform._search = AsyncMock()
+        transform._render_results = AsyncMock(return_value=[])
+        search_tool = transform._make_search_tool()
+        await search_tool.run({"query": ""})
+        return transform._render_results.call_args[0][0]
+
+    rendered_with = asyncio.run(run())
+    assert rendered_with == all_tools
+    assert not transform._search.called
+
+
+def test_search_tool_regex_with_no_query_returns_all_visible_tools() -> None:
     """Regex strategy returns all visible tools when called with no arguments."""
     import asyncio
     from unittest.mock import AsyncMock
@@ -1306,7 +1343,7 @@ def test_search_tool_regex_with_no_query_returns_all_visible_tools():
 
     all_tools = [MagicMock(), MagicMock()]
 
-    async def run():
+    async def run() -> list[MagicMock]:
         transform._get_visible_tools = AsyncMock(return_value=all_tools)
         transform._render_results = AsyncMock(return_value=[])
         search_tool = transform._make_search_tool()

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -1232,7 +1232,12 @@ def test_create_serializer_include_schemas_true_with_compact():
 
 
 def test_search_tool_query_is_optional_in_schema():
-    """search_tools parameters schema marks query as optional (not required)."""
+    """search_tools schema marks query optional with a flat concrete type.
+
+    The query schema must not use ``anyOf`` — MCP bridges (mcp-remote,
+    Claude Desktop) strip ``anyOf`` and leave the field typeless, the same
+    failure mode ``_fix_call_tool_arguments`` guards against.
+    """
     mock_mcp = MagicMock()
     config = {
         "strategy": "bm25",
@@ -1247,6 +1252,9 @@ def test_search_tool_query_is_optional_in_schema():
 
     params = search_tool.parameters
     assert "query" not in params.get("required", [])
+    query_schema = params["properties"]["query"]
+    assert query_schema["type"] == "string"
+    assert "anyOf" not in query_schema
 
 
 def test_search_tool_with_no_query_returns_all_visible_tools():


### PR DESCRIPTION
## Summary

- **Root cause**: `BM25SearchTransform._make_search_tool()` declares `query: str` (required). When an LLM calls `search_tools({})` for tool discovery, `TypeAdapter.validate_python({})` raises `ValidationError` because the required field is missing. `StructuredContentStripperMiddleware` catches this and returns error text instead of the tool catalog — so the LLM receives null/empty content.
- **Fix**: Override `_make_search_tool()` in both `_FixedBM25SearchTransform` and `_FixedRegexSearchTransform` to accept `query: str | None = None`. When omitted, returns all visible tools directly; when provided, runs the configured search strategy as before.
- **Tests**: Three new unit tests verify the schema marks `query` as optional, calling with no args returns all tools (BM25 + regex strategies).

## Test plan

- [ ] `pytest tests/unit_tests/mcp_service/test_tool_search_transform.py::test_search_tool_query_is_optional_in_schema`
- [ ] `pytest tests/unit_tests/mcp_service/test_tool_search_transform.py::test_search_tool_with_no_query_returns_all_visible_tools`
- [ ] `pytest tests/unit_tests/mcp_service/test_tool_search_transform.py::test_search_tool_regex_with_no_query_returns_all_visible_tools`