### PR TITLE
fix(mcp): accept Superset vocabulary in chart configs and clarify query_dataset metric errors

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1773,6 +1773,7 @@ _VIZ_TYPE_TO_CHART_TYPE: dict[str, tuple[str, str | None]] = {
     "echarts_area": ("xy", "area"),
     "scatter": ("xy", "scatter"),
     "echarts_timeseries_scatter": ("xy", "scatter"),
+    "ag-grid-table": ("table", None),
     "big_number_total": ("big_number", None),
     "pivot_table_v2": ("pivot_table", None),
 }
@@ -1793,19 +1794,21 @@ def _normalize_chart_request_input(data: Any) -> Any:
         data["dataset_id"] = data.pop("datasource_id")
     config = data.get("config")
     if isinstance(config, dict):
-        if "viz_type" in config:
-            viz_type = config["viz_type"]
-            if "chart_type" not in config:
-                config["chart_type"] = viz_type
-                config.pop("viz_type")
-            elif config.get("chart_type") != "table":
-                config.pop("viz_type")
+        viz_type = config.get("viz_type")
+        if isinstance(viz_type, str) and "chart_type" not in config:
+            config["chart_type"] = viz_type
         chart_type = config.get("chart_type")
         if isinstance(chart_type, str) and chart_type in _VIZ_TYPE_TO_CHART_TYPE:
             mapped_type, kind = _VIZ_TYPE_TO_CHART_TYPE[chart_type]
             config["chart_type"] = mapped_type
             if kind is not None:
                 config.setdefault("kind", kind)
+            if mapped_type == "table":
+                config.setdefault("viz_type", chart_type)
+            else:
+                config.pop("viz_type", None)
+        elif config.get("chart_type") != "table":
+            config.pop("viz_type", None)
     return data
 
 
@@ -1815,6 +1818,7 @@ class ChartRequestNormalizerMixin(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize_request_vocabulary(cls, data: Any) -> Any:
+        """Normalize Superset-style request keys before Pydantic validation."""
         return _normalize_chart_request_input(data)
 
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1760,8 +1760,9 @@ ChartConfig = Annotated[
 
 
 # Superset viz_type values that LLM clients routinely send where this API
-# expects its chart_type discriminator. Each maps to (chart_type, kind);
-# kind is only meaningful for the xy family.
+# expects its chart_type discriminator. Extend this observed-pattern map when
+# recurring session traces show additional unambiguous aliases. Each maps to
+# (chart_type, kind); kind is only meaningful for the xy family.
 _VIZ_TYPE_TO_CHART_TYPE: dict[str, tuple[str, str | None]] = {
     "bar": ("xy", "bar"),
     "dist_bar": ("xy", "bar"),

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1794,8 +1794,12 @@ def _normalize_chart_request_input(data: Any) -> Any:
     config = data.get("config")
     if isinstance(config, dict):
         if "viz_type" in config:
-            viz_type = config.pop("viz_type")
-            config.setdefault("chart_type", viz_type)
+            viz_type = config["viz_type"]
+            if "chart_type" not in config:
+                config["chart_type"] = viz_type
+                config.pop("viz_type")
+            elif config.get("chart_type") != "table":
+                config.pop("viz_type")
         chart_type = config.get("chart_type")
         if isinstance(chart_type, str) and chart_type in _VIZ_TYPE_TO_CHART_TYPE:
             mapped_type, kind = _VIZ_TYPE_TO_CHART_TYPE[chart_type]

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1593,7 +1593,9 @@ class XYChartConfig(UnknownFieldCheckMixin):
         validation_alias=AliasChoices("time_grain", "time_grain_sqla"),
     )
     orientation: Literal["vertical", "horizontal"] | None = Field(
-        None, description="Bar orientation (only for kind='bar')"
+        None,
+        description="Bar orientation (only for kind='bar')",
+        validation_alias=AliasChoices("orientation", "chart_orientation"),
     )
     stacked: bool = Field(
         False,
@@ -1608,7 +1610,10 @@ class XYChartConfig(UnknownFieldCheckMixin):
     )
     x_axis: AxisConfig | None = None
     y_axis: AxisConfig | None = None
-    legend: LegendConfig | None = None
+    legend: LegendConfig | None = Field(
+        None,
+        validation_alias=AliasChoices("legend", "show_legend"),
+    )
     x_axis_time_format: str | None = Field(
         None,
         description=(
@@ -1652,6 +1657,24 @@ class XYChartConfig(UnknownFieldCheckMixin):
     @classmethod
     def wrap_single_group_by(cls, v: Any) -> Any:
         return _normalize_group_by_input(v)
+
+    @field_validator("x", mode="before")
+    @classmethod
+    def coerce_x_column_name(cls, v: Any) -> Any:
+        """Accept a bare column name string for the x-axis."""
+        return {"name": v} if isinstance(v, str) else v
+
+    @field_validator("y", mode="before")
+    @classmethod
+    def coerce_y_column_names(cls, v: Any) -> Any:
+        """Accept bare strings or a single entry for the y-axis metrics."""
+        return _normalize_group_by_input(v)
+
+    @field_validator("legend", mode="before")
+    @classmethod
+    def coerce_legend_flag(cls, v: Any) -> Any:
+        """Accept the form_data-style show_legend boolean."""
+        return {"show": v} if isinstance(v, bool) else v
 
     @model_validator(mode="after")
     def reject_sql_expression_on_dimensions(self) -> "XYChartConfig":
@@ -1734,6 +1757,61 @@ ChartConfig = Annotated[
 
 # Compact description for JSON Schema — keeps tool inputSchema small while
 # giving LLMs enough context to construct valid configs.
+
+
+# Superset viz_type values that LLM clients routinely send where this API
+# expects its chart_type discriminator. Each maps to (chart_type, kind);
+# kind is only meaningful for the xy family.
+_VIZ_TYPE_TO_CHART_TYPE: dict[str, tuple[str, str | None]] = {
+    "bar": ("xy", "bar"),
+    "dist_bar": ("xy", "bar"),
+    "echarts_timeseries_bar": ("xy", "bar"),
+    "line": ("xy", "line"),
+    "echarts_timeseries_line": ("xy", "line"),
+    "echarts_timeseries_smooth": ("xy", "line"),
+    "area": ("xy", "area"),
+    "echarts_area": ("xy", "area"),
+    "scatter": ("xy", "scatter"),
+    "echarts_timeseries_scatter": ("xy", "scatter"),
+    "big_number_total": ("big_number", None),
+    "pivot_table_v2": ("pivot_table", None),
+}
+
+
+def _normalize_chart_request_input(data: Any) -> Any:
+    """Accept common Superset REST/form_data vocabulary in chart requests.
+
+    LLM clients reliably reach for Superset's public field names —
+    ``datasource_id``, ``viz_type``, and concrete viz plugin names such as
+    ``echarts_timeseries_bar`` — before consulting this API's schema. Each
+    rejection costs the client a model round trip, so the unambiguous
+    synonyms are translated instead of refused.
+    """
+    if not isinstance(data, dict):
+        return data
+    if "dataset_id" not in data and "datasource_id" in data:
+        data["dataset_id"] = data.pop("datasource_id")
+    config = data.get("config")
+    if isinstance(config, dict):
+        if "viz_type" in config:
+            viz_type = config.pop("viz_type")
+            config.setdefault("chart_type", viz_type)
+        chart_type = config.get("chart_type")
+        if isinstance(chart_type, str) and chart_type in _VIZ_TYPE_TO_CHART_TYPE:
+            mapped_type, kind = _VIZ_TYPE_TO_CHART_TYPE[chart_type]
+            config["chart_type"] = mapped_type
+            if kind is not None:
+                config.setdefault("kind", kind)
+    return data
+
+
+class ChartRequestNormalizerMixin(BaseModel):
+    """Mixin translating Superset-vocabulary synonyms before validation."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_request_vocabulary(cls, data: Any) -> Any:
+        return _normalize_chart_request_input(data)
 
 
 class ListChartsRequest(OwnedByMeMixin, CreatedByMeMixin, MetadataCacheControl):
@@ -1830,7 +1908,7 @@ class ListChartsRequest(OwnedByMeMixin, CreatedByMeMixin, MetadataCacheControl):
 
 
 # The tool input models
-class GenerateChartRequest(QueryCacheControl):
+class GenerateChartRequest(ChartRequestNormalizerMixin, QueryCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
@@ -1930,7 +2008,7 @@ class GenerateChartRequest(QueryCacheControl):
         return self
 
 
-class GenerateExploreLinkRequest(FormDataCacheControl):
+class GenerateExploreLinkRequest(ChartRequestNormalizerMixin, FormDataCacheControl):
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
     config: ChartConfig | None = Field(
         None,
@@ -1942,7 +2020,7 @@ class GenerateExploreLinkRequest(FormDataCacheControl):
     )
 
 
-class UpdateChartRequest(QueryCacheControl):
+class UpdateChartRequest(ChartRequestNormalizerMixin, QueryCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
     identifier: int | str = Field(..., description="Chart ID or UUID")
@@ -1980,7 +2058,7 @@ class UpdateChartRequest(QueryCacheControl):
         return sanitize_user_input(v, "Chart name", max_length=255, allow_empty=True)
 
 
-class UpdateChartPreviewRequest(FormDataCacheControl):
+class UpdateChartPreviewRequest(ChartRequestNormalizerMixin, FormDataCacheControl):
     form_data_key: str | None = Field(
         None,
         description=(

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -108,7 +108,13 @@ def _validate_names(
                     msg += f". Did you mean: {', '.join(suggestions)}?"
                 elif list_valid_on_miss:
                     shown = sorted(valid)[:10]
-                    msg += f". Valid {kind}s: {', '.join(shown)}"
+                    more = len(valid) - len(shown)
+                    suffix = (
+                        f" (and {more} more; call get_dataset_info for the full list)"
+                        if more > 0
+                        else ""
+                    )
+                    msg += f". Valid {kind}s: {', '.join(shown)}{suffix}"
             errors.append(msg)
     return errors
 

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -84,20 +84,40 @@ def _validate_names(
     requested: list[str],
     valid: set[str],
     kind: str,
+    *,
+    empty_hint: str | None = None,
+    list_valid_on_miss: bool = False,
 ) -> list[str]:
     """Return list of error messages for names not found in *valid*.
 
-    Includes close-match suggestions when available.
+    Includes close-match suggestions when available. When *valid* is empty,
+    appends *empty_hint* instead of a useless fuzzy match. When no close
+    match exists and *list_valid_on_miss* is set, lists the valid names so
+    the caller does not have to guess again.
     """
     errors: list[str] = []
     for name in requested:
         if name not in valid:
-            suggestions = difflib.get_close_matches(name, valid, n=3, cutoff=0.6)
             msg = f"Unknown {kind}: '{name}'"
-            if suggestions:
-                msg += f". Did you mean: {', '.join(suggestions)}?"
+            if not valid:
+                if empty_hint:
+                    msg += f". {empty_hint}"
+            else:
+                suggestions = difflib.get_close_matches(name, valid, n=3, cutoff=0.6)
+                if suggestions:
+                    msg += f". Did you mean: {', '.join(suggestions)}?"
+                elif list_valid_on_miss:
+                    shown = sorted(valid)[:10]
+                    msg += f". Valid {kind}s: {', '.join(shown)}"
             errors.append(msg)
     return errors
+
+
+_NO_SAVED_METRICS_HINT = (
+    "This dataset has no saved metrics, and query_dataset accepts saved "
+    "metric names only (not ad-hoc expressions). Use execute_sql for "
+    "ad-hoc aggregates, or add a saved metric to the dataset."
+)
 
 
 @requires_data_model_metadata_access
@@ -118,6 +138,10 @@ async def query_dataset(  # noqa: C901
     Returns tabular data without requiring a saved chart. Use this when you want
     to compute saved metrics, group by dimensions, or apply filters directly
     against a dataset's curated semantic layer.
+
+    Metrics must be saved metric names from get_dataset_info; ad-hoc
+    expressions such as "SUM(col)" are not accepted. When the dataset has no
+    saved metric for the aggregate you need, use execute_sql instead.
 
     Workflow:
     1. list_datasets -> find a dataset
@@ -213,7 +237,13 @@ async def query_dataset(  # noqa: C901
             _validate_names(request.columns, valid_columns, "column")
         )
         validation_errors.extend(
-            _validate_names(request.metrics, valid_metrics, "metric")
+            _validate_names(
+                request.metrics,
+                valid_metrics,
+                "metric",
+                empty_hint=_NO_SAVED_METRICS_HINT,
+                list_valid_on_miss=True,
+            )
         )
         # Validate filter column names against dataset columns
         filter_cols = [f.col for f in request.filters]

--- a/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
@@ -35,7 +35,10 @@ from superset.mcp_service.chart.schemas import (
     UpdateChartRequest,
     XYChartConfig,
 )
-from superset.mcp_service.dataset.tool.query_dataset import _validate_names
+from superset.mcp_service.dataset.tool.query_dataset import (
+    _NO_SAVED_METRICS_HINT,
+    _validate_names,
+)
 
 XY_BAR_CONFIG = {
     "chart_type": "xy",
@@ -236,10 +239,10 @@ class TestQueryDatasetMetricGuidance:
             ["sum__global_sales"],
             set(),
             "metric",
-            empty_hint="No saved metrics. Use execute_sql.",
+            empty_hint=_NO_SAVED_METRICS_HINT,
         )
         assert len(errors) == 1
-        assert "No saved metrics. Use execute_sql." in errors[0]
+        assert _NO_SAVED_METRICS_HINT in errors[0]
         assert "Did you mean" not in errors[0]
 
     def test_valid_metrics_listed_when_no_close_match(self) -> None:
@@ -251,6 +254,21 @@ class TestQueryDatasetMetricGuidance:
         )
         assert len(errors) == 1
         assert "Valid metrics: count, revenue_total" in errors[0]
+
+    def test_truncated_valid_metrics_report_remaining_count(self) -> None:
+        valid_metrics = {f"metric_{idx:02d}" for idx in range(12)}
+
+        errors = _validate_names(
+            ["zzz_nonexistent"],
+            valid_metrics,
+            "metric",
+            list_valid_on_miss=True,
+        )
+
+        assert len(errors) == 1
+        assert "metric_00, metric_01" in errors[0]
+        assert "metric_10" not in errors[0]
+        assert "and 2 more; call get_dataset_info for the full list" in errors[0]
 
     def test_close_match_suggestion_unchanged(self) -> None:
         errors = _validate_names(

--- a/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 from superset.mcp_service.chart.schemas import (
     GenerateChartRequest,
     GenerateExploreLinkRequest,
+    TableChartConfig,
     UpdateChartPreviewRequest,
     UpdateChartRequest,
     XYChartConfig,
@@ -100,6 +101,20 @@ class TestVizTypeTranslation:
             {"dataset_id": 23, "config": config}
         )
         assert request.config.chart_type == "xy"
+
+    def test_table_viz_type_is_preserved_with_explicit_chart_type(self) -> None:
+        request = GenerateExploreLinkRequest.model_validate(
+            {
+                "dataset_id": 23,
+                "config": {
+                    "chart_type": "table",
+                    "viz_type": "ag-grid-table",
+                    "columns": [{"name": "genre"}],
+                },
+            }
+        )
+        assert isinstance(request.config, TableChartConfig)
+        assert request.config.viz_type == "ag-grid-table"
 
     def test_explicit_kind_is_preserved(self) -> None:
         config = dict(XY_BAR_CONFIG)

--- a/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
@@ -46,6 +46,8 @@ XY_BAR_CONFIG = {
 
 
 class TestDatasourceIdAlias:
+    """Datasource alias normalization for chart request models."""
+
     def test_generate_chart_accepts_datasource_id(self) -> None:
         request = GenerateChartRequest.model_validate(
             {"datasource_id": 23, "config": dict(XY_BAR_CONFIG)}
@@ -60,6 +62,8 @@ class TestDatasourceIdAlias:
 
 
 class TestVizTypeTranslation:
+    """Superset viz plugin names map to MCP chart config discriminators."""
+
     @pytest.mark.parametrize(
         "viz_type,expected_kind",
         [
@@ -116,6 +120,33 @@ class TestVizTypeTranslation:
         assert isinstance(request.config, TableChartConfig)
         assert request.config.viz_type == "ag-grid-table"
 
+    def test_table_viz_type_key_maps_to_table_config(self) -> None:
+        request = GenerateExploreLinkRequest.model_validate(
+            {
+                "dataset_id": 23,
+                "config": {
+                    "viz_type": "ag-grid-table",
+                    "columns": [{"name": "genre"}],
+                },
+            }
+        )
+        assert isinstance(request.config, TableChartConfig)
+        assert request.config.chart_type == "table"
+        assert request.config.viz_type == "ag-grid-table"
+
+    def test_explicit_invalid_chart_type_wins_over_viz_type(self) -> None:
+        with pytest.raises(ValidationError, match="xyy"):
+            GenerateChartRequest.model_validate(
+                {
+                    "dataset_id": 23,
+                    "config": {
+                        **XY_BAR_CONFIG,
+                        "chart_type": "xyy",
+                        "viz_type": "echarts_timeseries_bar",
+                    },
+                }
+            )
+
     def test_explicit_kind_is_preserved(self) -> None:
         config = dict(XY_BAR_CONFIG)
         config["chart_type"] = "echarts_timeseries_bar"
@@ -139,6 +170,8 @@ class TestVizTypeTranslation:
 
 
 class TestRequestModelsShareNormalization:
+    """Request models share chart vocabulary normalization behavior."""
+
     def test_update_chart_request(self) -> None:
         request = UpdateChartRequest.model_validate(
             {"identifier": 409, "config": {**XY_BAR_CONFIG, "chart_type": "bar"}}
@@ -163,6 +196,8 @@ class TestRequestModelsShareNormalization:
 
 
 class TestXYFieldCoercion:
+    """XY chart config accepts common Superset form-data field shapes."""
+
     def test_x_accepts_bare_column_name(self) -> None:
         config = XYChartConfig.model_validate({**XY_BAR_CONFIG, "x": "genre"})
         assert config.x is not None
@@ -194,6 +229,8 @@ class TestXYFieldCoercion:
 
 
 class TestQueryDatasetMetricGuidance:
+    """Metric validation errors guide callers toward saved metric names."""
+
     def test_no_saved_metrics_hint(self) -> None:
         errors = _validate_names(
             ["sum__global_sales"],

--- a/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
@@ -1,0 +1,211 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for Superset-vocabulary coercion in MCP chart request schemas.
+
+LLM clients reliably send Superset's public field names (datasource_id,
+viz_type, show_legend, plugin viz names) before consulting the MCP tool
+schema. These tests pin the translations that absorb those inputs instead
+of rejecting them.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from superset.mcp_service.chart.schemas import (
+    GenerateChartRequest,
+    GenerateExploreLinkRequest,
+    UpdateChartPreviewRequest,
+    UpdateChartRequest,
+    XYChartConfig,
+)
+from superset.mcp_service.dataset.tool.query_dataset import _validate_names
+
+XY_BAR_CONFIG = {
+    "chart_type": "xy",
+    "kind": "bar",
+    "x": {"name": "genre"},
+    "y": [{"name": "global_sales", "aggregate": "SUM"}],
+}
+
+
+class TestDatasourceIdAlias:
+    def test_generate_chart_accepts_datasource_id(self) -> None:
+        request = GenerateChartRequest.model_validate(
+            {"datasource_id": 23, "config": dict(XY_BAR_CONFIG)}
+        )
+        assert request.dataset_id == 23
+
+    def test_dataset_id_wins_over_datasource_id(self) -> None:
+        request = GenerateChartRequest.model_validate(
+            {"dataset_id": 7, "datasource_id": 23, "config": dict(XY_BAR_CONFIG)}
+        )
+        assert request.dataset_id == 7
+
+
+class TestVizTypeTranslation:
+    @pytest.mark.parametrize(
+        "viz_type,expected_kind",
+        [
+            ("bar", "bar"),
+            ("dist_bar", "bar"),
+            ("echarts_timeseries_bar", "bar"),
+            ("echarts_timeseries_line", "line"),
+            ("area", "area"),
+            ("echarts_timeseries_scatter", "scatter"),
+        ],
+    )
+    def test_xy_family_viz_types_map_to_xy(
+        self, viz_type: str, expected_kind: str
+    ) -> None:
+        config = dict(XY_BAR_CONFIG)
+        del config["kind"]
+        config["chart_type"] = viz_type
+        request = GenerateChartRequest.model_validate(
+            {"dataset_id": 23, "config": config}
+        )
+        assert request.config.chart_type == "xy"
+        assert request.config.kind == expected_kind
+
+    def test_viz_type_key_is_accepted_as_chart_type(self) -> None:
+        config = dict(XY_BAR_CONFIG)
+        del config["chart_type"]
+        del config["kind"]
+        config["viz_type"] = "bar"
+        request = GenerateChartRequest.model_validate(
+            {"dataset_id": 23, "config": config}
+        )
+        assert request.config.chart_type == "xy"
+        assert request.config.kind == "bar"
+
+    def test_explicit_chart_type_wins_over_viz_type(self) -> None:
+        config = dict(XY_BAR_CONFIG)
+        config["viz_type"] = "pie"
+        request = GenerateChartRequest.model_validate(
+            {"dataset_id": 23, "config": config}
+        )
+        assert request.config.chart_type == "xy"
+
+    def test_explicit_kind_is_preserved(self) -> None:
+        config = dict(XY_BAR_CONFIG)
+        config["chart_type"] = "echarts_timeseries_bar"
+        config["kind"] = "line"
+        request = GenerateChartRequest.model_validate(
+            {"dataset_id": 23, "config": config}
+        )
+        assert request.config.kind == "line"
+
+    def test_big_number_total_maps_to_big_number(self) -> None:
+        request = GenerateChartRequest.model_validate(
+            {
+                "dataset_id": 23,
+                "config": {
+                    "chart_type": "big_number_total",
+                    "metric": {"name": "global_sales", "aggregate": "SUM"},
+                },
+            }
+        )
+        assert request.config.chart_type == "big_number"
+
+
+class TestRequestModelsShareNormalization:
+    def test_update_chart_request(self) -> None:
+        request = UpdateChartRequest.model_validate(
+            {"identifier": 409, "config": {**XY_BAR_CONFIG, "chart_type": "bar"}}
+        )
+        assert request.config is not None
+        assert request.config.chart_type == "xy"
+
+    def test_update_chart_preview_request(self) -> None:
+        request = UpdateChartPreviewRequest.model_validate(
+            {"datasource_id": 23, "config": {**XY_BAR_CONFIG, "chart_type": "bar"}}
+        )
+        assert request.dataset_id == 23
+        assert request.config.chart_type == "xy"
+
+    def test_generate_explore_link_request(self) -> None:
+        request = GenerateExploreLinkRequest.model_validate(
+            {"datasource_id": 23, "config": {**XY_BAR_CONFIG, "chart_type": "bar"}}
+        )
+        assert request.dataset_id == 23
+        assert request.config is not None
+        assert request.config.chart_type == "xy"
+
+
+class TestXYFieldCoercion:
+    def test_x_accepts_bare_column_name(self) -> None:
+        config = XYChartConfig.model_validate({**XY_BAR_CONFIG, "x": "genre"})
+        assert config.x is not None
+        assert config.x.name == "genre"
+
+    def test_y_accepts_bare_metric_names(self) -> None:
+        config = XYChartConfig.model_validate({**XY_BAR_CONFIG, "y": ["count"]})
+        assert config.y[0].name == "count"
+
+    def test_show_legend_bool_becomes_legend_config(self) -> None:
+        config = XYChartConfig.model_validate({**XY_BAR_CONFIG, "show_legend": True})
+        assert config.legend is not None
+        assert config.legend.show is True
+
+    def test_show_legend_false(self) -> None:
+        config = XYChartConfig.model_validate({**XY_BAR_CONFIG, "show_legend": False})
+        assert config.legend is not None
+        assert config.legend.show is False
+
+    def test_chart_orientation_alias(self) -> None:
+        config = XYChartConfig.model_validate(
+            {**XY_BAR_CONFIG, "chart_orientation": "horizontal"}
+        )
+        assert config.orientation == "horizontal"
+
+    def test_unknown_fields_still_rejected_with_suggestion(self) -> None:
+        with pytest.raises(ValidationError, match="order_desc"):
+            XYChartConfig.model_validate({**XY_BAR_CONFIG, "order_desc": True})
+
+
+class TestQueryDatasetMetricGuidance:
+    def test_no_saved_metrics_hint(self) -> None:
+        errors = _validate_names(
+            ["sum__global_sales"],
+            set(),
+            "metric",
+            empty_hint="No saved metrics. Use execute_sql.",
+        )
+        assert len(errors) == 1
+        assert "No saved metrics. Use execute_sql." in errors[0]
+        assert "Did you mean" not in errors[0]
+
+    def test_valid_metrics_listed_when_no_close_match(self) -> None:
+        errors = _validate_names(
+            ["zzz_nonexistent"],
+            {"count", "revenue_total"},
+            "metric",
+            list_valid_on_miss=True,
+        )
+        assert len(errors) == 1
+        assert "Valid metrics: count, revenue_total" in errors[0]
+
+    def test_close_match_suggestion_unchanged(self) -> None:
+        errors = _validate_names(
+            ["revenue_totl"],
+            {"count", "revenue_total"},
+            "metric",
+            list_valid_on_miss=True,
+        )
+        assert len(errors) == 1
+        assert "Did you mean: revenue_total?" in errors[0]


### PR DESCRIPTION
### SUMMARY

LLM clients talking to the MCP service reliably reach for Superset's public vocabulary — `datasource_id`, `viz_type`, plugin viz names like `echarts_timeseries_bar`, form_data fields like `show_legend` — before consulting the MCP tool schema. Today each of those guesses is rejected by validation, and every rejection costs the client a full model round trip (and, in MCP hosts that gate non-read-only tools, a user approval prompt per retry).

We instrumented live agentic sessions against a workspace running this service and found that **every `generate_chart` retry across all test conditions was the same request-shape guess**, in a small set of recurring forms:

1. `datasource_id` instead of `dataset_id` (Superset's REST vocabulary)
2. `viz_type: "bar"` / `"dist_bar"` / `"echarts_timeseries_bar"` where the config union expects its `chart_type` discriminator (`xy`, `pie`, ...)
3. form_data field names inside the xy config: `show_legend` (and a bool where `LegendConfig` is expected), `chart_orientation`
4. bare strings where `ColumnRef` objects are expected (`"x_axis": "genre"`, `"y": ["count"]`)

A typical session burned 2–4 rejected `generate_chart` calls plus `get_chart_type_schema` consultations before converging — roughly doubling wall-clock time for a simple "create a bar chart" request.

Separately, `query_dataset`'s metric validation produced a misleading hint chain: on a dataset with no saved metrics, `Unknown metric: 'sum__global_sales'` carried no guidance, while the adjacent `order_by` error suggested `Did you mean: global_sales?` (a column, valid for order_by) — which LLM clients then tried *as a metric*, failing again in a loop. The tool is saved-metrics-only by design, but nothing in the error said so.

This PR makes the validation layer absorb the unambiguous synonyms instead of refusing them, and makes the saved-metrics-only contract explicit:

**Chart request schemas (`chart/schemas.py`)**
- `ChartRequestNormalizerMixin` on `GenerateChartRequest`, `UpdateChartRequest`, `UpdateChartPreviewRequest`, and `GenerateExploreLinkRequest`:
  - `datasource_id` → `dataset_id` (explicit `dataset_id` wins)
  - `viz_type` key accepted as a `chart_type` synonym (explicit `chart_type` wins)
  - common Superset viz plugin names translate to the discriminator + `kind`: `bar`/`dist_bar`/`echarts_timeseries_bar` → `xy`+`bar`, `echarts_timeseries_line` → `xy`+`line`, `big_number_total` → `big_number`, etc. An explicitly provided `kind` is never overridden.
- `XYChartConfig`:
  - `x` accepts a bare column-name string (matching the existing `group_by` coercion)
  - `y` accepts bare strings / a single entry (reuses `_normalize_group_by_input`)
  - `legend` gains a `show_legend` alias and accepts a bool (`True` → `{"show": true}`)
  - `orientation` gains a `chart_orientation` alias

The `UnknownFieldCheckMixin` "did you mean?" behavior is unchanged for genuinely unknown fields — `order_desc` still gets a clear rejection (covered by a regression test).

**`query_dataset` metric errors (`dataset/tool/query_dataset.py`)**
- When the dataset has **no saved metrics**, the error now states the contract and the escape hatch: *"This dataset has no saved metrics, and query_dataset accepts saved metric names only (not ad-hoc expressions). Use execute_sql for ad-hoc aggregates, or add a saved metric to the dataset."*
- When metrics exist but nothing fuzzy-matches, the valid metric names are listed (capped at 10) so the client doesn't guess again.
- The tool docstring states the saved-metrics-only contract up front, since it is the primary text LLM clients read.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (API validation behavior).

Before (live transcript excerpts):

```
Error: 2 validation errors for call[generate_chart] request.dataset_id
  Field required [input_value={'datasource_id': 23, ...}]
Error: 1 validation error for call[generate_chart] request.config
  Input tag 'bar' found using 'chart_type' does not match any of the
  expected tags: 'xy', 'table', 'pie', ...
Error: 1 validation error for call[generate_chart] request.config.xy
  Value error, Unknown field 'show_legend' — did you mean 'legend'?
```

After: each of those payloads validates on the first attempt.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/chart/test_chart_config_coercion.py
pytest tests/unit_tests/mcp_service/chart/ tests/unit_tests/mcp_service/dataset/
```

24 new unit tests cover the alias/coercion paths (including precedence rules and the unknown-field regression); the full chart + dataset MCP suites pass (1006 tests).

For a live check: call `generate_chart` with `{"datasource_id": <id>, "config": {"viz_type": "bar", "x_axis": "<column>", "y": [{"name": "<column>", "aggregate": "SUM"}], "show_legend": true}}` — it should produce a chart instead of three validation errors.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
