### PR TITLE
test(mcp): fix update_chart test patching the re-exported function, unbreaking master

### DIFF
--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -1480,9 +1480,8 @@ class TestUpdateChartDatasetIdIntegration:
         "superset.commands.chart.update.UpdateChartCommand",
         new_callable=Mock,
     )
-    @patch(
-        "superset.mcp_service.chart.tool.update_chart._validate_update_against_dataset",
-        return_value=None,
+    @patch.object(
+        update_chart_module, "_validate_update_against_dataset", return_value=None
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
     @patch("superset.db.session")


### PR DESCRIPTION
### SUMMARY

`Python-Unit` has been failing on every master commit since #40853 merged (June 12). A single test, `test_dataset_id_passed_to_update_command`, patches `_validate_update_against_dataset` via a string path:

```python
@patch("superset.mcp_service.chart.tool.update_chart._validate_update_against_dataset", ...)
```

Because `superset/mcp_service/chart/tool/__init__.py` re-exports the `update_chart` **function**, `mock`'s importer resolves `...tool.update_chart` to the function rather than the submodule and raises:

```
AttributeError: <function update_chart> does not have the attribute '_validate_update_against_dataset'
```

This fails deterministically (reproducible in isolation), which is why master has been solidly red rather than intermittently flaky.

The other three patches of the same symbol in this file already use `patch.object(update_chart_module, ...)` — there's even a comment near the top of the file (the `update_chart_module = importlib.import_module(...)` block) explaining this exact trap. This one decorator just missed the pattern. The fix aligns it with the rest of the file.

### TESTING INSTRUCTIONS

```bash
# Fails on master, passes with this change:
pytest "tests/unit_tests/mcp_service/chart/tool/test_update_chart.py::TestUpdateChartDatasetIdIntegration::test_dataset_id_passed_to_update_command"
# Whole file:
pytest tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
