### PR TITLE
feat(docker): enable debug mode by default to allow running docker-composed Superset

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -63,8 +63,8 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 
 # Development and logging configuration
-# FLASK_DEBUG: Enables Flask dev features (auto-reload, better error pages) - keep 'true' for development
-FLASK_DEBUG=true
+# SUPERSET_DEBUG_ENABLED: Enables Flask dev features (auto-reload, better error pages, Werkzeug debugger) - keep 'true' for development
+SUPERSET_DEBUG_ENABLED=true
 # SUPERSET_LOG_LEVEL: Controls Superset application logging verbosity (debug, info, warning, error, critical)
 SUPERSET_LOG_LEVEL=info
 

--- a/docs/developer_docs/contributing/development-setup.md
+++ b/docs/developer_docs/contributing/development-setup.md
@@ -103,7 +103,7 @@ Affecting the Docker build process:
 - **SUPERSET_LOG_LEVEL (default=info)**: Can be set to debug, info, warning, error, critical
   for more verbose logging
 - **SUPERSET_DEBUG_ENABLED (default=true)**: Enable Werkzeug debugger with interactive console.
-  Set to `false` for simulate production environment: `SUPERSET_DEBUG_ENABLED=true docker compose up`
+  Set to `false` for simulate production environment: `SUPERSET_DEBUG_ENABLED=false docker compose up`
 
 For more env vars that affect your configuration, see this
 [superset_config.py](https://github.com/apache/superset/blob/master/docker/pythonpath_dev/superset_config.py)

--- a/docs/developer_docs/contributing/development-setup.md
+++ b/docs/developer_docs/contributing/development-setup.md
@@ -102,8 +102,8 @@ Affecting the Docker build process:
   save some precious time on startup by `SUPERSET_LOAD_EXAMPLES=no docker compose up`
 - **SUPERSET_LOG_LEVEL (default=info)**: Can be set to debug, info, warning, error, critical
   for more verbose logging
-- **SUPERSET_DEBUG_ENABLED (default=false)**: Enable Werkzeug debugger with interactive console.
-  Set to `true` for debugging: `SUPERSET_DEBUG_ENABLED=true docker compose up`
+- **SUPERSET_DEBUG_ENABLED (default=true)**: Enable Werkzeug debugger with interactive console.
+  Set to `false` for simulate production environment: `SUPERSET_DEBUG_ENABLED=true docker compose up`
 
 For more env vars that affect your configuration, see this
 [superset_config.py](https://github.com/apache/superset/blob/master/docker/pythonpath_dev/superset_config.py)


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(docker): enable debug mode by default to allow running docker-composed Superset

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After https://github.com/apache/superset/pull/40327, `SUPERSET_DEBUG_ENABLED` supersedes `FLASK_DEBUG` and since by default not set in `docker/.env`,  *production* Talisman config would be used. This doesn't allow `unsafe-eval` script-src by React-Refresh and would be blocked by CSRF directive.

<img width="1103" height="750" alt="image" src="https://github.com/user-attachments/assets/bc98ae32-010f-4599-9119-9c3b59fd5a26" />


This PR helps fixing said issue and restore DevExp.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Run `docker compose up --build`
2. Check that Superset app is accessible on localhost:8088

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
