### PR TITLE
fix(echarts): allow forcing categorical x-axis for temporal columns

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -238,11 +238,16 @@ export const xAxisForceCategoricalControl = {
       return state?.form_data?.x_axis_sort !== undefined || control.value;
     },
     renderTrigger: true,
+    // Expose the toggle for numeric and temporal x-axes. Temporal columns
+    // default to a continuous time scale, where ECharts places ticks at "nice"
+    // intervals that don't align with the actual buckets (e.g. weekly grain
+    // markers landing between month ticks). Treating the axis as categorical
+    // lets each bucket map to a discrete, tick-aligned category.
     visibility: ({ controls }: { controls: ControlStateMapping }) =>
       checkColumnType(
         getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
         controls?.datasource?.datasource,
-        [GenericDataType.Numeric],
+        [GenericDataType.Numeric, GenericDataType.Temporal],
       ),
     shouldMapStateToProps: () => true,
   },

--- a/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
@@ -44,7 +44,7 @@ test('xAxisForceCategoricalControl should not treat temporal columns as categori
       x_axis: { value: 'date_column' },
       datasource: { datasource: {} },
     } as unknown as ControlStateMapping,
-  } as ControlPanelState;
+  } as unknown as ControlPanelState;
 
   const result = xAxisForceCategoricalControl.config.initialValue!(
     control,

--- a/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
@@ -55,3 +55,27 @@ test('xAxisForceCategoricalControl should not treat temporal columns as categori
 
   mockCheckColumnType.mockClear();
 });
+
+test('xAxisForceCategoricalControl is visible for numeric and temporal x-axes', () => {
+  const mockCheckColumnType = jest.mocked(checkColumnType);
+  mockCheckColumnType.mockReturnValue(true);
+
+  const controls = {
+    x_axis: { value: 'date_column' },
+    datasource: { datasource: {} },
+  };
+
+  const visible = xAxisForceCategoricalControl.config.visibility!({
+    controls,
+  } as any);
+
+  expect(visible).toBe(true);
+  // Temporal columns must be included so the toggle is exposed for time-grain
+  // charts (e.g. weekly grain), where the time scale misaligns ticks/markers.
+  expect(mockCheckColumnType).toHaveBeenCalledWith('date_column', {}, [
+    GenericDataType.Numeric,
+    GenericDataType.Temporal,
+  ]);
+
+  mockCheckColumnType.mockClear();
+});

--- a/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
@@ -20,7 +20,11 @@
 import { GenericDataType } from '@apache-superset/core/common';
 import { xAxisForceCategoricalControl } from '../../src/shared-controls/customControls';
 import { checkColumnType } from '../../src/utils/checkColumnType';
-import type { ControlState } from '@superset-ui/chart-controls';
+import type {
+  ControlPanelState,
+  ControlState,
+  ControlStateMapping,
+} from '@superset-ui/chart-controls';
 
 jest.mock('../../src/utils/checkColumnType');
 jest.mock('@superset-ui/core', () => ({
@@ -39,12 +43,12 @@ test('xAxisForceCategoricalControl should not treat temporal columns as categori
     controls: {
       x_axis: { value: 'date_column' },
       datasource: { datasource: {} },
-    },
-  };
+    } as unknown as ControlStateMapping,
+  } as ControlPanelState;
 
   const result = xAxisForceCategoricalControl.config.initialValue!(
     control,
-    state as any,
+    state,
   );
 
   // Verify: should return control value (false) for non-numeric columns
@@ -63,11 +67,11 @@ test('xAxisForceCategoricalControl is visible for numeric and temporal x-axes', 
   const controls = {
     x_axis: { value: 'date_column' },
     datasource: { datasource: {} },
-  };
+  } as unknown as ControlStateMapping;
 
   const visible = xAxisForceCategoricalControl.config.visibility!({
     controls,
-  } as any);
+  });
 
   expect(visible).toBe(true);
   // Temporal columns must be included so the toggle is exposed for time-grain

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1569,6 +1569,47 @@ test('xAxisForceCategorical forces Category axis regardless of Numeric coltype',
   expect(xAxis.type).toBe(AxisType.Category);
 });
 
+test('temporal x coltype forced categorical yields a Category axis with date labels', () => {
+  // Issue #28204: with a temporal x-axis (e.g. weekly grain) the default Time
+  // scale places ticks at "nice" intervals that don't line up with the buckets.
+  // Forcing categorical maps each bucket to a discrete, tick-aligned category
+  // while still formatting the labels as dates rather than raw timestamps.
+  const ts1 = 1745784000000;
+  const ts2 = 1745870400000;
+  const chartProps = createTestChartProps({
+    formData: {
+      metrics: ['metric'],
+      granularity_sqla: 'ds',
+      x_axis: '__timestamp',
+      xAxisForceCategorical: true,
+    },
+    queriesData: [
+      createTestQueryData(
+        [
+          { __timestamp: ts1, metric: 10 },
+          { __timestamp: ts2, metric: 20 },
+        ],
+        {
+          colnames: ['__timestamp', 'metric'],
+          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+        },
+      ),
+    ],
+  });
+
+  const { echartOptions } = transformProps(chartProps);
+  const xAxis = echartOptions.xAxis as {
+    type: string;
+    axisLabel: { formatter: (v: Date) => string };
+  };
+
+  expect(xAxis.type).toBe(AxisType.Category);
+  const label = xAxis.axisLabel.formatter(new Date(ts1));
+  expect(typeof label).toBe('string');
+  expect(label).not.toMatch(/NaN/);
+  expect(label).not.toBe(String(ts1));
+});
+
 test('temporal x coltype wires the time formatter and Time axis', () => {
   // Regression guard: the happy path for time-series charts. Ensures that
   // Temporal coltype keeps routing through the TimeFormatter so a refactor


### PR DESCRIPTION
### SUMMARY

Fixes #28204

On a temporal x-axis (any chart using a time grain), Superset hands ECharts `xAxis.type: 'time'`, a continuous linear scale. Bars/points are placed at their exact timestamp, but ECharts auto-computes "nice" tick positions (month boundaries, even N-day divisions) that don't coincide with the actual buckets. With weekly grain this is very visible: a bucket starting `Nov 30` renders right on top of the `Dec` tick, and 5 weekly bars can produce 8 misaligned ticks.

Superset already has the right tool for this: the **Force categorical** toggle (`xAxisForceCategoricalControl`), which switches the axis to `type: 'category'` so each bucket becomes a discrete, tick-aligned category. The transform layer already handles temporal data on a categorical axis (the date formatter is selected by column type, not axis type). The only thing blocking these users was the control's `visibility` gate, which only showed the toggle for **Numeric** x-axis columns.

This PR expands that gate to include **Temporal** columns, so the toggle is exposed for time-grain charts. The numeric-only "auto-force when sorted" logic in `initialValue` is untouched, so existing temporal charts keep their continuous time scale unless the user explicitly opts in (default stays `false`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: on weekly grain, the "Force categorical" toggle is hidden for date x-axes, so ticks land between the weekly markers (see [the reporter's screenshots](https://github.com/apache/superset/discussions/18338#discussioncomment-15871141)).

After: the toggle appears for temporal x-axes; enabling it renders one category per bucket with aligned, date-formatted ticks.

### TESTING INSTRUCTIONS

1. Create a Bar Chart (or Line/Area/Mixed) with a temporal x-axis and **Week** time grain.
2. Confirm a new **Force categorical** checkbox now appears under the Query section (it previously only showed for numeric x-axes).
3. Enable it and verify each weekly bucket gets its own tick, with labels formatted as dates and aligned to the bars/markers.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #28204
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
