### PR TITLE
fix(dashboard): block dependent filter from fetching until defaultToFirstItem parent selects

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.test.tsx
@@ -190,114 +190,112 @@ test('does not render loading spinner when filter has no data source', () => {
   expect(screen.getByTestId('mock-super-chart')).toBeInTheDocument();
 });
 
-describe('defaultToFirstItem parent readiness guard', () => {
-  const parentFilter = createMockFilter({
-    id: 'NATIVE_FILTER-PARENT',
-    controlValues: { defaultToFirstItem: true },
-  });
-  const childFilter = createMockFilter({
-    id: 'NATIVE_FILTER-CHILD',
-    cascadeParentIds: ['NATIVE_FILTER-PARENT'],
-  });
-  const stateWithBothFilters = {
-    nativeFilters: {
-      filters: {
-        'NATIVE_FILTER-CHILD': childFilter,
-        'NATIVE_FILTER-PARENT': parentFilter,
-      },
-      filterSets: {},
+const defaultFirstItemParentFilter = createMockFilter({
+  id: 'NATIVE_FILTER-PARENT',
+  controlValues: { defaultToFirstItem: true },
+});
+const guardChildFilter = createMockFilter({
+  id: 'NATIVE_FILTER-CHILD',
+  cascadeParentIds: ['NATIVE_FILTER-PARENT'],
+});
+const stateWithDefaultFirstItemParent = {
+  nativeFilters: {
+    filters: {
+      'NATIVE_FILTER-CHILD': guardChildFilter,
+      'NATIVE_FILTER-PARENT': defaultFirstItemParentFilter,
     },
-  };
+    filterSets: {},
+  },
+};
 
-  test('does not fetch while a defaultToFirstItem parent has not yet auto-selected', () => {
-    // Reproduces sc-108451: B should not fetch from unfiltered data before A selects.
-    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
-    mockUseFilterDependencies.mockReturnValue({});
+test('guard: does not fetch while a defaultToFirstItem parent has not yet auto-selected', () => {
+  // Reproduces sc-108451: B should not fetch from unfiltered data before A selects.
+  mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+  mockUseFilterDependencies.mockReturnValue({});
 
-    renderFilterValue(
-      {
-        filter: childFilter,
-        // Parent entry exists but filterState.value is undefined (no selection yet).
-        dataMaskSelected: {
-          'NATIVE_FILTER-PARENT': { filterState: {}, extraFormData: {} },
-        },
+  renderFilterValue(
+    {
+      filter: guardChildFilter,
+      // Parent entry exists but filterState.value is undefined (no selection yet).
+      dataMaskSelected: {
+        'NATIVE_FILTER-PARENT': { filterState: {}, extraFormData: {} },
       },
-      stateWithBothFilters,
-    );
+    },
+    stateWithDefaultFirstItemParent,
+  );
 
-    expect(mockGetChartDataRequest).not.toHaveBeenCalled();
+  expect(mockGetChartDataRequest).not.toHaveBeenCalled();
+});
+
+test('guard: fetches once a defaultToFirstItem parent has set its first value', async () => {
+  mockGetChartDataRequest.mockResolvedValue({
+    response: { status: 200 },
+    json: { result: [{ data: [{ model: 'Corolla' }] }] },
+  });
+  mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+  mockUseFilterDependencies.mockReturnValue({
+    filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
   });
 
-  test('fetches once a defaultToFirstItem parent has set its first value', async () => {
-    mockGetChartDataRequest.mockResolvedValue({
-      response: { status: 200 },
-      json: { result: [{ data: [{ model: 'Corolla' }] }] },
-    });
-    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
-    mockUseFilterDependencies.mockReturnValue({
-      filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
-    });
-
-    renderFilterValue(
-      {
-        filter: childFilter,
-        dataMaskSelected: {
-          'NATIVE_FILTER-PARENT': {
-            // Parent has auto-selected its first value → guard should pass.
-            filterState: { value: ['Toyota'] },
-            extraFormData: {
-              filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
-            },
+  renderFilterValue(
+    {
+      filter: guardChildFilter,
+      dataMaskSelected: {
+        'NATIVE_FILTER-PARENT': {
+          // Parent has auto-selected its first value → guard should pass.
+          filterState: { value: ['Toyota'] },
+          extraFormData: {
+            filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
           },
         },
       },
-      stateWithBothFilters,
-    );
+    },
+    stateWithDefaultFirstItemParent,
+  );
 
-    await waitFor(() => {
-      expect(mockGetChartDataRequest).toHaveBeenCalled();
-    });
+  await waitFor(() => {
+    expect(mockGetChartDataRequest).toHaveBeenCalled();
+  });
+});
+
+test('guard: does not block fetch for a parent without defaultToFirstItem', async () => {
+  // Non-defaultToFirstItem parents with values should pass the guard as before.
+  mockGetChartDataRequest.mockResolvedValue({
+    response: { status: 200 },
+    json: { result: [{ data: [] }] },
+  });
+  mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+  mockUseFilterDependencies.mockReturnValue({
+    filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
   });
 
-  test('does not block fetch for a parent without defaultToFirstItem', async () => {
-    // Non-defaultToFirstItem parents with values should pass the guard as before.
-    mockGetChartDataRequest.mockResolvedValue({
-      response: { status: 200 },
-      json: { result: [{ data: [] }] },
-    });
-    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
-    mockUseFilterDependencies.mockReturnValue({
-      filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
-    });
+  const regularParent = createMockFilter({ id: 'NATIVE_FILTER-PARENT' });
 
-    const regularParent = createMockFilter({ id: 'NATIVE_FILTER-PARENT' });
-
-    renderFilterValue(
-      {
-        filter: childFilter,
-        dataMaskSelected: {
-          'NATIVE_FILTER-PARENT': {
-            filterState: { value: ['Toyota'] },
-            extraFormData: {
-              filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
-            },
+  renderFilterValue(
+    {
+      filter: guardChildFilter,
+      dataMaskSelected: {
+        'NATIVE_FILTER-PARENT': {
+          filterState: { value: ['Toyota'] },
+          extraFormData: {
+            filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
           },
         },
       },
-      {
-        nativeFilters: {
-          filters: {
-            'NATIVE_FILTER-CHILD': childFilter,
-            'NATIVE_FILTER-PARENT': regularParent,
-          },
-          filterSets: {},
+    },
+    {
+      nativeFilters: {
+        filters: {
+          'NATIVE_FILTER-CHILD': guardChildFilter,
+          'NATIVE_FILTER-PARENT': regularParent,
         },
+        filterSets: {},
       },
-    );
+    },
+  );
 
-    await waitFor(() => {
-      expect(mockGetChartDataRequest).toHaveBeenCalled();
-    });
+  await waitFor(() => {
+    expect(mockGetChartDataRequest).toHaveBeenCalled();
   });
 });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.test.tsx
@@ -190,6 +190,117 @@ test('does not render loading spinner when filter has no data source', () => {
   expect(screen.getByTestId('mock-super-chart')).toBeInTheDocument();
 });
 
+describe('defaultToFirstItem parent readiness guard', () => {
+  const parentFilter = createMockFilter({
+    id: 'NATIVE_FILTER-PARENT',
+    controlValues: { defaultToFirstItem: true },
+  });
+  const childFilter = createMockFilter({
+    id: 'NATIVE_FILTER-CHILD',
+    cascadeParentIds: ['NATIVE_FILTER-PARENT'],
+  });
+  const stateWithBothFilters = {
+    nativeFilters: {
+      filters: {
+        'NATIVE_FILTER-CHILD': childFilter,
+        'NATIVE_FILTER-PARENT': parentFilter,
+      },
+      filterSets: {},
+    },
+  };
+
+  test('does not fetch while a defaultToFirstItem parent has not yet auto-selected', () => {
+    // Reproduces sc-108451: B should not fetch from unfiltered data before A selects.
+    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+    mockUseFilterDependencies.mockReturnValue({});
+
+    renderFilterValue(
+      {
+        filter: childFilter,
+        // Parent entry exists but filterState.value is undefined (no selection yet).
+        dataMaskSelected: {
+          'NATIVE_FILTER-PARENT': { filterState: {}, extraFormData: {} },
+        },
+      },
+      stateWithBothFilters,
+    );
+
+    expect(mockGetChartDataRequest).not.toHaveBeenCalled();
+  });
+
+  test('fetches once a defaultToFirstItem parent has set its first value', async () => {
+    mockGetChartDataRequest.mockResolvedValue({
+      response: { status: 200 },
+      json: { result: [{ data: [{ model: 'Corolla' }] }] },
+    });
+    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+    mockUseFilterDependencies.mockReturnValue({
+      filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
+    });
+
+    renderFilterValue(
+      {
+        filter: childFilter,
+        dataMaskSelected: {
+          'NATIVE_FILTER-PARENT': {
+            // Parent has auto-selected its first value → guard should pass.
+            filterState: { value: ['Toyota'] },
+            extraFormData: {
+              filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
+            },
+          },
+        },
+      },
+      stateWithBothFilters,
+    );
+
+    await waitFor(() => {
+      expect(mockGetChartDataRequest).toHaveBeenCalled();
+    });
+  });
+
+  test('does not block fetch for a parent without defaultToFirstItem', async () => {
+    // Non-defaultToFirstItem parents with values should pass the guard as before.
+    mockGetChartDataRequest.mockResolvedValue({
+      response: { status: 200 },
+      json: { result: [{ data: [] }] },
+    });
+    mockUseTransitiveParentIds.mockReturnValue(['NATIVE_FILTER-PARENT']);
+    mockUseFilterDependencies.mockReturnValue({
+      filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
+    });
+
+    const regularParent = createMockFilter({ id: 'NATIVE_FILTER-PARENT' });
+
+    renderFilterValue(
+      {
+        filter: childFilter,
+        dataMaskSelected: {
+          'NATIVE_FILTER-PARENT': {
+            filterState: { value: ['Toyota'] },
+            extraFormData: {
+              filters: [{ col: 'make', op: 'IN', val: ['Toyota'] }],
+            },
+          },
+        },
+      },
+      {
+        nativeFilters: {
+          filters: {
+            'NATIVE_FILTER-CHILD': childFilter,
+            'NATIVE_FILTER-PARENT': regularParent,
+          },
+          filterSets: {},
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockGetChartDataRequest).toHaveBeenCalled();
+    });
+  });
+});
+
 test('skips data fetch when cascade parent filters have no values selected', () => {
   // useFilterDependencies returns dependencies with a filter (from parent defaults),
   // but dataMaskSelected has no extraFormData for the parent -- counts disagree, so

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -125,8 +125,16 @@ const FilterValue: FC<FilterValueProps> = ({
   const transitiveParentIds = useTransitiveParentIds(id);
   const shouldRefresh = useShouldFilterRefresh();
 
-  const allFiltersConfig = useSelector(
-    (state: RootState) => state.nativeFilters?.filters,
+  // Derive only the defaultToFirstItem flag per filter to avoid re-renders
+  // when unrelated filter config fields change.
+  const parentDefaultToFirstItem = useSelector(
+    (state: RootState) =>
+      Object.fromEntries(
+        Object.entries(state.nativeFilters?.filters ?? {}).map(([fId, f]) => [
+          fId,
+          Boolean(f.controlValues?.defaultToFirstItem),
+        ]),
+      ),
     shallowEqual,
   );
 
@@ -213,10 +221,9 @@ const FilterValue: FC<FilterValueProps> = ({
       // auto-selects, leading to a stale first-value dispatch that never
       // gets corrected because subsequent re-selections are not first-initialization.
       const hasDefaultFirstParentPending = transitiveParentIds.some(pId => {
-        const parentFilter = allFiltersConfig?.[pId];
         const parentMask = dataMaskSelected?.[pId];
         return (
-          parentFilter?.controlValues?.defaultToFirstItem &&
+          parentDefaultToFirstItem[pId] &&
           parentMask?.filterState?.value === undefined
         );
       });
@@ -328,7 +335,7 @@ const FilterValue: FC<FilterValueProps> = ({
     dataMaskSelected,
     setHasDepsFilterValue,
     transitiveParentIds,
-    allFiltersConfig,
+    parentDefaultToFirstItem,
   ]);
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -44,7 +44,7 @@ import {
 } from '@superset-ui/core';
 import { styled, SupersetTheme } from '@apache-superset/core/theme';
 import { useTheme } from '@emotion/react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { isEqual, isEqualWith } from 'lodash-es';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ErrorAlert, ErrorMessageWithStackTrace } from 'src/components';
@@ -125,6 +125,11 @@ const FilterValue: FC<FilterValueProps> = ({
   const transitiveParentIds = useTransitiveParentIds(id);
   const shouldRefresh = useShouldFilterRefresh();
 
+  const allFiltersConfig = useSelector(
+    (state: RootState) => state.nativeFilters?.filters,
+    shallowEqual,
+  );
+
   const behaviors = useMemo(
     () => [
       isCustomization ? Behavior.ChartCustomization : Behavior.NativeFilter,
@@ -202,6 +207,22 @@ const FilterValue: FC<FilterValueProps> = ({
       // selections first. We walk the full transitive ancestor chain (not just
       // direct parents) so the counts line up with `dependencies`, which is
       // itself built from the transitive chain by `useFilterDependencies`.
+
+      // Block if any parent with defaultToFirstItem hasn't auto-selected yet.
+      // Without this, the child fetches unfiltered options before the parent
+      // auto-selects, leading to a stale first-value dispatch that never
+      // gets corrected because subsequent re-selections are not first-initialization.
+      const hasDefaultFirstParentPending = transitiveParentIds.some(pId => {
+        const parentFilter = allFiltersConfig?.[pId];
+        const parentMask = dataMaskSelected?.[pId];
+        return (
+          parentFilter?.controlValues?.defaultToFirstItem &&
+          parentMask?.filterState?.value === undefined
+        );
+      });
+      if (hasDefaultFirstParentPending) {
+        return;
+      }
 
       let selectedParentFilterValueCounts = 0;
       let isTimeRangeSelected = false;
@@ -307,6 +328,7 @@ const FilterValue: FC<FilterValueProps> = ({
     dataMaskSelected,
     setHasDepsFilterValue,
     transitiveParentIds,
+    allFiltersConfig,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### SUMMARY

When filters A and B both have **Select first filter value** (`defaultToFirstItem = true`) enabled and B depends on A, charts received a partial/incorrect filter set on dashboard load. The user had to click **Apply** a second time to get the correct result.

**Root cause:** The readiness guard in `FilterValue.tsx` compares `selectedParentFilterValueCounts` against `depsCount`. On initial load both values are `0` (A's `extraFormData` is empty — it hasn't auto-selected yet), so `0 === 0` passes the guard and B fetches options from the unfiltered dataset immediately. B then auto-selects the first unfiltered item (e.g. `model = 'Acura'`) and, because it is a first-initialization with `requiredFirst = true` (set by `defaultToFirstItem`), dispatches that value to charts.

When A later auto-selects its first item (e.g. `make = 'Toyota'`), B re-fetches with Toyota's filter and re-selects the correct first Toyota model. But by this point B is **no longer** a first-initialization event, so `shouldDispatch` is `false` in `handleFilterSelectionChange` and the corrected value is silently dropped. Charts are left with A=Toyota + B=Acura (wrong).

**Fix:** Before the existing count-based check in the readiness guard, add a short-circuit that returns early when any transitive ancestor with `defaultToFirstItem = true` has not yet set `filterState.value`. This ensures B's first fetch and auto-select happen only after A has settled, keeping the first-initialization dispatch path intact.

Shortcut: sc-108451
Related: #39504 (sc-102912, transitive ancestor chain fix)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavior-only fix, no UI change.

### TESTING INSTRUCTIONS

1. Create a dashboard with the **Vehicle Sales** dataset.
2. Add two native **Value** filters:
   - Filter A — column `make`, enable **Select first filter value**
   - Filter B — column `model`, enable **Select first filter value**, set **Parent filter** = A
3. Scope both filters to a chart that uses `make` and `model`.
4. Save, then **reload** the dashboard (do not click Apply).
5. **Before this fix:** the chart is filtered by only one of the two values; a second Apply is needed.
6. **After this fix:** both filters are auto-applied correctly on the first load — B shows the first model belonging to A's first make.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API