### PR TITLE
fix(rls): preserve tables/roles on partial RLS rule updates

### DIFF
--- a/superset/commands/security/update.py
+++ b/superset/commands/security/update.py
@@ -66,3 +66,9 @@ class UpdateRLSRuleCommand(BaseCommand):
                 raise DatasourceNotFoundValidationError()
             raise_for_datasource_access(tables)
             self._properties["tables"] = tables
+        else:
+            # A partial update that omits ``tables`` still mutates the rule, so
+            # enforce datasource access against the rule's existing tables to
+            # avoid letting a caller edit a rule bound to datasources they
+            # cannot access.
+            raise_for_datasource_access(self._model.tables)

--- a/superset/commands/security/update.py
+++ b/superset/commands/security/update.py
@@ -50,14 +50,19 @@ class UpdateRLSRuleCommand(BaseCommand):
         self._model = RLSDAO.find_by_id(int(self._model_id))
         if not self._model:
             raise RLSRuleNotFoundError()
-        roles = populate_roles(self._roles)
-        tables = (
-            db.session.query(SqlaTable)
-            .filter(SqlaTable.id.in_(self._tables))  # type: ignore[attr-defined]
-            .all()
-        )
-        if len(tables) != len(self._tables):
-            raise DatasourceNotFoundValidationError()
-        raise_for_datasource_access(tables)
-        self._properties["roles"] = roles
-        self._properties["tables"] = tables
+        # Only resolve and overwrite the relationships that are actually present
+        # in the request body. A partial update (e.g. changing only the name)
+        # must leave the rule's existing tables/roles bindings untouched rather
+        # than replacing them with empty lists.
+        if "roles" in self._properties:
+            self._properties["roles"] = populate_roles(self._roles)
+        if "tables" in self._properties:
+            tables = (
+                db.session.query(SqlaTable)
+                .filter(SqlaTable.id.in_(self._tables))  # type: ignore[attr-defined]
+                .all()
+            )
+            if len(tables) != len(self._tables):
+                raise DatasourceNotFoundValidationError()
+            raise_for_datasource_access(tables)
+            self._properties["tables"] = tables

--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -169,6 +169,7 @@ class RLSPutSchema(Schema):
         metadata={"description": "tables_description"},
         required=False,
         allow_none=False,
+        validate=Length(1),
     )
     roles = fields.List(
         fields.Integer(),

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -159,15 +159,21 @@ def test_update_rls_rule_partial_update_preserves_tables_and_roles() -> None:
     those keys to the properties passed to the DAO, so the existing bindings
     are left untouched instead of being overwritten with empty lists.
     """
+    rule = MagicMock()
+    rule.tables = _mock_tables(1)
     with (
         patch(
             "superset.commands.security.update.RLSDAO.find_by_id",
-            return_value=MagicMock(),
+            return_value=rule,
         ),
         patch(
             "superset.commands.security.update.populate_roles",
         ) as populate_roles,
         patch("superset.commands.security.update.db.session.query") as query,
+        patch(
+            "superset.commands.security.utils.security_manager.can_access_datasource",
+            return_value=True,
+        ),
     ):
         command = UpdateRLSRuleCommand(1, {"name": "new name"})
         command.validate()
@@ -182,16 +188,22 @@ def test_update_rls_rule_partial_update_preserves_tables_and_roles() -> None:
 
 def test_update_rls_rule_only_roles_present_does_not_touch_tables() -> None:
     """Updating only ``roles`` must not resolve or overwrite ``tables``."""
+    rule = MagicMock()
+    rule.tables = _mock_tables(1)
     with (
         patch(
             "superset.commands.security.update.RLSDAO.find_by_id",
-            return_value=MagicMock(),
+            return_value=rule,
         ),
         patch(
             "superset.commands.security.update.populate_roles",
             return_value=["resolved-role"],
         ) as populate_roles,
         patch("superset.commands.security.update.db.session.query") as query,
+        patch(
+            "superset.commands.security.utils.security_manager.can_access_datasource",
+            return_value=True,
+        ),
     ):
         command = UpdateRLSRuleCommand(1, {"roles": [1]})
         command.validate()
@@ -200,6 +212,35 @@ def test_update_rls_rule_only_roles_present_does_not_touch_tables() -> None:
     query.assert_not_called()
     assert command._properties["roles"] == ["resolved-role"]
     assert "tables" not in command._properties
+
+
+def test_update_rls_rule_partial_update_enforces_access_on_existing_tables() -> None:
+    """A partial update that omits ``tables`` still enforces datasource access.
+
+    The rule's existing table bindings must be authorized so a caller cannot
+    edit a rule tied to datasources they cannot access by simply omitting
+    ``tables`` from the payload.
+    """
+    rule = MagicMock()
+    rule.tables = _mock_tables(1)
+    with (
+        patch(
+            "superset.commands.security.update.RLSDAO.find_by_id",
+            return_value=rule,
+        ),
+        patch("superset.commands.security.update.db.session.query") as query,
+        patch(
+            "superset.commands.security.utils.security_manager.can_access_datasource",
+            return_value=False,
+        ) as can_access,
+    ):
+        command = UpdateRLSRuleCommand(1, {"name": "new name"})
+        with pytest.raises(RLSDatasourceForbiddenError):
+            command.validate()
+
+    # Access is checked against the rule's existing tables, not a submitted set.
+    can_access.assert_called_once_with(datasource=rule.tables[0])
+    query.assert_not_called()
 
 
 def test_delete_rls_rule_forbidden_when_no_datasource_access() -> None:

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -152,6 +152,56 @@ def test_update_rls_rule_allowed_when_datasource_access() -> None:
     assert command._properties["tables"] == tables
 
 
+def test_update_rls_rule_partial_update_preserves_tables_and_roles() -> None:
+    """A partial update without tables/roles must not clear those bindings.
+
+    When the request body omits ``tables``/``roles``, validate() must not add
+    those keys to the properties passed to the DAO, so the existing bindings
+    are left untouched instead of being overwritten with empty lists.
+    """
+    with (
+        patch(
+            "superset.commands.security.update.RLSDAO.find_by_id",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "superset.commands.security.update.populate_roles",
+        ) as populate_roles,
+        patch("superset.commands.security.update.db.session.query") as query,
+    ):
+        command = UpdateRLSRuleCommand(1, {"name": "new name"})
+        command.validate()
+
+    # Omitted relationships are not resolved or written back.
+    populate_roles.assert_not_called()
+    query.assert_not_called()
+    assert "tables" not in command._properties
+    assert "roles" not in command._properties
+    assert command._properties["name"] == "new name"
+
+
+def test_update_rls_rule_only_roles_present_does_not_touch_tables() -> None:
+    """Updating only ``roles`` must not resolve or overwrite ``tables``."""
+    with (
+        patch(
+            "superset.commands.security.update.RLSDAO.find_by_id",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "superset.commands.security.update.populate_roles",
+            return_value=["resolved-role"],
+        ) as populate_roles,
+        patch("superset.commands.security.update.db.session.query") as query,
+    ):
+        command = UpdateRLSRuleCommand(1, {"roles": [1]})
+        command.validate()
+
+    populate_roles.assert_called_once()
+    query.assert_not_called()
+    assert command._properties["roles"] == ["resolved-role"]
+    assert "tables" not in command._properties
+
+
 def test_delete_rls_rule_forbidden_when_no_datasource_access() -> None:
     tables = _mock_tables(1)
     rule = MagicMock()


### PR DESCRIPTION
### SUMMARY

`UpdateRLSRuleCommand` read `tables`/`roles` from the request body defaulting to `[]`, and unconditionally wrote them back during `validate()`. As a result, a partial `PUT` that omitted those fields (e.g. `{"name": "new name"}`) replaced the rule's table and role bindings with empty lists — silently changing which rows the RLS filter constrains.

This makes partial updates behave as expected:

- `validate()` now only resolves and overwrites the relationships that are actually present in the request body. Omitted `tables`/`roles` are left untouched.
- `RLSPutSchema.tables` gains `Length(1)`, mirroring `RLSPostSchema`, so `tables` cannot be set to an empty list on update either.

`roles` keeps no minimum-length constraint, matching the create schema (base filters may legitimately specify zero excluded roles).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend command/schema behavior.

### TESTING INSTRUCTIONS

Unit tests added in `tests/unit_tests/commands/security/rls_test.py`:

- A partial update omitting `tables`/`roles` does not resolve or write those keys (existing bindings preserved).
- An update touching only `roles` does not resolve or overwrite `tables`.

Run: `pytest tests/unit_tests/commands/security/rls_test.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

> Note: `PUT /api/v1/rowlevelsecurity/<pk>` with an explicit empty `tables` list is now rejected (must contain at least one table), consistent with create.
