### PR TITLE
fix(extensions): log extension-init failures via the logger, not print()

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -610,9 +610,14 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
                     with extension_context(extension.manifest):
                         eager_import(backend.entrypoint)
 
-                except Exception as ex:  # pylint: disable=broad-except  # noqa: S110
-                    # Surface exceptions during initialization of extensions
-                    print(ex)
+                except Exception:  # pylint: disable=broad-except
+                    # Surface extension-initialization failures through the
+                    # configured logger (with traceback) so they reach log
+                    # aggregation, rather than being written to stdout.
+                    logger.exception(
+                        "Failed to initialize extension '%s'",
+                        extension.manifest.id,
+                    )
 
     def init_app_in_ctx(self) -> None:
         """

--- a/tests/unit_tests/test_init_extensions_logging.py
+++ b/tests/unit_tests/test_init_extensions_logging.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for extension-initialization error logging."""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from superset.initialization import SupersetAppInitializer
+
+
+def _extension_that_fails_to_init():
+    extension = MagicMock()
+    extension.backend = None  # skip the in-memory importer branch
+    extension.manifest.id = "acme.broken_extension"
+    extension.manifest.backend.entrypoint = "acme.broken:init"
+    return extension
+
+
+def test_init_extensions_logs_exception_instead_of_printing():
+    """An extension entrypoint failure is routed through logger.exception."""
+    initializer = object.__new__(SupersetAppInitializer)
+    extension = _extension_that_fails_to_init()
+
+    with (
+        patch(
+            "superset.extensions.utils.get_extensions",
+            return_value={"acme.broken_extension": extension},
+        ),
+        patch("superset.extensions.utils.install_in_memory_importer"),
+        patch(
+            "superset.extensions.utils.eager_import",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("superset.initialization.extension_context", return_value=nullcontext()),
+        patch("superset.initialization.logger") as mock_logger,
+    ):
+        initializer.init_extensions()
+
+    mock_logger.exception.assert_called_once()
+    # The failing extension id is included in the log call args.
+    assert "acme.broken_extension" in mock_logger.exception.call_args.args

--- a/tests/unit_tests/test_init_extensions_logging.py
+++ b/tests/unit_tests/test_init_extensions_logging.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 from superset.initialization import SupersetAppInitializer
 
 
-def _extension_that_fails_to_init():
+def _extension_that_fails_to_init() -> MagicMock:
     extension = MagicMock()
     extension.backend = None  # skip the in-memory importer branch
     extension.manifest.id = "acme.broken_extension"
@@ -30,7 +30,7 @@ def _extension_that_fails_to_init():
     return extension
 
 
-def test_init_extensions_logs_exception_instead_of_printing():
+def test_init_extensions_logs_exception_instead_of_printing() -> None:
     """An extension entrypoint failure is routed through logger.exception."""
     initializer = object.__new__(SupersetAppInitializer)
     extension = _extension_that_fails_to_init()


### PR DESCRIPTION
### SUMMARY

`init_extensions` caught extension-initialization exceptions and emitted them via `print(ex)` to stdout, bypassing the configured structured logging pipeline (formatting, severity levels, configured destinations). Initialization failures were therefore invisible to operators relying on log aggregation.

This routes those failures through `logger.exception(...)`, which records the failing extension id and a full traceback at error level through the standard logger.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — logging behavior.

### TESTING INSTRUCTIONS

Unit test added in `tests/unit_tests/test_init_extensions_logging.py`: an extension entrypoint that raises during init is logged via `logger.exception`, and the failing extension id is included in the log args.

Run: `pytest tests/unit_tests/test_init_extensions_logging.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
