### PR TITLE
fix(embedded-sdk): omit registry-url so npm uses OIDC publishing

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -26,17 +26,23 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      # Note: registry-url is intentionally omitted. When set, actions/setup-node
+      # writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}` and a placeholder
+      # token, which makes npm attempt token auth and skip the OIDC
+      # trusted-publishing exchange. With no .npmrc auth line, npm authenticates
+      # via OIDC against the default registry (registry.npmjs.org).
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
-          registry-url: "https://registry.npmjs.org"
+      # Diagnostic: confirm GitHub OIDC is granted to this job. npm trusted
+      # publishing needs the id-token request env vars; "no" here means OIDC was
+      # not issued and publishing cannot authenticate.
+      - name: Check OIDC availability
+        run: |
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+            echo "GitHub OIDC available to job: yes"
+          else
+            echo "GitHub OIDC available to job: no"
+          fi
       - run: npm ci
       - run: npm run ci:release
-        env:
-          # actions/setup-node injects a placeholder NODE_AUTH_TOKEN
-          # (XXXXX-XXXXX-XXXXX-XXXXX) when registry-url is set, which makes npm
-          # attempt failed token auth and skip the OIDC trusted-publishing
-          # exchange. Clear it so npm authenticates via OIDC. The Node pinned in
-          # .nvmrc (v24.16.0) ships npm 11.13, satisfying the >= 11.5.1
-          # trusted-publishing requirement, so no manual npm upgrade is needed.
-          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
### SUMMARY

Continues the fix for the failing **Embedded SDK Release** job (after #41207 OIDC migration, #41206 stderr visibility, #41210 token clearing).

**Progress so far:** #41210 cleared the placeholder token, which moved the error from `E404` (npm tried a bogus token) to `ENEEDAUTH` (npm has no auth) — and critically, npm *still* performed **no OIDC exchange at all** (zero OIDC/`id-token` activity in the run logs), despite npm 11.13 and `id-token: write` on the job.

Two causes remained, indistinguishable from the current logs:
1. `actions/setup-node` with `registry-url` writes an `.npmrc` `_authToken=` line that suppresses OIDC even when the token is empty, **or**
2. GitHub isn't actually granting the OIDC id-token to this job.

This PR settles it in one run:

- **Omit `registry-url`** from setup-node, so no `.npmrc` auth line is written at all. npm then authenticates via OIDC against the default registry (`registry.npmjs.org`). This is the leading fix.
- **Add a non-leaking diagnostic step** that prints whether `ACTIONS_ID_TOKEN_REQUEST_URL` is present, i.e. whether GitHub OIDC was granted to the job.

### EXPECTED OUTCOMES (read the "Check OIDC availability" step in the run)

- **"OIDC available: yes" + job green** → fixed; `0.4.0` publishes with provenance.
- **"OIDC available: yes" + still ENEEDAUTH** → points to the npmjs.com Trusted Publisher config (exact repo + workflow-filename match), not the workflow.
- **"OIDC available: no"** → GitHub isn't issuing the id-token (e.g. org-level restriction); we'd pursue org settings or fall back to a token.

### TESTING INSTRUCTIONS

After merge, the next push to `master` runs *Embedded SDK Release*; inspect the "Check OIDC availability" step and the publish result per the matrix above. The diagnostic step can be removed in a follow-up once publishing is confirmed green.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)