### PR TITLE
fix(charts): rename deprecated query object fields in schema before QueryObject construction

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1455,11 +1455,18 @@ class ChartDataQueryObjectSchema(Schema):
     )
 
     @post_load
-    def rename_deprecated_groupby(
+    def rename_deprecated_fields(
         self, data: dict[str, Any], **kwargs: Any
     ) -> dict[str, Any]:
-        if groupby := data.pop("groupby", None):
-            data["columns"] = groupby
+        _renames = (
+            ("groupby", "columns"),
+            ("granularity_sqla", "granularity"),
+            ("timeseries_limit", "series_limit"),
+            ("timeseries_limit_metric", "series_limit_metric"),
+        )
+        for old, new in _renames:
+            if value := data.pop(old, None):
+                data[new] = value
         return data
 
 

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1454,6 +1454,14 @@ class ChartDataQueryObjectSchema(Schema):
         allow_none=True,
     )
 
+    @post_load
+    def rename_deprecated_groupby(
+        self, data: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        if groupby := data.pop("groupby", None):
+            data["columns"] = groupby
+        return data
+
 
 class ChartDataQueryContextSchema(Schema):
     query_context_factory: QueryContextFactory | None = None

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -213,10 +213,10 @@ def test_chart_data_query_object_schema_time_grain_sqla_validation(
     assert result["extras"]["time_grain_sqla"] is None
 
 
-def test_chart_data_query_object_schema_groupby_renamed_to_columns(
+def test_chart_data_query_object_schema_deprecated_fields_renamed(
     app_context: None,
 ) -> None:
-    """groupby is renamed to columns by the schema post_load hook."""
+    """Deprecated query object fields are renamed to their canonical names."""
     schema = ChartDataQueryObjectSchema()
 
     # groupby alone → becomes columns
@@ -234,10 +234,30 @@ def test_chart_data_query_object_schema_groupby_renamed_to_columns(
     assert result.get("columns") == ["country_name"]
     assert "groupby" not in result
 
+    # null groupby is discarded; existing columns is preserved (allow_none=True)
+    result = schema.load({"groupby": None, "columns": ["country_name"]})
+    assert result.get("columns") == ["country_name"]
+    assert "groupby" not in result
+
     # no groupby → columns passes through unchanged
     result = schema.load({"columns": ["country_name"]})
     assert result.get("columns") == ["country_name"]
     assert "groupby" not in result
+
+    # granularity_sqla → granularity
+    result = schema.load({"granularity_sqla": "ds"})
+    assert result.get("granularity") == "ds"
+    assert "granularity_sqla" not in result
+
+    # timeseries_limit → series_limit
+    result = schema.load({"timeseries_limit": 5})
+    assert result.get("series_limit") == 5
+    assert "timeseries_limit" not in result
+
+    # timeseries_limit_metric → series_limit_metric
+    result = schema.load({"timeseries_limit_metric": "count"})
+    assert result.get("series_limit_metric") == "count"
+    assert "timeseries_limit_metric" not in result
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -213,6 +213,33 @@ def test_chart_data_query_object_schema_time_grain_sqla_validation(
     assert result["extras"]["time_grain_sqla"] is None
 
 
+def test_chart_data_query_object_schema_groupby_renamed_to_columns(
+    app_context: None,
+) -> None:
+    """groupby is renamed to columns by the schema post_load hook."""
+    schema = ChartDataQueryObjectSchema()
+
+    # groupby alone → becomes columns
+    result = schema.load({"groupby": ["country_name"]})
+    assert result.get("columns") == ["country_name"]
+    assert "groupby" not in result
+
+    # groupby overwrites columns when both are provided
+    result = schema.load({"groupby": ["region"], "columns": ["country_name"]})
+    assert result.get("columns") == ["region"]
+    assert "groupby" not in result
+
+    # empty groupby is discarded; existing columns is preserved
+    result = schema.load({"groupby": [], "columns": ["country_name"]})
+    assert result.get("columns") == ["country_name"]
+    assert "groupby" not in result
+
+    # no groupby → columns passes through unchanged
+    result = schema.load({"columns": ["country_name"]})
+    assert result.get("columns") == ["country_name"]
+    assert "groupby" not in result
+
+
 @pytest.mark.parametrize(
     "app",
     [{"TIME_GRAIN_ADDONS": {"PT10M": "10 minutes"}}],


### PR DESCRIPTION
### What was the warning?

Every chart data request (`POST /api/v1/chart/data`) from a chart with `groupby`
in its saved query context emitted a `logger.warning` per request:

```
The field `groupby` is deprecated, please use `columns` instead.
```

This fires in `QueryObject._rename_deprecated_fields` (superset/common/query_object.py:224)
whenever `groupby` lands in `**kwargs`. The same path exists for `granularity_sqla`,
`timeseries_limit`, and `timeseries_limit_metric`.

Observed in logs on every time a
chart using the legacy `groupby` key is loaded.

### What was changed?

Added a `@post_load` hook (`rename_deprecated_fields`) to `ChartDataQueryObjectSchema`
that renames all four deprecated query object fields to their canonical names at the
API schema boundary:

| Deprecated | Canonical |
|---|---|
| `groupby` | `columns` |
| `granularity_sqla` | `granularity` |
| `timeseries_limit` | `series_limit` |
| `timeseries_limit_metric` | `series_limit_metric` |

This matches the existing behavior of `_rename_deprecated_fields` exactly:
if the old name is truthy, it becomes the new name; falsy values (empty list,
`None`, `0`) are discarded and the existing canonical value is preserved.

### No behavior change

`QueryObject` still receives the same canonical field names and values as
before. The only difference is the rename now happens at the schema layer
(before `QueryObjectFactory.create()`) instead of inside `QueryObject.__init__`.
The `_rename_deprecated_fields` method remains as a defensive fallback for
any non-schema callers.

### Test plan

- [ ] New unit tests in `tests/unit_tests/charts/test_schemas.py`:
  - `groupby` alone → becomes `columns`
  - `groupby` overwrites existing `columns` (matches existing behavior)
  - empty `groupby` (`[]`) → `columns` preserved
  - `null` `groupby` (valid per `allow_none=True`) → `columns` preserved
  - no `groupby` → `columns` unchanged
  - `granularity_sqla` → `granularity`
  - `timeseries_limit` → `series_limit`
  - `timeseries_limit_metric` → `series_limit_metric`
- [ ] All pre-commit hooks pass (mypy, ruff, pylint, blacklist)
- [ ] Confirm `logger.warning` no longer fires for `groupby`-bearing chart data requests in production