### PR TITLE
fix(sql_lab): serialize dict/list cell values as valid JSON strings

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -76,13 +76,13 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
                     val = obj.item()
                     if isinstance(val, (dict, list)):
                         try:
-                            # Use json.dumps to produce valid double-quoted JSON.
-                            # Python's str() gives single-quoted repr like {'a': 1}
-                            # which is not valid JSON and breaks the frontend cell viewer.
+                            # Use json.dumps for valid double-quoted JSON.
+                            # str() gives single-quoted repr like {'a': 1}
+                            # which breaks the frontend cell viewer.
                             obj[...] = stringify(val)
                         except TypeError:
-                            # Non-JSON-serializable nested value (e.g. bytes, custom
-                            # objects): fall back to str() to preserve non-crashing behavior.
+                            # Non-JSON-serializable value (e.g. bytes, custom
+                            # objects): fall back to str() to avoid crashing.
                             obj[...] = str(val)
                     else:
                         # for simple string conversions

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -75,10 +75,15 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
                 try:
                     val = obj.item()
                     if isinstance(val, (dict, list)):
-                        # Use json.dumps to produce valid double-quoted JSON.
-                        # Python's str() gives single-quoted repr like {'a': 1}
-                        # which is not valid JSON and breaks the frontend cell viewer.
-                        obj[...] = stringify(val)
+                        try:
+                            # Use json.dumps to produce valid double-quoted JSON.
+                            # Python's str() gives single-quoted repr like {'a': 1}
+                            # which is not valid JSON and breaks the frontend cell viewer.
+                            obj[...] = stringify(val)
+                        except TypeError:
+                            # Non-JSON-serializable nested value (e.g. bytes, custom
+                            # objects): fall back to str() to preserve non-crashing behavior.
+                            obj[...] = str(val)
                     else:
                         # for simple string conversions
                         # this handles odd character types better

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -73,9 +73,16 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
                 obj[na_obj] = None
             else:
                 try:
-                    # for simple string conversions
-                    # this handles odd character types better
-                    obj[...] = obj.astype(str)
+                    val = obj.item()
+                    if isinstance(val, (dict, list)):
+                        # Use json.dumps to produce valid double-quoted JSON.
+                        # Python's str() gives single-quoted repr like {'a': 1}
+                        # which is not valid JSON and breaks the frontend cell viewer.
+                        obj[...] = stringify(val)
+                    else:
+                        # for simple string conversions
+                        # this handles odd character types better
+                        obj[...] = obj.astype(str)
                 except ValueError:
                     obj[...] = stringify(obj)
 

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -463,7 +463,9 @@ def test_stringify_values_dict_and_list_produce_valid_json() -> None:
     data = np.array(
         [
             {"key": "value", "nested": {"a": 1}},
-            [1, 2, 3],
+            # List with string elements: str() gives ['a', 'b'] (single-quoted, invalid JSON)
+            # while json.dumps gives ["a", "b"] (double-quoted, valid JSON).
+            ["a", "b"],
             {"items": [1, 2, 3], "d": "Hello, World!"},
             None,
         ],
@@ -473,7 +475,7 @@ def test_stringify_values_dict_and_list_produce_valid_json() -> None:
 
     # Must be valid JSON strings (double-quoted), not Python repr (single-quoted)
     assert result[0] == '{"key": "value", "nested": {"a": 1}}'
-    assert result[1] == "[1, 2, 3]"
+    assert result[1] == '["a", "b"]'
     assert result[2] == '{"items": [1, 2, 3], "d": "Hello, World!"}'
     assert result[3] is None
 
@@ -481,7 +483,7 @@ def test_stringify_values_dict_and_list_produce_valid_json() -> None:
     parsed = superset_json.loads(result[0])
     assert parsed == {"key": "value", "nested": {"a": 1}}
     parsed = superset_json.loads(result[1])
-    assert parsed == [1, 2, 3]
+    assert parsed == ["a", "b"]
 
 
 def test_clickhouse_json_column_in_pa_table_is_valid_json() -> None:
@@ -518,3 +520,23 @@ def test_clickhouse_json_column_in_pa_table_is_valid_json() -> None:
     assert parsed0 == {"a": {"b": 42}, "c": [1, 2, 3], "d": "Hello, World!"}
     parsed1 = superset_json.loads(val1)
     assert parsed1 == {"e": 5}
+
+
+def test_stringify_values_non_serializable_dict_falls_back_to_str() -> None:
+    """
+    When a dict/list contains a value that json.dumps cannot serialize (e.g. bytes),
+    stringify_values must fall back to str() rather than raising TypeError and crashing
+    the result-set construction path.
+    """
+
+    class _Unserializable:
+        def __repr__(self) -> str:
+            return "unserializable"
+
+    data = np.array(
+        [{"key": _Unserializable()}],
+        dtype=object,
+    )
+    # Must not raise — falls back to str()
+    result = stringify_values(data)
+    assert result[0] == str({"key": _Unserializable()})

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -463,8 +463,8 @@ def test_stringify_values_dict_and_list_produce_valid_json() -> None:
     data = np.array(
         [
             {"key": "value", "nested": {"a": 1}},
-            # List with string elements: str() gives ['a', 'b'] (single-quoted, invalid JSON)
-            # while json.dumps gives ["a", "b"] (double-quoted, valid JSON).
+            # str() gives ['a', 'b'] (single-quoted, invalid JSON);
+            # json.dumps gives ["a", "b"] (double-quoted, valid JSON).
             ["a", "b"],
             {"items": [1, 2, 3], "d": "Hello, World!"},
             None,

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -450,3 +450,71 @@ def test_stringify_extension_columns() -> None:
     # plain binary BLOBs and other types are left untouched
     assert pa.types.is_binary(result.schema.field("blob").type)
     assert pa.types.is_integer(result.schema.field("n").type)
+
+
+def test_stringify_values_dict_and_list_produce_valid_json() -> None:
+    """
+    ClickHouse native JSON and Map types return Python dicts. When stringified for
+    Arrow array storage they must produce valid double-quoted JSON strings, not
+    Python's single-quoted repr. Single-quoted strings pass the cheap '{' prefix
+    check in the frontend's safeJsonObjectParse but then fail JSONbig.parse(),
+    so the SQL Lab cell viewer never activates.
+    """
+    data = np.array(
+        [
+            {"key": "value", "nested": {"a": 1}},
+            [1, 2, 3],
+            {"items": [1, 2, 3], "d": "Hello, World!"},
+            None,
+        ],
+        dtype=object,
+    )
+    result = stringify_values(data)
+
+    # Must be valid JSON strings (double-quoted), not Python repr (single-quoted)
+    assert result[0] == '{"key": "value", "nested": {"a": 1}}'
+    assert result[1] == "[1, 2, 3]"
+    assert result[2] == '{"items": [1, 2, 3], "d": "Hello, World!"}'
+    assert result[3] is None
+
+    # Parseable by a JSON parser — confirms the frontend's JSON.parse would succeed
+    parsed = superset_json.loads(result[0])
+    assert parsed == {"key": "value", "nested": {"a": 1}}
+    parsed = superset_json.loads(result[1])
+    assert parsed == [1, 2, 3]
+
+
+def test_clickhouse_json_column_in_pa_table_is_valid_json() -> None:
+    """
+    Verify that ClickHouse-style heterogeneous dict columns produce valid JSON
+    strings in the Arrow table used by the msgpack serialization path.
+
+    When clickhouse-connect returns Python dicts for JSON/Map type columns,
+    SupersetResultSet must serialize them with json.dumps (not str()) so that
+    the SQL Lab grid's cell viewer can call JSON.parse on the value.
+    """
+    data = [
+        (1, {"a": {"b": 42}, "c": [1, 2, 3], "d": "Hello, World!"}),
+        (2, {"e": 5}),
+        (3, None),
+    ]
+    description = [
+        ("id", 3, None, None, None, None, None),
+        ("json_col", None, None, None, None, None, None),
+    ]
+    result_set = SupersetResultSet(data, description, BaseEngineSpec)  # type: ignore
+
+    df_from_pa = SupersetResultSet.convert_table_to_df(result_set.pa_table)
+
+    val0 = df_from_pa["json_col"].iloc[0]
+    val1 = df_from_pa["json_col"].iloc[1]
+
+    # Values in pa_table must be valid JSON strings (parseable by JSON.parse)
+    assert isinstance(val0, str)
+    assert isinstance(val1, str)
+
+    # Double-quoted JSON, not single-quoted Python repr
+    parsed0 = superset_json.loads(val0)
+    assert parsed0 == {"a": {"b": 42}, "c": [1, 2, 3], "d": "Hello, World!"}
+    parsed1 = superset_json.loads(val1)
+    assert parsed1 == {"e": 5}


### PR DESCRIPTION
### Summary

When a database driver returns Python `dict` or `list` objects as cell values (e.g. ClickHouse's native JSON and Map types via clickhouse-connect), Superset's `stringify_values()` in `result_set.py` converted them via `obj.astype(str)`, which calls Python's `str()` built-in and produces single-quoted repr:

```
{'a': {'b': 42}, 'c': [1, 2, 3]}
```

This is not valid JSON. The SQL Lab cell viewer calls `safeJsonObjectParse()` (which uses `JSONbig.parse()` internally) on cell values — it fails silently on single-quoted strings, so the interactive tree viewer never activates for those cells.

The fix: in `stringify_values()`, when the extracted Python value is a `dict` or `list`, use the existing `stringify()` helper (which calls `json.dumps`) to produce valid double-quoted JSON:

```
{"a": {"b": 42}, "c": [1, 2, 3]}
```

This makes the cell viewer work for ClickHouse native JSON/Map columns and any other driver that returns dict/list objects.

### Reproduction

Using ClickHouse 25.3+ with either `clickhouse-connect` or `clickhouse-sqlalchemy`:

```sql
WITH '{"a":{"b":42},"c":[1,2,3]}'::JSON AS json
SELECT json, json::String
```

Before: clicking the `json` cell opens nothing. After: opens the interactive tree viewer.

### Testing

- `tests/unit_tests/result_set_test.py::test_stringify_values_dict_and_list_produce_valid_json` — unit test for the `stringify_values` change
- `tests/unit_tests/result_set_test.py::test_clickhouse_json_column_in_pa_table_is_valid_json` — integration-style test using `SupersetResultSet` with ClickHouse-style dict rows

### Checklist

- [x] Unit tests added/updated
- [x] All existing `result_set_test.py` tests pass
- [x] No frontend changes required — fix is entirely in the serialization path