### PR TITLE
chore(deps): bump pyjwt to 2.13.0 (CVE-2026-48526)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -315,7 +315,7 @@ pygeohash==3.2.2
     # via apache-superset (pyproject.toml)
 pygments==2.20.0
     # via rich
-pyjwt==2.12.0
+pyjwt==2.13.0
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -769,7 +769,7 @@ pyhive==0.7.0
     # via apache-superset
 pyinstrument==5.1.2
     # via apache-superset
-pyjwt==2.12.0
+pyjwt==2.13.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset


### PR DESCRIPTION
### SUMMARY

Bumps `pyjwt` from `2.12.0` to `2.13.0` to address **CVE-2026-48526** ([GHSA-xgmm-8j9v-c9wx](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-xgmm-8j9v-c9wx)): PyJWT < 2.13.0 accepts a public-key JWK as an HMAC secret, allowing forged HS256 tokens when mixed key families are permitted.

PyJWT is a direct dependency (`pyproject.toml`: `PyJWT>=2.4.0, <3.0`) and is used for JWT handling, including embedded/guest tokens. The existing constraint already permits `2.13.0`, so this is just a lockfile patch bump in `requirements/base.txt` and `requirements/development.txt`.

This clears the open Dependabot alerts for `pyjwt` (#1342 high, plus the medium/low duplicates) which had no Dependabot PR since `pyjwt` is resolved transitively in the compiled lockfiles.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, dependency bump.

### TESTING INSTRUCTIONS

CI. No code changes; patch-level bump of a backward-compatible release.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
