### PR TITLE
feat(security): record audit metadata on guest token issuance

### DIFF
--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -34,7 +34,11 @@ from superset.commands.dashboard.embedded.exceptions import (
 from superset.commands.exceptions import ForbiddenError
 from superset.exceptions import SupersetGenericErrorException
 from superset.extensions import db, event_logger
-from superset.security.guest_token import GuestTokenResourceType
+from superset.security.guest_token import (
+    build_guest_token_audit_payload,
+    GuestTokenResourceType,
+)
+from superset.utils.core import get_user_id
 from superset.views.base_api import (
     BaseSupersetApi,
     BaseSupersetModelRestApi,
@@ -203,6 +207,15 @@ class SecurityRestApi(BaseSupersetApi):
                 body["resources"],
                 body["rls"],
                 **({"datasets": body["datasets"]} if "datasets" in body else {}),
+            )
+            logger.info(
+                "Guest token issued: %s",
+                build_guest_token_audit_payload(
+                    issuer_user_id=get_user_id(),
+                    source_ip=request.remote_addr,
+                    body=body,
+                    token=token,
+                ),
             )
             return self.response(200, token=token)
         except EmbeddedDashboardNotFoundError as error:

--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -14,8 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import hashlib
 import logging
-from typing import Optional, TypedDict, Union
+from typing import Any, Optional, TypedDict, Union
 
 from flask_appbuilder.security.sqla.models import Group, Role
 from flask_login import AnonymousUserMixin
@@ -23,6 +24,38 @@ from flask_login import AnonymousUserMixin
 from superset.utils.backports import StrEnum
 
 logger = logging.getLogger(__name__)
+
+
+def build_guest_token_audit_payload(
+    issuer_user_id: Optional[int],
+    source_ip: Optional[str],
+    body: dict[str, Any],
+    token: str,
+) -> dict[str, Any]:
+    """Build security-relevant metadata for a guest-token issuance event.
+
+    Captures who issued the token, from where, what it grants, and a hash of
+    the issued token (never the raw token) so a later investigation into a
+    misissued or over-scoped token can be scoped from the audit log.
+    """
+    resources = body.get("resources") or []
+    rls = body.get("rls") or []
+    return {
+        "issuer_user_id": issuer_user_id,
+        "source_ip": source_ip,
+        "resources": [
+            f"{resource.get('type')}:{resource.get('id')}" for resource in resources
+        ],
+        "datasets": body.get("datasets"),
+        # RLS clauses can carry data values; record only the datasets in scope
+        # and the rule count, not the clause text.
+        "rls_datasets": [rule.get("dataset") for rule in rls],
+        "rls_rule_count": len(rls),
+        # Hash, not the raw token, so the log can be correlated without
+        # becoming a credential store.
+        "token_sha256": hashlib.sha256(token.encode("utf-8")).hexdigest(),
+    }
+
 
 # JWT claim that carries the revocation version a token was minted with.
 GUEST_TOKEN_REVOCATION_CLAIM = "rev"  # noqa: S105

--- a/tests/unit_tests/security/guest_token_audit_test.py
+++ b/tests/unit_tests/security/guest_token_audit_test.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for guest-token issuance audit metadata."""
+
+import hashlib
+
+from superset.security.guest_token import build_guest_token_audit_payload
+
+
+def test_build_guest_token_audit_payload_captures_issuance_metadata():
+    body = {
+        "user": {"username": "guest"},
+        "resources": [{"type": "dashboard", "id": "abc-123"}],
+        "datasets": [1, 2],
+        "rls": [{"dataset": 1, "clause": "tenant_id = 9"}],
+    }
+    payload = build_guest_token_audit_payload(
+        issuer_user_id=42,
+        source_ip="10.0.0.1",
+        body=body,
+        token="the-secret-token",  # noqa: S106
+    )
+
+    assert payload["issuer_user_id"] == 42
+    assert payload["source_ip"] == "10.0.0.1"
+    assert payload["resources"] == ["dashboard:abc-123"]
+    assert payload["datasets"] == [1, 2]
+    assert payload["rls_datasets"] == [1]
+    assert payload["rls_rule_count"] == 1
+
+
+def test_build_guest_token_audit_payload_hashes_token_and_omits_raw():
+    token = "the-secret-token"  # noqa: S105
+    payload = build_guest_token_audit_payload(
+        issuer_user_id=1,
+        source_ip=None,
+        body={"resources": [], "rls": []},
+        token=token,
+    )
+
+    # The raw token is never present; only its hash is recorded.
+    assert token not in payload.values()
+    assert payload["token_sha256"] == hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def test_build_guest_token_audit_payload_omits_rls_clause_text():
+    body = {
+        "resources": [],
+        "rls": [{"dataset": 7, "clause": "secret_value = 'pii'"}],
+    }
+    payload = build_guest_token_audit_payload(
+        issuer_user_id=1,
+        source_ip=None,
+        body=body,
+        token="t",  # noqa: S106
+    )
+
+    # Clause text (which can carry data values) is not recorded.
+    assert "secret_value = 'pii'" not in str(payload)
+    assert payload["rls_datasets"] == [7]

--- a/tests/unit_tests/security/guest_token_audit_test.py
+++ b/tests/unit_tests/security/guest_token_audit_test.py
@@ -21,7 +21,7 @@ import hashlib
 from superset.security.guest_token import build_guest_token_audit_payload
 
 
-def test_build_guest_token_audit_payload_captures_issuance_metadata():
+def test_build_guest_token_audit_payload_captures_issuance_metadata() -> None:
     body = {
         "user": {"username": "guest"},
         "resources": [{"type": "dashboard", "id": "abc-123"}],
@@ -43,7 +43,7 @@ def test_build_guest_token_audit_payload_captures_issuance_metadata():
     assert payload["rls_rule_count"] == 1
 
 
-def test_build_guest_token_audit_payload_hashes_token_and_omits_raw():
+def test_build_guest_token_audit_payload_hashes_token_and_omits_raw() -> None:
     token = "the-secret-token"  # noqa: S105
     payload = build_guest_token_audit_payload(
         issuer_user_id=1,
@@ -57,7 +57,7 @@ def test_build_guest_token_audit_payload_hashes_token_and_omits_raw():
     assert payload["token_sha256"] == hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
-def test_build_guest_token_audit_payload_omits_rls_clause_text():
+def test_build_guest_token_audit_payload_omits_rls_clause_text() -> None:
     body = {
         "resources": [],
         "rls": [{"dataset": 7, "clause": "secret_value = 'pii'"}],


### PR DESCRIPTION
### SUMMARY

The guest-token issuance endpoint recorded only the coarse action name via `@event_logger.log_this`, without the metadata needed to scope an investigation if a misissued or over-scoped token were later abused.

This emits an explicit issuance event on successful guest-token creation capturing:

- issuer user id
- source IP
- granted resources (`type:id`)
- dataset allowlist
- RLS dataset scope and rule count
- a SHA-256 hash of the issued token (never the raw token)

RLS clause text is intentionally omitted since it can carry data values. The metadata is assembled by a small pure helper, `build_guest_token_audit_payload`, so it is easy to test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — audit logging.

### TESTING INSTRUCTIONS

Unit tests in `tests/unit_tests/security/guest_token_audit_test.py`:

- The payload captures issuer/source-IP/resources/datasets/RLS scope.
- The raw token is never present; only its SHA-256 hash is recorded.
- RLS clause text is not included.

Run: `pytest tests/unit_tests/security/guest_token_audit_test.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
