### PR TITLE
fix(big-number): respect extra_form_data.time_compare in Big Number with Time Comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -29,7 +29,7 @@ import {
 import { isEmpty } from 'lodash';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { cols: groupby } = formData;
+  const { cols: groupby, extra_form_data } = formData;
 
   const queryContextA = buildQueryContext(formData, baseQueryObject => {
     const postProcessing: PostProcessingRule[] = [];
@@ -58,14 +58,24 @@ export default function buildQuery(formData: QueryFormData) {
         timeOffsets = timeOffsets.concat(['inherit']);
       }
     }
+
+    if (
+      extra_form_data?.time_compare &&
+      !timeOffsets.includes(extra_form_data.time_compare)
+    ) {
+      timeOffsets = [extra_form_data.time_compare];
+    }
+
     return [
       {
         ...baseQueryObject,
         groupby,
         post_processing: postProcessing,
-        time_offsets: isTimeComparison(formData, baseQueryObject)
-          ? ensureIsArray(timeOffsets)
-          : [],
+        time_offsets:
+          isTimeComparison(formData, baseQueryObject) ||
+          extra_form_data?.time_compare
+            ? ensureIsArray(timeOffsets)
+            : [],
       },
     ];
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -111,7 +111,11 @@ export default function transformProps(chartProps: ChartProps) {
   const metrics = chartProps.datasource?.metrics || [];
   const originalLabel = getOriginalLabel(metric, metrics);
   const showMetricName = chartProps.rawFormData?.show_metric_name ?? false;
-  const timeComparison = ensureIsArray(chartProps.rawFormData?.time_compare)[0];
+
+  const dashboardTimeCompare = formData?.extraFormData?.time_compare;
+  const timeComparison =
+    dashboardTimeCompare ||
+    ensureIsArray(chartProps.rawFormData?.time_compare)[0];
   const startDateOffset = chartProps.rawFormData?.start_date_offset;
   const currentTimeRangeFilter = chartProps.rawFormData?.adhoc_filters?.filter(
     (adhoc_filter: SimpleAdhocFilter) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/BigNumberPeriodOverPeriod/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/BigNumberPeriodOverPeriod/buildQuery.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import buildQuery from '../../../src/BigNumber/BigNumberPeriodOverPeriod/buildQuery';
+
+describe('BigNumberPeriodOverPeriod buildQuery', () => {
+  const baseFormData: QueryFormData = {
+    datasource: '1__table',
+    viz_type: 'pop_kpi',
+    metric: 'count',
+    cols: [],
+    adhoc_filters: [
+      {
+        clause: 'WHERE',
+        subject: 'order_date',
+        operator: 'TEMPORAL_RANGE',
+        comparator: '2003-07-01 : 2004-01-01',
+        expressionType: 'SIMPLE',
+      },
+    ],
+  };
+
+  test('flows extra_form_data.time_compare override into time_offsets', () => {
+    const queryContext = buildQuery({
+      ...baseFormData,
+      extra_form_data: { time_compare: '1 year ago' },
+    });
+
+    expect(queryContext.queries[0].time_offsets).toEqual(['1 year ago']);
+  });
+
+  test('requests offsets from the override even without the chart time_compare control', () => {
+    const queryContext = buildQuery({
+      ...baseFormData,
+      time_compare: undefined,
+      extra_form_data: { time_compare: '1 year ago' },
+    });
+
+    expect(queryContext.queries[0].time_offsets).toEqual(['1 year ago']);
+  });
+
+  test('does not duplicate the offset when it already matches time_compare', () => {
+    const queryContext = buildQuery({
+      ...baseFormData,
+      time_compare: ['1 year ago'],
+      extra_form_data: { time_compare: '1 year ago' },
+    });
+
+    expect(queryContext.queries[0].time_offsets).toEqual(['1 year ago']);
+  });
+
+  test('omits time_offsets when neither the control nor the override is set', () => {
+    const queryContext = buildQuery(baseFormData);
+
+    expect(queryContext.queries[0].time_offsets).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Big Number with Time Comparison (`pop_kpi`) ignores `extra_form_data.time_compare`.
When that override is set, the chart still computes its comparison from its own `time_compare` control, so the displayed comparison value, delta, and "Data for …" tooltip don't reflect the override.

### Fix
Read `extra_form_data.time_compare` and let it drive the comparison, mirroring how the Table chart already handles it (#33947):

- **buildQuery.ts** — when `extra_form_data.time_compare` is present, use it as
  `time_offsets` (and request offsets in that case) so the backend computes the
  comparison against the overridden range.
- **transformProps.ts** — prefer `extra_form_data.time_compare` when selecting the
  comparison column and computing the tooltip shift.
- Added a `buildQuery` test covering the override.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
With `extra_form_data.time_compare` set, the Big Number's comparison value, delta, and percent now match the Table chart for the same data.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
