### PR TITLE
fix(sqllab): quote autocomplete table names that need it

### DIFF
--- a/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.test.ts
@@ -44,13 +44,13 @@ const fakeTableApiResult = {
   result: [
     {
       id: 1,
-      value: 'fake api result1',
+      value: 'fake_api_result1',
       label: 'fake api label1',
       type: 'table',
     },
     {
       id: 2,
-      value: 'fake api result2',
+      value: 'fake_api_result2',
       label: 'fake api label2',
       type: 'table',
     },
@@ -150,6 +150,64 @@ test('returns keywords including fetched function_names data', async () => {
       }),
     );
   });
+});
+
+test('quotes table identifiers that require quoting in the inserted value', async () => {
+  const dbFunctionNamesApiRoute = `glob:*/api/v1/database/${expectDbId}/function_names/`;
+  fetchMock.get(dbFunctionNamesApiRoute, fakeFunctionNamesApiResult);
+
+  act(() => {
+    store.dispatch(
+      tableApiUtil.upsertQueryData(
+        'tables',
+        { dbId: expectDbId, schema: expectSchema },
+        {
+          options: [
+            { value: 'COVID Vaccines', label: 'COVID Vaccines', type: 'table' },
+            { value: 'simple_table', label: 'simple_table', type: 'table' },
+          ],
+          hasMore: false,
+        },
+      ),
+    );
+  });
+
+  const { result } = renderHook(
+    () =>
+      useKeywords({
+        queryEditorId: 'testqueryid',
+        dbId: expectDbId,
+        schema: expectSchema,
+      }),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store,
+      }),
+    },
+  );
+
+  await waitFor(() =>
+    expect(fetchMock.callHistory.calls(dbFunctionNamesApiRoute).length).toBe(1),
+  );
+
+  // A name that needs quoting is inserted as a double-quoted identifier,
+  // while its display name stays human-readable.
+  expect(result.current).toContainEqual(
+    expect.objectContaining({
+      name: 'COVID Vaccines',
+      value: '"COVID Vaccines"',
+      meta: 'table',
+    }),
+  );
+  // A simple identifier is inserted as-is, without quotes.
+  expect(result.current).toContainEqual(
+    expect.objectContaining({
+      name: 'simple_table',
+      value: 'simple_table',
+      meta: 'table',
+    }),
+  );
 });
 
 test('skip fetching if autocomplete skipped', () => {

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.ts
@@ -53,6 +53,14 @@ const getHelperText = (value: string) =>
     detail: value,
   };
 
+// Names that aren't simple identifiers (spaces, punctuation, leading digits)
+// must be double-quoted to be valid SQL, with embedded quotes doubled.
+const SIMPLE_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const quoteIdentifier = (identifier: string) =>
+  SIMPLE_IDENTIFIER_RE.test(identifier)
+    ? identifier
+    : `"${identifier.replace(/"/g, '""')}"`;
+
 const extensionsRegistry = getExtensionsRegistry();
 
 export function useKeywords(
@@ -197,7 +205,7 @@ export function useKeywords(
     () =>
       allCachedTables.map(({ value, label, schema: tableSchema }) => ({
         name: label,
-        value,
+        value: quoteIdentifier(value),
         schema: tableSchema,
         score: TABLE_AUTOCOMPLETE_SCORE,
         meta: 'table',


### PR DESCRIPTION
### SUMMARY

SQL Lab autocomplete inserted table names exactly as stored. When a name isn't a simple identifier (it contains spaces or punctuation, or starts with a digit), inserting it verbatim produces invalid SQL. Picking a table like `COVID Vaccines` from the dropdown gave `SELECT * FROM COVID Vaccines`, which fails to parse.

This quotes the inserted value with double quotes when the name isn't a simple identifier, doubling any embedded quotes so names containing `"` stay valid. Simple identifiers are still inserted as-is, and the human-readable label shown in the dropdown is unchanged.

Quoting uses ANSI double-quote identifiers. Dialect-specific quote characters (e.g. backticks on MySQL) would be a reasonable follow-up.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE:
<img width="1440" height="820" alt="sc102556-before" src="https://github.com/user-attachments/assets/d9fc4e04-77e1-4041-aa50-7af543d5a5ba" />

AFTER:
<img width="1440" height="820" alt="sc102556-after" src="https://github.com/user-attachments/assets/408eb337-7394-4c0d-b4ec-336350f13f1e" />


### TESTING INSTRUCTIONS

1. In SQL Lab, connect to a database/schema that has a table whose name needs quoting (for example, a name containing a space such as `COVID Vaccines`).
2. Start typing the table name in the editor and pick it from the autocomplete dropdown.
   - Before: the name is inserted unquoted (`FROM COVID Vaccines`) and the query fails to parse.
   - After: the name is inserted quoted (`FROM "COVID Vaccines"`) and runs.
3. Confirm a normal table name (e.g. `simple_table`) is still inserted without quotes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
