### PR TITLE
fix(docker): restore working `docker compose up` for the dev stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,20 +72,23 @@ services:
       - -c
       - |
         url="http://host.docker.internal:9000/static/assets/manifest.json"
-        max_attempts=150  # ~5 minutes at 2s intervals
-        echo "Waiting for webpack dev server at $url..."
+        max_attempts=300  # ~10 minutes at 2s intervals; first build can be slow
+        echo "Waiting for webpack dev server at $$url..."
         attempt=0
-        until curl -sf --max-time 5 -o /dev/null "$url"; do
-          attempt=$((attempt + 1))
-          if [ "$attempt" -ge "$max_attempts" ]; then
-            echo "ERROR: webpack dev server did not serve $url after $max_attempts attempts (~5 minutes)." >&2
+        until curl -sf --max-time 5 -H "Host: localhost" -o /dev/null "$$url"; do
+          attempt=$$((attempt + 1))
+          if [ "$$attempt" -ge "$$max_attempts" ]; then
+            echo "ERROR: webpack dev server did not serve $$url after $$max_attempts attempts." >&2
             echo "Is the dev server running? With BUILD_SUPERSET_FRONTEND_IN_DOCKER=false you must start it on the host (e.g. 'npm run dev' in superset-frontend)." >&2
             exit 1
+          fi
+          if [ $$((attempt % 15)) -eq 0 ]; then
+            echo "Still waiting for webpack dev server... ($$attempt/$$max_attempts)"
           fi
           sleep 2
         done
         echo "Webpack dev server is ready; starting nginx."
-        exec nginx -g 'daemon off;'
+        exec /docker-entrypoint.sh nginx -g 'daemon off;'
 
   redis:
     image: redis:7

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -81,10 +81,12 @@ case "${1}" in
   app)
     echo "Starting web app (using development server)..."
 
-    # Always run in Flask debug mode here: this is the dev compose entrypoint,
-    # and Superset's Talisman selector keys off app.debug to serve the dev CSP
-    # (which permits 'unsafe-eval' required by React Refresh / HMR).
-    export FLASK_DEBUG=1
+    # Default to Flask debug mode in this dev compose entrypoint so the Talisman
+    # dev CSP (which permits 'unsafe-eval' required by React Refresh / HMR) is
+    # served. Operators can still set FLASK_DEBUG=false in docker/.env-local
+    # to exercise the production-like CSP and error handling.
+    : "${FLASK_DEBUG:=1}"
+    export FLASK_DEBUG
 
     # Werkzeug's interactive debugger (/console) is a separate, security-sensitive
     # feature and must be opted into explicitly via SUPERSET_DEBUG_ENABLED=true.

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -81,17 +81,17 @@ case "${1}" in
   app)
     echo "Starting web app (using development server)..."
 
-    # Environment-based debugger control for security
-    # Only enable Werkzeug interactive debugger when explicitly requested
-    # Modern Werkzeug (3.0+) includes PIN protection, but defense-in-depth approach
-    # Override FLASK_DEBUG so the effective state matches SUPERSET_DEBUG_ENABLED even
-    # when FLASK_DEBUG=true is inherited from docker/.env or .flaskenv
+    # Always run in Flask debug mode here: this is the dev compose entrypoint,
+    # and Superset's Talisman selector keys off app.debug to serve the dev CSP
+    # (which permits 'unsafe-eval' required by React Refresh / HMR).
+    export FLASK_DEBUG=1
+
+    # Werkzeug's interactive debugger (/console) is a separate, security-sensitive
+    # feature and must be opted into explicitly via SUPERSET_DEBUG_ENABLED=true.
     if [[ "${SUPERSET_DEBUG_ENABLED:-}" == "true" ]]; then
-        export FLASK_DEBUG=1
         DEBUGGER_FLAG="--debugger"
         echo "  ⚠️  Werkzeug debugger enabled (requires PIN for /console access)"
     else
-        export FLASK_DEBUG=0
         DEBUGGER_FLAG="--no-debugger"
         echo "  🔒 Werkzeug debugger disabled (set SUPERSET_DEBUG_ENABLED=true to enable)"
     fi


### PR DESCRIPTION
### SUMMARY

`docker compose up` against `master` no longer brings up a working dev stack. Three independent regressions stacked on top of each other; this PR fixes all of them while preserving the security goals of the original PRs.

**1. nginx wait loop loops forever (from #38161)**

`docker-compose.yml` overrides the nginx `command:` with a bash loop that polls the webpack dev server before starting nginx. The loop has four bugs:

- Shell variable references (`$url`, `$attempt`, `$max_attempts`) are not escaped, so Docker Compose interpolates them to empty strings before `bash` sees them. `curl ""` fails immediately every iteration, and `[ "" -ge "" ]` is a syntax error (non-zero return → false), so the timeout check never fires and the loop runs forever instead of bailing at 5 min. Fixed by `$$` escaping.
- The loop polls silently — even a working loop looked like a hang during a fresh `npm install` + first webpack compile. Added a heartbeat every ~30 s.
- The probe sends `Host: host.docker.internal:9000`, which is not in webpack-dev-server's `allowedHosts` list (`superset-frontend/webpack.config.js:692-701`), so the dev server returns **403** instead of 200. Fixed by sending `-H "Host: localhost"` — the same trick the nginx config itself uses when proxying to `superset-node` (`docker/nginx/templates/superset.conf.template:43`).
- The override replaces nginx's default CMD, so the official nginx image's `/docker-entrypoint.d/` scripts are skipped and `/etc/nginx/templates/superset.conf.template` is never rendered via `envsubst`, causing `open() "/etc/nginx/conf.d/superset.conf" failed (2: No such file or directory)`. Fixed by `exec /docker-entrypoint.sh nginx -g 'daemon off;'` so the image's init scripts run.

**2. Werkzeug debugger control over-reached (from #40327)**

That PR's *security goal* — keep the Werkzeug interactive debugger (`/console`) off by default to mitigate the PIN-bypass attack in Docker — is correct and preserved here. But the implementation also forcibly set `FLASK_DEBUG=0`, which had an unrelated side effect:

`superset/initialization/__init__.py:996-998` picks `TALISMAN_DEV_CONFIG` (with `'unsafe-eval'`) when `app.debug` is true and `TALISMAN_CONFIG` otherwise. With `FLASK_DEBUG=0`, the dev stack started serving the **production CSP**, which blocks the `eval()` that React Refresh's HMR client uses:

> Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script…

The `FLASK_DEBUG` override also silently overrode `docker/.env`'s `FLASK_DEBUG=true` (commented "keep 'true' for development") and any `docker/.env-local` override, so there was no local-config escape hatch.

This PR decouples the two concerns:
- `FLASK_DEBUG=1` is always set in the dev `app` entrypoint (this restores `app.debug = True` so the dev CSP is served and HMR works).
- `--debugger` / `--no-debugger` (the actual control for `/console`) is still gated on `SUPERSET_DEBUG_ENABLED=true`, defaulting to `--no-debugger`.

Verified after the fix: `GET /console` still returns **404** in the default setup — the security mitigation is intact. Only the CSP regression is reverted.

### TESTING INSTRUCTIONS

1. Clean environment:
   ```bash
   docker compose down -v
   ```
2. Start the dev stack:
   ```bash
   docker compose up
   ```
3. Watch the nginx logs — you should see `Waiting for webpack dev server…`, a few `Still waiting…` heartbeats during the first build, then `Webpack dev server is ready; starting nginx.` followed by the standard `docker-entrypoint.sh` init log lines.
4. Open http://localhost — the UI should load and the browser console should be clean (no `EvalError` from React Refresh).
5. Confirm the security mitigation is intact:
   ```bash
   curl -sI http://localhost:8088/console     # expect HTTP/1.1 404 NOT FOUND
   ```
6. Confirm the opt-in still works:
   ```bash
   SUPERSET_DEBUG_ENABLED=true docker compose up
   # superset container logs: "⚠️  Werkzeug debugger enabled"
   curl -sI http://localhost:8088/console     # expect 200 with PIN prompt
   ```
7. Confirm the dev CSP is served:
   ```bash
   docker exec superset-superset-1 curl -sI http://localhost:8088/health \
     | grep -oE "script-src[^;]*"
   # expect: script-src 'self' 'unsafe-inline' 'unsafe-eval' 'nonce-…'
   ```

### ADDITIONAL INFORMATION

- [x] Has associated issue: regression of #38161 (nginx wait loop bugs) and #40327 (CSP side effect)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API