### PR TITLE
fix(config): expose build details (git SHA/build number) to admins only

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -38,7 +38,7 @@ When the MCP service has JWT auth enabled (`MCP_AUTH_ENABLED = True`), an audien
 
 ### Build details (git SHA / build number) are admin-only by default
 
-The git SHA and build number surfaced in the "About" section and the bootstrap payload are now only included for admin users by default; the release version string is still shown to everyone. To expose the build details to all users (the previous behavior), set the `SUPERSET_EXPOSE_BUILD_DETAILS` environment variable (or `EXPOSE_BUILD_DETAILS_TO_USERS = True` in `superset_config.py`).
+The git SHA and build number surfaced in the "About" section, the bootstrap payload, and the public `/version` endpoint are now only included for admin users by default; the release version string is still shown to everyone. To expose the build details to all users (the previous behavior), set the `SUPERSET_EXPOSE_BUILD_DETAILS` environment variable (or `EXPOSE_BUILD_DETAILS_TO_USERS = True` in `superset_config.py`).
 
 ### Pivot table First/Last aggregations follow data order
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -36,6 +36,10 @@ When the MCP service has JWT auth enabled (`MCP_AUTH_ENABLED = True`), an audien
 
 `FAB_API_SWAGGER_UI` now defaults to `False` and is driven by the `SUPERSET_ENABLE_SWAGGER_UI` environment variable. The interactive Swagger UI / OpenAPI documentation endpoints (e.g. `/swagger/v1`) are therefore no longer exposed by default. To enable them, set `SUPERSET_ENABLE_SWAGGER_UI=true` (the bundled Docker development environment sets this) or override `FAB_API_SWAGGER_UI = True` in `superset_config.py`.
 
+### Build details (git SHA / build number) are admin-only by default
+
+The git SHA and build number surfaced in the "About" section and the bootstrap payload are now only included for admin users by default; the release version string is still shown to everyone. To expose the build details to all users (the previous behavior), set the `SUPERSET_EXPOSE_BUILD_DETAILS` environment variable (or `EXPOSE_BUILD_DETAILS_TO_USERS = True` in `superset_config.py`).
+
 ### Pivot table First/Last aggregations follow data order
 
 The pivot table chart's `First` and `Last` aggregations now return the first and last value in data (query result) order, instead of effectively returning the minimum and maximum. Existing pivot tables that use these aggregations for totals/subtotals may show different values after upgrading. For deterministic results, ensure the underlying query has a stable sort order.

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -776,8 +776,11 @@ const RightMenu = ({
       )}
       <TelemetryPixel
         version={navbarRight.version_string}
-        sha={navbarRight.version_sha}
-        build={navbarRight.build_number}
+        // Build details may be redacted to empty/null for non-admins; fall back
+        // to the component's "unknown" defaults instead of emitting empty path
+        // segments in the Scarf pixel URL.
+        sha={navbarRight.version_sha || undefined}
+        build={navbarRight.build_number || undefined}
       />
     </StyledDiv>
   );

--- a/superset/config.py
+++ b/superset/config.py
@@ -160,6 +160,15 @@ VERSION_SHA = _try_json_readsha(VERSION_INFO_FILE, VERSION_SHA_LENGTH)
 # can be replaced at build time to expose build information.
 BUILD_NUMBER = None
 
+# Whether to expose precise build details (the git SHA and build number) to
+# all users via the "About" section and the bootstrap payload. When False
+# (default), these are only included for admins, so non-admin/anonymous viewers
+# cannot read the exact commit/build of the deployment. The release version
+# string is always included. Enable with SUPERSET_EXPOSE_BUILD_DETAILS.
+EXPOSE_BUILD_DETAILS_TO_USERS = utils.cast_to_boolean(
+    os.environ.get("SUPERSET_EXPOSE_BUILD_DETAILS", False)
+)
+
 # default viz used in chart explorer & SQL Lab explore
 DEFAULT_VIZ_TYPE = "table"
 

--- a/superset/utils/version.py
+++ b/superset/utils/version.py
@@ -57,6 +57,21 @@ def get_version_metadata() -> dict[str, Any]:
     return metadata
 
 
+def visible_version_metadata(
+    metadata: dict[str, Any], expose_build_details: bool
+) -> dict[str, Any]:
+    """Return version metadata for user-facing surfaces.
+
+    The release ``version_string`` is always included. Precise build details
+    (the git SHA and build number), which let a viewer map the deployment to a
+    specific commit/build, are blanked out unless ``expose_build_details`` is
+    True (e.g. the viewer is an admin or the deployment opted in).
+    """
+    if expose_build_details:
+        return metadata
+    return {**metadata, "version_sha": "", "build_number": None}
+
+
 def get_dev_env_label() -> str:
     """
     Generate development environment label with branch/SHA info.

--- a/superset/utils/version.py
+++ b/superset/utils/version.py
@@ -63,13 +63,15 @@ def visible_version_metadata(
     """Return version metadata for user-facing surfaces.
 
     The release ``version_string`` is always included. Precise build details
-    (the git SHA and build number), which let a viewer map the deployment to a
+    (the git SHAs and build number), which let a viewer map the deployment to a
     specific commit/build, are blanked out unless ``expose_build_details`` is
     True (e.g. the viewer is an admin or the deployment opted in).
     """
     if expose_build_details:
         return metadata
-    return {**metadata, "version_sha": "", "build_number": None}
+    redacted = {**metadata, "version_sha": "", "build_number": None}
+    redacted.pop("full_sha", None)
+    return redacted
 
 
 def get_dev_env_label() -> str:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -67,7 +67,7 @@ from superset.themes.utils import (
 )
 from superset.utils import core as utils, json
 from superset.utils.filters import get_dataset_access_filters
-from superset.utils.version import get_version_metadata
+from superset.utils.version import get_version_metadata, visible_version_metadata
 from superset.views.error_handling import json_error_response
 
 from .utils import bootstrap_user_data, get_config_value
@@ -280,8 +280,16 @@ def menu_data(user: User) -> dict[str, Any]:
     if callable(brand_text := app.config["LOGO_RIGHT_TEXT"]):
         brand_text = brand_text()
 
-    # Get centralized version metadata
-    version_metadata = get_version_metadata()
+    # Get centralized version metadata. Precise build details (git SHA and
+    # build number) let a viewer map the deployment to a specific commit/build,
+    # so expose them only to admins unless the deployment opts in via
+    # EXPOSE_BUILD_DETAILS_TO_USERS. The release version string is always shown.
+    expose_build_details = (
+        app.config["EXPOSE_BUILD_DETAILS_TO_USERS"] or security_manager.is_admin()
+    )
+    version_metadata = visible_version_metadata(
+        get_version_metadata(), expose_build_details
+    )
 
     return {
         "menu": appbuilder.menu.get_data(),

--- a/superset/views/health.py
+++ b/superset/views/health.py
@@ -37,9 +37,20 @@ def health() -> FlaskResponse:
 @talisman(force_https=False)
 def version() -> FlaskResponse:
     """
-    Return comprehensive version information including Git SHA
-    and branch when available.
+    Return version information. Precise build details (the git SHA and build
+    number) are only exposed to admins unless the deployment opts in via
+    EXPOSE_BUILD_DETAILS_TO_USERS; the release version string is always
+    included.
     """
-    from superset.utils.version import get_version_metadata
+    from superset import security_manager
+    from superset.utils.version import (
+        get_version_metadata,
+        visible_version_metadata,
+    )
 
-    return jsonify(get_version_metadata())
+    expose_build_details = (
+        app.config["EXPOSE_BUILD_DETAILS_TO_USERS"] or security_manager.is_admin()
+    )
+    return jsonify(
+        visible_version_metadata(get_version_metadata(), expose_build_details)
+    )

--- a/tests/unit_tests/utils/version_test.py
+++ b/tests/unit_tests/utils/version_test.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for superset.utils.version helpers."""
+
+from superset.utils.version import visible_version_metadata
+
+
+def _metadata():
+    return {
+        "version_string": "4.0.0",
+        "version_sha": "abcdef12",
+        "build_number": "build-42",
+    }
+
+
+def test_visible_version_metadata_hides_build_details_when_not_exposed():
+    """Build details are blanked while the release version string is kept."""
+    result = visible_version_metadata(_metadata(), expose_build_details=False)
+    assert result["version_string"] == "4.0.0"
+    assert result["version_sha"] == ""
+    assert result["build_number"] is None
+
+
+def test_visible_version_metadata_keeps_build_details_when_exposed():
+    """All details pass through unchanged when exposure is allowed."""
+    metadata = _metadata()
+    result = visible_version_metadata(metadata, expose_build_details=True)
+    assert result == metadata
+
+
+def test_visible_version_metadata_does_not_mutate_input():
+    """Hiding build details must not mutate the caller's metadata dict."""
+    metadata = _metadata()
+    visible_version_metadata(metadata, expose_build_details=False)
+    assert metadata["version_sha"] == "abcdef12"
+    assert metadata["build_number"] == "build-42"

--- a/tests/unit_tests/utils/version_test.py
+++ b/tests/unit_tests/utils/version_test.py
@@ -16,10 +16,12 @@
 # under the License.
 """Tests for superset.utils.version helpers."""
 
+from typing import Any
+
 from superset.utils.version import visible_version_metadata
 
 
-def _metadata():
+def _metadata() -> dict[str, Any]:
     return {
         "version_string": "4.0.0",
         "version_sha": "abcdef12",
@@ -27,7 +29,7 @@ def _metadata():
     }
 
 
-def test_visible_version_metadata_hides_build_details_when_not_exposed():
+def test_visible_version_metadata_hides_build_details_when_not_exposed() -> None:
     """Build details are blanked while the release version string is kept."""
     result = visible_version_metadata(_metadata(), expose_build_details=False)
     assert result["version_string"] == "4.0.0"
@@ -35,14 +37,21 @@ def test_visible_version_metadata_hides_build_details_when_not_exposed():
     assert result["build_number"] is None
 
 
-def test_visible_version_metadata_keeps_build_details_when_exposed():
+def test_visible_version_metadata_drops_full_sha_when_not_exposed() -> None:
+    """The exact commit SHA must not survive redaction."""
+    metadata = {**_metadata(), "full_sha": "abcdef1234567890"}
+    result = visible_version_metadata(metadata, expose_build_details=False)
+    assert "full_sha" not in result
+
+
+def test_visible_version_metadata_keeps_build_details_when_exposed() -> None:
     """All details pass through unchanged when exposure is allowed."""
     metadata = _metadata()
     result = visible_version_metadata(metadata, expose_build_details=True)
     assert result == metadata
 
 
-def test_visible_version_metadata_does_not_mutate_input():
+def test_visible_version_metadata_does_not_mutate_input() -> None:
     """Hiding build details must not mutate the caller's metadata dict."""
     metadata = _metadata()
     visible_version_metadata(metadata, expose_build_details=False)

--- a/tests/unit_tests/utils/version_test.py
+++ b/tests/unit_tests/utils/version_test.py
@@ -22,6 +22,7 @@ from superset.utils.version import visible_version_metadata
 
 
 def _metadata() -> dict[str, Any]:
+    """Build a sample version-metadata dict for the redaction tests."""
     return {
         "version_string": "4.0.0",
         "version_sha": "abcdef12",

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -16,6 +16,7 @@
 # under the License.
 """Tests for superset.views.base module"""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,6 +74,59 @@ def test_default_map_renderer_is_exposed_to_frontend_config() -> None:
     from superset.views.base import FRONTEND_CONF_KEYS
 
     assert "DEFAULT_MAP_RENDERER" in FRONTEND_CONF_KEYS
+
+
+_FULL_METADATA = {
+    "version_string": "4.0.0",
+    "version_sha": "abcdef12",
+    "build_number": "build-42",
+    "full_sha": "abcdef1234567890",
+}
+
+
+def _menu_data_navbar(*, is_admin: bool, config_opt_in: bool) -> dict[str, Any]:
+    """Call menu_data with appbuilder isolated, returning navbar_right."""
+    from superset.views import base as base_module
+
+    with (
+        patch.object(
+            base_module, "get_version_metadata", return_value=dict(_FULL_METADATA)
+        ),
+        patch.object(base_module, "security_manager") as mock_sm,
+        patch.object(base_module, "get_environment_tag", return_value={}),
+        patch.object(base_module, "appbuilder") as mock_appbuilder,
+        base_module.app.test_request_context(),
+    ):
+        mock_sm.is_admin = MagicMock(return_value=is_admin)
+        mock_appbuilder.languages = {}
+        mock_appbuilder.menu.get_data.return_value = {}
+        with patch.dict(
+            base_module.app.config,
+            {"EXPOSE_BUILD_DETAILS_TO_USERS": config_opt_in},
+        ):
+            return base_module.menu_data(MagicMock())["navbar_right"]
+
+
+def test_menu_data_exposes_build_details_to_admin() -> None:
+    """Admins see the precise build details in the navbar payload."""
+    navbar_right = _menu_data_navbar(is_admin=True, config_opt_in=False)
+    assert navbar_right["version_sha"] == "abcdef12"
+    assert navbar_right["build_number"] == "build-42"
+
+
+def test_menu_data_redacts_build_details_for_non_admin() -> None:
+    """Non-admins get the version string but redacted build details."""
+    navbar_right = _menu_data_navbar(is_admin=False, config_opt_in=False)
+    assert navbar_right["version_string"] == "4.0.0"
+    assert navbar_right["version_sha"] == ""
+    assert navbar_right["build_number"] is None
+
+
+def test_menu_data_exposes_build_details_when_config_opts_in() -> None:
+    """The config opt-in exposes build details even for non-admins."""
+    navbar_right = _menu_data_navbar(is_admin=False, config_opt_in=True)
+    assert navbar_right["version_sha"] == "abcdef12"
+    assert navbar_right["build_number"] == "build-42"
 
 
 def _extract_language(

--- a/tests/unit_tests/views/test_health.py
+++ b/tests/unit_tests/views/test_health.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the public ``/version`` endpoint redaction gate."""
+
+from unittest.mock import MagicMock, patch
+
+_FULL_METADATA = {
+    "version_string": "4.0.0",
+    "version_sha": "abcdef12",
+    "build_number": "build-42",
+    "full_sha": "abcdef1234567890",
+}
+
+
+def _version_payload(*, is_admin: bool, config_opt_in: bool) -> dict[str, object]:
+    """Call the /version view and return the decoded JSON body."""
+    from superset.views import health as health_module
+
+    with (
+        patch(
+            "superset.utils.version.get_version_metadata",
+            return_value=dict(_FULL_METADATA),
+        ),
+        patch("superset.security_manager") as mock_sm,
+        patch.dict(
+            health_module.app.config,
+            {"EXPOSE_BUILD_DETAILS_TO_USERS": config_opt_in},
+        ),
+    ):
+        mock_sm.is_admin = MagicMock(return_value=is_admin)
+        with health_module.app.test_request_context():
+            return health_module.version().get_json()
+
+
+def test_version_endpoint_redacts_build_details_for_anonymous() -> None:
+    """The unauthenticated /version endpoint must not leak build details."""
+    payload = _version_payload(is_admin=False, config_opt_in=False)
+    assert payload["version_string"] == "4.0.0"
+    assert payload["version_sha"] == ""
+    assert payload["build_number"] is None
+    assert "full_sha" not in payload
+
+
+def test_version_endpoint_exposes_build_details_to_admin() -> None:
+    """Admins see the precise build details on /version."""
+    payload = _version_payload(is_admin=True, config_opt_in=False)
+    assert payload["version_sha"] == "abcdef12"
+    assert payload["build_number"] == "build-42"
+
+
+def test_version_endpoint_exposes_build_details_when_config_opts_in() -> None:
+    """The config opt-in exposes build details on /version for everyone."""
+    payload = _version_payload(is_admin=False, config_opt_in=True)
+    assert payload["version_sha"] == "abcdef12"
+    assert payload["build_number"] == "build-42"


### PR DESCRIPTION
### SUMMARY

`VERSION_SHA` and `BUILD_NUMBER` were surfaced in the frontend "About" section and the common bootstrap payload for every viewer, disclosing the precise git commit and build of the deployment (useful reconnaissance for mapping to known issues for an exact build).

This gates those precise build details behind a new `EXPOSE_BUILD_DETAILS_TO_USERS` config (env: `SUPERSET_EXPOSE_BUILD_DETAILS`, default off). The git SHA and build number are included only for admin users unless a deployment opts in. The release `version_string` is still shown to everyone (it is widely used in the UI/About).

A small pure helper `visible_version_metadata()` encapsulates the gating so it is easy to test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — bootstrap payload contents.

### TESTING INSTRUCTIONS

Unit tests added in `tests/unit_tests/utils/version_test.py`:

- When not exposed, `version_sha`/`build_number` are blanked while `version_string` is kept.
- When exposed, all details pass through.
- The input dict is not mutated.

Run: `pytest tests/unit_tests/utils/version_test.py`

Manual: as a non-admin, the bootstrap payload `navbar_right.version_sha` is empty and `build_number` is null; as an admin (or with `SUPERSET_EXPOSE_BUILD_DETAILS=true`) they are populated.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

> Note: changes default visibility of build details (admin-only by default); documented in `UPDATING.md`.
