### PR TITLE
fix(world-map): rely on built-in highlightOnHover to reset hover highlight

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
@@ -304,36 +304,16 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
       key: JSON.stringify,
     },
     done: datamap => {
+      // Hover highlighting and its reset are handled entirely by Datamaps'
+      // built-in highlightOnHover, which saves each country's original fill on
+      // mouseover and restores it on mouseout. Adding our own mouseover/mouseout
+      // fill handlers here creates a second, competing restore path whose
+      // execution order is browser-timing-dependent, which left the highlight
+      // stuck on Chrome/Edge (see #37761).
       datamap.svg
         .selectAll('.datamaps-subunit')
         .on('contextmenu', handleContextMenu)
-        .on('click', handleClick)
-        // Use namespaced events to avoid overriding Datamaps' default tooltip handlers
-        .on('mouseover.fillPreserve', function onMouseOver() {
-          if (inContextMenu) {
-            return;
-          }
-          const element = d3.select(this);
-          const classes = element.attr('class') || '';
-          const countryId = classes.split(' ')[1];
-          const countryData = mapData[countryId];
-          const originalFill =
-            (countryData && countryData.fillColor) || theme.colorBorder;
-          // Store original fill color for restoration
-          element.attr('data-original-fill', originalFill);
-        })
-        .on('mouseout.fillPreserve', function onMouseOut() {
-          if (inContextMenu) {
-            return;
-          }
-          const element = d3.select(this);
-          const originalFill = element.attr('data-original-fill');
-          // Restore the original fill color (data-based or default no-data color)
-          if (originalFill) {
-            element.style('fill', originalFill);
-            element.attr('data-original-fill', null);
-          }
-        });
+        .on('click', handleClick);
     },
   });
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -58,15 +58,6 @@ interface WorldMapProps {
   formatter: ValueFormatter;
 }
 
-type MouseEventHandler = (this: HTMLElement) => void;
-
-interface MockD3Selection {
-  attr: jest.Mock;
-  style: jest.Mock;
-  classed: jest.Mock;
-  selectAll: jest.Mock;
-}
-
 // Mock Datamap
 const mockBubbles = jest.fn();
 const mockUpdateChoropleth = jest.fn();
@@ -157,244 +148,24 @@ afterEach(() => {
   document.body.removeChild(container);
 });
 
-test('sets up mouseover and mouseout handlers on countries', () => {
+test('relies on Datamaps highlightOnHover without adding conflicting fill handlers', () => {
+  // Regression test for #37761. The hover highlight got stuck on Chrome/Edge
+  // because hand-written mouseover/mouseout handlers competed with Datamaps'
+  // built-in highlightOnHover restore path, and the winning path was
+  // browser-timing-dependent. The chart should rely on the single built-in
+  // path and register no custom fill-restoring hover handlers on the countries.
   WorldMap(container, baseProps);
 
-  expect(mockSvg.selectAll).toHaveBeenCalledWith('.datamaps-subunit');
-  const onCalls = mockSvg.on.mock.calls;
+  const geographyConfig = lastDatamapConfig?.geographyConfig as Record<
+    string,
+    unknown
+  >;
+  expect(geographyConfig?.highlightOnHover).toBe(true);
 
-  // Find mouseover and mouseout handler registrations (namespaced events)
-  const hasMouseover = onCalls.some(
-    call => call[0] === 'mouseover.fillPreserve',
+  const hoverHandlers = mockSvg.on.mock.calls.filter((call: [string]) =>
+    /^mouse(over|out)/.test(call[0]),
   );
-  const hasMouseout = onCalls.some(call => call[0] === 'mouseout.fillPreserve');
-
-  expect(hasMouseover).toBe(true);
-  expect(hasMouseout).toBe(true);
-});
-
-test('stores original fill color on mouseover', () => {
-  // Create a mock DOM element with d3 selection capabilities
-  const mockElement = document.createElement('path');
-  mockElement.setAttribute('class', 'datamaps-subunit USA');
-  mockElement.style.fill = 'rgb(100, 150, 200)';
-  container.appendChild(mockElement);
-
-  let mouseoverHandler: MouseEventHandler | null = null;
-
-  // Mock d3.select to return the mock element
-  const mockD3Selection: MockD3Selection = {
-    attr: jest.fn((attrName: string, value?: string) => {
-      if (value !== undefined) {
-        mockElement.setAttribute(attrName, value);
-      } else {
-        return mockElement.getAttribute(attrName);
-      }
-      return mockD3Selection;
-    }),
-    style: jest.fn((styleName: string, value?: string) => {
-      if (value !== undefined) {
-        mockElement.style[styleName as any] = value;
-      } else {
-        return mockElement.style[styleName as any];
-      }
-      return mockD3Selection;
-    }),
-    classed: jest.fn().mockReturnThis(),
-    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
-  };
-
-  jest.spyOn(d3 as any, 'select').mockReturnValue(mockD3Selection as any);
-
-  // Capture the mouseover handler (namespaced event)
-  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
-    if (event === 'mouseover.fillPreserve') {
-      mouseoverHandler = handler;
-    }
-    return mockSvg;
-  });
-
-  WorldMap(container, baseProps);
-
-  // Simulate mouseover
-  if (mouseoverHandler) {
-    (mouseoverHandler as MouseEventHandler).call(mockElement);
-  }
-
-  // Verify that data-original-fill attribute was set
-  expect(mockD3Selection.attr).toHaveBeenCalledWith(
-    'data-original-fill',
-    expect.any(String),
-  );
-});
-
-test('restores original fill color on mouseout for country with data', () => {
-  const mockElement = document.createElement('path');
-  mockElement.setAttribute('class', 'datamaps-subunit USA');
-  mockElement.style.fill = 'rgb(100, 150, 200)';
-  mockElement.setAttribute('data-original-fill', 'rgb(100, 150, 200)');
-  container.appendChild(mockElement);
-
-  let mouseoutHandler: MouseEventHandler | null = null;
-
-  const mockD3Selection: MockD3Selection = {
-    attr: jest.fn((attrName: string, value?: string | null) => {
-      if (value !== undefined) {
-        if (value === null) {
-          mockElement.removeAttribute(attrName);
-        } else {
-          mockElement.setAttribute(attrName, value);
-        }
-        return mockD3Selection;
-      }
-      return mockElement.getAttribute(attrName);
-    }),
-    style: jest.fn((styleName: string, value?: string) => {
-      if (value !== undefined) {
-        mockElement.style[styleName as any] = value;
-      }
-      return mockElement.style[styleName as any] || mockD3Selection;
-    }),
-    classed: jest.fn().mockReturnThis(),
-    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
-  };
-
-  jest.spyOn(d3 as any, 'select').mockReturnValue(mockD3Selection as any);
-
-  // Capture the mouseout handler (namespaced event)
-  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
-    if (event === 'mouseout.fillPreserve') {
-      mouseoutHandler = handler;
-    }
-    return mockSvg;
-  });
-
-  WorldMap(container, baseProps);
-
-  // Simulate mouseout
-  if (mouseoutHandler) {
-    (mouseoutHandler as MouseEventHandler).call(mockElement);
-  }
-
-  // Verify that original fill was restored
-  expect(mockD3Selection.style).toHaveBeenCalledWith(
-    'fill',
-    'rgb(100, 150, 200)',
-  );
-  expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
-});
-
-test('restores default fill color on mouseout for country with no data', () => {
-  const mockElement = document.createElement('path');
-  mockElement.setAttribute('class', 'datamaps-subunit XXX');
-  mockElement.style.fill = '#e0e0e0'; // Default border color
-  mockElement.setAttribute('data-original-fill', '#e0e0e0');
-  container.appendChild(mockElement);
-
-  let mouseoutHandler: MouseEventHandler | null = null;
-
-  const mockD3Selection: MockD3Selection = {
-    attr: jest.fn((attrName: string, value?: string | null) => {
-      if (value !== undefined) {
-        if (value === null) {
-          mockElement.removeAttribute(attrName);
-        } else {
-          mockElement.setAttribute(attrName, value);
-        }
-        return mockD3Selection;
-      }
-      return mockElement.getAttribute(attrName);
-    }),
-    style: jest.fn((styleName: string, value?: string) => {
-      if (value !== undefined) {
-        mockElement.style[styleName as any] = value;
-      }
-      return mockElement.style[styleName as any] || mockD3Selection;
-    }),
-    classed: jest.fn().mockReturnThis(),
-    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
-  };
-
-  jest.spyOn(d3 as any, 'select').mockReturnValue(mockD3Selection as any);
-
-  // Capture the mouseout handler (namespaced event)
-  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
-    if (event === 'mouseout.fillPreserve') {
-      mouseoutHandler = handler;
-    }
-    return mockSvg;
-  });
-
-  WorldMap(container, baseProps);
-
-  // Simulate mouseout
-  if (mouseoutHandler) {
-    (mouseoutHandler as MouseEventHandler).call(mockElement);
-  }
-
-  // Verify that default fill was restored (no-data color)
-  expect(mockD3Selection.style).toHaveBeenCalledWith('fill', '#e0e0e0');
-  expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
-});
-
-test('does not handle mouse events when inContextMenu is true', () => {
-  const propsWithContextMenu = {
-    ...baseProps,
-    inContextMenu: true,
-  };
-
-  const mockElement = document.createElement('path');
-  mockElement.setAttribute('class', 'datamaps-subunit USA');
-  mockElement.style.fill = 'rgb(100, 150, 200)';
-  container.appendChild(mockElement);
-
-  let mouseoverHandler: MouseEventHandler | null = null;
-  let mouseoutHandler: MouseEventHandler | null = null;
-
-  const mockD3Selection: MockD3Selection = {
-    attr: jest.fn(() => mockD3Selection),
-    style: jest.fn(() => mockD3Selection),
-    classed: jest.fn().mockReturnThis(),
-    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
-  };
-
-  jest.spyOn(d3 as any, 'select').mockReturnValue(mockD3Selection as any);
-
-  // Capture namespaced event handlers
-  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
-    if (event === 'mouseover.fillPreserve') {
-      mouseoverHandler = handler;
-    }
-    if (event === 'mouseout.fillPreserve') {
-      mouseoutHandler = handler;
-    }
-    return mockSvg;
-  });
-
-  WorldMap(container, propsWithContextMenu);
-
-  // Simulate mouseover and mouseout
-  if (mouseoverHandler) {
-    (mouseoverHandler as MouseEventHandler).call(mockElement);
-  }
-  if (mouseoutHandler) {
-    (mouseoutHandler as MouseEventHandler).call(mockElement);
-  }
-
-  // When inContextMenu is true, handlers should exit early without modifying anything
-  // We verify this by checking that attr and style weren't called to change fill
-  const attrCalls = mockD3Selection.attr.mock.calls;
-  const fillChangeCalls = attrCalls.filter(
-    (call: [string, unknown]) =>
-      call[0] === 'data-original-fill' && call[1] !== undefined,
-  );
-  const styleCalls = mockD3Selection.style.mock.calls;
-  const fillStyleChangeCalls = styleCalls.filter(
-    (call: [string, unknown]) => call[0] === 'fill' && call[1] !== undefined,
-  );
-  // The handlers should return early, so no state changes
-  expect(fillChangeCalls.length).toBe(0);
-  expect(fillStyleChangeCalls.length).toBe(0);
+  expect(hoverHandlers).toEqual([]);
 });
 
 test('does not throw error when onContextMenu is undefined', () => {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -168,6 +168,18 @@ test('relies on Datamaps highlightOnHover without adding conflicting fill handle
   expect(hoverHandlers).toEqual([]);
 });
 
+test('disables Datamaps highlightOnHover while the context menu is open', () => {
+  // Companion to the regression guard above: when the context menu is open we
+  // pass highlightOnHover: false so hover highlighting is suppressed at init.
+  WorldMap(container, { ...baseProps, inContextMenu: true });
+
+  const geographyConfig = lastDatamapConfig?.geographyConfig as Record<
+    string,
+    unknown
+  >;
+  expect(geographyConfig?.highlightOnHover).toBe(false);
+});
+
 test('does not throw error when onContextMenu is undefined', () => {
   const propsWithoutContextMenu = {
     ...baseProps,


### PR DESCRIPTION
### SUMMARY

Fixes #37761, where the World Map hover highlight stays stuck on Chrome/Edge (works in Firefox).

The root cause was diagnosed by @singer-cheng in the issue thread, with cross-browser testing: the hand-written `mouseover`/`mouseout` handlers added in #37716 duplicate Datamaps' built-in `highlightOnHover` behavior. Datamaps already saves each country's original fill on `mouseover` (into `data-previousAttributes`) and restores it on `mouseout`. The custom handlers stored/restored the fill a second way (via `data-original-fill` + `element.style('fill', ...)`), creating two competing restore paths. Their execution order is browser-timing-dependent, so on Chrome/Edge the highlight never resets, while Firefox happened to win the race.

This removes the redundant handlers and relies solely on the built-in path. Datamaps applies the initial fill (including the no-data `defaultFill`) as an inline `style('fill', ...)` on every subunit, so its save/restore is symmetric for both data and no-data countries, which covers the original #37569/#37716 concern.

Credit to @singer-cheng for the root-cause analysis and the cross-browser verification (Chrome/Edge/Firefox).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (behavioral fix). Before: hovering a country on Chrome/Edge leaves it highlighted after the cursor moves away. After: the highlight resets on mouse-out for both data and no-data countries.

### TESTING INSTRUCTIONS

1. Open a World Map chart (ideally with some countries that have no data) in Chrome or Edge.
2. Hover over a country, then move the cursor away.
3. Confirm the country returns to its original fill (data color, or the neutral no-data color) instead of staying highlighted.
4. Repeat across data and no-data countries.

Unit tests: `cd superset-frontend && npx jest plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts`

Note: the unit suite mocks Datamaps, so it can't reproduce the native browser-event ordering itself. The added regression test instead locks in the fix's invariant - the chart relies on `highlightOnHover` and registers no competing custom hover-fill handlers on the countries - and the obsolete tests for the removed handlers were dropped. The real cross-browser behavior was verified manually (see issue thread).

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #37761
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)