### PR TITLE
fix(security): return generic error and log internally in RoleRestAPI.get_list

### DIFF
--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -358,8 +358,12 @@ class RoleRestAPI(BaseSupersetApi):
             )
         except ForbiddenError as e:
             return self.response_403(message=str(e))
-        except Exception as e:
-            return self.response_500(message=str(e))
+        except Exception:
+            # Log the full error server-side for operator visibility, but return
+            # a generic message so internal details (ORM/driver error text, SQL
+            # fragments, schema names) are not echoed back to the caller.
+            logger.exception("Unexpected error in RoleRestAPI.get_list")
+            return self.response_500(message="An unexpected error occurred")
 
 
 class UserRegistrationsRestAPI(BaseSupersetModelRestApi):

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -350,6 +350,30 @@ class TestSecurityRolesApi(SupersetTestCase):
         )
         self.assert403(response)
 
+    def test_show_roles_unexpected_error_returns_generic_message(self):
+        """
+        Security API: an unexpected error in role listing returns a generic 500
+        body (no raw exception text) and is logged server-side.
+        """
+        from unittest.mock import patch
+
+        self.login(ADMIN_USERNAME)
+        error_detail = "raw-driver-detail-should-not-leak"
+        with (
+            patch(
+                "superset.security.api.db.session.query",
+                side_effect=Exception(error_detail),
+            ),
+            patch("superset.security.api.logger") as mock_logger,
+        ):
+            response = self.client.get(self.show_uri)
+
+        assert response.status_code == 500
+        body = response.data.decode("utf-8")
+        assert error_detail not in body
+        assert "An unexpected error occurred" in body
+        mock_logger.exception.assert_called_once()
+
     def test_show_roles_admin(self):
         """
         Security API: Admin should be able to show roles with permissions and users

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -359,9 +359,12 @@ class TestSecurityRolesApi(SupersetTestCase):
 
         self.login(ADMIN_USERNAME)
         error_detail = "raw-driver-detail-should-not-leak"
+        # Patch a symbol used only inside get_list's query construction so the
+        # failure happens within the handler's try/except, not in the @protect()
+        # auth check (which also touches db.session.query).
         with (
             patch(
-                "superset.security.api.db.session.query",
+                "superset.security.api.selectinload",
                 side_effect=Exception(error_detail),
             ),
             patch("superset.security.api.logger") as mock_logger,


### PR DESCRIPTION
### SUMMARY

`RoleRestAPI.get_list` (`/api/v1/security/roles/search/`) caught unexpected errors with a hand-written `except Exception` that returned `str(e)` directly in the HTTP 500 response body and made no logging call. This meant raw ORM/driver error text could surface to the caller, while the same error was invisible in the structured logging pipeline.

This change:

- Logs the exception server-side via `logger.exception(...)` so operators get the full detail and stack trace.
- Returns a generic `"An unexpected error occurred"` message to the caller instead of the raw exception text.

The endpoint remains gated behind `@protect()` / `list_roles`; this only changes what an unexpected-error response body contains and ensures the error is recorded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend error-handling behavior.

### TESTING INSTRUCTIONS

Integration test added in `tests/integration_tests/security/api_tests.py` (`test_show_roles_unexpected_error_returns_generic_message`):

- Forces an exception inside `get_list`.
- Asserts the 500 body does not contain the raw exception detail, contains the generic message, and that `logger.exception` was called.

Run: `pytest tests/integration_tests/security/api_tests.py -k unexpected_error`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
