### PR TITLE
fix(mcp): fail closed when the JWT verifier has no pinned algorithm

### DIFF
--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -511,7 +511,17 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                     _sanitize_for_log(token_alg),
                 )
                 return None
-            if self.algorithm and token_alg != self.algorithm:
+            # Require a pinned signing algorithm. Without one, the accepted
+            # algorithm family would be whatever the verification key or the
+            # underlying library permits; refuse rather than validating against
+            # an unconstrained algorithm set. The production factory always
+            # pins an algorithm, so this guards the directly-constructed case.
+            if not self.algorithm:
+                reason = "No signing algorithm pinned"
+                _jwt_failure_reason.set(reason)
+                logger.debug("Rejected token: verifier has no pinned signing algorithm")
+                return None
+            if token_alg != self.algorithm:
                 reason = "Algorithm mismatch"
                 _jwt_failure_reason.set(reason)
                 logger.debug(

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -84,6 +84,29 @@ async def test_algorithm_mismatch(hs256_verifier):
 
 
 @pytest.mark.asyncio
+async def test_unpinned_algorithm_is_rejected(hs256_verifier):
+    """A verifier with no pinned algorithm must reject signed tokens.
+
+    The upstream JWTVerifier currently always defaults the algorithm to RS256,
+    so this state is not reachable through normal construction. This asserts the
+    fail-closed guard so the verifier does not silently rely on that upstream
+    default: if the pinned algorithm is ever absent, tokens are rejected rather
+    than validated against an unconstrained algorithm family.
+    """
+    # Simulate an unpinned verifier (e.g. a future upstream default change).
+    hs256_verifier.algorithm = None
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+
+    result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    assert _jwt_failure_reason.get() == "No signing algorithm pinned"
+
+
+@pytest.mark.asyncio
 async def test_malformed_token_header(hs256_verifier):
     """Token with invalid header should report malformed header."""
     # A token with only 2 parts (missing signature)

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -84,7 +84,9 @@ async def test_algorithm_mismatch(hs256_verifier):
 
 
 @pytest.mark.asyncio
-async def test_unpinned_algorithm_is_rejected(hs256_verifier):
+async def test_unpinned_algorithm_is_rejected(
+    hs256_verifier: DetailedJWTVerifier,
+) -> None:
     """A verifier with no pinned algorithm must reject signed tokens.
 
     The upstream JWTVerifier currently always defaults the algorithm to RS256,


### PR DESCRIPTION
### SUMMARY

`DetailedJWTVerifier.load_access_token` rejected the `none` algorithm and otherwise compared the token's `alg` against `self.algorithm` — but only inside an `if self.algorithm` guard. The pinned value is currently always populated because the upstream `JWTVerifier` defaults `algorithm` to `RS256`, so the verifier was effectively relying on that upstream default to keep the algorithm pinned.

This makes the pinning explicit and self-contained: if no algorithm is pinned, the verifier now rejects the token (fail closed) rather than validating against whatever algorithm family the key/library would otherwise permit. It removes the implicit dependency on the upstream default.

This is a small defense-in-depth change — under current behavior `self.algorithm` is always set — so there is no functional change for normally constructed verifiers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend verification behavior.

### TESTING INSTRUCTIONS

Unit test added in `tests/unit_tests/mcp_service/test_jwt_verifier.py` (`test_unpinned_algorithm_is_rejected`): an unpinned verifier rejects a signed token with reason `"No signing algorithm pinned"`.

Run: `pytest tests/unit_tests/mcp_service/test_jwt_verifier.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
