### PR TITLE
fix(config): make Swagger UI opt-in (off by default)

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,6 +32,10 @@ The `rls` rules passed to `POST /api/v1/security/guest_token/` are now validated
 
 When the MCP service has JWT auth enabled (`MCP_AUTH_ENABLED = True`), an audience must be configured via `MCP_JWT_AUDIENCE` so issued tokens are bound to this service. The service now fails to start with a clear configuration error when the audience is unset, instead of starting with audience validation skipped. Deployments that enable MCP JWT auth must set `MCP_JWT_AUDIENCE` to the audience value their identity provider issues for the MCP service. API-key-only MCP deployments (JWT auth disabled) are unaffected.
 
+### Swagger UI is opt-in (off by default)
+
+`FAB_API_SWAGGER_UI` now defaults to `False` and is driven by the `SUPERSET_ENABLE_SWAGGER_UI` environment variable. The interactive Swagger UI / OpenAPI documentation endpoints (e.g. `/swagger/v1`) are therefore no longer exposed by default. To enable them, set `SUPERSET_ENABLE_SWAGGER_UI=true` (the bundled Docker development environment sets this) or override `FAB_API_SWAGGER_UI = True` in `superset_config.py`.
+
 ### Pivot table First/Last aggregations follow data order
 
 The pivot table chart's `First` and `Last` aggregations now return the first and last value in data (query result) order, instead of effectively returning the minimum and maximum. Existing pivot tables that use these aggregations for totals/subtotals may show different values after upgrading. For deterministic results, ensure the underlying query has a stable sort order.

--- a/docker/.env
+++ b/docker/.env
@@ -70,6 +70,8 @@ SUPERSET_LOG_LEVEL=info
 
 SUPERSET_APP_ROOT="/"
 SUPERSET_ENV=development
+# Swagger UI is opt-in (off by default); enable it for local development.
+SUPERSET_ENABLE_SWAGGER_UI=true
 SUPERSET_LOAD_EXAMPLES=yes
 CYPRESS_CONFIG=false
 SUPERSET_PORT=8088

--- a/superset/config.py
+++ b/superset/config.py
@@ -434,7 +434,13 @@ LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1
-FAB_API_SWAGGER_UI = True
+# Disabled by default so the interactive API documentation surface is opt-in.
+# Enable it by setting the SUPERSET_ENABLE_SWAGGER_UI environment variable
+# (e.g. for local development) or by overriding FAB_API_SWAGGER_UI in
+# superset_config.py.
+FAB_API_SWAGGER_UI = utils.cast_to_boolean(
+    os.environ.get("SUPERSET_ENABLE_SWAGGER_UI", False)
+)
 
 # ----------------------------------------------------
 # AUTHENTICATION CONFIG

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -135,6 +135,10 @@ ALERT_REPORTS_QUERY_EXECUTION_MAX_TRIES = 3
 
 FAB_ADD_SECURITY_API = True
 
+# Swagger UI / OpenAPI spec is opt-in in the base config; enable it for tests
+# that exercise the /api/v1/_openapi spec endpoint.
+FAB_API_SWAGGER_UI = True
+
 
 class CeleryConfig:
     broker_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"

--- a/tests/unit_tests/config_swagger_ui_test.py
+++ b/tests/unit_tests/config_swagger_ui_test.py
@@ -29,8 +29,21 @@ import pytest
 
 
 def _resolve_swagger_default(env_value: str | None) -> str:
+    """Resolve ``FAB_API_SWAGGER_UI`` for a given ``SUPERSET_ENABLE_SWAGGER_UI``.
+
+    Evaluates ``superset.config`` in a fresh subprocess under a controlled
+    environment so the result reflects only the supplied env var. Config-path
+    overrides are stripped so a local ``superset_config`` cannot taint the
+    default, and only the final stdout line is read in case config loading
+    emits banner output.
+    """
     env = dict(os.environ)
-    env.pop("SUPERSET_ENABLE_SWAGGER_UI", None)
+    for var in (
+        "SUPERSET_ENABLE_SWAGGER_UI",
+        "SUPERSET_CONFIG_PATH",
+        "SUPERSET_CONFIG",
+    ):
+        env.pop(var, None)
     if env_value is not None:
         env["SUPERSET_ENABLE_SWAGGER_UI"] = env_value
     result = subprocess.run(  # noqa: S603
@@ -44,7 +57,7 @@ def _resolve_swagger_default(env_value: str | None) -> str:
         text=True,
         check=True,
     )
-    return result.stdout.strip()
+    return result.stdout.strip().splitlines()[-1]
 
 
 @pytest.mark.parametrize(
@@ -60,4 +73,5 @@ def _resolve_swagger_default(env_value: str | None) -> str:
 def test_fab_api_swagger_ui_is_env_driven_and_off_by_default(
     env_value: str | None, expected: str
 ) -> None:
+    """Swagger UI defaults to off and follows ``SUPERSET_ENABLE_SWAGGER_UI``."""
     assert _resolve_swagger_default(env_value) == expected

--- a/tests/unit_tests/config_swagger_ui_test.py
+++ b/tests/unit_tests/config_swagger_ui_test.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for environment-driven Swagger UI config defaults."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        (None, False),  # unset -> off by default
+        ("true", True),
+        ("True", True),
+        ("false", False),
+        ("", False),
+    ],
+)
+def test_fab_api_swagger_ui_is_env_driven_and_off_by_default(
+    monkeypatch, env_value, expected
+):
+    if env_value is None:
+        monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
+    else:
+        monkeypatch.setenv("SUPERSET_ENABLE_SWAGGER_UI", env_value)
+
+    import superset.config as config
+
+    importlib.reload(config)
+    try:
+        assert config.FAB_API_SWAGGER_UI is expected
+    finally:
+        # Restore the module to its environment-default state for other tests.
+        monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
+        importlib.reload(config)

--- a/tests/unit_tests/config_swagger_ui_test.py
+++ b/tests/unit_tests/config_swagger_ui_test.py
@@ -17,6 +17,7 @@
 """Tests for environment-driven Swagger UI config defaults."""
 
 import importlib
+import os
 
 import pytest
 
@@ -32,8 +33,10 @@ import pytest
     ],
 )
 def test_fab_api_swagger_ui_is_env_driven_and_off_by_default(
-    monkeypatch, env_value, expected
-):
+    monkeypatch: pytest.MonkeyPatch, env_value: str | None, expected: bool
+) -> None:
+    original = os.environ.get("SUPERSET_ENABLE_SWAGGER_UI")
+
     if env_value is None:
         monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
     else:
@@ -45,6 +48,11 @@ def test_fab_api_swagger_ui_is_env_driven_and_off_by_default(
     try:
         assert config.FAB_API_SWAGGER_UI is expected
     finally:
-        # Restore the module to its environment-default state for other tests.
-        monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
+        # Reload against the env value present before this test ran so the
+        # module state stays consistent with what monkeypatch restores on
+        # teardown, avoiding leakage into other tests.
+        if original is None:
+            monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
+        else:
+            monkeypatch.setenv("SUPERSET_ENABLE_SWAGGER_UI", original)
         importlib.reload(config)

--- a/tests/unit_tests/config_swagger_ui_test.py
+++ b/tests/unit_tests/config_swagger_ui_test.py
@@ -14,45 +14,50 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Tests for environment-driven Swagger UI config defaults."""
+"""Tests for environment-driven Swagger UI config defaults.
 
-import importlib
+``superset.config`` is imported in a fresh subprocess for each case so the
+module is evaluated under a controlled environment without reloading (and
+mutating) the config module shared by the rest of the test session.
+"""
+
 import os
+import subprocess
+import sys
 
 import pytest
+
+
+def _resolve_swagger_default(env_value: str | None) -> str:
+    env = dict(os.environ)
+    env.pop("SUPERSET_ENABLE_SWAGGER_UI", None)
+    if env_value is not None:
+        env["SUPERSET_ENABLE_SWAGGER_UI"] = env_value
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import superset.config as c; print(c.FAB_API_SWAGGER_UI)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 @pytest.mark.parametrize(
     "env_value, expected",
     [
-        (None, False),  # unset -> off by default
-        ("true", True),
-        ("True", True),
-        ("false", False),
-        ("", False),
+        (None, "False"),  # unset -> off by default
+        ("true", "True"),
+        ("True", "True"),
+        ("false", "False"),
+        ("", "False"),
     ],
 )
 def test_fab_api_swagger_ui_is_env_driven_and_off_by_default(
-    monkeypatch: pytest.MonkeyPatch, env_value: str | None, expected: bool
+    env_value: str | None, expected: str
 ) -> None:
-    original = os.environ.get("SUPERSET_ENABLE_SWAGGER_UI")
-
-    if env_value is None:
-        monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
-    else:
-        monkeypatch.setenv("SUPERSET_ENABLE_SWAGGER_UI", env_value)
-
-    import superset.config as config
-
-    importlib.reload(config)
-    try:
-        assert config.FAB_API_SWAGGER_UI is expected
-    finally:
-        # Reload against the env value present before this test ran so the
-        # module state stays consistent with what monkeypatch restores on
-        # teardown, avoiding leakage into other tests.
-        if original is None:
-            monkeypatch.delenv("SUPERSET_ENABLE_SWAGGER_UI", raising=False)
-        else:
-            monkeypatch.setenv("SUPERSET_ENABLE_SWAGGER_UI", original)
-        importlib.reload(config)
+    assert _resolve_swagger_default(env_value) == expected

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -25,7 +25,9 @@ from superset.security.api import RlsRuleSchema
 
 @pytest.mark.parametrize(
     "app",
-    [{"WTF_CSRF_ENABLED": True}],
+    # Enable the Swagger UI / OpenAPI spec (opt-in, off by default) so the
+    # OpenApi blueprint is registered and included in the exempt set below.
+    [{"WTF_CSRF_ENABLED": True, "FAB_API_SWAGGER_UI": True}],
     indirect=True,
 )
 def test_csrf_exempt_blueprints(app_context: None) -> None:


### PR DESCRIPTION
### SUMMARY

`FAB_API_SWAGGER_UI` was hardcoded to `True` in the base configuration, so Flask-AppBuilder registered the interactive Swagger UI and OpenAPI spec endpoints (e.g. `/swagger/v1`) by default in every deployment that inherits the base config.

This makes the documentation surface opt-in: `FAB_API_SWAGGER_UI` is now driven by the `SUPERSET_ENABLE_SWAGGER_UI` environment variable and defaults to off. The bundled Docker development environment sets `SUPERSET_ENABLE_SWAGGER_UI=true`, so local development behavior is unchanged; production deployments are documentation-off by default and can opt in via the env var or by overriding `FAB_API_SWAGGER_UI` in `superset_config.py`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — configuration default change.

### TESTING INSTRUCTIONS

Unit test added in `tests/unit_tests/config_swagger_ui_test.py` asserting the env-driven default (off when unset, on when `SUPERSET_ENABLE_SWAGGER_UI=true`).

Run: `pytest tests/unit_tests/config_swagger_ui_test.py`

Manual: with the env var unset, `/swagger/v1` is not registered; with `SUPERSET_ENABLE_SWAGGER_UI=true` it is.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

> Note: this changes a default (Swagger UI off by default); documented in `UPDATING.md`.
