### PR TITLE
chore(deck.gl): remove leftover debug className from Legend

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -137,7 +137,7 @@ const Legend = ({
   };
 
   return (
-    <StyledLegend className="dupa" style={style}>
+    <StyledLegend style={style}>
       <ul>{categories}</ul>
     </StyledLegend>
   );


### PR DESCRIPTION
### SUMMARY

The deck.gl `Legend` component carries a stray `className="dupa"` left over from the plugin modernization (#38035). It has no CSS attached anywhere and serves no purpose, so this just removes it.

```diff
-    <StyledLegend className="dupa" style={style}>
+    <StyledLegend style={style}>
```

Spotted while investigating #36329.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (no visual change; the class had no styles).

### TESTING INSTRUCTIONS

Open any deck.gl chart with a legend (e.g. Deck.gl Polygons) and confirm the legend renders unchanged.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)