### PR TITLE
fix(upload): database field shows validation warning after selecting a database

### DIFF
--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -437,6 +437,32 @@ describe('UploadDataModal - Form Validation', () => {
       expect(screen.getByText('Table name is required')).toBeInTheDocument();
     });
   });
+
+  test('database validation error clears after selecting a database', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    const uploadButton = screen.getByRole('button', { name: 'Upload' });
+    await userEvent.click(uploadButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Selecting a database is required'),
+      ).toBeInTheDocument();
+    });
+
+    const selectDatabase = screen.getByRole('combobox', {
+      name: /select a database/i,
+    });
+    await userEvent.click(selectDatabase);
+    await waitFor(() => screen.getByText('database1'));
+    await userEvent.click(screen.getByText('database1'));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Selecting a database is required'),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/features/databases/UploadDataModel/index.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/index.tsx
@@ -578,8 +578,11 @@ const UploadDataModal: FunctionComponent<UploadDataModalProps> = ({
     return Promise.resolve();
   };
 
-  const validateDatabase = (_: any, value: string) => {
-    if (!currentDatabaseId) {
+  const validateDatabase = (
+    _: any,
+    value: { value: number; label: string } | null | undefined,
+  ) => {
+    if (!value?.value) {
       return Promise.reject(t('Selecting a database is required'));
     }
     return Promise.resolve();


### PR DESCRIPTION
### Summary

The Database field in the CSV/Excel/Columnar upload modal displayed a red validation warning even after a database had been successfully selected.

**Root cause:** `validateDatabase` read `currentDatabaseId` from a stale closure. Ant Design fires the Ant Design Form validator synchronously on `onChange` — before React processes the `setCurrentDatabaseId` state update — so the validator always saw the previous value (`0`) and rejected.

**Fix:** Use the `value` parameter that Ant Design passes directly to the validator (the current form field value) instead of the stale state variable.

```diff
-const validateDatabase = (_: any, value: string) => {
-  if (!currentDatabaseId) {
+const validateDatabase = (
+  _: any,
+  value: { value: number; label: string } | null | undefined,
+) => {
+  if (!value?.value) {
     return Promise.reject(t('Selecting a database is required'));
   }
```

### Testing

- Added a test in `UploadDataModal.test.tsx` that triggers validation errors via the Upload button, selects a database, and asserts the error message disappears.
- Applies to CSV, Excel, and Columnar upload modals (all use the same `UploadDataModal` component).

### Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test added