### PR TITLE
fix: remove erroneous box shadow when bulk selecting

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -166,7 +166,6 @@ const BulkSelectWrapper = styled(Alert)`
       margin: ${`${-theme.sizeUnit * 2}px 0 ${-theme.sizeUnit * 2}px ${theme.sizeUnit * 4}px`};
       width: 1px;
       height: ${theme.sizeUnit * 8}px;
-      box-shadow: inset -1px 0px 0px ${theme.colorBorder};
       display: inline-flex;
       vertical-align: middle;
       position: relative;


### PR DESCRIPTION
### SUMMARY
Remove the erroneous box shadow when bulk selecting that creates a vertical 1px line.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="467" height="239" alt="image" src="https://github.com/user-attachments/assets/82523b33-6594-4ae7-aaa3-eef483ecf75f" />

-->

<img width="467" height="235" alt="image" src="https://github.com/user-attachments/assets/7365a3f7-8f03-44bd-a8f4-bad02e083beb" />


### TESTING INSTRUCTIONS
Use bulk selection in the dashboards/charts/datasets list. Select one or more items, observe that the line is gone.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
