### PR TITLE
fix(oracle): replace deprecated cx-Oracle extra with oracledb

### DIFF
--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -7235,10 +7235,10 @@
         "pypi_packages": [
           "oracledb"
         ],
-        "connection_string": "oracle://{username}:{password}@{hostname}:{port}",
+        "connection_string": "oracle+oracledb://{username}:{password}@{hostname}:{port}",
         "default_port": 1521,
         "notes": "Previously used cx_Oracle, now uses oracledb.",
-        "docs_url": "https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html",
+        "docs_url": "https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html",
         "category": "Other Databases"
       },
       "engine": "oracle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ ocient = [
     "shapely",
     "geojson",
 ]
-oracle = ["cx-Oracle>8.0.0, <8.4"]
+oracle = ["oracledb>=2.0.0, <5"]
 parseable = ["sqlalchemy-parseable>=0.1.3,<0.2.0"]
 pinot = ["pinotdb>=5.0.0, <10.0.0"]
 playwright = ["playwright>=1.60.0, <2"]

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -36,10 +36,10 @@ class OracleEngineSpec(BaseEngineSpec):
             DatabaseCategory.PROPRIETARY,
         ],
         "pypi_packages": ["oracledb"],
-        "connection_string": "oracle://{username}:{password}@{hostname}:{port}",
+        "connection_string": "oracle+oracledb://{username}:{password}@{hostname}:{port}",
         "default_port": 1521,
         "notes": "Previously used cx_Oracle, now uses oracledb.",
-        "docs_url": "https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html",
+        "docs_url": "https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html",
     }
     force_column_alias_quotes = True
     max_column_name_length = 128


### PR DESCRIPTION
### SUMMARY

The `oracle` pip extra in `pyproject.toml` still installed the deprecated **cx-Oracle** driver (`cx-Oracle>8.0.0, <8.4`), even though the Oracle engine spec already documents **python-oracledb** as the driver (`"pypi_packages": ["oracledb"]` and the note "Previously used cx_Oracle, now uses oracledb"). cx-Oracle was deprecated by Oracle in 2022 and does not support Python 3.11+, which conflicts with Superset's `requires-python = ">=3.10"`.

This was surfaced by a Bito review on the Dependabot PR #41088 (which merely bumped the cx-Oracle range). Rather than bumping a dependency we intend to drop, this PR completes the migration:

- `pyproject.toml`: `oracle` extra → `oracledb>=2.0.0, <5`
- `superset/db_engine_specs/oracle.py`: connection-string template → `oracle+oracledb://…` and `docs_url` → python-oracledb docs
- `docs/src/data/databases.json`: regenerated metadata to match the engine spec

**Why the connection-string change is required:** SQLAlchemy maps the bare `oracle://` dialect to `cx_oracle`, which does `import cx_Oracle`. With only `oracledb` installed, `oracle://` URIs would raise `ModuleNotFoundError`. python-oracledb registers under the `oracle+oracledb` dialect, so the suggested URI template must use it.

Note: python-oracledb's SQLAlchemy dialect requires SQLAlchemy ≥ 1.4.43. Superset pins `sqlalchemy>=1.4, <2`; the resolved 1.4.x already satisfies this, but maintainers may want to tighten the lower bound in a follow-up.

This supersedes #41088, which can be closed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

- `pip install "apache-superset[oracle]"` now installs `oracledb` (no native Oracle Instant Client build step required, unlike cx-Oracle).
- Connect to an Oracle database using a `oracle+oracledb://user:pass@host:port/?service_name=…` SQLAlchemy URI.
- Pre-commit `database engine spec metadata validation` hook passes (confirms `oracle.py` metadata and `databases.json` stay in sync).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API
  - Drops the deprecated cx-Oracle driver from the `oracle` extra in favor of python-oracledb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)