### PR TITLE
ci(embedded-sdk): fix release CI by publishing via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -10,25 +10,15 @@ permissions:
   contents: read
 
 jobs:
-  config:
-    runs-on: ubuntu-24.04
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${NPM_TOKEN}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
-        env:
-          NPM_TOKEN: ${{ (secrets.NPM_TOKEN != '') || '' }}
   build:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    # Publishing uses npm trusted publishing (OIDC), so there is no NPM_TOKEN to
+    # gate on. Restrict to the canonical repo: forks cannot mint a valid OIDC
+    # token for this package and must not publish.
+    if: github.repository == 'apache/superset'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # required for npm trusted publishing (OIDC)
     defaults:
       run:
         working-directory: superset-embedded-sdk
@@ -40,7 +30,8 @@ jobs:
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing requires npm >= 11.5.1; ensure it regardless of the
+      # version bundled with the pinned Node release.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run ci:release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### SUMMARY

Fixes the failing **Embedded SDK Release** job on `master` by replacing the long-lived `NPM_TOKEN` with **npm trusted publishing (OIDC)**.

**Root cause:** The job failed on every push to `master` after #40991 bumped `@superset-ui/embedded-sdk` to `0.4.0`. It wasn't a code regression — the publish credential had gone stale. Because the version had sat at `0.3.0` (already on npm), `release-if-necessary.js` always took the "version already exists, exiting" path, so the publish step hadn't actually run since November 2025. The version bump forced it to run, and it failed. The error was invisible in CI because the release script only echoed `err.stdout` while npm writes failure details to `err.stderr` (separately fixed in #41206).

**Fix:** OIDC trusted publishing removes the token entirely. Each publish mints a short-lived, workflow-scoped credential, so there's nothing to expire, rotate, or leak — and npm provenance is enabled automatically. This eliminates the recurrence risk (a stale credential discovered months later) rather than just resetting it with a fresh token.

### CHANGES

- Add `id-token: write` to the build job (required for the OIDC exchange).
- Drop `NODE_AUTH_TOKEN` from the publish step.
- Remove the `config` job that gated on the `NPM_TOKEN` secret existing — under OIDC there is no secret, so that gate would make the job skip forever. Replaced with `if: github.repository == 'apache/superset'`, preserving the original "don't publish from forks" intent.
- Add `npm install -g npm@latest` to guarantee npm ≥ 11.5.1 (trusted-publishing requirement). The pinned Node (`.nvmrc` = v24.16.0) already satisfies the Node ≥ 22.14.0 requirement.

### PREREQUISITE — ✅ DONE

- [x] Trusted Publisher configured on npmjs.com for `@superset-ui/embedded-sdk` (GitHub Actions → `apache/superset` / `embedded-sdk-release.yml`)

This PR is now safe to merge. After merge, the next push to `master` should publish the current SDK version (with provenance) and the job should go green.

Follow-up (no infra needed, harmless to defer): the now-unused `NPM_TOKEN` repo secret can be deleted whenever convenient — the workflow no longer references it.

### TESTING INSTRUCTIONS

After merge, the next push to `master` triggers *Embedded SDK Release*; it should authenticate via OIDC (no token referenced anywhere in the workflow) and publish successfully.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)