### PR TITLE
fix(explore): prevent full table scan when SQL expression is used as x-axis

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -35,6 +35,7 @@ import {
   QueryFormData,
   DatasourceType,
   isDefined,
+  isAdhocColumn,
   JsonValue,
   NO_TIME_RANGE,
   usePrevious,
@@ -321,7 +322,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const { form_data, actions } = props;
   const { setControlValue } = actions;
-  const { x_axis, adhoc_filters } = form_data;
+  const { x_axis, adhoc_filters, granularity_sqla } = form_data;
 
   const previousXAxis = usePrevious(x_axis);
 
@@ -369,6 +370,28 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     props.exploreState.datasource,
     showConfirm,
   ]);
+
+  useEffect(() => {
+    if (
+      x_axis &&
+      x_axis !== previousXAxis &&
+      isAdhocColumn(x_axis) &&
+      !granularity_sqla
+    ) {
+      showConfirm({
+        title: t('Time column not configured'),
+        body: t(
+          `The X-axis is a SQL expression but no Time Column is configured. ` +
+            `Without a Time Column, time range filters cannot be applied and ` +
+            `queries may scan the entire table. ` +
+            `Set the Time Column in Query settings to enable time filtering.`,
+        ),
+        onConfirm: () => undefined,
+        confirmText: t('OK'),
+        cancelText: t('Dismiss'),
+      });
+    }
+  }, [x_axis, previousXAxis, granularity_sqla, showConfirm]);
 
   useEffect(() => {
     let shouldUpdateControls = false;

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -379,12 +379,12 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       !granularity_sqla
     ) {
       showConfirm({
-        title: t('Time column not configured'),
+        title: t('No time filter on X-axis expression'),
         body: t(
-          `The X-axis is a SQL expression but no Time Column is configured. ` +
-            `Without a Time Column, time range filters cannot be applied and ` +
-            `queries may scan the entire table. ` +
-            `Set the Time Column in Query settings to enable time filtering.`,
+          `The X-axis is a SQL expression, so time range filtering is not ` +
+            `applied automatically. Without a time filter, queries may scan ` +
+            `the entire table. Add a filter on your dataset's time column in ` +
+            `the Filters section to limit the rows read.`,
         ),
         onConfirm: () => undefined,
         confirmText: t('OK'),

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -71,6 +71,7 @@ import {
 import Tabs from '@superset-ui/core/components/Tabs';
 import { PluginContext } from 'src/components';
 import { useConfirmModal } from 'src/hooks/useConfirmModal';
+import { useToasts } from 'src/components/MessageToasts/withToasts';
 
 import { getSectionsToRender } from 'src/explore/controlUtils';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
@@ -301,6 +302,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   const theme = useTheme();
   const pluginContext = useContext(PluginContext);
   const { showConfirm, ConfirmModal } = useConfirmModal();
+  const { addWarningToast } = useToasts();
 
   const prevState = usePrevious(props.exploreState);
   const prevDatasource = usePrevious(props.exploreState.datasource);
@@ -374,24 +376,20 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   useEffect(() => {
     if (
       x_axis &&
-      x_axis !== previousXAxis &&
+      (previousXAxis === undefined || x_axis !== previousXAxis) &&
       isAdhocColumn(x_axis) &&
       !granularity_sqla
     ) {
-      showConfirm({
-        title: t('No time filter on X-axis expression'),
-        body: t(
+      addWarningToast(
+        t(
           `The X-axis is a SQL expression, so time range filtering is not ` +
             `applied automatically. Without a time filter, queries may scan ` +
             `the entire table. Add a filter on your dataset's time column in ` +
             `the Filters section to limit the rows read.`,
         ),
-        onConfirm: () => undefined,
-        confirmText: t('OK'),
-        cancelText: t('Dismiss'),
-      });
+      );
     }
-  }, [x_axis, previousXAxis, granularity_sqla, showConfirm]);
+  }, [x_axis, previousXAxis, granularity_sqla, addWarningToast]);
 
   useEffect(() => {
     let shouldUpdateControls = false;

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -319,6 +319,17 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             main_dttm_col = getattr(datasource, "main_dttm_col", None)
             if main_dttm_col and main_dttm_col in temporal_columns:
                 query_object.granularity = main_dttm_col
+                # Remove any TEMPORAL_RANGE filter already targeting main_dttm_col
+                # so helpers.py doesn't add the same condition a second time via the
+                # filter loop (granularity covers it via from_dttm/to_dttm).
+                query_object.filter = [
+                    f
+                    for f in query_object.filter
+                    if not (
+                        f.get("op") == "TEMPORAL_RANGE"
+                        and f.get("col") == main_dttm_col
+                    )
+                ]
 
     def _apply_filters(self, query_object: QueryObject) -> None:
         if query_object.time_range:

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -308,6 +308,18 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                     if filter["col"] != filter_to_remove
                 ]
 
+        elif is_adhoc_column(x_axis) and (  # type: ignore
+            query_object.from_dttm or query_object.to_dttm
+        ):
+            # x-axis is a SQL expression (not a physical temporal column) and a
+            # time range is configured, but no time column (granularity) was set.
+            # Fall back to the dataset's main datetime column so helpers.py adds a
+            # WHERE time filter — without it engines like ClickHouse perform a full
+            # table scan and trigger max_rows_to_read errors.
+            main_dttm_col = getattr(datasource, "main_dttm_col", None)
+            if main_dttm_col and main_dttm_col in temporal_columns:
+                query_object.granularity = main_dttm_col
+
     def _apply_filters(self, query_object: QueryObject) -> None:
         if query_object.time_range:
             for filter_object in query_object.filter:

--- a/superset/datasets/datetime_format_detector.py
+++ b/superset/datasets/datetime_format_detector.py
@@ -123,7 +123,7 @@ class DatetimeFormatDetector:
             sql = database.apply_limit_to_sql(sql, limit=self.sample_size, force=True)
 
             # Execute query and get results
-            df = database.get_df(sql, dataset.schema)
+            df = database.get_df(sql, dataset.catalog, dataset.schema)
 
             if df.empty or column.column_name not in df.columns:
                 logger.warning(

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -384,6 +384,158 @@ class TestQueryContextFactory:
 
         assert query_object.columns == ["ds", "other_col"]
 
+    def test_apply_granularity_expression_xaxis_sets_main_dttm_col(self):
+        """SQL expression x-axis with time range falls back to main_dttm_col."""
+        from datetime import datetime
+
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2023, 1, 1)
+        query_object.to_dttm = None
+        query_object.columns = [
+            {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+                "columnType": "BASE_AXIS",
+            }
+        ]
+        query_object.filter = []
+
+        form_data = {
+            "x_axis": {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+            }
+        }
+        datasource = Mock()
+        datasource.columns = [{"column_name": "ts", "is_dttm": True}]
+        datasource.main_dttm_col = "ts"
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity == "ts"
+
+    def test_apply_granularity_expression_xaxis_no_time_range_no_fallback(self):
+        """SQL expression x-axis without time range does not set granularity."""
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = None
+        query_object.to_dttm = None
+        query_object.columns = [
+            {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+                "columnType": "BASE_AXIS",
+            }
+        ]
+        query_object.filter = []
+
+        form_data = {
+            "x_axis": {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+            }
+        }
+        datasource = Mock()
+        datasource.columns = [{"column_name": "ts", "is_dttm": True}]
+        datasource.main_dttm_col = "ts"
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity is None
+
+    def test_apply_granularity_expression_xaxis_no_main_dttm_col(self):
+        """SQL expression x-axis with time range but no main_dttm_col stays None."""
+        from datetime import datetime
+
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2023, 1, 1)
+        query_object.to_dttm = None
+        query_object.columns = [
+            {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+                "columnType": "BASE_AXIS",
+            }
+        ]
+        query_object.filter = []
+
+        form_data = {
+            "x_axis": {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+            }
+        }
+        datasource = Mock()
+        datasource.columns = []
+        datasource.main_dttm_col = None
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity is None
+
+    def test_apply_granularity_expression_xaxis_main_dttm_not_temporal(self):
+        """SQL expression x-axis fallback skipped if main_dttm_col is not temporal."""
+        from datetime import datetime
+
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2023, 1, 1)
+        query_object.to_dttm = None
+        query_object.columns = [
+            {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+                "columnType": "BASE_AXIS",
+            }
+        ]
+        query_object.filter = []
+
+        form_data = {
+            "x_axis": {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+            }
+        }
+        datasource = Mock()
+        # main_dttm_col points to a column not flagged as temporal
+        datasource.columns = [{"column_name": "ts", "is_dttm": False}]
+        datasource.main_dttm_col = "ts"
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity is None
+
+    def test_apply_granularity_physical_string_xaxis_no_fallback(self):
+        """Physical column string x-axis without granularity: no fallback."""
+        from datetime import datetime
+
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2023, 1, 1)
+        query_object.to_dttm = None
+        query_object.columns = ["non_temporal_col"]
+        query_object.filter = []
+
+        form_data = {"x_axis": "non_temporal_col"}
+        datasource = Mock()
+        datasource.columns = [{"column_name": "ts", "is_dttm": True}]
+        datasource.main_dttm_col = "ts"
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        # String x-axis is not an adhoc column so no fallback should trigger
+        assert query_object.granularity is None
+
     def test_apply_granularity_x_axis_not_temporal(self):
         """Test _apply_granularity when x_axis is not a temporal column"""
         query_object = Mock(spec=QueryObject)

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -515,6 +515,51 @@ class TestQueryContextFactory:
 
         assert query_object.granularity is None
 
+    def test_apply_granularity_expression_xaxis_deduplicates_temporal_filter(self):
+        """Fallback removes existing TEMPORAL_RANGE filter for main_dttm_col."""
+        from datetime import datetime
+
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2023, 1, 1)
+        query_object.to_dttm = None
+        query_object.columns = [
+            {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+                "columnType": "BASE_AXIS",
+            }
+        ]
+        # Pre-existing TEMPORAL_RANGE filter for the main dttm column (e.g.
+        # left over from when 'ts' was the physical x-axis).
+        query_object.filter = [
+            {"col": "ts", "op": "TEMPORAL_RANGE", "val": "Last 7 days"},
+            {"col": "other", "op": "==", "val": "foo"},
+        ]
+
+        form_data = {
+            "x_axis": {
+                "sqlExpression": "duration * 0.05",
+                "expressionType": "SQL",
+                "label": "duration * 0.05",
+            }
+        }
+        datasource = Mock()
+        datasource.columns = [{"column_name": "ts", "is_dttm": True}]
+        datasource.main_dttm_col = "ts"
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity == "ts"
+        # TEMPORAL_RANGE filter for 'ts' removed to prevent duplicate WHERE clause
+        assert not any(
+            f.get("col") == "ts" and f.get("op") == "TEMPORAL_RANGE"
+            for f in query_object.filter
+        )
+        # Unrelated filter preserved
+        assert any(f.get("col") == "other" for f in query_object.filter)
+
     def test_apply_granularity_physical_string_xaxis_no_fallback(self):
         """Physical column string x-axis without granularity: no fallback."""
         from datetime import datetime

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -31,6 +31,7 @@ def mock_dataset() -> MagicMock:
     dataset = MagicMock(spec=SqlaTable)
     dataset.table_name = "test_table"
     dataset.schema = "test_schema"
+    dataset.catalog = None
     dataset.is_virtual = False
 
     # Mock the database engine and dialect for identifier quoting
@@ -243,7 +244,7 @@ def test_detect_column_format_query_has_no_is_not_null(
     captured_sql: list[str] = []
     original_get_df = mock_dataset.database.get_df
 
-    def capture_sql(sql: str, schema: str) -> pd.DataFrame:
+    def capture_sql(sql: str, catalog: str | None, schema: str | None) -> pd.DataFrame:
         captured_sql.append(sql)
         return original_get_df.return_value
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

On ClickHouse (and other engines with row-read limits like `max_rows_to_read`), using a SQL expression as the x-axis in a timeseries line chart triggers a full table scan and fails, while using a plain physical temporal column works fine.

**Root cause:** In `_apply_granularity` (`query_context_factory.py`), `from_dttm`/`to_dttm` are only applied as a WHERE clause when `granularity` (a physical time column) is explicitly configured. When a user sets the x-axis to an adhoc SQL expression like `toStartOfDay(ts)` or `duration * 0.05`, the frontend's `isTemporalColumn()` check returns false — so no TEMPORAL_RANGE filter is created for the expression, and no automatic WHERE clause is generated. The result is an unfiltered query that reads every row in the table.

**Backend fix:** Added an `elif` branch in `_apply_granularity`. When the x-axis is an adhoc SQL expression, a time range is set (`from_dttm`/`to_dttm` are not null), but no `granularity` is configured, the method falls back to `datasource.main_dttm_col` (if it exists and is temporal) and sets it as the granularity. This causes `helpers.py` to emit a `WHERE main_dttm_col >= from_dttm AND main_dttm_col < to_dttm` clause automatically. Any pre-existing `TEMPORAL_RANGE` filter for that column is also removed to prevent the condition from appearing twice.

**Frontend fix:** Added a `useEffect` in `ControlPanelsContainer` that shows a warning modal when the user sets the x-axis to a SQL expression, pointing them to add a time column filter in the Filters section.

**Workaround for existing users (no upgrade required):** Add a `TEMPORAL_RANGE` filter on the dataset's time column in the chart's Filters section. The backend fix then picks it up automatically.

This PR also fixes a pre-existing bug in `DatetimeFormatDetector` where `get_df` was called with `schema` in the `catalog` position, causing incorrect behavior on databases that use both catalogs and schemas.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="598" height="249" alt="Screenshot 2026-06-23 at 10 20 48 AM" src="https://github.com/user-attachments/assets/a1b48387-4c4a-4abd-bae7-216224304ecf" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Connect Superset to a ClickHouse database. Configure `max_rows_to_read` to a value smaller than the total row count of a test table (e.g. `max_rows_to_read = 100000` on a 500K-row table ordered by a `DateTime` column `ts`).
2. Create a Line Chart using that table.
3. Set the X-axis to a SQL expression, e.g. `toStartOfDay(ts)`. Leave the Filters section empty.
4. **Before:** query fails with `Code: 158. DB::Exception: Limit for rows (max_rows_to_read) exceeded`.
5. Add a `TEMPORAL_RANGE` filter on `ts` (e.g. "Last year") in the Filters section and run again.
6. **After:** query succeeds. Check **··· → View Query** — a single `WHERE ts >= ... AND ts < ...` clause should appear, with no duplication.
7. Verify the warning modal appears when switching the X-axis from a physical temporal column to a SQL expression.
8. Verify charts using a physical temporal column as X-axis are unaffected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI (warning modal in Explore)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
