### PR TITLE
fix(explore): stop metric edits from bleeding across metrics with duplicate optionNames

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -136,6 +136,37 @@ test('coerceMetrics regenerates duplicate optionNames so each metric stays uniqu
   expect(result[1].aggregate).toBe(AGGREGATES.AVG);
 });
 
+test('coerceMetrics regenerates duplicate optionNames for SQL adhoc metrics too', () => {
+  // The same collision can happen with custom SQL metrics, which take a
+  // different code path than column-backed metrics but must dedupe the same way.
+  const dup = 'shared_option';
+  const result = coerceMetrics(
+    [
+      {
+        expressionType: EXPRESSION_TYPES.SQL,
+        sqlExpression: 'COUNT(*)',
+        label: 'count',
+        optionName: dup,
+      },
+      {
+        expressionType: EXPRESSION_TYPES.SQL,
+        sqlExpression: 'SUM(value)',
+        label: 'total',
+        optionName: dup,
+      },
+    ] as any,
+    defaultProps.savedMetrics as unknown as Metric[],
+    defaultProps.columns,
+  ) as AdhocMetric[];
+
+  expect(result).toHaveLength(2);
+  expect(result[0].optionName).toBe(dup);
+  expect(result[1].optionName).not.toBe(dup);
+  // Each metric definition is otherwise preserved.
+  expect(result[0].sqlExpression).toBe('COUNT(*)');
+  expect(result[1].sqlExpression).toBe('SUM(value)');
+});
+
 test('renders with default props', () => {
   render(<DndMetricSelect {...defaultProps} />, {
     useDndKit: true,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -24,11 +24,15 @@ import {
   waitFor,
   within,
 } from 'spec/helpers/testing-library';
+import { Metric } from '@superset-ui/core';
 import { useDroppable } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
-import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
+import {
+  DndMetricSelect,
+  coerceMetrics,
+} from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
 import { AGGREGATES } from 'src/explore/constants';
-import { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
+import AdhocMetric, { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
 import { DndItemType } from '../../DndItemType';
 import {
   CapturedDroppable,
@@ -98,6 +102,39 @@ const adhocMetricB = {
   aggregate: AGGREGATES.SUM,
   optionName: 'def',
 };
+
+test('coerceMetrics regenerates duplicate optionNames so each metric stays unique', () => {
+  // A saved chart can carry two adhoc metrics with the same optionName (e.g.
+  // born from a duplicated metric). Since edits are matched by optionName, the
+  // duplicates must be split apart on load or editing one overwrites the other.
+  const dup = 'shared_option';
+  const result = coerceMetrics(
+    [
+      {
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+        column: defaultProps.columns[0],
+        aggregate: AGGREGATES.SUM,
+        optionName: dup,
+      },
+      {
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+        column: defaultProps.columns[1],
+        aggregate: AGGREGATES.AVG,
+        optionName: dup,
+      },
+    ] as any,
+    defaultProps.savedMetrics as unknown as Metric[],
+    defaultProps.columns,
+  ) as AdhocMetric[];
+
+  expect(result).toHaveLength(2);
+  // First keeps the optionName, second is regenerated to avoid the collision.
+  expect(result[0].optionName).toBe(dup);
+  expect(result[1].optionName).not.toBe(dup);
+  // Each metric definition is otherwise preserved.
+  expect(result[0].aggregate).toBe(AGGREGATES.SUM);
+  expect(result[1].aggregate).toBe(AGGREGATES.AVG);
+});
 
 test('renders with default props', () => {
   render(<DndMetricSelect {...defaultProps} />, {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -30,7 +30,9 @@ import {
 import { tn } from '@apache-superset/core/translation';
 import { GenericDataType } from '@apache-superset/core/common';
 import { ColumnMeta } from '@superset-ui/chart-controls';
-import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
+import AdhocMetric, {
+  dedupeAdhocMetricOptionName,
+} from 'src/explore/components/controls/MetricControl/AdhocMetric';
 import AdhocMetricPopoverTrigger from 'src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger';
 import MetricDefinitionValue from 'src/explore/components/controls/MetricControl/MetricDefinitionValue';
 import {
@@ -72,22 +74,8 @@ export const coerceMetrics = (
   );
 
   // Metrics are identified by optionName when editing; regenerate any that
-  // collide so each keeps a unique identity and editing one never overwrites
-  // another (a saved chart can carry duplicate optionNames, e.g. from a
-  // duplicated metric).
+  // collide so each keeps a unique identity (see dedupeAdhocMetricOptionName).
   const seenOptionNames = new Set<string>();
-  const dedupeOptionName = (metric: AdhocMetric) => {
-    if (!seenOptionNames.has(metric.optionName)) {
-      seenOptionNames.add(metric.optionName);
-      return metric;
-    }
-    const deduped = new AdhocMetric({
-      ...(metric as unknown as Record<string, unknown>),
-      optionName: undefined,
-    });
-    seenOptionNames.add(deduped.optionName);
-    return deduped;
-  };
 
   return metricsCompatibleWithDataset.map(metric => {
     if (
@@ -112,17 +100,19 @@ export const coerceMetrics = (
       );
       if (column) {
         // Cast entire config object to handle type mismatch between @superset-ui/core and local types
-        return dedupeOptionName(
+        return dedupeAdhocMetricOptionName(
           new AdhocMetric({
             ...(metric as unknown as Record<string, unknown>),
             column,
           } as Record<string, unknown>),
+          seenOptionNames,
         );
       }
     }
     // Cast to unknown first to handle type mismatch between @superset-ui/core and local AdhocMetric
-    return dedupeOptionName(
+    return dedupeAdhocMetricOptionName(
       new AdhocMetric(metric as unknown as Record<string, unknown>),
+      seenOptionNames,
     );
   });
 };

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -52,7 +52,7 @@ const isDictionaryForAdhocMetric = (value: QueryFormMetric) =>
   typeof value !== 'string' &&
   value.expressionType;
 
-const coerceMetrics = (
+export const coerceMetrics = (
   addedMetrics: QueryFormMetric | QueryFormMetric[] | undefined | null,
   savedMetrics: Metric[],
   columns: ColumnMeta[],
@@ -70,6 +70,24 @@ const coerceMetrics = (
       return true;
     },
   );
+
+  // Metrics are identified by optionName when editing; regenerate any that
+  // collide so each keeps a unique identity and editing one never overwrites
+  // another (a saved chart can carry duplicate optionNames, e.g. from a
+  // duplicated metric).
+  const seenOptionNames = new Set<string>();
+  const dedupeOptionName = (metric: AdhocMetric) => {
+    if (!seenOptionNames.has(metric.optionName)) {
+      seenOptionNames.add(metric.optionName);
+      return metric;
+    }
+    const deduped = new AdhocMetric({
+      ...(metric as unknown as Record<string, unknown>),
+      optionName: undefined,
+    });
+    seenOptionNames.add(deduped.optionName);
+    return deduped;
+  };
 
   return metricsCompatibleWithDataset.map(metric => {
     if (
@@ -94,14 +112,18 @@ const coerceMetrics = (
       );
       if (column) {
         // Cast entire config object to handle type mismatch between @superset-ui/core and local types
-        return new AdhocMetric({
-          ...(metric as unknown as Record<string, unknown>),
-          column,
-        } as Record<string, unknown>);
+        return dedupeOptionName(
+          new AdhocMetric({
+            ...(metric as unknown as Record<string, unknown>),
+            column,
+          } as Record<string, unknown>),
+        );
       }
     }
     // Cast to unknown first to handle type mismatch between @superset-ui/core and local AdhocMetric
-    return new AdhocMetric(metric as unknown as Record<string, unknown>);
+    return dedupeOptionName(
+      new AdhocMetric(metric as unknown as Record<string, unknown>),
+    );
   });
 };
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.ts
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.ts
@@ -224,3 +224,27 @@ export function isDictionaryForAdhocMetric(
 export function fromCoreAdhocMetric(metric: CoreAdhocMetric): AdhocMetric {
   return new AdhocMetric(metric as AdhocMetricInput);
 }
+
+/**
+ * Metrics are identified by `optionName` when editing, so two metrics sharing
+ * one (a saved chart can carry duplicate optionNames, e.g. from a duplicated
+ * metric) would let an edit to one bleed into the other. Given a `seen` set
+ * shared across a list, return the metric unchanged the first time its
+ * optionName is encountered, or a copy with a freshly generated optionName on a
+ * collision, so each metric keeps a unique identity.
+ */
+export function dedupeAdhocMetricOptionName(
+  metric: AdhocMetric,
+  seenOptionNames: Set<string>,
+): AdhocMetric {
+  if (!seenOptionNames.has(metric.optionName)) {
+    seenOptionNames.add(metric.optionName);
+    return metric;
+  }
+  const deduped = new AdhocMetric({
+    ...(metric as unknown as Record<string, unknown>),
+    optionName: undefined,
+  });
+  seenOptionNames.add(deduped.optionName);
+  return deduped;
+}

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.test.tsx
@@ -124,6 +124,48 @@ test('accepts an edited metric from an AdhocMetricEditPopover', async () => {
   ]);
 });
 
+test('only edits the targeted metric when two metrics share an optionName', async () => {
+  // A saved chart can carry two adhoc metrics with the same optionName (e.g.
+  // born from a duplicated metric). Editing one must not overwrite the other.
+  // Saved charts store metrics as plain dictionaries in form_data, so mirror
+  // that shape (not AdhocMetric instances) to exercise the real load path.
+  const sharedOptionName = 'metric_shared_option';
+  const { onChange } = setup({
+    value: [
+      {
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+        column: valueColumn,
+        aggregate: AGGREGATES.SUM,
+        label: 'SUM(value)',
+        optionName: sharedOptionName,
+      },
+      {
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+        column: valueColumn,
+        aggregate: AGGREGATES.AVG,
+        label: 'AVG(value)',
+        optionName: sharedOptionName,
+      },
+    ],
+  });
+
+  userEvent.click(screen.getByText('SUM(value)'));
+  await screen.findByText('aggregate');
+  await selectOption('MAX', 'Select aggregate options');
+  await screen.findByText('MAX(value)');
+  userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  // The untouched AVG(value) metric must still be present and unchanged.
+  expect(onChange).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        aggregate: AGGREGATES.AVG,
+        label: 'AVG(value)',
+      }),
+    ]),
+  );
+});
+
 test('removes metrics if savedMetrics changes', async () => {
   setup({
     value: [sumValueAdhocMetric],

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.test.tsx
@@ -155,9 +155,14 @@ test('only edits the targeted metric when two metrics share an optionName', asyn
   await screen.findByText('MAX(value)');
   userEvent.click(screen.getByRole('button', { name: /save/i }));
 
-  // The untouched AVG(value) metric must still be present and unchanged.
+  // The edit must propagate to the targeted metric (SUM → MAX) while the
+  // untouched AVG(value) metric stays present and unchanged.
   expect(onChange).toHaveBeenCalledWith(
     expect.arrayContaining([
+      expect.objectContaining({
+        aggregate: AGGREGATES.MAX,
+        label: 'MAX(value)',
+      }),
       expect.objectContaining({
         aggregate: AGGREGATES.AVG,
         label: 'AVG(value)',

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
@@ -66,10 +66,20 @@ function coerceAdhocMetrics(value: any) {
     }
     return [value];
   }
+  // Metrics are identified by optionName when editing; regenerate any that
+  // collide so each keeps a unique identity and editing one never overwrites
+  // another (a saved chart can carry duplicate optionNames, e.g. from a
+  // duplicated metric).
+  const seenOptionNames = new Set<string>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return value.map((val: any) => {
     if (isDictionaryForAdhocMetric(val)) {
-      return new AdhocMetric(val);
+      const metric =
+        val.optionName && seenOptionNames.has(val.optionName)
+          ? new AdhocMetric({ ...val, optionName: undefined })
+          : new AdhocMetric(val);
+      seenOptionNames.add(metric.optionName);
+      return metric;
     }
     return val;
   });

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
@@ -29,7 +29,7 @@ import {
   LabelsContainer,
 } from 'src/explore/components/controls/OptionControls';
 import MetricDefinitionValue from './MetricDefinitionValue';
-import AdhocMetric from './AdhocMetric';
+import AdhocMetric, { dedupeAdhocMetricOptionName } from './AdhocMetric';
 import AdhocMetricPopoverTrigger from './AdhocMetricPopoverTrigger';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,19 +67,12 @@ function coerceAdhocMetrics(value: any) {
     return [value];
   }
   // Metrics are identified by optionName when editing; regenerate any that
-  // collide so each keeps a unique identity and editing one never overwrites
-  // another (a saved chart can carry duplicate optionNames, e.g. from a
-  // duplicated metric).
+  // collide so each keeps a unique identity (see dedupeAdhocMetricOptionName).
   const seenOptionNames = new Set<string>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return value.map((val: any) => {
     if (isDictionaryForAdhocMetric(val)) {
-      const metric =
-        val.optionName && seenOptionNames.has(val.optionName)
-          ? new AdhocMetric({ ...val, optionName: undefined })
-          : new AdhocMetric(val);
-      seenOptionNames.add(metric.optionName);
-      return metric;
+      return dedupeAdhocMetricOptionName(new AdhocMetric(val), seenOptionNames);
     }
     return val;
   });


### PR DESCRIPTION
### SUMMARY

Editing one custom (adhoc) metric could silently rewrite other metrics on the same chart. When a chart's saved metrics include two adhoc metrics that share an `optionName` (which can happen, for example after duplicating a metric), editing one of them overwrote every metric with that `optionName` — both the label and the definition snapped to the edited one.

Root cause: the metric controls match an edit back to its metric by `optionName`, but nothing guaranteed `optionName` was unique. This fixes it where metrics are loaded into the control (`coerceMetrics` / `coerceAdhocMetrics`): a metric whose `optionName` collides with an earlier one is given a fresh `optionName`, so each metric keeps a unique identity. That both heals already-affected saved charts and prevents the behavior going forward. The fix is applied to the drag-and-drop metric control used by Explore and to the legacy metrics control, which share the same matching logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE: 
<img width="1440" height="820" alt="sc102554-before" src="https://github.com/user-attachments/assets/d3ab02db-22e8-47f0-8aca-6be0bab93d5b" />
editing one metric's aggregate (SUM → MAX) also changes the second metric, leaving two identical `MAX(num)` metrics.


AFTER:
<img width="1440" height="820" alt="sc102554-after" src="https://github.com/user-attachments/assets/75489780-4cc2-4746-9279-ce8561488c80" />

 only the edited metric changes; the second metric stays `AVG(num)`.

### TESTING INSTRUCTIONS

1. Open a chart whose `form_data` holds two adhoc metrics on the same column that share an `optionName` (this is the state a duplicated metric can leave behind).
2. Edit one metric (e.g. change its aggregate or label) and save.
   - Before: both metrics change together.
   - After: only the edited metric changes; the other is untouched.
3. Unit coverage: `DndMetricSelect.test.tsx` and `MetricsControl.test.tsx` assert that loading two metrics with a duplicate `optionName` yields unique identities so an edit touches only one.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
