### PR TITLE
chore(ci): correct action ref version comments (zizmor)

### DIFF
--- a/.github/workflows/generate-FOSSA-report.yml
+++ b/.github/workflows/generate-FOSSA-report.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "11"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "11"

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           node-version-file: "./docs/.nvmrc"
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"


### PR DESCRIPTION
### SUMMARY

Resolves code-scanning alerts #2543, #2544, #2545 (zizmor `ref-version-mismatch`).

All three alerts point at the same pinned action, `actions/setup-java`, with a trailing version comment that disagrees with the commit it pins. SHA `be666c2fcd27ec809703dec50e508c2fdc7f6654` is tag **v5.2.0** (confirmed via `gh api repos/actions/setup-java/tags`), but the comment read `# v5`, which zizmor flags as a misleading/stale ref-version comment.

This corrects the comment to match the actual tag the SHA points at. **The SHA is not changed** — only the comment is made truthful.

Per file:

| Alert | File:line | Before | After |
|-------|-----------|--------|-------|
| #2545 | `.github/workflows/superset-docs-deploy.yml:74` | `actions/setup-java@be666c2… # v5` | `… # v5.2.0` |
| #2544 | `.github/workflows/license-check.yml:26` | `actions/setup-java@be666c2… # v5` | `… # v5.2.0` |
| #2543 | `.github/workflows/generate-FOSSA-report.yml:40` | `actions/setup-java@be666c2… # v5` | `… # v5.2.0` |

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — comment-only change.

### TESTING INSTRUCTIONS

`pre-commit run --files .github/workflows/superset-docs-deploy.yml .github/workflows/license-check.yml .github/workflows/generate-FOSSA-report.yml` — the `zizmor (GHA security audit)` hook passes. The pinned SHA is byte-for-byte unchanged, so action behavior is unaffected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
