### PR TITLE
fix(tests): stabilize update_chart MCP test failing on previous-Python CI leg

### DIFF
--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -1480,8 +1480,9 @@ class TestUpdateChartDatasetIdIntegration:
         "superset.commands.chart.update.UpdateChartCommand",
         new_callable=Mock,
     )
-    @patch(
-        "superset.mcp_service.chart.tool.update_chart._validate_update_against_dataset",
+    @patch.object(
+        update_chart_module,
+        "_validate_update_against_dataset",
         return_value=None,
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)


### PR DESCRIPTION
### SUMMARY

The `unit-tests (previous)` (and the aggregate `unit-tests-required`) CI leg has been **red on roughly half of recent master commits** — not flakiness, but a single deterministic failure:

```
tests/unit_tests/mcp_service/chart/tool/test_update_chart.py::TestUpdateChartDatasetIdIntegration::test_dataset_id_passed_to_update_command
AttributeError: <function update_chart ...> does not have the attribute '_validate_update_against_dataset'
```

**Root cause (a logical merge conflict):** `superset/mcp_service/chart/tool/__init__.py` re-exports the `update_chart` *function* (`from .update_chart import update_chart`), which shadows the `update_chart` **submodule** attribute on the `tool` package. The failing test used a string-based decorator:

```python
@patch("superset.mcp_service.chart.tool.update_chart._validate_update_against_dataset", ...)
```

`unittest.mock` resolves that dotted path via `getattr(tool, "update_chart")`, which returns the **function** rather than the module, so the attribute lookup raises `AttributeError`. Older `unittest.mock` returns the shadowing attribute while newer versions prefer the submodule — which is exactly why only the **previous-Python** matrix leg fails while the current-Python leg passes, letting it slip past per-PR CI and land on master repeatedly.

The other three tests in this same file already anticipate the shadowing and patch via the `importlib`-resolved module object:

```python
update_chart_module = importlib.import_module("superset.mcp_service.chart.tool.update_chart")
...
@patch.object(update_chart_module, "_validate_update_against_dataset", ...)
```

This PR makes the one remaining test consistent with them. One-line-scope change; no production code touched.

### TESTING INSTRUCTIONS

Verified locally on **Python 3.10** (the previous-version leg):

```bash
python -m pytest "tests/unit_tests/mcp_service/chart/tool/test_update_chart.py::TestUpdateChartDatasetIdIntegration::test_dataset_id_passed_to_update_command"
```

- Before: fails with the `AttributeError` above.
- After: passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)