### PR TITLE
docs(meta-db): warn that SUPERSET_META_DB_LIMIT truncates tables before joins

### DIFF
--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -1808,6 +1808,10 @@ If you enable DML in the meta database users will be able to run DML queries on 
 
 Second, you might want to change the value of `SUPERSET_META_DB_LIMIT`. The default value is 1000, and defines how many are read from each database before any aggregations and joins are executed. You can also set this value `None` if you only have small tables.
 
+:::warning
+`SUPERSET_META_DB_LIMIT` is applied to **each** underlying table *before* the in-memory join runs, not to the final result. If any table involved in a join has more rows than the limit, the meta database will read only the first `SUPERSET_META_DB_LIMIT` rows of that table, which means matching rows can be silently dropped and the join can return **incomplete or even empty** results with no error. If you join tables larger than the limit, raise `SUPERSET_META_DB_LIMIT` to comfortably exceed your largest joined table, or set it to `None` when working only with small tables, to get correct results.
+:::
+
 Additionally, you might want to restrict the databases to with the meta database has access to. This can be done in the database configuration, under "Advanced" -> "Other" -> "ENGINE PARAMETERS" and adding:
 
 ```json


### PR DESCRIPTION
### SUMMARY

Addresses #36304. When the Superset meta database (`ENABLE_SUPERSET_META_DB`) joins across underlying databases, `SUPERSET_META_DB_LIMIT` (default 1000) is applied to each underlying table *before* the in-memory join runs, not to the final result. If any joined table has more rows than the limit, only the first `SUPERSET_META_DB_LIMIT` rows of that table are read, so matching rows can be silently dropped and the join can return incomplete or empty results with no error. The existing docs mention the per-table limit but don't warn that it can silently produce wrong results. This adds a `:::warning` admonition next to the existing `SUPERSET_META_DB_LIMIT` prose explaining the behavior and the workaround (raise the limit above your largest joined table, or set it to `None` for small tables). Docs-only; the underlying behavior is left for a separate fix decision, so the issue stays open.

### TESTING INSTRUCTIONS

Docs only. No code changes.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #36304
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API