### PR TITLE
feat: enable translation or customization of the constants "<NULL>", "TRUE", "FALSE" and "<empty string>"

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -145,7 +145,7 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
 
   data.forEach(datum => {
     const dataName = bubbleSeries ? datum[bubbleSeries] : datum[entity];
-    const name = dataName ? String(dataName) : NULL_STRING;
+    const name = dataName ? String(dataName) : NULL_STRING();
     const bubbleSeriesValue = bubbleSeries ? datum[bubbleSeries] : null;
 
     series.push({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -150,7 +150,7 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
 
   data.forEach(datum => {
     const dataName = seriesLabel ? datum[seriesLabel] : datum[entityLabel];
-    const name = dataName ? String(dataName) : NULL_STRING;
+    const name = dataName ? String(dataName) : NULL_STRING();
     const bubbleSeriesValue = seriesLabel ? datum[seriesLabel] : null;
 
     series.push({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -130,7 +130,7 @@ export function formatTooltip({
   const parentNode =
     treePathInfo.length > 2 ? treePathInfo[treePathInfo.length - 2] : undefined;
 
-  const title = (node.name || NULL_STRING)
+  const title = (node.name || NULL_STRING())
     .toString()
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');
@@ -144,8 +144,8 @@ export function formatTooltip({
   rows.push([metricLabel, formattedValue]);
   if (!colorByCategory) {
     rows.push([
-      secondaryMetricLabel || NULL_STRING,
-      formattedSecondaryValue || NULL_STRING,
+      secondaryMetricLabel || NULL_STRING(),
+      formattedSecondaryValue || NULL_STRING(),
     ]);
     rows.push([
       `${metricLabel}/${secondaryMetricLabel}`,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -124,7 +124,7 @@ export default function EchartsTreemap({
           const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
           const drillByFilters: BinaryQueryObjectFilterClause[] = [];
           treePath.forEach((path, i) => {
-            const val = path === 'null' ? NULL_STRING : path;
+            const val = path === 'null' ? NULL_STRING() : path;
             drillToDetailFilters.push({
               col: groupby[i],
               op: '==',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -70,7 +70,7 @@ function formatTooltip({
 
   const isTotal = series?.seriesName === totalMark;
   if (!series) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
 
   const title =
@@ -329,7 +329,7 @@ export default function transformProps(
       value = row[breakdownName];
     }
     if (!value) {
-      value = NULL_STRING;
+      value = NULL_STRING();
     }
     if (typeof value !== 'string' && typeof value !== 'number') {
       value = String(value);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -70,7 +70,7 @@ function formatTooltip({
 
   const isTotal = series?.seriesName === totalMark;
   if (!series) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
 
   const title =
@@ -331,7 +331,7 @@ export default function transformProps(
       value = row[breakdownName];
     }
     if (!value) {
-      value = NULL_STRING;
+      value = NULL_STRING();
     }
     if (typeof value !== 'string' && typeof value !== 'number') {
       value = String(value);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -27,8 +27,12 @@ import {
   TitleFormData,
 } from './types';
 
-// eslint-disable-next-line import/prefer-default-export
-export const NULL_STRING = '<NULL>';
+// ATTENTION: If you change any constants, make sure to also change constants.py
+
+export const EMPTY_STRING = () => t('<empty string>');
+export const NULL_STRING = () => t('<NULL>');
+export const TRUE_STRING = () => t('TRUE');
+export const FALSE_STRING = () => t('FALSE');
 
 export const TIMESERIES_CONSTANTS = {
   gridOffsetRight: 20,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -652,7 +652,7 @@ export function extractSeries(
     ...datum,
     [xAxis]:
       datum[xAxis] === null && xAxisType === AxisType.Category
-        ? NULL_STRING
+        ? NULL_STRING()
         : datum[xAxis],
   }));
   const sortedSeries = sortAndFilterSeries(
@@ -730,7 +730,7 @@ export function formatSeriesName(
   } = {},
 ): string {
   if (name === undefined || name === null) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
   if (typeof name === 'boolean' || typeof name === 'bigint') {
     return name.toString();

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -648,7 +648,7 @@ export function extractSeries(
     });
     normalized[xAxis] =
       datum[xAxis] === null && xAxisType === AxisType.Category
-        ? NULL_STRING
+        ? NULL_STRING()
         : normalized[xAxis];
     return normalized;
   });
@@ -737,7 +737,7 @@ export function formatSeriesName(
   } = {},
 ): string {
   if (name === undefined || name === null) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
   if (typeof name === 'boolean' || typeof name === 'bigint') {
     return name.toString();

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -558,7 +558,7 @@ describe('extractSeries', () => {
     ]);
   });
 
-  test('should convert NULL x-values to NULL_STRING for categorical axis', () => {
+  test('should convert NULL x-values to NULL_STRING() for categorical axis', () => {
     const data = [
       {
         browser: 'Firefox',
@@ -585,7 +585,7 @@ describe('extractSeries', () => {
           name: 'count',
           data: [
             ['Firefox', 5],
-            [NULL_STRING, 10],
+            [NULL_STRING(), 10],
             ['Chrome', 8],
           ],
         },
@@ -1351,7 +1351,7 @@ describe('dedupSeries', () => {
 
 describe('sanitizeHtml', () => {
   test('should remove html tags from series name', () => {
-    expect(sanitizeHtml(NULL_STRING)).toEqual('&lt;NULL&gt;');
+    expect(sanitizeHtml('<NULL>')).toEqual('&lt;NULL&gt;');
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -667,7 +667,7 @@ describe('extractSeries', () => {
     ]);
   });
 
-  test('should convert NULL x-values to NULL_STRING for categorical axis', () => {
+  test('should convert NULL x-values to NULL_STRING() for categorical axis', () => {
     const data = [
       {
         browser: 'Firefox',
@@ -694,7 +694,7 @@ describe('extractSeries', () => {
           name: 'count',
           data: [
             ['Firefox', 5],
-            [NULL_STRING, 10],
+            [NULL_STRING(), 10],
             ['Chrome', 8],
           ],
         },
@@ -1624,7 +1624,7 @@ describe('dedupSeries', () => {
 
 describe('sanitizeHtml', () => {
   test('should remove html tags from series name', () => {
-    expect(sanitizeHtml(NULL_STRING)).toEqual('&lt;NULL&gt;');
+    expect(sanitizeHtml('<NULL>')).toEqual('&lt;NULL&gt;');
   });
 });
 

--- a/superset-frontend/src/components/FilterableTable/useCellContentParser.test.ts
+++ b/superset-frontend/src/components/FilterableTable/useCellContentParser.test.ts
@@ -18,14 +18,14 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useCellContentParser } from './useCellContentParser';
+import { NULL_STRING, useCellContentParser } from './useCellContentParser';
 
-test('should return NULL for null cell data', () => {
+test('should return NULL_STRING() for null cell data', () => {
   const { result } = renderHook(() =>
     useCellContentParser({ columnKeys: [], expandedColumns: [] }),
   );
   const parser = result.current;
-  expect(parser({ cellData: null, columnKey: '' })).toBe('NULL');
+  expect(parser({ cellData: null, columnKey: '' })).toBe(NULL_STRING());
 });
 
 test('should return truncated string for complex columns', () => {

--- a/superset-frontend/src/components/FilterableTable/useCellContentParser.ts
+++ b/superset-frontend/src/components/FilterableTable/useCellContentParser.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { useCallback, useMemo } from 'react';
+import { t } from '@apache-superset/core/translation';
 
 export type CellDataType = string | number | null;
 
-export const NULL_STRING = 'NULL';
+export const NULL_STRING = () => t('NULL');
 
 type Params = {
   columnKeys: string[];
@@ -50,7 +51,7 @@ export function useCellContentParser({ columnKeys, expandedColumns }: Params) {
       columnKey: string;
     }) => {
       if (cellData === null) {
-        return NULL_STRING;
+        return NULL_STRING();
       }
       const content = String(cellData);
       const firstCharacter = content.substring(0, 1);

--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -41,7 +41,7 @@ export const renderResultCell = ({
   const cellNode =
     getCellContent?.({ cellData, columnKey }) ?? String(cellData);
   if (cellData === null) {
-    return <i className="text-muted">{NULL_STRING}</i>;
+    return <i className="text-muted">{NULL_STRING()}</i>;
   }
   const jsonObject = safeJsonObjectParse(cellData);
   if (jsonObject) {

--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -45,7 +45,7 @@ export const renderResultCell = ({
   const cellNode =
     getCellContent?.({ cellData, columnKey }) ?? String(cellData);
   if (cellData === null) {
-    return <i className="text-muted">{NULL_STRING}</i>;
+    return <i className="text-muted">{NULL_STRING()}</i>;
   }
   const jsonObject = safeJsonObjectParse(cellData);
   if (jsonObject) {

--- a/superset-frontend/src/explore/components/controls/CollectionControl/CollectionControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl/CollectionControl.test.tsx
@@ -20,6 +20,7 @@ import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import CollectionControl from '.';
 
 jest.mock('@superset-ui/chart-controls', () => ({
+  ...jest.requireActual('@superset-ui/chart-controls'),
   InfoTooltip: (props: any) => (
     <button
       onClick={props.onClick}

--- a/superset-frontend/src/explore/exploreUtils/getSimpleSQLExpression.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getSimpleSQLExpression.test.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 import { cleanup } from 'spec/helpers/testing-library';
-import { EMPTY_STRING, NULL_STRING } from 'src/utils/common';
+import {
+  EMPTY_STRING,
+  NULL_STRING,
+  TRUE_STRING,
+  FALSE_STRING,
+} from 'src/utils/common';
 import { getSimpleSQLExpression } from '.';
 import { Operators } from '../constants';
 
@@ -45,7 +50,7 @@ test('Should return "" if subject is falsy', () => {
 
 test('Should return null string and empty string', () => {
   expect(getSimpleSQLExpression(params.subject, Operators.In, [null, ''])).toBe(
-    `subject ${Operators.In} (${NULL_STRING}, ${EMPTY_STRING})`,
+    `subject ${Operators.In} (${NULL_STRING()}, ${EMPTY_STRING()})`,
   );
 });
 
@@ -73,12 +78,12 @@ test('Should return correct string when subject and operator are valid values', 
 
 test('Should handle boolean false comparator as a string value', () => {
   expect(getSimpleSQLExpression(params.subject, params.operator, false)).toBe(
-    "subject operator 'FALSE'",
+    `subject operator '${FALSE_STRING()}'`,
   );
 });
 
 test('Should handle boolean true comparator as a string value', () => {
   expect(getSimpleSQLExpression(params.subject, params.operator, true)).toBe(
-    "subject operator 'TRUE'",
+    `subject operator '${TRUE_STRING()}'`,
   );
 });

--- a/superset-frontend/src/explore/exploreUtils/getSimpleSQLExpression.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getSimpleSQLExpression.test.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 import { cleanup } from 'spec/helpers/testing-library';
-import { EMPTY_STRING, NULL_STRING } from 'src/utils/common';
+import {
+  EMPTY_STRING,
+  NULL_STRING,
+  TRUE_STRING,
+  FALSE_STRING,
+} from 'src/utils/common';
 import { getSimpleSQLExpression } from '.';
 import { Operators } from '../constants';
 
@@ -45,7 +50,7 @@ test('Should return "" if subject is falsy', () => {
 
 test('Should return null string and empty string', () => {
   expect(getSimpleSQLExpression(params.subject, Operators.In, [null, ''])).toBe(
-    `subject ${Operators.In} (${NULL_STRING}, ${EMPTY_STRING})`,
+    `subject ${Operators.In} (${NULL_STRING()}, ${EMPTY_STRING()})`,
   );
 });
 
@@ -73,13 +78,13 @@ test('Should return correct string when subject and operator are valid values', 
 
 test('Should handle boolean false comparator as a string value', () => {
   expect(getSimpleSQLExpression(params.subject, params.operator, false)).toBe(
-    "subject operator 'FALSE'",
+    `subject operator '${FALSE_STRING()}'`,
   );
 });
 
 test('Should handle boolean true comparator as a string value', () => {
   expect(getSimpleSQLExpression(params.subject, params.operator, true)).toBe(
-    "subject operator 'TRUE'",
+    `subject operator '${TRUE_STRING()}'`,
   );
 });
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -279,7 +279,7 @@ describe('SelectFilterPlugin', () => {
     const filterSelect = screen.getAllByRole('combobox')[0];
     userEvent.click(filterSelect);
     expect(await screen.findByRole('combobox')).toBeInTheDocument();
-    userEvent.click(screen.getByTitle(NULL_STRING));
+    userEvent.click(screen.getByTitle(NULL_STRING()));
     expect(setDataMask).toHaveBeenLastCalledWith({
       extraFormData: {
         filters: [
@@ -291,7 +291,7 @@ describe('SelectFilterPlugin', () => {
         ],
       },
       filterState: {
-        label: `boy, ${NULL_STRING}`,
+        label: `boy, ${NULL_STRING()}`,
         value: ['boy', null],
         excludeFilterValues: true,
       },
@@ -1002,7 +1002,7 @@ test('Select boolean filter with null values', async () => {
   const filterSelect = screen.getByRole('combobox');
   userEvent.click(filterSelect);
 
-  const nullOption = await screen.findByRole('option', { name: NULL_STRING });
+  const nullOption = await screen.findByRole('option', { name: NULL_STRING() });
   userEvent.click(nullOption);
 
   await waitFor(() => {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -285,7 +285,7 @@ describe('SelectFilterPlugin', () => {
     const filterSelect = screen.getAllByRole('combobox')[0];
     userEvent.click(filterSelect);
     expect(await screen.findByRole('combobox')).toBeInTheDocument();
-    userEvent.click(screen.getByTitle(NULL_STRING));
+    userEvent.click(screen.getByTitle(NULL_STRING()));
     expect(setDataMask).toHaveBeenLastCalledWith({
       extraFormData: {
         filters: [
@@ -297,7 +297,7 @@ describe('SelectFilterPlugin', () => {
         ],
       },
       filterState: {
-        label: `boy, ${NULL_STRING}`,
+        label: `boy, ${NULL_STRING()}`,
         value: ['boy', null],
         excludeFilterValues: true,
       },
@@ -1303,7 +1303,7 @@ test('Select boolean filter with null values', async () => {
   const filterSelect = screen.getByRole('combobox');
   userEvent.click(filterSelect);
 
-  const nullOption = await screen.findByRole('option', { name: NULL_STRING });
+  const nullOption = await screen.findByRole('option', { name: NULL_STRING() });
   userEvent.click(nullOption);
 
   await waitFor(() => {

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -143,23 +143,27 @@ describe('Filter utils', () => {
   describe('getDataRecordFormatter', () => {
     test('default formatter returns expected values', () => {
       const formatter = getDataRecordFormatter();
-      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING);
+      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING());
       expect(formatter('foo', GenericDataType.String)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Numeric)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Temporal)).toEqual('foo');
-      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(true, GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter(false, GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter('true', GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter('false', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter('TRUE', GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter('FALSE', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(1, GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter(2, GenericDataType.Boolean)).toEqual(TRUE_STRING);
+      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter(true, GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter(false, GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter('true', GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter('false', GenericDataType.Boolean)).toEqual(
+        FALSE_STRING(),
+      );
+      expect(formatter('TRUE', GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter('FALSE', GenericDataType.Boolean)).toEqual(
+        FALSE_STRING(),
+      );
+      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter(1, GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter(2, GenericDataType.Boolean)).toEqual(TRUE_STRING());
       expect(formatter(0, GenericDataType.String)).toEqual('0');
       expect(formatter(0, GenericDataType.Numeric)).toEqual('0');
       expect(formatter(0, GenericDataType.Temporal)).toEqual('0');
@@ -173,7 +177,7 @@ describe('Filter utils', () => {
         '1234567.89',
       );
       expect(formatter(1234567.89, GenericDataType.Boolean)).toEqual(
-        TRUE_STRING,
+        TRUE_STRING(),
       );
     });
 
@@ -182,20 +186,20 @@ describe('Filter utils', () => {
         timeFormatter: getTimeFormatter(TimeFormats.DATABASE_DATETIME),
         numberFormatter: getNumberFormatter(NumberFormats.SMART_NUMBER),
       });
-      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING);
+      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING());
       expect(formatter('foo', GenericDataType.String)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Numeric)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Temporal)).toEqual('foo');
-      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING);
+      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING());
       expect(formatter(0, GenericDataType.String)).toEqual('0');
       expect(formatter(0, GenericDataType.Numeric)).toEqual('0');
       expect(formatter(0, GenericDataType.Temporal)).toEqual(
         '1970-01-01 00:00:00',
       );
-      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING);
+      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING());
       expect(formatter(1234567.89, GenericDataType.String)).toEqual(
         '1234567.89',
       );
@@ -204,7 +208,7 @@ describe('Filter utils', () => {
         '1970-01-01 00:20:34',
       );
       expect(formatter(1234567.89, GenericDataType.Boolean)).toEqual(
-        TRUE_STRING,
+        TRUE_STRING(),
       );
       expect(formatter('1970-01-01 00:00:00', GenericDataType.String)).toEqual(
         '1970-01-01 00:00:00',
@@ -213,7 +217,7 @@ describe('Filter utils', () => {
         '1970-01-01 00:00:00',
       );
       expect(formatter('1970-01-01 00:00:00', GenericDataType.Boolean)).toEqual(
-        FALSE_STRING,
+        FALSE_STRING(),
       );
       expect(
         formatter('1970-01-01 00:00:00', GenericDataType.Temporal),

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -143,23 +143,27 @@ describe('Filter utils', () => {
   describe('getDataRecordFormatter', () => {
     test('default formatter returns expected values', () => {
       const formatter = getDataRecordFormatter();
-      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING);
+      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING());
       expect(formatter('foo', GenericDataType.String)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Numeric)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Temporal)).toEqual('foo');
-      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(true, GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter(false, GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter('true', GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter('false', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter('TRUE', GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter('FALSE', GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING);
-      expect(formatter(1, GenericDataType.Boolean)).toEqual(TRUE_STRING);
-      expect(formatter(2, GenericDataType.Boolean)).toEqual(TRUE_STRING);
+      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter(true, GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter(false, GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter('true', GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter('false', GenericDataType.Boolean)).toEqual(
+        FALSE_STRING(),
+      );
+      expect(formatter('TRUE', GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter('FALSE', GenericDataType.Boolean)).toEqual(
+        FALSE_STRING(),
+      );
+      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING());
+      expect(formatter(1, GenericDataType.Boolean)).toEqual(TRUE_STRING());
+      expect(formatter(2, GenericDataType.Boolean)).toEqual(TRUE_STRING());
       expect(formatter(0, GenericDataType.String)).toEqual('0');
       expect(formatter(0, GenericDataType.Numeric)).toEqual('0');
       expect(formatter(0, GenericDataType.Temporal)).toEqual('0');
@@ -173,7 +177,7 @@ describe('Filter utils', () => {
         '1234567.89',
       );
       expect(formatter(1234567.89, GenericDataType.Boolean)).toEqual(
-        TRUE_STRING,
+        TRUE_STRING(),
       );
     });
 
@@ -204,20 +208,20 @@ describe('Filter utils', () => {
         timeFormatter: getTimeFormatter(TimeFormats.DATABASE_DATETIME),
         numberFormatter: getNumberFormatter(NumberFormats.SMART_NUMBER),
       });
-      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING);
-      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING);
+      expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Temporal)).toEqual(NULL_STRING());
+      expect(formatter(null, GenericDataType.Boolean)).toEqual(NULL_STRING());
       expect(formatter('foo', GenericDataType.String)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Numeric)).toEqual('foo');
       expect(formatter('foo', GenericDataType.Temporal)).toEqual('foo');
-      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING);
+      expect(formatter('foo', GenericDataType.Boolean)).toEqual(FALSE_STRING());
       expect(formatter(0, GenericDataType.String)).toEqual('0');
       expect(formatter(0, GenericDataType.Numeric)).toEqual('0');
       expect(formatter(0, GenericDataType.Temporal)).toEqual(
         '1970-01-01 00:00:00',
       );
-      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING);
+      expect(formatter(0, GenericDataType.Boolean)).toEqual(FALSE_STRING());
       expect(formatter(1234567.89, GenericDataType.String)).toEqual(
         '1234567.89',
       );
@@ -226,7 +230,7 @@ describe('Filter utils', () => {
         '1970-01-01 00:20:34',
       );
       expect(formatter(1234567.89, GenericDataType.Boolean)).toEqual(
-        TRUE_STRING,
+        TRUE_STRING(),
       );
       expect(formatter('1970-01-01 00:00:00', GenericDataType.String)).toEqual(
         '1970-01-01 00:00:00',
@@ -235,7 +239,7 @@ describe('Filter utils', () => {
         '1970-01-01 00:00:00',
       );
       expect(formatter('1970-01-01 00:00:00', GenericDataType.Boolean)).toEqual(
-        FALSE_STRING,
+        FALSE_STRING(),
       );
       expect(
         formatter('1970-01-01 00:00:00', GenericDataType.Temporal),

--- a/superset-frontend/src/filters/utils.ts
+++ b/superset-frontend/src/filters/utils.ts
@@ -130,18 +130,18 @@ export function getDataRecordFormatter({
 } = {}): DataRecordValueFormatter {
   return (value, dtype) => {
     if (value === null || value === undefined) {
-      return NULL_STRING;
+      return NULL_STRING();
     }
     if (typeof value === 'boolean') {
-      return value ? TRUE_STRING : FALSE_STRING;
+      return value ? TRUE_STRING() : FALSE_STRING();
     }
     if (dtype === GenericDataType.Boolean) {
       try {
         return JSON.parse(String(value).toLowerCase())
-          ? TRUE_STRING
-          : FALSE_STRING;
+          ? TRUE_STRING()
+          : FALSE_STRING();
       } catch {
-        return FALSE_STRING;
+        return FALSE_STRING();
       }
     }
     if (typeof value === 'string') {

--- a/superset-frontend/src/utils/common.test.tsx
+++ b/superset-frontend/src/utils/common.test.tsx
@@ -34,15 +34,15 @@ describe('utils/common', () => {
     test('converts values as expected', () => {
       expect(optionFromValue(false)).toEqual({
         value: false,
-        label: FALSE_STRING,
+        label: FALSE_STRING(),
       });
       expect(optionFromValue(true)).toEqual({
         value: true,
-        label: TRUE_STRING,
+        label: TRUE_STRING(),
       });
       expect(optionFromValue(null)).toEqual({
-        value: NULL_STRING,
-        label: NULL_STRING,
+        value: NULL_STRING(),
+        label: NULL_STRING(),
       });
       expect(optionFromValue('')).toEqual({
         value: '',

--- a/superset-frontend/src/utils/common.test.tsx
+++ b/superset-frontend/src/utils/common.test.tsx
@@ -30,15 +30,15 @@ import {
 test('converts values as expected', () => {
   expect(optionFromValue(false)).toEqual({
     value: false,
-    label: FALSE_STRING,
+    label: FALSE_STRING(),
   });
   expect(optionFromValue(true)).toEqual({
     value: true,
-    label: TRUE_STRING,
+    label: TRUE_STRING(),
   });
   expect(optionFromValue(null)).toEqual({
-    value: NULL_STRING,
-    label: NULL_STRING,
+    value: NULL_STRING(),
+    label: NULL_STRING(),
   });
   expect(optionFromValue('')).toEqual({
     value: '',

--- a/superset-frontend/src/utils/common.ts
+++ b/superset-frontend/src/utils/common.ts
@@ -24,12 +24,14 @@ import {
   JsonObject,
 } from '@superset-ui/core';
 
-// ATTENTION: If you change any constants, make sure to also change constants.py
+import {
+  EMPTY_STRING,
+  NULL_STRING,
+  TRUE_STRING,
+  FALSE_STRING,
+} from '../../plugins/plugin-chart-echarts/src/constants';
 
-export const EMPTY_STRING = '<empty string>';
-export const NULL_STRING = '<NULL>';
-export const TRUE_STRING = 'TRUE';
-export const FALSE_STRING = 'FALSE';
+export { EMPTY_STRING, NULL_STRING, TRUE_STRING, FALSE_STRING };
 
 // dayjs time format strings
 export const SHORT_DATE = 'MMM D, YYYY';
@@ -40,7 +42,7 @@ const DATETIME_FORMATTER = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
 export type OptionValue = string | number | boolean | null;
 
 export interface OptionItem {
-  value: OptionValue | typeof NULL_STRING;
+  value: OptionValue | ReturnType<typeof NULL_STRING>;
   label: string;
 }
 
@@ -65,16 +67,16 @@ export function storeQuery(query: JsonObject): Promise<string> {
 
 export function optionLabel(opt: OptionValue): string {
   if (opt === null) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
   if (opt === '') {
-    return EMPTY_STRING;
+    return EMPTY_STRING();
   }
   if (opt === true) {
-    return TRUE_STRING;
+    return TRUE_STRING();
   }
   if (opt === false) {
-    return FALSE_STRING;
+    return FALSE_STRING();
   }
   if (typeof opt !== 'string' && typeof opt === 'number') {
     return opt.toString();
@@ -84,9 +86,9 @@ export function optionLabel(opt: OptionValue): string {
 
 export function optionValue(
   opt: OptionValue,
-): OptionValue | typeof NULL_STRING {
+): OptionValue | ReturnType<typeof NULL_STRING> {
   if (opt === null) {
-    return NULL_STRING;
+    return NULL_STRING();
   }
   return opt;
 }

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -15,17 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# ATTENTION: If you change any constants, make sure to also change utils/common.js
+# ATTENTION: If you change any constants, make sure to also change
+# plugins/plugin-chart-echarts/src/constants.ts
 
 # string to use when None values *need* to be converted to/from strings
 from enum import Enum
+
+from flask_babel import gettext as __
 
 from superset.utils.backports import StrEnum
 
 DEFAULT_USER_AGENT = "Apache Superset"
 
-NULL_STRING = "<NULL>"
-EMPTY_STRING = "<empty string>"
+NULL_STRING = __("<NULL>")
+EMPTY_STRING = __("<empty string>")
 
 CHANGE_ME_SECRET_KEY = "CHANGE_ME_TO_A_COMPLEX_RANDOM_SECRET"  # noqa: S105
 CHANGE_ME_GUEST_TOKEN_JWT_SECRET = "test-guest-secret-change-me"  # noqa: S105


### PR DESCRIPTION
### SUMMARY

This PR aims to easily allow translation or customization of the constants `<NULL>`, `TRUE`, `FALSE`, and `<empty string>`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Here is an example of customizing  `<NULL>` into French, before and after:

<img width="1218" height="348" alt="image" src="https://github.com/user-attachments/assets/cc68f2ca-3d89-4df1-9be4-ee7e1ec0fc3f" />

<img width="1207" height="391" alt="image" src="https://github.com/user-attachments/assets/a88d2569-a781-45a5-bcdf-a68511eed684" />

### TESTING INSTRUCTIONS

To test this change, you must first translate the strings in question and observe the screens where they may be displayed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
