### PR TITLE
fix(reports): require user in get_screenshot, simplify Selenium lifecycle, and fail on tiled screenshot error

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -466,8 +466,12 @@ class BaseReportState:
         try:
             imges = []
             for screenshot in screenshots:
-                if imge := screenshot.get_screenshot(user=user):
-                    imges.append(imge)
+                imge = screenshot.get_screenshot(user=user)
+                if imge is None:
+                    raise ReportScheduleScreenshotFailedError(
+                        "Screenshot failed; aborting to avoid sending a partial report"
+                    )
+                imges.append(imge)
             elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
             logger.info(
                 "Screenshot capture took %.2fs - execution_id: %s",

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -375,15 +375,12 @@ class WebDriverPlaywright(WebDriverProxy):
                             animation_wait=selenium_animation_wait,
                         )
                         if img is None:
-                            logger.warning(
-                                (
-                                    "Tiled screenshot failed, "
-                                    "falling back to standard screenshot"
-                                )
+                            logger.error(
+                                "Tiled screenshot failed at url %s; "
+                                "not falling back to avoid sending a blank PDF",
+                                url,
                             )
-                            img = WebDriverPlaywright._get_screenshot(
-                                page, element, element_name
-                            )
+                            return None
                     else:
                         # Standard screenshot captures the full element including
                         # below-the-fold content, so wait for all spinners globally.

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -905,7 +905,7 @@ class TestWebDriverPlaywrightErrorHandling:
     @patch("superset.utils.webdriver.take_tiled_screenshot")
     def test_tiled_screenshot_failure_returns_none_without_fallback(
         self, mock_take_tiled, mock_logger, mock_sync_playwright
-    ):
+    ) -> None:
         """When take_tiled_screenshot fails, return None rather than fall back to a
         potentially blank standard screenshot."""
         mock_user = MagicMock()

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -898,3 +898,76 @@ class TestWebDriverPlaywrightErrorHandling:
             "dashboard",
             "http://example.com",
         )
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver.logger")
+    @patch("superset.utils.webdriver.take_tiled_screenshot")
+    def test_tiled_screenshot_failure_returns_none_without_fallback(
+        self, mock_take_tiled, mock_logger, mock_sync_playwright
+    ):
+        """When take_tiled_screenshot fails, return None rather than fall back to a
+        potentially blank standard screenshot."""
+        mock_user = MagicMock()
+        mock_user.username = "test_user"
+
+        mock_playwright_instance = MagicMock()
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+        mock_element = MagicMock()
+
+        mock_sync_playwright.return_value.__enter__.return_value = (
+            mock_playwright_instance
+        )
+        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+        mock_page.locator.return_value = mock_element
+        mock_element.wait_for.return_value = None
+        mock_element.screenshot.return_value = b"should_not_be_called"
+
+        def evaluate_side_effect(script):
+            if "querySelectorAll" in script:
+                return 25  # chart_count >= threshold
+            if "const target" in script:
+                return 6000  # dashboard_height > height_threshold and > tile_height
+            return None
+
+        mock_page.evaluate.side_effect = evaluate_side_effect
+        mock_take_tiled.return_value = None  # tiled screenshot fails
+
+        with patch("superset.utils.webdriver.app") as mock_app:
+            mock_app.config = {
+                "WEBDRIVER_OPTION_ARGS": [],
+                "WEBDRIVER_WINDOW": {"pixel_density": 1},
+                "SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT": 30000,
+                "SCREENSHOT_PLAYWRIGHT_WAIT_EVENT": "networkidle",
+                "SCREENSHOT_SELENIUM_HEADSTART": 0,
+                "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 0,
+                "SCREENSHOT_LOCATE_WAIT": 10,
+                "SCREENSHOT_LOAD_WAIT": 10,
+                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE": 10,
+                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE": 10,
+                "SCREENSHOT_REPLACE_UNEXPECTED_ERRORS": False,
+                "SCREENSHOT_TILED_ENABLED": True,
+                "SCREENSHOT_TILED_CHART_THRESHOLD": 20,
+                "SCREENSHOT_TILED_HEIGHT_THRESHOLD": 5000,
+                "SCREENSHOT_TILED_VIEWPORT_HEIGHT": 600,
+            }
+
+            with patch.object(WebDriverPlaywright, "auth") as mock_auth:
+                mock_auth.return_value = mock_context
+
+                driver = WebDriverPlaywright("chrome")
+                result = driver.get_screenshot(
+                    "http://example.com", "dashboard", mock_user
+                )
+
+        assert result is None
+        mock_element.screenshot.assert_not_called()
+        mock_logger.error.assert_any_call(
+            "Tiled screenshot failed at url %s; "
+            "not falling back to avoid sending a blank PDF",
+            "http://example.com",
+        )


### PR DESCRIPTION
### SUMMARY

Two related changes to `superset/utils/webdriver.py`:

**1. Require `user` in `get_screenshot` / simplify `WebDriverSelenium` lifecycle**

`get_screenshot` previously accepted `User | None` with defensive guards throughout. All callers pass a real `User`, so the optional was dead code that obscured the type contract and caused username logging to emit `"None"` instead of raising early.

`WebDriverSelenium` had a persistent-driver pattern (`__init__` storing `_user`/`_driver`, a lazy `driver` property, public `create()`/`destroy()` wrappers). This made the class stateful in a way that risked reusing a stale driver across requests. The class is now stateless: `get_screenshot` creates the driver, authenticates, takes the screenshot, and destroys the driver in a `finally` block. `screenshots.py` is updated to match (drop the now-redundant external `destroy()` call and the unused `user` arg to the constructor).

**2. Fail instead of silently falling back on tiled screenshot error**

When `take_tiled_screenshot` returned `None`, the previous code immediately fell back to a standard `element.screenshot()` with **no spinner wait and no animation wait**. This produced a blank (all-white) image that became a blank PDF silently sent to report recipients.

The fallback is removed. Returning `None` now propagates through `_get_screenshots()` → `ReportScheduleScreenshotFailedError` → ERROR execution state with owner notification, so failures are visible rather than silent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend change, no UI impact.

### TESTING INSTRUCTIONS

1. Run the new unit test:
   ```bash
   pytest tests/unit_tests/utils/webdriver_test.py -k "test_tiled_screenshot_failure_returns_none_without_fallback" -v
   ```

2. To verify the blank-PDF fix end-to-end: configure a report on a large dashboard (≥20 charts or >5000px height, so tiled mode activates) with `SCREENSHOT_TILED_ENABLED=True`, then trigger a condition where `take_tiled_screenshot` fails (e.g., element not found). Confirm the execution state is ERROR and the owner receives an error notification rather than a blank PDF.

3. To verify the `User` requirement: mypy passes (`pre-commit run mypy`).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #39895 and #40694 (per-tile spinner and animation waits).