### PR TITLE
fix(i18n-fr): improve French translation on 6.1 branch

### DIFF
--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -9143,9 +9143,7 @@ msgid "No data"
 msgstr "Aucune donnée"
 
 msgid "No data after filtering or data is NULL for the latest time record"
-msgstr ""
-"Pas de données après le filtrage ou données NULLES pour le dernier "
-"enregistrement temporel"
+msgstr "Aucune donnée à afficher avec le filtrage courant"
 
 msgid "No data in file"
 msgstr "Pas de données dans le fichier"

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -4550,7 +4550,7 @@ msgstr "Jeu de données"
 
 #, fuzzy, python-format
 msgid "Dataset %(table)s already exists"
-msgstr "Le jeu de données %(name)s existe déjà"
+msgstr "Le jeu de données %(table)s existe déjà"
 
 msgid "Dataset Name"
 msgstr "Nom du jeu de données"

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -140,7 +140,7 @@ msgid " near '%(highlight)s'"
 msgstr " près de '%(highlight)s'"
 
 msgid " source code of Superset's sandboxed parser"
-msgstr " code source de l'analyseur de bac à sable du standard Superset"
+msgstr " code source de l'analyseur de bac à sable de Superset"
 
 msgid ""
 " standard to ensure that the lexicographical ordering\n"
@@ -185,7 +185,7 @@ msgstr " pour marquer une colonne comme colonne temporelle"
 msgid " to open SQL Lab. From there you can save the query as a dataset."
 msgstr ""
 " pour ouvrir SQL Lab. À partir de là, vous pouvez enregistrer la requête "
-"sous forme d'ensemble de données."
+"sous forme de jeu de données."
 
 #, fuzzy
 msgid " to see details."
@@ -813,7 +813,7 @@ msgid "A report named \"%(name)s\" already exists"
 msgstr "Un rapport nommé \"%(name)s\" existe déjà"
 
 msgid "A reusable dataset will be saved with your chart."
-msgstr "Un ensemble de données réutilisable sera enregistré avec votre graphique."
+msgstr "Un jeu de données réutilisable sera enregistré avec votre graphique."
 
 msgid ""
 "A set of parameters that become available in the query using Jinja "
@@ -885,11 +885,11 @@ msgid "Action"
 msgstr "Action"
 
 msgid "Action Log"
-msgstr "Journaux d'actions"
+msgstr "Journal d'activité"
 
 #, fuzzy
 msgid "Action Logs"
-msgstr "Journaux d'actions"
+msgstr "Journaux d'activité"
 
 msgid "Actions"
 msgstr "Actions"
@@ -972,7 +972,7 @@ msgstr "Ajouter un plugiciel"
 
 #, fuzzy
 msgid "Add a dataset"
-msgstr "Ajouter un ensemble de données"
+msgstr "Ajouter un jeu de données"
 
 #, fuzzy
 msgid "Add a new tab"
@@ -1007,12 +1007,12 @@ msgstr "Ajouter une méthode de notification"
 
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des colonnes calculées au ensemble de données dans le modal « "
+"Ajouter des colonnes calculées au jeu de données dans le modal « "
 "Modifier la source de données »"
 
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des colonnes temporelles calculées au ensemble de données dans le"
+"Ajouter des colonnes temporelles calculées au jeu de données dans le"
 " modal « Modifier la source de données »"
 
 #, fuzzy
@@ -1092,7 +1092,7 @@ msgstr "Ajouter une mesure"
 
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des mesures au ensemble de données dans le modal « Modifier la "
+"Ajouter des mesures au jeu de données dans le modal « Modifier la "
 "source de données »"
 
 msgid "Add new color formatter"
@@ -1502,7 +1502,7 @@ msgid "An error occurred"
 msgstr "Un erreur s'est produite"
 
 msgid "An error occurred saving dataset"
-msgstr "Une erreur s'est produite durant la sauvegarde du ensemble de données"
+msgstr "Une erreur s'est produite durant la sauvegarde du jeu de données"
 
 #, fuzzy
 msgid "An error occurred when running alert query"
@@ -1624,24 +1624,24 @@ msgstr ""
 #, python-format
 msgid "An error occurred while fetching dataset owner values: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération des valeurs de "
-"l’ensemble de données :  %s"
+"Une erreur s'est produite lors de la récupération des valeurs du "
+"jeu de données :  %s"
 
 msgid "An error occurred while fetching dataset related data"
 msgstr ""
-"Une erreur s'est produite lors de l'extraction des données relatives à "
-"l'ensemble de données"
+"Une erreur s'est produite lors de l'extraction des données relatives au "
+"jeu de données"
 
 #, python-format
 msgid "An error occurred while fetching dataset related data: %s"
 msgstr ""
 "Une erreur s'est produite lors de la récupération des données relatives "
-"au ensemble de données : %s"
+"au jeu de données : %s"
 
 #, python-format
 msgid "An error occurred while fetching datasets: %s"
 msgstr ""
-"Une erreur s'est produite lors de l'extraction des ensembles de données. "
+"Une erreur s'est produite lors de l'extraction des jeux de données. "
 ": %s"
 
 msgid "An error occurred while fetching function names."
@@ -1673,7 +1673,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "An error occurred while fetching theme datasource values: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération de l’ensemble de "
+"Une erreur s'est produite lors de la récupération du jeu de "
 "données relatives à la source de données : %s"
 
 #, fuzzy
@@ -2022,7 +2022,7 @@ msgid "Are you sure you want to delete the selected dashboards?"
 msgstr "Voulez-vous vraiment supprimer les tableaux de bord sélectionnés?"
 
 msgid "Are you sure you want to delete the selected datasets?"
-msgstr "Voulez-vous vraiment supprimer les ensembles de données sélectionnés?"
+msgstr "Voulez-vous vraiment supprimer les jeux de données sélectionnés?"
 
 #, fuzzy
 msgid "Are you sure you want to delete the selected groups?"
@@ -2056,7 +2056,7 @@ msgstr "Voulez-vous vraiment supprimer les requêtes sélectionnées?"
 
 #, fuzzy
 msgid "Are you sure you want to overwrite this dataset?"
-msgstr "Voulez-vous vraiment remplacer cet ensemble de données?"
+msgstr "Voulez-vous vraiment remplacer ce jeu de données?"
 
 msgid "Are you sure you want to proceed?"
 msgstr "Voulez-vous vraiment continuer?"
@@ -2132,7 +2132,7 @@ msgstr "Trier par ordre croissant"
 
 #, fuzzy
 msgid "Assign a set of parameters as"
-msgstr "Les paramètres du ensemble de données sont invalides."
+msgstr "Les paramètres du jeu de données sont invalides."
 
 #, fuzzy
 msgid "Assist"
@@ -2716,7 +2716,7 @@ msgstr "Impossible d'accéder à la requête"
 msgid "Cannot delete a database that has datasets attached"
 msgstr ""
 "Impossible de supprimer une base de données à laquelle sont attachés des "
-"ensembles de données"
+"jeux de données"
 
 msgid "Cannot delete system themes"
 msgstr "Impossible de supprimer les thèmes système"
@@ -2883,16 +2883,16 @@ msgid ""
 "Changing the dataset may break the chart if the chart relies on columns "
 "or metadata that does not exist in the target dataset"
 msgstr ""
-"La modification de l'ensemble de données peut briser le graphique si "
+"La modification du jeu de données peut briser le graphique si "
 "celui-ci repose sur des colonnes ou des métadonnées qui n'existent pas "
-"dans l'ensemble de données cible"
+"dans le jeu de données cible"
 
 msgid ""
 "Changing these settings will affect all charts using this dataset, "
 "including charts owned by other people."
 msgstr ""
 "La modification de ces paramètres affectera tous les graphiques qui "
-"utilisent cet ensemble de données, y compris les graphiques qui "
+"utilisent ce jeu de données, y compris les graphiques qui "
 "appartiennent à d'autres personnes."
 
 msgid "Changing this Dashboard is forbidden"
@@ -2905,10 +2905,10 @@ msgid "Changing this control takes effect instantly"
 msgstr "Modifier ce contrôle prend effet instantanément"
 
 msgid "Changing this dataset is forbidden"
-msgstr "Modifier cet ensemble de données est interdit"
+msgstr "Modifier ce jeu de données est interdit"
 
 msgid "Changing this dataset is forbidden."
-msgstr "Modifier cet ensemble de données est interdit."
+msgstr "Modifier ce jeu de données est interdit."
 
 #, fuzzy
 msgid "Changing this datasource is forbidden"
@@ -3051,7 +3051,7 @@ msgid "Chart type"
 msgstr "Titre du graphique"
 
 msgid "Chart type requires a dataset"
-msgstr "Le type de graphique nécessite un ensemble de données"
+msgstr "Le type de graphique nécessite un jeu de données"
 
 #, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
@@ -3115,11 +3115,11 @@ msgid "Choose a database..."
 msgstr "Choisissez une base de donnée"
 
 msgid "Choose a dataset"
-msgstr "Choisissez un ensemble de donnée"
+msgstr "Choisissez un jeu de données"
 
 #, fuzzy
 msgid "Choose a delimiter"
-msgstr "Choisissez un ensemble de donnée"
+msgstr "Choisissez un jeu de données"
 
 msgid "Choose a metric for right axis"
 msgstr "Choisissez une mesure pour l'axe de droite"
@@ -3251,7 +3251,7 @@ msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
-"Vue classique d'un ensemble de données, rangée par colonne, à la manière "
+"Vue classique d'un jeu de données, rangée par colonne, à la manière "
 "d'une feuille de calcul. Utilisez les tableaux pour présenter une vue des"
 " données sous-jacentes ou pour montrer des mesures agrégées."
 
@@ -3350,10 +3350,10 @@ msgid "Click to edit chart."
 msgstr "Cliquer pour modifier le graphique."
 
 msgid "Click to edit label"
-msgstr "Cliquer pour éditer le l’étiquette"
+msgstr "Cliquer pour éditer l’étiquette"
 
 msgid "Click to favorite/unfavorite"
-msgstr "Cliquez pour favori ou non"
+msgstr "Marquer/Enlever comme favori"
 
 msgid "Click to force-refresh"
 msgstr "Cliquer pour forcer le rafraîchissement"
@@ -3361,13 +3361,11 @@ msgstr "Cliquer pour forcer le rafraîchissement"
 msgid "Click to see difference"
 msgstr "Cliquer pour voir la différence"
 
-#, fuzzy
 msgid "Click to sort ascending"
-msgstr "Cocher pour trier par ordre croissant"
+msgstr "Trier par ordre croissant"
 
-#, fuzzy
 msgid "Click to sort descending"
-msgstr "Tri décroissant"
+msgstr "Trier par ordre décroissant"
 
 #, fuzzy
 msgid "Client ID"
@@ -3581,7 +3579,7 @@ msgstr ""
 
 #, fuzzy, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
-msgstr "Colonnes absentes de l’ensemble de données : %(invalid_columns)s"
+msgstr "Colonnes absentes de le jeu de données : %(invalid_columns)s"
 
 #, python-format
 msgid "Columns missing in datasource: %(invalid_columns)s"
@@ -4002,13 +4000,13 @@ msgstr "créer"
 
 #, fuzzy
 msgid "Create a dataset"
-msgstr "Créer un ensemble de données"
+msgstr "Créer un jeu de données"
 
 msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
-"Créer un ensemble de données pour commencer à visualiser vos données sous"
+"Créer un jeu de données pour commencer à visualiser vos données sous"
 " forme de graphique ou aller à SQL Lab pour interroger vos données."
 
 msgid "Create a new Tag"
@@ -4018,7 +4016,7 @@ msgid "Create a new chart"
 msgstr "Créer un nouveau graphique"
 
 msgid "Create and explore dataset"
-msgstr "Créer et explorer un ensemble de données"
+msgstr "Créer et explorer un jeu de données"
 
 msgid "Create chart"
 msgstr "Créer un graphique"
@@ -4028,7 +4026,7 @@ msgid "Create dataframe index"
 msgstr "Index des cadres de données"
 
 msgid "Create dataset"
-msgstr "Créer un ensemble de données"
+msgstr "Créer un jeu de données"
 
 msgid "Create matrix columns by placing charts side-by-side"
 msgstr ""
@@ -4069,8 +4067,8 @@ msgstr "Cramoisi"
 
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
-"Le filtre croisé sera appliqué à tous les graphiques qui utilisent cet "
-"ensemble de données."
+"Le filtre croisé sera appliqué à tous les graphiques qui utilisent ce "
+"jeu de données."
 
 #, fuzzy
 msgid "Cross-filtering is not enabled for this dashboard."
@@ -4151,8 +4149,8 @@ msgstr "SQL personnalisé"
 
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr ""
-"Les mesures SQL ponctuelles personnalisées ne sont pas activées pour cet "
-"ensemble de données"
+"Les mesures SQL ponctuelles personnalisées ne sont pas activées pour ce "
+"jeu de données"
 
 msgid "Custom SQL fields cannot contain sub-queries."
 msgstr "Les champs SQL personnalisés ne peuvent pas contenir de sous-requêtes."
@@ -4465,7 +4463,7 @@ msgid "Database"
 msgstr "Base de données"
 
 msgid "Database Connections"
-msgstr "Connexions à la base de données"
+msgstr "Connexions aux bases de données"
 
 msgid "Database Creation Error"
 msgstr "Erreur de création de base de données"
@@ -4548,71 +4546,71 @@ msgid "Databases"
 msgstr "Bases de données"
 
 msgid "Dataset"
-msgstr "Ensemble de données"
+msgstr "Jeu de données"
 
 #, fuzzy, python-format
 msgid "Dataset %(table)s already exists"
-msgstr "L’ensemble de données %(name)s existe déjà"
+msgstr "Le jeu de données %(name)s existe déjà"
 
 msgid "Dataset Name"
-msgstr "Nom de l’ensemble de données"
+msgstr "Nom du jeu de données"
 
 msgid "Dataset column delete failed."
-msgstr "La suppression de l’ensemble de données a échoué."
+msgstr "La suppression du jeu de données a échoué."
 
 msgid "Dataset column not found."
-msgstr "Colonne de l’ensemble de données introuvable."
+msgstr "Colonne du jeu de données introuvable."
 
 msgid "Dataset could not be created."
-msgstr "L’ensemble de données n'a pas pu être créé."
+msgstr "Le jeu de données n'a pas pu être créé."
 
 msgid "Dataset could not be duplicated."
-msgstr "L’ensemble de données n'a pas pu être dupliqué."
+msgstr "Le jeu de données n'a pas pu être dupliqué."
 
 msgid "Dataset could not be updated."
-msgstr "L’ensemble de données n'a pas pu être mis à jour."
+msgstr "Le jeu de données n'a pas pu être mis à jour."
 
 msgid "Dataset does not exist"
-msgstr "L’ensemble de données n'existe pas"
+msgstr "Le jeu de données n'existe pas"
 
 msgid "Dataset imported"
-msgstr "Ensemble de données importé"
+msgstr "Jeu de données importé"
 
 msgid "Dataset is required"
-msgstr "Un ensemble de données est requis"
+msgstr "Un jeu de données est requis"
 
 msgid "Dataset metric delete failed."
-msgstr "La suppression de l’ensemble de données a échoué."
+msgstr "La suppression du jeu de données a échoué."
 
 msgid "Dataset metric not found."
-msgstr "Mesure de l'ensemble de données non trouvée."
+msgstr "Mesure du jeu de données non trouvée."
 
 msgid "Dataset name"
-msgstr "Nom de l’ensemble de données"
+msgstr "Nom du jeu de données"
 
 msgid "Dataset parameters are invalid."
-msgstr "Les paramètres de l'ensemble de données ne sont pas valides."
+msgstr "Les paramètres du jeu de données ne sont pas valides."
 
 #, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr "Le schéma de l'ensemble de données n'est pas valide : %(error)s"
+msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 msgid "Datasets"
-msgstr "Ensembles de données"
+msgstr "Jeux de données"
 
 msgid ""
 "Datasets can be created from database tables or SQL queries. Select a "
 "database table to the left or "
 msgstr ""
-"Les ensembles de données peuvent être créés à partir de tableaux de base "
+"Les jeux de données peuvent être créés à partir de tableaux de base "
 "de données ou de requêtes SQL. Sélectionnez un tableau de base de données"
 " à gauche ou "
 
 msgid "Datasets could not be deleted."
-msgstr "L'ensemble de données n'a pas pu être supprimé."
+msgstr "Le jeu de données n'a pas pu être supprimé."
 
 msgid "Datasets do not contain a temporal column"
-msgstr "Les ensembles de données ne comportent pas de colonne temporelle"
+msgstr "Les jeux de données ne comportent pas de colonne temporelle"
 
 msgid "Datasource"
 msgstr "Source de données"
@@ -4777,7 +4775,7 @@ msgstr "Toujours filtrer sur la colonne temporelle principale"
 
 #, fuzzy
 msgid "Default folders cannot be nested"
-msgstr "L’ensemble de données n'a pas pu être créé."
+msgstr "Le jeu de données n'a pas pu être créé."
 
 msgid "Default latitude"
 msgstr "Latitude par défaut"
@@ -4926,7 +4924,7 @@ msgid "Delete Database?"
 msgstr "Supprimer la base de données?"
 
 msgid "Delete Dataset?"
-msgstr "Supprimer l’ensemble de données?"
+msgstr "Supprimer le jeu de données?"
 
 #, fuzzy
 msgid "Delete Group?"
@@ -5042,8 +5040,8 @@ msgstr[1] "%(num)d tableaux de bord supprimés"
 #, python-format
 msgid "Deleted %(num)d dataset"
 msgid_plural "Deleted %(num)d datasets"
-msgstr[0] "Ensemble de données %(num)d supprimé"
-msgstr[1] "Ensemble de données %(num)d supprimés"
+msgstr[0] "Jeu de données %(num)d supprimé"
+msgstr[1] "Jeu de données %(num)d supprimés"
 
 #, python-format
 msgid "Deleted %(num)d report schedule"
@@ -5152,9 +5150,8 @@ msgstr "Désélectionner tout"
 msgid "Design with"
 msgstr "Se connecter avec"
 
-#, fuzzy
 msgid "Details"
-msgstr "Totaux"
+msgstr "Détails"
 
 msgid "Details of the certification"
 msgstr "Détails de la certification"
@@ -5257,7 +5254,7 @@ msgstr "Désactivé"
 
 #, fuzzy
 msgid "Disables the drill to detail feature for this database."
-msgstr "Aucun échantillon n'a été renvoyé pour cet ensemble de données"
+msgstr "Aucun échantillon n'a été renvoyé pour ce jeu de données"
 
 #, fuzzy
 msgid "Discard"
@@ -5557,7 +5554,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Duplicate dataset"
-msgstr "Éditer l’ensemble de données"
+msgstr "Éditer le jeu de données"
 
 #, fuzzy, python-format
 msgid "Duplicate folder name: %s"
@@ -5596,7 +5593,7 @@ msgid ""
 msgstr ""
 "Durée (en secondes) du délai de mise en cache pour ce graphique. "
 "Définissez -1 pour contourner le cache. Notez que cette valeur correspond"
-" par défaut au délai d'attente de l’ensemble de données s'il n'est pas "
+" par défaut au délai d'attente du jeu de données s'il n'est pas "
 "défini."
 
 msgid ""
@@ -5688,35 +5685,29 @@ msgid "Edit Dashboard"
 msgstr "Modifier le tableau de bord"
 
 msgid "Edit Dataset "
-msgstr "Modifier l’ensemble de données "
+msgstr "Modifier le jeu de données "
 
-#, fuzzy
 msgid "Edit Group"
-msgstr "mode edition"
+msgstr "Modifier le groupe"
 
 msgid "Edit Log"
 msgstr "Modifier le journal"
 
 msgid "Edit Plugin"
-msgstr "Modifier le plugiciel"
+msgstr "Modifier le plugin"
 
-#, fuzzy
 msgid "Edit Role"
-msgstr "mode edition"
+msgstr "Modifier le rôle"
 
-#, fuzzy
 msgid "Edit Rule"
 msgstr "Modifier la règle"
 
-#, fuzzy
 msgid "Edit Tag"
-msgstr "Éditer le log"
+msgstr "Modifier le tag"
 
-#, fuzzy
 msgid "Edit User"
-msgstr "Modifier la requête"
+msgstr "Modifier l'utilisateur"
 
-#, fuzzy
 msgid "Edit alert"
 msgstr "Modifier l’alerte"
 
@@ -5743,7 +5734,7 @@ msgid "Edit database"
 msgstr "Modifier la base de données"
 
 msgid "Edit dataset"
-msgstr "Modifier l’ensemble de données"
+msgstr "Modifier le jeu de données"
 
 msgid "Edit email report"
 msgstr "Modifier le rapport par courriel"
@@ -5751,9 +5742,8 @@ msgstr "Modifier le rapport par courriel"
 msgid "Edit formatter"
 msgstr "Modifier le formateur"
 
-#, fuzzy
 msgid "Edit group"
-msgstr "mode edition"
+msgstr "Modifiter le groupe"
 
 msgid "Edit properties"
 msgstr "Modifier les propriétés"
@@ -5762,13 +5752,11 @@ msgstr "Modifier les propriétés"
 msgid "Edit report"
 msgstr "Modifier le rapport par courriel"
 
-#, fuzzy
 msgid "Edit role"
-msgstr "mode edition"
+msgstr "Modifier le rôle"
 
-#, fuzzy
 msgid "Edit tag"
-msgstr "Éditer le log"
+msgstr "Modifier le tag"
 
 msgid "Edit template"
 msgstr "Modifier le modèle"
@@ -5779,16 +5767,14 @@ msgstr "Modifier les paramètres du modèle"
 msgid "Edit the dashboard"
 msgstr "Modifier le tableau de bord"
 
-#, fuzzy
 msgid "Edit theme properties"
-msgstr "Modifier les propriétés"
+msgstr "Modifier les propriétés du thème"
 
 msgid "Edit time range"
 msgstr "Modifier l’intervalle de temps"
 
-#, fuzzy
 msgid "Edit user"
-msgstr "Modifier la requête"
+msgstr "Modifier l'utilisateur"
 
 msgid "Edited"
 msgstr "Édité"
@@ -5822,17 +5808,14 @@ msgstr "Recharger"
 msgid "Elevation"
 msgstr "Élévation"
 
-#, fuzzy
 msgid "Email"
-msgstr "Totaux"
+msgstr "Email"
 
-#, fuzzy
 msgid "Email is required"
-msgstr "Une valeur est obligatoire"
+msgstr "Vous devez saisir l'adresse email"
 
-#, fuzzy
 msgid "Email link"
-msgstr "Totaux"
+msgstr "Adresse email"
 
 msgid "Email reports active"
 msgstr "Rapports par courriel actifs"
@@ -6200,7 +6183,7 @@ msgstr "Une erreur s'est produite durant la récupération des graphiques"
 #, python-format
 msgid "Error while rendering virtual dataset query: %(msg)s"
 msgstr ""
-"Erreur durant le rendu de la requête de l’ensemble de données virtuel : "
+"Erreur durant le rendu de la requête du jeu de données virtuel : "
 "%(msg)s"
 
 #, python-format
@@ -6290,7 +6273,7 @@ msgid "Execution log"
 msgstr "Journal d'exécution"
 
 msgid "Existing dataset"
-msgstr "Ensemble de données existant"
+msgstr "Jeu de données existant"
 
 msgid "Exit fullscreen"
 msgstr "Sortir du mode plein écran"
@@ -6478,7 +6461,7 @@ msgstr "FEB"
 
 #, fuzzy
 msgid "FIT DATA"
-msgstr "Modifier l’ensemble de données"
+msgstr "Modifier le jeu de données"
 
 msgid "FRI"
 msgstr "FRI"
@@ -6785,21 +6768,17 @@ msgstr "Terminer"
 msgid "First"
 msgstr "Premier"
 
-#, fuzzy
 msgid "First Name"
-msgstr "Nom du graphique"
+msgstr "Prénom"
 
-#, fuzzy
 msgid "First name"
-msgstr "Nom du graphique"
+msgstr "Prénom"
 
-#, fuzzy
 msgid "First name is required"
-msgstr "Le nom est obligatoire"
+msgstr "Le prénom est obligatoire"
 
-#, fuzzy
 msgid "Fit columns dynamically"
-msgstr "Trier les colonnes alphabétiquement"
+msgstr "Ajuster les colonnes dynamiquement"
 
 msgid ""
 "Fix the trend line to the full time range specified in case filtered "
@@ -6952,7 +6931,7 @@ msgstr ""
 
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr ""
-"Les données du formulaire n'ont pas été trouvées dans l’ensemble de "
+"Les données du formulaire n'ont pas été trouvées dans le jeu de "
 "données, les métadonnées du graphique ont été rétablies."
 
 #, fuzzy
@@ -7131,35 +7110,29 @@ msgstr "Disposition du graphique"
 msgid "Gravity"
 msgstr "Gravité"
 
-#, fuzzy
 msgid "Greater Than"
-msgstr "La valeur doit être plus grande que 0"
+msgstr "Plus grand que"
 
-#, fuzzy
 msgid "Greater Than or Equal"
 msgstr "Plus grand ou égal (>=)"
 
-#, fuzzy
 msgid "Greater or equal (>=)"
 msgstr "Plus grand ou égal (>=)"
 
-#, fuzzy
 msgid "Greater than (>)"
 msgstr "Plus grand que (>)"
 
 msgid "Green for increase, red for decrease"
 msgstr "Vert pour l'augmentation, rouge pour la diminution"
 
-#, fuzzy
 msgid "Grid"
 msgstr "Grille"
 
-#, fuzzy
 msgid "Grid Size"
 msgstr "Taille de la grille"
 
 msgid "Group"
-msgstr "Grouper"
+msgstr "Groupe"
 
 msgid "Group By"
 msgstr "Grouper par"
@@ -7458,10 +7431,10 @@ msgid "Import database from file"
 msgstr "Importer la base de données depuis un fichier"
 
 msgid "Import dataset failed for an unknown reason"
-msgstr "L'import de l’ensemble de données a échoué pour une raison inconnue"
+msgstr "L'import du jeu de données a échoué pour une raison inconnue"
 
 msgid "Import datasets"
-msgstr "Importer des ensembles de données"
+msgstr "Importer des jeux de données"
 
 msgid "Import queries"
 msgstr "Importer des requêtes"
@@ -7661,7 +7634,7 @@ msgstr "Certificat invalide."
 
 #, fuzzy, python-format
 msgid "Invalid SQL: %(error)s"
-msgstr "Le schéma de l'ensemble de données n'est pas valide : %(error)s"
+msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 #, fuzzy, python-format
 msgid "Invalid advanced data type: %(advanced_data_type)s"
@@ -7776,40 +7749,32 @@ msgstr "Certificat invalide."
 msgid "Invalid tab ids: %s(tab_ids)"
 msgstr "Identifiants d’onglet non valides : %s(tab_ids)"
 
-#, fuzzy
 msgid "Invalid username or password"
 msgstr "Le nom d’utilisateur ou le mot de passe est incorrect."
 
-#, fuzzy
 msgid "Inverse selection"
 msgstr "Sélection inverse"
 
-#, fuzzy
 msgid "Invert current page"
 msgstr "Inverser la page actuelle"
 
-#, fuzzy
 msgid "Is Active?"
-msgstr "Alerte actives"
+msgstr "Actif ?"
 
-#, fuzzy
 msgid "Is active?"
-msgstr "Alerte actives"
+msgstr "Actif ?"
 
-#, fuzzy
 msgid "Is certified"
-msgstr "est certifié"
+msgstr "Est certifié"
 
-#, fuzzy
 msgid "Is custom tag"
-msgstr "Configurer un intervalle de temps personnalisée"
+msgstr "Est un tag personnalisé"
 
 msgid "Is dimension"
 msgstr "Est une Dimension"
 
-#, fuzzy
 msgid "Is false"
-msgstr "est faux"
+msgstr "Est faux"
 
 msgid "Is favorite"
 msgstr "Est favori"
@@ -7845,7 +7810,7 @@ msgstr "Isoligne"
 #, fuzzy
 msgid "Issue 1000 - The dataset is too large to query."
 msgstr ""
-"Problème 1000 - L'ensemble de données est trop volumineux pour être "
+"Problème 1000 - Le jeu de données est trop volumineux pour être "
 "interrogé."
 
 #, fuzzy
@@ -8028,9 +7993,8 @@ msgstr "Étiquettes pour les marqueurs"
 msgid "Labels for the ranges"
 msgstr "Étiquettes pour les plages"
 
-#, fuzzy
 msgid "Languages"
-msgstr "Intervalles"
+msgstr "Langages"
 
 #, fuzzy
 msgid "Large"
@@ -8039,9 +8003,8 @@ msgstr "Grand"
 msgid "Last"
 msgstr "Dernier"
 
-#, fuzzy
 msgid "Last Name"
-msgstr "nom de l’ensemble de données"
+msgstr "Nom de famille"
 
 #, python-format
 msgid "Last Updated %s"
@@ -8055,51 +8018,41 @@ msgstr "Dernière mise à jour %s par %s"
 msgid "Last available value seen on %s"
 msgstr "Dernière valeur disponible vue sur %s"
 
-#, fuzzy
 msgid "Last day"
-msgstr "dernier jour"
+msgstr "Dernier jour"
 
-#, fuzzy
 msgid "Last login"
-msgstr "mois dernier"
+msgstr "Dernier login"
 
 msgid "Last modified"
 msgstr "Dernière modification"
 
-#, fuzzy
 msgid "Last month"
-msgstr "mois dernier"
+msgstr "Mois dernier"
 
-#, fuzzy
 msgid "Last name"
-msgstr "nom de l’ensemble de données"
+msgstr "Nom de famille"
 
-#, fuzzy
 msgid "Last name is required"
-msgstr "Le nom est obligatoire"
+msgstr "Le nom de famille est obligatoire"
 
-#, fuzzy
 msgid "Last quarter"
-msgstr "trimestre dernier"
+msgstr "Trimestre dernier"
 
-#, fuzzy
 msgid "Last queried at"
-msgstr "trimestre dernier"
+msgstr "Date de dernière requête"
 
 msgid "Last run"
 msgstr "Dernière exécution"
 
-#, fuzzy
 msgid "Last week"
-msgstr "semaine dernière"
+msgstr "Semaine dernière"
 
-#, fuzzy
 msgid "Last year"
-msgstr "an dernier "
+msgstr "An dernier"
 
-#, fuzzy
 msgid "Lat"
-msgstr "plat"
+msgstr "Lat"
 
 msgid "Latitude"
 msgstr "Latitude"
@@ -8107,19 +8060,18 @@ msgstr "Latitude"
 msgid "Latitude of default viewport"
 msgstr "Latitude de la fenêtre d'affichage par défaut"
 
-#, fuzzy
 msgid "Layer"
-msgstr "année"
+msgstr "Couche"
 
 #, fuzzy
 msgid "Layer Name"
-msgstr "Nom de l'alerte"
+msgstr "Nom de la couche"
 
 msgid "Layer URL"
 msgstr "URL de la couche"
 
 msgid "Layer configuration"
-msgstr "Configuration de filtre"
+msgstr "Configuration de la couche"
 
 #, fuzzy
 msgid "Layer title"
@@ -8129,9 +8081,8 @@ msgstr "Titre du graphique"
 msgid "Layer type"
 msgstr "Type de filtre"
 
-#, fuzzy
 msgid "Layers"
-msgstr "alertes"
+msgstr "Couches"
 
 msgid "Layout"
 msgstr "Disposition"
@@ -8148,7 +8099,6 @@ msgstr "Type de disposition de l’arbre"
 msgid "Least recently modified"
 msgstr "Dernière modification en date"
 
-#, fuzzy
 msgid "Left"
 msgstr "Gauche"
 
@@ -8169,39 +8119,30 @@ msgstr "Valeur gauche"
 msgid "Legacy"
 msgstr "Hérité"
 
-#, fuzzy
 msgid "Legend"
 msgstr "Légende"
 
-#, fuzzy
 msgid "Legend Format"
 msgstr "Format de la légende"
 
-#, fuzzy
 msgid "Legend Orientation"
 msgstr "Orientation de la légende"
 
-#, fuzzy
 msgid "Legend Position"
 msgstr "Position de la légende"
 
-#, fuzzy
 msgid "Legend Type"
-msgstr "Type du filtre"
+msgstr "Type de légende"
 
-#, fuzzy
 msgid "Legend type"
-msgstr "Type du filtre"
+msgstr "Type de légende"
 
-#, fuzzy
 msgid "Less Than"
 msgstr "Valeur inférieure à"
 
-#, fuzzy
 msgid "Less Than or Equal"
 msgstr "Plus petit ou égal (<=)"
 
-#, fuzzy
 msgid "Less or equal (<=)"
 msgstr "Plus petit ou égal (<=)"
 
@@ -8211,7 +8152,6 @@ msgstr "Moins de (<)"
 msgid "Lift percent precision"
 msgstr "Précision du pourcentage de levée"
 
-#, fuzzy
 msgid "Light"
 msgstr "Clair"
 
@@ -8221,21 +8161,17 @@ msgstr "Mode clair"
 msgid "Like"
 msgstr "Comme"
 
-#, fuzzy
 msgid "Like (case insensitive)"
-msgstr "Comme (sensible à la casse)"
+msgstr "Comme (insensible à la casse)"
 
-#, fuzzy
 msgid "Limit"
-msgstr "LIMITE"
+msgstr "Limite"
 
-#, fuzzy
 msgid "Limit type"
 msgstr "Type de limite"
 
-#, fuzzy
 msgid "Limits the number of cells that get retrieved."
-msgstr "Limite le nombre de lignes qui sont récupérées."
+msgstr "Limite le nombre de cellules qui sont récupérées."
 
 msgid "Limits the number of rows that get displayed."
 msgstr "Limite le nombre de lignes qui sont affichées."
@@ -8263,7 +8199,6 @@ msgstr ""
 "de ce tableau. Cette fonction peut être utilisée pour modifier les "
 "propriétés des données, filtrer ou enrichir le tableau."
 
-#, fuzzy
 msgid "Line"
 msgstr "Ligne"
 
@@ -8293,13 +8228,11 @@ msgid "Line interpolation as defined by d3.js"
 msgstr "Interpolation de lignes telle que définie par d3.js"
 
 msgid "Line width"
-msgstr "Largeur de la ligne"
+msgstr "Épaisseur du trait"
 
-#, fuzzy
 msgid "Line width unit"
-msgstr "L'épaisseur de la ligne"
+msgstr "Unité de l'épaisseur de trait"
 
-#, fuzzy
 msgid "Linear Color Scheme"
 msgstr "Schéma de couleurs linéaire"
 
@@ -8309,9 +8242,8 @@ msgstr "Schéma de couleurs linéaire"
 msgid "Linear interpolation"
 msgstr "Interpolation linéaire"
 
-#, fuzzy
 msgid "Linear palette"
-msgstr "Effacer tout"
+msgstr "Palette linéaire"
 
 #, fuzzy
 msgid "Lines column"
@@ -8332,7 +8264,7 @@ msgid "List Roles"
 msgstr "Liste des rôles"
 
 msgid "List Unique Values"
-msgstr "Liste des valeurs uniques"
+msgstr "Lister les valeurs uniques"
 
 msgid "List Users"
 msgstr "Liste des utilisateurs"
@@ -8905,7 +8837,7 @@ msgid "Missing URL parameters"
 msgstr "Paramètres URL manquants"
 
 msgid "Missing dataset"
-msgstr "Ensemble de données manquant"
+msgstr "Jeu de données manquant"
 
 #, fuzzy
 msgid "Mixed Chart"
@@ -9107,11 +9039,11 @@ msgstr "Nouveau graphique"
 
 #, fuzzy
 msgid "New dataset"
-msgstr "Nouvel ensemble de données"
+msgstr "Nouveau jeu de données"
 
 #, fuzzy
 msgid "New dataset name"
-msgstr "Nom de l’ensemble de données"
+msgstr "Nom du jeu de données"
 
 #, fuzzy
 msgid "New header"
@@ -9145,7 +9077,7 @@ msgid "No %s yet"
 msgstr "Pas encore de %s"
 
 msgid "No Data"
-msgstr "Aucune donnée"
+msgstr "Non applicable"
 
 #, fuzzy
 msgid "No Logs yet"
@@ -9194,14 +9126,14 @@ msgstr "Aucune colonne trouvée"
 
 #, fuzzy
 msgid "No compatible catalog found"
-msgstr "Aucun ensemble de données compatible trouvé"
+msgstr "Aucun jeu de données compatible trouvé"
 
 msgid "No compatible columns found"
 msgstr "Aucune colonne compatible trouvée"
 
 #, fuzzy
 msgid "No compatible datasets found"
-msgstr "Aucun ensemble de données compatible trouvé"
+msgstr "Aucun jeu de données compatible trouvé"
 
 #, fuzzy
 msgid "No compatible schema found"
@@ -9309,11 +9241,11 @@ msgstr "Pas encore de règles"
 
 #, fuzzy
 msgid "No rows were returned for this dataset"
-msgstr "Aucun résultat avec cet ensemble de données"
+msgstr "Aucun résultat avec ce jeu de données"
 
 #, fuzzy
 msgid "No samples were returned for this dataset"
-msgstr "Aucun échantillon n'a été renvoyé pour cet ensemble de données"
+msgstr "Aucun échantillon n'a été renvoyé pour ce jeu de données"
 
 #, fuzzy
 msgid "No saved expressions found"
@@ -10096,23 +10028,19 @@ msgstr "Moyenne de la période"
 msgid "Periods"
 msgstr "Périodes"
 
-#, fuzzy
 msgid "Periods must be a whole number"
 msgstr "Les périodes doivent être un nombre entier"
 
-#, fuzzy
 msgid "Permissions"
-msgstr "Version"
+msgstr "Permissions"
 
 #, python-format
 msgid "Permissions successfully synced for %s"
 msgstr "Permissions synchronisées avec succès pour %s"
 
-#, fuzzy
 msgid "Person or group that has certified this chart."
 msgstr "Personne ou groupe qui a certifié ce graphique."
 
-#, fuzzy
 msgid "Person or group that has certified this dashboard."
 msgstr "Personne ou groupe qui a certifié ce tableau de bord."
 
@@ -10120,7 +10048,7 @@ msgid "Person or group that has certified this metric"
 msgstr "Personne ou groupe qui a certifié cette mesure"
 
 msgid "Personal info"
-msgstr ""
+msgstr "Informations personnelles"
 
 msgid "Physical"
 msgstr "Physique"
@@ -10142,7 +10070,6 @@ msgstr "Choisissez une mesure à afficher"
 msgid "Pick a name to help you identify this database."
 msgstr "Choisissez un nom pour vous aider à identifier cette base de données."
 
-#, fuzzy
 msgid "Pick a nickname for how the database will display in Superset."
 msgstr "Choisissez un surnom pour l'affichage de la base de données dans Superset."
 
@@ -10177,28 +10104,23 @@ msgstr "Forme circulaire"
 msgid "Piecewise"
 msgstr "Par morceaux"
 
-#, fuzzy
 msgid "Pin"
-msgstr "NIP"
+msgstr "Épingler"
 
-#, fuzzy
 msgid "Pin Column"
-msgstr "Colonne des lignes"
+msgstr "Épingler la colonne"
 
-#, fuzzy
 msgid "Pin Left"
-msgstr "Haut à gauche"
+msgstr "Épingler à gauche"
 
-#, fuzzy
 msgid "Pin Right"
-msgstr "Haut à droite"
+msgstr "Épingler à droite"
 
 msgid "Pin to the result panel"
 msgstr ""
 
-#, fuzzy
 msgid "Pivot Mode"
-msgstr "mode edition"
+msgstr "Mode tableau croisé
 
 msgid "Pivot Table"
 msgstr "Tableau croisé"
@@ -10346,7 +10268,7 @@ msgstr "Veuillez choisir au moins un groupe par"
 
 msgid "Please select both a Dataset and a Chart type to proceed"
 msgstr ""
-"Veuillez sélectionner un ensemble de données et un type de graphique pour"
+"Veuillez sélectionner un jeu de données et un type de graphique pour"
 " continuer"
 
 #, python-format
@@ -11183,13 +11105,11 @@ msgstr ""
 msgid "Role"
 msgstr "Rôle"
 
-#, fuzzy
 msgid "Role Name"
-msgstr "Nom de l'alerte"
+msgstr "Nom du rôle"
 
-#, fuzzy
 msgid "Role name is required"
-msgstr "Le nom est obligatoire"
+msgstr "Le nom de rôle est nécessaire"
 
 msgid "Roles"
 msgstr "Rôles"
@@ -11202,7 +11122,7 @@ msgid ""
 msgstr ""
 "Les rôles sont une liste qui définit l'accès au tableau de bord. En "
 "accordant à un rôle l'accès à un tableau de bord, les contrôles au niveau"
-" de l'ensemble de données seront contournés. Si aucun rôle n'est défini, "
+" du jeu de données seront contournés. Si aucun rôle n'est défini, "
 "les autorisations d'accès normales s'appliquent."
 
 #, fuzzy
@@ -11213,7 +11133,7 @@ msgid ""
 msgstr ""
 "Les rôles sont une liste qui définit l'accès au tableau de bord. En "
 "accordant à un rôle l'accès à un tableau de bord, les contrôles au niveau"
-" de l'ensemble de données seront contournés. Si aucun rôle n'est défini, "
+" du jeu de données seront contournés. Si aucun rôle n'est défini, "
 "les autorisations d'accès normales s'appliquent."
 
 #, fuzzy
@@ -11257,7 +11177,7 @@ msgid "Row"
 msgstr "Rangée"
 
 msgid "Row Level Security"
-msgstr "Sécurité au niveau de la rangée"
+msgstr "Contrôle d'accès par ligne"
 
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
@@ -11458,7 +11378,7 @@ msgstr "Exemples"
 
 #, fuzzy
 msgid "Samples for dataset could not be retrieved."
-msgstr "Les exemples de l'ensemble de données n'ont pas pu être récupérés."
+msgstr "Les exemples du jeu de données n'ont pas pu être récupérés."
 
 #, fuzzy
 msgid "Samples for datasource could not be retrieved."
@@ -11495,11 +11415,11 @@ msgstr "Enregistrer sous"
 
 #, fuzzy
 msgid "Save as Dataset"
-msgstr "Enregistrer comme ensemble de données"
+msgstr "Enregistrer comme jeu de données"
 
 #, fuzzy
 msgid "Save as dataset"
-msgstr "Enregistrer comme ensemble de données"
+msgstr "Enregistrer comme jeu de données"
 
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -11533,20 +11453,20 @@ msgstr "Enregistrer le tableau de Bord"
 
 #, fuzzy
 msgid "Save dataset"
-msgstr "Enregistrer l’ensemble de données"
+msgstr "Enregistrer le jeu de données"
 
 msgid "Save for this session"
 msgstr "Enregistrer pour cette session"
 
 msgid "Save or Overwrite Dataset"
-msgstr "Enregistrer ou remplacer l’ensemble de données"
+msgstr "Enregistrer ou remplacer le jeu de données"
 
 msgid "Save query"
 msgstr "Enregistrer la requête"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr ""
-"Enregistrez cette requête en tant qu’ensemble de données virtuel pour "
+"Enregistrez cette requête en tant que jeu de données virtuel pour "
 "continuer à explorer"
 
 msgid "Saved"
@@ -11806,7 +11726,7 @@ msgstr "Supprimer la base de données"
 #, fuzzy
 msgid "Select a database table and create dataset"
 msgstr ""
-"Sélectionner une tableau de base de données et créer un ensemble de "
+"Sélectionner une tableau de base de données et créer un jeu de "
 "données"
 
 #, fuzzy
@@ -11982,7 +11902,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Select dataset source"
-msgstr "Sélectionner la source de l’ensemble de données"
+msgstr "Sélectionner la source du jeu de données"
 
 #, fuzzy
 msgid "Select datetime column"
@@ -12069,7 +11989,7 @@ msgstr "Sélectionner ou renseigner une valeur"
 
 #, fuzzy
 msgid "Select or type dataset name"
-msgstr "Sélectionner la base de données ou taper le nom de l’ensemble de données"
+msgstr "Sélectionner la base de données ou taper le nom du jeu de données"
 
 msgid "Select owners"
 msgstr "Sélectionner les propriétaires"
@@ -12134,7 +12054,7 @@ msgstr ""
 " ne sera pas filtré lors de l'application de filtres croisés à partir de "
 "n'importe quel graphique du tableau de bord. Vous pouvez sélectionner « "
 "Tous les graphiques » pour appliquer des filtres croisés à tous les "
-"graphiques qui utilisent le même ensemble de données ou contiennent le "
+"graphiques qui utilisent le même jeu de données ou contiennent le "
 "même nom de colonne dans le tableau de bord."
 
 msgid ""
@@ -12146,7 +12066,7 @@ msgstr ""
 "Sélectionnez les graphiques auxquels vous souhaitez appliquer des filtres"
 " croisés lorsque vous interagissez avec ce graphique. Vous pouvez "
 "sélectionner « Tous les graphiques » pour appliquer des filtres à tous "
-"les graphiques qui utilisent le même ensemble de données ou contiennent "
+"les graphiques qui utilisent le même jeu de données ou contiennent "
 "le même nom de colonne dans le tableau de bord."
 
 msgid "Select the color used for values that indicate an increase in the chart"
@@ -12686,7 +12606,7 @@ msgstr "Simple"
 
 msgid "Simple ad-hoc metrics are not enabled for this dataset"
 msgstr ""
-"Les mesures ponctuelles simples ne sont pas activées pour cet ensemble de"
+"Les mesures ponctuelles simples ne sont pas activées pour ce jeu de"
 " données"
 
 msgid "Single"
@@ -13118,7 +13038,7 @@ msgid "Stop running (Ctrl + x)"
 msgstr "Arrêter l'exécution (Ctrl + x)"
 
 msgid "Stopped an unsafe database connection"
-msgstr "Une connexion non sécurisée avec la base de données a été arrêtée"
+msgstr "Une connexion non sécurisée avec la base de données a été interrompue"
 
 #, fuzzy
 msgid "Stream"
@@ -13177,7 +13097,7 @@ msgstr "Réussite"
 
 #, fuzzy
 msgid "Successfully changed dataset!"
-msgstr "Ensemble de données modifé avec succès"
+msgstr "Jeu de données modifé avec succès"
 
 msgid "Suffix"
 msgstr "Suffixe"
@@ -13240,7 +13160,7 @@ msgstr "Bases de données prises en charge"
 
 #, fuzzy
 msgid "Swap dataset"
-msgstr "Échanger l'ensembles de données"
+msgstr "Changer de jeu de données"
 
 msgid "Swap rows and columns"
 msgstr "Échanger les rangées et les colonnes"
@@ -13326,7 +13246,7 @@ msgstr "Nom de l'onglet"
 
 #, fuzzy, python-format
 msgid "Tab schema is invalid, caused by: %(error)s"
-msgstr "Le schéma de l'ensemble de données n'est pas valide : %(error)s"
+msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 msgid "Tab title"
 msgstr "Titre de l’onglet"
@@ -13739,10 +13659,10 @@ msgstr "Base de données introuvable."
 
 #, fuzzy
 msgid "The dataset"
-msgstr "Nouvel ensemble de données"
+msgstr "Nouveau jeu de données"
 
 msgid "The dataset associated with this chart no longer exists"
-msgstr "L’ensemble de donnée associé à ce graphique n'existe plus"
+msgstr "Le jeu de données associé à ce graphique n'existe plus"
 
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
 msgstr ""
@@ -13775,15 +13695,15 @@ msgid ""
 "                in undesirable ways."
 msgstr ""
 "La configuration du jeu de donnée indiqué ici                s'applique à"
-" tous les graphiques utilisant ce ensemble de données.                "
+" tous les graphiques utilisant ce jeu de données.                "
 "Rappelez vous que changer ces paramètres                peut affecter "
 "d'autres graphiques                de manière non voulue."
 
 msgid "The dataset has been saved"
-msgstr "L’ensemble de données a été sauvegardé"
+msgstr "Le jeu de données a été sauvegardé"
 
 msgid "The dataset linked to this chart may have been deleted."
-msgstr "L’ensemble de données lié à ce graphique semble avoir été effacé."
+msgstr "Le jeu de données lié à ce graphique semble avoir été effacé."
 
 msgid "The datasource couldn't be loaded"
 msgstr "La source de données ne peut pas être chargée"
@@ -14119,7 +14039,7 @@ msgid ""
 "needed."
 msgstr ""
 "Les mots de passe pour les bases de données ci-dessous sont nécessaires "
-"pour les importer en même temps que les ensembles de données. Notez que "
+"pour les importer en même temps que les jeux de données. Notez que "
 "les sections « Securité supplémentaire » et « Certificat » de la "
 "configuration de la base de données ne sont pas présents dans les "
 "fichiers d'export et doivent être ajoutés manuellement après l'import si "
@@ -14606,13 +14526,13 @@ msgstr "Une erreur s'est produite lors de la récupération des schémas"
 
 #, fuzzy
 msgid "There was an error duplicating the role. Please, try again."
-msgstr "Il y a eu un problème de duplication de l'ensemble de données."
+msgstr "Il y a eu un problème de duplication du jeu de données."
 
 #, fuzzy
 msgid "There was an error fetching dataset"
 msgstr ""
 "Désolé, une erreur s'est produite lors de la récupération des "
-"informations de cet ensemble de données"
+"informations de ce jeu de données"
 
 #, fuzzy
 msgid "There was an error fetching dataset's related objects"
@@ -14674,7 +14594,7 @@ msgstr "Une erreur s'est produite lors de la récupération des schémas"
 msgid "There was an error while fetching users"
 msgstr ""
 "Désolé, une erreur s'est produite lors de la récupération des "
-"informations de cet ensemble de données"
+"informations de ce jeu de données"
 
 msgid "There was an error with your request"
 msgstr "Il y avait une erreur avec vore requête"
@@ -14717,7 +14637,7 @@ msgstr "Il y a eu un problème lors de la suppression des graphiques sélectionn
 #, python-format
 msgid "There was an issue deleting the selected datasets: %s"
 msgstr ""
-"Il y a eu un problème lors de la suppression des ensembles de données "
+"Il y a eu un problème lors de la suppression des jeux de données "
 "sélectionnés : %s"
 
 #, python-format
@@ -14744,17 +14664,17 @@ msgstr "Il y a eu un problème lors de la suppression de : %s"
 
 #, fuzzy
 msgid "There was an issue duplicating the dataset."
-msgstr "Il y a eu un problème de duplication de l'ensemble de données."
+msgstr "Il y a eu un problème de duplication du jeu de données."
 
 #, fuzzy, python-format
 msgid "There was an issue duplicating the selected datasets: %s"
 msgstr ""
-"Il y a eu un problème de duplication des ensembles de données "
+"Il y a eu un problème de duplication des jeux de données "
 "sélectionnés : %s"
 
 #, fuzzy
 msgid "There was an issue exporting the database"
-msgstr "Il y a eu un problème de duplication de l'ensemble de données."
+msgstr "Il y a eu un problème de duplication du jeu de données."
 
 #, fuzzy, python-format
 msgid "There was an issue exporting the selected charts"
@@ -14769,7 +14689,7 @@ msgstr "Il y a eu un problème lors de la suppression des graphiques sélectionn
 #, fuzzy, python-format
 msgid "There was an issue exporting the selected datasets"
 msgstr ""
-"Il y a eu un problème lors de la suppression des ensembles de données "
+"Il y a eu un problème lors de la suppression des jeux de données "
 "sélectionnés : %s"
 
 #, fuzzy, python-format
@@ -14880,7 +14800,7 @@ msgid ""
 " with the same name."
 msgstr ""
 "Ce graphique applique des filtres croisés aux graphiques dont les "
-"ensembles de données contiennent des colonnes du même nom."
+"jeux de données contiennent des colonnes du même nom."
 
 msgid "This chart has been moved to a different filter scope."
 msgstr "Ce graphique a été déplacé vers un autre champ de filtrage."
@@ -14892,7 +14812,7 @@ msgstr ""
 
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
-"Ce graphique peut être incompatible avec le filtre (les ensembles de "
+"Ce graphique peut être incompatible avec le filtre (les jeux de "
 "données ne correspondent pas)"
 
 msgid ""
@@ -14903,7 +14823,7 @@ msgstr ""
 " requête non enregistrée comme source graphique. "
 
 msgid "This column might be incompatible with current dataset"
-msgstr "Cette colonne peut être incompatible avec l’ensemble de données actuel"
+msgstr "Cette colonne peut être incompatible avec le jeu de données actuel"
 
 msgid "This column must contain date/time information."
 msgstr "Cette colonne doit contenir une information date/heure."
@@ -15007,7 +14927,7 @@ msgstr ""
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
-"Cet ensemble de données est géré à l'externe et ne peut pas être modifié "
+"Ce jeu de données est géré à l'externe et ne peut pas être modifié "
 "dans Superset"
 
 msgid "This defines the element to be plotted on the chart"
@@ -15042,7 +14962,7 @@ msgid "This filter already exist on the report"
 msgstr "La liste de valeurs du filtre ne peut pas être vide"
 
 msgid "This filter might be incompatible with current dataset"
-msgstr "Ce filtre pourrait être incompatible avec l’ensemble de données actuel"
+msgstr "Ce filtre pourrait être incompatible avec le jeu de données actuel"
 
 msgid "This folder is currently empty"
 msgstr ""
@@ -15129,7 +15049,7 @@ msgid "This may be triggered by:"
 msgstr "Cela peut être déclenché par :"
 
 msgid "This metric might be incompatible with current dataset"
-msgstr "Cette mesure pourrait être incompatible avec l’ensemble de données actuel"
+msgstr "Cette mesure pourrait être incompatible avec le jeu de données actuel"
 
 msgid "This name is already taken. Please choose another one."
 msgstr "Ce nom est déjà pris. Veuillez en choisir un autre."
@@ -15173,14 +15093,14 @@ msgstr ""
 "correctement."
 
 msgid "This table already has a dataset"
-msgstr "Ce tableau contient déjà un ensemble de données"
+msgstr "Ce tableau contient déjà un jeu de données"
 
 msgid ""
 "This table already has a dataset associated with it. You can only "
 "associate one dataset with a table.\n"
 msgstr ""
-"Ce tableau est déjà associé à un ensemble de données. Vous ne pouvez "
-"associer qu'un seul ensemble de données à un tableau.\n"
+"Ce tableau est déjà associé à un jeu de données. Vous ne pouvez "
+"associer qu'un seul jeu de données à un tableau.\n"
 
 #, fuzzy
 msgid "This theme is set locally"
@@ -15325,7 +15245,7 @@ msgstr "Colonne de temps"
 
 #, python-format
 msgid "Time column \"%(col)s\" does not exist in dataset"
-msgstr "La colonne temporelle « %(col)s » n'existe pas dans l’ensemble de données"
+msgstr "La colonne temporelle « %(col)s » n'existe pas dans le jeu de données"
 
 #, fuzzy
 msgid "Time column chart customization plugin"
@@ -15925,7 +15845,7 @@ msgstr "Fragment de temps non pris en charge : %(time_grain)s"
 
 #, fuzzy
 msgid "Untitled Dataset"
-msgstr "Ensemble de données sans titre"
+msgstr "Jeu de données sans titre"
 
 #, fuzzy
 msgid "Untitled Query"
@@ -16101,7 +16021,7 @@ msgid ""
 "status and assignee, active users by age and location. Not the most "
 "visually stunning visualization, but highly informative and versatile."
 msgstr ""
-"Utilisé pour résumer un ensemble de données en regroupant plusieurs "
+"Utilisé pour résumer un jeu de données en regroupant plusieurs "
 "statistiques le long de deux axes. Exemples : Chiffre d'affaires par "
 "région et par mois, tâches par statut et par "
 "destinataire,utilisateur·rice·s actif·ve·s par âge et par lieu. Ce n'est "
@@ -16313,7 +16233,7 @@ msgstr "Tout voir »"
 
 #, fuzzy
 msgid "View Dataset"
-msgstr "Éditer l’ensemble de données"
+msgstr "Éditer le jeu de données"
 
 #, fuzzy
 msgid "View all charts"
@@ -16355,16 +16275,16 @@ msgid "Virtual (SQL)"
 msgstr "Virtuel (SQL)"
 
 msgid "Virtual dataset query cannot be empty"
-msgstr "L’ensemble de données virtuel ne peut pas être vide"
+msgstr "Le jeu de données virtuel ne peut pas être vide"
 
 msgid "Virtual dataset query cannot consist of multiple statements"
 msgstr ""
-"Une requête sur un ensemble de données virtuel ne peut pas être composée "
+"Une requête sur un jeu de données virtuel ne peut pas être composée "
 "de plusieurs instructions"
 
 msgid "Virtual dataset query must be read-only"
 msgstr ""
-"L'interrogation de l'ensemble de données virtuel doit être en lecture "
+"L'interrogation du jeu de données virtuel doit être en lecture "
 "seule"
 
 msgid "Visual Tweaks"
@@ -16515,7 +16435,7 @@ msgid ""
 "Warning! Changing the dataset may break the chart if the metadata does "
 "not exist."
 msgstr ""
-"Attention! Changer l’ensemble de données peut mettre en erreur le "
+"Attention! Changer le jeu de données peut mettre en erreur le "
 "graphique si la métadonnées n'existe pas."
 
 msgid "Was unable to check your query"
@@ -16563,7 +16483,7 @@ msgid ""
 "dataset."
 msgstr ""
 "Nous n’avons pas été en mesure de reporter les contrôles lors du passage "
-"à ce nouvel ensemble de données."
+"à ce nouveau jeu de données."
 
 #, python-format
 msgid ""
@@ -17171,7 +17091,7 @@ msgid ""
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
-"Vous importez un ou plusieurs ensembles de données qui existent déjà. "
+"Vous importez un ou plusieurs jeux de données qui existent déjà. "
 "L'écrasement pourrait vous faire perdre une partie de votre travail. "
 "Êtes-vous sûr de vouloir les écraser?"
 
@@ -17190,7 +17110,7 @@ msgid ""
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
-"Vous importez un ou plusieurs ensembles de données qui existent déjà. "
+"Vous importez un ou plusieurs jeux de données qui existent déjà. "
 "L'écrasement pourrait vous faire perdre une partie de votre travail. "
 "Êtes-vous sûr de vouloir les écraser?"
 
@@ -17298,7 +17218,7 @@ msgstr "Vous n'avez pas accès à ce tableau de bord."
 
 #, fuzzy
 msgid "You don't have access to this dataset."
-msgstr "Vous n'avez pas accès à cet ensemble de données."
+msgstr "Vous n'avez pas accès à ce jeu de données."
 
 #, fuzzy
 msgid "You don't have access to this embedded dashboard config."
@@ -17356,8 +17276,8 @@ msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
 "dataset owner to request modifications or edit access."
 msgstr ""
-"Vous devez être propriétaire d'un ensemble de données pour pouvoir le "
-"modifier. Veuillez communiquer avec un propriétaire d’ensemble de données"
+"Vous devez être propriétaire d'un jeu de données pour pouvoir le "
+"modifier. Veuillez communiquer avec un propriétaire de jeu de données"
 " pour demander des modifications ou modifier l’accès."
 
 msgid "You must pick a name for the new dashboard"
@@ -17382,8 +17302,8 @@ msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
 msgstr ""
-"Vous avez modifié les ensembles de données. Tous les contrôles contenant "
-"des données (colonnes, mesures) qui correspondent à ce nouveau ensemble "
+"Vous avez modifié les jeux de données. Tous les contrôles contenant "
+"des données (colonnes, mesures) qui correspondent à ce nouveau jeu "
 "de données ont été conservés."
 
 msgid "Your account is activated. You can log in with your credentials."
@@ -17468,7 +17388,7 @@ msgid "[Longitude] and [Latitude] must be set"
 msgstr "Les colonnes [Longitude] et [Latitude] doivent êtres définies"
 
 msgid "[Missing Dataset]"
-msgstr "[Ensemble de données manquant]"
+msgstr "[Jeu de données manquant]"
 
 msgid "[Untitled]"
 msgstr "[Sans titre]"
@@ -17679,7 +17599,7 @@ msgid "create a new chart"
 msgstr "créer un nouveau graphique"
 
 msgid "create dataset from SQL query"
-msgstr "créer un ensemble de données à partir d'une requête SQL"
+msgstr "créer un jeu de données à partir d'une requête SQL"
 
 msgid "crontab"
 msgstr "crontab"
@@ -17704,10 +17624,10 @@ msgid "database"
 msgstr "base de données"
 
 msgid "dataset"
-msgstr "ensemble de données"
+msgstr "jeu de données"
 
 msgid "dataset name"
-msgstr "nom de l’ensemble de données"
+msgstr "nom du jeu de données"
 
 msgid "date"
 msgstr "date"
@@ -17964,9 +17884,9 @@ msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
 msgstr ""
-"L'ensemble de données %s est lié aux graphiques %s qui apparaissent dans "
+"Le jeu de données %s est lié aux graphiques %s qui apparaissent dans "
 "%s tableaux de bord. Êtes-vous sûr de vouloir continuer? La suppression "
-"de l'ensemble de données brisera ces objets."
+"du jeu de données brisera ces objets."
 
 msgid "is not"
 msgstr "n'est pas"


### PR DESCRIPTION
### SUMMARY
Bring some improvements in the French translations. Striking changes are:
- fix several really erroneous translations
- replace "ensemble de données" (dataset) by "jeu de données", which is a much more commonly used term for this

\+ some extra improvements as it goes

If approved, I'll make another PR backporting as much as I can into `master`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
For instance, when editing the user profile, we had:
<img width="1083" height="822" alt="image" src="https://github.com/user-attachments/assets/abd0e435-7e4c-483d-a684-df10fb1a5e77" />

now:

<img  height="600" alt="image" src="https://github.com/user-attachments/assets/a6af0103-1767-487c-88d7-fc253d34f22b" />


### TESTING INSTRUCTIONS
- Build Superset  with the translations
- activate french translations
```python
LANGUAGES = {
    'fr': {'flag': 'fr', 'name': 'French'},
    'en': {'flag': 'us', 'name': 'English'},
}
```
- check for instance the "Edit user" form
