### PR TITLE
fix(sqllab): replace native prompt with modal for tab rename

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -158,6 +158,127 @@ describe('SqlEditorTabHeader', () => {
       );
     });
 
+    test('prefills the rename input with the current tab name', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      expect(input).toHaveValue(defaultQueryEditor.name);
+    });
+
+    test('focuses the rename input when the modal opens', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      await waitFor(() => expect(input).toHaveFocus());
+    });
+
+    test('disables Save when the input is empty or whitespace', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: '   ' } });
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    test('does not dispatch or dismiss on Enter when the input is empty', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, charCode: 13 });
+
+      const dispatchedTitleChange = store
+        .getActions()
+        .some(action => action.type === QUERY_EDITOR_SET_TITLE);
+      expect(dispatchedTitleChange).toBe(false);
+      // the modal must stay open so the user can correct the name,
+      // mirroring the disabled Save button rather than dismissing like Escape
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+
+    test('does not dispatch a title change when the modal is cancelled', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: 'discarded text' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(store.getActions()).toEqual([]);
+    });
+
+    test('does not dispatch a title change when dismissed with the close button', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: 'discarded text' } });
+      fireEvent.click(screen.getByTestId('close-modal-btn'));
+
+      expect(store.getActions()).toEqual([]);
+    });
+
+    test('returns focus to the tab header after the modal is cancelled', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      await screen.findByTestId('rename-tab-input');
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
+      );
+    });
+
+    test('returns focus to the tab header after a successful rename', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: 'renamed tab' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
+      );
+    });
+
     test('should dispatch removeAllOtherQueryEditors action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
@@ -197,5 +318,43 @@ describe('SqlEditorTabHeader', () => {
         }),
       );
     });
+  });
+
+  test('does not leak tab-editing keystrokes from the rename input to the surrounding tabs', async () => {
+    const onContainerKeyDown = jest.fn();
+    const store = mockStore(initialState);
+    render(
+      <div onKeyDown={onContainerKeyDown}>
+        <SqlEditorTabHeader queryEditor={defaultQueryEditor} />
+      </div>,
+      { useRedux: true, store },
+    );
+
+    userEvent.click(screen.getByTestId('dropdown-trigger'));
+    await waitFor(() =>
+      expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+    const input = await screen.findByTestId('rename-tab-input');
+
+    // The modal portals over the editable-card tabs, whose keyboard handler would
+    // otherwise remove, navigate, or activate a tab (and swallow Space). None of
+    // these keys should escape the modal to the surrounding container.
+    [
+      'Delete',
+      'Backspace',
+      'ArrowLeft',
+      'ArrowRight',
+      'Home',
+      'End',
+      ' ',
+    ].forEach(key => fireEvent.keyDown(input, { key }));
+    expect(onContainerKeyDown).not.toHaveBeenCalled();
+
+    // Escape (close) and Tab (focus trap) must still reach the Modal.
+    fireEvent.keyDown(input, { key: 'Tab' });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    const reached = onContainerKeyDown.mock.calls.map(call => call[0].key);
+    expect(reached).toEqual(expect.arrayContaining(['Tab', 'Escape']));
   });
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -135,13 +135,16 @@ describe('SqlEditorTabHeader', () => {
 
     test('should dispatch queryEditorSetTitle action', async () => {
       await waitFor(() =>
-        expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
       );
       const expectedTitle = 'typed text';
-      const mockPrompt = jest
-        .spyOn(window, 'prompt')
-        .mockImplementation(() => expectedTitle);
       fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: expectedTitle } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
       const actions = store.getActions();
       await waitFor(() =>
@@ -153,7 +156,6 @@ describe('SqlEditorTabHeader', () => {
           }),
         }),
       );
-      mockPrompt.mockClear();
     });
 
     test('should dispatch removeAllOtherQueryEditors action', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -114,7 +114,7 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
 
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [newTitle, setNewTitle] = useState('');
-  const renameInputRef = useRef<InputRef | null>(null);
+  const renameInputRef = useRef<InputRef>(null);
   const tabHeaderRef = useRef<HTMLDivElement>(null);
   const trimmedTitle = newTitle.trim();
 

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, FC } from 'react';
+import { useMemo, useState, FC } from 'react';
 
 import { bindActionCreators } from 'redux';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
-import { MenuDotsDropdown } from '@superset-ui/core/components';
+import { MenuDotsDropdown, Modal, Input } from '@superset-ui/core/components';
 import { Menu, MenuItemType } from '@superset-ui/core/components/Menu';
 import { t } from '@apache-superset/core/translation';
 import { QueryState } from '@superset-ui/core';
@@ -107,13 +107,20 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
     [dispatch],
   );
 
-  function renameTab() {
-    // TODO: Replace native prompt with a proper modal dialog
-    // eslint-disable-next-line no-alert
-    const newTitle = prompt(t('Enter a new title for the tab'));
-    if (newTitle) {
-      actions.queryEditorSetTitle(qe, newTitle, qe.id);
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+
+  function openRenameModal() {
+    setNewTitle(qe.name);
+    setIsRenameModalOpen(true);
+  }
+
+  function handleRenameTab() {
+    const trimmedTitle = newTitle.trim();
+    if (trimmedTitle) {
+      actions.queryEditorSetTitle(qe, trimmedTitle, qe.id);
     }
+    setIsRenameModalOpen(false);
   }
   const getStatusColor = (state: QueryState, theme: SupersetTheme): string => {
     const statusColors: Record<QueryState, string> = {
@@ -158,7 +165,7 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
               } as MenuItemType,
               {
                 key: '2',
-                onClick: renameTab,
+                onClick: openRenameModal,
                 'data-test': 'rename-tab-menu-option',
                 label: (
                   <>
@@ -220,6 +227,22 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
         iconSize="m"
         iconColor={getStatusColor(queryState, theme)}
       />{' '}
+      <Modal
+        show={isRenameModalOpen}
+        onHide={() => setIsRenameModalOpen(false)}
+        title={t('Rename tab')}
+        onHandledPrimaryAction={handleRenameTab}
+        primaryButtonName={t('Save')}
+        disablePrimaryButton={!newTitle.trim()}
+      >
+        <Input
+          data-test="rename-tab-input"
+          aria-label={t('Tab name')}
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          onPressEnter={handleRenameTab}
+        />
+      </Modal>
     </TabTitleWrapper>
   );
 };

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -16,12 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, useState, FC } from 'react';
+import { useEffect, useMemo, useRef, useState, FC } from 'react';
 
 import { bindActionCreators } from 'redux';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
-import { MenuDotsDropdown, Modal, Input } from '@superset-ui/core/components';
+import {
+  MenuDotsDropdown,
+  Modal,
+  Input,
+  InputRef,
+} from '@superset-ui/core/components';
 import { Menu, MenuItemType } from '@superset-ui/core/components/Menu';
 import { t } from '@apache-superset/core/translation';
 import { QueryState } from '@superset-ui/core';
@@ -109,18 +114,33 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
 
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [newTitle, setNewTitle] = useState('');
+  const renameInputRef = useRef<InputRef | null>(null);
+  const tabHeaderRef = useRef<HTMLDivElement>(null);
+  const trimmedTitle = newTitle.trim();
 
   function openRenameModal() {
     setNewTitle(qe.name);
     setIsRenameModalOpen(true);
   }
 
+  // antd's Modal moves focus to the dialog container on open, which overrides
+  // the Input's autoFocus, so focus and select the field via a ref once the
+  // modal is open (select lets the prefilled name be overtyped, like prompt()).
+  useEffect(() => {
+    if (isRenameModalOpen) {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }
+  }, [isRenameModalOpen]);
+
   function handleRenameTab() {
-    const trimmedTitle = newTitle.trim();
     if (trimmedTitle) {
       actions.queryEditorSetTitle(qe, trimmedTitle, qe.id);
     }
     setIsRenameModalOpen(false);
+    // Save closes via the show prop rather than the Modal's onHide, so return
+    // focus to the tab header here, matching what openerRef does on dismiss.
+    tabHeaderRef.current?.focus();
   }
   const getStatusColor = (state: QueryState, theme: SupersetTheme): string => {
     const statusColors: Record<QueryState, string> = {
@@ -138,7 +158,11 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
     return statusColors[state] || theme.colorIcon;
   };
   return (
-    <TabTitleWrapper>
+    <TabTitleWrapper
+      ref={tabHeaderRef}
+      tabIndex={-1}
+      data-test="sql-editor-tab-header"
+    >
       <MenuDotsDropdown
         trigger={['click']}
         overlay={
@@ -233,14 +257,29 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
         title={t('Rename tab')}
         onHandledPrimaryAction={handleRenameTab}
         primaryButtonName={t('Save')}
-        disablePrimaryButton={!newTitle.trim()}
+        disablePrimaryButton={!trimmedTitle}
+        openerRef={tabHeaderRef}
       >
         <Input
+          ref={renameInputRef}
           data-test="rename-tab-input"
           aria-label={t('Tab name')}
           value={newTitle}
           onChange={e => setNewTitle(e.target.value)}
-          onPressEnter={handleRenameTab}
+          onPressEnter={() => {
+            if (trimmedTitle) {
+              handleRenameTab();
+            }
+          }}
+          onKeyDown={e => {
+            // The modal portals over the editable-card tabs; without this, keys
+            // bubble to their handler and remove, navigate, or activate a tab
+            // (Space included). Escape and Tab are left to bubble so the Modal
+            // can close and trap focus.
+            if (e.key !== 'Escape' && e.key !== 'Tab') {
+              e.stopPropagation();
+            }
+          }}
         />
       </Modal>
     </TabTitleWrapper>


### PR DESCRIPTION
### SUMMARY

SQL Lab's tab rename used the native browser `prompt()` dialog, which can't be
styled, is blocked in some environments, and is inconsistent with the rest of
the UI (the code carried a `// TODO` to replace it). This swaps it for the
existing `Modal` component with a text input: the current tab name is
prefilled, Enter submits, and Save is disabled when the field is empty.

Closes #40401

### Screenshots

Before:
<img width="1458" height="901" alt="Screenshot_Before" src="https://github.com/user-attachments/assets/62af034f-3bbe-4ce7-9024-ab4516a125cd" />


After:
<img width="1456" height="902" alt="Screenshot_After_1" src="https://github.com/user-attachments/assets/940e1eaf-5566-4736-85bf-10662a551939" />


After (renamed):
<img width="1456" height="483" alt="Screenshot_After_2" src="https://github.com/user-attachments/assets/9bad5a26-cbc3-4812-a6f8-13932ced9b8c" />


### TESTING INSTRUCTIONS

1. Open SQL Lab.
2. On a query tab, open the `⋮` menu and choose "Rename tab".
3. A styled modal appears with the current tab name prefilled.
4. Edit and click Save (or press Enter); the tab title updates. Cancel/close leaves it unchanged.

Unit test in `SqlEditorTabHeader.test.tsx` updated to drive the modal instead of the native prompt.

### Note for reviewers

Since the rename UI is now an in-page input rather than a native browser prompt, keystrokes in the field would otherwise bubble to SQL Lab's editable-card tab keyboard handler, where Delete/Backspace removes the tab, the arrow keys and Home/End navigate tabs, and Space is swallowed. The input now stops those keys from propagating out of the modal, while still letting
Escape and Tab through so the dialog can close and trap focus. Covered by a unit test.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Closes #40401
- [x] Changes UI