### PR TITLE
fix(viz): use series_limit/series_limit_metric in query_obj dict

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -440,9 +440,9 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             "metrics": metrics,
             "row_limit": row_limit,
             "filter": self.form_data.get("filters", []),
-            "timeseries_limit": limit,
+            "series_limit": limit,
             "extras": extras,
-            "timeseries_limit_metric": timeseries_limit_metric,
+            "series_limit_metric": timeseries_limit_metric,
             "order_desc": order_desc,
         }
 


### PR DESCRIPTION
### What's the change?

`BaseViz.query_obj()` was returning a `QueryObjectDict` with the deprecated keys `timeseries_limit` and `timeseries_limit_metric`. These keys hit `QueryObject._rename_deprecated_fields()` on every chart render, which logs a `WARNING`-level deprecation message per request.

**Production warning (Datadog, 2026-06-12):**
```
/home/superset/preset/superset-oss/superset/common/query_object.py:223:
  The field `timeseries_limit` is deprecated, please use `series_limit` instead.
  The field `timeseries_limit_metric` is deprecated, please use `series_limit_metric` instead.
```

### What changed?

In `superset/viz.py`, the two keys in the returned dict were renamed:
- `"timeseries_limit": limit` → `"series_limit": limit`  
- `"timeseries_limit_metric": timeseries_limit_metric` → `"series_limit_metric": timeseries_limit_metric`

`form_data.get("timeseries_limit_metric")` reads on lines 383/993/1421/2648 are untouched — those read from user-saved chart configurations and must keep accepting the old field name for backward compatibility.

### No behavior change

`_rename_deprecated_fields()` would have copied the old-key values to the same `series_limit`/`series_limit_metric` attributes anyway. This fix just bypasses the deprecated path entirely.

`QueryObjectDict` is defined with `total=False`, so removing `timeseries_limit` from the returned dict does not break the type contract.

### Test plan

- [ ] Existing `tests/integration_tests/query_context_tests.py` covers the deprecation-rename path end-to-end (old field in → `query_object.series_limit == value`)
- [ ] `viz_tests.py` assertions on `query_obj()` do not assert on these specific keys — no updates needed
- [ ] All pre-commit hooks pass (mypy, ruff, pylint, auto-walrus, blacklist)