### PR TITLE
fix(currency): derive default symbol position from locale when unset

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -84,6 +84,11 @@ Operators can tune or disable the policy via config:
 ### Data uploads bounded by UPLOAD_MAX_FILE_SIZE_BYTES
 
 Single data-file uploads (CSV, Excel, columnar) are now bounded by the `UPLOAD_MAX_FILE_SIZE_BYTES` config option, which defaults to `100 * 1024 * 1024` (100 MB). Files larger than this are rejected with a `413` before their contents are buffered into memory. Set `UPLOAD_MAX_FILE_SIZE_BYTES = None` to disable the check and restore unbounded uploads.
+### Currency symbol position follows the locale when unset
+
+When a chart's currency control leaves the **Prefix or suffix** field empty, the currency symbol position is now derived from the deployment locale's own convention via `Intl.NumberFormat` instead of always defaulting to a suffix. For example, under the default `en-US` locale `USD`, `GBP`, and `EUR` render as a prefix (`$ 1,000`), while eurozone locales such as `fr-FR` render `EUR` as a suffix (`1 000 €`). An explicit Prefix/Suffix selection is always honored and is unaffected.
+
+Charts that relied on the previous always-suffix default for an unset position will render the symbol on the locale-appropriate side instead; set the position explicitly on the metric's currency control to pin it.
 
 ### Duration formatter precision
 

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
@@ -22,6 +22,11 @@ import { getNumberFormatter, NumberFormats } from '../number-format';
 import { Currency } from '../query';
 import { RowData, RowDataValue } from './types';
 import { AUTO_CURRENCY_SYMBOL, ISO_4217_REGEX } from './CurrencyFormats';
+import { getCurrencyLocale } from './currencyLocale';
+import {
+  resolveSymbolPosition,
+  formatWithSymbolPosition,
+} from './symbolPosition';
 
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 
@@ -86,7 +91,7 @@ class CurrencyFormatter extends ExtensibleFunction {
     );
     this.d3Format = config.d3Format || NumberFormats.SMART_NUMBER;
     this.currency = config.currency;
-    this.locale = config.locale || 'en-US';
+    this.locale = config.locale || getCurrencyLocale();
   }
 
   hasValidCurrency() {
@@ -124,13 +129,16 @@ class CurrencyFormatter extends ExtensibleFunction {
           try {
             const symbol = getCurrencySymbol({ symbol: normalizedCurrency });
             if (symbol) {
-              if (this.currency.symbolPosition === 'prefix') {
-                return `${symbol} ${normalizedValue}`;
-              } else if (this.currency.symbolPosition === 'suffix') {
-                return `${normalizedValue} ${symbol}`;
-              }
-              // Unknown symbolPosition - default to suffix
-              return `${normalizedValue} ${symbol}`;
+              const position = resolveSymbolPosition(
+                normalizedCurrency,
+                this.currency.symbolPosition,
+                this.locale,
+              );
+              return formatWithSymbolPosition(
+                symbol,
+                normalizedValue,
+                position,
+              );
             }
           } catch {
             // Invalid currency code - return value without currency symbol
@@ -143,13 +151,15 @@ class CurrencyFormatter extends ExtensibleFunction {
 
     try {
       const symbol = getCurrencySymbol(this.currency);
-      if (this.currency.symbolPosition === 'prefix') {
-        return `${symbol} ${normalizedValue}`;
-      } else if (this.currency.symbolPosition === 'suffix') {
-        return `${normalizedValue} ${symbol}`;
+      if (!symbol) {
+        return formattedValue;
       }
-      // Unknown symbolPosition - default to suffix
-      return `${normalizedValue} ${symbol}`;
+      const position = resolveSymbolPosition(
+        this.currency.symbol,
+        this.currency.symbolPosition,
+        this.locale,
+      );
+      return formatWithSymbolPosition(symbol, normalizedValue, position);
     } catch {
       // Invalid currency code - return value without currency symbol
       return formattedValue;

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/currencyLocale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/currencyLocale.ts
@@ -17,18 +17,24 @@
  * under the License.
  */
 
-export { default as CurrencyFormatter } from './CurrencyFormatter';
-export {
-  getCurrencySymbol,
-  normalizeCurrency,
-  hasMixedCurrencies,
-} from './CurrencyFormatter';
-export { AUTO_CURRENCY_SYMBOL, ISO_4217_REGEX } from './CurrencyFormats';
-export { getCurrencyLocale, setCurrencyLocale } from './currencyLocale';
-export {
-  resolveSymbolPosition,
-  formatWithSymbolPosition,
-  type SymbolPosition,
-} from './symbolPosition';
-export * from './types';
-export * from './utils';
+const DEFAULT_CURRENCY_LOCALE = 'en-US';
+
+let currencyLocale: string = DEFAULT_CURRENCY_LOCALE;
+
+/**
+ * Set the locale used to resolve the default currency symbol position.
+ *
+ * Called once at application bootstrap with the deployment locale so that
+ * currency formatting follows the conventions of that locale (e.g. EUR is a
+ * suffix in `fr-FR`/`de-DE` but a prefix in `en-US`).
+ */
+export function setCurrencyLocale(locale?: string): void {
+  if (locale) {
+    currencyLocale = locale;
+  }
+}
+
+/** Get the locale used to resolve the default currency symbol position. */
+export function getCurrencyLocale(): string {
+  return currencyLocale;
+}

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/currencyLocale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/currencyLocale.ts
@@ -27,10 +27,22 @@ let currencyLocale: string = DEFAULT_CURRENCY_LOCALE;
  * Called once at application bootstrap with the deployment locale so that
  * currency formatting follows the conventions of that locale (e.g. EUR is a
  * suffix in `fr-FR`/`de-DE` but a prefix in `en-US`).
+ *
+ * Superset's bootstrap locale can be underscore-formatted (e.g. `zh_TW`,
+ * `pt_BR`), but `Intl.NumberFormat` expects BCP-47 tags with hyphens. The
+ * value is canonicalized before storing so symbol resolution does not throw
+ * and silently fall back. Empty or invalid tags leave the locale unchanged.
  */
 export function setCurrencyLocale(locale?: string): void {
-  if (locale) {
-    currencyLocale = locale;
+  if (!locale) {
+    return;
+  }
+  try {
+    // getCanonicalLocales throws on a malformed tag and otherwise returns a
+    // non-empty list, so the first entry is always a valid canonical tag here.
+    [currencyLocale] = Intl.getCanonicalLocales(locale.replace(/_/g, '-'));
+  } catch {
+    // Invalid locale tag — keep the previously configured locale.
   }
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/symbolPosition.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/symbolPosition.ts
@@ -29,6 +29,13 @@ const NUMERIC_PART_TYPES = new Set<Intl.NumberFormatPartTypes>([
 ]);
 
 /**
+ * Memoize resolved positions by `(locale, currencyCode)`. `format` runs on a
+ * hot per-value path (every currency cell of every chart), so avoid rebuilding
+ * an `Intl.NumberFormat` and re-parsing the locale for repeated values.
+ */
+const positionCache = new Map<string, SymbolPosition>();
+
+/**
  * Resolve where the currency symbol should be placed relative to the value.
  *
  * An explicit `prefix`/`suffix` is always honored. When the position is unset,
@@ -47,6 +54,11 @@ export function resolveSymbolPosition(
   }
 
   if (currencyCode) {
+    const cacheKey = `${locale}|${currencyCode}`;
+    const cached = positionCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
     try {
       const parts = new Intl.NumberFormat(locale, {
         style: 'currency',
@@ -57,7 +69,9 @@ export function resolveSymbolPosition(
         NUMERIC_PART_TYPES.has(part.type),
       );
       if (currencyIndex !== -1 && valueIndex !== -1) {
-        return currencyIndex < valueIndex ? 'prefix' : 'suffix';
+        const position = currencyIndex < valueIndex ? 'prefix' : 'suffix';
+        positionCache.set(cacheKey, position);
+        return position;
       }
     } catch {
       // Unknown currency or locale — fall back to the default below.

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/symbolPosition.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/symbolPosition.ts
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getCurrencyLocale } from './currencyLocale';
+
+export type SymbolPosition = 'prefix' | 'suffix';
+
+const NUMERIC_PART_TYPES = new Set<Intl.NumberFormatPartTypes>([
+  'integer',
+  'group',
+  'decimal',
+  'fraction',
+]);
+
+/**
+ * Resolve where the currency symbol should be placed relative to the value.
+ *
+ * An explicit `prefix`/`suffix` is always honored. When the position is unset,
+ * it is derived from the locale's own convention for that currency via
+ * `Intl.NumberFormat` (e.g. `$1` in `en-US` is a prefix, `1 €` in `fr-FR` is a
+ * suffix). Unknown currency codes fall back to `prefix`, the most common
+ * convention worldwide.
+ */
+export function resolveSymbolPosition(
+  currencyCode: string | undefined,
+  symbolPosition?: string,
+  locale: string = getCurrencyLocale(),
+): SymbolPosition {
+  if (symbolPosition === 'prefix' || symbolPosition === 'suffix') {
+    return symbolPosition;
+  }
+
+  if (currencyCode) {
+    try {
+      const parts = new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: currencyCode,
+      }).formatToParts(1);
+      const currencyIndex = parts.findIndex(part => part.type === 'currency');
+      const valueIndex = parts.findIndex(part =>
+        NUMERIC_PART_TYPES.has(part.type),
+      );
+      if (currencyIndex !== -1 && valueIndex !== -1) {
+        return currencyIndex < valueIndex ? 'prefix' : 'suffix';
+      }
+    } catch {
+      // Unknown currency or locale — fall back to the default below.
+    }
+  }
+
+  return 'prefix';
+}
+
+/**
+ * Combine a symbol and a formatted value according to the resolved position.
+ */
+export function formatWithSymbolPosition(
+  symbol: string,
+  value: string,
+  position: SymbolPosition,
+): string {
+  return position === 'prefix' ? `${symbol} ${value}` : `${value} ${symbol}`;
+}

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
@@ -285,3 +285,23 @@ test('CurrencyFormatter AUTO mode falls back to plain value when getCurrencySymb
 
   expect(result).toBe('1,000.00');
 });
+
+test('CurrencyFormatter static mode returns plain value when getCurrencySymbol returns undefined', () => {
+  const formatter = new CurrencyFormatter({
+    currency: { symbol: 'USD', symbolPosition: 'prefix' },
+    d3Format: ',.2f',
+  });
+
+  const OrigNumberFormat = Intl.NumberFormat;
+  // formatToParts without a 'currency' entry → getCurrencySymbol returns
+  // undefined, exercising the `if (!symbol)` guard in the static branch.
+  Intl.NumberFormat = jest.fn().mockImplementation(() => ({
+    formatToParts: () => [{ type: 'integer', value: '1' }],
+  })) as unknown as typeof Intl.NumberFormat;
+
+  const result = formatter.format(1000);
+
+  Intl.NumberFormat = OrigNumberFormat;
+
+  expect(result).toBe('1,000.00');
+});

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
@@ -21,7 +21,13 @@ import {
   CurrencyFormatter,
   getCurrencySymbol,
   NumberFormats,
+  setCurrencyLocale,
 } from '@superset-ui/core';
+
+afterEach(() => {
+  // Guard against any test mutating the shared currency locale singleton.
+  setCurrencyLocale('en-US');
+});
 
 test('getCurrencySymbol', () => {
   expect(
@@ -132,7 +138,9 @@ test('CurrencyFormatter:format', () => {
     // @ts-expect-error
     currency: { symbol: 'USD' },
   });
-  expect(currencyFormatterWithoutPosition(VALUE)).toEqual('56.1M $');
+  // With no explicit position, placement follows the locale convention.
+  // USD is a prefix in the default en-US locale.
+  expect(currencyFormatterWithoutPosition(VALUE)).toEqual('$ 56.1M');
 
   // @ts-expect-error
   const currencyFormatterWithoutCurrency = new CurrencyFormatter({});
@@ -200,17 +208,29 @@ test('CurrencyFormatter AUTO mode uses suffix position from row context', () => 
   expect(result).toMatch(/1,000\.00.*€/);
 });
 
-test('CurrencyFormatter AUTO mode uses default suffix when symbolPosition is unknown', () => {
-  const formatter = new CurrencyFormatter({
+test('CurrencyFormatter AUTO mode resolves position from locale when symbolPosition is unset', () => {
+  // Default en-US locale: EUR symbol is a prefix.
+  const enFormatter = new CurrencyFormatter({
     // @ts-expect-error
     currency: { symbol: 'AUTO' },
     d3Format: ',.2f',
   });
 
   const row = { currency: 'EUR' };
-  const result = formatter.format(1000, row, 'currency');
-  expect(result).toContain('€');
-  expect(result).toMatch(/1,000\.00.*€/);
+  const enResult = enFormatter.format(1000, row, 'currency');
+  expect(enResult).toContain('€');
+  expect(enResult).toMatch(/€.*1,000\.00/);
+
+  // fr-FR locale: EUR symbol is a suffix.
+  const frFormatter = new CurrencyFormatter({
+    // @ts-expect-error
+    currency: { symbol: 'AUTO' },
+    d3Format: ',.2f',
+    locale: 'fr-FR',
+  });
+  const frResult = frFormatter.format(1000, row, 'currency');
+  expect(frResult).toContain('€');
+  expect(frResult).toMatch(/1,000\.00.*€/);
 });
 
 test('CurrencyFormatter AUTO mode returns plain value when row currency is not a string (line 52)', () => {

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/currencyLocale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/currencyLocale.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,18 +17,31 @@
  * under the License.
  */
 
-export { default as CurrencyFormatter } from './CurrencyFormatter';
-export {
-  getCurrencySymbol,
-  normalizeCurrency,
-  hasMixedCurrencies,
-} from './CurrencyFormatter';
-export { AUTO_CURRENCY_SYMBOL, ISO_4217_REGEX } from './CurrencyFormats';
-export { getCurrencyLocale, setCurrencyLocale } from './currencyLocale';
-export {
+import {
+  getCurrencyLocale,
+  setCurrencyLocale,
   resolveSymbolPosition,
-  formatWithSymbolPosition,
-  type SymbolPosition,
-} from './symbolPosition';
-export * from './types';
-export * from './utils';
+} from '@superset-ui/core';
+
+afterEach(() => {
+  // Restore the default so other tests are not affected by the global locale.
+  setCurrencyLocale('en-US');
+});
+
+test('currency locale defaults to en-US', () => {
+  expect(getCurrencyLocale()).toEqual('en-US');
+});
+
+test('setCurrencyLocale updates the locale used to resolve unset positions', () => {
+  setCurrencyLocale('fr-FR');
+  expect(getCurrencyLocale()).toEqual('fr-FR');
+  // EUR is a suffix in fr-FR.
+  expect(resolveSymbolPosition('EUR')).toEqual('suffix');
+});
+
+test('setCurrencyLocale ignores empty values', () => {
+  setCurrencyLocale('de-DE');
+  setCurrencyLocale(undefined);
+  setCurrencyLocale('');
+  expect(getCurrencyLocale()).toEqual('de-DE');
+});

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/currencyLocale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/currencyLocale.test.ts
@@ -45,3 +45,21 @@ test('setCurrencyLocale ignores empty values', () => {
   setCurrencyLocale('');
   expect(getCurrencyLocale()).toEqual('de-DE');
 });
+
+test('setCurrencyLocale canonicalizes underscore-formatted locales to BCP-47', () => {
+  // Superset bootstrap can emit underscore tags like `pt_BR`/`zh_TW`.
+  setCurrencyLocale('pt_BR');
+  expect(getCurrencyLocale()).toEqual('pt-BR');
+  // BRL is a prefix in pt-BR; the placement must resolve instead of throwing
+  // and falling back.
+  expect(resolveSymbolPosition('BRL')).toEqual('prefix');
+
+  setCurrencyLocale('zh_TW');
+  expect(getCurrencyLocale()).toEqual('zh-TW');
+});
+
+test('setCurrencyLocale keeps the previous locale for invalid tags', () => {
+  setCurrencyLocale('fr-FR');
+  setCurrencyLocale('not a locale!');
+  expect(getCurrencyLocale()).toEqual('fr-FR');
+});

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
@@ -38,6 +38,12 @@ test('resolveSymbolPosition derives the position from the locale when unset', ()
   expect(resolveSymbolPosition('EUR', undefined, 'de-DE')).toEqual('suffix');
 });
 
+test('resolveSymbolPosition returns the same result on repeated calls (cached)', () => {
+  // The second call hits the memoized (locale, currencyCode) entry.
+  expect(resolveSymbolPosition('EUR', undefined, 'fr-FR')).toEqual('suffix');
+  expect(resolveSymbolPosition('EUR', undefined, 'fr-FR')).toEqual('suffix');
+});
+
 test('resolveSymbolPosition falls back to prefix for unknown currencies', () => {
   expect(resolveSymbolPosition('INVALID_CODE', undefined, 'en-US')).toEqual(
     'prefix',

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
@@ -53,6 +53,21 @@ test('resolveSymbolPosition falls back to prefix for unknown currencies', () => 
   );
 });
 
+test('resolveSymbolPosition falls back to prefix when locale parts lack a currency', () => {
+  const OrigNumberFormat = Intl.NumberFormat;
+  // formatToParts without a 'currency' part → currencyIndex is -1, so the
+  // position cannot be derived and the default prefix is returned. Use a
+  // locale/currency pair not exercised elsewhere so the memoization cache
+  // does not short-circuit this call.
+  Intl.NumberFormat = jest.fn().mockImplementation(() => ({
+    formatToParts: () => [{ type: 'integer', value: '1' }],
+  })) as unknown as typeof Intl.NumberFormat;
+
+  expect(resolveSymbolPosition('USD', undefined, 'zz-mock')).toEqual('prefix');
+
+  Intl.NumberFormat = OrigNumberFormat;
+});
+
 test('formatWithSymbolPosition places the symbol according to the position', () => {
   expect(formatWithSymbolPosition('$', '1,000', 'prefix')).toEqual('$ 1,000');
   expect(formatWithSymbolPosition('€', '1,000', 'suffix')).toEqual('1,000 €');

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/symbolPosition.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  resolveSymbolPosition,
+  formatWithSymbolPosition,
+} from '@superset-ui/core';
+
+test('resolveSymbolPosition honors an explicit position regardless of locale', () => {
+  expect(resolveSymbolPosition('EUR', 'prefix', 'fr-FR')).toEqual('prefix');
+  expect(resolveSymbolPosition('USD', 'suffix', 'en-US')).toEqual('suffix');
+});
+
+test('resolveSymbolPosition derives the position from the locale when unset', () => {
+  // en-US places the symbol before the value for these currencies.
+  expect(resolveSymbolPosition('USD', undefined, 'en-US')).toEqual('prefix');
+  expect(resolveSymbolPosition('GBP', undefined, 'en-US')).toEqual('prefix');
+  expect(resolveSymbolPosition('EUR', undefined, 'en-US')).toEqual('prefix');
+
+  // Eurozone locales place the EUR symbol after the value.
+  expect(resolveSymbolPosition('EUR', undefined, 'fr-FR')).toEqual('suffix');
+  expect(resolveSymbolPosition('EUR', undefined, 'de-DE')).toEqual('suffix');
+});
+
+test('resolveSymbolPosition falls back to prefix for unknown currencies', () => {
+  expect(resolveSymbolPosition('INVALID_CODE', undefined, 'en-US')).toEqual(
+    'prefix',
+  );
+  expect(resolveSymbolPosition(undefined, undefined, 'en-US')).toEqual(
+    'prefix',
+  );
+});
+
+test('formatWithSymbolPosition places the symbol according to the position', () => {
+  expect(formatWithSymbolPosition('$', '1,000', 'prefix')).toEqual('$ 1,000');
+  expect(formatWithSymbolPosition('€', '1,000', 'suffix')).toEqual('1,000 €');
+});

--- a/superset-frontend/src/setup/setupFormatters.test.ts
+++ b/superset-frontend/src/setup/setupFormatters.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const mockSetCurrencyLocale = jest.fn();
+
+// Stub the formatter registries so the test focuses on the currency-locale
+// wiring without exercising real d3/Intl registry setup.
+const chainableRegistry = () => {
+  const registry: Record<string, jest.Mock> = {};
+  ['setD3Format', 'registerValue', 'setDefaultKey'].forEach(method => {
+    registry[method] = jest.fn(() => registry);
+  });
+  registry.d3Format = jest.fn() as unknown as jest.Mock;
+  return registry;
+};
+
+jest.mock('@superset-ui/core', () => ({
+  setCurrencyLocale: mockSetCurrencyLocale,
+  getNumberFormatterRegistry: jest.fn(() => chainableRegistry()),
+  getTimeFormatterRegistry: jest.fn(() => chainableRegistry()),
+  getNumberFormatter: jest.fn(() => jest.fn()),
+  createDurationFormatter: jest.fn(() => jest.fn()),
+  createMemoryFormatter: jest.fn(() => jest.fn()),
+  createSmartDateFormatter: jest.fn(() => jest.fn()),
+  createSmartDateVerboseFormatter: jest.fn(() => jest.fn()),
+  createSmartDateDetailedFormatter: jest.fn(() => jest.fn()),
+  NumberFormats: { INTEGER: ',d', INTEGER_SIGNED: '+,d' },
+  SMART_DATE_ID: 'smart_date',
+  SMART_DATE_DETAILED_ID: 'smart_date_detailed',
+  SMART_DATE_VERBOSE_ID: 'smart_date_verbose',
+}));
+
+async function runSetupFormatters(locale: string) {
+  // Imported lazily so the jest.mock factory above is initialized first.
+  const { default: setupFormatters } = await import('./setupFormatters');
+  setupFormatters({}, {}, locale);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('setupFormatters wires the deployment locale into the currency locale', async () => {
+  await runSetupFormatters('fr-FR');
+
+  expect(mockSetCurrencyLocale).toHaveBeenCalledWith('fr-FR');
+});
+
+test('setupFormatters forwards an underscore-formatted locale to setCurrencyLocale', async () => {
+  // currencyLocale.setCurrencyLocale is responsible for canonicalizing the tag;
+  // setupFormatters must forward it untouched.
+  await runSetupFormatters('pt_BR');
+
+  expect(mockSetCurrencyLocale).toHaveBeenCalledWith('pt_BR');
+});

--- a/superset-frontend/src/setup/setupFormatters.ts
+++ b/superset-frontend/src/setup/setupFormatters.ts
@@ -29,6 +29,7 @@ import {
   createSmartDateVerboseFormatter,
   createSmartDateDetailedFormatter,
   createMemoryFormatter,
+  setCurrencyLocale,
 } from '@superset-ui/core';
 import { FormatLocaleDefinition } from 'd3-format';
 import { TimeLocaleDefinition } from 'd3-time-format';
@@ -38,6 +39,10 @@ export default function setupFormatters(
   d3TimeFormat: Partial<TimeLocaleDefinition>,
   locale: string,
 ) {
+  // Resolve the default currency symbol position (prefix/suffix) according to
+  // the deployment locale's conventions when a chart leaves it unset.
+  setCurrencyLocale(locale);
+
   getNumberFormatterRegistry()
     .setD3Format(d3NumberFormat)
     // Add shims for format strings that are deprecated or common typos.


### PR DESCRIPTION
### SUMMARY

Resolves #40930. Co-authored with @kleostouraiti, based on her original implementation.

When a chart's currency control leaves the **Prefix or suffix** field empty, `CurrencyFormatter` always placed the symbol as a **suffix**, regardless of currency or locale (`// Unknown symbolPosition - default to suffix`). This renders common currencies on the wrong side — e.g. `56.1M $` instead of `$ 56.1M` under `en-US`.

This change derives the default symbol position from the deployment locale's own convention via `Intl.NumberFormat`, falling back to `prefix` for unknown currency codes:

- `en-US`: `USD`, `GBP`, `EUR` → prefix (`$ 56.1M`)
- `fr-FR` / `de-DE`: `EUR` → suffix (`56.1M €`)

An **explicit** Prefix/Suffix selection is always honored and is unaffected. The locale is wired through `setupFormatters` at bootstrap, reusing the same locale already passed to it for d3 number formatting, so no new plumbing is threaded through chart plugins.

**Design notes**
- New `currencyLocale.ts` holds a small module-level locale singleton (`get/setCurrencyLocale`, default `en-US`), mirroring how d3 formatting is configured globally — this avoids adding a `locale` argument to the widely-used `getValueFormatter`/`buildCustomFormatters` call sites.
- New `symbolPosition.ts` exposes `resolveSymbolPosition()` (never throws; falls back to `prefix`) and `formatWithSymbolPosition()`.
- `Intl.NumberFormat` is used as the single source of truth for per-locale/per-currency placement, so there is no hardcoded currency list to maintain.

This is a backwards-incompatible change for charts that relied on the previous always-suffix default for an unset position; documented in `UPDATING.md`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — placement-only change. Behavior is covered by unit tests; example outputs:

| Locale | Currency | Position unset — before | Position unset — after |
|--------|----------|-------------------------|------------------------|
| en-US  | USD      | `56.1M $`               | `$ 56.1M`              |
| en-US  | EUR      | `56.1M €`               | `€ 56.1M`              |
| fr-FR  | EUR      | `56.1M €`               | `56.1M €`              |

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- packages/superset-ui-core/test/currency-format
```

New/updated suites: `symbolPosition.test.ts`, `currencyLocale.test.ts`, `CurrencyFormatter.test.ts` (7 suites, 51 tests pass). Manual: set a metric's currency without choosing Prefix/Suffix on a deployment configured with `en-US` vs `fr-FR` and confirm the symbol side follows the locale.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40930
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
