### PR TITLE
fix(safe-markdown): do not mutate the shared sanitization schema

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -22,7 +22,7 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 // remark-gfm v4+ requires react-markdown v9+, which requires React 18.
 // Currently pinned to v3.0.1 for compatibility with react-markdown v8 and React 17.
 import remarkGfm from 'remark-gfm';
-import { mergeWith } from 'lodash';
+import { cloneDeep, mergeWith } from 'lodash';
 import { FeatureFlag, isFeatureEnabled } from '../../utils';
 
 interface SafeMarkdownProps {
@@ -82,8 +82,15 @@ export function getOverrideHtmlSchema(
   originalSchema: typeof defaultSchema,
   htmlSchemaOverrides: SafeMarkdownProps['htmlSchemaOverrides'],
 ) {
-  return mergeWith(originalSchema, htmlSchemaOverrides, (objValue, srcValue) =>
-    Array.isArray(objValue) ? objValue.concat(srcValue) : undefined,
+  // Merge into a fresh clone: mergeWith mutates its first argument, and the
+  // array customizer concatenates, so merging into the shared defaultSchema
+  // import would progressively widen the sanitization allowlist for every
+  // SafeMarkdown instance app-wide.
+  return mergeWith(
+    cloneDeep(originalSchema),
+    htmlSchemaOverrides,
+    (objValue, srcValue) =>
+      Array.isArray(objValue) ? objValue.concat(srcValue) : undefined,
   );
 }
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -17,6 +17,8 @@
  * under the License.
  */
 import { render } from '@testing-library/react';
+import { cloneDeep } from 'lodash';
+import { defaultSchema } from 'rehype-sanitize';
 import {
   getOverrideHtmlSchema,
   SafeMarkdown,
@@ -50,6 +52,36 @@ describe('getOverrideHtmlSchema', () => {
     expect(result.clobberPrefix).toEqual('custom-prefix');
     expect(result.attributes).toEqual({ '*': ['size', 'src'], h1: ['style'] });
     expect(result.tagNames).toEqual(['h1', 'h2', 'h3', 'iframe']);
+  });
+
+  test('should not mutate the original schema', () => {
+    const original = {
+      attributes: { '*': ['size'] },
+      tagNames: ['h1'],
+    };
+    getOverrideHtmlSchema(original, {
+      attributes: { '*': ['src'] },
+      tagNames: ['iframe'],
+    });
+    // The original passed in is left untouched.
+    expect(original.attributes).toEqual({ '*': ['size'] });
+    expect(original.tagNames).toEqual(['h1']);
+  });
+
+  test('should not mutate the shared defaultSchema import or accumulate across calls', () => {
+    const snapshot = cloneDeep(defaultSchema);
+    const overrides = { tagNames: ['iframe'] };
+
+    const first = getOverrideHtmlSchema(defaultSchema, overrides);
+    const second = getOverrideHtmlSchema(defaultSchema, overrides);
+
+    // The shared singleton is never modified...
+    expect(defaultSchema).toEqual(snapshot);
+    // ...and repeated calls do not accumulate the override (no growing arrays).
+    expect(first.tagNames).toEqual(second.tagNames);
+    expect(
+      (second.tagNames ?? []).filter(name => name === 'iframe'),
+    ).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
### SUMMARY

`getOverrideHtmlSchema` passed the module-level `defaultSchema` import from `rehype-sanitize` as the first argument to lodash `mergeWith`, which mutates its first argument in place. Because the array customizer concatenates rather than replaces, the allowed tags/attributes/protocols arrays grew on each call — progressively widening the sanitization allowlist for every `SafeMarkdown` instance across the app, not just the one with overrides.

This merges into a fresh `cloneDeep` of the schema so the shared singleton is never modified and repeated calls do not accumulate overrides.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal behavior.

### TESTING INSTRUCTIONS

Tests added in `superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx`:

- The original schema passed in is not mutated.
- The shared `defaultSchema` import is unchanged after calls, and repeated calls do not accumulate the override (arrays do not grow).

Run: `cd superset-frontend && npm run test -- packages/superset-ui-core/test/components/SafeMarkdown.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
