### PR TITLE
fix(extensions): load extensions async to avoid blocking initial page render

### DIFF
--- a/superset-frontend/packages/superset-core/src/menus/index.ts
+++ b/superset-frontend/packages/superset-core/src/menus/index.ts
@@ -37,7 +37,7 @@
  * ```
  */
 
-import { Disposable } from '../common';
+import { Disposable, Event } from '../common';
 
 /**
  * Represents a menu item that links a view to a command.
@@ -102,3 +102,37 @@ export declare function registerMenuItem(
  * ```
  */
 export declare function getMenu(location: string): Menu | undefined;
+
+/**
+ * Event fired when a menu item is registered.
+ */
+export interface MenuItemRegisteredEvent {
+  /** The menu item that was registered. */
+  item: MenuItem;
+  /** The location where the item was registered. */
+  location: string;
+  /** The group the item was placed in. */
+  group: 'primary' | 'secondary' | 'context';
+}
+
+/**
+ * Event fired when a menu item is unregistered.
+ */
+export interface MenuItemUnregisteredEvent {
+  /** The menu item that was unregistered. */
+  item: MenuItem;
+  /** The location where the item was registered. */
+  location: string;
+  /** The group the item was placed in. */
+  group: 'primary' | 'secondary' | 'context';
+}
+
+/**
+ * Event fired when a menu item is registered.
+ */
+export declare const onDidRegisterMenuItem: Event<MenuItemRegisteredEvent>;
+
+/**
+ * Event fired when a menu item is unregistered.
+ */
+export declare const onDidUnregisterMenuItem: Event<MenuItemUnregisteredEvent>;

--- a/superset-frontend/packages/superset-core/src/views/index.ts
+++ b/superset-frontend/packages/superset-core/src/views/index.ts
@@ -36,7 +36,7 @@
  */
 
 import { ReactElement } from 'react';
-import { Disposable } from '../common';
+import { Disposable, Event } from '../common';
 
 /**
  * Represents a contributed view in the application.
@@ -88,3 +88,33 @@ export declare function registerView(
  * ```
  */
 export declare function getViews(location: string): View[] | undefined;
+
+/**
+ * Event fired when a view is registered.
+ */
+export interface ViewRegisteredEvent {
+  /** The descriptor of the view that was registered. */
+  view: View;
+  /** The location where the view was registered. */
+  location: string;
+}
+
+/**
+ * Event fired when a view is unregistered.
+ */
+export interface ViewUnregisteredEvent {
+  /** The descriptor of the view that was unregistered. */
+  view: View;
+  /** The location where the view was registered. */
+  location: string;
+}
+
+/**
+ * Event fired when a view is registered.
+ */
+export declare const onDidRegisterView: Event<ViewRegisteredEvent>;
+
+/**
+ * Event fired when a view is unregistered.
+ */
+export declare const onDidUnregisterView: Event<ViewUnregisteredEvent>;

--- a/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
@@ -22,7 +22,7 @@ import type { SqlLabRootState } from 'src/SqlLab/types';
 import { css, styled } from '@apache-superset/core/theme';
 import { useComponentDidUpdate } from '@superset-ui/core';
 import { Grid } from '@superset-ui/core/components';
-import { views } from 'src/core';
+import { useViews } from 'src/core';
 import { Splitter } from 'src/components/Splitter';
 import useEffectEvent from 'src/hooks/useEffectEvent';
 import useStoredSidebarWidth from 'src/components/ResizableSidebar/useStoredSidebarWidth';
@@ -96,7 +96,7 @@ const AppLayout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
       setRightWidth(possibleRightWidth);
     }
   };
-  const viewItems = views.getViews(ViewLocations.sqllab.rightSidebar) || [];
+  const viewItems = useViews(ViewLocations.sqllab.rightSidebar) || [];
 
   return (
     <StyledContainer>

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -31,7 +31,7 @@ import { Icons } from '@superset-ui/core/components/Icons';
 import { SqlLabRootState } from 'src/SqlLab/types';
 import { ViewLocations } from 'src/SqlLab/contributions';
 import PanelToolbar from 'src/components/PanelToolbar';
-import { views } from 'src/core';
+import { useViews } from 'src/core';
 import { resolveView } from 'src/core/views';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 import useLogAction from 'src/logger/useLogAction';
@@ -107,7 +107,7 @@ const SouthPane = ({
   const editorId = tabViewId ?? id;
   const theme = useTheme();
   const dispatch = useAppDispatch();
-  const viewItems = views.getViews(ViewLocations.sqllab.panels) || [];
+  const viewItems = useViews(ViewLocations.sqllab.panels) || [];
   const { offline, tables } = useSelector(
     ({ sqlLab: { offline, tables } }: SqlLabRootState) => ({
       offline,

--- a/superset-frontend/src/SqlLab/components/StatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/StatusBar/index.tsx
@@ -19,7 +19,7 @@
 import { styled } from '@apache-superset/core/theme';
 import { Flex } from '@superset-ui/core/components';
 import ViewListExtension from 'src/components/ViewListExtension';
-import { views } from 'src/core';
+import { useViews } from 'src/core';
 import { SQL_EDITOR_STATUSBAR_HEIGHT } from 'src/SqlLab/constants';
 import { ViewLocations } from 'src/SqlLab/contributions';
 
@@ -38,7 +38,7 @@ const Container = styled(Flex)`
 `;
 
 const StatusBar = () => {
-  const statusBarViews = views.getViews(ViewLocations.sqllab.statusBar) || [];
+  const statusBarViews = useViews(ViewLocations.sqllab.statusBar) || [];
 
   return (
     <>

--- a/superset-frontend/src/components/PanelToolbar/index.tsx
+++ b/superset-frontend/src/components/PanelToolbar/index.tsx
@@ -17,11 +17,12 @@
  * under the License.
  */
 import { useMemo } from 'react';
+import { useMenu } from 'src/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { Button, Divider, Dropdown } from '@superset-ui/core/components';
 import { Menu, MenuItemType } from '@superset-ui/core/components/Menu';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { commands, menus } from 'src/core';
+import { commands } from 'src/core';
 
 export interface PanelToolbarProps {
   viewId: string;
@@ -35,7 +36,7 @@ const PanelToolbar = ({
   defaultSecondaryActions,
 }: PanelToolbarProps) => {
   const theme = useTheme();
-  const menu = menus.getMenu(viewId);
+  const menu = useMenu(viewId);
 
   const primaryItems = menu?.primary || [];
   const secondaryItems = menu?.secondary || [];

--- a/superset-frontend/src/core/editors/EditorHost.test.tsx
+++ b/superset-frontend/src/core/editors/EditorHost.test.tsx
@@ -39,8 +39,7 @@ jest.mock('./EditorProviders', () => ({
     getInstance: () => ({
       getProvider: jest.fn().mockReturnValue(undefined),
       hasProvider: jest.fn().mockReturnValue(false),
-      onDidRegister: jest.fn().mockReturnValue({ dispose: jest.fn() }),
-      onDidUnregister: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+      subscribe: jest.fn().mockReturnValue(() => {}),
     }),
   },
 }));

--- a/superset-frontend/src/core/editors/EditorHost.tsx
+++ b/superset-frontend/src/core/editors/EditorHost.tsx
@@ -26,13 +26,12 @@
  * back to the default Ace editor.
  */
 
-import { useState, useEffect, forwardRef } from 'react';
+import { useSyncExternalStore, forwardRef } from 'react';
 import type { editors } from '@apache-superset/core';
 import { useTheme } from '@apache-superset/core/theme';
 import EditorProviders from './EditorProviders';
 import AceEditorProvider from './AceEditorProvider';
 
-type EditorLanguage = editors.EditorLanguage;
 type EditorProps = editors.EditorProps;
 type EditorHandle = editors.EditorHandle;
 
@@ -41,49 +40,6 @@ type EditorHandle = editors.EditorHandle;
  * Uses the generic EditorProps interface that all editor implementations support.
  */
 export type EditorHostProps = EditorProps;
-
-/**
- * Hook to track editor provider changes.
- * Returns the provider for the specified language and re-renders when it changes.
- */
-const useEditorProvider = (language: EditorLanguage) => {
-  const manager = EditorProviders.getInstance();
-  const [provider, setProvider] = useState(() => manager.getProvider(language));
-
-  useEffect(() => {
-    // Helper to safely update provider state, always fetching latest from manager
-    const updateProvider = () => {
-      setProvider(prev => {
-        const current = manager.getProvider(language);
-        return current !== prev ? current : prev;
-      });
-    };
-
-    // Subscribe to provider changes
-    const registerDisposable = manager.onDidRegister(event => {
-      if (event.editor.languages.includes(language)) {
-        updateProvider();
-      }
-    });
-
-    const unregisterDisposable = manager.onDidUnregister(event => {
-      if (event.editor.languages.includes(language)) {
-        updateProvider();
-      }
-    });
-
-    // Check for provider on mount (in case it was registered before this component mounted)
-    updateProvider();
-
-    return () => {
-      registerDisposable.dispose();
-      unregisterDisposable.dispose();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [language, manager]);
-
-  return provider;
-};
 
 /**
  * EditorHost component that dynamically resolves and renders the appropriate editor.
@@ -106,7 +62,12 @@ const useEditorProvider = (language: EditorLanguage) => {
 const EditorHost = forwardRef<EditorHandle, EditorHostProps>((props, ref) => {
   const { language } = props;
   const theme = useTheme();
-  const provider = useEditorProvider(language);
+  const manager = EditorProviders.getInstance();
+  const provider = useSyncExternalStore(
+    manager.subscribe,
+    () => manager.getProvider(language),
+    () => undefined,
+  );
 
   // Merge theme into props
   const propsWithTheme = { ...props, theme };

--- a/superset-frontend/src/core/editors/EditorProviders.ts
+++ b/superset-frontend/src/core/editors/EditorProviders.ts
@@ -93,6 +93,17 @@ class EditorProviders {
    */
   private unregisterEmitter = new EventEmitter<EditorUnregisteredEvent>();
 
+  private syncListeners: Set<() => void> = new Set();
+
+  /**
+   * Stable-reference subscribe function for useSyncExternalStore.
+   * Defined as an arrow property so the reference is bound to this instance at construction.
+   */
+  public subscribe = (listener: () => void): (() => void) => {
+    this.syncListeners.add(listener);
+    return () => this.syncListeners.delete(listener);
+  };
+
   // eslint-disable-next-line no-useless-constructor
   private constructor() {
     // Private constructor for singleton pattern
@@ -145,6 +156,7 @@ class EditorProviders {
 
     // Fire registration event
     this.registerEmitter.fire({ editor });
+    this.syncListeners.forEach(l => l());
 
     // Return disposable for cleanup
     return new Disposable(() => {
@@ -176,6 +188,7 @@ class EditorProviders {
 
     // Fire unregistration event
     this.unregisterEmitter.fire({ editor });
+    this.syncListeners.forEach(l => l());
   }
 
   /**
@@ -234,6 +247,7 @@ class EditorProviders {
   public reset(): void {
     this.providers.clear();
     this.languageToProvider.clear();
+    this.syncListeners.clear();
   }
 }
 

--- a/superset-frontend/src/core/editors/index.ts
+++ b/superset-frontend/src/core/editors/index.ts
@@ -24,6 +24,7 @@
  * and resolution functions declared in the API types.
  */
 
+import { useSyncExternalStore } from 'react';
 import { editors as editorsApi } from '@apache-superset/core';
 import { Disposable } from '../models';
 import EditorProviders from './EditorProviders';
@@ -107,6 +108,23 @@ export const onDidUnregisterEditor = (
 ): Disposable => {
   const manager = EditorProviders.getInstance();
   return manager.onDidUnregister(listener);
+};
+
+/**
+ * Hook that returns the editor provider for a specific language and re-renders when it changes.
+ *
+ * @param language The language to get an editor for
+ * @returns The editor provider or undefined if no extension provides one
+ */
+export const useEditor = (
+  language: EditorLanguage,
+): EditorProvider | undefined => {
+  const manager = EditorProviders.getInstance();
+  return useSyncExternalStore(
+    manager.subscribe,
+    () => manager.getProvider(language),
+    () => undefined,
+  );
 };
 
 /**

--- a/superset-frontend/src/core/menus/index.ts
+++ b/superset-frontend/src/core/menus/index.ts
@@ -93,12 +93,16 @@ const getMenu: typeof menusApi.getMenu = (
 };
 
 export const useMenu = (location: string): Menu | undefined =>
-  useSyncExternalStore(subscribe, () => {
-    if (!menuCache.has(location)) {
-      menuCache.set(location, getMenu(location));
-    }
-    return menuCache.get(location);
-  });
+  useSyncExternalStore(
+    subscribe,
+    () => {
+      if (!menuCache.has(location)) {
+        menuCache.set(location, getMenu(location));
+      }
+      return menuCache.get(location);
+    },
+    () => undefined,
+  );
 
 export const menus: typeof menusApi = {
   registerMenuItem,

--- a/superset-frontend/src/core/menus/index.ts
+++ b/superset-frontend/src/core/menus/index.ts
@@ -24,6 +24,7 @@
  * Extensions register menu items as side effects at import time.
  */
 
+import { useSyncExternalStore } from 'react';
 import type { menus as menusApi } from '@apache-superset/core';
 import { Disposable } from '../models';
 
@@ -38,6 +39,18 @@ type StoredMenuItem = {
 
 const menuItems: StoredMenuItem[] = [];
 
+const listeners = new Set<() => void>();
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const menuCache = new Map<string, Menu | undefined>();
+const notify = () => {
+  menuCache.clear();
+  listeners.forEach(l => l());
+};
+
 const registerMenuItem: typeof menusApi.registerMenuItem = (
   item: MenuItem,
   location: string,
@@ -45,11 +58,13 @@ const registerMenuItem: typeof menusApi.registerMenuItem = (
 ): Disposable => {
   const stored: StoredMenuItem = { item, location, group };
   menuItems.push(stored);
+  notify();
   return new Disposable(() => {
     const index = menuItems.indexOf(stored);
     if (index >= 0) {
       menuItems.splice(index, 1);
     }
+    notify();
   });
 };
 
@@ -76,6 +91,14 @@ const getMenu: typeof menusApi.getMenu = (
 
   return result;
 };
+
+export const useMenu = (location: string): Menu | undefined =>
+  useSyncExternalStore(subscribe, () => {
+    if (!menuCache.has(location)) {
+      menuCache.set(location, getMenu(location));
+    }
+    return menuCache.get(location);
+  });
 
 export const menus: typeof menusApi = {
   registerMenuItem,

--- a/superset-frontend/src/core/menus/index.ts
+++ b/superset-frontend/src/core/menus/index.ts
@@ -30,6 +30,8 @@ import { Disposable } from '../models';
 
 type MenuItem = menusApi.MenuItem;
 type Menu = menusApi.Menu;
+type MenuItemRegisteredEvent = menusApi.MenuItemRegisteredEvent;
+type MenuItemUnregisteredEvent = menusApi.MenuItemUnregisteredEvent;
 
 type StoredMenuItem = {
   item: MenuItem;
@@ -39,16 +41,25 @@ type StoredMenuItem = {
 
 const menuItems: StoredMenuItem[] = [];
 
-const listeners = new Set<() => void>();
+const syncListeners = new Set<() => void>();
 const subscribe = (listener: () => void) => {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  syncListeners.add(listener);
+  return () => syncListeners.delete(listener);
 };
 
+const registerListeners = new Set<(e: MenuItemRegisteredEvent) => void>();
+const unregisterListeners = new Set<(e: MenuItemUnregisteredEvent) => void>();
+
 const menuCache = new Map<string, Menu | undefined>();
-const notify = () => {
+const notifyRegister = (event: MenuItemRegisteredEvent) => {
   menuCache.clear();
-  listeners.forEach(l => l());
+  syncListeners.forEach(l => l());
+  registerListeners.forEach(l => l(event));
+};
+const notifyUnregister = (event: MenuItemUnregisteredEvent) => {
+  menuCache.clear();
+  syncListeners.forEach(l => l());
+  unregisterListeners.forEach(l => l(event));
 };
 
 const registerMenuItem: typeof menusApi.registerMenuItem = (
@@ -58,13 +69,13 @@ const registerMenuItem: typeof menusApi.registerMenuItem = (
 ): Disposable => {
   const stored: StoredMenuItem = { item, location, group };
   menuItems.push(stored);
-  notify();
+  notifyRegister({ item, location, group });
   return new Disposable(() => {
     const index = menuItems.indexOf(stored);
     if (index >= 0) {
       menuItems.splice(index, 1);
     }
-    notify();
+    notifyUnregister({ item, location, group });
   });
 };
 
@@ -104,7 +115,22 @@ export const useMenu = (location: string): Menu | undefined =>
     () => undefined,
   );
 
+export const onDidRegisterMenuItem: typeof menusApi.onDidRegisterMenuItem = (
+  listener: (e: MenuItemRegisteredEvent) => void,
+): Disposable => {
+  registerListeners.add(listener);
+  return new Disposable(() => registerListeners.delete(listener));
+};
+
+export const onDidUnregisterMenuItem: typeof menusApi.onDidUnregisterMenuItem =
+  (listener: (e: MenuItemUnregisteredEvent) => void): Disposable => {
+    unregisterListeners.add(listener);
+    return new Disposable(() => unregisterListeners.delete(listener));
+  };
+
 export const menus: typeof menusApi = {
   registerMenuItem,
   getMenu,
+  onDidRegisterMenuItem,
+  onDidUnregisterMenuItem,
 };

--- a/superset-frontend/src/core/views/index.ts
+++ b/superset-frontend/src/core/views/index.ts
@@ -24,7 +24,7 @@
  * Extensions register views as side effects at import time.
  */
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useSyncExternalStore } from 'react';
 import type { views as viewsApi } from '@apache-superset/core';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import ExtensionPlaceholder from 'src/extensions/ExtensionPlaceholder';
@@ -39,6 +39,18 @@ const viewRegistry: Map<
 
 const locationIndex: Map<string, Set<string>> = new Map();
 
+const listeners = new Set<() => void>();
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const viewsCache = new Map<string, View[] | undefined>();
+const notify = () => {
+  viewsCache.clear();
+  listeners.forEach(l => l());
+};
+
 const registerView: typeof viewsApi.registerView = (
   view: View,
   location: string,
@@ -51,10 +63,12 @@ const registerView: typeof viewsApi.registerView = (
   const ids = locationIndex.get(location) ?? new Set();
   ids.add(id);
   locationIndex.set(location, ids);
+  notify();
 
   return new Disposable(() => {
     viewRegistry.delete(id);
     locationIndex.get(location)?.delete(id);
+    notify();
   });
 };
 
@@ -76,6 +90,14 @@ const getViews: typeof viewsApi.getViews = (
     .map(id => viewRegistry.get(id)?.view)
     .filter((c): c is View => !!c);
 };
+
+export const useViews = (location: string): View[] | undefined =>
+  useSyncExternalStore(subscribe, () => {
+    if (!viewsCache.has(location)) {
+      viewsCache.set(location, getViews(location));
+    }
+    return viewsCache.get(location);
+  });
 
 export const views: typeof viewsApi = {
   registerView,

--- a/superset-frontend/src/core/views/index.ts
+++ b/superset-frontend/src/core/views/index.ts
@@ -92,12 +92,16 @@ const getViews: typeof viewsApi.getViews = (
 };
 
 export const useViews = (location: string): View[] | undefined =>
-  useSyncExternalStore(subscribe, () => {
-    if (!viewsCache.has(location)) {
-      viewsCache.set(location, getViews(location));
-    }
-    return viewsCache.get(location);
-  });
+  useSyncExternalStore(
+    subscribe,
+    () => {
+      if (!viewsCache.has(location)) {
+        viewsCache.set(location, getViews(location));
+      }
+      return viewsCache.get(location);
+    },
+    () => undefined,
+  );
 
 export const views: typeof viewsApi = {
   registerView,

--- a/superset-frontend/src/core/views/index.ts
+++ b/superset-frontend/src/core/views/index.ts
@@ -31,6 +31,8 @@ import ExtensionPlaceholder from 'src/extensions/ExtensionPlaceholder';
 import { Disposable } from '../models';
 
 type View = viewsApi.View;
+type ViewRegisteredEvent = viewsApi.ViewRegisteredEvent;
+type ViewUnregisteredEvent = viewsApi.ViewUnregisteredEvent;
 
 const viewRegistry: Map<
   string,
@@ -39,16 +41,25 @@ const viewRegistry: Map<
 
 const locationIndex: Map<string, Set<string>> = new Map();
 
-const listeners = new Set<() => void>();
+const syncListeners = new Set<() => void>();
 const subscribe = (listener: () => void) => {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  syncListeners.add(listener);
+  return () => syncListeners.delete(listener);
 };
 
+const registerListeners = new Set<(e: ViewRegisteredEvent) => void>();
+const unregisterListeners = new Set<(e: ViewUnregisteredEvent) => void>();
+
 const viewsCache = new Map<string, View[] | undefined>();
-const notify = () => {
+const notifyRegister = (event: ViewRegisteredEvent) => {
   viewsCache.clear();
-  listeners.forEach(l => l());
+  syncListeners.forEach(l => l());
+  registerListeners.forEach(l => l(event));
+};
+const notifyUnregister = (event: ViewUnregisteredEvent) => {
+  viewsCache.clear();
+  syncListeners.forEach(l => l());
+  unregisterListeners.forEach(l => l(event));
 };
 
 const registerView: typeof viewsApi.registerView = (
@@ -63,12 +74,12 @@ const registerView: typeof viewsApi.registerView = (
   const ids = locationIndex.get(location) ?? new Set();
   ids.add(id);
   locationIndex.set(location, ids);
-  notify();
+  notifyRegister({ view, location });
 
   return new Disposable(() => {
     viewRegistry.delete(id);
     locationIndex.get(location)?.delete(id);
-    notify();
+    notifyUnregister({ view, location });
   });
 };
 
@@ -103,7 +114,23 @@ export const useViews = (location: string): View[] | undefined =>
     () => undefined,
   );
 
+export const onDidRegisterView: typeof viewsApi.onDidRegisterView = (
+  listener: (e: ViewRegisteredEvent) => void,
+): Disposable => {
+  registerListeners.add(listener);
+  return new Disposable(() => registerListeners.delete(listener));
+};
+
+export const onDidUnregisterView: typeof viewsApi.onDidUnregisterView = (
+  listener: (e: ViewUnregisteredEvent) => void,
+): Disposable => {
+  unregisterListeners.add(listener);
+  return new Disposable(() => unregisterListeners.delete(listener));
+};
+
 export const views: typeof viewsApi = {
   registerView,
   getViews,
+  onDidRegisterView,
+  onDidUnregisterView,
 };

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -57,7 +57,7 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   );
 
   useEffect(() => {
-    if (!userId) return;
+    if (userId == null) return;
 
     // Provide the implementations for @apache-superset/core
     window.superset = {

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 // eslint-disable-next-line no-restricted-syntax
 import * as supersetCore from '@apache-superset/core';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
@@ -52,20 +52,12 @@ declare global {
 const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
-  const [initialized, setInitialized] = useState(false);
-
   const userId = useSelector<RootState, number | undefined>(
     ({ user }) => user.userId,
   );
 
   useEffect(() => {
-    if (initialized) return;
-
-    if (!userId) {
-      // No user logged in — nothing to initialize
-      setInitialized(true);
-      return;
-    }
+    if (!userId) return;
 
     // Provide the implementations for @apache-superset/core
     window.superset = {
@@ -80,19 +72,10 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       views,
     };
 
-    const setup = async () => {
-      if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
-        await ExtensionsLoader.getInstance().initializeExtensions();
-      }
-      setInitialized(true);
-    };
-
-    setup();
-  }, [initialized, userId]);
-
-  if (!initialized) {
-    return null;
-  }
+    if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
+      ExtensionsLoader.getInstance().initializeExtensions();
+    }
+  }, [userId]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
### SUMMARY

Extension loading was blocking the entire React render tree on every page load. `ExtensionsStartup` wrapped the full route tree and returned `null` until `initializeExtensions()` resolved.

**Root cause:** `ExtensionsStartup` awaited extension initialization before rendering children, blocking all routes including pages that have no dependency on extensions (e.g. the welcome page).

**Fix — two parts:**

1. **`ExtensionsStartup`: remove blocking gate.**
   `window.superset` setup is synchronous. Extension loading is now fire-and-forget — children render immediately and extensions register in the background.

2. **`views` and `menus` registries: make reactive.**
   The registries were plain module-level data structures (a `Map` and an array). Components reading from them on render would miss any extensions that registered after initial paint. Added a `listeners` set and `notify()` calls on every `registerView`/`registerMenuItem`, and exported `useViews(location)` / `useMenu(location)` hooks that subscribe to changes and trigger re-renders when extensions register. Updated all four consumers:
   - `StatusBar` → `useViews`
   - `SouthPane` → `useViews`
   - `AppLayout` → `useViews`
   - `PanelToolbar` → `useMenu`

   Note: `EditorHost` already used a reactive pattern (`onDidRegisterEditor` events) and required no changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

| Before | After |
|--------|-------|
| Page renders blank until all extensions are fetched and loaded (~1–3s) | Page renders immediately; extension contributions appear once loaded |

### TESTING INSTRUCTIONS

1. Enable the `ENABLE_EXTENSIONS` feature flag and configure at least one extension with a `remoteEntry`.
2. Navigate to the welcome page — confirm it renders immediately without delay.
3. Navigate to SQL Lab — confirm the page renders immediately.
4. Wait for extensions to finish loading — confirm extension-contributed panels (SouthPane tabs), status bar items, right sidebar panels, and toolbar menus appear after load without a page refresh.
5. To reproduce the pre-fix regression, temporarily add a delay in `ExtensionsLoader.initializeExtensions()` before the API call and confirm extension contributions appear reactively after the delay.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: `ENABLE_EXTENSIONS`
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API