### PR TITLE
fix(ag-grid-table): respect row limit with server pagination

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -58,7 +58,7 @@ export function getQueryMode(formData: TableChartFormData) {
   return hasRawColumns ? QueryMode.Raw : QueryMode.Aggregate;
 }
 
-const buildQuery: BuildQuery<TableChartFormData> = (
+export const buildQuery: BuildQuery<TableChartFormData> = (
   formData: TableChartFormData,
   options,
 ) => {
@@ -209,6 +209,17 @@ const buildQuery: BuildQuery<TableChartFormData> = (
 
     const moreProps: Partial<QueryObject> = {};
     const ownState = options?.ownState ?? {};
+    // Server pagination sizing, shared between the per-page request below and
+    // the filter-change reset further down.
+    const pageSize =
+      Number(ownState.pageSize ?? formDataCopy.server_page_length) || 0;
+    const configuredRowLimit = Number(formDataCopy.row_limit) || 0;
+    // row_limit for the first page, capped by the configured row limit. Used
+    // when a filter change resets pagination back to page 0.
+    const firstPageRowLimit =
+      configuredRowLimit > 0
+        ? Math.min(pageSize, configuredRowLimit)
+        : pageSize;
 
     // Build Query flag to check if its for either download as csv, excel or json
     const isDownloadQuery =
@@ -222,11 +233,24 @@ const buildQuery: BuildQuery<TableChartFormData> = (
     }
 
     if (!isDownloadQuery && formDataCopy.server_pagination) {
-      const pageSize = ownState.pageSize ?? formDataCopy.server_page_length;
-      const currentPage = ownState.currentPage ?? 0;
+      // Never page past the configured row limit. Clamping the page to the last
+      // one that still falls within the limit keeps the request inside the cap
+      // and avoids emitting row_limit: 0, which the backend treats as
+      // "no limit" rather than "no rows" (see helpers.py get_sqla_query).
+      const lastPage =
+        configuredRowLimit > 0 && pageSize > 0
+          ? Math.max(Math.ceil(configuredRowLimit / pageSize) - 1, 0)
+          : Number(ownState.currentPage) || 0;
+      const currentPage = Math.min(Number(ownState.currentPage) || 0, lastPage);
+      const rowOffset = currentPage * pageSize;
+      const remainingRows =
+        configuredRowLimit > 0
+          ? Math.max(configuredRowLimit - rowOffset, 0)
+          : pageSize;
 
-      moreProps.row_limit = pageSize;
-      moreProps.row_offset = currentPage * pageSize;
+      moreProps.row_limit =
+        configuredRowLimit > 0 ? Math.min(pageSize, remainingRows) : pageSize;
+      moreProps.row_offset = rowOffset;
     }
 
     let sortByFromOwnState: QueryFormOrderBy[] | undefined;
@@ -378,11 +402,19 @@ const buildQuery: BuildQuery<TableChartFormData> = (
       JSON.stringify(options?.extras?.cachedChanges?.[formData.slice_id]) !==
         JSON.stringify(queryObject.filters)
     ) {
-      queryObject = { ...queryObject, row_offset: 0 };
+      // Reset to the first page: restore the full first-page row_limit rather
+      // than carrying over the last page's capped value.
+      queryObject = {
+        ...queryObject,
+        row_offset: 0,
+        row_limit: firstPageRowLimit,
+      };
       const modifiedOwnState = {
         ...options?.ownState,
         currentPage: 0,
-        pageSize: queryObject.row_limit ?? 0,
+        // Persist the user-selected page size, not the per-request row_limit,
+        // which may be capped to the remaining rows on the last page.
+        pageSize,
         lastFilteredColumn: undefined,
         lastFilteredInputPosition: undefined,
       };

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -397,13 +397,16 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
     };
 
     if (
+      !isDownloadQuery &&
       formData.server_pagination &&
       options?.extras?.cachedChanges?.[formData.slice_id] &&
       JSON.stringify(options?.extras?.cachedChanges?.[formData.slice_id]) !==
         JSON.stringify(queryObject.filters)
     ) {
       // Reset to the first page: restore the full first-page row_limit rather
-      // than carrying over the last page's capped value.
+      // than carrying over the last page's capped value. Skipped for download
+      // queries so CSV/JSON exports keep the full configured row_limit instead
+      // of being capped to the page size.
       queryObject = {
         ...queryObject,
         row_offset: 0,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -215,11 +215,14 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
       Number(ownState.pageSize ?? formDataCopy.server_page_length) || 0;
     const configuredRowLimit = Number(formDataCopy.row_limit) || 0;
     // row_limit for the first page, capped by the configured row limit. Used
-    // when a filter change resets pagination back to page 0.
+    // when a filter change resets pagination back to page 0. A pageSize of 0
+    // means "no pagination", so the configured row limit applies directly.
     const firstPageRowLimit =
-      configuredRowLimit > 0
-        ? Math.min(pageSize, configuredRowLimit)
-        : pageSize;
+      pageSize > 0
+        ? configuredRowLimit > 0
+          ? Math.min(pageSize, configuredRowLimit)
+          : pageSize
+        : configuredRowLimit;
 
     // Build Query flag to check if its for either download as csv, excel or json
     const isDownloadQuery =
@@ -233,24 +236,36 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
     }
 
     if (!isDownloadQuery && formDataCopy.server_pagination) {
-      // Never page past the configured row limit. Clamping the page to the last
-      // one that still falls within the limit keeps the request inside the cap
-      // and avoids emitting row_limit: 0, which the backend treats as
-      // "no limit" rather than "no rows" (see helpers.py get_sqla_query).
-      const lastPage =
-        configuredRowLimit > 0 && pageSize > 0
-          ? Math.max(Math.ceil(configuredRowLimit / pageSize) - 1, 0)
-          : Number(ownState.currentPage) || 0;
-      const currentPage = Math.min(Number(ownState.currentPage) || 0, lastPage);
-      const rowOffset = currentPage * pageSize;
-      const remainingRows =
-        configuredRowLimit > 0
-          ? Math.max(configuredRowLimit - rowOffset, 0)
-          : pageSize;
+      if (pageSize > 0) {
+        // Never page past the configured row limit. Clamping the page to the
+        // last one that still falls within the limit keeps the request inside
+        // the cap and avoids emitting row_limit: 0, which the backend treats
+        // as "no limit" rather than "no rows" (see helpers.py get_sqla_query).
+        const lastPage =
+          configuredRowLimit > 0
+            ? Math.max(Math.ceil(configuredRowLimit / pageSize) - 1, 0)
+            : Number(ownState.currentPage) || 0;
+        const currentPage = Math.min(
+          Number(ownState.currentPage) || 0,
+          lastPage,
+        );
+        const rowOffset = currentPage * pageSize;
+        const remainingRows =
+          configuredRowLimit > 0
+            ? Math.max(configuredRowLimit - rowOffset, 0)
+            : pageSize;
 
-      moreProps.row_limit =
-        configuredRowLimit > 0 ? Math.min(pageSize, remainingRows) : pageSize;
-      moreProps.row_offset = rowOffset;
+        moreProps.row_limit =
+          configuredRowLimit > 0 ? Math.min(pageSize, remainingRows) : pageSize;
+        moreProps.row_offset = rowOffset;
+      } else {
+        // A pageSize of 0 means "no pagination" (server_page_length: 0), so
+        // request a single unpaginated result capped at the configured row
+        // limit. Feeding 0 into the paging math would emit row_limit: 0,
+        // which the backend treats as "no limit".
+        moreProps.row_limit = configuredRowLimit;
+        moreProps.row_offset = 0;
+      }
     }
 
     let sortByFromOwnState: QueryFormOrderBy[] | undefined;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -1672,6 +1672,36 @@ describe('plugin-chart-ag-grid-table', () => {
       });
     });
 
+    test('keeps the full export row limit on a download after a filter change', () => {
+      // A CSV/JSON export uses the same buildQuery, so a filter-reset caused
+      // by stale cachedChanges must not shrink the export to the page size.
+      const { queries } = buildQueryUncached(
+        {
+          ...serverPaginationFormData,
+          row_limit: 120,
+          server_page_length: 50,
+          result_format: 'csv',
+          slice_id: 107,
+        },
+        {
+          ownState: {
+            currentPage: 2,
+            pageSize: 50,
+          },
+          extras: {
+            cachedChanges: {
+              107: [{ col: 'state', op: '==', val: 'previous' }],
+            },
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 120,
+        row_offset: 0,
+      });
+    });
+
     test('persists the user page size, not the capped limit, on filter reset', () => {
       const setDataMask = jest.fn();
       buildQueryUncached(

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -1737,6 +1737,58 @@ describe('plugin-chart-ag-grid-table', () => {
       );
     });
 
+    test('applies the configured row limit when pagination is disabled via page size 0', () => {
+      // server_page_length: 0 means "no pagination"; the request must still
+      // honor the configured row limit instead of emitting row_limit: 0,
+      // which the backend treats as "no limit".
+      const { queries } = buildQuery(
+        {
+          ...serverPaginationFormData,
+          row_limit: 1000,
+          server_page_length: 0,
+          slice_id: 108,
+        },
+        {
+          ownState: {
+            currentPage: 0,
+            pageSize: 0,
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 1000,
+        row_offset: 0,
+      });
+    });
+
+    test('restores the configured row limit on filter reset when pagination is disabled', () => {
+      const { queries } = buildQueryUncached(
+        {
+          ...serverPaginationFormData,
+          row_limit: 1000,
+          server_page_length: 0,
+          slice_id: 109,
+        },
+        {
+          ownState: {
+            currentPage: 0,
+            pageSize: 0,
+          },
+          extras: {
+            cachedChanges: {
+              109: [{ col: 'state', op: '==', val: 'previous' }],
+            },
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 1000,
+        row_offset: 0,
+      });
+    });
+
     test('falls back to the page size when no row limit is configured', () => {
       const { queries } = buildQuery(
         {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -17,7 +17,9 @@
  * under the License.
  */
 import { AdhocColumn, QueryMode, VizType } from '@superset-ui/core';
-import buildQuery from '../src/buildQuery';
+import buildQuery, {
+  buildQuery as buildQueryUncached,
+} from '../src/buildQuery';
 import { TableChartFormData } from '../src/types';
 
 const basicFormData: TableChartFormData = {
@@ -1559,6 +1561,172 @@ describe('plugin-chart-ag-grid-table', () => {
       expect(queries).toHaveLength(2);
       expect(queries[1].columns).toEqual([]);
       expect(queries[1].metrics).toEqual(['count']);
+    });
+  });
+
+  describe('buildQuery - server pagination row limit', () => {
+    const serverPaginationFormData: TableChartFormData = {
+      ...basicFormData,
+      server_pagination: true,
+    };
+
+    test('uses user row limit when it is lower than server page size', () => {
+      const { queries } = buildQuery(
+        {
+          ...serverPaginationFormData,
+          row_limit: 10,
+          server_page_length: 20,
+          slice_id: 101,
+        },
+        {
+          ownState: {
+            currentPage: 0,
+            pageSize: 20,
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 10,
+        row_offset: 0,
+      });
+    });
+
+    test('limits server page size by remaining rows inside user row limit', () => {
+      const { queries } = buildQuery(
+        {
+          ...serverPaginationFormData,
+          row_limit: 120,
+          server_page_length: 50,
+          slice_id: 102,
+        },
+        {
+          ownState: {
+            currentPage: 2,
+            pageSize: 50,
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 20,
+        row_offset: 100,
+      });
+    });
+
+    test('clamps pages beyond the row limit instead of emitting row_limit: 0', () => {
+      const { queries } = buildQuery(
+        {
+          ...serverPaginationFormData,
+          row_limit: 120,
+          server_page_length: 50,
+          slice_id: 103,
+        },
+        {
+          ownState: {
+            // Page 5 is well past the cap; offset would be 250 > 120, which
+            // previously made row_limit collapse to 0 ("no limit").
+            currentPage: 5,
+            pageSize: 50,
+          },
+        },
+      );
+
+      expect(queries[0].row_limit).not.toBe(0);
+      expect(queries[0]).toMatchObject({
+        row_limit: 20,
+        row_offset: 100,
+      });
+    });
+
+    test('restores the full first-page row limit after a filter change reset', () => {
+      // Uncached export lets us seed cachedChanges directly; the default
+      // export overrides extras with its own closure.
+      const { queries } = buildQueryUncached(
+        {
+          ...serverPaginationFormData,
+          row_limit: 120,
+          server_page_length: 50,
+          slice_id: 104,
+        },
+        {
+          // User was on the capped last page (row_limit would be 20)...
+          ownState: {
+            currentPage: 2,
+            pageSize: 50,
+          },
+          // ...then an external filter changed, so the cached filters differ
+          // from the current ones and pagination resets to page 0.
+          extras: {
+            cachedChanges: {
+              104: [{ col: 'state', op: '==', val: 'previous' }],
+            },
+          },
+        },
+      );
+
+      expect(queries[0].row_limit).not.toBe(0);
+      expect(queries[0]).toMatchObject({
+        row_limit: 50,
+        row_offset: 0,
+      });
+    });
+
+    test('persists the user page size, not the capped limit, on filter reset', () => {
+      const setDataMask = jest.fn();
+      buildQueryUncached(
+        {
+          ...serverPaginationFormData,
+          row_limit: 120,
+          server_page_length: 50,
+          slice_id: 106,
+        },
+        {
+          // On the capped last page, the per-request row_limit is 20.
+          ownState: {
+            currentPage: 2,
+            pageSize: 50,
+          },
+          extras: {
+            cachedChanges: {
+              106: [{ col: 'state', op: '==', val: 'previous' }],
+            },
+          },
+          hooks: { setDataMask, setCachedChanges: jest.fn() },
+        },
+      );
+
+      // The persisted page size must stay 50, not collapse to the capped 20.
+      expect(setDataMask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownState: expect.objectContaining({
+            currentPage: 0,
+            pageSize: 50,
+          }),
+        }),
+      );
+    });
+
+    test('falls back to the page size when no row limit is configured', () => {
+      const { queries } = buildQuery(
+        {
+          ...serverPaginationFormData,
+          row_limit: undefined,
+          server_page_length: 50,
+          slice_id: 105,
+        },
+        {
+          ownState: {
+            currentPage: 3,
+            pageSize: 50,
+          },
+        },
+      );
+
+      expect(queries[0]).toMatchObject({
+        row_limit: 50,
+        row_offset: 150,
+      });
     });
   });
 });


### PR DESCRIPTION
### SUMMARY

Follow-up to #41024, which fixed server-pagination row-limit handling in `plugin-chart-table`. The `plugin-chart-ag-grid-table` plugin carries a near-identical `buildQuery` implementation and therefore has the **same two bugs**, still present on master:

```js
// plugin-chart-ag-grid-table/src/buildQuery.ts (before)
const pageSize = ownState.pageSize ?? formDataCopy.server_page_length;
const currentPage = ownState.currentPage ?? 0;
moreProps.row_limit = pageSize;
moreProps.row_offset = currentPage * pageSize;
```

1. **Row-limit cap bypass.** When the page offset exceeds the configured `row_limit`, the remaining-rows math collapses `row_limit` to `0`, which the backend (`helpers.py get_sqla_query`) treats as **"no limit"** rather than "no rows" — silently returning more rows than the configured limit. The page is now clamped to the last page that still falls within the limit, and the per-page `row_limit` is capped to the remaining rows.
2. **Page size shrink on filter reset.** On a filter-change reset, the per-request (last-page-capped) `row_limit` was persisted into `ownState.pageSize`, shrinking the user's page size. The reset now restores the full first-page `row_limit` and persists the user-selected page size.

The fix mirrors #41024 exactly so the two table implementations stay in sync. (A shared `buildQuery` utility between the two plugins — as noted by bot review on #41024 — would be a worthwhile separate refactor.)

### TESTING INSTRUCTIONS

Added unit tests to `plugin-chart-ag-grid-table/test/buildQuery.test.ts` mirroring the plugin-chart-table coverage. All 6 pass locally:

```bash
cd superset-frontend
npx jest plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts -t "server pagination row limit"
```

Covers: user row limit lower than page size, remaining-rows capping on the last page, page-beyond-limit clamping (no `row_limit: 0`), first-page row-limit restore after filter reset, page-size persistence on reset, and the no-row-limit fallback.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related: #41024

🤖 Generated with [Claude Code](https://claude.com/claude-code)