### PR TITLE
test(pie): guard NULL + named group values all render as slices (#33174)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -86,6 +86,49 @@ describe('Pie transformProps', () => {
     );
   });
 
+  test('renders every slice when a NULL group value is mixed with named ones', () => {
+    // Regression guard for https://github.com/apache/superset/issues/33174:
+    // a Pie chart whose groupby dimension contains a NULL/empty value alongside
+    // named values reportedly dropped the named slices (or rendered only the
+    // NULL one). This asserts the transform keeps one slice per row, mapping the
+    // NULL group to the `<NULL>` placeholder and preserving every other slice.
+    const nullMixedChartProps = new ChartProps({
+      formData: {
+        colorScheme: 'bnbColors',
+        datasource: '3__table',
+        granularity_sqla: 'ds',
+        metric: 'sum__num',
+        groupby: ['region'],
+        viz_type: 'pie',
+      } as SqlaFormData,
+      width: 800,
+      height: 600,
+      queriesData: [
+        {
+          data: [
+            { region: '국내', sum__num: 817280006121 },
+            { region: '해외', sum__num: 118777753521 },
+            { region: null, sum__num: 20596314924 },
+          ],
+        },
+      ],
+      theme: supersetTheme,
+    });
+
+    const series = (
+      transformProps(nullMixedChartProps as EchartsPieChartProps).echartOptions
+        .series as PieSeriesOption[]
+    )[0];
+    const data = series.data as PieChartDataItem[];
+
+    // every input row must still produce a slice -- none are dropped
+    expect(data).toHaveLength(3);
+    expect(data.map(d => d.name)).toEqual(['국내', '해외', '<NULL>']);
+    expect(data.map(d => d.value)).toEqual([
+      817280006121, 118777753521, 20596314924,
+    ]);
+  });
+
   test('falls back to scroll for plain legends with overlong labels', () => {
     const longLegendChartProps = new ChartProps({
       formData: {


### PR DESCRIPTION
### SUMMARY

A test-only regression guard for #33174, where a Pie chart whose groupby dimension contains a NULL/empty value alongside named values reportedly dropped the named slices (or rendered only the NULL slice).

I added a `Pie/transformProps` unit test using the exact data shape from the issue (two named groups + one NULL group, with NULL being the smallest value) and asserted that the transform keeps **one slice per input row**, maps the NULL group to the `<NULL>` placeholder, and preserves every other slice with its value.

**This test PASSES on current `master`.** The `transformProps` layer handles NULL-mixed data correctly — `formatSeriesName` maps `null` to `<NULL>` and `transformedData` is built with a straight `data.map(...)`, so no row is dropped. That means the rendering drop described in the issue does **not** originate in `transformProps`.

I'm filing this as an **honest green guard** rather than a fix because:

- The reporter explicitly notes it **does not reproduce with sample data** (reported on 4.1.2 with a specific Korean-language dataset / DB view), and it isn't reproducible at the chart-transform layer.
- Where a NULL-name collision *could* bite is cross-filtering (`labelMap` keys by computed name and `selectedValues` uses `findIndex`, so two rows that both render as `<NULL>` would share a filter index) — but that's a separate, narrower concern from the reported "named slices disappear" symptom and isn't exercised here.

This PR pins the transform-layer contract so any future regression that *does* drop slices fails loudly, and localizes the residual investigation to the data layer / echarts rendering rather than the transform. Happy to extend it (e.g. a cross-filter assertion, or an E2E) if maintainers want to pursue the collision angle.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts -t "NULL group value"
```

Expected: **passes** on master. It is a guard, not a failing reproduction.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #33174
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)