### PR TITLE
fix(pandas_postprocessing): pass string operator names to GroupBy.agg to avoid FutureWarning

### DIFF
--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -52,6 +52,13 @@ NUMPY_FUNCTIONS: dict[str, Callable[..., Any]] = {
     "var": np.var,
 }
 
+# Operators that pandas GroupBy.agg accepts as string names. Passing the string
+# avoids a FutureWarning raised when pandas receives a numpy callable it internally
+# maps to its own method (e.g. np.mean → SeriesGroupBy.mean).
+_PANDAS_STRING_AGGREGATORS: frozenset[str] = frozenset(
+    {"count", "max", "mean", "median", "min", "prod", "std", "sum", "var"}
+)
+
 DENYLIST_ROLLING_FUNCTIONS = (
     "count",
     "corr",
@@ -164,7 +171,7 @@ def _get_aggregate_funcs(
             )
         operator = agg_obj["operator"]
         if callable(operator):
-            aggfunc = operator
+            aggfunc: str | Callable[..., Any] = operator
         else:
             func = NUMPY_FUNCTIONS.get(operator)
             if not func:
@@ -175,7 +182,10 @@ def _get_aggregate_funcs(
                     )
                 )
             options = agg_obj.get("options", {})
-            aggfunc = partial(func, **options)
+            if not options and operator in _PANDAS_STRING_AGGREGATORS:
+                aggfunc = operator
+            else:
+                aggfunc = partial(func, **options)
         agg_funcs[name] = NamedAgg(column=column, aggfunc=aggfunc)
 
     return agg_funcs

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -56,7 +56,7 @@ NUMPY_FUNCTIONS: dict[str, Callable[..., Any]] = {
 # avoids a FutureWarning raised when pandas receives a numpy callable it internally
 # maps to its own method (e.g. np.mean → SeriesGroupBy.mean).
 _PANDAS_STRING_AGGREGATORS: frozenset[str] = frozenset(
-    {"count", "max", "mean", "median", "min", "prod", "std", "sum", "var"}
+    {"max", "mean", "median", "min", "prod", "std", "sum", "var"}
 )
 
 DENYLIST_ROLLING_FUNCTIONS = (

--- a/tests/unit_tests/pandas_postprocessing/test_aggregate.py
+++ b/tests/unit_tests/pandas_postprocessing/test_aggregate.py
@@ -38,3 +38,31 @@ def test_aggregate():
     assert series_to_list(df["asc sum"])[0] == 5050
     assert series_to_list(df["asc q2"])[0] == 75
     assert series_to_list(df["desc q1"])[0] == 25
+
+
+def test_aggregate_string_operators():
+    """mean, median, and other operators in _PANDAS_STRING_AGGREGATORS use the
+    pandas string path; verify results match expected values on asc_idx [0..100]."""
+    aggregates = {
+        "asc mean": {"column": "asc_idx", "operator": "mean"},
+        "asc median": {"column": "asc_idx", "operator": "median"},
+        "asc max": {"column": "asc_idx", "operator": "max"},
+        "asc min": {"column": "asc_idx", "operator": "min"},
+    }
+    df = aggregate(df=categories_df, groupby=["constant"], aggregates=aggregates)
+    assert series_to_list(df["asc mean"])[0] == 50.0
+    assert series_to_list(df["asc median"])[0] == 50.0
+    assert series_to_list(df["asc max"])[0] == 100
+    assert series_to_list(df["asc min"])[0] == 0
+
+
+def test_aggregate_count_includes_nulls():
+    """'count' operator uses np.ma.count, which counts all rows including NaN.
+    It is intentionally excluded from _PANDAS_STRING_AGGREGATORS to preserve this
+    behavior (pandas SeriesGroupBy.count excludes NaN)."""
+    aggregates = {
+        "null_count": {"column": "idx_nulls", "operator": "count"},
+    }
+    df = aggregate(df=categories_df, groupby=["constant"], aggregates=aggregates)
+    # idx_nulls has 101 rows total; np.ma.count returns all 101 (NaN included)
+    assert series_to_list(df["null_count"])[0] == 101


### PR DESCRIPTION
## What changed

`superset/utils/pandas_postprocessing/utils.py` — `_get_aggregate_funcs`

**Before:** every operator resolved from `NUMPY_FUNCTIONS` was passed to `GroupBy.agg()` as a `functools.partial(np_func)` callable, even when no keyword options were needed.

**After:** for operators that pandas natively supports as string names (`max`, `mean`, `median`, `min`, `prod`, `std`, `sum`, `var`), the string is passed directly. Operators with no pandas string equivalent (`nanmean`, `average`, `percentile`, etc.) or any operator supplied with non-empty `options` continue to use `partial(func, **options)`.

`"count"` is intentionally **not** included: `NUMPY_FUNCTIONS["count"]` maps to `np.ma.count`, which counts NaN-inclusive (returns the total row count), while `pandas SeriesGroupBy.count` excludes NaN. Changing behavior silently would be wrong.

## Why

pandas warns on every aggregation call when it receives a numpy callable it internally routes to its own Series method:

```
FutureWarning: The provided callable <function mean at 0x…> is currently using
SeriesGroupBy.mean. In a future version of pandas, the provided callable will be
used directly. To keep current behavior pass the string "mean" instead.
```

This warning fires in production on every chart render that uses the `aggregate` post-processing step with `mean` or `median` operators. Passing the string alias invokes the same pandas method — no behavior change.

## No-behavior-change note

For the 8 operators in `_PANDAS_STRING_AGGREGATORS`, pandas was *already* routing the numpy callable to its own GroupBy method. Using the string alias calls exactly the same method. The only observable change is the absence of the FutureWarning.

## Test plan

- `test_aggregate` (existing) — sum + percentile still pass
- `test_aggregate_string_operators` (new) — confirms `mean`/`median`/`max`/`min` produce correct values via the string path
- `test_aggregate_count_includes_nulls` (new) — documents and guards the `np.ma.count` NaN-inclusive behavior that motivated excluding `"count"` from the string set

Run with:
```bash
pytest tests/unit_tests/pandas_postprocessing/test_aggregate.py -v
```