### PR TITLE
feat(soft-delete): gate soft delete behind a temporary SOFT_DELETE release toggle

### DIFF
--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -91,7 +91,7 @@
         "name": "SOFT_DELETE",
         "default": false,
         "lifecycle": "development",
-        "description": "Temporary rollout / kill-switch gate for soft delete (default off = legacy hard delete). An emergency stop, not a clean rollback: flipping ON->OFF resurrects already-soft-deleted rows. To be removed once soft delete is stable; see config.py for the full rationale and the gate points to remove."
+        "description": "Temporary rollout / kill-switch gate for soft delete (default off = legacy hard delete). An emergency stop, not a clean rollback: flipping ON->OFF resurrects already-soft-deleted rows. Removed (along with its two gate points \u2014 BaseDAO.delete routing and the do_orm_execute visibility listener) once soft delete is stable."
       },
       {
         "name": "TABLE_V2_TIME_COMPARISON_ENABLED",

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -88,6 +88,12 @@
         "description": "Enable semantic layers and show semantic views alongside datasets"
       },
       {
+        "name": "SOFT_DELETE",
+        "default": false,
+        "lifecycle": "development",
+        "description": "Temporary rollout / kill-switch gate for soft delete. Default off. When off: DELETE hard-deletes (legacy) and the read-path visibility filter is inactive, so the substrate ships dark; the import pipeline's existing-row detection inherits this via the same listener (no separate check); restore has nothing to act on because no row carries deleted_at. Flipping ON->OFF after rows were soft-deleted RESURRECTS them (they become visible/active again) \u2014 an emergency stop, not a clean rollback. Not a permanent toggle: REMOVE this flag and its two gate points (BaseDAO.delete routing; the do_orm_execute visibility listener) once soft delete is stable."
+      },
+      {
         "name": "TABLE_V2_TIME_COMPARISON_ENABLED",
         "default": false,
         "lifecycle": "development",

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -91,7 +91,7 @@
         "name": "SOFT_DELETE",
         "default": false,
         "lifecycle": "development",
-        "description": "Temporary rollout / kill-switch gate for soft delete. Default off. When off: DELETE hard-deletes (legacy) and the read-path visibility filter is inactive, so the substrate ships dark; the import pipeline's existing-row detection inherits this via the same listener (no separate check); restore has nothing to act on because no row carries deleted_at. Flipping ON->OFF after rows were soft-deleted RESURRECTS them (they become visible/active again) \u2014 an emergency stop, not a clean rollback. Not a permanent toggle: REMOVE this flag and its two gate points (BaseDAO.delete routing; the do_orm_execute visibility listener) once soft delete is stable."
+        "description": "Temporary rollout / kill-switch gate for soft delete (default off = legacy hard delete). An emergency stop, not a clean rollback: flipping ON->OFF resurrects already-soft-deleted rows. To be removed once soft delete is stable; see config.py for the full rationale and the gate points to remove."
       },
       {
         "name": "TABLE_V2_TIME_COMPARISON_ENABLED",

--- a/superset/config.py
+++ b/superset/config.py
@@ -657,6 +657,18 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # can_copy_clipboard) instead of the single can_csv permission
     # @lifecycle: development
     "GRANULAR_EXPORT_CONTROLS": False,
+    # Temporary rollout / kill-switch gate for soft delete. Default off. When
+    # off: DELETE hard-deletes (legacy) and
+    # the read-path visibility filter is inactive, so the substrate ships dark;
+    # the import pipeline's existing-row detection inherits this via the same
+    # listener (no separate check); restore has nothing to act on because no row
+    # carries deleted_at. Flipping ON->OFF after rows were soft-deleted RESURRECTS
+    # them (they become visible/active again) — an emergency stop, not a clean
+    # rollback. Not a permanent toggle: REMOVE this flag and its two gate points
+    # (BaseDAO.delete routing; the do_orm_execute visibility listener) once soft
+    # delete is stable.
+    # @lifecycle: development
+    "SOFT_DELETE": False,
     # Enable semantic layers and show semantic views alongside datasets
     # @lifecycle: development
     "SEMANTIC_LAYERS": False,

--- a/superset/config.py
+++ b/superset/config.py
@@ -657,16 +657,11 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # can_copy_clipboard) instead of the single can_csv permission
     # @lifecycle: development
     "GRANULAR_EXPORT_CONTROLS": False,
-    # Temporary rollout / kill-switch gate for soft delete. Default off. When
-    # off: DELETE hard-deletes (legacy) and
-    # the read-path visibility filter is inactive, so the substrate ships dark;
-    # the import pipeline's existing-row detection inherits this via the same
-    # listener (no separate check); restore has nothing to act on because no row
-    # carries deleted_at. Flipping ON->OFF after rows were soft-deleted RESURRECTS
-    # them (they become visible/active again) — an emergency stop, not a clean
-    # rollback. Not a permanent toggle: REMOVE this flag and its two gate points
-    # (BaseDAO.delete routing; the do_orm_execute visibility listener) once soft
-    # delete is stable.
+    # Temporary rollout / kill-switch gate for soft delete (default off = legacy
+    # hard delete). An emergency stop, not a clean rollback: flipping ON->OFF
+    # resurrects already-soft-deleted rows. Removed (along with its two gate
+    # points — BaseDAO.delete routing and the do_orm_execute visibility listener)
+    # once soft delete is stable.
     # @lifecycle: development
     "SOFT_DELETE": False,
     # Enable semantic layers and show semantic views alongside datasets

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -45,6 +45,7 @@ from sqlalchemy.orm import ColumnProperty, joinedload, Query, RelationshipProper
 from superset_core.common.daos import BaseDAO as CoreBaseDAO
 from superset_core.common.models import CoreModel
 
+from superset import is_feature_enabled
 from superset.constants import SKIP_VISIBILITY_FILTER_CLASSES
 from superset.daos.exceptions import (
     DAOFindFailedError,
@@ -526,16 +527,22 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         soft delete.
 
         For models that include ``SoftDeleteMixin``, this calls
-        ``soft_delete()``. For all other models, this calls ``hard_delete()``
-        (the original behaviour).
+        ``soft_delete()`` — but only while the temporary ``SOFT_DELETE`` rollout
+        gate is enabled. When the gate is off, every model
+        hard-deletes (the original behaviour), so the substrate can ship dark.
+        For all other models, this always calls ``hard_delete()``.
 
         :param items: The items to delete
         """
         from superset.models.helpers import (
-            SoftDeleteMixin,  # pylint: disable=import-outside-toplevel
+            SoftDeleteMixin,  # avoid circular import: models.helpers <-> daos
         )
 
-        if cls.model_cls is not None and issubclass(cls.model_cls, SoftDeleteMixin):
+        if (
+            cls.model_cls is not None
+            and issubclass(cls.model_cls, SoftDeleteMixin)
+            and is_feature_enabled("SOFT_DELETE")
+        ):
             cls.soft_delete(items)
         else:
             cls.hard_delete(items)

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -798,8 +798,17 @@ def _should_attach_soft_delete_criteria(execute_state: ORMExecuteState) -> bool:
     relationship-load event closes that gap. The resulting WHERE
     clause may have ``deleted_at IS NULL`` twice when propagation
     DOES work — harmless redundancy, idempotent SQL.
+
+    Gated by the temporary ``SOFT_DELETE`` rollout flag: while it is
+    off, no criteria are attached, so soft-deleted rows (which the delete path
+    does not create while the flag is off) are not filtered. The flag and this
+    gate are removed once soft delete is stable.
     """
-    return execute_state.is_select and not execute_state.is_column_load
+    return (
+        execute_state.is_select
+        and not execute_state.is_column_load
+        and is_feature_enabled("SOFT_DELETE")
+    )
 
 
 def _all_soft_delete_subclasses() -> list[type[SoftDeleteMixin]]:

--- a/tests/unit_tests/daos/test_base_dao_soft_delete.py
+++ b/tests/unit_tests/daos/test_base_dao_soft_delete.py
@@ -64,7 +64,7 @@ def test_delete_routes_to_soft_delete_for_mixin_models(
     mock_flag: MagicMock, app_context: None
 ) -> None:
     """delete() soft-deletes a mixin model when the SOFT_DELETE gate is ON."""
-    items = [MagicMock(), MagicMock()]
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
 
     with patch.object(_SoftDeletableDAO, "soft_delete") as mock_soft:
         _SoftDeletableDAO.delete(items)
@@ -77,7 +77,7 @@ def test_delete_hard_deletes_mixin_model_when_gate_off(
 ) -> None:
     """With the SOFT_DELETE gate OFF (default), even a mixin model hard-deletes
     — the substrate ships dark."""
-    items = [MagicMock(), MagicMock()]
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
 
     with patch.object(_SoftDeletableDAO, "hard_delete") as mock_hard:
         _SoftDeletableDAO.delete(items)
@@ -90,7 +90,21 @@ def test_delete_routes_to_hard_delete_for_non_mixin_models(
 ) -> None:
     """delete() calls hard_delete() for non-SoftDeleteMixin models — regardless
     of the gate (here ON, to show the gate doesn't make a plain model soft)."""
-    items = [MagicMock(), MagicMock()]
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
+
+    with patch.object(_PlainDAO, "hard_delete") as mock_hard:
+        _PlainDAO.delete(items)
+        mock_hard.assert_called_once_with(items)
+
+
+@patch("superset.daos.base.is_feature_enabled", return_value=False)
+def test_delete_hard_deletes_non_mixin_model_when_gate_off(
+    mock_flag: MagicMock, app_context: None
+) -> None:
+    """A non-SoftDeleteMixin model hard-deletes with the gate OFF too — the
+    mixin check short-circuits to hard_delete before the gate is evaluated.
+    Completes the (gate, model_type) matrix's fourth cell."""
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
 
     with patch.object(_PlainDAO, "hard_delete") as mock_hard:
         _PlainDAO.delete(items)
@@ -102,7 +116,7 @@ def test_hard_delete_calls_session_delete(
     mock_db: MagicMock, app_context: None
 ) -> None:
     """hard_delete() calls db.session.delete() on each item."""
-    items = [MagicMock(), MagicMock()]
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
 
     BaseDAO.hard_delete(items)
 
@@ -113,7 +127,7 @@ def test_hard_delete_calls_session_delete(
 
 def test_soft_delete_calls_item_soft_delete(app_context: None) -> None:
     """soft_delete() calls soft_delete() on each item."""
-    items = [MagicMock(), MagicMock()]
+    items: list[MagicMock] = [MagicMock(), MagicMock()]
 
     BaseDAO.soft_delete(items)
     items[0].soft_delete.assert_called_once()

--- a/tests/unit_tests/daos/test_base_dao_soft_delete.py
+++ b/tests/unit_tests/daos/test_base_dao_soft_delete.py
@@ -59,8 +59,11 @@ class _PlainDAO(BaseDAO[_Plain]):
     model_cls = _Plain
 
 
-def test_delete_routes_to_soft_delete_for_mixin_models(app_context: None) -> None:
-    """delete() calls soft_delete() when model_cls includes SoftDeleteMixin."""
+@patch("superset.daos.base.is_feature_enabled", return_value=True)
+def test_delete_routes_to_soft_delete_for_mixin_models(
+    mock_flag: MagicMock, app_context: None
+) -> None:
+    """delete() soft-deletes a mixin model when the SOFT_DELETE gate is ON."""
     items = [MagicMock(), MagicMock()]
 
     with patch.object(_SoftDeletableDAO, "soft_delete") as mock_soft:
@@ -68,8 +71,25 @@ def test_delete_routes_to_soft_delete_for_mixin_models(app_context: None) -> Non
         mock_soft.assert_called_once_with(items)
 
 
-def test_delete_routes_to_hard_delete_for_non_mixin_models(app_context: None) -> None:
-    """delete() calls hard_delete() for non-SoftDeleteMixin models."""
+@patch("superset.daos.base.is_feature_enabled", return_value=False)
+def test_delete_hard_deletes_mixin_model_when_gate_off(
+    mock_flag: MagicMock, app_context: None
+) -> None:
+    """With the SOFT_DELETE gate OFF (default), even a mixin model hard-deletes
+    — the substrate ships dark."""
+    items = [MagicMock(), MagicMock()]
+
+    with patch.object(_SoftDeletableDAO, "hard_delete") as mock_hard:
+        _SoftDeletableDAO.delete(items)
+        mock_hard.assert_called_once_with(items)
+
+
+@patch("superset.daos.base.is_feature_enabled", return_value=True)
+def test_delete_routes_to_hard_delete_for_non_mixin_models(
+    mock_flag: MagicMock, app_context: None
+) -> None:
+    """delete() calls hard_delete() for non-SoftDeleteMixin models — regardless
+    of the gate (here ON, to show the gate doesn't make a plain model soft)."""
     items = [MagicMock(), MagicMock()]
 
     with patch.object(_PlainDAO, "hard_delete") as mock_hard:

--- a/tests/unit_tests/models/test_soft_delete_mixin.py
+++ b/tests/unit_tests/models/test_soft_delete_mixin.py
@@ -186,17 +186,17 @@ def test_listener_noop_when_gate_off(app_context: None, session: Session) -> Non
     soft-deleted row is NOT hidden — the substrate is dark. (While
     the gate is off the delete path also doesn't create such rows; this pins the
     listener side.)"""
-    obj = _SoftDeletable(name="visible_when_gate_off")
+    obj: _SoftDeletable = _SoftDeletable(name="visible_when_gate_off")
     session.add(obj)
     session.flush()
-    obj_id = obj.id
+    obj_id: int = obj.id
 
     obj.soft_delete()
     session.flush()
     session.expire_all()
 
     with patch("superset.models.helpers.is_feature_enabled", return_value=False):
-        result = (
+        result: _SoftDeletable | None = (
             session.query(_SoftDeletable)
             .filter(_SoftDeletable.id == obj_id)
             .one_or_none()

--- a/tests/unit_tests/models/test_soft_delete_mixin.py
+++ b/tests/unit_tests/models/test_soft_delete_mixin.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import Column, ForeignKey, Integer, String
@@ -88,6 +89,18 @@ def _synthetic_tables(session: Session) -> Generator[None, None, None]:
     _TestBase.metadata.create_all(session.get_bind())
     yield
     _TestBase.metadata.drop_all(session.get_bind())
+
+
+@pytest.fixture(autouse=True)
+def _soft_delete_gate_on() -> Generator[None, None, None]:
+    """The ``do_orm_execute`` visibility listener is gated by the temporary
+    ``SOFT_DELETE`` rollout flag, default off. These tests exercise
+    the listener's filtering, so enable the gate for the whole module. The
+    gate-off (listener-noop) behaviour is pinned separately by
+    ``test_listener_noop_when_gate_off``.
+    """
+    with patch("superset.models.helpers.is_feature_enabled", return_value=True):
+        yield
 
 
 @pytest.mark.usefixtures("_synthetic_tables")
@@ -165,6 +178,31 @@ def test_global_filter_excludes_soft_deleted_rows(
         session.query(_SoftDeletable).filter(_SoftDeletable.id == obj_id).one_or_none()
     )
     assert result is None
+
+
+@pytest.mark.usefixtures("_synthetic_tables")
+def test_listener_noop_when_gate_off(app_context: None, session: Session) -> None:
+    """With the ``SOFT_DELETE`` gate OFF, the listener attaches no criteria, so a
+    soft-deleted row is NOT hidden — the substrate is dark. (While
+    the gate is off the delete path also doesn't create such rows; this pins the
+    listener side.)"""
+    obj = _SoftDeletable(name="visible_when_gate_off")
+    session.add(obj)
+    session.flush()
+    obj_id = obj.id
+
+    obj.soft_delete()
+    session.flush()
+    session.expire_all()
+
+    with patch("superset.models.helpers.is_feature_enabled", return_value=False):
+        result = (
+            session.query(_SoftDeletable)
+            .filter(_SoftDeletable.id == obj_id)
+            .one_or_none()
+        )
+    assert result is not None
+    assert result.id == obj_id
 
 
 @pytest.mark.usefixtures("_synthetic_tables")


### PR DESCRIPTION
### SUMMARY

Adds a **temporary** rollout / kill-switch feature flag — `SOFT_DELETE` (default **off**) — so the soft-delete substrate can ship **dark** and be activated per-deploy once validated, separating deploy from release for a behavior change with cross-entity blast radius (DELETE semantics + read-path visibility filtering).

This is **deployment scaffolding, not a permanent toggle**: it is removed once soft delete is stable, leaving the unconditional "always active once deployed" end state. Until an operator opts in, existing deployments retain byte-for-byte legacy `DELETE` (hard-delete) behavior.

**Two gate points**, both no-op to legacy behavior when off:
- `BaseDAO.delete()` routes to `soft_delete()` only when the flag is on; otherwise `hard_delete()`.
- The `do_orm_execute` visibility listener attaches no `deleted_at IS NULL` criteria when off.

Both the write path and the read path gate on the **same flag**, so they cannot diverge. Restore needs no explicit gate — with the flag off no row carries `deleted_at`, so a restore call has nothing to act on. The flag docstring documents the kill-switch semantics (flipping **off after** rows are soft-deleted resurrects them — emergency stop, not a clean rollback) and that the import pipeline's existing-row detection is gated transitively via the listener.

The `deleted_at` migration (from the substrate PRs) stays **un-gated** (additive). Removal of this flag + its two gate points is a small follow-up once soaked.

### THIS IS A *RELEASE TOGGLE*, NOT A FEATURE FLAG

A common and reasonable objection is "feature flags that change functionality are a maintenance hazard." That objection is about **long-lived** flags — permanent configuration surface that parameterizes product behavior, branches the test matrix indefinitely, and accumulates as config sprawl. This flag is a different category.

In the [Continuous Delivery](https://martinfowler.com/articles/feature-toggles.html) taxonomy this is a **Release Toggle**: a *transitory* toggle whose only job is to decouple **deploy** from **release** so a not-yet-validated change can land on `master` and ship dark, then be switched on once trusted — and then **deleted**. It is not a Permission/Experiment/Ops toggle that lives forever.

- Martin Fowler — *Feature Toggles (aka Feature Flags)*, "Release Toggles": https://martinfowler.com/articles/feature-toggles.html#ReleaseToggles
- Octopus — *Feature flags*, "1. Release toggles": https://octopus.com/devops/feature-flags/#1-release-toggles

Why the distinction matters here:

| | Long-lived feature flag (the thing people are wary of) | This flag (release toggle) |
|---|---|---|
| Lifespan | Indefinite | Removed after the change soaks |
| Purpose | Permanently parameterize behavior / experiment per tenant | De-risk rollout of one high-blast-radius change |
| End state | Both branches maintained forever | Single unconditional code path; flag + both gate points deleted |
| Test matrix | Permanent fork | Temporary; off-path is the existing legacy behavior |

So the change is deliberately scoped as scaffolding with a removal plan, default **off**, both gate points keyed to the **same** flag so the write and read paths can't diverge. It exists to make a behavior change with cross-entity reach safe to deploy continuously — not to add a permanent toggle to the product.

### TESTING INSTRUCTIONS

**Automated** — unit tests cover both flag states (default-off and on):

```
pytest tests/unit_tests/daos/test_base_dao_soft_delete.py \
       tests/unit_tests/models/test_soft_delete_mixin.py
```

- With `FEATURE_FLAGS = {"SOFT_DELETE": False}` (default): a `DELETE` on a `SoftDeleteMixin` model hard-deletes, and the read-path listener does not hide soft-deleted rows.
- With `SOFT_DELETE` on: `DELETE` soft-deletes and the listener filters soft-deleted rows out of reads (existing substrate behavior).

**QA / manual** — this PR is the gate only; to exercise it end-to-end, build it together with the entity PRs (#40129 charts / #40128 dashboards / #40130 datasets), since on master alone no model carries `SoftDeleteMixin` yet.

1. **Gate OFF (default) → legacy hard delete.** With `SOFT_DELETE` unset/false, `DELETE` a chart/dashboard/dataset (UI or API). Confirm the row is **physically gone** (no `deleted_at` ghost; absent from both the API and a direct DB query), exactly as today — even though the model now carries the mixin and the `deleted_at` column exists. The gate is inert: the substrate ships dark.
2. **Flip the flag.** Set `FEATURE_FLAGS = {"SOFT_DELETE": True}` and restart.
3. **Gate ON → soft delete.** `DELETE` the same entity types. Confirm the row **survives** with `deleted_at` stamped, is hidden from list/detail/relationship loads, and is invisible to normal ORM reads (only a raw SQL query or the deleted-state filter sees it).
4. **Restore round-trip.** `POST /api/v1/{chart,dashboard,dataset}/<uuid>/restore` → `200`; confirm `deleted_at` is cleared and the row reappears in the default API.
5. **Kill-switch semantics.** Note that flipping `SOFT_DELETE` **off after** rows are soft-deleted makes those rows visible again to the legacy code path (resurrection) — this is an emergency stop, not a clean rollback. Pair any rollback with a data decision.

Both gate points (write path `BaseDAO.delete()` and read path `do_orm_execute` listener) key off the **same** flag, so they cannot diverge between on/off.

### ADDITIONAL INFORMATION

- [x] Required feature flags: **`SOFT_DELETE`** (default off; temporary rollout/kill-switch — to be removed after stabilization)
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

