### PR TITLE
fix(dashboard): Remove 308 redirect when creating new dashboards

### DIFF
--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -243,7 +243,7 @@ test('handles create dashboard button click', async () => {
 
   const createButton = screen.getByRole('button', { name: /dashboard$/i });
   await userEvent.click(createButton);
-  expect(assignMock).toHaveBeenCalledWith('/dashboard/new');
+  expect(assignMock).toHaveBeenCalledWith('/dashboard/new/');
   locationSpy.mockRestore();
 });
 

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -203,7 +203,7 @@ function DashboardTable({
             name: t('Dashboard'),
             buttonStyle: 'secondary',
             onClick: () => {
-              navigateTo('/dashboard/new', { assign: true });
+              navigateTo('/dashboard/new/', { assign: true });
             },
           },
           {

--- a/superset-frontend/src/features/home/EmptyState.tsx
+++ b/superset-frontend/src/features/home/EmptyState.tsx
@@ -57,7 +57,7 @@ const LABELS = {
 const REDIRECTS = {
   create: {
     [WelcomeTable.Charts]: '/chart/add',
-    [WelcomeTable.Dashboards]: '/dashboard/new',
+    [WelcomeTable.Dashboards]: '/dashboard/new/',
     // navigateTo() applies the application root internally; keep this
     // relative so the prefix isn't added twice.
     [WelcomeTable.SavedQueries]: '/sqllab?new=true',

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -89,7 +89,7 @@ const dropdownItems = [
   },
   {
     label: 'Dashboard',
-    url: '/dashboard/new',
+    url: '/dashboard/new/',
     icon: 'fa-fw fa-dashboard',
     perm: 'can_write',
     view: 'Dashboard',

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -105,7 +105,7 @@ const dropdownItems = [
   },
   {
     label: 'Dashboard',
-    url: '/dashboard/new',
+    url: '/dashboard/new/',
     icon: 'fa-fw fa-dashboard',
     perm: 'can_write',
     view: 'Dashboard',

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -232,7 +232,7 @@ const RightMenu = ({
     },
     {
       label: t('Dashboard'),
-      url: '/dashboard/new',
+      url: '/dashboard/new/',
       icon: (
         <Icons.DashboardOutlined data-test={`menu-item-${t('Dashboard')}`} />
       ),

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -762,7 +762,7 @@ function DashboardList(props: DashboardListProps) {
       name: t('Dashboard'),
       buttonStyle: 'primary',
       onClick: () => {
-        navigateTo('/dashboard/new', { assign: true });
+        navigateTo('/dashboard/new/', { assign: true });
       },
     });
   }


### PR DESCRIPTION
### SUMMARY

Adopts #28754, original by @ericsong. Related to #20577.

The frontend's create-dashboard entry points navigate to `/dashboard/new`, but the backend exposes the route as `/dashboard/new/` (`@expose("/new/")` in `superset/views/dashboard/views.py`). Flask answers the slash-less URL with a 308 permanent redirect to the canonical trailing-slash version. In some infrastructure setups (behind certain proxies/load balancers) that redirect resolves to an invalid address and breaks the create-dashboard flow — see the discussion in #20577. This change points every create-dashboard link/button (welcome empty-state, right-hand menu, dashboard table, and dashboard list) directly at `/dashboard/new/` so the browser hits the backend endpoint with no 308. The corresponding frontend tests are updated to expect the trailing-slash URL. No behavioral change beyond the URL; rebased cleanly onto current `master`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See the screenshots in the original PR #28754 (before: 308 redirect on `/dashboard/new`; after: direct navigation to `/dashboard/new/`).

### TESTING INSTRUCTIONS

1. Hard-refresh to clear any cached redirect for `/dashboard/new`.
2. Create a new dashboard from the "+" menu, the welcome page empty state, or the Dashboards list "Dashboard" button.
3. Confirm the network panel shows a direct request to `/dashboard/new/` with no 308 redirect.

Unit tests: `cd superset-frontend && npm run test -- src/features/home/DashboardTable.test.tsx src/features/home/Menu.test.tsx src/features/home/RightMenu.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---
Adopts #28754 (original author @ericsong), rebased onto current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)