### PR TITLE
fix(explore): default Save As for new charts in save dialog

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -280,6 +280,22 @@ test('disables overwrite option for new slice', () => {
   expect(getByRole('radio', { name: 'Save (Overwrite)' })).toBeDisabled();
 });
 
+test('defaults to Save As for new chart even when can_overwrite is true', () => {
+  const { getByRole } = setup(
+    {},
+    mockStore({
+      ...initialState,
+      explore: {
+        ...initialState.explore,
+        slice: null,
+        can_overwrite: true,
+      },
+    }),
+  );
+  expect(getByRole('radio', { name: 'Save (Overwrite)' })).toBeDisabled();
+  expect(getByRole('radio', { name: 'Save as...' })).toBeChecked();
+});
+
 test('disables overwrite option for non-owner', () => {
   const { getByRole, getByText } = setup(
     {},

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -229,6 +229,7 @@ const SaveModal = ({
 
   const canOverwriteSlice = useCallback(
     (): boolean =>
+      !!slice &&
       (can_overwrite ||
         isUserAdmin(user) ||
         slice?.owners?.includes(user.userId)) &&


### PR DESCRIPTION
### Summary

When creating a **new (unsaved) chart** and clicking Save, the dialog defaulted to **Overwrite** mode. Since no chart existed yet, overwriting failed. Users had to manually switch to **Save As**.

**Root cause:** `canOverwriteSlice()` in `SaveModal.tsx` returned `true` for new charts when `can_overwrite=true` or the user was an admin, because those permission checks short-circuited before checking whether a `slice` even exists.

**Fix:** Added `!!this.props.slice &&` as the first guard in `canOverwriteSlice()`, so Overwrite is only enabled (and never pre-selected) when an existing chart is loaded.

### Testing

- Added unit test: `'defaults to Save As for new chart even when can_overwrite is true'` — verifies that with `slice: null` and `can_overwrite: true`, the Overwrite radio is disabled and Save As is checked.
- All pre-commit hooks pass (end-of-file, prettier, oxlint, trim whitespace).

### Checklist

- [x] Unit test added
- [x] Pre-commit clean
- [x] Changelog entry not required (bug fix in UI only)