### PR TITLE
chore(ci): set least-privilege workflow permissions (zizmor)

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -1,6 +1,11 @@
 # Python integration tests
 name: Python-Integration
 
+# Least-privilege default for GITHUB_TOKEN. Jobs that need more (e.g. OIDC for
+# codecov uploads) opt in via their own job-level `permissions:` block.
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -1,6 +1,11 @@
 # Python unit tests
 name: Python-Unit
 
+# Least-privilege default for GITHUB_TOKEN. Jobs that need more (e.g. OIDC for
+# codecov uploads) opt in via their own job-level `permissions:` block.
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
### SUMMARY

Adds an explicit top-level `permissions: contents: read` block to the two Python test workflows:

- `.github/workflows/superset-python-unittest.yml`
- `.github/workflows/superset-python-integrationtest.yml`

Both workflows previously omitted a workflow-level `permissions:` block, so every job inherited the broad default `GITHUB_TOKEN` scope. zizmor's `excessive-permissions` audit flags this as overly broad permissions at the workflow level, and also for the result-anchor jobs that inherit the broad default without needing any token scope.

Setting a restrictive `contents: read` default at the workflow level fixes all four findings at once:

- The result-check anchor jobs (`unit-tests-required`, `test-postgres-required`) only inspect a prior job's result via a shell `if` and need no token scope — they now inherit the least-privilege default.
- Jobs that genuinely need more already declare their own job-level `permissions:` blocks and are unchanged:
  - `changes` jobs: `contents: read` + `pull-requests: read` (change detection)
  - `unit-tests` / `test-mysql` / `test-postgres` / `test-sqlite`: `id-token: write` (codecov OIDC upload)

No job loses a permission it was using, so workflow behavior is unchanged.

Verified locally with `zizmor 1.25.2` (the pinned pre-commit version): 4 `excessive-permissions` findings on the pre-change files, 0 after. `pre-commit run --files <both yml>` passes (zizmor, check-yaml, whitespace).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI config only.

### TESTING INSTRUCTIONS

```bash
pre-commit run --files \
  .github/workflows/superset-python-unittest.yml \
  .github/workflows/superset-python-integrationtest.yml
# or directly:
zizmor .github/workflows/superset-python-unittest.yml \
       .github/workflows/superset-python-integrationtest.yml
```

zizmor should report no `excessive-permissions` findings on these files, and the test workflows should run as before.

### ADDITIONAL INFORMATION

Resolves code-scanning alerts #2527, #2528, #2529, #2530 (zizmor excessive-permissions).

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)