### PR TITLE
fix(views): emit deprecated-endpoint log warning once per endpoint per process

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -171,20 +171,25 @@ def deprecated(
     """
 
     def _deprecated(f: Callable[..., FlaskResponse]) -> Callable[..., FlaskResponse]:
+        _warned = False
+
         def wraps(self: BaseSupersetView, *args: Any, **kwargs: Any) -> FlaskResponse:
-            message = (
-                "%s.%s "
-                "This API endpoint is deprecated and will be removed in version %s"
-            )
-            logger_args = [
-                self.__class__.__name__,
-                f.__name__,
-                eol_version,
-            ]
-            if new_target:
-                message += " . Use the following API endpoint instead: %s"
-                logger_args.append(new_target)
-            logger.warning(message, *logger_args)
+            nonlocal _warned
+            if not _warned:
+                _warned = True
+                message = (
+                    "%s.%s "
+                    "This API endpoint is deprecated and will be removed in version %s"
+                )
+                logger_args = [
+                    self.__class__.__name__,
+                    f.__name__,
+                    eol_version,
+                ]
+                if new_target:
+                    message += " . Use the following API endpoint instead: %s"
+                    logger_args.append(new_target)
+                logger.warning(message, *logger_args)
             return f(self, *args, **kwargs)
 
         return functools.update_wrapper(wraps, f)

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -209,3 +209,21 @@ def test_csv_response_leaves_bytes_untouched() -> None:
 
     payload = "Ürün\n".encode("utf-8-sig")
     assert CsvResponse(payload).get_data() == payload
+
+
+def test_deprecated_logs_warning_exactly_once() -> None:
+    from superset.views.base import BaseSupersetView, deprecated
+
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
+    def endpoint(self: BaseSupersetView) -> None:
+        return None
+
+    view = MagicMock(spec=BaseSupersetView)
+    view.__class__.__name__ = "Superset"
+
+    with patch("superset.views.base.logger") as mock_logger:
+        endpoint(view)
+        endpoint(view)
+
+    assert mock_logger.warning.call_count == 1
+    assert "5.0.0" in mock_logger.warning.call_args[0][0]

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -226,4 +226,7 @@ def test_deprecated_logs_warning_exactly_once() -> None:
         endpoint(view)
 
     assert mock_logger.warning.call_count == 1
-    assert "5.0.0" in mock_logger.warning.call_args[0][0]
+    # logger.warning uses lazy %-style formatting, so the version is a
+    # separate positional arg rather than being interpolated into the
+    # message template string itself.
+    assert "5.0.0" in mock_logger.warning.call_args[0]


### PR DESCRIPTION
## Summary

**Deprecation warning found in production Datadog:**
`Superset.explore_json This API endpoint is deprecated and will be removed in version 5.0.0`

This message fired on **every** HTTP request to any endpoint decorated with `@deprecated` in `views/base.py`. The `explore_json` endpoint — still used by legacy chart types with `useLegacyApi: true` — was generating this warning thousands of times per day, making the log signal meaningless and adding noise to Datadog.

**What changed:**
- Added a `_warned = False` closure variable inside `_deprecated` (one flag per decorated endpoint, allocated at decoration time).
- The warning now fires exactly **once per endpoint per worker process** on the first call to that endpoint.
- Subsequent requests to the same deprecated endpoint are handled silently.
- Message text and format are unchanged.

**No behavior change:** the endpoint continues to respond normally on every request. Only the repeated log line is suppressed.

**Thread safety:** the first-call race on multi-threaded workers is benign — at worst two or three log lines on startup, then silence. No lock needed.

## Test plan

- [ ] Verify `explore_json` deprecation warning appears exactly once in logs after a gunicorn worker starts (not on every request)
- [ ] Verify the endpoint itself still returns correct responses (no logic change)
- [ ] Run existing integration tests: `pytest tests/integration_tests/core_tests.py -k explore_json`
- [ ] Confirm no existing tests assert the warning fires on every request (none exist: `grep -rn "deprecated.*Warning" tests/` returns no hits for `views/base`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)