### PR TITLE
fix(security): bump pyjwt 2.12.0 to 2.13.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -317,7 +317,7 @@ pygeohash==3.2.2
     # via apache-superset (pyproject.toml)
 pygments==2.20.0
     # via rich
-pyjwt==2.12.0
+pyjwt==2.13.0
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -770,7 +770,7 @@ pyhive==0.7.0
     # via apache-superset
 pyinstrument==5.1.2
     # via apache-superset
-pyjwt==2.12.0
+pyjwt==2.13.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset


### PR DESCRIPTION
## Summary
- Bumps `pyjwt` from 2.12.0 to 2.13.0 in `requirements/base.txt` and `requirements/development.txt`

### CVEs patched
| CVE | Vulnerability | CVSS |
|-----|--------------|------|
| CVE-2026-48526 | Improper Authentication | 8.8 (High) |
| CVE-2026-48523 | Improper Verification of Cryptographic Signature | 5.3 (Medium) |
| CVE-2026-48525 | Allocation of Resources Without Limits or Throttling | 6.9 (Medium) |
| CVE-2026-48524 | Improper Cleanup on Thrown Exception | - |

PyJWT's `pyproject.toml` constraint is `>=2.4.0, <3.0`, so 2.13.0 is within the allowed range.

## Test plan
- [ ] CI passes with updated dependency
- [ ] JWT-based authentication continues to work correctly