### PR TITLE
fix(explore): pre-populate SaveModal dashboard from chart metadata

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -615,6 +615,170 @@ test('onTabChange correctly updates selectedTab via forceUpdate', () => {
   });
 });
 
+const ownerUser = {
+  userId: 1,
+  username: 'testuser',
+  firstName: 'Test',
+  lastName: 'User',
+  isActive: true,
+  isAnonymous: false,
+  permissions: {},
+  roles: { Alpha: [['can_write', 'Dashboard']] as [string, string][] },
+  groups: [],
+};
+
+const makeMetadataDashboard = (id: number, title: string) => ({
+  id,
+  dashboard_title: title,
+  owners: [{ id: 1, first_name: 'Test', last_name: 'User' }],
+  extra_owners: [],
+  roles: [],
+  url: `/superset/dashboard/${id}/`,
+  slug: null,
+  thumbnail_url: null,
+  published: true,
+  changed_by_name: 'Test User',
+  changed_by: { id: 1, first_name: 'Test', last_name: 'User' },
+  changed_on: '2024-01-01',
+  charts: [],
+});
+
+test('pre-populates dashboard from metadata.dashboards when dashboardId prop is absent', async () => {
+  const dashboardId = 5;
+  const dashboardTitle = 'Chart Dashboard';
+
+  const myProps = {
+    ...defaultProps,
+    dashboardId: null,
+    metadata: {
+      dashboards: [{ id: dashboardId, dashboard_title: dashboardTitle }],
+      owners: ['Test User'],
+      created_on_humanized: '2 days ago',
+      changed_on_humanized: '1 day ago',
+    },
+    user: ownerUser,
+    slice: { slice_id: 1, slice_name: 'My Chart', owners: [1] },
+    dispatch: jest.fn(),
+    addDangerToast: jest.fn(),
+  };
+
+  const component = new TestSaveModal(myProps);
+  const mockFull = makeMetadataDashboard(dashboardId, dashboardTitle);
+
+  component.loadDashboard = jest.fn().mockResolvedValue(mockFull);
+  component.loadTabs = jest.fn().mockResolvedValue([]);
+
+  const stateUpdates: any[] = [];
+  component.setState = jest.fn((update: any) => {
+    stateUpdates.push(update);
+  });
+
+  try {
+    sessionStorage.clear();
+  } catch (_) {
+    // ignore
+  }
+
+  await component.componentDidMount();
+
+  expect(component.loadDashboard).toHaveBeenCalledWith(dashboardId);
+  expect(stateUpdates).toContainEqual({
+    dashboard: { label: dashboardTitle, value: dashboardId },
+  });
+  expect(component.loadTabs).toHaveBeenCalledWith(dashboardId);
+});
+
+test('skips non-editable dashboards and picks the first editable one from metadata', async () => {
+  const editableId = 7;
+  const editableTitle = 'Editable Dashboard';
+
+  const myProps = {
+    ...defaultProps,
+    dashboardId: null,
+    metadata: {
+      dashboards: [
+        { id: 6, dashboard_title: 'Not Mine' },
+        { id: editableId, dashboard_title: editableTitle },
+      ],
+      owners: ['Test User'],
+      created_on_humanized: '2 days ago',
+      changed_on_humanized: '1 day ago',
+    },
+    user: ownerUser,
+    slice: { slice_id: 1, slice_name: 'My Chart', owners: [1] },
+    dispatch: jest.fn(),
+    addDangerToast: jest.fn(),
+  };
+
+  const component = new TestSaveModal(myProps);
+
+  const notMine = makeMetadataDashboard(6, 'Not Mine');
+  notMine.owners = [{ id: 99, first_name: 'Other', last_name: 'Owner' }];
+  const editable = makeMetadataDashboard(editableId, editableTitle);
+
+  component.loadDashboard = jest.fn().mockImplementation((id: number) =>
+    Promise.resolve(id === 6 ? notMine : editable),
+  );
+  component.loadTabs = jest.fn().mockResolvedValue([]);
+
+  const stateUpdates: any[] = [];
+  component.setState = jest.fn((update: any) => {
+    stateUpdates.push(update);
+  });
+
+  try {
+    sessionStorage.clear();
+  } catch (_) {
+    // ignore
+  }
+
+  await component.componentDidMount();
+
+  expect(stateUpdates).toContainEqual({
+    dashboard: { label: editableTitle, value: editableId },
+  });
+  expect(component.loadTabs).toHaveBeenCalledWith(editableId);
+});
+
+test('does not use metadata fallback when dashboardId prop is set', async () => {
+  const propDashboardId = 3;
+  const propDashboardTitle = 'Prop Dashboard';
+
+  const myProps = {
+    ...defaultProps,
+    dashboardId: propDashboardId,
+    metadata: {
+      dashboards: [{ id: 99, dashboard_title: 'Should Not Be Used' }],
+      owners: ['Test User'],
+      created_on_humanized: '2 days ago',
+      changed_on_humanized: '1 day ago',
+    },
+    user: ownerUser,
+    slice: { slice_id: 1, slice_name: 'My Chart', owners: [1] },
+    dispatch: jest.fn(),
+    addDangerToast: jest.fn(),
+  };
+
+  const component = new TestSaveModal(myProps);
+  const mockFull = makeMetadataDashboard(propDashboardId, propDashboardTitle);
+
+  component.loadDashboard = jest.fn().mockResolvedValue(mockFull);
+  component.loadTabs = jest.fn().mockResolvedValue([]);
+
+  const stateUpdates: any[] = [];
+  component.setState = jest.fn((update: any) => {
+    stateUpdates.push(update);
+  });
+
+  await component.componentDidMount();
+
+  expect(component.loadDashboard).toHaveBeenCalledWith(propDashboardId);
+  expect(component.loadDashboard).not.toHaveBeenCalledWith(99);
+  expect(stateUpdates).toContainEqual({
+    dashboard: { label: propDashboardTitle, value: propDashboardId },
+  });
+});
+
 test('chart placement logic finds row with available space', () => {
   // Test case 1: Row has space (8 + 4 = 12 <= 12)
   const positionJson1 = {

--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -716,9 +716,11 @@ test('skips non-editable dashboards and picks the first editable one from metada
   notMine.owners = [{ id: 99, first_name: 'Other', last_name: 'Owner' }];
   const editable = makeMetadataDashboard(editableId, editableTitle);
 
-  component.loadDashboard = jest.fn().mockImplementation((id: number) =>
-    Promise.resolve(id === 6 ? notMine : editable),
-  );
+  component.loadDashboard = jest
+    .fn()
+    .mockImplementation((id: number) =>
+      Promise.resolve(id === 6 ? notMine : editable),
+    );
   component.loadTabs = jest.fn().mockResolvedValue([]);
 
   const stateUpdates: any[] = [];

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -174,14 +174,15 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
         // metadata). Pre-populate with the first dashboard the user can edit so the
         // "Save & go to dashboard" button works out of the box.
         try {
-          const loaded = await Promise.all(
-            metadataDashboards.map(({ id }) =>
-              this.loadDashboard(id).catch(() => null),
-            ),
-          );
-          const editable = (loaded as (Dashboard | null)[]).find(
-            d => d && canUserEditDashboard(d, this.props.user),
-          ) as Dashboard | undefined;
+          let editable: Dashboard | undefined;
+          for (const { id } of metadataDashboards) {
+            // eslint-disable-next-line no-await-in-loop
+            const result = await this.loadDashboard(id).catch(() => null);
+            if (result && canUserEditDashboard(result, this.props.user)) {
+              editable = result as Dashboard;
+              break;
+            }
+          }
           if (editable) {
             this.setState({
               dashboard: {

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -54,7 +54,7 @@ import {
   isUserAdmin,
 } from 'src/dashboard/util/permissionUtils';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
-import { SaveActionType, ChartStatusType } from 'src/explore/types';
+import { SaveActionType, ChartStatusType, ExplorePageInitialData } from 'src/explore/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import {
   removeChartState,
@@ -81,6 +81,7 @@ interface SaveModalProps extends RouteComponentProps {
   isVisible: boolean;
   dispatch: Dispatch;
   theme: SupersetTheme;
+  metadata?: ExplorePageInitialData['metadata'];
 }
 
 type SaveModalState = {
@@ -161,6 +162,34 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
         this.props.addDangerToast(
           t('An error occurred while loading dashboard information.'),
         );
+      }
+    } else {
+      const metadataDashboards = this.props.metadata?.dashboards;
+      if (metadataDashboards?.length) {
+        // Fallback: the chart is already on one or more dashboards (from Explore API
+        // metadata). Pre-populate with the first dashboard the user can edit so the
+        // "Save & go to dashboard" button works out of the box.
+        try {
+          const loaded = await Promise.all(
+            metadataDashboards.map(({ id }) =>
+              this.loadDashboard(id).catch(() => null),
+            ),
+          );
+          const editable = (loaded as (Dashboard | null)[]).find(
+            d => d && canUserEditDashboard(d, this.props.user),
+          ) as Dashboard | undefined;
+          if (editable) {
+            this.setState({
+              dashboard: {
+                label: editable.dashboard_title,
+                value: editable.id,
+              },
+            });
+            await this.loadTabs(editable.id);
+          }
+        } catch (error) {
+          logging.warn(error);
+        }
       }
     }
   }
@@ -826,6 +855,7 @@ interface StateProps {
   dashboards: any;
   alert: any;
   isVisible: boolean;
+  metadata?: ExplorePageInitialData['metadata'];
 }
 
 function mapStateToProps({
@@ -841,6 +871,7 @@ function mapStateToProps({
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,
     isVisible: saveModal.isVisible,
+    metadata: explore.metadata,
   };
 }
 

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -54,7 +54,11 @@ import {
   isUserAdmin,
 } from 'src/dashboard/util/permissionUtils';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
-import { SaveActionType, ChartStatusType, ExplorePageInitialData } from 'src/explore/types';
+import {
+  SaveActionType,
+  ChartStatusType,
+  ExplorePageInitialData,
+} from 'src/explore/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import {
   removeChartState,


### PR DESCRIPTION
### SUMMARY

Fixes the blank **Dashboard** field in the chart save modal (SaveModal) when the chart is already on one or more dashboards.

**Root cause:** `SaveModal.componentDidMount` only tried to pre-populate the Dashboard dropdown from two sources — the `dashboardId` URL param (only present when navigating from a dashboard view) or `sessionStorage`. But the `/api/v1/explore/` response already includes `metadata.dashboards` — the full list of dashboards the chart belongs to — and this data was available in Redux state (`explore.metadata`) but never read by SaveModal.

**Fix:** Add `metadata` to `mapStateToProps` and add a fallback in `componentDidMount`: when no `dashboardId` is found from URL/sessionStorage, load each dashboard from `metadata.dashboards` in parallel and pre-select the first one the user can edit.

Relates to the "Save & go to dashboard" UX bug reported internally as sc-104553.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavioral fix; no visual UI changes.

### TESTING INSTRUCTIONS

1. Save a chart to a dashboard.
2. Navigate to the chart at `/explore/?slice_id=<id>` directly (no `dashboard_id` URL param).
3. Open the Save modal.
4. **Before:** Dashboard field is blank. **After:** Dashboard field is pre-populated with the first dashboard the chart belongs to that you can edit.
5. "Save & go to dashboard" should now work from a direct chart URL.

Unit tests added:
- `pre-populates dashboard from metadata.dashboards when dashboardId prop is absent`
- `skips non-editable dashboards and picks the first editable one from metadata`
- `does not use metadata fallback when dashboardId prop is set`

### ADDITIONAL INFORMATION

- [x] Has associated issue: sc-104553 (internal)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API