### PR TITLE
fix(deck.gl): render all rings of a MultiPolygon in Polygon layer

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -409,6 +409,90 @@ describe('Polygon transformProps', () => {
     ]);
   });
 
+  test('should explode a MultiPolygon into one feature per polygon', () => {
+    const multiPolygonProps = {
+      ...mockChartProps,
+      queriesData: [
+        {
+          data: [
+            {
+              geom: JSON.stringify({
+                type: 'MultiPolygon',
+                coordinates: [
+                  [
+                    [
+                      [-122.4, 37.8],
+                      [-122.3, 37.8],
+                      [-122.3, 37.9],
+                      [-122.4, 37.8],
+                    ],
+                  ],
+                  [
+                    [
+                      [-121.4, 36.8],
+                      [-121.3, 36.8],
+                      [-121.3, 36.9],
+                      [-121.4, 36.8],
+                    ],
+                  ],
+                ],
+              }),
+              population: 50000,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(multiPolygonProps as ChartProps);
+
+    const features = result.payload.data.features as PolygonFeature[];
+    expect(features).toHaveLength(2);
+    expect(features[0]?.polygon).toEqual([
+      [-122.4, 37.8],
+      [-122.3, 37.8],
+      [-122.3, 37.9],
+      [-122.4, 37.8],
+    ]);
+    expect(features[1]?.polygon).toEqual([
+      [-121.4, 36.8],
+      [-121.3, 36.8],
+      [-121.3, 36.9],
+      [-121.4, 36.8],
+    ]);
+  });
+
+  test('should explode a MultiPolygon wrapped in a GeoJSON Feature', () => {
+    const featureProps = {
+      ...mockChartProps,
+      queriesData: [
+        {
+          data: [
+            {
+              geom: JSON.stringify({
+                type: 'Feature',
+                geometry: {
+                  type: 'MultiPolygon',
+                  coordinates: [
+                    [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                    [[[2, 2], [3, 2], [3, 3], [2, 2]]],
+                  ],
+                },
+              }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(featureProps as ChartProps);
+
+    const features = result.payload.data.features as PolygonFeature[];
+    expect(features).toHaveLength(2);
+    expect(features[0]?.polygon).toEqual([[0, 0], [1, 0], [1, 1], [0, 0]]);
+    expect(features[1]?.polygon).toEqual([[2, 2], [3, 2], [3, 3], [2, 2]]);
+  });
+
   test('should handle geohash decoding successfully', () => {
     const props = {
       ...mockedChartPropsWithGeoHash,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
@@ -33,7 +33,7 @@ function parseElevationValue(value: string): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-interface PolygonFeature {
+interface PolygonFeature extends Record<string, unknown> {
   polygon?: number[][];
   name?: string;
   elevation?: number;
@@ -83,98 +83,92 @@ function processPolygonData(
 
   const excludeKeys = new Set([line_column, ...(js_columns || [])]);
 
-  return records
-    .map(record => {
-      let feature: PolygonFeature = {
-        extraProps: {},
-        metrics: {},
-      };
+  return records.flatMap(record => {
+    let feature: PolygonFeature = {
+      extraProps: {},
+      metrics: {},
+    };
 
-      feature = addJsColumnsToExtraProps(feature, record, js_columns);
-      const updatedFeature = addPropertiesToFeature(
-        feature as unknown as Record<string, unknown>,
-        record,
-        excludeKeys,
-      );
-      feature = updatedFeature as unknown as PolygonFeature;
+    feature = addJsColumnsToExtraProps(feature, record, js_columns);
+    feature = addPropertiesToFeature(feature, record, excludeKeys);
 
-      const rawPolygonData = record[line_column];
-      if (!rawPolygonData) {
-        return null;
+    const rawPolygonData = record[line_column];
+    if (!rawPolygonData) {
+      return [];
+    }
+
+    try {
+      // One ring per polygon; a MultiPolygon yields several rings, all other
+      // shapes yield exactly one.
+      let rings: number[][][];
+
+      switch (line_type) {
+        case 'json': {
+          const parsed =
+            typeof rawPolygonData === 'string'
+              ? JSON.parse(rawPolygonData)
+              : rawPolygonData;
+          // Unwrap GeoJSON Feature ({ geometry: { type, coordinates } })
+          const geom = parsed.geometry ?? parsed;
+
+          if (geom.type === 'MultiPolygon') {
+            // Only the outer ring of each polygon is used; inner rings (holes) are
+            // intentionally ignored because the downstream layer does not support them.
+            rings = geom.coordinates.map((poly: number[][][]) => poly[0]);
+          } else if (geom.coordinates) {
+            // coordinates[0] is the outer ring for Polygon; holes are not rendered.
+            rings = [geom.coordinates[0] || geom.coordinates];
+          } else if (Array.isArray(geom)) {
+            rings = [geom];
+          } else {
+            return [];
+          }
+          break;
+        }
+        case 'geohash': {
+          const decoded = decode_bbox(String(rawPolygonData));
+          if (!decoded) {
+            return [];
+          }
+          rings = [
+            [
+              [decoded[1], decoded[0]], // SW
+              [decoded[1], decoded[2]], // NW
+              [decoded[3], decoded[2]], // NE
+              [decoded[3], decoded[0]], // SE
+              [decoded[1], decoded[0]], // close
+            ],
+          ];
+          break;
+        }
+        case 'zipcode':
+        default:
+          rings = [Array.isArray(rawPolygonData) ? rawPolygonData : []];
       }
 
-      try {
-        let polygonCoords: number[][];
-
-        switch (line_type) {
-          case 'json': {
-            const parsed =
-              typeof rawPolygonData === 'string'
-                ? JSON.parse(rawPolygonData)
-                : rawPolygonData;
-
-            if (parsed.coordinates) {
-              polygonCoords = parsed.coordinates[0] || parsed.coordinates;
-            } else if (parsed.geometry?.coordinates) {
-              // Non-standard format with nested geometry
-              polygonCoords =
-                parsed.geometry.coordinates[0] || parsed.geometry.coordinates;
-            } else if (Array.isArray(parsed)) {
-              polygonCoords = parsed;
-            } else {
-              return null;
-            }
-            break;
-          }
-          case 'geohash':
-            polygonCoords = [];
-            const decoded = decode_bbox(String(rawPolygonData));
-            if (decoded) {
-              polygonCoords.push([decoded[1], decoded[0]]); // SW (minLon, minLat)
-              polygonCoords.push([decoded[1], decoded[2]]); // NW (minLon, maxLat)
-              polygonCoords.push([decoded[3], decoded[2]]); // NE (maxLon, maxLat)
-              polygonCoords.push([decoded[3], decoded[0]]); // SE (maxLon, minLat)
-              polygonCoords.push([decoded[1], decoded[0]]); // SW (close polygon)
-            }
-            break;
-          case 'zipcode':
-          default: {
-            polygonCoords = Array.isArray(rawPolygonData) ? rawPolygonData : [];
-            break;
-          }
-        }
-
-        if (reverse_long_lat && polygonCoords.length > 0) {
-          polygonCoords = polygonCoords.map(coord => [coord[1], coord[0]]);
-        }
-
-        feature.polygon = polygonCoords;
-
-        if (fixedElevationValue !== undefined) {
-          feature.elevation = fixedElevationValue;
-        } else if (elevationLabel && record[elevationLabel] != null) {
-          const elevationValue = parseMetricValue(record[elevationLabel]);
-          if (elevationValue !== undefined) {
-            feature.elevation = elevationValue;
-          }
-        }
-
-        if (metricLabel && record[metricLabel] != null) {
-          const metricValue = record[metricLabel];
-          if (
-            typeof metricValue === 'string' ||
-            typeof metricValue === 'number'
-          ) {
-            feature.metrics![metricLabel] = metricValue;
-          }
-        }
-      } catch {
-        return null;
+      let elevation: number | undefined;
+      if (fixedElevationValue !== undefined) {
+        elevation = fixedElevationValue;
+      } else if (elevationLabel && record[elevationLabel] != null) {
+        elevation = parseMetricValue(record[elevationLabel]);
       }
 
-      return feature;
-    })
-    .filter((feature): feature is PolygonFeature => feature !== null);
+      const metrics = { ...feature.metrics };
+      const metricValue = metricLabel ? record[metricLabel] : undefined;
+      if (typeof metricValue === 'string' || typeof metricValue === 'number') {
+        metrics[metricLabel!] = metricValue;
+      }
+
+      return rings.map(ring => ({
+        ...feature,
+        polygon: reverse_long_lat ? ring.map(c => [c[1], c[0]]) : ring,
+        elevation,
+        metrics,
+      }));
+    } catch {
+      return [];
+    }
+  });
 }
 
 export default function transformProps(chartProps: ChartProps) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Fixes: #32127

### SUMMARY
Expand each record into one feature per polygon ring so MultiPolygon geometries display fully instead of only the first polygon. Skip records whose geohash fails to decode instead of emitting an empty polygon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1485" height="998" alt="Screenshot 2026-06-20 at 11 15 39" src="https://github.com/user-attachments/assets/f6289e8a-96e3-439c-8c65-eaee3e58b8ef" />

After:
<img width="1486" height="1001" alt="Screenshot 2026-06-20 at 11 13 58" src="https://github.com/user-attachments/assets/ee17f81a-23a0-4f2d-a1b9-6935228a584e" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
sql for testing and instructions in #32127

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #32127
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
