### PR TITLE
ci(docker): free disk space before image build to fix "no space left on device"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,6 +75,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Free up disk space
+        shell: bash
+        run: |
+          # Reclaim large preinstalled toolchains we don't use. The image
+          # build, and especially the docker-compose sanity check (which
+          # rebuilds from scratch whenever the registry cache image
+          # apache/superset-cache is unavailable), can otherwise exhaust the
+          # runner's root disk and fail with "no space left on device".
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Setup Docker Environment
         uses: ./.github/actions/setup-docker
         with:
@@ -148,6 +166,21 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Free up disk space
+        shell: bash
+        run: |
+          # The sanity check rebuilds the image from scratch whenever the
+          # registry cache image apache/superset-cache is unavailable, which
+          # can exhaust the runner's root disk ("no space left on device").
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost || true
+          echo "Disk after cleanup:"; df -h /
       - name: Setup Docker Environment
         uses: ./.github/actions/setup-docker
         with:


### PR DESCRIPTION
### SUMMARY

The `Build & publish docker images` workflow fails intermittently on master. I classified the 18 most recent failures by their *fatal* error: ~83% are infra/runner flakiness, and the largest non-network cluster is **`no space left on device`**.

Root cause: the `docker-compose sanity check` step runs `docker compose build superset-init`, which is meant to "reuse the CACHED image built in the previous steps" but actually rebuilds the image **from scratch** — because `docker-compose.yml` builds with `cache_from: apache/superset-cache:<tag>`, and that registry cache image is consistently **not found** (`failed to configure registry cache importer: docker.io/apache/superset-cache:3.10-slim-trixie: not found`). The uncached full rebuild then exhausts the runner's ~14 GB root disk:

```
failed to solve: ... write /app/.venv/.../_duckdb...so: no space left on device
```

This PR reclaims the large preinstalled toolchains the build doesn't use (dotnet, android, ghc, ghcup, CodeQL, boost) right after checkout in both the `docker-build` and `docker-compose-image-tag` jobs, recovering ~20+ GB of headroom. It's a plain shell step — no new third-party action dependency, no pinning/zizmor concerns.

This is a targeted mitigation for the DISK cluster. The remaining clusters (Docker Hub registry network errors on build pull/push, occasional websocket `npm run build` SIGSEGV) are tracked separately; restoring/refreshing the `apache/superset-cache` image so the sanity check actually hits cache is the deeper fix and is left for a follow-up.

### TESTING INSTRUCTIONS

CI: the `docker-build (dev)` and `docker-compose-image-tag` jobs log `Disk before/after cleanup` and should no longer hit `no space left on device`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
