### PR TITLE
fix(sql): avoid false positives in disallowed function checks

### DIFF
--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -691,15 +691,8 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        if not script.check_functions_present(engine_disallowed):
-            return None
-
-        # Return only disallowed functions actually invoked in the query.
-        found = {
-            func
-            for func in engine_disallowed
-            if script.check_functions_present({func})
-        }
+        present = script.get_present_functions()
+        found = {func for func in engine_disallowed if func.upper() in present}
         return found or None
 
     def _check_disallowed_tables(self, script: SQLScript) -> set[str] | None:

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -691,16 +691,16 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        # Check each statement for disallowed functions
-        found = set()
-        for statement in script.statements:
-            # Use the statement's AST to check for function calls
-            statement_str = str(statement).upper()
-            for func in engine_disallowed:
-                if func.upper() in statement_str:
-                    found.add(func)
+        if not script.check_functions_present(engine_disallowed):
+            return None
 
-        return found if found else None
+        # Return only disallowed functions actually invoked in the query.
+        found = {
+            func
+            for func in engine_disallowed
+            if script.check_functions_present({func})
+        }
+        return found or None
 
     def _check_disallowed_tables(self, script: SQLScript) -> set[str] | None:
         """

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import logging
+import re
 import time
 import uuid
 from datetime import datetime
@@ -71,6 +72,7 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     OAuth2Error,
     OAuth2RedirectError,
+    SupersetParseError,
     SupersetSecurityException,
     SupersetTimeoutException,
 )
@@ -429,7 +431,30 @@ class SQLExecutor:
         rendered_sql = self._render_sql_template(sql, opts.template_params)
 
         # 2. Parse SQL with SQLScript - this is the ORIGINAL script
-        original_script = SQLScript(rendered_sql, self.database.db_engine_spec.engine)
+        #
+        # Some disallowed functions (e.g. MySQL's `KILL`) are reserved
+        # statement-level keywords in the dialect grammar and cannot appear
+        # as a function call inside a SELECT projection, so sqlglot fails to
+        # parse SQL like `SELECT KILL(123)` rather than returning an AST we
+        # could inspect via the normal AST-based check in _check_security().
+        # Without this fallback, such SQL would still be blocked (parsing
+        # failure halts execution either way) but would surface a generic
+        # parse-error message instead of the clearer "Disallowed SQL
+        # functions" error.
+        try:
+            original_script = SQLScript(
+                rendered_sql, self.database.db_engine_spec.engine
+            )
+        except SupersetParseError:
+            if disallowed := self._check_disallowed_functions_in_raw_sql(rendered_sql):
+                raise SupersetSecurityException(
+                    SupersetError(
+                        message=(f"Disallowed SQL functions: {', '.join(disallowed)}"),
+                        error_type=SupersetErrorType.INVALID_SQL_ERROR,
+                        level=ErrorLevel.ERROR,
+                    )
+                ) from None
+            raise
 
         # 3. Create a copy for transformation
         transformed_script = SQLScript(
@@ -693,6 +718,33 @@ class SQLExecutor:
 
         present = script.get_present_functions()
         found = {func for func in engine_disallowed if func.upper() in present}
+        return found or None
+
+    def _check_disallowed_functions_in_raw_sql(self, sql: str) -> set[str] | None:
+        """
+        Fallback, text-based disallowed-function check for SQL that failed
+        to parse entirely.
+
+        This is intentionally only used when AST parsing fails (see
+        ``_prepare_sql``) — using a word-boundary regex on raw SQL as the
+        primary check would reintroduce the false positives the AST-based
+        ``_check_disallowed_functions`` was built to avoid.
+
+        :param sql: Raw (rendered) SQL that could not be parsed
+        :returns: Set of disallowed functions found, or None if none found
+        """
+        disallowed_config = app.config.get("DISALLOWED_SQL_FUNCTIONS", {})
+        engine_name = self.database.db_engine_spec.engine
+
+        engine_disallowed = disallowed_config.get(engine_name, set())
+        if not engine_disallowed:
+            return None
+
+        found = {
+            func
+            for func in engine_disallowed
+            if re.search(rf"\b{re.escape(func)}\b", sql, re.IGNORECASE)
+        }
         return found or None
 
     def _check_disallowed_tables(self, script: SQLScript) -> set[str] | None:

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import logging
+import re
 import time
 import uuid
 from datetime import datetime
@@ -542,7 +543,30 @@ class SQLExecutor:
         rendered_sql = self._render_sql_template(sql, opts.template_params)
 
         # 2. Parse SQL with SQLScript - this is the ORIGINAL script
-        original_script = SQLScript(rendered_sql, self.database.db_engine_spec.engine)
+        #
+        # Some disallowed functions (e.g. MySQL's `KILL`) are reserved
+        # statement-level keywords in the dialect grammar and cannot appear
+        # as a function call inside a SELECT projection, so sqlglot fails to
+        # parse SQL like `SELECT KILL(123)` rather than returning an AST we
+        # could inspect via the normal AST-based check in _check_security().
+        # Without this fallback, such SQL would still be blocked (parsing
+        # failure halts execution either way) but would surface a generic
+        # parse-error message instead of the clearer "Disallowed SQL
+        # functions" error.
+        try:
+            original_script = SQLScript(
+                rendered_sql, self.database.db_engine_spec.engine
+            )
+        except SupersetParseError:
+            if disallowed := self._check_disallowed_functions_in_raw_sql(rendered_sql):
+                raise SupersetSecurityException(
+                    SupersetError(
+                        message=(f"Disallowed SQL functions: {', '.join(disallowed)}"),
+                        error_type=SupersetErrorType.INVALID_SQL_ERROR,
+                        level=ErrorLevel.ERROR,
+                    )
+                ) from None
+            raise
 
         # 3. Create a copy for transformation
         transformed_script = SQLScript(
@@ -846,6 +870,33 @@ class SQLExecutor:
         return self.database.resolve_query_default_schema(
             sql, opts.schema, catalog, opts.template_params
         )
+
+    def _check_disallowed_functions_in_raw_sql(self, sql: str) -> set[str] | None:
+        """
+        Fallback, text-based disallowed-function check for SQL that failed
+        to parse entirely.
+
+        This is intentionally only used when AST parsing fails (see
+        ``_prepare_sql``) — using a word-boundary regex on raw SQL as the
+        primary check would reintroduce the false positives the AST-based
+        ``_check_disallowed_functions`` was built to avoid.
+
+        :param sql: Raw (rendered) SQL that could not be parsed
+        :returns: Set of disallowed functions found, or None if none found
+        """
+        disallowed_config = app.config.get("DISALLOWED_SQL_FUNCTIONS", {})
+        engine_name = self.database.db_engine_spec.engine
+
+        engine_disallowed = disallowed_config.get(engine_name, set())
+        if not engine_disallowed:
+            return None
+
+        found = {
+            func
+            for func in engine_disallowed
+            if re.search(rf"\b{re.escape(func)}\b", sql, re.IGNORECASE)
+        }
+        return found or None
 
     def _check_disallowed_tables(
         self, script: SQLScript, schema: str | None = None

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -825,15 +825,8 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        if not script.check_functions_present(engine_disallowed):
-            return None
-
-        # Return only disallowed functions actually invoked in the query.
-        found = {
-            func
-            for func in engine_disallowed
-            if script.check_functions_present({func})
-        }
+        present = script.get_present_functions()
+        found = {func for func in engine_disallowed if func.upper() in present}
         return found or None
 
     def _resolve_query_schema(

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -825,16 +825,16 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        # Check each statement for disallowed functions
-        found = set()
-        for statement in script.statements:
-            # Use the statement's AST to check for function calls
-            statement_str = str(statement).upper()
-            for func in engine_disallowed:
-                if func.upper() in statement_str:
-                    found.add(func)
+        if not script.check_functions_present(engine_disallowed):
+            return None
 
-        return found if found else None
+        # Return only disallowed functions actually invoked in the query.
+        found = {
+            func
+            for func in engine_disallowed
+            if script.check_functions_present({func})
+        }
+        return found or None
 
     def _resolve_query_schema(
         self, sql: str, opts: QueryOptions, catalog: str | None

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -483,6 +483,12 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked in the statement.
+        """
+        raise NotImplementedError()
+
     def check_functions_present(self, functions: set[str]) -> bool:
         """
         Check if any of the given functions are present in the script.
@@ -490,7 +496,8 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         :param functions: List of functions to check for
         :return: True if any of the functions are present
         """
-        raise NotImplementedError()
+        present = self.get_present_functions()
+        return any(function.upper() in present for function in functions)
 
     def check_tables_present(self, tables: set[str]) -> bool:
         """
@@ -948,19 +955,16 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         return SQLStatement(ast=optimized, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
+    def get_present_functions(self) -> set[str]:
         """
-        Check if any of the given functions are present in the script.
+        Return SQL function names invoked in the statement.
 
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
+        For Anonymous nodes the name is stored directly; for named Func nodes we
+        use sql_name(). We also add dialect parser aliases so that functions
+        that are normalised by a dialect (e.g. VERSION() -> CurrentVersion in
+        Postgres, sql_name = CURRENT_VERSION) can still be matched by their
+        original SQL name.
         """
-        # Build the set of SQL-level function names present in the AST. For
-        # Anonymous nodes the name is stored directly; for named Func nodes we
-        # use sql_name(). We also add dialect parser aliases so that functions
-        # that are normalised by a dialect (e.g. VERSION() -> CurrentVersion in
-        # Postgres, sql_name = CURRENT_VERSION) can still be matched by their
-        # original SQL name.
         dialect_cls = Dialect.get_or_raise(self._dialect) if self._dialect else None
         parser_cls = getattr(dialect_cls, "parser_class", None) if dialect_cls else None
         parser_functions: dict[str, Any] = (
@@ -991,7 +995,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         for param in self._parsed.find_all(exp.SessionParameter):
             present.add(param.name.upper())
 
-        return any(function.upper() in present for function in functions)
+        return present
 
     def check_tables_present(self, tables: set[str]) -> bool:
         """
@@ -1419,15 +1423,9 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         """
         return KustoKQLStatement(ast=self._parsed, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
-        """
-        Check if any of the given functions are present in the script.
-
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
-        """
+    def get_present_functions(self) -> set[str]:
         logger.warning("Kusto KQL doesn't support checking for functions present.")
-        return False
+        return set()
 
     def check_tables_present(self, tables: set[str]) -> bool:
         """
@@ -1598,6 +1596,15 @@ class SQLScript:
 
         return script
 
+    def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked across all statements in the script.
+        """
+        present: set[str] = set()
+        for statement in self.statements:
+            present.update(statement.get_present_functions())
+        return present
+
     def check_functions_present(self, functions: set[str]) -> bool:
         """
         Check if any of the given functions are present in the script.
@@ -1605,10 +1612,8 @@ class SQLScript:
         :param functions: List of functions to check for
         :return: True if any of the functions are present
         """
-        return any(
-            statement.check_functions_present(functions)
-            for statement in self.statements
-        )
+        present = self.get_present_functions()
+        return any(function.upper() in present for function in functions)
 
     def check_tables_present(self, tables: set[str]) -> bool:
         """

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1424,6 +1424,12 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         return KustoKQLStatement(ast=self._parsed, engine=self.engine)
 
     def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked in the statement.
+
+        Kusto KQL doesn't support function detection, so this always
+        returns an empty set.
+        """
         logger.warning("Kusto KQL doesn't support checking for functions present.")
         return set()
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1996,6 +1996,12 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         return KustoKQLStatement(ast=self._parsed, engine=self.engine)
 
     def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked in the statement.
+
+        Kusto KQL doesn't support function detection, so this always
+        returns an empty set.
+        """
         logger.warning("Kusto KQL doesn't support checking for functions present.")
         return set()
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -587,6 +587,12 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked in the statement.
+        """
+        raise NotImplementedError()
+
     def check_functions_present(self, functions: set[str]) -> bool:
         """
         Check if any of the given functions are present in the script.
@@ -594,7 +600,8 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         :param functions: List of functions to check for
         :return: True if any of the functions are present
         """
-        raise NotImplementedError()
+        present = self.get_present_functions()
+        return any(function.upper() in present for function in functions)
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None
@@ -1226,19 +1233,16 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         return SQLStatement(ast=optimized, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
+    def get_present_functions(self) -> set[str]:
         """
-        Check if any of the given functions are present in the script.
+        Return SQL function names invoked in the statement.
 
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
+        For Anonymous nodes the name is stored directly; for named Func nodes we
+        use sql_name(). We also add dialect parser aliases so that functions
+        that are normalised by a dialect (e.g. VERSION() -> CurrentVersion in
+        Postgres, sql_name = CURRENT_VERSION) can still be matched by their
+        original SQL name.
         """
-        # Build the set of SQL-level function names present in the AST. For
-        # Anonymous nodes the name is stored directly; for named Func nodes we
-        # use sql_name(). We also add dialect parser aliases so that functions
-        # that are normalised by a dialect (e.g. VERSION() -> CurrentVersion in
-        # Postgres, sql_name = CURRENT_VERSION) can still be matched by their
-        # original SQL name.
         dialect_cls = Dialect.get_or_raise(self._dialect) if self._dialect else None
         parser_cls = getattr(dialect_cls, "parser_class", None) if dialect_cls else None
         parser_functions: dict[str, Any] = (
@@ -1269,7 +1273,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         for param in self._parsed.find_all(exp.SessionParameter):
             present.add(param.name.upper())
 
-        return any(function.upper() in present for function in functions)
+        return present
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None
@@ -1991,15 +1995,9 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         """
         return KustoKQLStatement(ast=self._parsed, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
-        """
-        Check if any of the given functions are present in the script.
-
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
-        """
+    def get_present_functions(self) -> set[str]:
         logger.warning("Kusto KQL doesn't support checking for functions present.")
-        return False
+        return set()
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None
@@ -2209,6 +2207,15 @@ class SQLScript:
 
         return script
 
+    def get_present_functions(self) -> set[str]:
+        """
+        Return SQL function names invoked across all statements in the script.
+        """
+        present: set[str] = set()
+        for statement in self.statements:
+            present.update(statement.get_present_functions())
+        return present
+
     def check_functions_present(self, functions: set[str]) -> bool:
         """
         Check if any of the given functions are present in the script.
@@ -2216,10 +2223,8 @@ class SQLScript:
         :param functions: List of functions to check for
         :return: True if any of the functions are present
         """
-        return any(
-            statement.check_functions_present(functions)
-            for statement in self.statements
-        )
+        present = self.get_present_functions()
+        return any(function.upper() in present for function in functions)
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -350,6 +350,60 @@ def test_execute_allowed_functions(
     assert result.status == QueryStatus.SUCCESS
 
 
+def test_execute_disallowed_function_not_matched_in_identifiers(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Identifiers containing disallowed function names should not be blocked."""
+    mock_query_execution(
+        mocker,
+        database,
+        return_data=[(1, "Alice", "Alice Full", 5)],
+        column_names=["id", "name", "fullname", "skilllevel"],
+    )
+    mocker.patch.object(database.db_engine_spec, "engine", "mysql")
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
+            "QUERY_LOGGER": None,
+        },
+    )
+
+    sql = (
+        "SELECT r.id, r.name, r.fullname, s.skilllevel "
+        "FROM ppb_db.PPB_OMD_SKILLS s "
+        "JOIN ppb_db.PPB_OMD_RESOURCES r ON s.resource_id = r.id "
+        "WHERE s.SkillName = 'ELIS'"
+    )
+    result = database.execute(sql)
+
+    assert result.status == QueryStatus.SUCCESS
+
+
+def test_execute_disallowed_mysql_kill_function(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Actual disallowed function calls should still be blocked."""
+    mocker.patch.object(database.db_engine_spec, "engine", "mysql")
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
+        },
+    )
+
+    result = database.execute("SELECT KILL(123)")
+
+    assert result.status == QueryStatus.FAILED
+    assert result.error_message is not None
+    assert "kill" in result.error_message.lower()
+
+
 def test_execute_disallowed_tables(
     mocker: MockerFixture, database: Database, app_context: None
 ) -> None:

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -393,6 +393,8 @@ def test_execute_disallowed_mysql_kill_function(
         {
             "SQL_QUERY_MUTATOR": None,
             "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "QUERY_LOGGER": None,
             "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
         },
     )
@@ -400,8 +402,7 @@ def test_execute_disallowed_mysql_kill_function(
     result = database.execute("SELECT KILL(123)")
 
     assert result.status == QueryStatus.FAILED
-    assert result.error_message is not None
-    assert "kill" in result.error_message.lower()
+    assert result.error_message == "Disallowed SQL functions: kill"
 
 
 def test_execute_disallowed_tables(

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -354,6 +354,60 @@ def test_execute_allowed_functions(
     assert result.status == QueryStatus.SUCCESS
 
 
+def test_execute_disallowed_function_not_matched_in_identifiers(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Identifiers containing disallowed function names should not be blocked."""
+    mock_query_execution(
+        mocker,
+        database,
+        return_data=[(1, "Alice", "Alice Full", 5)],
+        column_names=["id", "name", "fullname", "skilllevel"],
+    )
+    mocker.patch.object(database.db_engine_spec, "engine", "mysql")
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
+            "QUERY_LOGGER": None,
+        },
+    )
+
+    sql = (
+        "SELECT r.id, r.name, r.fullname, s.skilllevel "
+        "FROM ppb_db.PPB_OMD_SKILLS s "
+        "JOIN ppb_db.PPB_OMD_RESOURCES r ON s.resource_id = r.id "
+        "WHERE s.SkillName = 'ELIS'"
+    )
+    result = database.execute(sql)
+
+    assert result.status == QueryStatus.SUCCESS
+
+
+def test_execute_disallowed_mysql_kill_function(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Actual disallowed function calls should still be blocked."""
+    mocker.patch.object(database.db_engine_spec, "engine", "mysql")
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
+        },
+    )
+
+    result = database.execute("SELECT KILL(123)")
+
+    assert result.status == QueryStatus.FAILED
+    assert result.error_message is not None
+    assert "kill" in result.error_message.lower()
+
+
 def test_execute_disallowed_tables(
     mocker: MockerFixture, database: Database, app_context: None
 ) -> None:

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -397,6 +397,8 @@ def test_execute_disallowed_mysql_kill_function(
         {
             "SQL_QUERY_MUTATOR": None,
             "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "QUERY_LOGGER": None,
             "DISALLOWED_SQL_FUNCTIONS": {"mysql": {"kill"}},
         },
     )
@@ -404,8 +406,7 @@ def test_execute_disallowed_mysql_kill_function(
     result = database.execute("SELECT KILL(123)")
 
     assert result.status == QueryStatus.FAILED
-    assert result.error_message is not None
-    assert "kill" in result.error_message.lower()
+    assert result.error_message == "Disallowed SQL functions: kill"
 
 
 def test_execute_disallowed_tables(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3411,6 +3411,63 @@ def test_check_functions_present(sql: str, engine: str, expected: bool) -> None:
 @pytest.mark.parametrize(
     "sql, engine, expected",
     [
+        ("SELECT * FROM table", "postgresql", set()),
+        ("SELECT VERSION()", "postgresql", {"VERSION"}),
+        ("SELECT version(), query_to_xml()", "postgresql", {"VERSION", "QUERY_TO_XML"}),
+        ("SELECT @@version", "mysql", {"VERSION"}),
+        ("SELECT @@global.version, @@hostname", "mysql", {"VERSION", "HOSTNAME"}),
+        ("SELECT lo_export(12345, '/tmp/x')", "postgresql", {"LO_EXPORT"}),
+    ],
+)
+def test_sql_statement_get_present_functions(
+    sql: str, engine: str, expected: set[str]
+) -> None:
+    """
+    `SQLStatement.get_present_functions` should return the set of SQL
+    function names invoked in the statement, including names introduced by
+    `exp.SessionParameter` nodes (eg. MySQL `@@version`).
+
+    Dialects may normalise a call to a different internal name and record
+    aliases for it (eg. Postgres `VERSION()` -> `CurrentVersion`, which also
+    adds `CURRENT_VERSION` to the present set), so we only assert that the
+    expected names are a subset of what's returned rather than pinning down
+    the exact set.
+    """
+    present = SQLStatement(sql, engine).get_present_functions()
+    assert expected <= present
+    if not expected:
+        assert present == set()
+
+
+def test_sql_script_get_present_functions_aggregates_statements() -> None:
+    """
+    `SQLScript.get_present_functions` should union the present functions
+    across every statement in the script, not just the first one.
+    """
+    sql = "SELECT version(); SELECT query_to_xml(); SELECT 1"
+    present = SQLScript(sql, "postgresql").get_present_functions()
+    assert {"VERSION", "QUERY_TO_XML"} <= present
+
+
+def test_sql_script_get_present_functions_empty_script() -> None:
+    """
+    A script with no function calls should return an empty set, not raise.
+    """
+    assert SQLScript("SELECT 1", "postgresql").get_present_functions() == set()
+
+
+def test_kusto_kql_get_present_functions_returns_empty_set() -> None:
+    """
+    Kusto KQL doesn't support function detection; `get_present_functions`
+    should degrade gracefully to an empty set rather than raising.
+    """
+    statement = SQLScript("Table | limit 10", "kustokql").statements[0]
+    assert statement.get_present_functions() == set()
+
+
+@pytest.mark.parametrize(
+    "sql, engine, expected",
+    [
         ("SELECT * FROM my_table", "postgresql", False),
         ("SELECT * FROM pg_stat_activity", "postgresql", True),
         ("SELECT * FROM PG_STAT_ACTIVITY", "postgresql", True),

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -5220,6 +5220,63 @@ def test_check_functions_present(sql: str, engine: str, expected: bool) -> None:
 @pytest.mark.parametrize(
     "sql, engine, expected",
     [
+        ("SELECT * FROM table", "postgresql", set()),
+        ("SELECT VERSION()", "postgresql", {"VERSION"}),
+        ("SELECT version(), query_to_xml()", "postgresql", {"VERSION", "QUERY_TO_XML"}),
+        ("SELECT @@version", "mysql", {"VERSION"}),
+        ("SELECT @@global.version, @@hostname", "mysql", {"VERSION", "HOSTNAME"}),
+        ("SELECT lo_export(12345, '/tmp/x')", "postgresql", {"LO_EXPORT"}),
+    ],
+)
+def test_sql_statement_get_present_functions(
+    sql: str, engine: str, expected: set[str]
+) -> None:
+    """
+    `SQLStatement.get_present_functions` should return the set of SQL
+    function names invoked in the statement, including names introduced by
+    `exp.SessionParameter` nodes (eg. MySQL `@@version`).
+
+    Dialects may normalise a call to a different internal name and record
+    aliases for it (eg. Postgres `VERSION()` -> `CurrentVersion`, which also
+    adds `CURRENT_VERSION` to the present set), so we only assert that the
+    expected names are a subset of what's returned rather than pinning down
+    the exact set.
+    """
+    present = SQLStatement(sql, engine).get_present_functions()
+    assert expected <= present
+    if not expected:
+        assert present == set()
+
+
+def test_sql_script_get_present_functions_aggregates_statements() -> None:
+    """
+    `SQLScript.get_present_functions` should union the present functions
+    across every statement in the script, not just the first one.
+    """
+    sql = "SELECT version(); SELECT query_to_xml(); SELECT 1"
+    present = SQLScript(sql, "postgresql").get_present_functions()
+    assert {"VERSION", "QUERY_TO_XML"} <= present
+
+
+def test_sql_script_get_present_functions_empty_script() -> None:
+    """
+    A script with no function calls should return an empty set, not raise.
+    """
+    assert SQLScript("SELECT 1", "postgresql").get_present_functions() == set()
+
+
+def test_kusto_kql_get_present_functions_returns_empty_set() -> None:
+    """
+    Kusto KQL doesn't support function detection; `get_present_functions`
+    should degrade gracefully to an empty set rather than raising.
+    """
+    statement = SQLScript("Table | limit 10", "kustokql").statements[0]
+    assert statement.get_present_functions() == set()
+
+
+@pytest.mark.parametrize(
+    "sql, engine, expected",
+    [
         ("SELECT * FROM my_table", "postgresql", False),
         ("SELECT * FROM pg_stat_activity", "postgresql", True),
         ("SELECT * FROM PG_STAT_ACTIVITY", "postgresql", True),


### PR DESCRIPTION
### SUMMARY

The SQL executor's disallowed-function check used substring matching on the raw SQL string, causing false positives when column or table names contained a disallowed function name as a substring (e.g. `skilllevel` triggering the `kill` blocklist for MySQL).

This change uses `SQLScript.check_functions_present()` — the same AST-based approach already used in `sql_lab.py` and `models/helpers.py` — so only actual function invocations are blocked.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Configure `DISALLOWED_SQL_FUNCTIONS` with `{"mysql": {"kill"}}` in `superset_config.py`
2. Run a query that references a column like `skilllevel` — it should succeed
3. Run `SELECT KILL(123)` — it should be rejected with an error mentioning `kill`
4. Run unit tests:
   ```bash
   pytest tests/unit_tests/sql/execution/test_executor.py::test_execute_disallowed_function_not_matched_in_identifiers tests/unit_tests/sql/execution/test_executor.py::test_execute_disallowed_mysql_kill_function -v
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
