### PR TITLE
chore: fix lint on untouched files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,7 +375,6 @@ select = [
 
 ignore = [
     "S101",
-    "PT004",  # Fixtures that don't return values - underscore prefix conflicts with pytest usage
     "PT006",
     "T201",
     "N999",

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -74,7 +74,10 @@ export function transformLinkUri(uri: string): string {
   // "java\tscript:" or "java\x01script:") are ignored by browsers, so strip
   // them before comparing against the blocklist.
   // eslint-disable-next-line no-control-regex
-  const scheme = url.slice(0, colon).replace(/[\u0000-\u0020]/g, '').toLowerCase();
+  const scheme = url
+    .slice(0, colon)
+    .replace(/[\u0000-\u0020]/g, '')
+    .toLowerCase();
   return DANGEROUS_LINK_PROTOCOLS.includes(scheme) ? '' : url;
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -519,7 +519,8 @@ const Select = forwardRef(
               handleSelectAll();
             }}
           >
-            {t('Select all')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
+            {t('Select all')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
           </Button>
           <Button
             type="link"
@@ -536,7 +537,8 @@ const Select = forwardRef(
               handleDeselectAll();
             }}
           >
-            {t('Clear')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
+            {t('Clear')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
           </Button>
         </StyledBulkActionsContainer>
       ),

--- a/superset-frontend/playwright/tests/chart/handlebars-format-date.spec.ts
+++ b/superset-frontend/playwright/tests/chart/handlebars-format-date.spec.ts
@@ -97,8 +97,11 @@ testWithAssets(
     });
 
     // At least one list item should contain a DD.MM.YYYY formatted date.
-    await expect(panel.locator('li').first()).toHaveText(/\d{2}\.\d{2}\.\d{4}/, {
-      timeout: TIMEOUT.API_RESPONSE,
-    });
+    await expect(panel.locator('li').first()).toHaveText(
+      /\d{2}\.\d{2}\.\d{4}/,
+      {
+        timeout: TIMEOUT.API_RESPONSE,
+      },
+    );
   },
 );

--- a/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
@@ -182,10 +182,7 @@ testWithAssets(
     // Now track POST /api/v1/chart/data requests around Clear All
     const postsAfterClearAll: string[] = [];
     const handler = (req: any) => {
-      if (
-        req.url().includes('/api/v1/chart/data') &&
-        req.method() === 'POST'
-      ) {
+      if (req.url().includes('/api/v1/chart/data') && req.method() === 'POST') {
         postsAfterClearAll.push(req.url());
       }
     };

--- a/superset-frontend/playwright/tests/dashboard/mixed-chart-dashboard-filters.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/mixed-chart-dashboard-filters.spec.ts
@@ -109,7 +109,12 @@ testWithAssets(
         id: chartLayoutKey,
         children: [],
         parents: ['ROOT_ID', 'GRID_ID', 'ROW-1'],
-        meta: { chartId, width: 8, height: 60, sliceName: 'mixed_filter_repro' },
+        meta: {
+          chartId,
+          width: 8,
+          height: 60,
+          sliceName: 'mixed_filter_repro',
+        },
       },
     };
     const jsonMetadata = {
@@ -130,9 +135,7 @@ testWithAssets(
           defaultDataMask: {
             filterState: { value: [FILTER_VALUE] },
             extraFormData: {
-              filters: [
-                { col: FILTER_COLUMN, op: 'IN', val: [FILTER_VALUE] },
-              ],
+              filters: [{ col: FILTER_COLUMN, op: 'IN', val: [FILTER_VALUE] }],
             },
           },
           cascadeParentIds: [],
@@ -158,15 +161,14 @@ testWithAssets(
     const dashboardId: number = dashBody.result?.id ?? dashBody.id;
     testAssets.trackDashboard(dashboardId);
 
-    await apiPut(page, `api/v1/chart/${chartId}`, { dashboards: [dashboardId] });
+    await apiPut(page, `api/v1/chart/${chartId}`, {
+      dashboards: [dashboardId],
+    });
 
     // Capture the Mixed chart's data request (the one with two queries).
     const twoQueryPayloads: any[] = [];
     page.on('request', req => {
-      if (
-        req.url().includes('/api/v1/chart/data') &&
-        req.method() === 'POST'
-      ) {
+      if (req.url().includes('/api/v1/chart/data') && req.method() === 'POST') {
         try {
           const body = req.postDataJSON();
           if (body?.queries?.length === 2) {

--- a/superset-frontend/playwright/tests/embedded/pivot-collapse-state.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/pivot-collapse-state.spec.ts
@@ -50,7 +50,10 @@ import {
   getGuestToken,
 } from '../../helpers/api/embedded';
 import { apiPost, apiPut } from '../../helpers/api/requests';
-import { apiPostDashboard, apiDeleteDashboard } from '../../helpers/api/dashboard';
+import {
+  apiPostDashboard,
+  apiDeleteDashboard,
+} from '../../helpers/api/dashboard';
 import { apiDeleteChart } from '../../helpers/api/chart';
 import { EmbeddedPage } from '../../pages/EmbeddedPage';
 import { EMBEDDED } from '../../utils/constants';

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/CountryMap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/CountryMap.ts
@@ -187,9 +187,11 @@ function CountryMap(element: HTMLElement, props: CountryMapProps) {
       region => region.country_id === d.properties.ISO,
     );
 
-    hoverPopup.style('display', 'block').html(
-      `<div><strong>${getNameOfRegion(d)}</strong><br>${result.length > 0 ? formatter(result[0].metric) : ''}</div>`,
-    );
+    hoverPopup
+      .style('display', 'block')
+      .html(
+        `<div><strong>${getNameOfRegion(d)}</strong><br>${result.length > 0 ? formatter(result[0].metric) : ''}</div>`,
+      );
     updatePopupPosition();
   };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
@@ -164,7 +164,8 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
     processedData = filteredData.map(d => ({
       ...d,
       radius: radiusScale(Math.sqrt(d.m2)),
-      fillColor: d.m1 != null ? colorFn(d.m1) ?? theme.colorBorder : theme.colorBorder,
+      fillColor:
+        d.m1 != null ? (colorFn(d.m1) ?? theme.colorBorder) : theme.colorBorder,
     }));
   }
 

--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -66,9 +66,9 @@ def cidr_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeResponse:
         else:
             resp["display_value"] = ", ".join(
                 map(  # noqa: C417
-                    lambda x: f"{x['start']} - {x['end']}"
-                    if isinstance(x, dict)
-                    else str(x),
+                    lambda x: (
+                        f"{x['start']} - {x['end']}" if isinstance(x, dict) else str(x)
+                    ),
                     resp["values"],
                 )
             )

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -95,9 +95,9 @@ def port_translation_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeRespo
         else:
             resp["display_value"] = ", ".join(
                 map(  # noqa: C417
-                    lambda x: f"{x['start']} - {x['end']}"
-                    if isinstance(x, dict)
-                    else str(x),
+                    lambda x: (
+                        f"{x['start']} - {x['end']}" if isinstance(x, dict) else str(x)
+                    ),
                     resp["values"],
                 )
             )

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -51,8 +51,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_column_values",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_column_values"
+        ),
         log_to_statsd=False,
     )
     def get_column_values(
@@ -152,8 +153,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".validate_expression",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.validate_expression"
+        ),
         log_to_statsd=False,
     )
     def validate_expression(

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -94,9 +94,9 @@ def apply_column_types(
                 # if the number is too large, convert it to a string
                 # Excel does not support numbers larger than 10^15
                 df[column] = df[column].apply(
-                    lambda x: str(x)
-                    if isinstance(x, (int, float)) and abs(x) > 10**15
-                    else x
+                    lambda x: (
+                        str(x) if isinstance(x, (int, float)) and abs(x) > 10**15 else x
+                    )
                 )
             except ValueError:
                 df[column] = df[column].astype(str)

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -122,8 +122,11 @@ def get_type_generator(  # pylint: disable=too-many-return-statements,too-many-b
             sqlalchemy.sql.sqltypes.DateTime,
         ),
     ):
-        return lambda: datetime.fromordinal(MINIMUM_DATE.toordinal()) + timedelta(
-            seconds=random.randrange(days_range * 86400)  # noqa: S311
+        return lambda: (
+            datetime.fromordinal(MINIMUM_DATE.toordinal())
+            + timedelta(
+                seconds=random.randrange(days_range * 86400)  # noqa: S311
+            )
         )
 
     if isinstance(sqltype, sqlalchemy.sql.sqltypes.Numeric):

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -108,8 +108,9 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     @statsd_metrics
     @parse_rison(get_recent_activity_schema)
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".recent_activity",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.recent_activity"
+        ),
         log_to_statsd=False,
     )
     def recent_activity(self, **kwargs: Any) -> FlaskResponse:

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -82,8 +82,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def verify_presto_column(self, column, expected_results):
         inspector = mock.Mock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         row = mock.Mock()
         row.Column, row.Type, row.Null = column
@@ -828,8 +828,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def test_show_columns(self):
         inspector = mock.MagicMock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         inspector.bind.execute.return_value.fetchall = mock.MagicMock(
             return_value=["a", "b"]
@@ -845,8 +845,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def test_show_columns_with_schema(self):
         inspector = mock.MagicMock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         inspector.bind.execute.return_value.fetchall = mock.MagicMock(
             return_value=["a", "b"]

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -260,8 +260,9 @@ class TestSecurityGuestTokenApiTokenValidator(SupersetTestCase):
 
     @with_config(
         {
-            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: len(x["rls"]) == 1
-            and "tenant_id=" in x["rls"][0]["clause"]
+            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: (
+                len(x["rls"]) == 1 and "tenant_id=" in x["rls"][0]["clause"]
+            )
         }
     )
     def test_guest_validator_hook_real_world_example_positive(self):
@@ -276,8 +277,9 @@ class TestSecurityGuestTokenApiTokenValidator(SupersetTestCase):
 
     @with_config(
         {
-            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: len(x["rls"]) == 1
-            and "tenant_id=" in x["rls"][0]["clause"]
+            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: (
+                len(x["rls"]) == 1 and "tenant_id=" in x["rls"][0]["clause"]
+            )
         }
     )
     def test_guest_validator_hook_real_world_example_negative(self):

--- a/tests/unit_tests/commands/export_test.py
+++ b/tests/unit_tests/commands/export_test.py
@@ -38,7 +38,11 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDatabasesCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Database\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\n"
+                "type: Database\n"
+                "timestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),
         ),
         ("databases/example.yaml", lambda: "<DATABASE CONTENTS>"),
     ]
@@ -48,7 +52,11 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDatasetsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Dataset\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\n"
+                "type: Dataset\n"
+                "timestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),
         ),
         ("datasets/example/dataset.yaml", lambda: "<DATASET CONTENTS>"),
     ]
@@ -58,7 +66,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportChartsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Slice\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: Slice\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),
         ),
         ("charts/pie.yaml", lambda: "<CHART CONTENTS>"),
     ]
@@ -68,7 +78,11 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDashboardsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Dashboard\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\n"
+                "type: Dashboard\n"
+                "timestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),
         ),
         ("dashboards/sales.yaml", lambda: "<DASHBOARD CONTENTS>"),
     ]
@@ -78,7 +92,11 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportSavedQueriesCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: SavedQuery\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\n"
+                "type: SavedQuery\n"
+                "timestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),
         ),
         ("queries/example/metric.yaml", lambda: "<SAVED QUERY CONTENTS>"),
     ]

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -140,8 +140,8 @@ class TestQueryContextFactory:
         existing_columns = {"existing_col"}
 
         with patch.object(self.factory, "_find_column_definition") as mock_find:
-            mock_find.side_effect = (
-                lambda qo, col: f"def_{col}" if col != "tooltip_col2" else None
+            mock_find.side_effect = lambda qo, col: (
+                f"def_{col}" if col != "tooltip_col2" else None
             )
 
             self.factory._append_missing_tooltip_columns(

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -44,8 +44,8 @@ def mock_dataset() -> MagicMock:
     dataset.database.get_sqla_engine.return_value.__exit__.return_value = None
 
     # Mock apply_limit_to_sql to return SQL with LIMIT
-    dataset.database.apply_limit_to_sql = (
-        lambda sql, limit, force: f"{sql} LIMIT {limit}"
+    dataset.database.apply_limit_to_sql = lambda sql, limit, force: (
+        f"{sql} LIMIT {limit}"
     )
 
     return dataset

--- a/tests/unit_tests/security/guest_rls_test.py
+++ b/tests/unit_tests/security/guest_rls_test.py
@@ -192,8 +192,8 @@ def _make_datasource_with_real_rls(dataset_id: int) -> MagicMock:
     datasource = _make_datasource(dataset_id)
     # Bind real BaseDatasource method so RLS logic executes against mocked
     # security_manager rather than returning MagicMock auto-stub
-    datasource.get_sqla_row_level_filters = (
-        lambda **kwargs: BaseDatasource.get_sqla_row_level_filters(datasource, **kwargs)
+    datasource.get_sqla_row_level_filters = lambda **kwargs: (
+        BaseDatasource.get_sqla_row_level_filters(datasource, **kwargs)
     )
     return datasource
 

--- a/tests/unit_tests/test_viz_cache_key.py
+++ b/tests/unit_tests/test_viz_cache_key.py
@@ -97,8 +97,8 @@ def test_cache_query_by_user_flag_yields_distinct_keys(feature_flag_mock):
     """
     Global ``CACHE_QUERY_BY_USER`` flag also reaches the legacy viz path.
     """
-    feature_flag_mock.is_feature_enabled.side_effect = (
-        lambda feature=None: feature == "CACHE_QUERY_BY_USER"
+    feature_flag_mock.is_feature_enabled.side_effect = lambda feature=None: (
+        feature == "CACHE_QUERY_BY_USER"
     )
     database = Database(database_name="d", sqlalchemy_uri="sqlite://")
     obj = _viz_for(database)

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -672,8 +672,9 @@ def test_get_user_agent(mocker: MockerFixture, app_context: None) -> None:
 
 @with_config(
     {
-        "USER_AGENT_FUNC": lambda database,
-        source: f"{database.database_name} {source.name}"
+        "USER_AGENT_FUNC": lambda database, source: (
+            f"{database.database_name} {source.name}"
+        )
     }
 )
 def test_get_user_agent_custom(mocker: MockerFixture, app_context: None) -> None:

--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -37,7 +37,7 @@ def test_rejected_form_data_keys_cover_all_js_control_keys() -> None:
 
 def test_get_form_data_strips_js_control_keys() -> None:
     """get_form_data drops all JS-executed keys when the flag is disabled."""
-    initial_form_data = {key: "data => data" for key in JS_CONTROL_FORM_DATA_KEYS}
+    initial_form_data = dict.fromkeys(JS_CONTROL_FORM_DATA_KEYS, "data => data")
     initial_form_data["viz_type"] = "deck_geojson"
 
     form_data, _ = get_form_data(initial_form_data=initial_form_data)


### PR DESCRIPTION
### SUMMARY
I've noticed we've accumulated some lint that doesn't get cleaned up during regular PR flows, as we don't run `pre-commit` on unchanged files. To clean these up I ran `pre-commit run --all-files` and committed the changes for those. I also remove the `PT004` rule, as that's no longer valid in the codebase (it always emits a false warning during pre-commit flow).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
