### PR TITLE
fix(security): avoid exception detail exposure in base views

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -130,7 +130,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_error_msg() -> str:
+    # Always preserve the full traceback server-side so operators retain it for
+    # debugging, independent of what is surfaced to the client.
+    logger.error("%s", traceback.format_exc())
     if app.config.get("SHOW_STACKTRACE"):
+        # Opt-in: operators can choose to expose the raw stacktrace in responses.
+        # This defaults to off so internal details are not leaked to clients.
         error_msg = traceback.format_exc()
     else:
         error_msg = "FATAL ERROR \n"

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -145,6 +145,64 @@ def test_locale_language_extraction_preserves_region_when_configured(
     assert _extract_language(locale_str, languages) == expected_language
 
 
+def test_get_error_msg_hides_stacktrace_by_default() -> None:
+    """``get_error_msg`` must not return the raw stacktrace to the client unless
+    the operator has explicitly opted in via ``SHOW_STACKTRACE``.
+
+    Regression guard for CodeQL ``py/stack-trace-exposure`` alerts: the default
+    response carries a generic message rather than internal exception detail.
+    """
+    from flask import current_app
+
+    from superset.views.base import get_error_msg
+
+    with patch.dict(current_app.config, {"SHOW_STACKTRACE": False}):
+        try:
+            raise RuntimeError("boom-secret-internal-detail")
+        except RuntimeError:
+            error_msg = get_error_msg()
+
+    assert "boom-secret-internal-detail" not in error_msg
+    assert "Traceback" not in error_msg
+    assert "Stacktrace is hidden" in error_msg
+
+
+def test_get_error_msg_exposes_stacktrace_when_opted_in() -> None:
+    """When ``SHOW_STACKTRACE`` is enabled the raw traceback is returned, matching
+    the documented opt-in debugging behavior."""
+    from flask import current_app
+
+    from superset.views.base import get_error_msg
+
+    with patch.dict(current_app.config, {"SHOW_STACKTRACE": True}):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            error_msg = get_error_msg()
+
+    assert "Traceback" in error_msg
+    assert "RuntimeError" in error_msg
+
+
+def test_get_error_msg_always_logs_full_traceback_server_side() -> None:
+    """The full traceback is always logged server-side, even when it is hidden
+    from the client response, so operators retain it for debugging."""
+    from flask import current_app
+
+    from superset.views.base import get_error_msg
+
+    with patch.dict(current_app.config, {"SHOW_STACKTRACE": False}):
+        with patch("superset.views.base.logger") as mock_logger:
+            try:
+                raise RuntimeError("boom-server-side")
+            except RuntimeError:
+                get_error_msg()
+
+    logged = " ".join(str(call) for call in mock_logger.error.call_args_list)
+    assert "Traceback" in logged
+    assert "boom-server-side" in logged
+
+
 def test_api_query_returns_json_content_type() -> None:
     """``Api.query`` returns a response with a JSON content type.
 


### PR DESCRIPTION
### SUMMARY

Resolves code-scanning alerts #2461 (`superset/views/base.py:146`) and #2540 (`superset/views/base.py:218`), both `py/stack-trace-exposure` ("Information exposure through an exception").

The two flagged sinks are the generic JSON response helpers `json_success` (line 146) and `BaseSupersetView.json_response` (line 218). CodeQL traces exception-derived strings reaching them and warns that a stack trace could be exposed to the client.

**What this PR changes (scoped to `base.py`):** `get_error_msg()` is the canonical stack-trace source in this file (`traceback.format_exc()`). This PR makes its safety contract explicit and stronger:

- The **full traceback is now always logged server-side** (`logger.error`), independent of what is returned to the client, so operators never lose debugging detail.
- The raw traceback is only ever placed in the client-facing response when the operator has **explicitly opted in via the `SHOW_STACKTRACE` config (default `False`)** — the existing, documented behavior — now clearly commented so both readers and scanners can see the gate.
- Adds regression tests covering the hidden-by-default, opt-in, and always-logged-server-side behaviors.

Error detail is still fully retained in server logs; only the client-facing leakage is gated.

### Why DRAFT — design judgment call

I want a maintainer gut-check before this is merged, because the change is deliberately narrow:

1. **The genuine stack-trace exposure was already mitigated.** Raw tracebacks (`get_error_msg`, `viz.get_stacktrace`) are already gated behind `SHOW_STACKTRACE`, which defaults to `False`. PR #40636 recently did the same for the viz payload's `stacktrace` field. This PR tightens and documents that contract in `base.py` rather than introducing a new control.

2. **The residual flows CodeQL tracks into sinks 146/218 originate in callers, not `base.py`** — specifically `Api.time_range` in `superset/views/api.py` (which interpolates `str(error)` from a `ValueError` into a `"Unexpected time range: ..."` message) and `viz.py` (`message=str(ex)`). Those are *error messages*, not stack traces. Per [`SECURITY.md`](https://github.com/apache/superset/blob/master/SECURITY.md) (out-of-scope list), "information disclosure through error messages ... that does not enable a further concrete exploit" is explicitly out of scope. I intentionally did **not** touch those callers, because (a) sanitizing the generic `json_success`/`json_response` helpers themselves would corrupt all legitimate payloads, and (b) blanking those user-facing messages would degrade UX for no in-scope security gain.

So: if the team considers the `SHOW_STACKTRACE` gating sufficient (I believe it is, and SECURITY.md backs that up), these two alerts can reasonably be **dismissed as "won't fix / out of scope"** with this PR's hardening + tests as the supporting rationale. If instead we want CodeQL fully green, the follow-up is to also sanitize the `str(ex)` interpolations in `api.py`/`viz.py` — happy to extend, but that exceeds the "base.py only" scope I held to here.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only error-handling change.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/views/test_base.py -k get_error_msg
```

- With `SHOW_STACKTRACE=False` (default): response message is generic ("Stacktrace is hidden..."), no traceback or exception text leaks; full traceback is logged server-side.
- With `SHOW_STACKTRACE=True`: raw traceback is returned (documented opt-in debugging behavior).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
