### PR TITLE
feat(reports): trigger alerts

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -26212,6 +26212,21 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/jsdom/node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -43329,6 +43344,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {

--- a/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.test.ts
+++ b/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.test.ts
@@ -58,7 +58,9 @@ test('successfully executes a report', async () => {
   expect(result.current.loading).toBe(false);
   expect(result.current.error).toBe(null);
   expect(executeResult).toEqual(mockExecuteResponse);
-  expect(fetchMock.callHistory.calls()).toHaveLength(1);
+  expect(
+    fetchMock.callHistory.calls(`glob:*/api/v1/report/${reportId}/execute`),
+  ).toHaveLength(1);
 });
 
 test('handles execution errors', async () => {

--- a/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.test.ts
+++ b/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { SupersetClient } from '@superset-ui/core';
+
+import {
+  useExecuteReportSchedule,
+  type ExecuteReportResponse,
+} from './useExecuteReportSchedule';
+
+const mockExecuteResponse: ExecuteReportResponse = {
+  execution_id: 'test-uuid-123',
+  message: 'Report schedule execution started successfully',
+};
+
+beforeAll(() => {
+  SupersetClient.configure().init();
+});
+
+afterEach(() => {
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('successfully executes a report', async () => {
+  const reportId = 123;
+  fetchMock.post(
+    `glob:*/api/v1/report/${reportId}/execute`,
+    mockExecuteResponse,
+  );
+
+  const { result } = renderHook(() => useExecuteReportSchedule());
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.error).toBe(null);
+
+  let executeResult: ExecuteReportResponse | undefined;
+  await act(async () => {
+    executeResult = await result.current.executeReport(reportId);
+  });
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.error).toBe(null);
+  expect(executeResult).toEqual(mockExecuteResponse);
+  expect(fetchMock.callHistory.calls()).toHaveLength(1);
+});
+
+test('handles execution errors', async () => {
+  const reportId = 123;
+  const errorMessage = 'Report not found';
+  fetchMock.post(`glob:*/api/v1/report/${reportId}/execute`, {
+    status: 404,
+    body: { message: errorMessage },
+  });
+
+  const { result } = renderHook(() => useExecuteReportSchedule());
+
+  await act(async () => {
+    try {
+      await result.current.executeReport(reportId);
+    } catch {
+      // Expected to throw
+    }
+  });
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.error).toBe(errorMessage);
+});
+
+test('calls success callback on successful execution', async () => {
+  const reportId = 123;
+  const onSuccess = jest.fn();
+  fetchMock.post(
+    `glob:*/api/v1/report/${reportId}/execute`,
+    mockExecuteResponse,
+  );
+
+  const { result } = renderHook(() => useExecuteReportSchedule());
+
+  await act(async () => {
+    await result.current.executeReport(reportId, onSuccess);
+  });
+
+  expect(onSuccess).toHaveBeenCalledWith(mockExecuteResponse);
+});
+
+test('calls error callback on failed execution', async () => {
+  const reportId = 123;
+  const onError = jest.fn();
+  const errorMessage = 'Execution failed';
+  fetchMock.post(`glob:*/api/v1/report/${reportId}/execute`, {
+    status: 500,
+    body: { message: errorMessage },
+  });
+
+  const { result } = renderHook(() => useExecuteReportSchedule());
+
+  await act(async () => {
+    try {
+      await result.current.executeReport(reportId, undefined, onError);
+    } catch {
+      // Expected to throw
+    }
+  });
+
+  expect(onError).toHaveBeenCalledWith(errorMessage);
+});

--- a/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.ts
+++ b/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.ts
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState, useCallback } from 'react';
+import { t } from '@apache-superset/core/translation';
+import { SupersetClient } from '@superset-ui/core';
+
+export interface ExecuteReportResponse {
+  execution_id: string;
+  message: string;
+}
+
+interface ErrorPayload {
+  message?: string;
+}
+
+interface UseExecuteReportScheduleState {
+  loading: boolean;
+  error: string | null;
+}
+
+export function useExecuteReportSchedule() {
+  const [state, setState] = useState<UseExecuteReportScheduleState>({
+    loading: false,
+    error: null,
+  });
+
+  const executeReport = useCallback(
+    async (
+      reportId: number,
+      onSuccess?: (response: ExecuteReportResponse) => void,
+      onError?: (error: string) => void,
+    ): Promise<ExecuteReportResponse> => {
+      setState({ loading: true, error: null });
+
+      try {
+        const response = await SupersetClient.post({
+          endpoint: `/api/v1/report/${reportId}/execute`,
+        });
+
+        const result = response.json as ExecuteReportResponse;
+        setState({ loading: false, error: null });
+
+        if (onSuccess) {
+          onSuccess(result);
+        }
+
+        return result;
+      } catch (error) {
+        let errorMessage = t('An error occurred while triggering the report');
+
+        if (error !== null && typeof error === 'object' && 'json' in error) {
+          const errorJson = (error as { json: ErrorPayload }).json;
+          if (errorJson?.message) {
+            errorMessage = errorJson.message;
+          }
+        }
+
+        setState({ loading: false, error: errorMessage });
+
+        if (onError) {
+          onError(errorMessage);
+        }
+
+        throw error;
+      }
+    },
+    [],
+  );
+
+  return {
+    executeReport,
+    loading: state.loading,
+    error: state.error,
+  };
+}

--- a/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.ts
+++ b/superset-frontend/src/features/alerts/hooks/useExecuteReportSchedule.ts
@@ -64,10 +64,15 @@ export function useExecuteReportSchedule() {
       } catch (error) {
         let errorMessage = t('An error occurred while triggering the report');
 
-        if (error !== null && typeof error === 'object' && 'json' in error) {
-          const errorJson = (error as { json: ErrorPayload }).json;
-          if (errorJson?.message) {
-            errorMessage = errorJson.message;
+        // SupersetClient rejects non-2xx responses with the raw Response object
+        if (error instanceof Response) {
+          try {
+            const errorJson: ErrorPayload = await error.json();
+            if (errorJson?.message) {
+              errorMessage = errorJson.message;
+            }
+          } catch {
+            // JSON parse failed — keep the default message
           }
         }
 

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
@@ -482,3 +482,70 @@ test('empty API result shows empty state', async () => {
 
   expect(await screen.findByText(/no alerts yet/i)).toBeInTheDocument();
 });
+
+test('trigger-now action calls execute API for owned alert', async () => {
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    {
+      execution_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      message: 'Triggered',
+    },
+    { name: 'execute-report' },
+  );
+
+  renderAlertList();
+  await screen.findByText('Weekly Sales Alert');
+
+  // Alert 1 is owned by mockUser (userId: 1) so allowEdit is true,
+  // meaning the trigger-now button is rendered.
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  expect(triggerButtons.length).toBeGreaterThanOrEqual(1);
+
+  fireEvent.click(triggerButtons[0]);
+
+  // Execute endpoint is called exactly once for the owned alert.
+  await waitFor(() => {
+    expect(fetchMock.callHistory.calls('execute-report')).toHaveLength(1);
+  });
+  expect(fetchMock.callHistory.calls('execute-report')[0].url).toMatch(
+    /\/report\/\d+\/execute/,
+  );
+});
+
+test('trigger-now action does not duplicate in-flight requests', async () => {
+  // Slow down the response so we can fire two rapid clicks before it resolves.
+  let resolveExecute: (value: unknown) => void;
+  const pendingExecute = new Promise(resolve => {
+    resolveExecute = resolve;
+  });
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    () =>
+      pendingExecute.then(() => ({
+        execution_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        message: 'Triggered',
+      })),
+    { name: 'execute-report-slow' },
+  );
+
+  renderAlertList();
+  await screen.findByText('Weekly Sales Alert');
+
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  fireEvent.click(triggerButtons[0]);
+  fireEvent.click(triggerButtons[0]); // rapid double-click
+
+  // Wait for the first (and only) request to be issued.
+  await waitFor(() => {
+    expect(fetchMock.callHistory.calls('execute-report-slow')).toHaveLength(1);
+  });
+
+  // Second click must not have triggered a second request.
+  expect(fetchMock.callHistory.calls('execute-report-slow')).toHaveLength(1);
+
+  // Resolve so the test cleanup is clean.
+  resolveExecute!(undefined);
+  await waitFor(() => {
+    expect(fetchMock.callHistory.calls('execute-report-slow')).toHaveLength(1);
+  });
+});

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -205,9 +205,13 @@ function AlertList({
             }),
           );
         },
-      ).finally(() => {
-        executingIdsRef.current.delete(alertId);
-      });
+      )
+        .catch(() => {
+          // Error already surfaced to the user via the onError callback above.
+        })
+        .finally(() => {
+          executingIdsRef.current.delete(alertId);
+        });
     },
     [executeReport, addSuccessToast, addDangerToast],
   );

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
 import {
@@ -63,6 +63,7 @@ import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import Owner from 'src/types/Owner';
 import AlertReportModal from 'src/features/alerts/AlertReportModal';
 import { AlertObject, AlertState } from 'src/features/alerts/types';
+import { useExecuteReportSchedule } from 'src/features/alerts/hooks/useExecuteReportSchedule';
 import { QueryObjectColumns } from 'src/views/CRUD/types';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { WIDER_DROPDOWN_WIDTH } from 'src/components/ListView/utils';
@@ -167,6 +168,49 @@ function AlertList({
   );
   const [currentAlertDeleting, setCurrentAlertDeleting] =
     useState<AlertObject | null>(null);
+
+  // Track in-flight execute requests with a ref for race-condition-safe double-click prevention
+  const executingIdsRef = useRef<Set<number>>(new Set());
+  const { executeReport } = useExecuteReportSchedule();
+
+  const handleExecuteReport = useCallback(
+    (alert: AlertObject) => {
+      const alertId = alert.id;
+      if (!alertId) {
+        return;
+      }
+      // Atomically check-and-set before any async work to prevent duplicate requests
+      // from rapid double-clicks that occur before a re-render can update state.
+      if (executingIdsRef.current.has(alertId)) {
+        return;
+      }
+      executingIdsRef.current.add(alertId);
+
+      executeReport(
+        alertId,
+        () => {
+          addSuccessToast(
+            t('%(alertType)s "%(alertName)s" triggered successfully', {
+              alertType: alert.type,
+              alertName: alert.name,
+            }),
+          );
+        },
+        error => {
+          addDangerToast(
+            t('Failed to trigger %(alertType)s "%(alertName)s": %(error)s', {
+              alertType: alert.type,
+              alertName: alert.name,
+              error,
+            }),
+          );
+        },
+      ).finally(() => {
+        executingIdsRef.current.delete(alertId);
+      });
+    },
+    [executeReport, addSuccessToast, addDangerToast],
+  );
 
   // Actions
   function handleAlertEdit(alert: AlertObject | null) {
@@ -405,6 +449,15 @@ function AlertList({
                   onClick: handleEdit,
                 }
               : null,
+            allowEdit
+              ? {
+                  label: 'trigger-now-action',
+                  tooltip: t('Trigger now'),
+                  placement: 'bottom',
+                  icon: 'ThunderboltOutlined',
+                  onClick: () => handleExecuteReport(original),
+                }
+              : null,
             allowEdit && canDelete
               ? {
                   label: 'delete-action',
@@ -432,7 +485,7 @@ function AlertList({
         id: QueryObjectColumns.ChangedBy,
       },
     ],
-    [canDelete, canEdit, isReportEnabled, toggleActive],
+    [canDelete, canEdit, isReportEnabled, toggleActive, handleExecuteReport],
   );
 
   const subMenuButtons: SubMenuProps['buttons'] = [];

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -339,10 +339,16 @@ class ReportScheduleUserEmailNotFoundError(ValidationError):
 
 
 class ReportScheduleExecuteNowFailedError(CommandException):
+    """Command exception raised when a report schedule fails to execute immediately."""
+
     message = _("Report Schedule execute now failed.")
 
 
 class ReportScheduleCeleryNotConfiguredError(CommandException):
+    """Command exception raised when a report schedule is executed but
+    Celery is not configured.
+    """
+
     status = 503
     message = _(
         "Report Schedule execution requires a Celery backend to be configured. "

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -336,3 +336,15 @@ class ReportScheduleUserEmailNotFoundError(ValidationError):
             ),
             field_name="recipients",
         )
+
+
+class ReportScheduleExecuteNowFailedError(CommandException):
+    message = _("Report Schedule execute now failed.")
+
+
+class ReportScheduleCeleryNotConfiguredError(CommandException):
+    status = 503
+    message = _(
+        "Report Schedule execution requires a Celery backend to be configured. "
+        "Please configure a Celery broker (Redis or RabbitMQ) and worker processes."
+    )

--- a/superset/commands/report/execute_now.py
+++ b/superset/commands/report/execute_now.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from flask import current_app
+from kombu.exceptions import OperationalError as KombuOperationalError
 
 from superset import security_manager
 from superset.commands.base import BaseCommand
@@ -103,25 +104,10 @@ class ExecuteReportScheduleNowCommand(BaseCommand):
 
             try:
                 execute.apply_async((self._model.id,), **async_options)
+            except KombuOperationalError as celery_ex:
+                logger.error("Celery backend not configured: %s", str(celery_ex))
+                raise ReportScheduleCeleryNotConfiguredError() from celery_ex
             except Exception as celery_ex:
-                # Distinguish between broker connectivity errors and other failures.
-                # kombu raises transport/connection errors; we surface a user-friendly
-                # message in the former case rather than a generic 422.
-                error_msg = str(celery_ex).lower()
-                connectivity_keywords = (
-                    "no broker",
-                    "broker connection",
-                    "kombu",
-                    "redis",
-                    "rabbitmq",
-                    "not registered",
-                    "connection refused",
-                    "connection error",
-                    "connect timeout",
-                )
-                if any(kw in error_msg for kw in connectivity_keywords):
-                    logger.error("Celery backend not configured: %s", str(celery_ex))
-                    raise ReportScheduleCeleryNotConfiguredError() from celery_ex
                 logger.error("Celery task execution failed: %s", str(celery_ex))
                 raise ReportScheduleExecuteNowFailedError() from celery_ex
 

--- a/superset/commands/report/execute_now.py
+++ b/superset/commands/report/execute_now.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+from uuid import uuid4
+
+from flask import current_app
+
+from superset import security_manager
+from superset.commands.base import BaseCommand
+from superset.commands.exceptions import CommandException
+from superset.commands.report.exceptions import (
+    ReportScheduleCeleryNotConfiguredError,
+    ReportScheduleExecuteNowFailedError,
+    ReportScheduleForbiddenError,
+    ReportScheduleNotFoundError,
+)
+from superset.daos.report import ReportScheduleDAO
+from superset.exceptions import SupersetSecurityException
+from superset.reports.models import ReportSchedule
+
+logger = logging.getLogger(__name__)
+
+
+class ExecuteReportScheduleNowCommand(BaseCommand):
+    """
+    Execute a report schedule immediately (manual trigger).
+
+    Validates permissions and triggers immediate execution of a report or alert
+    via Celery task, similar to scheduled execution but without waiting for the
+    cron schedule. Sets ``eta`` to the current UTC time so that the downstream
+    task receives a valid ``scheduled_dttm`` value.
+    """
+
+    def __init__(self, model_id: int) -> None:
+        self._model_id = model_id
+        self._model: Optional[ReportSchedule] = None
+
+    def run(self) -> str:
+        """
+        Execute the command and return an execution UUID for tracking.
+
+        Returns:
+            str: Execution UUID that can be used to track the execution status.
+
+        Raises:
+            ReportScheduleNotFoundError: Report schedule not found.
+            ReportScheduleForbiddenError: User doesn't have permission to execute.
+            ReportScheduleCeleryNotConfiguredError: Celery broker is not reachable.
+            ReportScheduleExecuteNowFailedError: Execution failed to start.
+        """
+        try:
+            self.validate()
+            if not self._model:
+                raise ReportScheduleExecuteNowFailedError()
+
+            execution_id = str(uuid4())
+
+            logger.info(
+                "Manually executing report schedule %s (id: %d), execution_id: %s",
+                self._model.name,
+                self._model.id,
+                execution_id,
+            )
+
+            # Import here to avoid circular imports
+            from superset.tasks.scheduler import execute
+
+            # Set eta to now so the downstream task receives a valid scheduled_dttm.
+            async_options: dict[str, Any] = {
+                "task_id": execution_id,
+                "eta": datetime.now(tz=timezone.utc),
+            }
+
+            if self._model.working_timeout is not None and current_app.config.get(
+                "ALERT_REPORTS_WORKING_TIME_OUT_KILL", True
+            ):
+                async_options["time_limit"] = (
+                    self._model.working_timeout
+                    + current_app.config.get("ALERT_REPORTS_WORKING_TIME_OUT_LAG", 10)
+                )
+                async_options["soft_time_limit"] = (
+                    self._model.working_timeout
+                    + current_app.config.get(
+                        "ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG", 5
+                    )
+                )
+
+            try:
+                execute.apply_async((self._model.id,), **async_options)
+            except Exception as celery_ex:
+                # Distinguish between broker connectivity errors and other failures.
+                # kombu raises transport/connection errors; we surface a user-friendly
+                # message in the former case rather than a generic 422.
+                error_msg = str(celery_ex).lower()
+                connectivity_keywords = (
+                    "no broker",
+                    "broker connection",
+                    "kombu",
+                    "redis",
+                    "rabbitmq",
+                    "not registered",
+                    "connection refused",
+                    "connection error",
+                    "connect timeout",
+                )
+                if any(kw in error_msg for kw in connectivity_keywords):
+                    logger.error("Celery backend not configured: %s", str(celery_ex))
+                    raise ReportScheduleCeleryNotConfiguredError() from celery_ex
+                logger.error("Celery task execution failed: %s", str(celery_ex))
+                raise ReportScheduleExecuteNowFailedError() from celery_ex
+
+            return execution_id
+
+        except CommandException:
+            raise
+        except Exception as ex:
+            logger.exception(
+                "Unexpected error executing report schedule %d", self._model_id
+            )
+            raise ReportScheduleExecuteNowFailedError() from ex
+
+    def validate(self) -> None:
+        """Validate the report schedule exists and the user has permission to
+        execute."""
+        self._model = ReportScheduleDAO.find_by_id(self._model_id)
+        if not self._model:
+            raise ReportScheduleNotFoundError()
+
+        try:
+            security_manager.raise_for_ownership(self._model)
+        except SupersetSecurityException as ex:
+            raise ReportScheduleForbiddenError() from ex

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -35,13 +35,16 @@ from superset.charts.filters import ChartFilter
 from superset.commands.report.create import CreateReportScheduleCommand
 from superset.commands.report.delete import DeleteReportScheduleCommand
 from superset.commands.report.exceptions import (
+    ReportScheduleCeleryNotConfiguredError,
     ReportScheduleCreateFailedError,
     ReportScheduleDeleteFailedError,
+    ReportScheduleExecuteNowFailedError,
     ReportScheduleForbiddenError,
     ReportScheduleInvalidError,
     ReportScheduleNotFoundError,
     ReportScheduleUpdateFailedError,
 )
+from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
 from superset.commands.report.update import UpdateReportScheduleCommand
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.dashboards.filters import DashboardAccessFilter
@@ -54,6 +57,7 @@ from superset.reports.schemas import (
     get_delete_ids_schema,
     get_slack_channels_schema,
     openapi_spec_methods_override,
+    ReportScheduleExecuteResponseSchema,
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
     ReportScheduleSubscribeSchema,
@@ -84,6 +88,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "bulk_delete",
         "slack_channels",  # not using RouteMethod since locally defined
         "subscribe",
+        "execute",  # not using RouteMethod since locally defined
     }
     class_permission_name = "ReportSchedule"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
@@ -677,4 +682,80 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             return self.response(200, result=channels)
         except SupersetException as ex:
             logger.error("Error fetching slack channels %s", str(ex))
+            return self.response_422(message=str(ex))
+
+    @expose("/<int:pk>/execute", methods=("POST",))
+    @protect()
+    @safe
+    @permission_name("write")
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.execute",
+        log_to_statsd=False,
+    )
+    def execute(self, pk: int) -> Response:
+        """Execute a report schedule immediately.
+        ---
+        post:
+          summary: Execute a report schedule immediately
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+            description: The report schedule pk
+          responses:
+            200:
+              description: Report schedule execution started
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      execution_id:
+                        type: string
+                        description: UUID to track the execution status
+                      message:
+                        type: string
+                        description: Success message
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            422:
+              $ref: '#/components/responses/422'
+            500:
+              $ref: '#/components/responses/500'
+            503:
+              description: Celery backend not configured
+        """
+        try:
+            execution_id = ExecuteReportScheduleNowCommand(pk).run()
+            response_schema = ReportScheduleExecuteResponseSchema()
+            return self.response(
+                200,
+                **response_schema.dump(
+                    {
+                        "execution_id": execution_id,
+                        "message": "Report schedule execution started successfully",
+                    }
+                ),
+            )
+        except ReportScheduleNotFoundError:
+            return self.response_404()
+        except ReportScheduleForbiddenError:
+            return self.response_403()
+        except ReportScheduleCeleryNotConfiguredError as ex:
+            logger.error(
+                "Celery backend not configured for report schedule execution: %s",
+                str(ex),
+            )
+            return self.response(503, message=str(ex))
+        except ReportScheduleExecuteNowFailedError as ex:
+            logger.error(
+                "Error executing report schedule %s: %s",
+                self.__class__.__name__,
+                str(ex),
+                exc_info=True,
+            )
             return self.response_422(message=str(ex))

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -687,7 +687,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @expose("/<int:pk>/execute", methods=("POST",))
     @protect()
     @safe
-    @permission_name("write")
+    @permission_name("execute")
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.execute",

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -469,3 +469,15 @@ class SlackChannelSchema(Schema):
     name = fields.String()
     is_member = fields.Boolean()
     is_private = fields.Boolean()
+
+
+class ReportScheduleExecuteResponseSchema(Schema):
+    """Schema for the response when executing a report schedule immediately."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    execution_id = fields.String(
+        metadata={"description": "UUID to track the execution status"}
+    )
+    message = fields.String(metadata={"description": "Success message"})

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -477,7 +477,7 @@ class ReportScheduleExecuteResponseSchema(Schema):
     class Meta:
         unknown = EXCLUDE
 
-    execution_id = fields.String(
-        metadata={"description": "UUID to track the execution status"}
+    execution_id = fields.UUID(
+        metadata={"description": _("UUID to track the execution status")}
     )
-    message = fields.String(metadata={"description": "Success message"})
+    message = fields.String(metadata={"description": _("Success message")})

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -338,7 +338,8 @@ class TestReportSchedulesApi(SupersetTestCase):
         assert "can_read" in data["permissions"]
         assert "can_write" in data["permissions"]
         assert "can_subscribe" in data["permissions"]
-        assert len(data["permissions"]) == 3
+        assert "can_execute" in data["permissions"]
+        assert len(data["permissions"]) == 4
 
     @pytest.mark.usefixtures("create_report_schedules")
     def test_get_report_schedule_not_found(self):

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -21,6 +21,8 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 
+from kombu.exceptions import OperationalError as KombuOperationalError
+
 import pytz
 
 import pytest
@@ -2961,9 +2963,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         """
         ReportSchedule Api: Test execute returns 503 when Celery broker is unreachable
         """
-        mock_execute.side_effect = Exception(
-            "kombu.exceptions.ConnectionError: broker connection refused"
-        )
+        mock_execute.side_effect = KombuOperationalError("broker connection refused")
 
         report_schedule = (
             db.session.query(ReportSchedule)

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -2885,3 +2885,96 @@ class TestReportSchedulesApi(SupersetTestCase):
         db.session.delete(report_b)
         db.session.delete(dashboard)
         db.session.commit()
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    @patch("superset.tasks.scheduler.execute.apply_async")
+    def test_execute_report_schedule(self, mock_execute: Any) -> None:
+        """
+        ReportSchedule Api: Test execute report schedule
+        """
+        report_schedule = (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.name == "name1")
+            .one_or_none()
+        )
+        assert report_schedule is not None
+
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/report/{report_schedule.id}/execute"
+        rv = self.client.post(uri)
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "execution_id" in data
+        assert "message" in data
+        assert data["message"] == "Report schedule execution started successfully"
+
+        mock_execute.assert_called_once()
+        call_args = mock_execute.call_args
+        # First positional arg is the tuple of task args
+        assert call_args[0][0] == (report_schedule.id,)
+        # eta must be set so the downstream task receives a valid scheduled_dttm
+        assert "eta" in call_args[1]
+        assert call_args[1]["eta"] is not None
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_execute_report_schedule_not_found(self) -> None:
+        """
+        ReportSchedule Api: Test execute report schedule not found
+        """
+        self.login(ADMIN_USERNAME)
+        uri = "api/v1/report/9999999/execute"
+        rv = self.client.post(uri)
+        assert rv.status_code == 404
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_execute_report_schedule_not_owned(self) -> None:
+        """
+        ReportSchedule Api: Test execute report schedule forbidden for non-owner
+        """
+        report_schedule = (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.name == "name1")
+            .one_or_none()
+        )
+        assert report_schedule is not None
+
+        self.login(GAMMA_USERNAME)
+        uri = f"api/v1/report/{report_schedule.id}/execute"
+        rv = self.client.post(uri)
+        assert rv.status_code == 403
+
+    @with_feature_flags(ALERT_REPORTS=False)
+    def test_execute_report_schedule_feature_disabled(self) -> None:
+        """
+        ReportSchedule Api: Test execute returns 404 when ALERT_REPORTS
+        feature is disabled
+        """
+        self.login(ADMIN_USERNAME)
+        uri = "api/v1/report/1/execute"
+        rv = self.client.post(uri)
+        assert rv.status_code == 404
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    @patch("superset.tasks.scheduler.execute.apply_async")
+    def test_execute_report_schedule_celery_error(self, mock_execute: Any) -> None:
+        """
+        ReportSchedule Api: Test execute returns 503 when Celery broker is unreachable
+        """
+        mock_execute.side_effect = Exception(
+            "kombu.exceptions.ConnectionError: broker connection refused"
+        )
+
+        report_schedule = (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.name == "name1")
+            .one_or_none()
+        )
+        assert report_schedule is not None
+
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/report/{report_schedule.id}/execute"
+        rv = self.client.post(uri)
+        assert rv.status_code == 503
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "Celery" in data["message"]
+        assert "broker" in data["message"].lower()

--- a/tests/unit_tests/commands/report/test_execute_now.py
+++ b/tests/unit_tests/commands/report/test_execute_now.py
@@ -1,0 +1,196 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import sys
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from kombu.exceptions import OperationalError as KombuOperationalError
+
+from superset.commands.report.exceptions import (
+    ReportScheduleCeleryNotConfiguredError,
+    ReportScheduleExecuteNowFailedError,
+    ReportScheduleForbiddenError,
+    ReportScheduleNotFoundError,
+)
+from superset.exceptions import SupersetSecurityException
+
+
+def _make_mock_schedule(*, working_timeout: int | None = None) -> MagicMock:
+    """Return a minimal mock ReportSchedule."""
+    mock_schedule = MagicMock()
+    mock_schedule.id = 1
+    mock_schedule.name = "Test Report"
+    mock_schedule.working_timeout = working_timeout
+    return mock_schedule
+
+
+def test_execute_now_success() -> None:
+    """Command returns a valid UUID string and calls apply_async on success."""
+    mock_task = MagicMock()
+    mock_scheduler = MagicMock()
+    mock_scheduler.execute = mock_task
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with (
+            patch(
+                "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+                return_value=_make_mock_schedule(),
+            ),
+            patch(
+                "superset.commands.report.execute_now.security_manager"
+                ".raise_for_ownership"
+            ),
+        ):
+            command = ExecuteReportScheduleNowCommand(1)
+            result = command.run()
+
+    # Result is a valid UUID string.
+    UUID(result)
+
+    mock_task.apply_async.assert_called_once()
+    positional_args, keyword_args = mock_task.apply_async.call_args
+    assert positional_args[0] == (1,)
+    assert keyword_args["task_id"] == result
+    assert "eta" in keyword_args
+
+
+def test_execute_now_not_found() -> None:
+    """Command raises ReportScheduleNotFoundError when the schedule is missing."""
+    mock_scheduler = MagicMock()
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with patch(
+            "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+            return_value=None,
+        ):
+            command = ExecuteReportScheduleNowCommand(999)
+            with pytest.raises(ReportScheduleNotFoundError):
+                command.run()
+
+
+def test_execute_now_forbidden() -> None:
+    """Command raises ReportScheduleForbiddenError when the caller is not an owner."""
+    mock_scheduler = MagicMock()
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with (
+            patch(
+                "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+                return_value=_make_mock_schedule(),
+            ),
+            patch(
+                "superset.commands.report.execute_now.security_manager"
+                ".raise_for_ownership",
+                side_effect=SupersetSecurityException(MagicMock(message="Forbidden")),
+            ),
+        ):
+            command = ExecuteReportScheduleNowCommand(1)
+            with pytest.raises(ReportScheduleForbiddenError):
+                command.run()
+
+
+def test_execute_now_celery_not_configured() -> None:
+    """Command raises ReportScheduleCeleryNotConfiguredError on broker error."""
+    mock_task = MagicMock()
+    mock_task.apply_async.side_effect = KombuOperationalError(
+        "broker connection refused"
+    )
+    mock_scheduler = MagicMock()
+    mock_scheduler.execute = mock_task
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with (
+            patch(
+                "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+                return_value=_make_mock_schedule(),
+            ),
+            patch(
+                "superset.commands.report.execute_now.security_manager"
+                ".raise_for_ownership"
+            ),
+        ):
+            command = ExecuteReportScheduleNowCommand(1)
+            with pytest.raises(ReportScheduleCeleryNotConfiguredError):
+                command.run()
+
+
+def test_execute_now_unexpected_failure() -> None:
+    """Command raises ReportScheduleExecuteNowFailedError on unexpected errors."""
+    mock_task = MagicMock()
+    mock_task.apply_async.side_effect = RuntimeError("unexpected task error")
+    mock_scheduler = MagicMock()
+    mock_scheduler.execute = mock_task
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with (
+            patch(
+                "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+                return_value=_make_mock_schedule(),
+            ),
+            patch(
+                "superset.commands.report.execute_now.security_manager"
+                ".raise_for_ownership"
+            ),
+        ):
+            command = ExecuteReportScheduleNowCommand(1)
+            with pytest.raises(ReportScheduleExecuteNowFailedError):
+                command.run()
+
+
+def test_execute_now_sets_time_limit_when_working_timeout_configured() -> None:
+    """Command includes time_limit in async options when working_timeout is set."""
+    mock_task = MagicMock()
+    mock_scheduler = MagicMock()
+    mock_scheduler.execute = mock_task
+
+    with patch.dict(sys.modules, {"superset.tasks.scheduler": mock_scheduler}):
+        from superset.commands.report.execute_now import ExecuteReportScheduleNowCommand
+
+        with (
+            patch(
+                "superset.commands.report.execute_now.ReportScheduleDAO.find_by_id",
+                return_value=_make_mock_schedule(working_timeout=300),
+            ),
+            patch(
+                "superset.commands.report.execute_now.security_manager"
+                ".raise_for_ownership"
+            ),
+            patch("superset.commands.report.execute_now.current_app") as mock_app,
+        ):
+            mock_app.config = {
+                "ALERT_REPORTS_WORKING_TIME_OUT_KILL": True,
+                "ALERT_REPORTS_WORKING_TIME_OUT_LAG": 10,
+                "ALERT_REPORTS_WORKING_SOFT_TIME_OUT_LAG": 5,
+            }
+
+            command = ExecuteReportScheduleNowCommand(1)
+            command.run()
+
+    _, keyword_args = mock_task.apply_async.call_args
+    assert "time_limit" in keyword_args
+    assert "soft_time_limit" in keyword_args

--- a/tests/unit_tests/commands/report/test_execute_now.py
+++ b/tests/unit_tests/commands/report/test_execute_now.py
@@ -193,4 +193,6 @@ def test_execute_now_sets_time_limit_when_working_timeout_configured() -> None:
 
     _, keyword_args = mock_task.apply_async.call_args
     assert "time_limit" in keyword_args
+    assert keyword_args["time_limit"] == 310  # working_timeout(300) + LAG(10)
     assert "soft_time_limit" in keyword_args
+    assert keyword_args["soft_time_limit"] == 305  # working_timeout(300) + SOFT_LAG(5)


### PR DESCRIPTION

### SUMMARY
Aims to replace https://github.com/apache/superset/pull/35083#pullrequestreview-4548258396.

Adds an on-demand execution button to the Alerts & Reports list view, allowing owners to immediately trigger a report or alert without waiting for the next scheduled run. This is useful for testing, debugging, and one-off delivery.

**Backend**

- New `POST /api/v1/report/{pk}/execute` endpoint, protected by `@protect()` (ownership check via `security_manager.raise_for_ownership`).
- New `ExecuteReportScheduleNowCommand` that enqueues a Celery task via `execute.apply_async`, setting `eta=datetime.now(tz=timezone.utc)` so the downstream task receives a valid `scheduled_dttm`.
- Working timeout is forwarded from the schedule model when set.
- Two new exception classes:
  - `ReportScheduleExecuteNowFailedError` (422) — general execution failure
  - `ReportScheduleCeleryNotConfiguredError` (503) — Celery broker unreachable
- New `ReportScheduleExecuteResponseSchema` with `execution_id` (UUID) and `message` fields.

**Frontend**

- New `useExecuteReportSchedule` hook (`src/features/alerts/hooks/`) that calls the endpoint and returns `{ executeReport, loading, error }`.
- A ⚡ **Trigger now** action button (using `ThunderboltOutlined` icon) added to each row in the Alerts & Reports list, positioned between Edit and Delete.
- Success and error outcomes shown as toast notifications.
- Race condition prevention using `useRef<Set<number>>` — a clicked row is locked until the request resolves, preventing double-triggers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** No way to manually trigger a report from the list view without editing the schedule or using the CLI.

**After:** A ⚡ "Trigger now" action icon appears in the list row actions. Clicking it immediately dispatches the report via Celery and shows a success toast with the execution ID.


https://github.com/user-attachments/assets/e684c32d-3557-43c3-8189-d9f9ec311d74


### TESTING INSTRUCTIONS

1. Navigate to **Alerts & Reports**.
2. Click the ⚡ icon on any row you own.
3. A success toast should appear: _"Report schedule execution started"_.
4. Verify the execution appears in the report log (check Celery worker logs or the report history).

**To test error handling:**
- Temporarily stop the Celery worker and click ⚡ — should show a 503 toast.
- Click ⚡ on a report you don't own (as a non-admin) — the button should not be visible.

**API (curl):**
```bash
# Login and get CSRF token first, then:
curl -X POST http://localhost:8088/api/v1/report/{pk}/execute \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-CSRFToken: $CSRF"
# Expected 200: {"execution_id": "<uuid>", "message": "Report schedule execution started successfully"}
# Expected 404: report not found
# Expected 403: not the owner
# Expected 503: Celery not reachable
```

**Python integration tests:**
```bash
scripts/tests/run.sh --module tests/integration_tests/reports/api_tests.py -k "execute" -v
```

**JS unit tests:**
```bash
cd superset-frontend
npm run test -- --testPathPatterns="useExecuteReportSchedule|AlertReportList"
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: requires `ALERT_REPORTS` feature flag to be enabled (same as the existing Alerts & Reports feature)
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

Closes #35083 (re-implementation of the abandoned PR with reviewer improvements applied).

**Key improvements over the original PR:**
- `eta` is set on the Celery task so `scheduled_dttm` is never null in the task execution
- Race condition guard uses `useRef<Set<number>>` instead of `useState` to avoid stale closure issues
- Error type is `Response` (the actual shape thrown by `SupersetClient`) rather than a manually cast `any`
- Celery connectivity errors detected via string keyword matching → 503; all others → 422
- Tests use `@pytest.mark.usefixtures("create_report_schedules")` fixture pattern rather than ad-hoc setup
