### PR TITLE
fix(dashboard): prevent premature filter initialization causing false "Select first value by default" error

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
@@ -217,6 +217,7 @@ export type NativeFiltersState = {
   filters: Filters;
   focusedFilterId?: string;
   hoveredFilterId?: string;
+  filtersInitialized: boolean;
 };
 
 export type ChartCustomizationConfiguration = Array<

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
@@ -46,6 +46,9 @@ export const useNativeFilters = () => {
 
   const filters = useFilters();
   const filterValues = useMemo(() => Object.values(filters), [filters]);
+  const filtersInitialized = useSelector<RootState, boolean>(
+    state => state.nativeFilters.filtersInitialized,
+  );
   const expandFilters = getUrlParam(URL_PARAMS.expandFilters);
   const chartCustomizations = useChartCustomizationFromRedux();
 
@@ -110,10 +113,10 @@ export const useNativeFilters = () => {
   ]);
 
   useEffect(() => {
-    if (showDashboard) {
+    if (showDashboard && filtersInitialized) {
       setIsInitialized(true);
     }
-  }, [showDashboard]);
+  }, [showDashboard, filtersInitialized]);
 
   return {
     showDashboard,

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -105,6 +105,7 @@ function handleFilterChangesComplete(
 export default function nativeFilterReducer(
   state: ExtendedNativeFiltersState = {
     filters: {},
+    filtersInitialized: false,
   },
   action: AnyFilterAction,
 ) {
@@ -139,6 +140,7 @@ export default function nativeFilterReducer(
 
       return {
         filters: mergedFilters,
+        filtersInitialized: true,
       };
     }
 


### PR DESCRIPTION
### SUMMARY
Fixes an intermittent race condition on dashboard load where the error "Unable to load dashboard. The following filters have the 'Select first value by default' option checked and could not be loaded" would flash briefly before disappearing.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1658" height="830" alt="image" src="https://github.com/user-attachments/assets/ae4b7d9a-c32a-4eae-9480-b0c793151add" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
