### PR TITLE
fix(telemetry): make SCARF_ANALYTICS opt-out work at runtime

### DIFF
--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -76,6 +76,14 @@ def test_default_map_renderer_is_exposed_to_frontend_config() -> None:
     assert "DEFAULT_MAP_RENDERER" in FRONTEND_CONF_KEYS
 
 
+def test_scarf_analytics_is_exposed_to_frontend_config() -> None:
+    # Exposed at runtime so pre-built images can opt out via the SCARF_ANALYTICS
+    # config/env var (the webpack build-time flag cannot be changed there).
+    from superset.views.base import FRONTEND_CONF_KEYS
+
+    assert "SCARF_ANALYTICS" in FRONTEND_CONF_KEYS
+
+
 _FULL_METADATA = {
     "version_string": "4.0.0",
     "version_sha": "abcdef12",

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -77,8 +77,9 @@ def test_default_map_renderer_is_exposed_to_frontend_config() -> None:
 
 
 def test_scarf_analytics_is_exposed_to_frontend_config() -> None:
-    # Exposed at runtime so pre-built images can opt out via the SCARF_ANALYTICS
-    # config/env var (the webpack build-time flag cannot be changed there).
+    """SCARF_ANALYTICS must reach the frontend config so pre-built images can opt
+    out at runtime via the config/env var (the webpack build-time flag cannot be
+    changed there)."""
     from superset.views.base import FRONTEND_CONF_KEYS
 
     assert "SCARF_ANALYTICS" in FRONTEND_CONF_KEYS


### PR DESCRIPTION
### SUMMARY

Fixes #32110. Multiple users report that `SCARF_ANALYTICS=false` does nothing on the official Docker image / PyPI wheel — the Scarf telemetry pixel keeps loading despite the documented opt-out.

**Root cause:** the pixel was gated solely on `process.env.SCARF_ANALYTICS`, which webpack's `DefinePlugin` inlines at **build time** (`webpack.config.js`). On pre-built artifacts the frontend bundle is already compiled, so setting the env var at container runtime (Helm `extraEnv`, `docker/.env`, k8s deployment) has no effect. The opt-out only ever worked when building the frontend yourself. There was no Python-side `SCARF_ANALYTICS` at all.

**Fix:** route the flag through the existing runtime config channel.

- `superset/config.py`: add `SCARF_ANALYTICS = utils.cast_to_boolean(os.environ.get("SCARF_ANALYTICS", True))` (same idiom as `TALISMAN_ENABLED`), so the env var is read at backend startup.
- `superset/views/base.py`: add `SCARF_ANALYTICS` to `FRONTEND_CONF_KEYS` so it ships to the client in the bootstrap payload (`common.conf`).
- `RightMenu.tsx`: read `common.conf.SCARF_ANALYTICS` and pass `enabled={SCARF_ANALYTICS !== false}` to `<TelemetryPixel>`.
- `TelemetryPixel` (superset-ui-core): add an `enabled` prop; render the pixel only when not disabled at runtime *and* not disabled at build time. The `process.env` check is kept as a short-circuit for source builds.

**Default behavior is unchanged** — telemetry stays on unless explicitly disabled. This only makes the *existing, documented* opt-out actually work at runtime. (Whether the default should flip to opt-out is a separate PMC/governance question; this PR deliberately doesn't touch it — the `os.environ.get(..., True)` default is a one-line change if the project decides to.)

Note: this addresses the *can't-disable-it* half of #32110. The separate "Scarf URL gets flagged as malicious by Brave/Chrome" half (the redirect-based `gateway.scarf.sh` pixel) is best fixed by switching to Scarf's native static pixel and will be handled separately.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (no visual change). Behavior:

- **Before:** `SCARF_ANALYTICS=false` in a container → pixel still requested.
- **After:** `SCARF_ANALYTICS=false` in a container → no pixel request; default (unset) → unchanged.

### TESTING INSTRUCTIONS

- Backend: `pytest tests/unit_tests/views/test_base.py` — includes a new assertion that `SCARF_ANALYTICS` is exposed via `FRONTEND_CONF_KEYS`.
- Frontend: `npm run test -- TelemetryPixel` — new cases cover `enabled={false}` (no pixel) and `enabled` (pixel) independent of the build-time flag.
- Manual: set `SCARF_ANALYTICS=false` via Helm `extraEnv` / `docker/.env` on a pre-built image and confirm no request to `scarf.sh` in the network tab.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #32110
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)