### PR TITLE
fix(chart): keep query-context updates bound to the chart's datasource

### DIFF
--- a/superset/commands/chart/exceptions.py
+++ b/superset/commands/chart/exceptions.py
@@ -103,6 +103,19 @@ class DatasourceTypeUpdateRequiredValidationError(ValidationError):
         )
 
 
+class ChartQueryContextDatasourceMismatchValidationError(ValidationError):
+    """
+    Raised when a query-context-only update carries a datasource that does not
+    match the chart's own datasource.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            _("The query context datasource does not match the chart datasource"),
+            field_name="query_context",
+        )
+
+
 class ChartNotFoundError(CommandException):
     message = "Chart not found."
 

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -29,6 +29,7 @@ from superset.commands.chart.exceptions import (
     ChartForbiddenError,
     ChartInvalidError,
     ChartNotFoundError,
+    ChartQueryContextDatasourceMismatchValidationError,
     ChartUpdateFailedError,
     DashboardsForbiddenError,
     DashboardsNotFoundValidationError,
@@ -46,6 +47,7 @@ from superset.exceptions import SupersetSecurityException
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.tags.models import ObjectType
+from superset.utils import json
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
@@ -106,6 +108,51 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
                 if not security_manager.is_editor(dash):
                     raise DashboardsForbiddenError()
 
+    def _validate_query_context_datasource(
+        self, exceptions: list[ValidationError]
+    ) -> None:
+        """
+        Ensure a query-context-only update keeps the chart's own datasource.
+
+        The submitted query context is only verified when it carries a parseable
+        ``datasource`` object; a payload that references a different datasource than
+        the chart's persisted one is rejected. Payloads without a datasource fall
+        back to the chart's datasource at execution time and need no check.
+        """
+        if not self._model:
+            return
+
+        raw_query_context = self._properties.get("query_context")
+        if not raw_query_context:
+            return
+
+        try:
+            query_context = json.loads(raw_query_context)
+        except (TypeError, ValueError):
+            # An unparseable payload cannot be verified or replayed; leave it for
+            # downstream handling rather than guessing at its intent.
+            return
+
+        datasource = (
+            query_context.get("datasource") if isinstance(query_context, dict) else None
+        )
+        if not isinstance(datasource, dict):
+            return
+
+        try:
+            ids_match = int(datasource["id"]) == self._model.datasource_id
+        except (KeyError, TypeError, ValueError):
+            ids_match = False
+
+        datasource_type = datasource.get("type")
+        types_match = (
+            datasource_type is None
+            or str(datasource_type) == self._model.datasource_type
+        )
+
+        if not ids_match or not types_match:
+            exceptions.append(ChartQueryContextDatasourceMismatchValidationError())
+
     def validate(self) -> None:  # noqa: C901
         exceptions: list[ValidationError] = []
         dashboard_ids = self._properties.get("dashboards")
@@ -140,6 +187,9 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
                 security_manager.raise_for_access(chart=self._model)
             except SupersetSecurityException as ex:
                 raise ChartForbiddenError() from ex
+            # Keep the refreshed payload bound to the chart's own datasource so it
+            # cannot be repointed at an unrelated one.
+            self._validate_query_context_datasource(exceptions)
 
         # validate tags
         try:

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -144,11 +144,12 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         except (KeyError, TypeError, ValueError):
             ids_match = False
 
+        # A datasource object must carry a type that matches the chart's own.
+        # Treating a missing type as valid would let an id-only payload through,
+        # and query-context loading reads datasource["type"] directly, so that
+        # payload raises KeyError when the saved context is later replayed.
         datasource_type = datasource.get("type")
-        types_match = (
-            datasource_type is None
-            or str(datasource_type) == self._model.datasource_type
-        )
+        types_match = str(datasource_type) == self._model.datasource_type
 
         if not ids_match or not types_match:
             exceptions.append(ChartQueryContextDatasourceMismatchValidationError())

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -129,8 +129,11 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         try:
             query_context = json.loads(raw_query_context)
         except (TypeError, ValueError):
-            # An unparseable payload cannot be verified or replayed; leave it for
-            # downstream handling rather than guessing at its intent.
+            # TypeError covers a query_context that isn't a string (e.g. an
+            # already-parsed dict); that shape is intentionally out of scope
+            # here since the schema serializes it as a JSON string. ValueError
+            # covers a string that failed to parse. Either way, an unverifiable
+            # payload is left for downstream handling rather than guessed at.
             return
 
         datasource = (

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -17,10 +17,11 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from superset.commands.chart.exceptions import ChartForbiddenError
+from superset.commands.chart.exceptions import ChartForbiddenError, ChartInvalidError
 from superset.commands.chart.update import UpdateChartCommand
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetSecurityException
+from superset.utils import json
 
 
 def _editorship_exc() -> SupersetSecurityException:
@@ -149,3 +150,76 @@ def test_update_chart_editor_can_perform_regular_update(
     exceptions = compute_subjects.call_args.args[2]
     assert properties["editors"] == [2]
     assert exceptions == []
+
+
+def _query_context_payload(datasource: object) -> dict[str, object]:
+    return {
+        "query_context": json.dumps({"datasource": datasource, "queries": []}),
+        "query_context_generation": True,
+    }
+
+
+def test_update_chart_query_context_matching_datasource_is_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """A query context that targets the chart's own datasource is accepted."""
+    find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
+    find_by_id.return_value = mocker.MagicMock(
+        id=1, tags=[], dashboards=[], datasource_id=42, datasource_type="table"
+    )
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_editorship")
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_access")
+
+    UpdateChartCommand(
+        1, _query_context_payload({"id": 42, "type": "table"})
+    ).validate()
+
+
+@pytest.mark.parametrize(
+    "datasource",
+    [
+        {"id": 99, "type": "table"},  # different id
+        {"id": 42, "type": "query"},  # different type
+        {"id": "99", "type": "table"},  # different id as string
+    ],
+)
+def test_update_chart_query_context_mismatched_datasource_is_rejected(
+    mocker: MockerFixture,
+    datasource: dict[str, object],
+) -> None:
+    """A query context pointing at a different datasource is rejected with a 4xx."""
+    find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
+    find_by_id.return_value = mocker.MagicMock(
+        id=1, tags=[], dashboards=[], datasource_id=42, datasource_type="table"
+    )
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_editorship")
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_access")
+
+    with pytest.raises(ChartInvalidError):
+        UpdateChartCommand(1, _query_context_payload(datasource)).validate()
+
+
+@pytest.mark.parametrize(
+    "query_context",
+    [
+        "{}",  # no datasource key
+        '{"datasource": null}',  # null datasource
+        "not-json",  # unparseable payload
+    ],
+)
+def test_update_chart_query_context_without_datasource_is_allowed(
+    mocker: MockerFixture,
+    query_context: str,
+) -> None:
+    """Payloads with no verifiable datasource fall back to the chart's own."""
+    find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
+    find_by_id.return_value = mocker.MagicMock(
+        id=1, tags=[], dashboards=[], datasource_id=42, datasource_type="table"
+    )
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_editorship")
+    mocker.patch("superset.commands.chart.update.security_manager.raise_for_access")
+
+    UpdateChartCommand(
+        1,
+        {"query_context": query_context, "query_context_generation": True},
+    ).validate()

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -160,19 +160,31 @@ def _query_context_payload(datasource: object) -> dict[str, object]:
     }
 
 
+@pytest.mark.parametrize(
+    "datasource_type",
+    [
+        "table",
+        "query",  # non-table datasource types must also be accepted when matching
+    ],
+)
 def test_update_chart_query_context_matching_datasource_is_allowed(
     mocker: MockerFixture,
+    datasource_type: str,
 ) -> None:
     """A query context that targets the chart's own datasource is accepted."""
     find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
     find_by_id.return_value = mocker.MagicMock(
-        id=1, tags=[], dashboards=[], datasource_id=42, datasource_type="table"
+        id=1,
+        tags=[],
+        dashboards=[],
+        datasource_id=42,
+        datasource_type=datasource_type,
     )
     mocker.patch("superset.commands.chart.update.security_manager.raise_for_editorship")
     mocker.patch("superset.commands.chart.update.security_manager.raise_for_access")
 
     UpdateChartCommand(
-        1, _query_context_payload({"id": 42, "type": "table"})
+        1, _query_context_payload({"id": 42, "type": datasource_type})
     ).validate()
 
 
@@ -183,6 +195,7 @@ def test_update_chart_query_context_matching_datasource_is_allowed(
         {"id": 42, "type": "query"},  # different type
         {"id": "99", "type": "table"},  # different id as string
         {"id": 42},  # matching id but missing type
+        {"id": "5f7b3c1a-...-uuid", "type": "table"},  # non-numeric id
     ],
 )
 def test_update_chart_query_context_mismatched_datasource_is_rejected(

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -153,6 +153,7 @@ def test_update_chart_editor_can_perform_regular_update(
 
 
 def _query_context_payload(datasource: object) -> dict[str, object]:
+    """Build a query-context-only update payload targeting ``datasource``."""
     return {
         "query_context": json.dumps({"datasource": datasource, "queries": []}),
         "query_context_generation": True,
@@ -181,6 +182,7 @@ def test_update_chart_query_context_matching_datasource_is_allowed(
         {"id": 99, "type": "table"},  # different id
         {"id": 42, "type": "query"},  # different type
         {"id": "99", "type": "table"},  # different id as string
+        {"id": 42},  # matching id but missing type
     ],
 )
 def test_update_chart_query_context_mismatched_datasource_is_rejected(


### PR DESCRIPTION
### SUMMARY

When a chart is updated with *only* a `query_context` (the
`{query_context, query_context_generation}` payload that report and alert
workers use to refresh a chart's cached payload), `UpdateChartCommand`
intentionally skips the ownership check so those background workers can save
context without owning the chart.

This change keeps that payload internally consistent: before saving, it
validates that the submitted `query_context.datasource` still references the
chart's own persisted `datasource_id` (and type). A payload that points at a
different datasource is rejected with a 400 rather than being stored as-is.
Payloads that don't carry a parseable `datasource` are unchanged — at execution
time they already fall back to the chart's own datasource — so there's no
behavior change for the normal save flow.

It's a small, well-scoped robustness check on the chart update path so a
chart's stored query context can't drift away from the chart's actual
datasource.

### TESTING INSTRUCTIONS

Unit tests added in `tests/unit_tests/commands/chart/update_test.py`:

- a query context targeting the chart's own datasource is accepted
- a query context referencing a different datasource id/type is rejected
  (`ChartInvalidError` → 400), including the id-as-string case
- payloads with no datasource / null datasource / unparseable JSON are left
  alone (no false positives)

```
pytest tests/unit_tests/commands/chart/update_test.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
