### PR TITLE
fix(embedded-sdk): clear placeholder token so npm uses OIDC publishing

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -30,8 +30,13 @@ jobs:
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
           registry-url: "https://registry.npmjs.org"
-      # Trusted publishing requires npm >= 11.5.1; ensure it regardless of the
-      # version bundled with the pinned Node release.
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run ci:release
+        env:
+          # actions/setup-node injects a placeholder NODE_AUTH_TOKEN
+          # (XXXXX-XXXXX-XXXXX-XXXXX) when registry-url is set, which makes npm
+          # attempt failed token auth and skip the OIDC trusted-publishing
+          # exchange. Clear it so npm authenticates via OIDC. The Node pinned in
+          # .nvmrc (v24.16.0) ships npm 11.13, satisfying the >= 11.5.1
+          # trusted-publishing requirement, so no manual npm upgrade is needed.
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
### SUMMARY

Follow-up to #41207 (OIDC trusted publishing) and #41206 (surface stderr). The OIDC switch merged but the **Embedded SDK Release** job still failed on every master push with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@superset-ui%2fembedded-sdk
npm error 404  The requested resource '@superset-ui/embedded-sdk@0.4.0' could not be found
              or you do not have permission to access it.
```

(E404 on a `PUT` is npm's misleading code for an **auth/permission failure** — it returns 404 rather than 401/403 so it doesn't leak package existence.)

**Root cause:** `actions/setup-node`, when `registry-url` is set, writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` **and** injects a placeholder `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX`. npm finds that bogus token, attempts token auth, gets rejected, and **never performs the OIDC exchange** — confirmed by the complete absence of any OIDC / `id-token` / provenance activity in the run logs. The packaging itself was perfect (22 files, valid tarball).

npm's official trusted-publishing example works precisely because `NODE_AUTH_TOKEN` is empty there. This PR replicates that by clearing it on the publish step, so npm takes the OIDC path.

### CHANGES

- Set `NODE_AUTH_TOKEN: ""` on the `npm run ci:release` step so the placeholder no longer pre-empts OIDC.
- Drop the redundant `npm install -g npm@latest` step — the run logs confirm the pinned Node (`v24.16.0`) already ships npm `11.13.0`, above the 11.5.1 trusted-publishing requirement.

### TESTING INSTRUCTIONS

After merge, the next push to `master` triggers *Embedded SDK Release*. Expected: npm performs the OIDC token exchange and publishes `@superset-ui/embedded-sdk@0.4.0` (with provenance), and the job goes green. If it instead fails with an OIDC/trust-specific error, that would point to the npmjs.com Trusted Publisher config (repo/workflow-filename match) rather than the token.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)