### PR TITLE
perf(screenshots): reuse Playwright browser across tasks instead of launching per-task

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -115,6 +116,48 @@ def check_playwright_availability() -> bool:
 
 
 PLAYWRIGHT_AVAILABLE = check_playwright_availability()
+
+
+class _PlaywrightBrowserManager:
+    """Manages a long-lived Playwright browser instance per worker process.
+
+    In Celery's prefork model, each worker process runs tasks sequentially,
+    so a single browser instance per process is safe and avoids the overhead
+    of launching/destroying Chromium on every screenshot task. Each task
+    creates a lightweight, isolated browser context instead of a full browser.
+    """
+
+    def __init__(self) -> None:
+        self._playwright: Any = None
+        self._browser: Any = None
+
+    def get_browser(self, browser_args: list[str]) -> Any:
+        """Return a reusable browser, creating one if needed."""
+        if self._browser is not None and self._browser.is_connected():
+            return self._browser
+
+        self._cleanup()
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(args=browser_args)
+        return self._browser
+
+    def _cleanup(self) -> None:
+        if self._browser is not None:
+            try:
+                self._browser.close()
+            except Exception:  # noqa: S110
+                pass
+            self._browser = None
+        if self._playwright is not None:
+            try:
+                self._playwright.stop()
+            except Exception:  # noqa: S110
+                pass
+            self._playwright = None
+
+
+_browser_manager = _PlaywrightBrowserManager()
+atexit.register(_browser_manager._cleanup)
 
 
 def validate_webdriver_config() -> dict[str, Any]:
@@ -237,26 +280,25 @@ class WebDriverPlaywright(WebDriverProxy):
             )
             return None
 
-        with sync_playwright() as playwright:
-            browser_args = app.config["WEBDRIVER_OPTION_ARGS"]
-            browser = playwright.chromium.launch(args=browser_args)
-            pixel_density = app.config["WEBDRIVER_WINDOW"].get("pixel_density", 1)
-            viewport_height = self._window[1]
-            viewport_width = self._window[0]
-            context = browser.new_context(
-                bypass_csp=True,
-                viewport={
-                    "height": viewport_height,
-                    "width": viewport_width,
-                },
-                device_scale_factor=pixel_density,
-            )
-            context.set_default_timeout(
-                app.config["SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT"]
-            )
-            if user:
-                self.auth(user, context)
-            page = context.new_page()
+        browser_args = app.config["WEBDRIVER_OPTION_ARGS"]
+        browser = _browser_manager.get_browser(browser_args)
+        pixel_density = app.config["WEBDRIVER_WINDOW"].get("pixel_density", 1)
+        viewport_height = self._window[1]
+        viewport_width = self._window[0]
+        context = browser.new_context(
+            bypass_csp=True,
+            viewport={
+                "height": viewport_height,
+                "width": viewport_width,
+            },
+            device_scale_factor=pixel_density,
+        )
+        context.set_default_timeout(app.config["SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT"])
+        if user:
+            self.auth(user, context)
+        page = context.new_page()
+        img: bytes | None = None
+        try:
             try:
                 page.goto(
                     url,
@@ -269,7 +311,6 @@ class WebDriverPlaywright(WebDriverProxy):
                     url,
                 )
 
-            img: bytes | None = None
             selenium_headstart = app.config["SCREENSHOT_SELENIUM_HEADSTART"]
             logger.debug("Sleeping for %i seconds", selenium_headstart)
             page.wait_for_timeout(selenium_headstart * 1000)
@@ -436,9 +477,9 @@ class WebDriverPlaywright(WebDriverProxy):
                 logger.exception(
                     "Encountered an unexpected error when requesting url %s", url
                 )
-            finally:
-                browser.close()
-            return img
+        finally:
+            context.close()
+        return img
 
 
 class WebDriverSelenium(WebDriverProxy):

--- a/tests/unit_tests/utils/test_playwright_migration_working.py
+++ b/tests/unit_tests/utils/test_playwright_migration_working.py
@@ -23,6 +23,7 @@ These tests demonstrate the core functionality works correctly.
 from unittest.mock import MagicMock, patch
 
 from superset.utils.webdriver import (
+    _PlaywrightBrowserManager,
     PLAYWRIGHT_AVAILABLE,
     validate_webdriver_config,
 )
@@ -98,3 +99,101 @@ class TestPlaywrightMigrationCore:
         # Should have required attributes
         assert hasattr(playwright_driver, "_driver_type")
         assert hasattr(selenium_driver, "_driver_type")
+
+
+class TestPlaywrightBrowserManager:
+    """Tests for the per-worker browser manager."""
+
+    def test_initial_state(self):
+        manager = _PlaywrightBrowserManager()
+        assert manager._playwright is None
+        assert manager._browser is None
+
+    def test_get_browser_creates_browser(self):
+        mock_browser = MagicMock()
+        mock_browser.is_connected.return_value = True
+
+        mock_pw_instance = MagicMock()
+        mock_pw_instance.chromium.launch.return_value = mock_browser
+
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.start.return_value = mock_pw_instance
+
+        manager = _PlaywrightBrowserManager()
+        with patch(
+            "superset.utils.webdriver.sync_playwright", return_value=mock_sync_pw
+        ):
+            browser = manager.get_browser(["--headless"])
+
+        assert browser is mock_browser
+        mock_pw_instance.chromium.launch.assert_called_once_with(args=["--headless"])
+
+    def test_get_browser_reuses_connected_browser(self):
+        mock_browser = MagicMock()
+        mock_browser.is_connected.return_value = True
+
+        manager = _PlaywrightBrowserManager()
+        manager._browser = mock_browser
+        manager._playwright = MagicMock()
+
+        browser = manager.get_browser(["--headless"])
+
+        assert browser is mock_browser
+        # Should NOT launch a new browser
+        manager._playwright.chromium.launch.assert_not_called()
+
+    def test_get_browser_recreates_on_disconnect(self):
+        stale_browser = MagicMock()
+        stale_browser.is_connected.return_value = False
+
+        new_browser = MagicMock()
+        new_browser.is_connected.return_value = True
+
+        mock_pw_instance = MagicMock()
+        mock_pw_instance.chromium.launch.return_value = new_browser
+
+        mock_sync_pw = MagicMock()
+        mock_sync_pw.start.return_value = mock_pw_instance
+
+        manager = _PlaywrightBrowserManager()
+        manager._browser = stale_browser
+        manager._playwright = MagicMock()
+
+        with patch(
+            "superset.utils.webdriver.sync_playwright", return_value=mock_sync_pw
+        ):
+            browser = manager.get_browser(["--headless"])
+
+        assert browser is new_browser
+        stale_browser.close.assert_called_once()
+
+    def test_cleanup(self):
+        mock_browser = MagicMock()
+        mock_playwright = MagicMock()
+
+        manager = _PlaywrightBrowserManager()
+        manager._browser = mock_browser
+        manager._playwright = mock_playwright
+
+        manager._cleanup()
+
+        mock_browser.close.assert_called_once()
+        mock_playwright.stop.assert_called_once()
+        assert manager._browser is None
+        assert manager._playwright is None
+
+    def test_cleanup_handles_exceptions(self):
+        mock_browser = MagicMock()
+        mock_browser.close.side_effect = Exception("crash")
+        mock_playwright = MagicMock()
+        mock_playwright.stop.side_effect = Exception("crash")
+
+        manager = _PlaywrightBrowserManager()
+        manager._browser = mock_browser
+        manager._playwright = mock_playwright
+
+        # Should not raise
+        manager._cleanup()
+
+        assert manager._browser is None
+        assert manager._playwright is None

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -877,27 +877,23 @@ class TestWebDriverPlaywrightErrorHandling:
         )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     @patch("superset.utils.webdriver.take_tiled_screenshot")
     def test_tiled_screenshot_failure_returns_none_without_fallback(
-        self, mock_take_tiled, mock_logger, mock_sync_playwright
+        self, mock_take_tiled, mock_logger, mock_browser_manager
     ) -> None:
         """When take_tiled_screenshot fails, return None rather than fall back to a
         potentially blank standard screenshot."""
         mock_user = MagicMock()
         mock_user.username = "test_user"
 
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
         mock_page.locator.return_value = mock_element

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -444,9 +444,9 @@ class TestWebDriverPlaywrightFallback:
         assert mock_logger.info.call_args[0][1] == PLAYWRIGHT_INSTALL_MESSAGE
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.app")
-    def test_get_screenshot_works_when_available(self, mock_app, mock_sync_playwright):
+    def test_get_screenshot_works_when_available(self, mock_app, mock_browser_manager):
         """Test WebDriverPlaywright.get_screenshot works when Playwright available."""
         # Setup mocks
         mock_user = MagicMock()
@@ -468,16 +468,12 @@ class TestWebDriverPlaywrightFallback:
         }
 
         # Setup playwright mocks
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
         mock_page.locator.return_value = mock_element
@@ -498,10 +494,10 @@ class TestWebDriverPlaywrightFallback:
         )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     def test_get_screenshot_handles_playwright_timeout(
-        self, mock_logger, mock_sync_playwright
+        self, mock_logger, mock_browser_manager
     ):
         """Test WebDriverPlaywright handles PlaywrightTimeout gracefully."""
         from superset.utils.webdriver import PlaywrightTimeout
@@ -510,15 +506,11 @@ class TestWebDriverPlaywrightFallback:
         mock_user.username = "test_user"
 
         # Setup playwright mocks to raise timeout
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
         mock_page.goto.side_effect = PlaywrightTimeout()
@@ -641,10 +633,10 @@ class TestWebDriverPlaywrightErrorHandling:
         mock_close_button.click.assert_called_once()
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.app")
     def test_uses_wait_for_function_to_detect_spinners(
-        self, mock_app, mock_sync_playwright
+        self, mock_app, mock_browser_manager
     ):
         """wait_for_function polls for spinner absence rather than snapshotting."""
         mock_user = MagicMock()
@@ -664,16 +656,12 @@ class TestWebDriverPlaywrightErrorHandling:
             "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE": 10,
         }
 
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
         mock_page.locator.return_value = mock_element
@@ -694,11 +682,11 @@ class TestWebDriverPlaywrightErrorHandling:
         assert loading_locator_calls == []
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     @patch("superset.utils.webdriver.app")
     def test_spinner_timeout_logs_warning_and_raises(
-        self, mock_app, mock_logger, mock_sync_playwright
+        self, mock_app, mock_logger, mock_browser_manager
     ):
         """Spinner timeout is logged as a warning and re-raised."""
         from superset.utils.webdriver import PlaywrightTimeout
@@ -720,16 +708,12 @@ class TestWebDriverPlaywrightErrorHandling:
             "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE": 10,
         }
 
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
         mock_page.locator.return_value = mock_element
@@ -750,10 +734,10 @@ class TestWebDriverPlaywrightErrorHandling:
         )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     def test_get_screenshot_raises_on_element_wait_timeout(
-        self, mock_logger, mock_sync_playwright
+        self, mock_logger, mock_browser_manager
     ):
         """Test that PlaywrightTimeout propagates when waiting for page elements."""
         from superset.utils.webdriver import PlaywrightTimeout
@@ -762,16 +746,12 @@ class TestWebDriverPlaywrightErrorHandling:
         mock_user.username = "test_user"
 
         # Setup mocks
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
 
@@ -787,6 +767,7 @@ class TestWebDriverPlaywrightErrorHandling:
                 "SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT": 30000,
                 "SCREENSHOT_PLAYWRIGHT_WAIT_EVENT": "networkidle",
                 "SCREENSHOT_SELENIUM_HEADSTART": 5,
+                "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 1,
                 "SCREENSHOT_LOCATE_WAIT": 10,
                 "SCREENSHOT_LOAD_WAIT": 10,
                 "SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE": 10,
@@ -813,26 +794,22 @@ class TestWebDriverPlaywrightErrorHandling:
         )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
-    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     def test_missing_element_for_dashboard_height_falls_back_without_crashing(
-        self, mock_logger, mock_sync_playwright
+        self, mock_logger, mock_browser_manager
     ):
         """Missing dashboard element should not crash height evaluation."""
         mock_user = MagicMock()
         mock_user.username = "test_user"
 
-        mock_playwright_instance = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
         mock_page = MagicMock()
         mock_element = MagicMock()
         mock_chart_container = MagicMock()
 
-        mock_sync_playwright.return_value.__enter__.return_value = (
-            mock_playwright_instance
-        )
-        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser_manager.get_browser.return_value = mock_browser
         mock_browser.new_context.return_value = mock_context
         mock_context.new_page.return_value = mock_page
 


### PR DESCRIPTION
### SUMMARY

The Playwright implementation spawns a brand-new Chromium process for every single screenshot task. Each Chromium instance consumes ~100-150 MB and the constant create/destroy cycle adds GC pressure and memory fragmentation.

This PR introduces a per-worker-process browser manager (`_PlaywrightBrowserManager`) that:
- **Lazily creates** a single Chromium browser per Celery worker process (after fork, avoiding Playwright fork-safety issues)
- **Reuses the browser** across tasks, creating only lightweight isolated **browser contexts** per task (~1ms vs ~500ms-1s for a full browser launch)
- **Auto-recovers** from browser crashes via `is_connected()` check
- **Cleans up** via `atexit` on process exit

This is safe because Celery's prefork model runs tasks **sequentially** within each worker process — there is no concurrent access to the browser instance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend performance improvement, no UI changes.

### TESTING INSTRUCTIONS
- Deploy to a staging environment with Playwright enabled (`PLAYWRIGHT_REPORTS_AND_THUMBNAILS` feature flag)
- Trigger multiple screenshot tasks (e.g., dashboard thumbnail generation)
- Verify screenshots are generated correctly
- Monitor worker memory — should see reduced peak memory and less fragmentation vs. baseline
- Verify that if the browser crashes mid-task, the next task recovers automatically

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API