### PR TITLE
chore(cursor): add demo hooks to block DB reads and audit tool calls

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/block-dangerous-commands.sh",
+        "failClosed": true
+      }
+    ],
+    "preToolUse": [
+      {
+        "command": ".cursor/hooks/block-dangerous-commands.sh",
+        "failClosed": true
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": ".cursor/hooks/audit-tool-calls.sh"
+      }
+    ],
+    "postToolUseFailure": [
+      {
+        "command": ".cursor/hooks/audit-tool-calls.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/audit-tool-calls.sh
+++ b/.cursor/hooks/audit-tool-calls.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Cursor audit hook: append agent tool call details to JSONL logs under
+# .cursor/audit-logs/. Intended for postToolUse and postToolUseFailure.
+#
+# Always exits 0 so auditing never blocks the agent.
+
+input=$(cat)
+
+log_dir=".cursor/audit-logs"
+mkdir -p "$log_dir"
+
+date_str=$(date -u +"%Y-%m-%d")
+log_file="${log_dir}/${date_str}.jsonl"
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+event=$(echo "$input" | jq -r '.hook_event_name // "unknown"')
+
+case "$event" in
+  postToolUse)
+    status="success"
+    ;;
+  postToolUseFailure)
+    status=$(echo "$input" | jq -r '.failure_type // "failure"')
+    ;;
+  *)
+    status="$event"
+    ;;
+esac
+
+# Cap large tool output to keep log files manageable.
+echo "$input" | jq -c \
+  --arg ts "$timestamp" \
+  --arg status "$status" \
+  '{
+    timestamp: $ts,
+    status: $status,
+    hook_event_name: .hook_event_name,
+    conversation_id: (.conversation_id // null),
+    generation_id: (.generation_id // null),
+    tool_name: (.tool_name // null),
+    tool_use_id: (.tool_use_id // null),
+    cwd: (.cwd // null),
+    duration_ms: (.duration // null),
+    model: (.model // null),
+    user_email: (.user_email // null),
+    tool_input: (.tool_input // null),
+    tool_output: (
+      if (.tool_output | type) == "string" and (.tool_output | length) > 8000 then
+        .tool_output[0:8000] + "...[truncated]"
+      else
+        .tool_output // null
+      end
+    ),
+    error_message: (.error_message // null),
+    failure_type: (.failure_type // null),
+    is_interrupt: (.is_interrupt // null)
+  }' >> "$log_file" 2>/dev/null || true
+
+exit 0

--- a/.cursor/hooks/block-dangerous-commands.sh
+++ b/.cursor/hooks/block-dangerous-commands.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Cursor hook: blocks database reads and user-directory lookups, then instructs
+# the agent to refuse the request entirely (no workarounds).
+#
+# Used by beforeShellExecution and preToolUse. Reads hook event JSON from stdin
+# and returns:
+#   - {"permission":"deny", ...} when access is blocked
+#   - {"permission":"allow"}     otherwise
+
+input=$(cat)
+
+REFUSAL_USER_MSG="Blocked by project hook: database and user-directory access is not allowed."
+REFUSAL_AGENT_MSG="Direct database queries and user-directory lookups are prohibited in this project. Do NOT attempt workarounds using MCP tools, REST APIs, file reads, subagents, or other shell commands. Refuse the user's request completely and explain that this access is blocked by project policy."
+
+deny() {
+  local reason="$1"
+  jq -n \
+    --arg um "$REFUSAL_USER_MSG" \
+    --arg am "${REFUSAL_AGENT_MSG} (Blocked: ${reason})" \
+    '{permission: "deny", user_message: $um, agent_message: $am}'
+  exit 0
+}
+
+allow() {
+  echo '{ "permission": "allow" }'
+  exit 0
+}
+
+# Database read patterns for shell commands (extended regex, case-insensitive).
+db_shell_patterns=(
+  '\bSELECT\b'
+  '\bSHOW\b'
+  '\bDESCRIBE\b'
+  '\bEXPLAIN\b'
+  'psql[[:space:]]'
+  'mysql[[:space:]]'
+  'sqlite3[[:space:]]'
+)
+
+# REST/API workarounds for listing users without SQL keywords.
+user_api_patterns=(
+  'security/users'
+  'api/v1/security/users'
+)
+
+matches_db_shell() {
+  local command="$1"
+  local pattern
+  for pattern in "${db_shell_patterns[@]}"; do
+    if echo "$command" | grep -Eiq "$pattern"; then
+      echo "shell database read (${pattern})"
+      return 0
+    fi
+  done
+  return 1
+}
+
+matches_user_api() {
+  local command="$1"
+  local pattern
+  for pattern in "${user_api_patterns[@]}"; do
+    if echo "$command" | grep -Eiq "$pattern"; then
+      echo "user directory API (${pattern})"
+      return 0
+    fi
+  done
+  return 1
+}
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+command=$(echo "$input" | jq -r '.command // .tool_input.command // empty')
+
+# preToolUse: block MCP workarounds and inspect Shell tool input.
+if [[ -n "$tool_name" ]]; then
+  if echo "$tool_name" | grep -Eiq 'find_users|execute_sql'; then
+    deny "MCP tool ${tool_name}"
+  fi
+
+  if [[ "$tool_name" == "Shell" && -n "$command" ]]; then
+    if reason=$(matches_db_shell "$command"); then
+      deny "$reason"
+    fi
+    if reason=$(matches_user_api "$command"); then
+      deny "$reason"
+    fi
+  fi
+
+  allow
+fi
+
+# beforeShellExecution: inspect the proposed shell command directly.
+if [[ -z "$command" ]]; then
+  allow
+fi
+
+if reason=$(matches_db_shell "$command"); then
+  deny "$reason"
+fi
+
+if reason=$(matches_user_api "$command"); then
+  deny "$reason"
+fi
+
+allow

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ PROJECT.md
 oxc-custom-build/
 *.code-workspace
 *.duckdb
+
+# Cursor agent audit logs (may contain tool output with sensitive data)
+.cursor/audit-logs/*.jsonl


### PR DESCRIPTION
Add project-level Cursor hooks that deny direct database and user-directory access with a refusal agent_message, plus JSONL audit logging for tool use.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
