### PR TITLE
fix(embedded): skip CSRF token fetch for guest streaming chart exports

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -425,6 +425,7 @@ const ResultSet = ({
                     url: makeUrl('/api/v1/sqllab/export_streaming/'),
                     payload: { client_id: query.id },
                     exportType: 'csv',
+                    exportSource: 'sqllab',
                     expectedRows: rows,
                   });
                 } else {

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -276,6 +276,7 @@ test('guest-token chart exports skip CSRF fetch and include guest_token form fie
       url: '/api/v1/chart/data',
       payload: { datasource: '1__table', viz_type: 'table' },
       exportType: 'csv',
+      exportSource: 'chart',
       expectedRows: 100000,
     });
   });
@@ -327,6 +328,7 @@ test('non-guest chart exports fetch CSRF and include X-CSRFToken header', async 
       url: '/api/v1/chart/data',
       payload: { datasource: '1__table', viz_type: 'table' },
       exportType: 'csv',
+      exportSource: 'chart',
     });
   });
 
@@ -382,6 +384,7 @@ test('SQL Lab exports fetch CSRF and omit guest_token even when guest token exis
       url: '/api/v1/sqllab/export_streaming/',
       payload: { client_id: 'test-id' },
       exportType: 'csv',
+      exportSource: 'sqllab',
     });
   });
 
@@ -397,6 +400,37 @@ test('SQL Lab exports fetch CSRF and omit guest_token even when guest token exis
     'X-CSRFToken': 'mock-csrf-token',
   });
   expect(body.get('client_id')).toBe('test-id');
+  expect(body.has('guest_token')).toBe(false);
+});
+
+test('guest tokens do not bypass CSRF for unclassified non-client exports', async () => {
+  applicationRoot.mockReturnValue('');
+  SupersetClient.getGuestToken.mockReturnValue('guest-token');
+
+  const mockFetch = createPrefixTestMockFetch();
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/other/export_streaming/',
+      payload: { export_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  expect(SupersetClient.getCSRFToken).toHaveBeenCalledTimes(1);
+  const [, requestInit] = mockFetch.mock.calls[0];
+  const body = requestInit.body as URLSearchParams;
+
+  expect(requestInit.headers).toMatchObject({
+    'X-CSRFToken': 'mock-csrf-token',
+  });
   expect(body.has('guest_token')).toBe(false);
 });
 

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -356,6 +356,7 @@ test('chart streaming export includes guest token in form body when configured',
       url: '/api/v1/chart/data',
       payload: { datasource: '1__table', viz_type: 'table' },
       exportType: 'csv',
+      exportSource: 'chart',
     });
   });
 

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -48,11 +48,11 @@ global.URL.revokeObjectURL = jest.fn();
 
 global.fetch = jest.fn();
 
-const { SupersetClient } = jest.requireMock('@superset-ui/core');
-
 beforeEach(() => {
   jest.clearAllMocks();
   global.fetch = jest.fn();
+  const { SupersetClient } = jest.requireMock('@superset-ui/core');
+  SupersetClient.getCSRFToken.mockResolvedValue('mock-csrf-token');
   SupersetClient.getGuestToken.mockReturnValue(undefined);
 });
 
@@ -228,6 +228,7 @@ test('sets ERROR status and calls onError when fetch rejects', async () => {
 // URL prefix guard tests - prevent regression of missing app root prefix
 const { applicationRoot } = jest.requireMock('src/utils/getBootstrapData');
 const { makeUrl } = jest.requireMock('src/utils/pathUtils');
+const { SupersetClient } = jest.requireMock('@superset-ui/core');
 
 const createPrefixTestMockFetch = () =>
   jest.fn().mockResolvedValue({
@@ -241,6 +242,105 @@ const createPrefixTestMockFetch = () =>
       }),
     },
   });
+
+test('guest-token chart exports skip CSRF fetch and include guest_token form field', async () => {
+  applicationRoot.mockReturnValue('');
+  SupersetClient.getGuestToken.mockReturnValue('guest-token');
+  SupersetClient.getCSRFToken.mockRejectedValue(new Error('CSRF forbidden'));
+
+  const csvData = new TextEncoder().encode('id,name\n1,Alice\n');
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="embedded.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/chart/data',
+      payload: { datasource: '1__table', viz_type: 'table' },
+      exportType: 'csv',
+      expectedRows: 100000,
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(SupersetClient.getCSRFToken).not.toHaveBeenCalled();
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [, requestInit] = mockFetch.mock.calls[0];
+  const body = requestInit.body as URLSearchParams;
+
+  expect(body.get('guest_token')).toBe('guest-token');
+  expect(body.get('expected_rows')).toBe('100000');
+  expect(body.get('form_data')).toBe(
+    JSON.stringify({ datasource: '1__table', viz_type: 'table' }),
+  );
+});
+
+test('non-guest chart exports fetch CSRF and include X-CSRFToken header', async () => {
+  applicationRoot.mockReturnValue('');
+
+  const csvData = new TextEncoder().encode('id,name\n1,Alice\n');
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="chart.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/chart/data',
+      payload: { datasource: '1__table', viz_type: 'table' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(SupersetClient.getCSRFToken).toHaveBeenCalledTimes(1);
+  const [, requestInit] = mockFetch.mock.calls[0];
+  expect(requestInit.headers).toMatchObject({
+    'X-CSRFToken': 'mock-csrf-token',
+  });
+  expect((requestInit.body as URLSearchParams).has('guest_token')).toBe(false);
+});
 
 test('chart streaming export includes guest token in form body when configured', async () => {
   SupersetClient.getGuestToken.mockReturnValue('guest-token');
@@ -266,6 +366,38 @@ test('chart streaming export includes guest token in form body when configured',
   expect(request.body.get('form_data')).toBe(
     JSON.stringify({ datasource: '1__table', viz_type: 'table' }),
   );
+});
+
+test('SQL Lab exports fetch CSRF and omit guest_token even when guest token exists', async () => {
+  applicationRoot.mockReturnValue('');
+  SupersetClient.getGuestToken.mockReturnValue('guest-token');
+
+  const mockFetch = createPrefixTestMockFetch();
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  expect(SupersetClient.getCSRFToken).toHaveBeenCalledTimes(1);
+  const [, requestInit] = mockFetch.mock.calls[0];
+  const body = requestInit.body as URLSearchParams;
+
+  expect(requestInit.headers).toMatchObject({
+    'X-CSRFToken': 'mock-csrf-token',
+  });
+  expect(body.get('client_id')).toBe('test-id');
+  expect(body.has('guest_token')).toBe(false);
 });
 
 test('URL prefix guard applies prefix to unprefixed relative URL when app root is configured', async () => {

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -102,10 +102,15 @@ const createFetchRequest = async (
     'Content-Type': 'application/x-www-form-urlencoded',
   };
 
-  // Get CSRF token using SupersetClient
-  const csrfToken = await SupersetClient.getCSRFToken();
-  if (csrfToken) {
-    headers['X-CSRFToken'] = csrfToken;
+  const guestToken = SupersetClient.getGuestToken();
+  const isGuestTokenChartExport =
+    Boolean(guestToken) && !('client_id' in payload);
+
+  if (!isGuestTokenChartExport) {
+    const csrfToken = await SupersetClient.getCSRFToken();
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
   }
 
   const formParams: Record<string, string> = {};
@@ -118,8 +123,7 @@ const createFetchRequest = async (
     formParams.expected_rows = expectedRows.toString();
   }
 
-  const guestToken = SupersetClient.getGuestToken();
-  if (guestToken) {
+  if (guestToken && isGuestTokenChartExport) {
     formParams.guest_token = guestToken;
   }
 

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -112,6 +112,8 @@ const createFetchRequest = async (
     exportSource === 'chart' &&
     !('client_id' in payload);
 
+  // Embedded guest sessions cannot fetch CSRF tokens. Guest chart exports are
+  // safe because chart data is CSRF-exempt and auth is carried by guest_token.
   if (!isGuestTokenChartExport) {
     const csrfToken = await SupersetClient.getCSRFToken();
     if (csrfToken) {

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -31,6 +31,8 @@ interface StreamingExportPayload {
   [key: string]: any;
 }
 
+type StreamingExportSource = 'chart' | 'sqllab';
+
 interface StreamingExportParams {
   /**
    * The API endpoint URL for the export request.
@@ -46,6 +48,7 @@ interface StreamingExportParams {
   payload: StreamingExportPayload;
   filename?: string;
   exportType: 'csv' | 'xlsx';
+  exportSource?: StreamingExportSource;
   expectedRows?: number;
 }
 
@@ -95,6 +98,7 @@ const createFetchRequest = async (
   payload: StreamingExportPayload,
   filename: string | undefined,
   _exportType: string,
+  exportSource: StreamingExportSource | undefined,
   expectedRows: number | undefined,
   signal: AbortSignal,
 ): Promise<RequestInit> => {
@@ -104,7 +108,9 @@ const createFetchRequest = async (
 
   const guestToken = SupersetClient.getGuestToken();
   const isGuestTokenChartExport =
-    Boolean(guestToken) && !('client_id' in payload);
+    Boolean(guestToken) &&
+    exportSource === 'chart' &&
+    !('client_id' in payload);
 
   if (!isGuestTokenChartExport) {
     const csrfToken = await SupersetClient.getCSRFToken();
@@ -189,7 +195,8 @@ export const useStreamingExport = (options: UseStreamingExportOptions = {}) => {
 
   const executeExport = useCallback(
     async (params: StreamingExportParams) => {
-      const { url, payload, filename, exportType, expectedRows } = params;
+      const { url, payload, filename, exportType, exportSource, expectedRows } =
+        params;
       if (isExportingRef.current) {
         return;
       }
@@ -214,6 +221,7 @@ export const useStreamingExport = (options: UseStreamingExportOptions = {}) => {
           payload,
           filename,
           exportType,
+          exportSource,
           expectedRows,
           abortControllerRef.current.signal,
         );

--- a/superset-frontend/src/explore/exploreUtils/index.ts
+++ b/superset-frontend/src/explore/exploreUtils/index.ts
@@ -99,6 +99,7 @@ interface ExportChartParams {
         url: string | null;
         payload: QueryFormData | ReturnType<typeof buildQueryContext>;
         exportType: string;
+        exportSource: 'chart';
       }) => void)
     | null;
 }
@@ -394,6 +395,7 @@ export const exportChart = async ({
       url: url ? ensureAppRoot(url) : url,
       payload,
       exportType: resultFormat,
+      exportSource: 'chart',
     });
   } else {
     // SupersetClient.postForm calls getUrl({ endpoint }) internally, which prepends


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Fixes embedded dashboard high-row-count CSV exports for guest-token sessions.

Before this change, the streaming CSV export path always tried to fetch a session CSRF token before building the native `fetch` POST. Embedded guest sessions do not rely on a logged-in Superset session cookie, so the export could fail before the chart data export request had the guest auth material it needed.

Guest token transport for streaming chart exports already exists (#40712), but the request construction still awaited the session CSRF fetch first, and embedded guest sessions cannot read `/api/v1/security/csrf_token/` — the export failed before the POST was ever sent. The export endpoints are CSRF-exempt and authenticate guests via the `guest_token` form field, so the CSRF bootstrap is unnecessary on this path.

This updates streaming export request construction to:

- skip the session CSRF fetch only for guest-token chart exports;
- scope the `guest_token` form field to chart exports, so SQL Lab streaming exports keep the session CSRF path and do not carry guest-token material;
- preserve the existing CSRF header path for logged-in non-guest exports and SQL Lab exports.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - no visual layout changes. The visible behavior change is covered by the live browser validation below: the CSV Export modal reaches `Export successful` in an embedded guest session instead of failing.

### TESTING INSTRUCTIONS

- Live browser validation in a local Docker Compose Superset runtime: opened an embedded dashboard host page in a fresh logged-out browser context, sent a fresh guest token, and exported a table chart configured with `row_limit=100000`; observed the CSV Export modal reach `Export successful`, the export `POST /api/v1/chart/data` include `guest_token` and `expected_rows=100000`, no CSRF token request during the guest export, and a downloaded CSV with 100000 data rows plus header.
- Live browser validation in the same local Docker Compose Superset runtime: repeated the export from a normal logged-in dashboard page for the same chart; observed the CSRF token request, `X-CSRFToken` on the export POST, no `guest_token` form field, `200 OK`, and the CSV download with 100000 data rows plus header.
- Focused regression test: `cd superset-frontend && npm run test -- src/components/StreamingExportModal/useStreamingExport.test.ts --testNamePattern "guest-token chart exports|non-guest chart exports|SQL Lab exports" --silent=false`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
