### PR TITLE
fix(tags): remove unsatisfiable foreign keys from tagged_object.object_id

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -54,23 +54,17 @@ The `thumbnail_url` field has been removed from `GET /api/v1/dashboard/` list re
 
 The thumbnail endpoint redirects to the current digest URL regardless of whether the supplied digest is exact. If the image is not yet cached, that digest URL may return `202` and trigger async generation. Using `changed_on_utc` as the digest is sufficient for cache-busting purposes.
 
-### Tagging on `create_all`-bootstrapped PostgreSQL/MySQL schemas
+### Tagging fix for `create_all`-bootstrapped schemas
 
-`tagged_object.object_id` is a polymorphic reference — depending on `object_type` it points at a dashboard, chart, or saved query — so it must not carry a foreign key to any single table. The canonical migration chain (`c82ee8a39623` onward) never created such constraints. Deployments that bootstrapped their metadata schema with SQLAlchemy's `create_all` (instead of `superset db upgrade`) on a backend that enforces foreign keys — PostgreSQL, or MySQL with `FOREIGN_KEY_CHECKS=1` — may carry three unsatisfiable FKs from `tagged_object.object_id` to `dashboards.id`, `slices.id`, and `saved_query.id`. These break tagging (`TAGGING_SYSTEM = True`) with a `ForeignKeyViolation`.
+Only affects deployments whose metadata schema was created with SQLAlchemy's `create_all` (rather than `superset db upgrade`) on a foreign-key-enforcing backend — PostgreSQL, or MySQL with `FOREIGN_KEY_CHECKS=1`. Such schemas carry three invalid foreign keys on `tagged_object.object_id` that break tagging (`TAGGING_SYSTEM = True`) with a `ForeignKeyViolation`. Schemas built via `superset db upgrade` are unaffected.
 
-This release removes the constraints from the ORM model so they are no longer emitted on future `create_all` runs. It does not (and a `downgrade` could never safely) drop constraints already present in such a schema, so affected operators should drop them manually. Constraint names vary by backend and creation order — inspect the table to find them first:
-
-PostgreSQL (names typically `tagged_object_object_id_fkey`, `…_fkey1`, `…_fkey2`):
+This release stops the ORM from emitting these constraints, but it cannot drop ones already present in your schema. If affected, drop them manually (names vary by backend, so look them up first):
 
 ```sql
-ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey;
-ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey1;
-ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey2;
-```
+-- PostgreSQL: names are typically tagged_object_object_id_fkey, _fkey1, _fkey2
+ALTER TABLE tagged_object DROP CONSTRAINT <constraint_name>;
 
-MySQL (find the constraint names via `SHOW CREATE TABLE tagged_object;`):
-
-```sql
+-- MySQL: find names via `SHOW CREATE TABLE tagged_object;`
 ALTER TABLE tagged_object DROP FOREIGN KEY <constraint_name>;
 ```
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -54,6 +54,26 @@ The `thumbnail_url` field has been removed from `GET /api/v1/dashboard/` list re
 
 The thumbnail endpoint redirects to the current digest URL regardless of whether the supplied digest is exact. If the image is not yet cached, that digest URL may return `202` and trigger async generation. Using `changed_on_utc` as the digest is sufficient for cache-busting purposes.
 
+### Tagging on `create_all`-bootstrapped PostgreSQL/MySQL schemas
+
+`tagged_object.object_id` is a polymorphic reference — depending on `object_type` it points at a dashboard, chart, or saved query — so it must not carry a foreign key to any single table. The canonical migration chain (`c82ee8a39623` onward) never created such constraints. Deployments that bootstrapped their metadata schema with SQLAlchemy's `create_all` (instead of `superset db upgrade`) on a backend that enforces foreign keys — PostgreSQL, or MySQL with `FOREIGN_KEY_CHECKS=1` — may carry three unsatisfiable FKs from `tagged_object.object_id` to `dashboards.id`, `slices.id`, and `saved_query.id`. These break tagging (`TAGGING_SYSTEM = True`) with a `ForeignKeyViolation`.
+
+This release removes the constraints from the ORM model so they are no longer emitted on future `create_all` runs. It does not (and a `downgrade` could never safely) drop constraints already present in such a schema, so affected operators should drop them manually. Constraint names vary by backend and creation order — inspect the table to find them first:
+
+PostgreSQL (names typically `tagged_object_object_id_fkey`, `…_fkey1`, `…_fkey2`):
+
+```sql
+ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey;
+ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey1;
+ALTER TABLE tagged_object DROP CONSTRAINT tagged_object_object_id_fkey2;
+```
+
+MySQL (find the constraint names via `SHOW CREATE TABLE tagged_object;`):
+
+```sql
+ALTER TABLE tagged_object DROP FOREIGN KEY <constraint_name>;
+```
+
 ### Webhook alerts/reports block private/internal hosts by default
 
 Webhook alert/report dispatch (`WebhookNotification.send`) now validates the target URL's host against the same private/internal-IP block applied to dataset import URLs. If the resolved host is in a loopback, link-local, private (RFC-1918), shared-CGNAT, or multicast range, the webhook is rejected with `NotificationParamException`.

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -111,12 +111,14 @@ class TaggedObject(Model, AuditMixinNullable):
     __tablename__ = "tagged_object"
     id = Column(Integer, primary_key=True)
     tag_id = Column(Integer, ForeignKey("tag.id"))
-    object_id = Column(
-        Integer,
-        ForeignKey("dashboards.id"),
-        ForeignKey("slices.id"),
-        ForeignKey("saved_query.id"),
-    )
+    # ``object_id`` is a polymorphic reference disambiguated by ``object_type``;
+    # the same value can point at a dashboard, chart or saved query. It must not
+    # carry a foreign key to any single table: declaring FKs to dashboards,
+    # slices and saved_query at once is unsatisfiable (a row would have to exist
+    # in all three) and breaks tagging, e.g. tagging a dashboard fails the
+    # slices FK. The original migration (c82ee8a39623) defined no FK here. See
+    # issue #35941.
+    object_id = Column(Integer)
     object_type = Column(Enum(ObjectType))
 
     tag = relationship("Tag", back_populates="objects", overlaps="tags")

--- a/tests/unit_tests/tags/models_test.py
+++ b/tests/unit_tests/tags/models_test.py
@@ -264,17 +264,10 @@ def test_tag_name_type_after_database_operation() -> None:
 
 
 def test_tagged_object_object_id_has_no_foreign_keys() -> None:
-    """
-    ``tagged_object.object_id`` is a polymorphic reference disambiguated by
-    ``object_type`` and must not carry a foreign key to any single table.
+    """Guard against ``tagged_object.object_id`` regaining a foreign key.
 
-    Declaring foreign keys to ``dashboards``, ``slices`` and ``saved_query`` on
-    the same column is unsatisfiable: a row would have to exist in all three
-    tables at once, so on a schema that enforces those constraints every tag
-    insert fails (e.g. tagging a dashboard violates the ``slices`` FK). This is
-    the regression behind issue #35941. The original migration (c82ee8a39623)
-    defined ``object_id`` without any FK, and this guards against the model
-    drifting back.
+    It is a polymorphic reference (see the rationale on the model); declaring
+    FKs there is unsatisfiable and breaks tagging (issue #35941).
     """
     foreign_keys = TaggedObject.__table__.c.object_id.foreign_keys
     assert foreign_keys == set(), (

--- a/tests/unit_tests/tags/models_test.py
+++ b/tests/unit_tests/tags/models_test.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock
 from markupsafe import Markup
 from sqlalchemy.orm import Session
 
-from superset.tags.models import get_tag, Tag, TagType
+from superset.tags.models import get_tag, Tag, TaggedObject, TagType
 
 
 def test_get_tag_returns_plain_string_not_markup() -> None:
@@ -260,4 +260,24 @@ def test_tag_name_type_after_database_operation() -> None:
     )
     assert added_tag.name.__class__ is str, (
         "Tag name should be exactly str type, not a subclass"
+    )
+
+
+def test_tagged_object_object_id_has_no_foreign_keys() -> None:
+    """
+    ``tagged_object.object_id`` is a polymorphic reference disambiguated by
+    ``object_type`` and must not carry a foreign key to any single table.
+
+    Declaring foreign keys to ``dashboards``, ``slices`` and ``saved_query`` on
+    the same column is unsatisfiable: a row would have to exist in all three
+    tables at once, so on a schema that enforces those constraints every tag
+    insert fails (e.g. tagging a dashboard violates the ``slices`` FK). This is
+    the regression behind issue #35941. The original migration (c82ee8a39623)
+    defined ``object_id`` without any FK, and this guards against the model
+    drifting back.
+    """
+    foreign_keys = TaggedObject.__table__.c.object_id.foreign_keys
+    assert foreign_keys == set(), (
+        "tagged_object.object_id must not declare foreign keys; it is a "
+        "polymorphic reference resolved via object_type"
     )


### PR DESCRIPTION
### SUMMARY

`tagged_object.object_id` is a polymorphic reference (it points at a dashboard, chart, or saved query, disambiguated by `object_type`). The model in `superset/tags/models.py`, however, declared **three foreign keys on the single column at once**:

```python
object_id = Column(
    Integer,
    ForeignKey("dashboards.id"),
    ForeignKey("slices.id"),
    ForeignKey("saved_query.id"),
)
```

Those constraints are conjunctive, so a row can only be inserted if the same `object_id` value exists in `dashboards` **and** `slices` **and** `saved_query` simultaneously, which is impossible. On any schema that actually enforces them, every tag insert fails. With `TAGGING_SYSTEM` enabled, the `after_insert` hook tags a newly created dashboard and the insert blows up with a `ForeignKeyViolation` against the `slices` table (issue #35941):

```
insert or update on table "tagged_object" violates foreign key constraint "tagged_object_object_id_fkey"
DETAIL: Key (object_id)=(72) is not present in table "slices".
```

The original migration that created this table (`c82ee8a39623`, 2018) defined `object_id = Column(Integer)` with **no** foreign key. No migration has ever added one, so a schema built via `superset db upgrade` doesn't carry the constraint and the bug is latent there, but a schema built from the models (`create_all`, as some dev/Docker setups do) materializes all three FKs and breaks. This restores the model to match the migration's polymorphic intent.

The ORM tag relationships on `Dashboard`, `Slice` and `SavedQuery` use `secondary="tagged_object"` with explicit `primaryjoin`/`secondaryjoin` conditions; SQLAlchemy resolves the join direction from those conditions and the real `tag_id` FK, so they are unaffected by removing the `object_id` FKs (verified: mappers configure cleanly and emit identical JOIN SQL with no warnings).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - model/schema change only.

**Before:** creating/tagging a dashboard with `TAGGING_SYSTEM: True` raises `IntegrityError: ForeignKeyViolation ... not present in table "slices"`.

**After:** `tagged_object.object_id` carries no foreign key; tagging works for dashboards, charts and saved queries.

### TESTING INSTRUCTIONS

Automated (deterministic, no DB FK enforcement needed):

```bash
pytest tests/unit_tests/tags/models_test.py::test_tagged_object_object_id_has_no_foreign_keys
```

The new test asserts `TaggedObject.__table__.c.object_id.foreign_keys == set()`. It is red on the old three-FK model and green after this change, guarding against the model drifting back.

Manual:
1. Set `"TAGGING_SYSTEM": True` in `superset_config.py`.
2. Build the metadata DB from the models (`create_all`) on a backend that enforces FKs (e.g. Postgres).
3. Create a new dashboard via the UI. Before this change it fails with the FK violation above; after, it succeeds and a `tagged_object` row is written.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #35941
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Note on migrations:** since no migration ever created these FK constraints, the canonical migration-built schema needs no change. Deployments whose schema was built from the models (`create_all`) and that already enforce the broken constraints would need them dropped to recover. I deliberately scoped this PR to the model fix rather than guessing at a fragile cross-dialect "drop constraint if exists" migration (the auto-generated names differ per backend, e.g. `..._fkey`, `..._fkey1`, `..._fkey2`). Happy to add a defensive migration if maintainers would prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)