### PR TITLE
fix(deps): restore np.nan in offset_metrics_df empty branch

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1979,7 +1979,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             if offset_metrics_df.empty:
                 offset_metrics_df = pd.DataFrame(
                     {
-                        col: [np.NaN]
+                        col: [np.nan]
                         for col in join_keys + list(metrics_mapping.values())
                     }
                 )


### PR DESCRIPTION
## What was the problem?

PR #40421 (`fix(sql): broaden mutating-statement detection`) accidentally reverted the `np.NaN → np.nan` fix from PR #41118, reintroducing the deprecated alias in `ExploreMixin.join_offset_dfs()`:

```python
# helpers.py — offset_metrics_df empty branch
{
    col: [np.NaN]          # ← reverted by #40421
    for col in join_keys + list(metrics_mapping.values())
}
```

`np.NaN` was deprecated in NumPy 1.20 and removed in NumPy 2.0. The canonical spelling is `np.nan`.

Source: production Datadog logs showing `DeprecationWarning: \`np.NaN\` was a deprecated alias`.

## What changed?

Single-line fix: `np.NaN` → `np.nan` at `superset/models/helpers.py:1982`.

No behavior change — both are `float('nan')` / IEEE 754 NaN. `np.nan` is the correct, forward-compatible alias.

## No-behavior-change note

`np.nan` and `np.NaN` are semantically identical on NumPy < 2.0. On NumPy ≥ 2.0, `np.NaN` raises `AttributeError`; this fix is strictly an improvement.

## Test plan

- [x] Pre-commit hooks passed (auto-walrus, mypy, ruff, pylint)
- [x] `grep -rn 'np\.NaN' superset/ --include='*.py'` → zero results (no other occurrences in production code)
- [ ] CI green