### PR TITLE
chore(embedded-sdk): remove temporary OIDC diagnostic step

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -34,15 +34,5 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
-      # Diagnostic: confirm GitHub OIDC is granted to this job. npm trusted
-      # publishing needs the id-token request env vars; "no" here means OIDC was
-      # not issued and publishing cannot authenticate.
-      - name: Check OIDC availability
-        run: |
-          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
-            echo "GitHub OIDC available to job: yes"
-          else
-            echo "GitHub OIDC available to job: no"
-          fi
       - run: npm ci
       - run: npm run ci:release


### PR DESCRIPTION
### SUMMARY

Cleanup. The `Check OIDC availability` step was temporary scaffolding added while debugging why the **Embedded SDK Release** job couldn't authenticate via npm trusted publishing. The root cause turned out to be a Trusted Publisher config mismatch on npmjs.com (now corrected), and `@superset-ui/embedded-sdk@0.4.0` published successfully. This removes the diagnostic step now that it's served its purpose.

The explanatory comment about intentionally omitting `registry-url` is **kept** on purpose — it guards against someone re-adding `registry-url`, which would re-introduce the `.npmrc` auth line that suppresses the OIDC exchange.

No functional change to publishing.

### TESTING INSTRUCTIONS

On the next push to `master`, *Embedded SDK Release* runs as before; the version-check script publishes only when the version is new, so it will no-op now that `0.4.0` is on npm.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)