### PR TITLE
fix(plugin-chart-echarts): show forecast tooltip values when they equal zero

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -98,12 +98,13 @@ export const formatForecastTooltipSeries = ({
 }): string[] => {
   const name = `${marker}${sanitizeHtml(seriesName)}`;
   let value = typeof observation === 'number' ? formatter(observation) : '';
-  // Use explicit numeric checks rather than truthiness so that legitimate
+  // Use finite-number checks rather than truthiness so that legitimate
   // zero values (e.g. a forecast that crosses zero, or a confidence bound of
-  // exactly 0) are not dropped from the tooltip.
-  const hasTrend = typeof forecastTrend === 'number';
-  const hasLower = typeof forecastLower === 'number';
-  const hasUpper = typeof forecastUpper === 'number';
+  // exactly 0) are not dropped from the tooltip, while non-finite values
+  // (NaN/Infinity) are still excluded.
+  const hasTrend = Number.isFinite(forecastTrend);
+  const hasLower = Number.isFinite(forecastLower);
+  const hasUpper = Number.isFinite(forecastUpper);
   if (hasTrend || hasLower || hasUpper) {
     // forecast values take the form of "20, y = 30 (10, 40)"
     // where the first part is the observation, the second part is the forecast trend

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -98,15 +98,21 @@ export const formatForecastTooltipSeries = ({
 }): string[] => {
   const name = `${marker}${sanitizeHtml(seriesName)}`;
   let value = typeof observation === 'number' ? formatter(observation) : '';
-  if (forecastTrend || forecastLower || forecastUpper) {
+  // Use explicit numeric checks rather than truthiness so that legitimate
+  // zero values (e.g. a forecast that crosses zero, or a confidence bound of
+  // exactly 0) are not dropped from the tooltip.
+  const hasTrend = typeof forecastTrend === 'number';
+  const hasLower = typeof forecastLower === 'number';
+  const hasUpper = typeof forecastUpper === 'number';
+  if (hasTrend || hasLower || hasUpper) {
     // forecast values take the form of "20, y = 30 (10, 40)"
     // where the first part is the observation, the second part is the forecast trend
     // and the third part is the lower and upper bounds
-    if (forecastTrend) {
+    if (hasTrend) {
       if (value) value += ', ';
       value += `ŷ = ${formatter(forecastTrend)}`;
     }
-    if (forecastLower && forecastUpper) {
+    if (hasLower && hasUpper) {
       if (value) value += ' ';
       // the lower bound needs to be added to the upper bound
       value += `(${formatter(forecastLower)}, ${formatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -111,11 +111,11 @@ export const formatForecastTooltipSeries = ({
     // forecast values take the form of "20, y = 30 (10, 40)"
     // where the first part is the observation, the second part is the forecast trend
     // and the third part is the lower and upper bounds
-    if (isFiniteNumber(forecastTrend)) {
+    if (hasTrend) {
       if (value) value += ', ';
       value += `ŷ = ${formatter(forecastTrend)}`;
     }
-    if (isFiniteNumber(forecastLower) && isFiniteNumber(forecastUpper)) {
+    if (hasLower && hasUpper) {
       if (value) value += ' ';
       // the lower bound needs to be added to the upper bound
       value += `(${formatter(forecastLower)}, ${formatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -102,18 +102,20 @@ export const formatForecastTooltipSeries = ({
   // zero values (e.g. a forecast that crosses zero, or a confidence bound of
   // exactly 0) are not dropped from the tooltip, while non-finite values
   // (NaN/Infinity) are still excluded.
-  const hasTrend = Number.isFinite(forecastTrend);
-  const hasLower = Number.isFinite(forecastLower);
-  const hasUpper = Number.isFinite(forecastUpper);
+  const isFiniteNumber = (val: number | undefined): val is number =>
+    typeof val === 'number' && Number.isFinite(val);
+  const hasTrend = isFiniteNumber(forecastTrend);
+  const hasLower = isFiniteNumber(forecastLower);
+  const hasUpper = isFiniteNumber(forecastUpper);
   if (hasTrend || hasLower || hasUpper) {
     // forecast values take the form of "20, y = 30 (10, 40)"
     // where the first part is the observation, the second part is the forecast trend
     // and the third part is the lower and upper bounds
-    if (hasTrend) {
+    if (isFiniteNumber(forecastTrend)) {
       if (value) value += ', ';
       value += `ŷ = ${formatter(forecastTrend)}`;
     }
-    if (hasLower && hasUpper) {
+    if (isFiniteNumber(forecastLower) && isFiniteNumber(forecastUpper)) {
       if (value) value += ' ';
       // the lower bound needs to be added to the upper bound
       value += `(${formatter(forecastLower)}, ${formatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -397,3 +397,17 @@ test('formatForecastTooltipSeries should show forecast trend and band all at zer
     }),
   ).toEqual(['<img>qwerty', 'ŷ = 0 (0, 0)']);
 });
+
+test('formatForecastTooltipSeries should skip non-finite forecast values', () => {
+  expect(
+    formatForecastTooltipSeries({
+      seriesName: 'qwerty',
+      marker: '<img>',
+      observation: 10,
+      forecastTrend: NaN,
+      forecastLower: Infinity,
+      forecastUpper: -Infinity,
+      formatter,
+    }),
+  ).toEqual(['<img>qwerty', '10']);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -342,3 +342,58 @@ test('formatForecastTooltipSeries should format forecast with only confidence ba
     }),
   ).toEqual(['<img>qwerty', '(7, 15)']);
 });
+
+test('formatForecastTooltipSeries should show forecast trend equal to zero', () => {
+  expect(
+    formatForecastTooltipSeries({
+      seriesName: 'qwerty',
+      marker: '<img>',
+      observation: 10,
+      forecastTrend: 0,
+      forecastLower: 5,
+      forecastUpper: 7,
+      formatter,
+    }),
+  ).toEqual(['<img>qwerty', '10, ŷ = 0 (5, 12)']);
+});
+
+test('formatForecastTooltipSeries should show confidence band when lower bound is zero', () => {
+  expect(
+    formatForecastTooltipSeries({
+      seriesName: 'qwerty',
+      marker: '<img>',
+      observation: 10,
+      forecastTrend: 5,
+      forecastLower: 0,
+      forecastUpper: 7,
+      formatter,
+    }),
+  ).toEqual(['<img>qwerty', '10, ŷ = 5 (0, 7)']);
+});
+
+test('formatForecastTooltipSeries should show confidence band when band height is zero', () => {
+  expect(
+    formatForecastTooltipSeries({
+      seriesName: 'qwerty',
+      marker: '<img>',
+      observation: 10,
+      forecastTrend: 5,
+      forecastLower: 4,
+      forecastUpper: 0,
+      formatter,
+    }),
+  ).toEqual(['<img>qwerty', '10, ŷ = 5 (4, 4)']);
+});
+
+test('formatForecastTooltipSeries should show forecast trend and band all at zero', () => {
+  expect(
+    formatForecastTooltipSeries({
+      seriesName: 'qwerty',
+      marker: '<img>',
+      forecastTrend: 0,
+      forecastLower: 0,
+      forecastUpper: 0,
+      formatter,
+    }),
+  ).toEqual(['<img>qwerty', 'ŷ = 0 (0, 0)']);
+});


### PR DESCRIPTION
### SUMMARY

Fixes #21734

Prophet forecast confidence intervals appeared to "disappear" in the chart tooltip whenever the forecast crossed zero. The root cause is in the ECharts time-series forecast tooltip formatter (`superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts`), which used **truthiness** checks on the forecast values:

```ts
if (forecastTrend) { ... }              // a trend of exactly 0 is skipped
if (forecastLower && forecastUpper) { } // a bound/height of 0 drops the whole band
```

Because `0` is falsy in JS, a legitimate forecast trend of `0`, a lower bound of `0`, or a zero-height band caused the corresponding values to be silently omitted from the tooltip. This matches the report in #21734 ("if the central estimate crosses 0, they are gone").

The fix switches these to explicit `typeof value === 'number'` checks — the same pattern already used for the `observation` value just above — so zero values are formatted and displayed like any other number.

Backend was already verified clean by the earlier test-only TDD guard (#40141): the Prophet wrapper does not clamp at zero. This PR addresses the remaining frontend rendering bug.

### BEFORE/AFTER

- **Before:** a forecast point with `ŷ = 0`, or a confidence bound of `0`, rendered no trend/interval in the tooltip.
- **After:** `ŷ = 0` and intervals like `(0, 7)` or `(4, 4)` render correctly.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest plugins/plugin-chart-echarts/test/utils/forecast.test.ts
```

Four new unit tests pin the zero-crossing behavior (trend = 0, lower = 0, zero-height band, all-zero). They fail on `master` and pass with this change.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #21734
- [ ] Required feature flags:
- [x] Changes UI (forecast tooltip rendering)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
