### PR TITLE
chore(embedded-sdk): verbose npm logging to diagnose OIDC publish

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -46,3 +46,8 @@ jobs:
           fi
       - run: npm ci
       - run: npm run ci:release
+        env:
+          # Temporary diagnostic: surface npm's OIDC trusted-publishing attempt
+          # and any registry rejection (npm redacts auth tokens in its logs).
+          # Remove once publishing is confirmed working.
+          NPM_CONFIG_LOGLEVEL: verbose


### PR DESCRIPTION
### SUMMARY

Temporary diagnostic to unblock the failing **Embedded SDK Release** job.

State after #41207/#41206/#41210/#41211:
- GitHub OIDC **is** granted to the job (the "Check OIDC availability" step prints `yes`).
- The placeholder token and `registry-url` are both cleared.
- npm 11.13, publishing to the default registry.
- Yet npm still fails with `ENEEDAUTH` and shows **no OIDC activity** at the default log level.

This enables `NPM_CONFIG_LOGLEVEL=verbose` on the publish step so the run logs reveal whether npm attempts the OIDC trusted-publishing exchange and, if so, how the registry rejects it (npm redacts auth tokens in its logs). That distinguishes "npm isn't trying OIDC" from "npmjs.com Trusted Publisher config rejects the exchange."

Temporary — to be reverted once publishing is confirmed working.

### TESTING INSTRUCTIONS

After merge, read the `npm run ci:release` step output in the next *Embedded SDK Release* run for OIDC/HTTP lines around the publish.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)