### PR TITLE
fix(permalink): accept null entries in activeTabs for v5-imported dashboards

### DIFF
--- a/superset/dashboards/permalink/schemas.py
+++ b/superset/dashboards/permalink/schemas.py
@@ -24,7 +24,13 @@ class DashboardPermalinkStateSchema(Schema):
         metadata={"description": "Data mask used for native filter state"},
     )
     activeTabs = fields.List(  # noqa: N815
-        fields.String(),
+        # ``allow_none`` on the inner ``fields.String`` is required because
+        # legacy v5 dashboard exports persist ``null`` entries inside the
+        # ``activeTabs`` list (one ``null`` per tab level that has no active
+        # child). Without it the import path through this schema rejects
+        # the whole permalink with ``{'activeTabs': {N: ['Field may not be
+        # null.']}}`` (#40934).
+        fields.String(allow_none=True),
         required=False,
         allow_none=True,
         metadata={"description": "Current active dashboard tabs"},

--- a/tests/unit_tests/dashboards/schema_tests.py
+++ b/tests/unit_tests/dashboards/schema_tests.py
@@ -21,6 +21,7 @@ import pytest
 from marshmallow import ValidationError
 from pytest_mock import MockerFixture
 
+from superset.dashboards.permalink.schemas import DashboardPermalinkStateSchema
 from superset.dashboards.schemas import (
     DashboardCopySchema,
     DashboardDatasetSchema,
@@ -162,3 +163,33 @@ def test_dashboard_copy_css_rejects_dangerous_constructs() -> None:
             }
         )
     assert "css" in exc_info.value.messages
+
+
+def test_permalink_state_schema_accepts_null_in_active_tabs() -> None:
+    """Regression test for #40934.
+
+    Legacy v5 dashboard exports persist ``null`` entries inside
+    ``activeTabs`` (one ``None`` per tab level that has no active child).
+    The permalink schema must accept those entries instead of rejecting
+    the whole payload with ``'activeTabs': {N: ['Field may not be null.']}``.
+    """
+    schema = DashboardPermalinkStateSchema()
+    loaded = schema.load({"activeTabs": ["TAB-abc", None, "TAB-xyz", None]})
+    assert loaded["activeTabs"] == ["TAB-abc", None, "TAB-xyz", None]
+
+
+def test_permalink_state_schema_still_accepts_null_active_tabs_list() -> None:
+    """A ``None`` for the whole ``activeTabs`` list (not just entries) must
+    keep working — this was the only ``allow_none`` path before #40934."""
+    schema = DashboardPermalinkStateSchema()
+    loaded = schema.load({"activeTabs": None})
+    assert loaded["activeTabs"] is None
+
+
+def test_permalink_state_schema_still_rejects_non_string_entries() -> None:
+    """Allowing ``None`` entries should NOT widen the type to ``Any`` —
+    non-string entries like ``int`` or ``dict`` must still be rejected."""
+    schema = DashboardPermalinkStateSchema()
+    with pytest.raises(ValidationError) as exc_info:
+        schema.load({"activeTabs": ["TAB-abc", 42]})
+    assert "activeTabs" in exc_info.value.messages


### PR DESCRIPTION
### SUMMARY

Fixes #40934.

\`DashboardPermalinkStateSchema.activeTabs\` is a Marshmallow \`fields.List(fields.String(), allow_none=True)\`. The list itself accepts \`None\`, but each **element** inside the list is a \`fields.String()\` without \`allow_none\`, so a list containing a \`None\` (e.g. \`[\"TAB-abc\", null, \"TAB-xyz\"]\`) fails validation with:

\`\`\`json
{ \"message\": \"{'activeTabs': {N: ['Field may not be null.']}}\" }
\`\`\`

That is exactly the shape v5-exported dashboards persist when one or more tab levels has no active child. Importing such a dashboard into v6 and generating a permalink fails systematically.

This PR adds \`allow_none=True\` to the inner \`fields.String\` so \`None\` entries are accepted while the outer list and the per-entry string typing are otherwise preserved.

### BEFORE / AFTER

| | Before | After |
|---|---|---|
| \`activeTabs: [\"a\", null, \"b\"]\` | Validation error | Loaded as-is |
| \`activeTabs: None\` (whole list null) | Loaded as None (unchanged) | Loaded as None (unchanged) |
| \`activeTabs: [\"a\", 42]\` (non-string entry) | Validation error | Still rejected — defensive |

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/dashboards/schema_tests.py -v
\`\`\`

Three new tests assert:

| Test | Behavior |
|---|---|
| \`test_permalink_state_schema_accepts_null_in_active_tabs\` | The reported v5 import case is now accepted |
| \`test_permalink_state_schema_still_accepts_null_active_tabs_list\` | The pre-existing \`allow_none\` on the outer list is unchanged |
| \`test_permalink_state_schema_still_rejects_non_string_entries\` | The fix does not widen the type — non-string entries are still rejected |

Manual verification:

1. Import any v5 dashboard whose \`activeTabs\` includes a \`null\` (the issue contains a minimal repro export attached)
2. Open the dashboard and click \"Share → Copy permalink\"
3. Permalink is generated; previously it failed with the validation error above

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40934
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (please mention any potential downtime)
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [x] Runtime introduces no new dependencies / changes existing dependencies
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API