### PR TITLE
Add cachetools as a direct Superset dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     # no bounds for apache-superset-core until we have a stable version
     "apache-superset-core",
     "backoff>=1.8.0",
+    "cachetools>=5.5.2, <7",
     "celery>=5.3.6, <6.0.0",
     "click>=8.4.0",
     "click-option-group",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,9 @@ apispec==6.6.1
 apsw==3.50.1.0
     # via shillelagh
 async-timeout==4.0.3
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   redis
 attrs==25.3.0
     # via
     #   cattrs
@@ -45,7 +47,9 @@ cachelib==0.13.0
     #   flask-caching
     #   flask-session
 cachetools==6.2.1
-    # via google-auth
+    # via
+    #   apache-superset (pyproject.toml)
+    #   google-auth
 cattrs==25.1.1
     # via requests-cache
 celery==5.5.2
@@ -344,7 +348,6 @@ python-dotenv==1.2.2
     # via apache-superset (pyproject.toml)
 pytz==2025.2
     # via
-    #   croniter
     #   flask-babel
     #   pandas
 pyxlsb==1.0.10

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -42,6 +42,10 @@ apsw==3.50.1.0
     #   shillelagh
 astroid==3.3.10
     # via pylint
+async-timeout==4.0.3
+    # via
+    #   -c requirements/base-constraint.txt
+    #   redis
 attrs==25.3.0
     # via
     #   -c requirements/base-constraint.txt
@@ -100,6 +104,7 @@ cachelib==0.13.0
 cachetools==6.2.1
     # via
     #   -c requirements/base-constraint.txt
+    #   apache-superset
     #   google-auth
     #   py-key-value-aio
 caio==0.9.25
@@ -841,7 +846,6 @@ python-multipart==0.0.29
 pytz==2025.2
     # via
     #   -c requirements/base-constraint.txt
-    #   croniter
     #   flask-babel
     #   pandas
     #   trino
@@ -1009,6 +1013,8 @@ tabulate==0.10.0
     #   apache-superset
 tiktoken==0.13.0
     # via apache-superset
+tomli==2.4.1
+    # via coverage
 tomli-w==1.2.0
     # via apache-superset-extensions-cli
 tomlkit==0.13.3


### PR DESCRIPTION
## Summary
- add an explicit `cachetools>=5.5.2,<7` runtime dependency in `pyproject.toml`
- regenerate `requirements/base.txt` and `requirements/development.txt` so the lockfiles mark `cachetools` as a direct Superset dependency
- keep the existing `google-auth` pin unchanged while ensuring future `google-auth` releases cannot drop `cachetools` from installs

## Testing
- `uv pip compile pyproject.toml requirements/base.in -o requirements/base.txt --python-platform x86_64-unknown-linux-gnu --python-version 3.11`
- `uv pip compile requirements/development.in -c requirements/base-constraint.txt -o requirements/development.txt --python-platform x86_64-unknown-linux-gnu --python-version 3.11`
- `python -c "import setuptools.build_meta as bm; from pathlib import Path; meta_dir = Path('dist-metadata'); meta_dir.mkdir(exist_ok=True); name = bm.prepare_metadata_for_build_wheel(str(meta_dir)); text = (meta_dir / name / 'METADATA').read_text(encoding='utf-8'); assert 'Requires-Dist: cachetools<7,>=5.5.2' in text"`

Closes #40962
