### PR TITLE
ci(docs): fix Netlify docs preview never skipping on non-docs PRs

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -28,14 +28,19 @@
   # Skip builds when no docs changes (exit 0 = skip, non-zero = build).
   # Checks for changes in docs/ and README.md (which gets pulled into docs).
   #
-  # $CACHED_COMMIT_REF is the last *deployed* commit. On a PR's first build it
-  # is empty, so the original `git diff` errored and Netlify fell back to
-  # building -- which is why every PR built a docs preview once even with no
-  # docs changes. When it is empty we instead diff the whole branch against its
-  # merge-base with master, so non-docs PRs are skipped from the very first
-  # build. Subsequent builds (and the master production build) keep the cheaper
-  # incremental $CACHED_COMMIT_REF diff. Any failure exits non-zero -> build.
-  ignore = 'if [ -n "$CACHED_COMMIT_REF" ]; then git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- . ../README.md; else git fetch origin master --depth=100 >/dev/null 2>&1; git diff --quiet "$(git merge-base origin/master "$COMMIT_REF" 2>/dev/null || echo origin/master)" "$COMMIT_REF" -- . ../README.md; fi'
+  # $CACHED_COMMIT_REF is the last *deployed* commit; it is set on incremental
+  # builds (notably the master production deploy) and empty on a context's
+  # first build (every deploy preview). The production path diffs against it
+  # and skips correctly.
+  #
+  # Deploy previews need different handling: Netlify checks out a *merge*
+  # commit, so $COMMIT_REF (the PR head SHA) is frequently not resolvable in
+  # the clone, and on a shallow clone `git merge-base` can fail too -- so the
+  # previous logic fell through to a build on every PR, even non-docs ones.
+  # Instead, always diff the checked-out HEAD against its merge-base with
+  # master, deepening the shallow clone until that merge-base resolves. If it
+  # genuinely can't be determined, exit non-zero to build (fail safe).
+  ignore = 'if [ -n "$CACHED_COMMIT_REF" ]; then git diff --quiet "$CACHED_COMMIT_REF" HEAD -- . ../README.md; else git fetch --no-tags origin master >/dev/null 2>&1 || true; i=0; while [ "$i" -lt 10 ] && ! git merge-base origin/master HEAD >/dev/null 2>&1; do git fetch --deepen=200 origin master >/dev/null 2>&1 || break; i=$((i+1)); done; BASE="$(git merge-base origin/master HEAD 2>/dev/null || true)"; if [ -z "$BASE" ]; then exit 1; fi; git diff --quiet "$BASE" HEAD -- . ../README.md; fi'
 
 [build.environment]
   # Node version matching docs/.nvmrc


### PR DESCRIPTION
### SUMMARY

The docs deploy-preview build is gated by an `ignore` command in `docs/netlify.toml`, but it has **never been skipping for PRs** — every pull request builds the docs preview whether or not it touches docs, wasting Netlify compute.

Evidence from the Netlify API (last 25 deploys of `superset-docs-preview`):

| context | skipped? |
|---|---|
| deploy-preview (PRs) | **0 of 17 skipped** |
| production (master) | skips correctly |

(The "Deploy Preview canceled" status some PRs show is a `state: error` build that ran then errored/was superseded — *not* a skip.)

**Cause:** the production path uses `$CACHED_COMMIT_REF` and works. The deploy-preview path referenced `$COMMIT_REF` (the PR head SHA), but Netlify checks out a **merge commit** for previews, so `$COMMIT_REF` is frequently unresolvable in the clone, and `git merge-base` can also fail on the shallow clone — so the command fell through to a build on every PR.

**Fix:** diff the checked-out `HEAD` against its merge-base with `master`, deepening the shallow clone until the merge-base resolves, and fail safe (build) only when it genuinely can't be determined.

### TESTING INSTRUCTIONS

Validated locally against real branches:
- a non-docs branch → `git diff --quiet <merge-base> HEAD -- docs/ README.md` returns 0 → **skip** ✅
- a docs-touching branch → returns non-zero → **build** ✅

Note: this PR itself changes `docs/netlify.toml` (under `docs/`), so its *own* preview will correctly build. The skip behavior takes effect for subsequent non-docs PRs; it can be confirmed by watching that non-docs PRs start showing skipped deploys after this merges.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
