### PR TITLE
feat(charts): add extensible extra metadata column to slices

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1735,6 +1735,7 @@ class ImportV1ChartSchema(Schema):
     viz_type = fields.String(required=True)
     params = fields.Dict()
     query_context = fields.String(allow_none=True, validate=utils.validate_json)
+    extra = fields.String(allow_none=True, validate=utils.validate_json)
     cache_timeout = fields.Integer(allow_none=True)
     uuid = fields.UUID(required=True)
     version = fields.String(required=True)

--- a/superset/migrations/versions/2026-06-17_16-58_9d4b2e8c1f0a_add_extra_column_to_slices.py
+++ b/superset/migrations/versions/2026-06-17_16-58_9d4b2e8c1f0a_add_extra_column_to_slices.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add extra column to slices
+
+Revision ID: 9d4b2e8c1f0a
+Revises: 78a40c08b4be
+Create Date: 2026-06-17 16:58:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from superset.migrations.shared.utils import add_columns, drop_columns
+from superset.utils.core import MediumText
+
+# revision identifiers, used by Alembic.
+revision = "9d4b2e8c1f0a"
+down_revision = "78a40c08b4be"
+
+
+def upgrade() -> None:
+    """Add the nullable ``extra`` column to ``slices``."""
+    add_columns(
+        "slices",
+        sa.Column("extra", MediumText(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``extra`` column from ``slices``."""
+    drop_columns("slices", "extra")

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -82,6 +82,7 @@ class Slice(  # pylint: disable=too-many-public-methods
     viz_type = Column(String(250))
     params = Column(utils.MediumText())
     query_context = Column(utils.MediumText())
+    extra = Column(utils.MediumText())
     description = Column(Text)
     cache_timeout = Column(Integer)
     perm = Column(String(1000))
@@ -134,6 +135,7 @@ class Slice(  # pylint: disable=too-many-public-methods
         "viz_type",
         "params",
         "query_context",
+        "extra",
         "cache_timeout",
     ]
     export_parent = "table"

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -158,6 +158,7 @@ class Slice(  # pylint: disable=too-many-public-methods
             params=self.params,
             description=self.description,
             cache_timeout=self.cache_timeout,
+            extra=self.extra,
         )
 
     @renders("datasource_name")

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -104,6 +104,7 @@ class TestExportChartsCommand(SupersetTestCase):
             "uuid": str(example_chart.uuid),
             "version": "1.0.0",
             "query_context": None,
+            "extra": None,
         }
 
     @patch("superset.utils.core.g")
@@ -152,6 +153,7 @@ class TestExportChartsCommand(SupersetTestCase):
             "viz_type",
             "params",
             "query_context",
+            "extra",
             "cache_timeout",
             "uuid",
             "version",


### PR DESCRIPTION
### SUMMARY

Adds a nullable `extra` column to the `slices` table (and the `Slice` model) to store open-ended, structured chart metadata, mirroring the long-standing dataset `extra` pattern.

Charts currently have no extensible metadata field. `description` is unsuitable because it is user-facing prose rendered as markdown and shown as a tooltip in the Charts list. Datasets already solve this with an `extra` JSON-bearing column (`SqlaTable.extra`), and columns/metrics have their own `extra` as well. This change brings the same proven, low-risk pattern to charts.

Design decisions:
- Column name `extra`, consistent with `tables.extra` and column/metric `extra`.
- Type `MediumText` (`superset.utils.core.MediumText`), which resolves to `TEXT` on Postgres/SQLite and `MEDIUMTEXT` on MySQL. This matches the existing JSON-bearing chart fields `params` and `query_context`, avoids MySQL's 64KB `TEXT` limit, and stores identical bytes across backends (unlike a native JSON column, which MySQL normalizes/reorders).
- Nullable, no server default. JSON is stored as a string and parsed at the application layer, exactly as `SqlaTable.extra_dict` does today.
- Added `extra` to `Slice.export_fields` so it round-trips through import/export.

This PR intentionally scopes to the model + migration foundation. Exposing `extra` through the chart REST API (`ChartPostSchema`/`ChartPutSchema`/response schema) and any UI can follow in a separate PR.

Associated SIP: https://github.com/apache/superset/issues/41171

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend schema change with no UI surface in this PR.

### TESTING INSTRUCTIONS

1. Run `superset db upgrade` and confirm the `extra` column is added to `slices` (nullable).
2. Run `superset db downgrade` and confirm the column is cleanly removed.
3. Confirm `superset db heads` reports a single head.
4. Set/read `Slice.extra` (e.g. via shell) and confirm round-trip through chart export/import.

The migration uses the idempotent `add_columns`/`drop_columns` helpers from `superset/migrations/shared/utils.py`, following the exact shape of the existing `94e7a3499973` (add `folders` to datasets) migration. Upgrade/downgrade of the additive column was exercised against a local metadata DB.

### ADDITIONAL INFORMATION

- [x] Has associated issue: https://github.com/apache/superset/issues/41171
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Runtime/downtime: adding a nullable column to `slices` is a metadata-only DDL change on Postgres (no table rewrite, no default backfill) and completes near-instantly; no downtime expected. MySQL 8 performs this as an INSTANT add for a nullable column.

Made with [Cursor](https://cursor.com)