### PR TITLE
test(dashboard): migrate standalone mode Cypress spec to RTL

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -165,6 +165,22 @@ describe('DashboardBuilder', () => {
     expect(header).toBeInTheDocument();
   });
 
+  test('should hide DashboardHeader when standalone mode hides nav and title (?standalone=2)', () => {
+    // React-level equivalent of the legacy `cy.get('#app-menu').should('not.exist')`
+    // Cypress assertion. The `#app-menu` node lives in Flask's spa.html template,
+    // gated by `{% if standalone_mode %}`, so RTL cannot reach it directly.
+    // `?standalone=2` maps to DashboardStandaloneMode.HideNavAndTitle, which the
+    // DashboardBuilder honours by suppressing the React-side DashboardHeader.
+    const originalSearch = window.location.search;
+    window.history.replaceState({}, '', '/?standalone=2');
+    try {
+      const { queryByTestId } = setup();
+      expect(queryByTestId('dashboard-header-container')).not.toBeInTheDocument();
+    } finally {
+      window.history.replaceState({}, '', `/${originalSearch}`);
+    }
+  });
+
   test('should render a Sticky top-level Tabs if the dashboard has tabs', async () => {
     const { findAllByTestId } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -175,19 +175,37 @@ describe('DashboardBuilder', () => {
     window.history.replaceState({}, '', '/?standalone=2');
     try {
       const { queryByTestId } = setup();
-      expect(queryByTestId('dashboard-header-container')).not.toBeInTheDocument();
+      expect(
+        queryByTestId('dashboard-header-container'),
+      ).not.toBeInTheDocument();
     } finally {
       window.history.replaceState({}, '', originalHref);
     }
   });
 
-  test('should apply editing class and hide header when both edit and standalone params are set', () => {
-    // Combined-params analogue of the legacy `?edit=true&standalone=true` Cypress
-    // mount. The two URL params are orthogonal on the React side: standalone=2
-    // suppresses DashboardHeader regardless of editMode, while editMode still
+  test('should keep the DashboardHeader when standalone mode only hides nav (?standalone=1)', () => {
+    // `?standalone=1` maps to DashboardStandaloneMode.HideNav, which only hides the
+    // Flask-rendered global app menu (#app-menu) — it must NOT suppress the React-side
+    // DashboardHeader. This pins the boundary against HideNavAndTitle (?standalone=2).
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=1');
+    try {
+      const { queryByTestId } = setup();
+      expect(queryByTestId('dashboard-header-container')).toBeInTheDocument();
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
+  test('should keep the header hidden in standalone mode (?standalone=2) while editMode is active', () => {
+    // Orthogonality analogue of the legacy `?edit=true&standalone=true` Cypress mount.
+    // editMode is sourced from Redux (state.dashboardState.editMode), not the URL —
+    // DashboardBuilder only reads URL_PARAMS.standalone — so the legacy `edit=true`
+    // param is inert here and is intentionally omitted. Contract under test:
+    // standalone=2 (HideNavAndTitle) suppresses DashboardHeader even while editMode
     // drives the `dashboard--editing` class on the wrapper.
     const originalHref = window.location.href;
-    window.history.replaceState({}, '', '/?edit=true&standalone=2');
+    window.history.replaceState({}, '', '/?standalone=2');
     try {
       const { getByTestId, queryByTestId } = setup({
         dashboardState: { ...mockState.dashboardState, editMode: true },
@@ -195,7 +213,9 @@ describe('DashboardBuilder', () => {
       expect(getByTestId('dashboard-content-wrapper')).toHaveClass(
         'dashboard dashboard--editing',
       );
-      expect(queryByTestId('dashboard-header-container')).not.toBeInTheDocument();
+      expect(
+        queryByTestId('dashboard-header-container'),
+      ).not.toBeInTheDocument();
     } finally {
       window.history.replaceState({}, '', originalHref);
     }

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -181,6 +181,26 @@ describe('DashboardBuilder', () => {
     }
   });
 
+  test('should apply editing class and hide header when both edit and standalone params are set', () => {
+    // Combined-params analogue of the legacy `?edit=true&standalone=true` Cypress
+    // mount. The two URL params are orthogonal on the React side: standalone=2
+    // suppresses DashboardHeader regardless of editMode, while editMode still
+    // drives the `dashboard--editing` class on the wrapper.
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?edit=true&standalone=2');
+    try {
+      const { getByTestId, queryByTestId } = setup({
+        dashboardState: { ...mockState.dashboardState, editMode: true },
+      });
+      expect(getByTestId('dashboard-content-wrapper')).toHaveClass(
+        'dashboard dashboard--editing',
+      );
+      expect(queryByTestId('dashboard-header-container')).not.toBeInTheDocument();
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
   test('should render a Sticky top-level Tabs if the dashboard has tabs', async () => {
     const { findAllByTestId } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -171,13 +171,13 @@ describe('DashboardBuilder', () => {
     // gated by `{% if standalone_mode %}`, so RTL cannot reach it directly.
     // `?standalone=2` maps to DashboardStandaloneMode.HideNavAndTitle, which the
     // DashboardBuilder honours by suppressing the React-side DashboardHeader.
-    const originalSearch = window.location.search;
+    const originalHref = window.location.href;
     window.history.replaceState({}, '', '/?standalone=2');
     try {
       const { queryByTestId } = setup();
       expect(queryByTestId('dashboard-header-container')).not.toBeInTheDocument();
     } finally {
-      window.history.replaceState({}, '', `/${originalSearch}`);
+      window.history.replaceState({}, '', originalHref);
     }
   });
 


### PR DESCRIPTION
### SUMMARY
Migrates the dashboard standalone-mode scenario from the deleted Cypress spec `cypress-base/cypress/e2e/dashboard/_skip.load.test.ts` (removed in #40384) to a component-level RTL test in `DashboardBuilder.test.tsx`. Part of the Cypress→Playwright/RTL migration epic.

The original Cypress spec opened `?edit=true&standalone=true` and asserted three things. Two are already covered by existing unit tests; the new RTL test covers the third:

| Original assertion | Where covered |
|---|---|
| `?edit=true` → `discard-changes-button` visible | URL→state in `extractUrlParams.test.ts`; state→DOM in `Header.test.tsx` (`should render the "Discard changes" button` under `editMode: true`). |
| `?standalone=true` → `#app-menu` not in DOM | `#app-menu` lives in Flask's `spa.html` and is gated server-side by `{% if standalone_mode %}` — out of RTL's reach. The React-side equivalent is `?standalone=2` (`DashboardStandaloneMode.HideNavAndTitle`), which makes `DashboardBuilder` suppress `<DashboardHeader />`. **Net-new RTL test added.** |
| Log emission (originally skipped as flaky) | Already covered by `logger.test.ts` (`should POST an event to /superset/log/ when called`). |

The literal `?standalone=true` parses to `1` (`HideNav`), which only hides the Flask-rendered app menu. Using `standalone=2` documents the closest React-level contract and is called out in the test's comment.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — test-only change.

### TESTING INSTRUCTIONS
\`\`\`bash
cd superset-frontend
npm run test -- src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
\`\`\`
All 25 tests should pass, including the new one:
- \`should hide DashboardHeader when standalone mode hides nav and title (?standalone=2)\`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API