### PR TITLE
fix(chart): preserve SQL_QUERY_MUTATOR line comments structure

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -780,8 +780,11 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             description = None
 
             for i, statement in enumerate(script.statements):
+                # For a single statement, execute the original SQL as-is. Re-rendering
+                # via statement.format() would round-trip through sqlglot
+                rendered = sql if len(script.statements) == 1 else statement.format()
                 sql_ = self.mutate_sql_based_on_config(
-                    statement.format(),
+                    rendered,
                     is_split=True,
                 )
                 _log_query(sql_)

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1597,3 +1597,29 @@ def test_clear_bootstrap_cache_logs_warning_on_failure(
     mock_logger.warning.assert_called_once()
     call_args = mock_logger.warning.call_args
     assert call_args[0][0] == "Failed to clear theme bootstrap cache: %s"
+
+
+def test_execute_sql_preserves_line_comments_single_statement(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A single statement is executed verbatim, so the ``--`` line comments added by
+    ``SQL_QUERY_MUTATOR`` are not round-tripped through sqlglot (which would rewrite
+    them into ``/* */`` blocks). Regression test for the comment-mangling bug.
+    """
+    database = Database(database_name="db", sqlalchemy_uri="sqlite://")
+    mocker.patch.object(database, "get_sqla_engine")
+    mocker.patch.object(database, "get_raw_connection")
+    mocker.patch.object(database.db_engine_spec, "fetch_data", return_value=[])
+    # Identity mutator so the test isolates whether the SQL got reformatted.
+    mocker.patch.object(
+        database, "mutate_sql_based_on_config", side_effect=lambda sql, **kwargs: sql
+    )
+    execute = mocker.patch.object(database.db_engine_spec, "execute")
+
+    sql = "SELECT 1 AS one\n-- user: alice\n-- company: dunder mifflin"
+    database._execute_sql_with_mutation_and_logging(sql, fetch_last_result=True)
+
+    executed_sql = execute.call_args.args[1]
+    assert executed_sql == sql
+    assert "/*" not in executed_sql


### PR DESCRIPTION
### SUMMARY
A common use case for `SQL_QUERY_MUTATOR` is to add metadata comments to a query. For example, a chart query could be:
``` sql
-- chart_id: 1
-- dataset_id: 1
SELECT COUNT(*) FROM cleaned_sales_data;
```

We were re-parsing the query after the mutator with `.format()`, which would change this query to:
``` sql
/* chart_id: 1 */ /* dataset_id: 1 */
SELECT COUNT(*) FROM cleaned_sales_data;
```

This breaks existing logic built externally to parse logs. Additionally, Superset should change queries as little as possible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Create a virtual dataset with multiple top-level comments like shared above (or configure comments via `SQL_QUERY_MUTATOR`. 
2. Execute a query and confirm it doesn't change the comment structure.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
