### PR TITLE
ci(docker): retry image build to absorb transient Docker Hub registry errors

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,13 +101,27 @@ jobs:
             PUSH_OR_LOAD="--load"
           fi
 
-          supersetbot docker \
-            $PUSH_OR_LOAD \
-            --preset "$BUILD_PRESET" \
-            --context "$EVENT" \
-            --context-ref "$RELEASE" $FORCE_LATEST \
-            --extra-flags "--build-arg INCLUDE_CHROMIUM=false --tag $IMAGE_TAG" \
-            $PLATFORM_ARG
+          # Retry to absorb transient Docker Hub registry errors (base-image
+          # pull timeouts, 504/401 on push, ECONNRESET) that otherwise fail
+          # the whole job. buildx reuses the buildkit layer cache from the
+          # failed attempt, so a retry mostly re-does just the failed push.
+          for attempt in 1 2 3; do
+            if supersetbot docker \
+              $PUSH_OR_LOAD \
+              --preset "$BUILD_PRESET" \
+              --context "$EVENT" \
+              --context-ref "$RELEASE" $FORCE_LATEST \
+              --extra-flags "--build-arg INCLUDE_CHROMIUM=false --tag $IMAGE_TAG" \
+              $PLATFORM_ARG; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::supersetbot docker build failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Build attempt ${attempt} failed; retrying in 30s..."
+            sleep 30
+          done
 
       # in the context of push (using multi-platform build), we need to pull the image locally
       - name: Docker pull


### PR DESCRIPTION
### SUMMARY

A large share of `Build & publish docker images` failures on master are **transient Docker Hub registry errors** during the supersetbot build/push, not real build breaks. From classifying recent failures:

- base-image pull timeouts — `Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded`
- push failures — `failed to push ...: 504 Gateway Timeout` / `401 Unauthorized` from `auth.docker.io`
- `npm error network ... ECONNRESET`

Each of these fails the whole matrix leg even though a re-run would succeed. This wraps the `supersetbot docker` build invocation in a 3-attempt retry loop with a 30s backoff, mirroring the retry that already exists on the subsequent `Docker pull` step. buildx reuses the buildkit layer cache from the failed attempt, so a retry mostly re-does just the failed push rather than rebuilding from scratch.

This is a flakiness mitigation, paired with the disk-space fix (#41068) and the GHCR service-image mirror (#40880) — together they target the three distinct failure clusters (build network, disk, service-container network). It does not address the stale `apache/superset-cache` cache reference, which is a separate (cross-repo) issue.

### TESTING INSTRUCTIONS

CI: on a transient registry error, the build step now logs `Build attempt N failed; retrying in 30s...` and continues, rather than failing the job. A genuine build error still fails after 3 attempts.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
