### PR TITLE
fix(models): use Series.iloc for positional access in post_process_df

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -704,7 +704,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             return (
                 not df_series.empty
                 and isinstance(df_series, pd.Series)
-                and isinstance(df_series[0], (list, dict))
+                and isinstance(df_series.iloc[0], (list, dict))
             )
 
         for col, coltype in df.dtypes.to_dict().items():

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -19,6 +19,8 @@
 from datetime import datetime
 from typing import Any, Callable
 
+import numpy
+import pandas as pd
 import pytest
 from flask import current_app
 from pytest_mock import MockerFixture
@@ -1623,3 +1625,17 @@ def test_execute_sql_preserves_line_comments_single_statement(
     executed_sql = execute.call_args.args[1]
     assert executed_sql == sql
     assert "/*" not in executed_sql
+
+
+def test_post_process_df_non_zero_based_index() -> None:
+    """
+    post_process_df must not raise when the DataFrame index doesn't contain 0
+    as a label (e.g. after filtering).  Regression test for the FutureWarning
+    caused by df_series[0] positional-but-label-based access on such Series.
+    """
+    df = pd.DataFrame({"col": [None, [1, 2], [3, 4]]}, dtype=object)
+    df = df[df["col"].notna()]  # index is now [1, 2], not [0, 1, 2]
+    result = Database.post_process_df(df)
+    assert result["col"].dtype == numpy.object_
+    assert result["col"].iloc[0] == "[1, 2]"
+    assert result["col"].iloc[1] == "[3, 4]"


### PR DESCRIPTION
### What was the deprecation warning?

```
FutureWarning: Series.__getitem__ treating keys as positions is deprecated.
In a future version, integer keys will always be treated as labels
(consistent with DataFrame behavior). To access a value by position,
use `ser.iloc[pos]`
```

Fired from `superset/models/core.py` in `Database.post_process_df`. The
inner helper `column_needs_conversion` used `df_series[0]` to peek at the
first element. When the Series index doesn't contain `0` as a label (e.g.
after a filter like `df[df.col > value]`), pandas raises this FutureWarning
and will raise a `KeyError` in a future pandas version.

### What was changed?

`df_series[0]` → `df_series.iloc[0]` in `post_process_df`.

`iloc` is unconditionally positional — it always means "first element"
regardless of the index labels.

### No behavior change

The empty-check (`not df_series.empty`) guards against `IndexError` on
`.iloc[0]`. The conversion logic is unchanged; only the access method
corrects the deprecation.

### Test plan

- Added `test_post_process_df_non_zero_based_index` in
  `tests/unit_tests/models/core_test.py`. Constructs a DataFrame with a
  non-zero-based index (by filtering rows so index is `[1, 2]` not `[0, 1,
  2]`) and asserts `post_process_df` correctly JSON-serializes list columns.
- `pytest tests/unit_tests/models/core_test.py::test_post_process_df_non_zero_based_index`