### PR TITLE
fix(reports): commit permalink before Playwright navigates to tab URL

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -358,6 +358,11 @@ class BaseReportState:
             dashboard_id=str(self._report_schedule.dashboard.uuid),
             state=dashboard_state,
         ).run()
+        # Commit the permalink immediately so Playwright's separate DB connection
+        # can resolve the URL. CreateDashboardPermalinkCommand only flushes when
+        # called inside an outer @transaction(), leaving the row invisible to
+        # other connections until we explicitly commit here.
+        db.session.commit()  # pylint: disable=consider-using-transaction
 
         return get_url_path(
             "Superset.dashboard_permalink",


### PR DESCRIPTION
## Problem

Dashboard screenshot reports that target a specific tab use `CreateDashboardPermalinkCommand` to generate a permalink URL (`/dashboard/p/<key>/`). When the report executor calls this command it is already running inside an outer `@transaction()` decorator on `AsyncExecuteReportScheduleCommand.run()`. The `@transaction()` nesting guard (`g.in_transaction`) detects this and skips the `db.session.commit()` inside the command, leaving the permalink row only flushed — visible in the current SQLAlchemy session but not committed to the database.

Playwright runs in a separate process with its own DB connection. When it navigates to `/dashboard/p/<key>/`, Flask can't find the row and returns a JSON 404. The page never renders `<body class="standalone">` (which is server-rendered in `spa.html`, not React-added), so Playwright waits the full `SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT` (600 s) before timing out.

## Fix

Add an explicit `db.session.commit()` in `_get_tab_url()` immediately after `CreateDashboardPermalinkCommand.run()` returns. This matches the existing pattern in `BaseReportState.create_log()` (which also commits directly inside the outer transaction to make the execution log immediately visible). At that point in the call chain the only pending write is the permalink INSERT — the WORKING state was already committed by `create_log()` earlier in `next()`.

## Testing

- Tab-specific dashboard report schedules (those with `ALERT_REPORT_TABS` enabled and an `anchor` or native-filter state) will successfully navigate to their permalink URL.
- Reports without tab state are unaffected (they call `get_url_path` directly, never reach `_get_tab_url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)