### PR TITLE
fix(plugin-chart-handlebars): follow the app theme in Customize code editors

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/handlebarTemplate.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/handlebarTemplate.tsx
@@ -23,7 +23,7 @@ import {
 } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core/translation';
 import { validateNonEmpty } from '@superset-ui/core';
-import { useTheme } from '@apache-superset/core/theme';
+import { useTheme, useThemeMode } from '@apache-superset/core/theme';
 import { InfoTooltip } from '@superset-ui/core/components';
 import { CodeEditor } from '../../components/CodeEditor/CodeEditor';
 import { ControlHeader } from '../../components/ControlHeader/controlHeader';
@@ -37,6 +37,7 @@ const HandlebarsTemplateControl = (
   props: CustomControlConfig<HandlebarsCustomControlProps>,
 ) => {
   const theme = useTheme();
+  const isDarkMode = useThemeMode();
   const val = String(
     props?.value ? props?.value : props?.default ? props?.default : '',
   );
@@ -65,7 +66,7 @@ const HandlebarsTemplateControl = (
         </div>
       </ControlHeader>
       <CodeEditor
-        theme="dark"
+        theme={isDarkMode ? 'dark' : 'light'}
         value={val}
         onChange={source => {
           debounceFunc(props.onChange, source || '');

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
@@ -22,7 +22,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core/translation';
-import { useTheme } from '@apache-superset/core/theme';
+import { useTheme, useThemeMode } from '@apache-superset/core/theme';
 import { InfoTooltip } from '@superset-ui/core/components';
 import { CodeEditor } from '../../components/CodeEditor/CodeEditor';
 import { ControlHeader } from '../../components/ControlHeader/controlHeader';
@@ -35,6 +35,7 @@ interface StyleCustomControlProps {
 
 const StyleControl = (props: CustomControlConfig<StyleCustomControlProps>) => {
   const theme = useTheme();
+  const isDarkMode = useThemeMode();
   const htmlSanitization = props.htmlSanitization ?? true;
 
   const defaultValue = props?.value
@@ -63,7 +64,7 @@ const StyleControl = (props: CustomControlConfig<StyleCustomControlProps>) => {
         </div>
       </ControlHeader>
       <CodeEditor
-        theme="dark"
+        theme={isDarkMode ? 'dark' : 'light'}
         mode="css"
         value={props.value}
         defaultValue={defaultValue}

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/editorTheme.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/editorTheme.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ComponentType } from 'react';
+import { CustomControlItem } from '@superset-ui/chart-controls';
+import { render } from 'spec/helpers/testing-library';
+import { useThemeMode } from '@apache-superset/core/theme';
+import { handlebarsTemplateControlSetItem } from '../../src/plugin/controls/handlebarTemplate';
+import { styleControlSetItem } from '../../src/plugin/controls/style';
+
+const mockCodeEditor = jest.fn((_props: { theme?: string }) => null);
+
+jest.mock('../../src/components/CodeEditor/CodeEditor', () => ({
+  CodeEditor: (props: { theme?: string }) => mockCodeEditor(props),
+}));
+
+jest.mock('@apache-superset/core/theme', () => ({
+  ...jest.requireActual('@apache-superset/core/theme'),
+  useThemeMode: jest.fn(),
+}));
+
+const HandlebarsTemplateControl = (
+  handlebarsTemplateControlSetItem as CustomControlItem
+).config.type as ComponentType<{ value: string; onChange: () => void }>;
+const StyleControl = (styleControlSetItem as CustomControlItem).config
+  .type as ComponentType<{ value: string; onChange: () => void }>;
+
+const mockedUseThemeMode = useThemeMode as jest.Mock;
+
+afterEach(() => jest.clearAllMocks());
+
+test('Handlebars Template editor uses the light Ace theme in a light UI', () => {
+  mockedUseThemeMode.mockReturnValue(false);
+  render(<HandlebarsTemplateControl value="x" onChange={jest.fn()} />);
+  expect(mockCodeEditor).toHaveBeenCalledWith(
+    expect.objectContaining({ theme: 'light' }),
+  );
+});
+
+test('Handlebars Template editor uses the dark Ace theme in a dark UI', () => {
+  mockedUseThemeMode.mockReturnValue(true);
+  render(<HandlebarsTemplateControl value="x" onChange={jest.fn()} />);
+  expect(mockCodeEditor).toHaveBeenCalledWith(
+    expect.objectContaining({ theme: 'dark' }),
+  );
+});
+
+test('CSS Styles editor uses the light Ace theme in a light UI', () => {
+  mockedUseThemeMode.mockReturnValue(false);
+  render(<StyleControl value="x" onChange={jest.fn()} />);
+  expect(mockCodeEditor).toHaveBeenCalledWith(
+    expect.objectContaining({ theme: 'light' }),
+  );
+});
+
+test('CSS Styles editor uses the dark Ace theme in a dark UI', () => {
+  mockedUseThemeMode.mockReturnValue(true);
+  render(<StyleControl value="x" onChange={jest.fn()} />);
+  expect(mockCodeEditor).toHaveBeenCalledWith(
+    expect.objectContaining({ theme: 'dark' }),
+  );
+});


### PR DESCRIPTION
### SUMMARY

The **Handlebars Template** and **CSS Styles** code editors in the Handlebars chart's Customize panel hard-coded the Ace `dark` theme, so they rendered as dark-mode islands inside a light UI (and would stay dark even when the rest of the app is light). This fixes the theme mismatch by deriving the editor theme from the active app theme via `useThemeMode()`, the same pattern already used by the deck.gl `TooltipTemplateEditor`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

| Before | After |
|---|---|
| ![before](https://files.catbox.moe/prc93x.png) | ![after](https://files.catbox.moe/9x7w83.png) |

### TESTING INSTRUCTIONS

1. With a light UI theme, create or edit a Handlebars chart in Explore.
2. Open the **Customize** tab.
3. The **Handlebars Template** and **CSS Styles** editors should use a light editor theme that matches the surrounding UI (previously they were dark).
4. Switch the app to a dark theme and confirm the editors follow to the dark editor theme.

Unit tests cover both editors in light and dark UI.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
