### PR TITLE
fix(nav): prevent full reload when clicking logo; redirect / to welcome

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -303,7 +303,7 @@ export function Menu({
       );
       link = (
         <StyledBrandWrapper margin={theme.brandLogoMargin}>
-          {isUrlExternal(brandHref) || !isFrontendRoute(brandHref) ? (
+          {isUrlExternal(brandHref) ? (
             <Typography.Link className="navbar-brand" href={brandHref}>
               {brandImage}
             </Typography.Link>

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -153,7 +153,7 @@ const StyledBrandWrapper = styled.div<{ margin?: string }>`
   `}
 `;
 
-const StyledBrandLink = styled(Typography.Link)`
+const StyledBrandLink = styled(GenericLink)`
   ${({ theme }) => css`
     align-items: center;
     display: flex;
@@ -294,7 +294,7 @@ export function Menu({
     if (theme.brandLogoUrl) {
       link = (
         <StyledBrandWrapper margin={theme.brandLogoMargin}>
-          <StyledBrandLink href={ensureAppRoot(theme.brandLogoHref)}>
+          <StyledBrandLink to={ensureAppRoot(theme.brandLogoHref)}>
             <StyledImage
               preview={false}
               src={ensureStaticPrefix(theme.brandLogoUrl)}

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -21,7 +21,7 @@ import { styled, css, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { ensureStaticPrefix } from 'src/utils/assetUrl';
 import { ensureAppRoot } from 'src/utils/pathUtils';
-import { getUrlParam } from 'src/utils/urlUtils';
+import { getUrlParam, isUrlExternal } from 'src/utils/urlUtils';
 import { MainNav, MenuItem } from '@superset-ui/core/components/Menu';
 import { Tooltip, Grid, Row, Col, Image } from '@superset-ui/core/components';
 import { GenericLink } from 'src/components';
@@ -292,16 +292,24 @@ export function Menu({
   const renderBrand = () => {
     let link;
     if (theme.brandLogoUrl) {
+      const brandHref = ensureAppRoot(theme.brandLogoHref);
+      const brandImage = (
+        <StyledImage
+          preview={false}
+          src={ensureStaticPrefix(theme.brandLogoUrl)}
+          alt={theme.brandLogoAlt || 'Apache Superset'}
+          height={theme.brandLogoHeight}
+        />
+      );
       link = (
         <StyledBrandWrapper margin={theme.brandLogoMargin}>
-          <StyledBrandLink to={ensureAppRoot(theme.brandLogoHref)}>
-            <StyledImage
-              preview={false}
-              src={ensureStaticPrefix(theme.brandLogoUrl)}
-              alt={theme.brandLogoAlt || 'Apache Superset'}
-              height={theme.brandLogoHeight}
-            />
-          </StyledBrandLink>
+          {isUrlExternal(brandHref) || !isFrontendRoute(brandHref) ? (
+            <Typography.Link className="navbar-brand" href={brandHref}>
+              {brandImage}
+            </Typography.Link>
+          ) : (
+            <StyledBrandLink to={brandHref}>{brandImage}</StyledBrandLink>
+          )}
         </StyledBrandWrapper>
       );
     } else if (isFrontendRoute(window.location.pathname)) {

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -21,6 +21,7 @@ import {
   BrowserRouter as Router,
   Switch,
   Route,
+  Redirect,
   useLocation,
 } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -111,6 +112,7 @@ const App = () => (
               </Suspense>
             </Route>
           ))}
+          <Redirect from="/" to="/superset/welcome/" exact />
         </Switch>
       </ExtensionsStartup>
       <ToastContainer />


### PR DESCRIPTION
### SUMMARY

Clicking the header logo was causing a full page reload instead of a client-side navigation.

**Root cause:** The brand logo link used `StyledBrandLink` (based on `Typography.Link`, a plain `<a>` tag), which triggers a full browser navigation. The app was relying on a server-side redirect from `/` → `/superset/welcome/` to resolve the destination, which only works on a hard reload.

**Fix:**
1. Replace `StyledBrandLink`'s base component from `Typography.Link` to `GenericLink`, which uses React Router's `<Link>` for internal URLs and a plain `<a>` for external ones — preserving support for custom external `brandLogoHref` values.
2. Add an explicit React Router `<Redirect from="/" to="/superset/welcome/" exact />` to replicate the server-side redirect client-side, so any navigation to `/` (not just from the logo) resolves correctly without a reload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

AFTER: The page does not reload when clicking on the logo.

https://github.com/user-attachments/assets/325de242-9d99-43ce-9b9c-58dbf470afec

### TESTING INSTRUCTIONS

1. Start the dev server
2. Click the header logo — it should navigate to `/superset/welcome/` without a full page reload
3. Configure a custom `brandLogoHref` with an external URL (e.g. `https://example.com`) — it should still open as a normal link

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)