### PR TITLE
fix(logout): purge the namespaced Cache API store on logout

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -401,6 +401,10 @@ test('Logs out and clears local storage item redux', async () => {
   expect(localStorage.getItem('redux')).not.toBeNull();
   expect(sessionStorage.getItem('login_attempted')).not.toBeNull();
 
+  // Mock the Cache API so we can assert the namespaced store is purged.
+  const deleteMock = jest.fn().mockResolvedValue(true);
+  (global as any).caches = { delete: deleteMock };
+
   await userEvent.hover(await screen.findByText(/Settings/i));
 
   // Simulate user clicking the logout button
@@ -412,6 +416,10 @@ test('Logs out and clears local storage item redux', async () => {
     expect(localStorage.getItem('redux')).toBeNull();
     expect(sessionStorage.getItem('login_attempted')).toBeNull();
   });
+  // The namespaced Cache API store is purged on logout.
+  expect(deleteMock).toHaveBeenCalledWith('@SUPERSET-UI/CONNECTION');
+
+  delete (global as any).caches;
 });
 
 test('shows logout button when not embedded', async () => {

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -402,7 +402,7 @@ test('Logs out and clears local storage item redux', async () => {
   expect(sessionStorage.getItem('login_attempted')).not.toBeNull();
 
   // Mock the Cache API so we can assert the namespaced store is purged.
-  const cacheGlobal = global as typeof global & { caches?: CacheStorage };
+  const cacheGlobal = global as unknown as { caches?: CacheStorage };
   const priorCaches = cacheGlobal.caches;
   const deleteMock = jest.fn().mockResolvedValue(true);
   cacheGlobal.caches = { delete: deleteMock } as unknown as CacheStorage;

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -402,24 +402,34 @@ test('Logs out and clears local storage item redux', async () => {
   expect(sessionStorage.getItem('login_attempted')).not.toBeNull();
 
   // Mock the Cache API so we can assert the namespaced store is purged.
+  const cacheGlobal = global as typeof global & { caches?: CacheStorage };
+  const priorCaches = cacheGlobal.caches;
   const deleteMock = jest.fn().mockResolvedValue(true);
-  (global as any).caches = { delete: deleteMock };
+  cacheGlobal.caches = { delete: deleteMock } as unknown as CacheStorage;
 
-  await userEvent.hover(await screen.findByText(/Settings/i));
+  try {
+    await userEvent.hover(await screen.findByText(/Settings/i));
 
-  // Simulate user clicking the logout button
-  const logoutButton = await screen.findByText('Logout');
-  await userEvent.click(logoutButton);
+    // Simulate user clicking the logout button
+    const logoutButton = await screen.findByText('Logout');
+    await userEvent.click(logoutButton);
 
-  // Wait for local and session storage to be cleared
-  await waitFor(() => {
-    expect(localStorage.getItem('redux')).toBeNull();
-    expect(sessionStorage.getItem('login_attempted')).toBeNull();
-  });
-  // The namespaced Cache API store is purged on logout.
-  expect(deleteMock).toHaveBeenCalledWith('@SUPERSET-UI/CONNECTION');
-
-  delete (global as any).caches;
+    // Wait for local and session storage to be cleared
+    await waitFor(() => {
+      expect(localStorage.getItem('redux')).toBeNull();
+      expect(sessionStorage.getItem('login_attempted')).toBeNull();
+    });
+    // The namespaced Cache API store is purged on logout.
+    expect(deleteMock).toHaveBeenCalledWith('@SUPERSET-UI/CONNECTION');
+  } finally {
+    // Restore the global so an early assertion failure cannot leak the mock
+    // into other tests.
+    if (priorCaches === undefined) {
+      delete cacheGlobal.caches;
+    } else {
+      cacheGlobal.caches = priorCaches;
+    }
+  }
 });
 
 test('shows logout button when not embedded', async () => {

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -24,7 +24,7 @@ import {
   userEvent,
   waitFor,
 } from 'spec/helpers/testing-library';
-import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag, CACHE_KEY } from '@superset-ui/core';
 import { isEmbedded } from 'src/dashboard/util/isEmbedded';
 import RightMenu from './RightMenu';
 import { GlobalMenuDataOptions, RightMenuProps } from './types';
@@ -420,7 +420,7 @@ test('Logs out and clears local storage item redux', async () => {
       expect(sessionStorage.getItem('login_attempted')).toBeNull();
     });
     // The namespaced Cache API store is purged on logout.
-    expect(deleteMock).toHaveBeenCalledWith('@SUPERSET-UI/CONNECTION');
+    expect(deleteMock).toHaveBeenCalledWith(CACHE_KEY);
   } finally {
     // Restore the global so an early assertion failure cannot leak the mock
     // into other tests.

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -28,6 +28,7 @@ import {
   getExtensionsRegistry,
   isFeatureEnabled,
   FeatureFlag,
+  CACHE_KEY,
 } from '@superset-ui/core';
 import {
   styled,
@@ -353,6 +354,14 @@ const RightMenu = ({
     try {
       window.localStorage.removeItem('redux');
       window.sessionStorage.removeItem('login_attempted');
+      // Purge the namespaced Cache API store so cached GET responses are not
+      // retained on the device after the session ends. Best-effort: the
+      // returned promise is not awaited since logout navigates away.
+      if (typeof caches !== 'undefined') {
+        caches.delete(CACHE_KEY).catch(() => {
+          /* best-effort: ignore cache deletion failures */
+        });
+      }
     } catch (error) {
       console.warn('Failed to clear storage on logout:', error);
     }


### PR DESCRIPTION
### SUMMARY

GET responses carrying an `ETag` were persisted into the `@SUPERSET-UI/CONNECTION` Cache API namespace and retained across sessions, with no purge on logout.

The logout handler in `RightMenu` already cleared the persisted redux `localStorage` (which holds SQL Lab editor/results state) and session storage. This extends it to also delete the namespaced Cache API store, so cached GET responses are not retained on the device after the session ends. The deletion is best-effort (the promise is not awaited, since logout immediately navigates away) and uses the exported `CACHE_KEY` constant.

This completes the on-logout client-state clearing: `localStorage['redux']` (already cleared), session storage (already cleared), and now the Cache API namespace.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — client-side cleanup behavior.

### TESTING INSTRUCTIONS

The existing `RightMenu` logout test is extended to mock the Cache API and assert `caches.delete('@SUPERSET-UI/CONNECTION')` is called on logout (alongside the existing localStorage/sessionStorage assertions).

Run: `cd superset-frontend && npm run test -- src/features/home/RightMenu.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
