### PR TITLE
fix(menu): highlight active nav tab in non-English locales

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -796,3 +796,105 @@ test('brand link falls back to brand.path when theme brandLogoUrl is absent', as
   // ensureAppRoot must have been applied: /welcome/ → /superset/welcome/
   expect(brandLink).toHaveAttribute('href', '/superset/welcome/');
 });
+
+// --- Active tab highlighting (regression tests for issue #36403) ---
+//
+// The active top-level tab is highlighted by matching the current route to a
+// menu item. The matching must rely on a stable identifier (the FAB `name`),
+// not the displayed label, otherwise highlighting breaks for any non-English
+// locale where the label is translated.
+
+// Returns the top-level <li> that contains the given visible text, so we can
+// assert whether antd marked it as the selected menu item.
+const getMenuItemByText = (text: string): HTMLElement | null =>
+  screen.getByText(text).closest('li');
+
+afterEach(() => {
+  // Reset the route so a pushed path does not leak into the next test.
+  window.history.pushState({}, '', '/');
+});
+
+test('highlights the active top-level tab on a matching route (English)', async () => {
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  window.history.pushState({}, '', '/dashboard/list/');
+
+  render(<Menu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+
+  await screen.findByText('Dashboards');
+  expect(getMenuItemByText('Dashboards')).toHaveClass('ant-menu-item-selected');
+});
+
+test('highlights the active top-level tab when the label is localized', async () => {
+  // Russian locale: the FAB `name` stays the stable English identifier while
+  // the displayed `label` is translated. Highlighting must still work.
+  const localizedProps = {
+    ...mockedProps,
+    data: {
+      ...mockedProps.data,
+      menu: mockedProps.data.menu.map(item =>
+        item.name === 'Dashboards' ? { ...item, label: 'Дашборды' } : item,
+      ),
+    },
+  };
+
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  window.history.pushState({}, '', '/dashboard/list/');
+
+  render(<Menu {...localizedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+
+  await screen.findByText('Дашборды');
+  expect(getMenuItemByText('Дашборды')).toHaveClass('ant-menu-item-selected');
+});
+
+test('highlights the active SQL tab when the label is localized', async () => {
+  // The SQL Lab top-level entry is a FAB category: its stable `name` is
+  // "SQL Lab" while its label ("SQL") is localized.
+  const localizedProps = {
+    ...mockedProps,
+    data: {
+      ...mockedProps.data,
+      menu: [
+        ...mockedProps.data.menu,
+        {
+          name: 'SQL Lab',
+          icon: 'fa-flask',
+          label: 'SQL запросы',
+          childs: [
+            {
+              name: 'SQL Editor',
+              label: 'SQL Lab',
+              url: '/sqllab/',
+              index: 1,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  window.history.pushState({}, '', '/sqllab/');
+
+  render(<Menu {...localizedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+
+  await screen.findByText('SQL запросы');
+  // SQL Lab renders as a submenu, so antd marks it with the submenu variant.
+  expect(getMenuItemByText('SQL запросы')).toHaveClass(
+    'ant-menu-submenu-selected',
+  );
+});

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -809,92 +809,98 @@ test('brand link falls back to brand.path when theme brandLogoUrl is absent', as
 const getMenuItemByText = (text: string): HTMLElement | null =>
   screen.getByText(text).closest('li');
 
-afterEach(() => {
-  // Reset the route so a pushed path does not leak into the next test.
-  window.history.pushState({}, '', '/');
-});
-
-test('highlights the active top-level tab on a matching route (English)', async () => {
-  useSelectorMock.mockReturnValue({ roles: user.roles });
-  window.history.pushState({}, '', '/dashboard/list/');
-
-  render(<Menu {...mockedProps} />, {
-    useRedux: true,
-    useQueryParams: true,
-    useRouter: true,
-    useTheme: true,
+// Scoped in a describe so the route-resetting afterEach only applies to these
+// tests and does not leak into the rest of the file.
+describe('active tab highlighting (regression #36403)', () => {
+  afterEach(() => {
+    // Reset the route so a pushed path does not leak into the next test.
+    window.history.pushState({}, '', '/');
   });
 
-  await screen.findByText('Dashboards');
-  expect(getMenuItemByText('Dashboards')).toHaveClass('ant-menu-item-selected');
-});
+  test('highlights the active top-level tab on a matching route (English)', async () => {
+    useSelectorMock.mockReturnValue({ roles: user.roles });
+    window.history.pushState({}, '', '/dashboard/list/');
 
-test('highlights the active top-level tab when the label is localized', async () => {
-  // Russian locale: the FAB `name` stays the stable English identifier while
-  // the displayed `label` is translated. Highlighting must still work.
-  const localizedProps = {
-    ...mockedProps,
-    data: {
-      ...mockedProps.data,
-      menu: mockedProps.data.menu.map(item =>
-        item.name === 'Dashboards' ? { ...item, label: 'Дашборды' } : item,
-      ),
-    },
-  };
+    render(<Menu {...mockedProps} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
 
-  useSelectorMock.mockReturnValue({ roles: user.roles });
-  window.history.pushState({}, '', '/dashboard/list/');
-
-  render(<Menu {...localizedProps} />, {
-    useRedux: true,
-    useQueryParams: true,
-    useRouter: true,
-    useTheme: true,
+    await screen.findByText('Dashboards');
+    expect(getMenuItemByText('Dashboards')).toHaveClass(
+      'ant-menu-item-selected',
+    );
   });
 
-  await screen.findByText('Дашборды');
-  expect(getMenuItemByText('Дашборды')).toHaveClass('ant-menu-item-selected');
-});
+  test('highlights the active top-level tab when the label is localized', async () => {
+    // Russian locale: the FAB `name` stays the stable English identifier while
+    // the displayed `label` is translated. Highlighting must still work.
+    const localizedProps = {
+      ...mockedProps,
+      data: {
+        ...mockedProps.data,
+        menu: mockedProps.data.menu.map(item =>
+          item.name === 'Dashboards' ? { ...item, label: 'Дашборды' } : item,
+        ),
+      },
+    };
 
-test('highlights the active SQL tab when the label is localized', async () => {
-  // The SQL Lab top-level entry is a FAB category: its stable `name` is
-  // "SQL Lab" while its label ("SQL") is localized.
-  const localizedProps = {
-    ...mockedProps,
-    data: {
-      ...mockedProps.data,
-      menu: [
-        ...mockedProps.data.menu,
-        {
-          name: 'SQL Lab',
-          icon: 'fa-flask',
-          label: 'SQL запросы',
-          childs: [
-            {
-              name: 'SQL Editor',
-              label: 'SQL Lab',
-              url: '/sqllab/',
-              index: 1,
-            },
-          ],
-        },
-      ],
-    },
-  };
+    useSelectorMock.mockReturnValue({ roles: user.roles });
+    window.history.pushState({}, '', '/dashboard/list/');
 
-  useSelectorMock.mockReturnValue({ roles: user.roles });
-  window.history.pushState({}, '', '/sqllab/');
+    render(<Menu {...localizedProps} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
 
-  render(<Menu {...localizedProps} />, {
-    useRedux: true,
-    useQueryParams: true,
-    useRouter: true,
-    useTheme: true,
+    await screen.findByText('Дашборды');
+    expect(getMenuItemByText('Дашборды')).toHaveClass('ant-menu-item-selected');
   });
 
-  await screen.findByText('SQL запросы');
-  // SQL Lab renders as a submenu, so antd marks it with the submenu variant.
-  expect(getMenuItemByText('SQL запросы')).toHaveClass(
-    'ant-menu-submenu-selected',
-  );
+  test('highlights the active SQL tab when the label is localized', async () => {
+    // The SQL Lab top-level entry is a FAB category: its stable `name` is
+    // "SQL Lab" while its label ("SQL") is localized.
+    const localizedProps = {
+      ...mockedProps,
+      data: {
+        ...mockedProps.data,
+        menu: [
+          ...mockedProps.data.menu,
+          {
+            name: 'SQL Lab',
+            icon: 'fa-flask',
+            label: 'SQL запросы',
+            childs: [
+              {
+                name: 'SQL Editor',
+                label: 'SQL Lab',
+                url: '/sqllab/',
+                index: 1,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    useSelectorMock.mockReturnValue({ roles: user.roles });
+    window.history.pushState({}, '', '/sqllab/');
+
+    render(<Menu {...localizedProps} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
+
+    await screen.findByText('SQL запросы');
+    // SQL Lab renders as a submenu, so antd marks it with the submenu variant.
+    expect(getMenuItemByText('SQL запросы')).toHaveClass(
+      'ant-menu-submenu-selected',
+    );
+  });
 });

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -282,7 +282,11 @@ export function Menu({
       } else if (typeof child !== 'string') {
         Object.assign(child, { label: t(child.label) });
         childItems.push({
-          key: `${child.label}`,
+          // Key children by the stable FAB `name` as well, so a child whose
+          // localized label coincides with a parent key (e.g. the "SQL Editor"
+          // child labeled "SQL Lab" under the "SQL Lab" category) doesn't
+          // collide with that parent. Fall back to the label when no name.
+          key: child.name ?? `${child.label}`,
           label: child.isFrontendRoute ? (
             <NavLink to={child.url || ''} exact activeClassName="is-active">
               {child.label}

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -211,6 +211,16 @@ export function Menu({
     SavedQueries = '/savedqueryview',
   }
 
+  // Stable Flask-AppBuilder menu identifiers (`name`), used as menu item keys.
+  // These are locale-independent, unlike the displayed labels, so matching the
+  // active tab against them keeps highlighting working in every language.
+  enum MenuKeys {
+    Dashboards = 'Dashboards',
+    Charts = 'Charts',
+    Datasets = 'Datasets',
+    SqlLab = 'SQL Lab',
+  }
+
   const defaultTabSelection: string[] = [];
   const [activeTabs, setActiveTabs] = useState(defaultTabSelection);
   const location = useLocation();
@@ -218,16 +228,16 @@ export function Menu({
     const path = location.pathname;
     switch (true) {
       case path.startsWith(Paths.Dashboard):
-        setActiveTabs([t('Dashboards')]);
+        setActiveTabs([MenuKeys.Dashboards]);
         break;
       case path.startsWith(Paths.Chart) || path.startsWith(Paths.Explore):
-        setActiveTabs([t('Charts')]);
+        setActiveTabs([MenuKeys.Charts]);
         break;
       case path.startsWith(Paths.Datasets):
-        setActiveTabs([datasetsLabel()]);
+        setActiveTabs([MenuKeys.Datasets]);
         break;
       case path.startsWith(Paths.SqlLab) || path.startsWith(Paths.SavedQueries):
-        setActiveTabs(['SQL']);
+        setActiveTabs([MenuKeys.SqlLab]);
         break;
       default:
         setActiveTabs(defaultTabSelection);
@@ -242,10 +252,14 @@ export function Menu({
     childs,
     url,
     isFrontendRoute,
+    name,
   }: MenuObjectProps): MenuItem => {
+    // Key items by the stable FAB `name` so active-tab matching is independent
+    // of the localized label. Fall back to the label when no name is provided.
+    const key = name ?? label;
     if (url && isFrontendRoute) {
       return {
-        key: label,
+        key,
         label: (
           <NavLink role="button" to={url} activeClassName="is-active">
             {label}
@@ -256,7 +270,7 @@ export function Menu({
 
     if (url) {
       return {
-        key: label,
+        key,
         label: <Typography.Link href={url}>{label}</Typography.Link>,
       };
     }
@@ -281,7 +295,7 @@ export function Menu({
     });
 
     return {
-      key: label,
+      key,
       label,
       ...(screens.md && {
         icon: <Icons.DownOutlined iconSize="xs" />,


### PR DESCRIPTION
### SUMMARY

The top navigation bar highlights the active tab by matching the current route against the menu item keys. Those keys were the menu items' **displayed labels**, while the active-tab matcher compared against **hardcoded English strings** (`"Dashboards"`, `"Charts"`, `"SQL"`, …). In any non-English locale the displayed label is translated, so it never matched the English comparison string and **no tab was highlighted**.

This is a systemic i18n bug — it affects every language whose menu translations differ from English, not just Russian (reported in #36403).

**Fix:** key each menu item by its stable Flask-AppBuilder `name` (the internal view/category identifier, which is locale-independent) instead of its localized label, and match the active tab against those same names. `name` falls back to `label` when absent, so operator-defined custom menu entries keep working.

The change is in `superset-frontend/src/features/home/Menu.tsx`:
- `buildMenuItem` now uses `key: name ?? label` for top-level entries.
- The route → active-tab effect sets the stable names (`Dashboards`, `Charts`, `Datasets`, `SQL Lab`) instead of English labels. As a bonus this decouples the Datasets tab from the semantic-layer label override.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before — Russian locale, on the Dashboards page, the **Dashboards** tab is not highlighted.
After — the active tab is highlighted in every language.

(See the screenshots in #36403 for the broken-vs-working comparison.)

### TESTING INSTRUCTIONS

1. Set two languages in `superset_config.py`:
   ```py
   LANGUAGES = {
       "en": {"flag": "us", "name": "English"},
       "ru": {"flag": "ru", "name": "Russian"},
   }
   ```
2. Switch the UI language to Russian.
3. Open the Dashboards (or Charts / Datasets / SQL Lab) page.
4. Confirm the corresponding top-nav tab is highlighted as active.

Automated coverage added in `Menu.test.tsx`:
- Highlights the active top-level tab on a matching route (English) — regression guard.
- Highlights the active top-level tab when the label is **localized**.
- Highlights the active SQL submenu tab when the label is localized.

```
npx jest src/features/home/Menu.test.tsx
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36403
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)