### PR TITLE
fix(dashboard): keep pasted filter values outside the loaded page

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1146,6 +1146,53 @@ test('pasting an non-existent option should not add it if allowNewOptions is fal
   expect(await findAllSelectOptions()).toHaveLength(0);
 });
 
+// Reference for the bug this tests: https://github.com/apache/superset/issues/32645
+// Dashboard filters with "Dynamically search all filter values" only load a
+// page of options client-side, so a pasted value outside that page used to be
+// silently dropped. allowNewOptionsOnPaste keeps such values so the filter can
+// still apply them.
+test('keeps pasted values outside loaded options when allowNewOptionsOnPaste is true', async () => {
+  render(
+    <Select
+      {...defaultProps}
+      mode="multiple"
+      allowNewOptions={false}
+      allowNewOptionsOnPaste
+    />,
+  );
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      // Liam is a loaded option; OutsideValue is not in the loaded page.
+      getData: () => 'Liam,OutsideValue',
+    },
+  });
+  fireEvent(input, paste);
+  await waitFor(() => {
+    const values = [
+      ...getElementsByClassName('.ant-select-selection-item'),
+    ].map(value => value.textContent);
+    expect(values).toEqual(expect.arrayContaining(['Liam', 'OutsideValue']));
+  });
+});
+
+test('drops pasted values outside loaded options when allowNewOptionsOnPaste is false', async () => {
+  render(<Select {...defaultProps} mode="multiple" allowNewOptions={false} />);
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => 'Liam,OutsideValue',
+    },
+  });
+  fireEvent(input, paste);
+  await waitFor(() => {
+    const values = [
+      ...getElementsByClassName('.ant-select-selection-item'),
+    ].map(value => value.textContent);
+    expect(values).toEqual(['Liam']);
+  });
+});
+
 test('does not fire onChange if the same value is selected in single mode', async () => {
   const onChange = jest.fn();
   render(<Select {...defaultProps} onChange={onChange} />);

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1187,6 +1187,39 @@ test('keeps pasted values outside loaded options when allowNewOptionsOnPaste is 
   );
 });
 
+test('trims whitespace around pasted comma-separated values', async () => {
+  const onChange = jest.fn();
+  render(
+    <Select
+      {...defaultProps}
+      mode="multiple"
+      allowNewOptions={false}
+      allowNewOptionsOnPaste
+      onChange={onChange}
+    />,
+  );
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      // Note the space after the comma — it must not leak into the value.
+      getData: () => 'Liam, OutsideValue',
+    },
+  });
+  fireEvent(input, paste);
+  await waitFor(() => {
+    const values = [
+      ...getElementsByClassName('.ant-select-selection-item'),
+    ].map(value => value.textContent);
+    expect(values).toEqual(['Liam', 'OutsideValue']);
+  });
+  expect(onChange).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({ value: 'OutsideValue' }),
+    ]),
+    expect.anything(),
+  );
+});
+
 test('drops pasted values outside loaded options when allowNewOptionsOnPaste is false', async () => {
   render(<Select {...defaultProps} mode="multiple" allowNewOptions={false} />);
   const input = getElementByClassName('.ant-select-selection-search-input');

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1152,12 +1152,14 @@ test('pasting an non-existent option should not add it if allowNewOptions is fal
 // silently dropped. allowNewOptionsOnPaste keeps such values so the filter can
 // still apply them.
 test('keeps pasted values outside loaded options when allowNewOptionsOnPaste is true', async () => {
+  const onChange = jest.fn();
   render(
     <Select
       {...defaultProps}
       mode="multiple"
       allowNewOptions={false}
       allowNewOptionsOnPaste
+      onChange={onChange}
     />,
   );
   const input = getElementByClassName('.ant-select-selection-search-input');
@@ -1172,8 +1174,17 @@ test('keeps pasted values outside loaded options when allowNewOptionsOnPaste is 
     const values = [
       ...getElementsByClassName('.ant-select-selection-item'),
     ].map(value => value.textContent);
-    expect(values).toEqual(expect.arrayContaining(['Liam', 'OutsideValue']));
+    // The paste handler appends, so the loaded option resolves first.
+    expect(values).toEqual(['Liam', 'OutsideValue']);
   });
+  // Assert the unloaded value actually reaches the change handler (the value
+  // that gets applied to the filter query), not just the rendered label.
+  expect(onChange).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({ value: 'OutsideValue' }),
+    ]),
+    expect.anything(),
+  );
 });
 
 test('drops pasted values outside loaded options when allowNewOptionsOnPaste is false', async () => {

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1220,6 +1220,36 @@ test('trims whitespace around pasted comma-separated values', async () => {
   );
 });
 
+test('does not create an empty option when pasting blank text', async () => {
+  const onChange = jest.fn();
+  render(
+    <Select
+      {...defaultProps}
+      mode="multiple"
+      allowNewOptions={false}
+      allowNewOptionsOnPaste
+      onChange={onChange}
+    />,
+  );
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => '   ',
+    },
+  });
+  fireEvent(input, paste);
+  await waitFor(() => {
+    const values = [
+      ...getElementsByClassName('.ant-select-selection-item'),
+    ].map(value => value.textContent);
+    expect(values).toEqual([]);
+  });
+  // No empty-string value should ever reach the handler.
+  onChange.mock.calls.forEach(([value]) => {
+    expect(value).not.toContain('');
+  });
+});
+
 test('drops pasted values outside loaded options when allowNewOptionsOnPaste is false', async () => {
   render(<Select {...defaultProps} mode="multiple" allowNewOptions={false} />);
   const input = getElementByClassName('.ant-select-selection-search-input');

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -91,6 +91,7 @@ const Select = forwardRef(
       className,
       allowClear,
       allowNewOptions = false,
+      allowNewOptionsOnPaste = false,
       allowSelectAll = true,
       ariaLabel,
       autoClearSearchValue = false,
@@ -519,7 +520,8 @@ const Select = forwardRef(
               handleSelectAll();
             }}
           >
-            {t('Select all')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
+            {t('Select all')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
           </Button>
           <Button
             type="link"
@@ -536,7 +538,8 @@ const Select = forwardRef(
               handleDeselectAll();
             }}
           >
-            {t('Clear')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
+            {t('Clear')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
           </Button>
         </StyledBulkActionsContainer>
       ),
@@ -693,17 +696,24 @@ const Select = forwardRef(
         const array = token ? uniq(pastedText.split(token)) : [pastedText];
 
         const newOptions: SelectOptionsType = [];
+        // When `allowNewOptionsOnPaste` is set, accept pasted values that are
+        // not in the loaded options even if `allowNewOptions` is false. The
+        // full option set is searched server-side and only partially loaded
+        // client-side, so a pasted value can legitimately exist in the dataset
+        // but fall outside the loaded page.
+        const keepUnknownValues = allowNewOptions || allowNewOptionsOnPaste;
 
         const values = array
           .map(item => {
             const option = getOption(item, fullSelectOptions, true);
-            if (!option && allowNewOptions) {
+            if (!option && keepUnknownValues) {
               const newOption = {
                 label: item,
                 value: item,
                 isNewOption: true,
               };
               newOptions.push(newOption);
+              return labelInValue ? { label: item, value: item } : item;
             }
             return getPastedTextValue(item);
           })

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -700,7 +700,7 @@ const Select = forwardRef(
                 .map(item => item.trim())
                 .filter(Boolean),
             )
-          : [pastedText.trim()];
+          : [pastedText.trim()].filter(Boolean);
 
         const newOptions: SelectOptionsType = [];
         // When `allowNewOptionsOnPaste` is set, accept pasted values that are

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -693,7 +693,14 @@ const Select = forwardRef(
         }
       } else {
         const token = tokenSeparators.find(token => pastedText.includes(token));
-        const array = token ? uniq(pastedText.split(token)) : [pastedText];
+        const array = token
+          ? uniq(
+              pastedText
+                .split(token)
+                .map(item => item.trim())
+                .filter(Boolean),
+            )
+          : [pastedText.trim()];
 
         const newOptions: SelectOptionsType = [];
         // When `allowNewOptionsOnPaste` is set, accept pasted values that are

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
@@ -95,6 +95,8 @@ export interface BaseSelectProps extends AntdExposedProps {
    * loaded on the client (e.g. dashboard filters with "Dynamically search all
    * filter values"), where a pasted value can legitimately exist in the
    * dataset but fall outside the loaded page.
+   * Only applies to multi-select paste; single-select paste resolves through
+   * `allowNewOptions` and ignores this flag.
    * False by default.
    * */
   allowNewOptionsOnPaste?: boolean;

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
@@ -89,6 +89,16 @@ export interface BaseSelectProps extends AntdExposedProps {
    * */
   allowNewOptions?: boolean;
   /**
+   * Accept values pasted into the Select even when they are not part of the
+   * currently loaded options and `allowNewOptions` is false. Useful for
+   * selects whose full option set is searched server-side and only partially
+   * loaded on the client (e.g. dashboard filters with "Dynamically search all
+   * filter values"), where a pasted value can legitimately exist in the
+   * dataset but fall outside the loaded page.
+   * False by default.
+   * */
+  allowNewOptionsOnPaste?: boolean;
+  /**
    * It adds the aria-label tag for accessibility standards.
    * Must be plain English and localized.
    */

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -592,6 +592,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
               allowClear
               autoClearSearchValue
               allowNewOptions={!searchAllOptions && creatable !== false}
+              allowNewOptionsOnPaste={multiSelect && searchAllOptions}
               allowSelectAll={!searchAllOptions}
               value={multiSelect ? filterState.value || [] : filterState.value}
               disabled={isDisabled}


### PR DESCRIPTION
### SUMMARY

Fixes #32645.

Dashboard filters configured with **Can select multiple values** + **Dynamically search all filter values** only load a single page of options on the client (the first ~1000 rows). When you paste a comma-separated list into such a filter, the synchronous `Select`'s paste handler only checked the currently-loaded options. Because `searchAllOptions` sets `allowNewOptions={false}`, any pasted value outside the loaded page was silently dropped, which made the entire paste look like it failed.

This adds an opt-in `allowNewOptionsOnPaste` prop to `Select`. When set, pasted values that aren't in the loaded options are kept (instead of dropped) so they can still be applied to the filter query - which is correct here, since for `searchAllOptions` the full value space lives server-side and a pasted value can legitimately exist beyond the loaded page. The filter plugin enables it for multi-select `searchAllOptions` filters.

The prop defaults to `false`, so paste behavior for every other `Select` (including the existing "don't create unknown options when `allowNewOptions` is false" contract) is unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_N/A - behavioral fix. See the repro steps in #32645._

Before: pasting `valueWithinFirst1000,valueBeyondFirst1000` selected nothing.
After: both values are selected and applied to the filter.

### TESTING INSTRUCTIONS

1. Create a native Select filter on a column with > 1000 distinct values.
2. Enable **Can select multiple values** and **Dynamically search all filter values**.
3. Copy a comma-separated list containing at least one value that sorts beyond the first 1000 loaded options.
4. Paste it into the filter - all values are now selected and the dashboard filters accordingly.

Unit tests added in `Select.test.tsx` cover both the new behavior (values kept when `allowNewOptionsOnPaste` is on) and the guard (values still dropped when it's off).

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #32645
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
