### PR TITLE
fix: use Series.iloc for positional access in generate_join_column

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2289,7 +2289,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         time_grain: str,
         time_offset: str | None = None,
     ) -> str:
-        value = row[column_index]
+        value = row.iloc[column_index]
 
         if hasattr(value, "strftime"):
             if time_offset and not ExploreMixin.is_valid_date_range_static(time_offset):


### PR DESCRIPTION
## What

Silences a pandas `FutureWarning` that fires on every chart render using time-shift joins:

```
FutureWarning: Series.__getitem__ treating keys as positions is deprecated.
In a future version, integer keys will always be treated as labels
(consistent with DataFrame behavior). To access a value by position,
use `ser.iloc[pos]`
  value = row[column_index]
```

**Source:** `superset/models/helpers.py` — `ExploreMixin.generate_join_column`

## Change

```diff
-        value = row[column_index]
+        value = row.iloc[column_index]
```

`df.apply(..., axis=1)` produces a `pd.Series` per row whose index labels are the DataFrame column names (always strings from SQL result sets). `row[0]` was being resolved positionally, which pandas now warns against. `.iloc[column_index]` is the explicit positional API and matches the original intent exactly.

## No behavior change

`row[0]` and `row.iloc[0]` return the same value for any DataFrame whose columns are string-labeled (the only case that can reach this code path). This is a pure deprecation fix.

## Test plan

- Existing tests in `tests/unit_tests/common/test_time_shifts.py` cover `generate_join_column` via all four time grains and pass on this branch.
- No new tests needed: the integer-label edge case cannot arise in production (all SQL result set columns are string-named).