### PR TITLE
ci: bump setup-python to v6 (Node 24) before Node 20 deprecation

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
         echo "python-version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
     - name: Set up Python ${{ steps.set-python-version.outputs.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
         cache: ${{ inputs.cache }}


### PR DESCRIPTION
### SUMMARY

GitHub is forcing Actions off Node.js 20 starting **June 16, 2026**:

> Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

The shared `setup-backend` composite action (used by the Python-Unit, Integration, and other backend jobs) still pins `actions/setup-python@v5`, which runs on Node 20 and emits this deprecation warning on every backend job. This bumps it to `v6` (Node 24).

The pinned SHA reused here (`a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6`) is the same one already in use in `.github/workflows/bump-python-package.yml`, so it's a known-good pin in this repo.

### TESTING INSTRUCTIONS

CI: the backend jobs that consume `setup-backend` should run without the Node 20 deprecation warning and continue to pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
