### PR TITLE
fix(explore): prevent Results FilterInput from stealing focus during remount

### DIFF
--- a/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
@@ -35,6 +35,24 @@ test('Render a FilterInput', async () => {
   expect(onChangeHandler).toHaveBeenCalledTimes(4);
 });
 
+test('FilterInput auto-focuses when a non-editable element (e.g. a tab) has focus', () => {
+  const onChangeHandler = jest.fn();
+  const button = document.createElement('button');
+  document.body.appendChild(button);
+  try {
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    render(<FilterInput onChangeHandler={onChangeHandler} shouldFocus />);
+    const filterInput = screen.getByPlaceholderText('Search');
+
+    // Auto-focus should fire — a button is not an editable element
+    expect(document.activeElement).toBe(filterInput);
+  } finally {
+    document.body.removeChild(button);
+  }
+});
+
 test('FilterInput does not steal focus when another input already has focus', () => {
   const onChangeHandler = jest.fn();
   const otherInput = document.createElement('input');

--- a/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
@@ -37,22 +37,19 @@ test('Render a FilterInput', async () => {
 
 test('FilterInput does not steal focus when another input already has focus', () => {
   const onChangeHandler = jest.fn();
-
-  // Create a plain DOM input, focus it before mounting FilterInput
   const otherInput = document.createElement('input');
   document.body.appendChild(otherInput);
-  otherInput.focus();
-  expect(document.activeElement).toBe(otherInput);
+  try {
+    otherInput.focus();
+    expect(document.activeElement).toBe(otherInput);
 
-  // Mount FilterInput with shouldFocus=true while the other input is focused
-  const { container } = render(
-    <FilterInput onChangeHandler={onChangeHandler} shouldFocus />,
-  );
-  const filterInput = container.querySelector('input') as HTMLInputElement;
+    render(<FilterInput onChangeHandler={onChangeHandler} shouldFocus />);
+    const filterInput = screen.getByPlaceholderText('Search');
 
-  // FilterInput should not have stolen focus from the already-focused input
-  expect(document.activeElement).not.toBe(filterInput);
-  expect(document.activeElement).toBe(otherInput);
-
-  document.body.removeChild(otherInput);
+    // FilterInput should not have stolen focus from the already-focused input
+    expect(document.activeElement).not.toBe(filterInput);
+    expect(document.activeElement).toBe(otherInput);
+  } finally {
+    document.body.removeChild(otherInput);
+  }
 });

--- a/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
@@ -34,3 +34,25 @@ test('Render a FilterInput', async () => {
 
   expect(onChangeHandler).toHaveBeenCalledTimes(4);
 });
+
+test('FilterInput does not steal focus when another input already has focus', () => {
+  const onChangeHandler = jest.fn();
+
+  // Create a plain DOM input, focus it before mounting FilterInput
+  const otherInput = document.createElement('input');
+  document.body.appendChild(otherInput);
+  otherInput.focus();
+  expect(document.activeElement).toBe(otherInput);
+
+  // Mount FilterInput with shouldFocus=true while the other input is focused
+  const { container } = render(
+    <FilterInput onChangeHandler={onChangeHandler} shouldFocus />,
+  );
+  const filterInput = container.querySelector('input') as HTMLInputElement;
+
+  // FilterInput should not have stolen focus from the already-focused input
+  expect(document.activeElement).not.toBe(filterInput);
+  expect(document.activeElement).toBe(otherInput);
+
+  document.body.removeChild(otherInput);
+});

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -109,14 +109,17 @@ export const FilterInput = ({
 
   useEffect(() => {
     if (inputRef.current && shouldFocus) {
-      // Skip auto-focus if any meaningful element already has focus (e.g. user
-      // is typing in another control when this pane remounts after a data refresh)
+      // Skip auto-focus only when an editable element already has focus (e.g.
+      // user is typing in a form control when this pane remounts after a data
+      // refresh). Non-editable focused elements like tabs/buttons still allow
+      // auto-focus so the search box focuses on first open.
       const activeEl = document.activeElement;
-      const noElementFocused =
-        activeEl === null ||
-        activeEl === document.body ||
-        activeEl === document.documentElement;
-      if (noElementFocused) {
+      const editableFocused =
+        activeEl instanceof HTMLElement &&
+        (activeEl.tagName === 'INPUT' ||
+          activeEl.tagName === 'TEXTAREA' ||
+          activeEl.isContentEditable);
+      if (!editableFocused) {
         inputRef.current.focus();
       }
     }

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -108,9 +108,16 @@ export const FilterInput = ({
   const inputRef: RefObject<any> = useRef(null);
 
   useEffect(() => {
-    // Focus the input element when the component mounts
     if (inputRef.current && shouldFocus) {
-      inputRef.current.focus();
+      const activeEl = document.activeElement;
+      const isInputFocused =
+        activeEl &&
+        (activeEl.tagName === 'INPUT' ||
+          activeEl.tagName === 'TEXTAREA' ||
+          (activeEl as HTMLElement).isContentEditable);
+      if (!isInputFocused) {
+        inputRef.current.focus();
+      }
     }
   }, []);
 

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -109,13 +109,14 @@ export const FilterInput = ({
 
   useEffect(() => {
     if (inputRef.current && shouldFocus) {
+      // Skip auto-focus if any meaningful element already has focus (e.g. user
+      // is typing in another control when this pane remounts after a data refresh)
       const activeEl = document.activeElement;
-      const isInputFocused =
-        activeEl &&
-        (activeEl.tagName === 'INPUT' ||
-          activeEl.tagName === 'TEXTAREA' ||
-          (activeEl as HTMLElement).isContentEditable);
-      if (!isInputFocused) {
+      const noElementFocused =
+        activeEl === null ||
+        activeEl === document.body ||
+        activeEl === document.documentElement;
+      if (noElementFocused) {
         inputRef.current.focus();
       }
     }


### PR DESCRIPTION
## Summary

- `FilterInput` in the Results pane (`DataTableControl/index.tsx`) auto-focuses on mount when `shouldFocus={true}` is set. It is always `true` in `DataTableControls.tsx`.
- When a renderTrigger control like `legendMargin` is edited, `queryFormData` changes → `cappedFormData` in `useResultsPane` is a new object → WeakMap cache miss → `setIsLoading(true)` → `SingleQueryResultPane` unmounts/remounts → `FilterInput` re-mounts and steals focus from whatever the user was editing.
- **Fix:** Guard `FilterInput.useEffect` to skip auto-focus if an INPUT, TEXTAREA, or contenteditable element already has focus. Preserves the auto-focus UX when the pane first opens (nothing is focused), prevents cursor theft during re-mounts.

## Test plan

- [ ] In Explore, open a Bar Chart, go to the Customize tab, enter a value in Legend margin, then clear it — cursor should stay in the legend margin field
- [ ] In Explore, open the Results pane for the first time — the search box should still auto-focus
- [ ] Unit tests: `npx jest src/explore/components/DataTableControl/FilterInput.test.tsx --no-coverage`

Fixes: https://app.shortcut.com/preset/story/108003

🤖 Generated with [Claude Code](https://claude.com/claude-code)