### PR TITLE
fix(rls): reject empty or whitespace-only RLS clauses

### DIFF
--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -16,12 +16,24 @@
 # under the License.
 
 
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, ValidationError
 from marshmallow.validate import Length, OneOf
 
 from superset.connectors.sqla.models import RowLevelSecurityFilter
 from superset.dashboards.schemas import UserSchema
 from superset.utils.core import RowLevelSecurityFilterType
+
+
+def validate_non_blank_clause(value: str) -> None:
+    """Reject empty or whitespace-only RLS clauses.
+
+    An empty clause produces a non-restrictive predicate, which silently
+    disables the control when used as a base filter. Require a non-blank clause
+    on both the create and update paths.
+    """
+    if not value or not value.strip():
+        raise ValidationError("clause cannot be empty or whitespace-only.")
+
 
 id_description = "Unique if of rls filter"
 name_description = "Name of rls filter"
@@ -140,7 +152,10 @@ class RLSPostSchema(Schema):
         allow_none=True,
     )
     clause = fields.String(
-        metadata={"description": "clause_description"}, required=True, allow_none=False
+        metadata={"description": "clause_description"},
+        required=True,
+        allow_none=False,
+        validate=validate_non_blank_clause,
     )
 
 
@@ -182,5 +197,8 @@ class RLSPutSchema(Schema):
         allow_none=True,
     )
     clause = fields.String(
-        metadata={"description": "clause_description"}, required=False, allow_none=False
+        metadata={"description": "clause_description"},
+        required=False,
+        allow_none=False,
+        validate=validate_non_blank_clause,
     )

--- a/tests/unit_tests/row_level_security/__init__.py
+++ b/tests/unit_tests/row_level_security/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/row_level_security/schema_test.py
+++ b/tests/unit_tests/row_level_security/schema_test.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for row-level security marshmallow schemas."""
+
+import pytest
+from marshmallow import ValidationError
+
+from superset.row_level_security.schemas import RLSPostSchema, RLSPutSchema
+
+
+def _post_payload(**overrides):
+    payload = {
+        "name": "rule",
+        "filter_type": "Regular",
+        "tables": [1],
+        "roles": [1],
+        "clause": "client_id = 9",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize("clause", ["", "   ", "\t\n"])
+def test_rls_post_schema_rejects_blank_clause(clause: str) -> None:
+    """An empty or whitespace-only clause is rejected on create."""
+    with pytest.raises(ValidationError) as exc:
+        RLSPostSchema().load(_post_payload(clause=clause))
+    assert "clause" in exc.value.messages
+
+
+def test_rls_post_schema_accepts_non_blank_clause() -> None:
+    """A non-blank clause is accepted on create."""
+    result = RLSPostSchema().load(_post_payload(clause="1 = 0"))
+    assert result["clause"] == "1 = 0"
+
+
+@pytest.mark.parametrize("clause", ["", "   ", "\t\n"])
+def test_rls_put_schema_rejects_blank_clause(clause: str) -> None:
+    """An empty or whitespace-only clause is rejected on update."""
+    with pytest.raises(ValidationError) as exc:
+        RLSPutSchema().load({"clause": clause})
+    assert "clause" in exc.value.messages
+
+
+def test_rls_put_schema_omitted_clause_is_allowed() -> None:
+    """A partial update that omits clause is still valid."""
+    result = RLSPutSchema().load({"name": "new name"})
+    assert "clause" not in result

--- a/tests/unit_tests/row_level_security/schema_test.py
+++ b/tests/unit_tests/row_level_security/schema_test.py
@@ -16,14 +16,16 @@
 # under the License.
 """Tests for row-level security marshmallow schemas."""
 
+from typing import Any
+
 import pytest
 from marshmallow import ValidationError
 
 from superset.row_level_security.schemas import RLSPostSchema, RLSPutSchema
 
 
-def _post_payload(**overrides):
-    payload = {
+def _post_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "name": "rule",
         "filter_type": "Regular",
         "tables": [1],


### PR DESCRIPTION
### SUMMARY

The RLS `clause` field was validated only for presence and type (`required=True` / `allow_none=False`), which does not reject an empty string and has no non-blank constraint. An empty or whitespace-only clause could be persisted; as a base filter (designed to always restrict) an empty clause produces a predicate that constrains nothing, silently disabling the control.

This adds a non-blank validator to the `clause` field on both the create (`RLSPostSchema`) and update (`RLSPutSchema`) schemas, rejecting empty and whitespace-only clauses on both paths.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — schema validation behavior.

### TESTING INSTRUCTIONS

Unit tests added in `tests/unit_tests/row_level_security/schema_test.py`:

- Blank/whitespace clauses are rejected on create and update.
- Non-blank clauses are accepted.
- A partial update that omits `clause` remains valid.

Run: `pytest tests/unit_tests/row_level_security/schema_test.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
