### PR TITLE
fix(embedded-sdk): surface npm publish stderr in release script

### DIFF
--- a/superset-embedded-sdk/release-if-necessary.js
+++ b/superset-embedded-sdk/release-if-necessary.js
@@ -47,7 +47,11 @@ function logError(...args) {
       execSync('npm publish --access public', { stdio: 'pipe' });
       log(`published ${version} to npm`);
     } catch (err) {
-      console.error(String(err.stdout));
+      // npm writes failure details to stderr (auth/permission/registry
+      // errors in particular), so surface both streams to avoid masking
+      // the real cause in CI logs.
+      if (err.stdout) console.error(String(err.stdout));
+      if (err.stderr) console.error(String(err.stderr));
       logError('Encountered an error, details should be above');
       process.exitCode = 1;
     }


### PR DESCRIPTION
### SUMMARY

The **Embedded SDK Release** workflow has been failing on every push to `master` since #40991 bumped `@superset-ui/embedded-sdk` to `0.4.0`. While the version sat at `0.3.0` (already on npm), `release-if-necessary.js` always took the "version already exists, exiting" path and the job stayed green. The bump made it actually run `npm publish` for the first time since November 2025, and the publish fails.

The real failure is invisible in CI: the catch block only prints `err.stdout`, but `npm publish` writes its failure details (auth/permission/registry errors) to **stderr**. So the logs show only:

```
[embedded-sdk-release] build successful, publishing
[embedded-sdk-release] Encountered an error, details should be above
##[error]Process completed with exit code 1.
```

…with nothing above it. This PR prints `err.stderr` as well so the actual npm error becomes visible.

Note: this is a **diagnostics** fix. The underlying publish failure is almost certainly an expired/invalid `NPM_TOKEN` (or a newer npm 2FA/provenance requirement) and must be resolved by a maintainer with npm org access — `release-if-necessary.js` only checks that the token is non-empty, not that it's valid. Once this lands, the next master run will reveal the exact error.

This workflow triggers only on `push` to `master`/release branches, so it does **not** gate PR merges — but it leaves a red ❌ on every master commit and means `0.4.0` is not being published.

### TESTING INSTRUCTIONS

The change is in the error-handling path of the release script. To verify the swallowing behavior, run the script with a command whose error goes to stderr; previously only stdout was echoed, now both streams are printed. The real verification is the next `Embedded SDK Release` run on master, which will now log the actual npm publish error.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)