### PR TITLE
fix(sqllab): preserve whitespace in grid result cells

### DIFF
--- a/superset-frontend/src/components/GridTable/index.tsx
+++ b/superset-frontend/src/components/GridTable/index.tsx
@@ -167,6 +167,14 @@ export function GridTable<RecordType extends object>({
           overflow: hidden;
         }
 
+        /* Preserve significant whitespace within cell values (e.g. option
+        symbols and other whitespace-sensitive data). ag-Grid's default
+        collapses runs of spaces, which can misrepresent the underlying
+        value. */
+        .ag-cell-value {
+          white-space: pre;
+        }
+
         & [role='columnheader']:hover .customHeaderAction {
           display: flex;
         }

--- a/superset-frontend/src/components/GridTable/index.tsx
+++ b/superset-frontend/src/components/GridTable/index.tsx
@@ -170,9 +170,19 @@ export function GridTable<RecordType extends object>({
         /* Preserve significant whitespace within cell values (e.g. option
         symbols and other whitespace-sensitive data). ag-Grid's default
         collapses runs of spaces, which can misrepresent the underlying
-        value. */
+        value.
+
+        'pre' is a deliberate trade-off over 'pre-wrap': it keeps values on a
+        single line so row heights and column sizing stay unchanged. CSS has no
+        value that preserves spaces while collapsing newlines, so an embedded
+        newline renders on multiple lines and is clipped by the fixed row
+        height; truncating such values to the visible row is acceptable here.
+        overflow/text-overflow keep over-long single-line values clipped with
+        an ellipsis rather than overflowing the cell. */
         .ag-cell-value {
           white-space: pre;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
 
         & [role='columnheader']:hover .customHeaderAction {


### PR DESCRIPTION
### SUMMARY

ag-Grid's default cell style collapses runs of whitespace, so values that depend on significant spacing - e.g. [option symbols](https://en.wikipedia.org/wiki/Option_symbol) and other financial identifiers - get rendered with the spaces squashed, misrepresenting the underlying data. This applies `white-space: pre` to `.ag-cell-value` in the shared `GridTable` (used by SQL Lab results and the Explore data panel) so the displayed value matches what's actually in the cell.

Single-line behavior is preserved (`pre` rather than `pre-wrap`), so row heights and column sizing are unchanged - only the previously-collapsed whitespace is now retained.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See the original report in #36042 for before/after visuals of the collapsed vs. preserved whitespace.

### TESTING INSTRUCTIONS

1. In SQL Lab, run a query that returns a value with multiple internal/trailing spaces, e.g. `SELECT 'F     ' AS osi_symbol`.
2. Before this change the spaces collapse to one; after, all five spaces are preserved in the result cell.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36042
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
