### PR TITLE
fix(sqllab): shrink Template Parameters editor height and add outline

### DIFF
--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -39,8 +39,10 @@ jest.mock('@superset-ui/core/components/Select/AsyncSelect', () => () => (
   <div data-test="mock-async-select" />
 ));
 jest.mock('src/core/editors', () => ({
-  EditorHost: ({ value }: { value: string }) => (
-    <div data-test="mock-async-ace-editor">{value}</div>
+  EditorHost: ({ value, height }: { value: string; height: string }) => (
+    <div data-test="mock-async-ace-editor" data-height={height}>
+      {value}
+    </div>
   ),
 }));
 
@@ -77,6 +79,18 @@ describe('TemplateParamsEditor', () => {
     await waitFor(() => {
       expect(getByTestId('mock-async-ace-editor')).toBeInTheDocument();
     });
+  });
+
+  test('renders the editor with a bounded height to avoid overflowing the popover', async () => {
+    const { container, getByTestId } = setup();
+    fireEvent.click(getByText(container, 'Parameters'));
+    await waitFor(() => {
+      expect(getByTestId('mock-async-ace-editor')).toBeInTheDocument();
+    });
+    expect(getByTestId('mock-async-ace-editor')).toHaveAttribute(
+      'data-height',
+      '360px',
+    );
   });
 
   test('renders templateParams', async () => {

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -31,10 +31,8 @@ import { EditorHost } from 'src/core/editors';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 
 const EditorOutline = styled.div`
-  & .ace_editor {
-    border: 1px solid ${({ theme }) => theme.colorBorder};
-    border-radius: ${({ theme }) => theme.borderRadius}px;
-  }
+  border: 1px solid ${({ theme }) => theme.colorBorder};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
 `;
 
 const StyledParagraph = styled.p`

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -31,9 +31,10 @@ import { EditorHost } from 'src/core/editors';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 
 const EditorOutline = styled.div`
-  border: 1px solid ${({ theme }) => theme.colorBorder};
-  border-radius: ${({ theme }) => theme.borderRadius}px;
-  overflow: hidden;
+  & .ace_editor {
+    border: 1px solid ${({ theme }) => theme.colorBorder};
+    border-radius: ${({ theme }) => theme.borderRadius}px;
+  }
 `;
 
 const StyledParagraph = styled.p`

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -30,10 +30,10 @@ import {
 import { EditorHost } from 'src/core/editors';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 
-const StyledEditorHost = styled(EditorHost)`
-  &.ace_editor {
-    border: 1px solid ${({ theme }) => theme.colorBorder};
-  }
+const EditorOutline = styled.div`
+  border: 1px solid ${({ theme }) => theme.colorBorder};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+  overflow: hidden;
 `;
 
 const StyledParagraph = styled.p`
@@ -87,14 +87,16 @@ const TemplateParamsEditor = ({
         </a>{' '}
         {t('syntax.')}
       </StyledParagraph>
-      <StyledEditorHost
-        id={`template-params-${queryEditorId}`}
-        height="800px"
-        onChange={debounce(onChange, Constants.FAST_DEBOUNCE)}
-        language={language === 'yaml' ? 'yaml' : 'json'}
-        width="100%"
-        value={code}
-      />
+      <EditorOutline>
+        <EditorHost
+          id={`template-params-${queryEditorId}`}
+          height="360px"
+          onChange={debounce(onChange, Constants.FAST_DEBOUNCE)}
+          language={language === 'yaml' ? 'yaml' : 'json'}
+          width="100%"
+          value={code}
+        />
+      </EditorOutline>
     </div>
   );
 


### PR DESCRIPTION
### SUMMARY

The SQL Lab "Template parameters" popover was overflowing on typical laptop viewports because the embedded JSON editor was hardcoded to `height="800px"`. This PR shrinks it to `360px` and adds a visible outline around the editor so it reads as a clearly framed code block (consistent with the SQL block in Explore → View Query).

It also removes a styled wrapper (`StyledEditorHost`) whose `&.ace_editor` selector was not rendering the intended border in practice — and replaces it with an `EditorOutline` div that applies the border directly. The new border uses `theme.colorBorder` and `theme.borderRadius` so it tracks both light and dark themes, matching the established idiom in `CssTemplateModal`, `KeyboardShortcutButton`, `ThemeModal`, and `AnnotationLayerModal`.

The popover under test is gated by the `ENABLE_TEMPLATE_PROCESSING` feature flag (`SqlEditor/index.tsx` only renders the "Parameters" menu item when it is enabled). For Showtime reviewers, the flag is requested below so the preview env exposes the popover:

FEATURE_ENABLE_TEMPLATE_PROCESSING=true

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="671" height="1066" alt="Screenshot 2026-06-16 at 4 23 29 PM" src="https://github.com/user-attachments/assets/72b00d9e-9142-4b1e-abc8-8c183fc9a9d7" />


**After:**
<img width="643" height="576" alt="Screenshot 2026-06-16 at 3 13 18 PM" src="https://github.com/user-attachments/assets/2af669ab-fd56-4b0d-8fc7-80d110f7ca86" />


### TESTING INSTRUCTIONS

1. Enable `ENABLE_TEMPLATE_PROCESSING` (Showtime does this automatically from the flag line above).
2. Open SQL Lab.
3. Click the ⋯ (ellipsis) button above the SQL editor.
4. Select **Parameters**.
5. Verify the popover fits within the browser window on a 1280×800 viewport.
6. Verify the JSON editor has a clearly visible outline in both light and dark themes.
7. Verify the editor's autocomplete dropdown is not clipped by the new wrapper.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_TEMPLATE_PROCESSING` (the popover under test is gated on it)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API