### PR TITLE
fix(security): clean up stale can_import permission on ImportExportRestApi

### DIFF
--- a/superset/migrations/versions/2026-06-23_03-23_a7d3f1b9c2e4_cleanup_stale_can_import_pvm.py
+++ b/superset/migrations/versions/2026-06-23_03-23_a7d3f1b9c2e4_cleanup_stale_can_import_pvm.py
@@ -45,6 +45,7 @@ revision = "a7d3f1b9c2e4"
 down_revision = "78a40c08b4be"
 
 from alembic import op  # noqa: E402
+from sqlalchemy.exc import SQLAlchemyError  # noqa: E402
 from sqlalchemy.orm import Session  # noqa: E402
 
 from superset.migrations.shared.security_converge import (  # noqa: E402
@@ -71,6 +72,8 @@ PVM_MAP = {
 
 
 def do_upgrade(session: Session) -> None:
+    """Ensure the live ``can_import_`` PVM exists and migrate any role holding the
+    stale ``can_import`` PVM onto it before the stale row is removed."""
     # Guarantee the live PVM exists before we point roles at it. ``add_pvms`` is
     # idempotent: it only creates rows that are missing.
     add_pvms(session, NEW_PVMS)
@@ -81,6 +84,10 @@ def do_upgrade(session: Session) -> None:
 
 
 def do_downgrade(session: Session) -> None:
+    """Intentionally a no-op: the upgrade only removes a stale duplicate PVM and
+    leaves the live ``can_import_`` permission untouched, so there is no prior
+    state worth restoring (recreating the stale row would just reintroduce the
+    duplicate)."""
     # No-op by design. Recreating the stale ``can_import`` PVM and moving roles
     # back onto it would reintroduce the very duplicate permission this
     # migration removes (and the orphaned row serves no purpose). The live
@@ -89,15 +96,25 @@ def do_downgrade(session: Session) -> None:
     pass
 
 
-def upgrade():
+def upgrade() -> None:
     bind = op.get_bind()
     session = Session(bind=bind)
     do_upgrade(session)
-    session.commit()
+    try:
+        session.commit()
+    except SQLAlchemyError as ex:
+        session.rollback()
+        raise Exception(f"An error occurred while upgrading permissions: {ex}") from ex
 
 
-def downgrade():
+def downgrade() -> None:
     bind = op.get_bind()
     session = Session(bind=bind)
     do_downgrade(session)
-    session.commit()
+    try:
+        session.commit()
+    except SQLAlchemyError as ex:
+        session.rollback()
+        raise Exception(
+            f"An error occurred while downgrading permissions: {ex}"
+        ) from ex

--- a/superset/migrations/versions/2026-06-23_03-23_a7d3f1b9c2e4_cleanup_stale_can_import_pvm.py
+++ b/superset/migrations/versions/2026-06-23_03-23_a7d3f1b9c2e4_cleanup_stale_can_import_pvm.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""clean up stale can_import permission on ImportExportRestApi
+
+The role-edit screen shows "can import on ImportExportRestApi" twice. Only one
+of those is real: the live permission is ``can_import_`` (note the trailing
+underscore), derived from the ``import_`` method on ``ImportExportRestApi``.
+The visual duplicate is a stale ``can_import`` (no trailing underscore)
+permission-view-menu (PVM) for the ``ImportExportRestApi`` view menu, left over
+from an older Superset/FAB era and persisted across upgrades. FAB renders
+``can_import_`` as "can import " and ``can_import`` as "can import", which look
+identical in the UI.
+
+Current code can no longer create the stale row, so this migration removes it.
+Before deleting, any role that holds the stale PVM is given the live
+``can_import_`` PVM so no role silently loses import access.
+
+This is scoped to the ``ImportExportRestApi`` view menu ONLY. It does not touch
+the ``can_import`` permission name globally; ``migrate_roles`` only deletes the
+``can_import`` permission row if it has become a true orphan (no remaining
+PVMs reference it).
+
+Revision ID: a7d3f1b9c2e4
+Revises: 78a40c08b4be
+Create Date: 2026-06-23 03:23:55.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a7d3f1b9c2e4"
+down_revision = "78a40c08b4be"
+
+from alembic import op  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from superset.migrations.shared.security_converge import (  # noqa: E402
+    add_pvms,
+    migrate_roles,
+    Pvm,
+)
+
+VIEW_MENU = "ImportExportRestApi"
+
+# The live permission that should exist for the import endpoint. We ensure it is
+# present (it normally is, created on startup by FAB) before reassigning roles to
+# it, so the lookup in ``migrate_roles`` cannot resolve to ``None``.
+NEW_PVMS = {VIEW_MENU: ("can_import_",)}
+
+# Map the stale PVM (``can_import`` with NO trailing underscore) to the live one
+# (``can_import_``). ``migrate_roles`` will, for every role holding the stale
+# PVM: add the live PVM (if missing), remove the stale PVM, then delete the
+# stale PVM row. The stale ``can_import`` permission row and the view menu are
+# only deleted by the helper if they become orphans afterwards.
+PVM_MAP = {
+    Pvm(VIEW_MENU, "can_import"): (Pvm(VIEW_MENU, "can_import_"),),
+}
+
+
+def do_upgrade(session: Session) -> None:
+    # Guarantee the live PVM exists before we point roles at it. ``add_pvms`` is
+    # idempotent: it only creates rows that are missing.
+    add_pvms(session, NEW_PVMS)
+    # On a clean install the stale PVM does not exist; ``migrate_roles`` resolves
+    # the old PVM to ``None`` and becomes a no-op, so this is safe to run
+    # everywhere.
+    migrate_roles(session, PVM_MAP)
+
+
+def do_downgrade(session: Session) -> None:
+    # No-op by design. Recreating the stale ``can_import`` PVM and moving roles
+    # back onto it would reintroduce the very duplicate permission this
+    # migration removes (and the orphaned row serves no purpose). The live
+    # ``can_import_`` permission is unaffected by the upgrade, so there is
+    # nothing meaningful to restore.
+    pass
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    do_upgrade(session)
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    do_downgrade(session)
+    session.commit()

--- a/tests/integration_tests/migrations/a7d3f1b9c2e4_cleanup_stale_can_import_pvm__tests.py
+++ b/tests/integration_tests/migrations/a7d3f1b9c2e4_cleanup_stale_can_import_pvm__tests.py
@@ -40,7 +40,7 @@ LIVE_PERM = "can_import_"  # trailing underscore (the real permission)
 
 
 @pytest.mark.usefixtures("app_context")
-def test_migration_reassigns_roles_and_removes_stale_pvm():
+def test_migration_reassigns_roles_and_removes_stale_pvm() -> None:
     # Arrange: simulate a metadata DB upgraded from an older era that still has
     # the stale ``can_import`` PVM on the ImportExportRestApi view menu, held by
     # a role.
@@ -73,7 +73,7 @@ def test_migration_reassigns_roles_and_removes_stale_pvm():
 
 
 @pytest.mark.usefixtures("app_context")
-def test_migration_is_noop_on_clean_install():
+def test_migration_is_noop_on_clean_install() -> None:
     # No stale PVM present (clean install). The migration must not error and must
     # leave the live permission intact.
     assert _find_pvm(db.session, VIEW, STALE_PERM) is None

--- a/tests/integration_tests/migrations/a7d3f1b9c2e4_cleanup_stale_can_import_pvm__tests.py
+++ b/tests/integration_tests/migrations/a7d3f1b9c2e4_cleanup_stale_can_import_pvm__tests.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from importlib import import_module
+
+import pytest
+
+from superset import db
+from superset.migrations.shared.security_converge import (
+    _add_permission,
+    _add_permission_view,
+    _add_view_menu,
+    _find_pvm,
+    Role,
+)
+
+migration_module = import_module(
+    "superset.migrations.versions."
+    "2026-06-23_03-23_a7d3f1b9c2e4_cleanup_stale_can_import_pvm"
+)
+
+upgrade = migration_module.do_upgrade
+
+VIEW = "ImportExportRestApi"
+STALE_PERM = "can_import"  # no trailing underscore
+LIVE_PERM = "can_import_"  # trailing underscore (the real permission)
+
+
+@pytest.mark.usefixtures("app_context")
+def test_migration_reassigns_roles_and_removes_stale_pvm():
+    # Arrange: simulate a metadata DB upgraded from an older era that still has
+    # the stale ``can_import`` PVM on the ImportExportRestApi view menu, held by
+    # a role.
+    view_menu = _add_view_menu(db.session, VIEW)
+    stale_permission = _add_permission(db.session, STALE_PERM)
+    stale_pvm = _add_permission_view(db.session, stale_permission, view_menu)
+
+    role = Role(name="stale_import_role")
+    role.permissions.append(stale_pvm)
+    db.session.add(role)
+    db.session.commit()
+
+    assert _find_pvm(db.session, VIEW, STALE_PERM) is not None
+
+    # Act
+    upgrade(db.session)
+
+    # Assert: the live PVM exists, the stale one is gone, and the role kept
+    # import access by being moved onto the live PVM.
+    live_pvm = _find_pvm(db.session, VIEW, LIVE_PERM)
+    assert live_pvm is not None
+    assert _find_pvm(db.session, VIEW, STALE_PERM) is None
+
+    refreshed_role = db.session.query(Role).filter_by(name="stale_import_role").one()
+    assert live_pvm in refreshed_role.permissions
+
+    # Cleanup
+    db.session.delete(refreshed_role)
+    db.session.commit()
+
+
+@pytest.mark.usefixtures("app_context")
+def test_migration_is_noop_on_clean_install():
+    # No stale PVM present (clean install). The migration must not error and must
+    # leave the live permission intact.
+    assert _find_pvm(db.session, VIEW, STALE_PERM) is None
+
+    upgrade(db.session)
+
+    assert _find_pvm(db.session, VIEW, STALE_PERM) is None
+    assert _find_pvm(db.session, VIEW, LIVE_PERM) is not None


### PR DESCRIPTION
### SUMMARY

On the role-edit screen, `can import on ImportExportRestApi` appears **twice**. Only one of those entries is real.

- The live permission is `can_import_` (note the **trailing underscore**), derived by Flask-AppBuilder from the `import_()` method on `ImportExportRestApi` (`superset/importexport/api.py`). It is registered exactly once.
- The visual "duplicate" is a **stale** `can_import` (no trailing underscore) permission-view-menu (PVM) row tied to the `ImportExportRestApi` view menu. It's a leftover from an older Superset/FAB era that has persisted across upgrades. FAB renders `can_import_` as "can import " and `can_import` as "can import", which look identical in the UI.

Current code can no longer create the stale row, so the right fix (Option A) is a cleanup migration.

This migration is scoped to the `ImportExportRestApi` view menu **only**:

1. Ensures the live `can_import_` PVM exists (`add_pvms`, idempotent).
2. For every role that holds the stale `can_import` PVM, adds the live `can_import_` PVM and removes the stale one — so **no role silently loses import access** (`migrate_roles`).
3. Deletes the stale `can_import` PVM. The shared `migrate_roles`/`_delete_old_permissions` helper deletes the `can_import` permission row and the view-menu row **only if they become true orphans** (no remaining PVMs reference them), so the global `can_import` permission name is never dropped while anything still uses it.

On a clean install the stale PVM doesn't exist, so the lookup resolves to `None` and the migration is a safe no-op.

`downgrade()` is intentionally a no-op (documented inline): recreating an orphaned stale PVM would reintroduce the exact duplicate this fixes, and the live `can_import_` permission is untouched by the upgrade, so there's nothing meaningful to restore.

### TESTING INSTRUCTIONS

- Automated: `pytest tests/integration_tests/migrations/a7d3f1b9c2e4_cleanup_stale_can_import_pvm__tests.py`
  - `test_migration_reassigns_roles_and_removes_stale_pvm` — seeds a stale `can_import`/`ImportExportRestApi` PVM on a role, runs upgrade, asserts the stale PVM is gone, the live `can_import_` PVM exists, and the role was reassigned to it.
  - `test_migration_is_noop_on_clean_install` — asserts no error and the live permission stays intact when no stale row exists.
- Manual: on a metadata DB that exhibits the duplicate, run `superset db upgrade`, then open Settings → List Roles → edit a role and confirm `can import on ImportExportRestApi` appears only once.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #36070
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Runtime/downtime: negligible — touches at most a single PVM row plus its role associations; no schema/DDL changes, no table scans, no downtime.