### PR TITLE
feat(api): log rejected related/distinct field access as security events

### DIFF
--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -223,6 +223,27 @@ class BaseSupersetApiMixin:
             f"{self.__class__.__name__}.{func_name}.{action}"
         )
 
+    def log_rejected_field_access(self, func_name: str, column_name: str) -> None:
+        """Emit a security log event when a related/distinct field is rejected.
+
+        The allowlist check itself blocks the request; this records the attempt
+        in the structured log (alongside the existing statsd counter) so that
+        rejected field access is visible to security monitoring and forensics,
+        with the caller's identity, the endpoint, and the attempted value.
+        """
+        # Sanitize the user-supplied column name to a single, bounded token so
+        # it cannot inject newlines or forge extra log lines.
+        sanitized_column = "".join(
+            ch for ch in str(column_name) if ch.isprintable() and ch not in "\r\n"
+        )[:200]
+        logger.warning(
+            "Rejected disallowed field access: user_id=%s endpoint=%s.%s column=%s",
+            get_user_id(),
+            self.__class__.__name__,
+            func_name,
+            sanitized_column,
+        )
+
     def timing_stats(self, action: str, func_name: str, value: float) -> None:
         """
         Proxy function for statsd.incr to impose a key structure for REST API's
@@ -619,6 +640,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
             return response
         if column_name not in self.allowed_rel_fields:
             self.incr_stats("error", self.related.__name__)
+            self.log_rejected_field_access(self.related.__name__, column_name)
             return self.response_404()
         args = kwargs.get("rison", {})
 
@@ -698,6 +720,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         """
         if column_name not in self.allowed_distinct_fields:
             self.incr_stats("error", self.related.__name__)
+            self.log_rejected_field_access(self.distinct.__name__, column_name)
             return self.response_404()
         args = kwargs.get("rison", {})
         # handle pagination

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -232,9 +232,11 @@ class BaseSupersetApiMixin:
         with the caller's identity, the endpoint, and the attempted value.
         """
         # Sanitize the user-supplied column name to a single, bounded token so
-        # it cannot inject newlines or forge extra log lines.
+        # it cannot inject newlines or forge extra key=value tokens in the log
+        # line. Restrict to a safe character set (column names are alphanumeric
+        # plus ``_-.``) and replace anything else with ``?``.
         sanitized_column = "".join(
-            ch for ch in str(column_name) if ch.isprintable() and ch not in "\r\n"
+            ch if (ch.isalnum() or ch in "_-.") else "?" for ch in str(column_name)
         )[:200]
         logger.warning(
             "Rejected disallowed field access: user_id=%s endpoint=%s.%s column=%s",

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -721,7 +721,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
               $ref: '#/components/responses/500'
         """
         if column_name not in self.allowed_distinct_fields:
-            self.incr_stats("error", self.related.__name__)
+            self.incr_stats("error", self.distinct.__name__)
             self.log_rejected_field_access(self.distinct.__name__, column_name)
             return self.response_404()
         args = kwargs.get("rison", {})

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -423,5 +423,13 @@ class ApiOwnersTestCaseMixin:
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/{self.resource_name}/related/owner"
 
-        rv = self.client.get(uri)
+        with patch("superset.views.base_api.logger") as mock_logger:
+            rv = self.client.get(uri)
         assert rv.status_code == 404
+        # A disallowed related field is recorded as a security log event,
+        # including the rejected column name, in addition to the 404.
+        mock_logger.warning.assert_called_once()
+        assert "column=owner" in (
+            mock_logger.warning.call_args.args[0]
+            % mock_logger.warning.call_args.args[1:]
+        )


### PR DESCRIPTION
### SUMMARY

When a user-supplied `column_name` fails the `related`/`distinct` allowlist check in `BaseSupersetModelRestApi`, the API incremented a statsd counter and returned a 404 but emitted no structured log event. As a result, rejected field-access attempts against these secondary checks were absent from the security audit trail — no caller identity, endpoint, or attempted value.

This adds a sanitized security log event (user id, endpoint, attempted column) at both denial points, alongside the existing statsd counter. The attempted column name is sanitized to a single bounded token (printable, no newlines, length-capped) so it cannot inject log lines. The allowlist control itself is unchanged.

This addresses two related audit-trail gaps in `views/base_api.py`: the secondary-authorization denial (the `related`/`distinct` 404) and the input-validation/allowlist-bypass attempt that produces it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — audit logging.

### TESTING INSTRUCTIONS

`test_get_related_fail` (run for each resource via `ApiOwnersTestCaseMixin`) is extended to assert a `logger.warning` security event is emitted with the rejected column name when a disallowed related field is requested.

Run e.g.: `pytest tests/integration_tests/charts/api_tests.py -k related_fail`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
