### PR TITLE
fix(sql): stop sanitize_clause from rewriting user SQL semantics (#36113)

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1856,13 +1856,15 @@ def sanitize_clause(clause: str, engine: str) -> str:
     Comments are the one exception: a trailing line comment can comment out
     surrounding SQL once the clause is embedded into a larger query (e.g.
     wrapped in parentheses), so any clause that contains comments is re-rendered
-    to normalize them into a safe form.
+    to normalize them into a safe form. A trailing statement terminator is
+    likewise stripped, since callers embed the clause inside a larger fragment
+    (``WHERE (...)``) where a stray ``;`` would produce invalid SQL.
     """
     try:
         statement = SQLStatement(clause, engine)
         parsed = statement._parsed  # pylint: disable=protected-access
         if not any(node.comments for node in parsed.walk()):
-            return clause
+            return clause.rstrip().rstrip(";").rstrip()
 
         return _normalized_generator(
             SQLGLOT_DIALECTS.get(engine),

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1843,16 +1843,33 @@ def process_jinja_sql(
 
 def sanitize_clause(clause: str, engine: str) -> str:
     """
-    Make sure the SQL clause is valid.
+    Validate a SQL clause and return it unchanged.
+
+    The clause is parsed to ensure it is a single, well-formed statement. We
+    intentionally return the *original* text rather than a re-rendered version:
+    round-tripping user SQL through SQLGlot's dialect generator can silently
+    alter semantics. For example, the Postgres dialect (borrowed by several
+    engines) rewrites ``ROUND(AVG(x), n)`` to ``ROUND(CAST(AVG(x) AS DECIMAL),
+    n)``, which rounds the value to an integer before the explicit ``ROUND`` on
+    engines whose unqualified ``DECIMAL`` defaults to scale 0 (see #36113).
+
+    Comments are the one exception: a trailing line comment can comment out
+    surrounding SQL once the clause is embedded into a larger query (e.g.
+    wrapped in parentheses), so any clause that contains comments is re-rendered
+    to normalize them into a safe form.
     """
     try:
         statement = SQLStatement(clause, engine)
+        parsed = statement._parsed  # pylint: disable=protected-access
+        if not any(node.comments for node in parsed.walk()):
+            return clause
+
         return _normalized_generator(
             SQLGLOT_DIALECTS.get(engine),
             pretty=False,
             comments=True,
         ).generate(
-            statement._parsed,  # pylint: disable=protected-access
+            parsed,
             copy=True,
         )
     except SupersetParseError as ex:

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1856,9 +1856,13 @@ def sanitize_clause(clause: str, engine: str) -> str:
     Comments are the one exception: a trailing line comment can comment out
     surrounding SQL once the clause is embedded into a larger query (e.g.
     wrapped in parentheses), so any clause that contains comments is re-rendered
-    to normalize them into a safe form. A trailing statement terminator is
-    likewise stripped, since callers embed the clause inside a larger fragment
-    (``WHERE (...)``) where a stray ``;`` would produce invalid SQL.
+    to normalize them into a safe form. That re-rendering uses the *base* dialect
+    rather than the engine dialect, so it normalizes comments without re-applying
+    the engine-specific rewrites (e.g. the Postgres ``ROUND``/``CAST`` rewrite
+    from #36113) that we deliberately avoid above. A trailing statement
+    terminator is likewise stripped, since callers embed the clause inside a
+    larger fragment (``WHERE (...)``) where a stray ``;`` would produce invalid
+    SQL.
     """
     try:
         statement = SQLStatement(clause, engine)
@@ -1867,7 +1871,7 @@ def sanitize_clause(clause: str, engine: str) -> str:
             return clause.rstrip().rstrip(";").rstrip()
 
         return _normalized_generator(
-            SQLGLOT_DIALECTS.get(engine),
+            None,
             pretty=False,
             comments=True,
         ).generate(

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -804,7 +804,7 @@ def test_get_samples_with_multiple_filters(
     assert "2000-01-02" in rv.json["result"]["query"]
     assert "2000-01-04" in rv.json["result"]["query"]
     assert "col3 = 1.2" in rv.json["result"]["query"]
-    assert "col4 IS NULL" in rv.json["result"]["query"]
+    assert "col4 is null" in rv.json["result"]["query"]
     assert "col2 = 'c'" in rv.json["result"]["query"]
 
 

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -21,7 +21,7 @@ import re
 from datetime import datetime
 from typing import Any, cast, Literal, NamedTuple, Optional, Union
 from re import Pattern
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 import numpy as np
@@ -138,8 +138,8 @@ class TestDatabaseModel(SupersetTestCase):
             assert col.is_temporal
 
     @patch("superset.jinja_context.get_username", return_value="abc")
-    def test_jinja_metrics_and_calc_columns(self, mock_username):
-        base_query_obj = {
+    def test_jinja_metrics_and_calc_columns(self, mock_username: MagicMock) -> None:
+        base_query_obj: dict[str, Any] = {
             "granularity": None,
             "from_dttm": None,
             "to_dttm": None,

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -199,8 +199,8 @@ class TestDatabaseModel(SupersetTestCase):
         assert "'foo_P1D'" in query
         # assert dataset saved metric
         assert "count('bar_P1D')" in query
-        # assert adhoc metric
-        assert "SUM(CASE WHEN user = 'user_abc' THEN 1 ELSE 0 END)" in query
+        # assert adhoc metric (sanitize_clause preserves the user's SQL verbatim)
+        assert "SUM(case when user = 'user_abc' then 1 else 0 end)" in query
         # Cleanup
         db.session.delete(table)
         db.session.commit()

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3259,6 +3259,15 @@ def test_sanitize_clause_preserves_aggregation_semantics_with_comment(
     assert "CAST" not in sanitized.upper(), (
         f"sanitize_clause injected a cast for engine {engine!r}: {sanitized!r}"
     )
+    # The comment-handling branch must preserve the user-authored expression and
+    # comment payload, not just avoid the cast (otherwise dropping the comment or
+    # rewriting the clause entirely would still pass the assertion above).
+    assert "ROUND(AVG(col), 4)" in sanitized, (
+        f"sanitize_clause rewrote the clause for engine {engine!r}: {sanitized!r}"
+    )
+    assert "precise_count_distinct=true" in sanitized, (
+        f"sanitize_clause dropped the comment for engine {engine!r}: {sanitized!r}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3148,6 +3148,10 @@ def test_is_valid_cvas(sql: str, engine: str, expected: bool) -> None:
         ),  # Block comments preserved
         ("col = 'col1 = 1) AND (col2 = 2'", "col = 'col1 = 1) AND (col2 = 2'", "base"),
         ("col = 'select 1; select 2'", "col = 'select 1; select 2'", "base"),
+        # Trailing statement terminators are stripped so the clause stays valid
+        # once embedded inside a larger fragment (e.g. ``WHERE (...)``).
+        ("col = 1;", "col = 1", "base"),
+        ("col = 1 ; ", "col = 1", "base"),
         ("col = 'abc -- comment'", "col = 'abc -- comment'", "base"),
         ("col1 = 1) AND (col2 = 2)", QueryClauseValidationException, "base"),
         ("(col1 = 1) AND (col2 = 2", QueryClauseValidationException, "base"),

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3123,7 +3123,8 @@ def test_is_valid_cvas(sql: str, engine: str, expected: bool) -> None:
     "sql, expected, engine",
     [
         ("col = 1", "col = 1", "base"),
-        ("1=\t\n1", "1 = 1", "base"),
+        # Comment-free clauses are returned verbatim (no semantic round-trip).
+        ("1=\t\n1", "1=\t\n1", "base"),
         ("(col = 1)", "(col = 1)", "base"),  # Compact format without newlines
         (
             "(col1 = 1) AND (col2 = 2)",

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3240,6 +3240,29 @@ def test_sanitize_clause_preserves_aggregation_semantics(engine: str) -> None:
 
 @pytest.mark.parametrize(
     "engine",
+    ["postgresql", "redshift", "cockroachdb", "netezza", "hana", "base", "mysql"],
+)
+def test_sanitize_clause_preserves_aggregation_semantics_with_comment(
+    engine: str,
+) -> None:
+    """
+    Regression test for https://github.com/apache/superset/issues/36113.
+
+    A clause that contains a comment takes the re-rendering branch of
+    ``sanitize_clause``. That branch must normalize comments using the *base*
+    dialect rather than the engine dialect, so it must not re-apply the Postgres
+    ``ROUND(AVG(x), n)`` -> ``ROUND(CAST(AVG(x) AS DECIMAL), n)`` rewrite that
+    truncates results on engines where ``DECIMAL`` defaults to scale 0.
+    """
+    clause = "ROUND(AVG(col), 4) /* precise_count_distinct=true */"
+    sanitized = sanitize_clause(clause, engine)
+    assert "CAST" not in sanitized.upper(), (
+        f"sanitize_clause injected a cast for engine {engine!r}: {sanitized!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "engine",
     [
         "postgresql",
         "presto",

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3210,6 +3210,31 @@ def test_sanitize_clause(sql: str, expected: str | Exception, engine: str) -> No
 
 @pytest.mark.parametrize(
     "engine",
+    ["postgresql", "redshift", "cockroachdb", "netezza", "hana", "base", "mysql"],
+)
+def test_sanitize_clause_preserves_aggregation_semantics(engine: str) -> None:
+    """
+    Regression test for https://github.com/apache/superset/issues/36113.
+
+    `sanitize_clause` must not silently rewrite a user-authored expression. The
+    Postgres SQLGlot dialect (which several engines borrow) rewrites
+    ``ROUND(AVG(x), n)`` to ``ROUND(CAST(AVG(x) AS DECIMAL), n)`` at generation
+    time. On engines whose unqualified ``DECIMAL`` defaults to scale 0 (e.g.
+    Redshift, Netezza) the injected cast rounds the aggregate to an integer
+    *before* the explicit ``ROUND``, producing wrong results.
+
+    The clause must be returned unchanged regardless of the engine dialect.
+    """
+    clause = "ROUND(AVG(col), 4)"
+    sanitized = sanitize_clause(clause, engine)
+    assert "CAST" not in sanitized.upper(), (
+        f"sanitize_clause injected a cast for engine {engine!r}: {sanitized!r}"
+    )
+    assert sanitized == clause
+
+
+@pytest.mark.parametrize(
+    "engine",
     [
         "postgresql",
         "presto",


### PR DESCRIPTION
### SUMMARY

Fixes #36113.

A dataset metric defined as `ROUND(AVG(x), 4)` was being executed as `ROUND(CAST(AVG(x) AS DECIMAL), 4)`, rounding the value to an integer *before* the explicit `ROUND` and returning `1` instead of `0.9496`.

#### Root cause

`superset.sql.parse.sanitize_clause` is documented as a validator, but it round-trips the user's clause through SQLGlot's **dialect generator** and returns the *re-rendered* SQL:

```python
return Dialect.get_or_raise(dialect).generate(statement._parsed, ...)
```

SQLGlot's Postgres dialect rewrites `ROUND(AVG(x), n)` into `ROUND(CAST(AVG(x) AS DECIMAL), n)` at generation time (Postgres only exposes `round(numeric, int)`). The cast is harmless on real PostgreSQL, where unqualified `numeric`/`DECIMAL` is unconstrained and preserves the value — but several engines **borrow the Postgres dialect** while defaulting unqualified `DECIMAL` to **scale 0** (Redshift historically, CockroachDB, Netezza, SAP HANA). On those engines the injected cast truncates the aggregate to an integer before the user's `ROUND`.

This is a regression from the `sqlparse` → SQLGlot migration: the legacy `sanitize_clause` only *validated* the clause and returned it **unchanged**.

#### Fix

Validate the clause by parsing it (raising on parse errors / multiple statements, exactly as before) but **return the original clause verbatim** instead of the re-rendered SQL — no more silent dialect-specific semantic rewrites.

Clauses that contain comments are the one exception: they are still re-rendered, because a trailing line comment can comment out surrounding SQL once the clause is embedded into a larger query (e.g. wrapped in parentheses for `WHERE`/`HAVING`). Comment detection walks the parsed AST, so `--` sequences inside string literals are correctly left untouched.

All call sites either discard the return value (pure validation) or use it as an embedded clause, so returning the user's original text is strictly safer.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/sql/parse_tests.py -k sanitize_clause
```

Added a parametrized regression test (`test_sanitize_clause_preserves_aggregation_semantics`) asserting `ROUND(AVG(col), 4)` is returned unchanged across `postgresql`, `redshift`, `cockroachdb`, `netezza`, `hana`, `mysql`, and `base`. It fails on `master` for the Postgres-dialect engines and passes with this fix.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #36113
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)