### PR TITLE
fix(views): add new_target to deprecated explore_json endpoints

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -237,7 +237,7 @@ class Superset(BaseSupersetView):
     @permission_name("explore_json")
     @expose("/explore_json/data/<cache_key>", methods=("GET",))
     @check_resource_permissions(check_explore_cache_perms)
-    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
+    @deprecated(eol_version="5.0.0")
     def explore_json_data(self, cache_key: str) -> FlaskResponse:
         """Serves cached result data for async explore_json calls
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -237,7 +237,7 @@ class Superset(BaseSupersetView):
     @permission_name("explore_json")
     @expose("/explore_json/data/<cache_key>", methods=("GET",))
     @check_resource_permissions(check_explore_cache_perms)
-    @deprecated(eol_version="5.0.0")
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
     def explore_json_data(self, cache_key: str) -> FlaskResponse:
         """Serves cached result data for async explore_json calls
 
@@ -294,7 +294,7 @@ class Superset(BaseSupersetView):
     )
     @etag_cache()
     @check_resource_permissions(check_datasource_perms)
-    @deprecated(eol_version="5.0.0")
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
     def explore_json(  # noqa: C901
         self, datasource_type: str | None = None, datasource_id: int | None = None
     ) -> FlaskResponse:


### PR DESCRIPTION
### What was the warning?

Production logs are emitting:

```
Superset.explore_json This API endpoint is deprecated and will be removed in version 5.0.0
```

The deprecation warning gives callers no migration guidance — no URL to migrate to.

### What was changed?

Two `@deprecated(eol_version="5.0.0")` decorators in `superset/views/core.py` were missing a `new_target` argument:

- `explore_json_data` (line 240) — serves cached async chart results via cache_key
- `explore_json` (line 297) — serves direct chart data queries

Added `new_target="/api/v1/chart/data"` to both, matching the pattern already used by other deprecated endpoints (e.g. `fetch_datasource_metadata`, `log`):

```python
# before
@deprecated(eol_version="5.0.0")

# after
@deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
```

The production warning will now read:

```
Superset.explore_json This API endpoint is deprecated and will be removed in version 5.0.0 . Use the following API endpoint instead: /api/v1/chart/data
```

### No behavior change

The endpoints continue to function identically. The only effect is the `logger.warning` message now includes the migration URL, giving operators actionable guidance.

### Test plan

- [ ] Verify that calling `/explore_json/` logs the warning with the new `new_target` URL appended
- [ ] Verify that calling `/explore_json/data/<cache_key>` logs the same
- [ ] Verify both endpoints still return correct responses (no functional regression)