### PR TITLE
feat(docker): add environment values to set log file for worker and beat

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -67,18 +67,24 @@ else
   echo "Skipping local overrides"
 fi
 
-HYPHEN_SYMBOL='-'
+LOGFILE_ARG=""
 
 case "${1}" in
   worker)
     echo "Starting Celery worker..."
+    if [ -n "$WORKER_LOG_FILE" ]; then
+      LOGFILE_ARG="--logfile=$WORKER_LOG_FILE"
+    fi
     # setting up only 2 workers by default to contain memory usage in dev environments
-    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} --logfile="${WORKER_LOG_FILE:-$HYPHEN_SYMBOL}"
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} ${LOGFILE_ARG}
     ;;
   beat)
     echo "Starting Celery beat..."
+    if [ -n "$BEAT_LOG_FILE" ]; then
+      LOGFILE_ARG="--logfile=$BEAT_LOG_FILE"
+    fi
     rm -f /tmp/celerybeat.pid
-    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule --logfile="${BEAT_LOG_FILE:-$HYPHEN_SYMBOL}"
+    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule ${LOGFILE_ARG}
     ;;
   app)
     echo "Starting web app (using development server)..."

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -67,24 +67,16 @@ else
   echo "Skipping local overrides"
 fi
 
-LOGFILE_ARG=""
-
 case "${1}" in
   worker)
     echo "Starting Celery worker..."
-    if [ -n "$WORKER_LOG_FILE" ]; then
-      LOGFILE_ARG="--logfile=$WORKER_LOG_FILE"
-    fi
     # setting up only 2 workers by default to contain memory usage in dev environments
-    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} ${LOGFILE_ARG}
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} ${WORKER_LOG_FILE:+--logfile=$WORKER_LOG_FILE}
     ;;
   beat)
     echo "Starting Celery beat..."
-    if [ -n "$BEAT_LOG_FILE" ]; then
-      LOGFILE_ARG="--logfile=$BEAT_LOG_FILE"
-    fi
     rm -f /tmp/celerybeat.pid
-    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule ${LOGFILE_ARG}
+    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule ${BEAT_LOG_FILE:+--logfile=$BEAT_LOG_FILE}
     ;;
   app)
     echo "Starting web app (using development server)..."

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -73,12 +73,12 @@ case "${1}" in
   worker)
     echo "Starting Celery worker..."
     # setting up only 2 workers by default to contain memory usage in dev environments
-    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} --logfile=${WORKER_LOG_FILE:-$HYPHEN_SYMBOL}
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} --logfile="${WORKER_LOG_FILE:-$HYPHEN_SYMBOL}"
     ;;
   beat)
     echo "Starting Celery beat..."
     rm -f /tmp/celerybeat.pid
-    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule --logfile=${BEAT_LOG_FILE:-$HYPHEN_SYMBOL}
+    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule --logfile="${BEAT_LOG_FILE:-$HYPHEN_SYMBOL}"
     ;;
   app)
     echo "Starting web app (using development server)..."

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -67,16 +67,18 @@ else
   echo "Skipping local overrides"
 fi
 
+HYPHEN_SYMBOL='-'
+
 case "${1}" in
   worker)
     echo "Starting Celery worker..."
     # setting up only 2 workers by default to contain memory usage in dev environments
-    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2}
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2} --logfile=${WORKER_LOG_FILE:-$HYPHEN_SYMBOL}
     ;;
   beat)
     echo "Starting Celery beat..."
     rm -f /tmp/celerybeat.pid
-    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
+    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule --logfile=${BEAT_LOG_FILE:-$HYPHEN_SYMBOL}
     ;;
   app)
     echo "Starting web app (using development server)..."


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR introduces two new environment variables, `WORKER_LOG_FILE` and `BEAT_LOG_FILE`, to configure log file destinations for the worker and beat in the default Docker environment. 

Default values remain unchanged to ensure backward compatibility.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
