### PR TITLE
fix(security): reject unknown fields on guest-token RLS rules

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Guest-token RLS rules reject unknown fields
+
+The `rls` rules passed to `POST /api/v1/security/guest_token/` are now validated strictly: a rule may only contain `dataset` and `clause`. Previously unknown fields were silently dropped, so a mistyped or legacy scope key (most commonly `datasource` instead of `dataset`) produced a rule with no `dataset`, which is treated as a *global* rule applied to every dataset the embedded resource can reach. Such a request now returns HTTP 400 identifying the offending field instead of issuing a token with an unintended global rule. Integrators that were sending extra fields in RLS rules must remove them; valid dataset-scoped (`{"dataset": 41, "clause": "..."}`) and global (`{"clause": "..."}`) rules are unaffected.
+
 ### Pivot table First/Last aggregations follow data order
 
 The pivot table chart's `First` and `Last` aggregations now return the first and last value in data (query result) order, instead of effectively returning the minimum and maximum. Existing pivot tables that use these aggregations for totals/subtotals may show different values after upgrading. For deterministic results, ensure the underlying query has a stable sort order.

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -24,7 +24,7 @@ from flask_appbuilder.api.schemas import get_list_schema
 from flask_appbuilder.security.decorators import permission_name, protect
 from flask_appbuilder.security.sqla.models import RegisterUser, Role
 from flask_wtf.csrf import generate_csrf
-from marshmallow import EXCLUDE, fields, post_load, Schema, ValidationError
+from marshmallow import EXCLUDE, fields, post_load, RAISE, Schema, ValidationError
 from sqlalchemy import asc, desc
 from sqlalchemy.orm import selectinload
 
@@ -74,7 +74,26 @@ class ResourceSchema(PermissiveSchema):
         return data
 
 
-class RlsRuleSchema(PermissiveSchema):
+class RlsRuleSchema(Schema):
+    """
+    Schema for a single row-level security rule attached to a guest token.
+
+    Unlike the other guest-token schemas, this one rejects unknown fields
+    instead of silently dropping them. A rule is scoped to a dataset only when
+    it carries a valid integer ``dataset`` key; a rule with no ``dataset`` is
+    treated as global and its ``clause`` is applied to every dataset the
+    embedded resource can reach (see ``get_guest_rls_filters``). Silently
+    excluding an unexpected field -- most commonly a mistyped or legacy scope
+    key such as ``datasource`` -- would therefore turn an intended
+    dataset-scoped rule into a global one without any feedback to the caller.
+    Raising on unknown fields surfaces the mistake as an HTTP 400 before a
+    token is ever issued and keeps the accepted payload aligned with the
+    documented ``RlsRule`` contract (``dataset`` and ``clause``).
+    """
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        unknown = RAISE
+
     dataset = fields.Integer()
     clause = fields.String(required=True)  # todo other options?
 

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -24,7 +24,15 @@ from flask_appbuilder.api.schemas import get_list_schema
 from flask_appbuilder.security.decorators import permission_name, protect
 from flask_appbuilder.security.sqla.models import RegisterUser, Role
 from flask_wtf.csrf import generate_csrf
-from marshmallow import EXCLUDE, fields, post_load, RAISE, Schema, ValidationError
+from marshmallow import (
+    EXCLUDE,
+    fields,
+    post_load,
+    RAISE,
+    Schema,
+    validate,
+    ValidationError,
+)
 from sqlalchemy import asc, desc
 from sqlalchemy.orm import selectinload
 
@@ -80,21 +88,27 @@ class RlsRuleSchema(Schema):
 
     Unlike the other guest-token schemas, this one rejects unknown fields
     instead of silently dropping them. A rule is scoped to a dataset only when
-    it carries a valid integer ``dataset`` key; a rule with no ``dataset`` is
-    treated as global and its ``clause`` is applied to every dataset the
-    embedded resource can reach (see ``get_guest_rls_filters``). Silently
-    excluding an unexpected field -- most commonly a mistyped or legacy scope
-    key such as ``datasource`` -- would therefore turn an intended
+    it carries a valid positive integer ``dataset`` key; a rule with no
+    ``dataset`` is treated as global and its ``clause`` is applied to every
+    dataset the embedded resource can reach (see ``get_guest_rls_filters``).
+    Silently excluding an unexpected field -- most commonly a mistyped or
+    legacy scope key such as ``datasource`` -- would therefore turn an intended
     dataset-scoped rule into a global one without any feedback to the caller.
     Raising on unknown fields surfaces the mistake as an HTTP 400 before a
     token is ever issued and keeps the accepted payload aligned with the
     documented ``RlsRule`` contract (``dataset`` and ``clause``).
+
+    For the same reason ``dataset`` is constrained to strict, positive
+    integers: a falsy value such as ``0`` (or ``false``, which marshmallow
+    coerces to ``0``) would pass a bare ``Integer`` field but then read as
+    falsy in ``get_guest_rls_filters``, silently widening a scoped rule to
+    every dataset.
     """
 
     class Meta:  # pylint: disable=too-few-public-methods
         unknown = RAISE
 
-    dataset = fields.Integer()
+    dataset = fields.Integer(strict=True, validate=validate.Range(min=1))
     clause = fields.String(required=True)  # todo other options?
 
 

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -17,8 +17,10 @@
 from typing import Any
 
 import pytest
+from marshmallow import ValidationError
 
 from superset.extensions import csrf
+from superset.security.api import RlsRuleSchema
 
 
 @pytest.mark.parametrize(
@@ -60,3 +62,44 @@ def test_csrf_exempt_blueprints_with_api_key(app: Any, app_context: None) -> Non
     config is enabled.
     """
     assert "ApiKeyApi" in {blueprint.name for blueprint in csrf._exempt_blueprints}
+
+
+def test_rls_rule_schema_accepts_dataset_scoped_rule() -> None:
+    """A rule with an integer ``dataset`` and a ``clause`` loads unchanged."""
+    result = RlsRuleSchema().load({"dataset": 41, "clause": "tenant_id = 1"})
+    assert result == {"dataset": 41, "clause": "tenant_id = 1"}
+
+
+def test_rls_rule_schema_accepts_global_rule() -> None:
+    """A rule with no ``dataset`` (a global rule) is still valid."""
+    result = RlsRuleSchema().load({"clause": "tenant_id = 1"})
+    assert result == {"clause": "tenant_id = 1"}
+
+
+def test_rls_rule_schema_rejects_unknown_scope_key() -> None:
+    """
+    A mistyped or legacy scope key (e.g. ``datasource`` instead of ``dataset``)
+    used to be silently dropped, turning the rule into an unintended global rule.
+    It now raises a ``ValidationError`` that names the offending field.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        RlsRuleSchema().load(
+            {"datasource": {"id": 41, "type": "table"}, "clause": "tenant_id = 1"}
+        )
+    assert "datasource" in exc_info.value.messages
+
+
+def test_rls_rule_schema_rejects_unknown_fields() -> None:
+    """Any unexpected field on an RLS rule is rejected."""
+    with pytest.raises(ValidationError) as exc_info:
+        RlsRuleSchema().load(
+            {"dataset": 41, "clause": "tenant_id = 1", "extra": "nope"}
+        )
+    assert "extra" in exc_info.value.messages
+
+
+def test_rls_rule_schema_requires_clause() -> None:
+    """``clause`` remains required."""
+    with pytest.raises(ValidationError) as exc_info:
+        RlsRuleSchema().load({"dataset": 41})
+    assert "clause" in exc_info.value.messages

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -103,3 +103,15 @@ def test_rls_rule_schema_requires_clause() -> None:
     with pytest.raises(ValidationError) as exc_info:
         RlsRuleSchema().load({"dataset": 41})
     assert "clause" in exc_info.value.messages
+
+
+@pytest.mark.parametrize("dataset", [0, -1, False])
+def test_rls_rule_schema_rejects_falsy_dataset(dataset: Any) -> None:
+    """
+    A falsy ``dataset`` (``0``, a negative id, or ``false`` which marshmallow
+    coerces to ``0``) would read as falsy in ``get_guest_rls_filters`` and
+    silently widen a scoped rule to every dataset. It is rejected at load time.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        RlsRuleSchema().load({"dataset": dataset, "clause": "tenant_id = 1"})
+    assert "dataset" in exc_info.value.messages


### PR DESCRIPTION
### SUMMARY

`RlsRuleSchema` (used to validate the `rls` rules in `POST /api/v1/security/guest_token/`) inherits from `PermissiveSchema`, whose `Meta.unknown = EXCLUDE` silently drops any field it doesn't recognize. So a guest-token RLS rule that uses a mistyped or legacy scope key — most commonly `datasource: { id, type }` (a leftover from older payloads) instead of the documented `dataset: <int>` — has that key stripped during deserialization. The resulting rule has no `dataset`.

`SecurityManager.get_guest_rls_filters()` treats a rule with no `dataset` as **global** (`if not rule.get("dataset")`, `superset/security/manager.py`), so the clause ends up applied to *every* dataset the embedded resource can reach instead of the single dataset the caller intended. The visible symptom is confusing query errors (e.g. `column "…" does not exist` when the clause lands on an unrelated dataset), and the rule's effective scope silently differs from what the integrator configured.

This makes `RlsRuleSchema` strict (`Meta.unknown = RAISE`) so an unexpected field raises a `ValidationError` (HTTP 400) that names the offending field, *before* a token is ever issued — instead of quietly producing a global rule. This:

- Aligns runtime validation with the documented `RlsRule` contract (the OpenAPI spec advertises only `dataset` and `clause`).
- Surfaces caller mistakes immediately rather than at query time on an unrelated dataset.
- Leaves valid rules untouched — both dataset-scoped (`{"dataset": 41, "clause": "…"}`) and intentionally global (`{"clause": "…"}`) rules still load.
- Keeps the rest of the guest-token payload (`GuestTokenCreateSchema`, `UserSchema`, `ResourceSchema`) permissive, so integrator-specific extra fields elsewhere are unaffected.

Framed as input-validation hardening / DX, not a privilege-escalation fix: the `guest_token` endpoint is called by a trusted integrator holding `can_grant_guest_token`, and RLS clauses are additive restrictions — so the impact is incorrect/over-broad rule scoping and confusing errors, not a Superset access-control bypass.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API-only change.

### TESTING INSTRUCTIONS

Unit tests added in `tests/unit_tests/security/api_test.py`:

- `test_rls_rule_schema_accepts_dataset_scoped_rule` — `{"dataset": 41, "clause": "…"}` still loads.
- `test_rls_rule_schema_accepts_global_rule` — `{"clause": "…"}` (no `dataset`) still loads.
- `test_rls_rule_schema_rejects_unknown_scope_key` — `{"datasource": {…}, "clause": "…"}` now raises `ValidationError` naming `datasource`.
- `test_rls_rule_schema_rejects_unknown_fields` — any other unknown field is rejected.
- `test_rls_rule_schema_requires_clause` — `clause` remains required.

```bash
pytest tests/unit_tests/security/api_test.py -v
```

Manual: `POST /api/v1/security/guest_token/` with an `rls` entry using `datasource` instead of `dataset` now returns HTTP 400 pointing at the `datasource` field, instead of issuing a token whose rule is silently global.

### ADDITIONAL INFORMATION

This tightens an API contract: integrators that were sending extra fields inside RLS rules (previously dropped) will now get a 400. Documented in `UPDATING.md`.

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)