### PR TITLE
fix(explore): theme SQL autocomplete completion highlight consistently

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
@@ -18,6 +18,7 @@
  */
 import { createRef } from 'react';
 import { render, screen, waitFor } from '@superset-ui/core/spec';
+import { supersetTheme } from '@apache-superset/core/theme';
 import type AceEditor from 'react-ace';
 import {
   AsyncAceEditor,
@@ -28,6 +29,7 @@ import {
   CssEditor,
   JsonEditor,
   ConfigEditor,
+  aceCompletionHighlightStyles,
 } from '.';
 
 import type { AceModule, AsyncAceEditorOptions } from './types';
@@ -40,6 +42,17 @@ test('renders SQLEditor', async () => {
   await waitFor(() => {
     expect(container.querySelector(selector)).toBeInTheDocument();
   });
+});
+
+test('themes the autocomplete completion highlight from the theme', () => {
+  // Ace ships a hardcoded `color: #000` for the matched-prefix highlight, which
+  // is invisible on the dark autocomplete popup. The shared editor overrides it
+  // from the theme so every Ace editor (SQL Lab, Explore Custom SQL, ...) stays
+  // consistent.
+  const { styles } = aceCompletionHighlightStyles(supersetTheme);
+
+  expect(styles).toContain('.ace_completion-highlight');
+  expect(styles).toContain(supersetTheme.colorPrimaryText);
 });
 
 test('SQLEditor uses fontFamilyCode from theme', async () => {

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
@@ -32,7 +32,7 @@ import {
   AsyncEsmComponent,
   PlaceholderProps,
 } from '@superset-ui/core/components/AsyncEsmComponent';
-import { useTheme, css } from '@apache-superset/core/theme';
+import { useTheme, css, type SupersetTheme } from '@apache-superset/core/theme';
 import { Global } from '@emotion/react';
 
 export { getTooltipHTML } from './Tooltip';
@@ -104,6 +104,19 @@ export type AsyncAceEditorOptions = {
     PlaceholderProps & Partial<IAceEditorProps>
   > | null;
 };
+
+/**
+ * Theme-aware styling for the matched-prefix highlight in the autocomplete
+ * popup. Ace ships a hardcoded `color: #000` that is invisible on the dark
+ * popup, so the override needs `!important` to win. Lives in the shared editor
+ * so every Ace editor (SQL Lab, Explore Custom SQL, ...) stays consistent.
+ */
+export const aceCompletionHighlightStyles = (token: SupersetTheme) => css`
+  .ace_completion-highlight {
+    color: ${token.colorPrimaryText} !important;
+    background-color: ${token.colorPrimaryBgHover};
+  }
+`;
 
 /**
  * Get an async AceEditor with automatical loading of specified ace modules.
@@ -369,6 +382,8 @@ export function AsyncAceEditor(
                 .ace_tooltip.ace_doc-tooltip {
                   display: flex !important;
                 }
+
+                ${aceCompletionHighlightStyles(token)}
 
                 &&& .tooltip-detail {
                   display: flex;

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
@@ -349,11 +349,6 @@ const EditorWrapper = ({
           width: ${theme.sizeUnit * 130}px !important;
         }
 
-        .ace_completion-highlight {
-          color: ${theme.colorPrimaryText} !important;
-          background-color: ${theme.colorPrimaryBgHover};
-        }
-
         .ace_tooltip {
           max-width: ${SQL_EDITOR_LEFTBAR_WIDTH}px;
         }


### PR DESCRIPTION
### SUMMARY

The matched-prefix highlight in the Ace autocomplete popup (`.ace_completion-highlight`) was only styled in SQL Lab, which adds its own global rule. Every other Ace editor falls back to Ace's built-in `color: #000`. The Custom SQL editor in Explore (metrics and filters) is one of those, so its autocomplete highlight renders black. On the dark autocomplete popup that prefix is black on dark and nearly invisible, and the two editors end up looking different from each other.

This moves the theme-aware highlight rule into the shared `AsyncAceEditor` global block so every Ace editor picks it up, and drops the now-redundant copy from SQL Lab's `EditorWrapper`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Explore, Custom SQL metric, dark mode, autocomplete open. The typed `SP` prefix goes from black (invisible) to the theme color, matching SQL Lab.

Before:

![before](https://files.catbox.moe/n66173.png)

After:

![after](https://files.catbox.moe/3nlgyb.png)

### TESTING INSTRUCTIONS

1. Switch to dark mode.
2. In Explore, click a metric, open the Custom SQL tab, and type a prefix that matches a column (e.g. `SP`). The matched prefix in the autocomplete dropdown should be visible, not black.
3. Do the same in SQL Lab. The highlight should look the same in both editors.
4. `AsyncAceEditor.test.tsx` has a unit test covering the rule.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
