### PR TITLE
fix(query_object_factory): normalize deprecated query fields before constructing QueryObject

### DIFF
--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any, cast, TYPE_CHECKING
 
 from superset.common.chart_data import ChartDataResultType
-from superset.common.query_object import QueryObject
+from superset.common.query_object import DEPRECATED_FIELDS, QueryObject
 from superset.common.utils.time_range_utils import get_since_until_from_time_range
 from superset.constants import NO_TIME_RANGE
 from superset.superset_typing import Column
@@ -65,6 +65,13 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
             datasource_model_instance = self._convert_to_model(datasource)
         processed_extras = self._process_extras(extras)
         result_type = kwargs.setdefault("result_type", parent_result_type)
+
+        # Rename deprecated kwargs before any processing so that downstream code
+        # (time-range resolution, QueryObject) only ever sees the canonical names.
+        for field in DEPRECATED_FIELDS:
+            if field.old_name in kwargs:
+                if value := kwargs.pop(field.old_name):
+                    kwargs.setdefault(field.new_name, value)
 
         # Process row limit taking server pagination into account
         row_limit = self._process_row_limit(

--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -69,9 +69,8 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         # Rename deprecated kwargs before any processing so that downstream code
         # (time-range resolution, QueryObject) only ever sees the canonical names.
         for field in DEPRECATED_FIELDS:
-            if field.old_name in kwargs:
-                if value := kwargs.pop(field.old_name):
-                    kwargs.setdefault(field.new_name, value)
+            if old_val := kwargs.pop(field.old_name, None):
+                kwargs.setdefault(field.new_name, old_val)
 
         # Process row limit taking server pagination into account
         row_limit = self._process_row_limit(

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -138,3 +138,32 @@ class TestQueryObjectFactory:
             **raw_query_object,
         )
         assert query_object.metric_names == ["SUM", "num_girls", "num_boys"]
+
+    def test_deprecated_groupby_renamed_to_columns(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """groupby in stored query_context should be silently renamed to columns."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object.pop("columns", None)
+        raw_query_object["groupby"] = ["name", "gender"]
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.columns == ["name", "gender"]
+        assert not hasattr(query_object, "groupby")
+
+    def test_deprecated_groupby_does_not_overwrite_columns(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """When both groupby and columns are present, columns takes precedence."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["columns"] = ["state"]
+        raw_query_object["groupby"] = ["name", "gender"]
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.columns == ["state"]

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -167,3 +167,61 @@ class TestQueryObjectFactory:
             raw_query_context["result_type"], **raw_query_object
         )
         assert query_object.columns == ["state"]
+
+    def test_deprecated_groupby_empty_list_is_ignored(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """groupby=[] is falsy — popped but columns should default to []."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object.pop("columns", None)
+        raw_query_object["groupby"] = []
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.columns == []
+        assert not hasattr(query_object, "groupby")
+
+    def test_deprecated_granularity_sqla_renamed_to_granularity(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """granularity_sqla in stored query_context should be renamed to granularity."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object.pop("granularity", None)
+        raw_query_object["granularity_sqla"] = "ds"
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.granularity == "ds"
+
+    def test_deprecated_timeseries_limit_renamed_to_series_limit(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """timeseries_limit should be renamed to series_limit."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object.pop("series_limit", None)
+        raw_query_object["timeseries_limit"] = 5
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.series_limit == 5
+
+    def test_deprecated_timeseries_limit_zero_is_not_renamed(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        """timeseries_limit=0 is falsy — popped; series_limit defaults to 0."""
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object.pop("series_limit", None)
+        raw_query_object["timeseries_limit"] = 0
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        # 0 is falsy so it does not propagate — QueryObject default is also 0
+        assert query_object.series_limit == 0


### PR DESCRIPTION
## What changed

**Deprecation warning found in production Datadog logs:**
```
The field `groupby` is deprecated, please use `columns` instead.
  file: query_object.py, line 219, func: _rename_deprecated_fields
  env: production, service: superset
```

Charts with a stored `query_context` column (in `slices.query_context`) that was saved
using the old `groupby` key emit this warning on **every render** via
`Slice.get_query_context()`. That path parses the stored JSON and calls
`QueryContextFactory.create()` directly, bypassing the Marshmallow
`ChartDataQueryObjectSchema.rename_deprecated_fields` `@post_load` hook that the
REST API path relies on. By the time `QueryObject._rename_deprecated_fields` sees
`groupby` in `**kwargs`, there is no caller who can act on the warning — it is pure
noise in production logs.

## What was changed

`QueryObjectFactory.create()` now normalises all four `DEPRECATED_FIELDS`
(`groupby → columns`, `granularity_sqla → granularity`, `timeseries_limit → series_limit`,
`timeseries_limit_metric → series_limit_metric`) **before** any downstream processing.

Two effects:

1. `QueryObject._rename_deprecated_fields` never sees the old keys for the factory path,
   so no warning is emitted for stored `query_context`.
2. **Bonus correctness fix:** `_process_time_range` calls `get_x_axis_label(kwargs.get("columns"))`.
   Previously, for stored `query_context` that used `groupby`, `columns` was `None` at that
   point, causing the x-axis temporal filter match to silently fall back to the first temporal
   filter. After this fix, `columns` is populated from `groupby` before time-range resolution.

`setdefault` semantics: if both the deprecated key and the canonical key are present,
the canonical key wins (semantically more correct than the old `setattr` overwrite in
`QueryObject._rename_deprecated_fields`). In practice, no stored `query_context` will
have both keys simultaneously.

## No behavior change

Charts that use stored `query_context` with `groupby` continue to produce the correct
result. The only observable change is the suppression of the deprecation warning and
the correctness improvement to temporal filter resolution described above.

## Test plan

- [ ] New unit tests in `test_query_object_factory.py`:
  - `test_deprecated_groupby_renamed_to_columns`
  - `test_deprecated_groupby_does_not_overwrite_columns` (canonical wins)
  - `test_deprecated_groupby_empty_list_is_ignored` (falsy edge case)
  - `test_deprecated_granularity_sqla_renamed_to_granularity`
  - `test_deprecated_timeseries_limit_renamed_to_series_limit`
  - `test_deprecated_timeseries_limit_zero_is_not_renamed` (integer 0 falsy edge case, documents correct default)
- [ ] All existing `TestQueryObjectFactory` tests continue to pass.
- [ ] CI green.