### PR TITLE
docs(config): document customizing the landing page via FAB_INDEX_VIEW

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -455,6 +455,51 @@ def FLASK_APP_MUTATOR(app: Flask) -> None:
     app.before_request_funcs.setdefault(None, []).append(make_session_permanent)
 ```
 
+## Customizing the landing page (index view)
+
+The page served at `/` is rendered by an index view. By default Superset registers
+`SupersetIndexView`, which redirects to `/superset/welcome/` and also adds the
+`/lang/<locale>` locale handler. You can replace it with your own view, for example
+to send users straight to a specific dashboard or to a chart list.
+
+Set `FAB_INDEX_VIEW` to the **importable dotted path** of your view class. Flask-AppBuilder
+resolves this during app initialization and uses it in place of the default:
+
+```python
+# my_overrides.py — must be importable on the PYTHONPATH
+from flask import redirect
+from superset.initialization import SupersetIndexView
+from superset.superset_typing import FlaskResponse
+from flask_appbuilder import expose
+
+
+class MyIndexView(SupersetIndexView):
+    @expose("/")
+    def index(self) -> FlaskResponse:
+        return redirect("/chart/list/")
+```
+
+```python
+# superset_config.py
+FAB_INDEX_VIEW = "my_overrides.MyIndexView"
+```
+
+A few things that commonly trip people up:
+
+- **Subclass `SupersetIndexView`, not Flask-AppBuilder's bare `IndexView`.** Subclassing
+  keeps Superset's `/lang/<locale>` locale handling; replacing it with a bare `IndexView`
+  silently drops that behavior.
+- **The class must be importable as a real module.** `FAB_INDEX_VIEW` is resolved by
+  importing the dotted path, which is independent of how `superset_config.py` itself is
+  loaded. Superset only copies **uppercase** names out of `superset_config.py` into its
+  runtime config, so a `FAB_INDEX_VIEW = "superset_config.MyIndexView"` reference only works
+  if `superset_config` is itself importable by that name on the `PYTHONPATH`. If you load
+  config via `SUPERSET_CONFIG_PATH` (an arbitrary file path), put the view in a separate
+  importable module instead and reference that module.
+- **Don't set `appbuilder.indexview` from `FLASK_APP_MUTATOR`.** The mutator runs after
+  routes are already registered, so the assignment has no effect on the `/` route. Use
+  `FAB_INDEX_VIEW` instead.
+
 ## Feature Flags
 
 To support a diverse set of users, Superset has some features that are not enabled by default. For


### PR DESCRIPTION
### SUMMARY

Adds a **"Customizing the landing page (index view)"** section to the configuration docs.

Customizing the `/` route via `FAB_INDEX_VIEW` actually works in current Superset — Flask-AppBuilder resolves it during `init_app` and it overrides the default `SupersetIndexView` (`superset/initialization/__init__.py`, `flask_appbuilder/base.py:169-173`). But the mechanism and its non-obvious gotchas are undocumented, which has produced recurring confusion (e.g. #34422, where the path was thought to be unsupported and folks resorted to monkeypatching workarounds).

The new section documents:
- Setting `FAB_INDEX_VIEW` to an importable dotted path, with a working example.
- **Subclass `SupersetIndexView`** (not bare `IndexView`) to retain the `/lang/<locale>` locale handling.
- The class must be **importable as a real module** on `PYTHONPATH`; only uppercase names are copied out of `superset_config.py`, so referencing a class defined there only works if `superset_config` is importable by name — otherwise put the view in a separate module (relevant when loading config via `SUPERSET_CONFIG_PATH`).
- Don't set `appbuilder.indexview` from `FLASK_APP_MUTATOR` — it runs after routes are registered, so it has no effect.

Imports in the example were verified against the codebase (`FlaskResponse` is in `superset.superset_typing`; `SupersetIndexView` is importable from `superset.initialization`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Docs-only; new subsection under "Flask app Configuration Hook" in `configuring-superset.mdx`. Netlify preview will render it.

### TESTING INSTRUCTIONS

Build the docs (or view the Netlify deploy preview) and confirm the new section renders under Configuration → Configuring Superset.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)