### PR TITLE
fix(chart): added Big Number chart support for MAX metric with VARCHAR column

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
@@ -256,7 +256,7 @@ describe('BigNumberTotal transformProps', () => {
     expect(result.bigNumber).toBe('some-varchar-result');
   });
 
-  test('should not fall back to raw string when value is numeric-looking VARCHAR (e.g. "123")', () => {
+  test('should pass through numeric-looking VARCHAR string literally (e.g. "123")', () => {
     const { parseMetricValue } = jest.requireMock('../utils');
     parseMetricValue.mockReturnValueOnce(null);
 
@@ -278,8 +278,7 @@ describe('BigNumberTotal transformProps', () => {
     const result = transformProps(
       chartProps as unknown as BigNumberTotalChartProps,
     );
-    // parsedValue is null and "123" is numeric, so bigNumber stays null (not "123")
-    expect(result.bigNumber).toBeNull();
+    expect(result.bigNumber).toBe('123');
   });
 
   test('should propagate colorThresholdFormatters from getColorFormatters', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
@@ -231,6 +231,31 @@ describe('BigNumberTotal transformProps', () => {
     expect(result.headerFormatter(500)).toBe('$500');
   });
 
+  test('should pass through raw string when parseMetricValue returns null (e.g. VARCHAR MAX)', () => {
+    const { parseMetricValue } = jest.requireMock('../utils');
+    parseMetricValue.mockReturnValueOnce(null);
+
+    const chartProps = {
+      width: 400,
+      height: 300,
+      queriesData: [
+        {
+          data: [{ value: 'some-varchar-result' }],
+          coltypes: [GenericDataType.String],
+        },
+      ],
+      formData: baseFormData,
+      rawFormData: baseRawFormData,
+      hooks: baseHooks,
+      datasource: baseDatasource,
+    };
+
+    const result = transformProps(
+      chartProps as unknown as BigNumberTotalChartProps,
+    );
+    expect(result.bigNumber).toBe('some-varchar-result');
+  });
+
   test('should propagate colorThresholdFormatters from getColorFormatters', () => {
     // Override the getColorFormatters mock to return specific value
     const mockFormatters = [{ formatter: 'red' }];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
@@ -231,7 +231,7 @@ describe('BigNumberTotal transformProps', () => {
     expect(result.headerFormatter(500)).toBe('$500');
   });
 
-  test('should pass through raw string when parseMetricValue returns null (e.g. VARCHAR MAX)', () => {
+  test('should pass through non-numeric raw string when parseMetricValue returns null (e.g. VARCHAR MAX)', () => {
     const { parseMetricValue } = jest.requireMock('../utils');
     parseMetricValue.mockReturnValueOnce(null);
 
@@ -254,6 +254,32 @@ describe('BigNumberTotal transformProps', () => {
       chartProps as unknown as BigNumberTotalChartProps,
     );
     expect(result.bigNumber).toBe('some-varchar-result');
+  });
+
+  test('should not fall back to raw string when value is numeric-looking VARCHAR (e.g. "123")', () => {
+    const { parseMetricValue } = jest.requireMock('../utils');
+    parseMetricValue.mockReturnValueOnce(null);
+
+    const chartProps = {
+      width: 400,
+      height: 300,
+      queriesData: [
+        {
+          data: [{ value: '123' }],
+          coltypes: [GenericDataType.String],
+        },
+      ],
+      formData: baseFormData,
+      rawFormData: baseRawFormData,
+      hooks: baseHooks,
+      datasource: baseDatasource,
+    };
+
+    const result = transformProps(
+      chartProps as unknown as BigNumberTotalChartProps,
+    );
+    // parsedValue is null and "123" is numeric, so bigNumber stays null (not "123")
+    expect(result.bigNumber).toBeNull();
   });
 
   test('should propagate colorThresholdFormatters from getColorFormatters', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -79,8 +79,13 @@ export default function transformProps(
   const formattedSubtitleFontSize = subtitle?.trim()
     ? (subtitleFontSize ?? PROPORTION.SUBHEADER)
     : (subheaderFontSize ?? subtitleFontSize ?? PROPORTION.SUBHEADER);
+  const rawValue = data.length === 0 ? null : data[0][metricName];
+  const parsedValue = rawValue == null ? null : parseMetricValue(rawValue);
+  // Preserve non-date strings for display-only path
   const bigNumber =
-    data.length === 0 ? null : parseMetricValue(data[0][metricName]);
+    parsedValue === null && typeof rawValue === 'string' && rawValue !== ''
+      ? rawValue
+      : parsedValue;
 
   let metricEntry: Metric | undefined;
   if (chartProps.datasource?.metrics) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -83,7 +83,9 @@ export default function transformProps(
   const parsedValue = rawValue == null ? null : parseMetricValue(rawValue);
 
   const bigNumber =
-    parsedValue === null && typeof rawValue === 'string' && rawValue.trim() !== ''
+    parsedValue === null &&
+    typeof rawValue === 'string' &&
+    rawValue.trim() !== ''
       ? rawValue
       : parsedValue;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -83,10 +83,7 @@ export default function transformProps(
   const parsedValue = rawValue == null ? null : parseMetricValue(rawValue);
 
   const bigNumber =
-    parsedValue === null &&
-    typeof rawValue === 'string' &&
-    rawValue !== '' &&
-    Number.isNaN(Number(rawValue))
+    parsedValue === null && typeof rawValue === 'string' && rawValue !== ''
       ? rawValue
       : parsedValue;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -81,9 +81,12 @@ export default function transformProps(
     : (subheaderFontSize ?? subtitleFontSize ?? PROPORTION.SUBHEADER);
   const rawValue = data.length === 0 ? null : data[0][metricName];
   const parsedValue = rawValue == null ? null : parseMetricValue(rawValue);
-  // Preserve non-date strings for display-only path
+
   const bigNumber =
-    parsedValue === null && typeof rawValue === 'string' && rawValue !== ''
+    parsedValue === null &&
+    typeof rawValue === 'string' &&
+    rawValue !== '' &&
+    Number.isNaN(Number(rawValue))
       ? rawValue
       : parsedValue;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -83,7 +83,7 @@ export default function transformProps(
   const parsedValue = rawValue == null ? null : parseMetricValue(rawValue);
 
   const bigNumber =
-    parsedValue === null && typeof rawValue === 'string' && rawValue !== ''
+    parsedValue === null && typeof rawValue === 'string' && rawValue.trim() !== ''
       ? rawValue
       : parsedValue;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -189,8 +189,10 @@ function BigNumberVis({
       text = t('No data');
     } else if (typeof bigNumber === 'number') {
       text = headerFormatter(bigNumber);
+    } else if (typeof bigNumber === 'string') {
+      text = bigNumber;
     } else {
-      // For string/boolean/Date values, convert to number if possible, else show as string
+      // For boolean/Date values, convert to number if possible, else show as string
       const numValue = Number(bigNumber);
       text = Number.isNaN(numValue)
         ? String(bigNumber)

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
@@ -37,7 +37,7 @@ export const parseMetricValue = (metricValue: number | string | null) => {
     if (dateObject.isValid()) {
       return dateObject.valueOf();
     }
-    return null;
+    return metricValue;
   }
   return metricValue;
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
@@ -37,7 +37,7 @@ export const parseMetricValue = (metricValue: number | string | null) => {
     if (dateObject.isValid()) {
       return dateObject.valueOf();
     }
-    return metricValue;
+    return null;
   }
   return metricValue;
 };


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The issue I am addressing is that Big Number charts previously displayed "No data" when the metric result was a non-empty, non-date string value. My fix for this is the below:
In ```utils.ts``` ```parseMetricValue``` returns null for non-date strings. Now, in ```transformProps.ts``` after ```parseMetricValue``` returns ```null```, if the original raw value was a non-empty string, it falls back to that string. ```BigNumberViz.tsx``` already handles string ```bigNumber``` by displaying it directly so "No data" will no longer appear.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="1762" height="935" alt="Screenshot 2026-06-17 at 9 14 56 PM" src="https://github.com/user-attachments/assets/1c1ebc10-b0c7-4401-ba3a-e8066d6ef58b" />
After
<img width="1760" height="936" alt="Screenshot 2026-06-17 at 8 26 58 PM" src="https://github.com/user-attachments/assets/e7800e66-0424-4538-b9c2-7e2f0dcaad75" />


### TESTING INSTRUCTIONS
1. Start Superset locally.
2. Create or use a dataset with a non-null VARCHAR column.
3. Create a Big Number chart using that dataset.
4. Set the metric to ```MAX(varchar_column)```.
5. Click ```Create Chart```.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #41030
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API