### PR TITLE
fix(theming): deep-merge partial THEME_DEFAULT overrides with built-in defaults

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1010,7 +1010,12 @@ EXTRA_CATEGORICAL_COLOR_SCHEMES: list[dict[str, Any]] = []
 
 # Default theme configuration - foundation for all themes
 # This acts as the base theme for all users
-THEME_DEFAULT: Theme = {
+#
+# _THEME_DEFAULT_BASE is a private copy of the built-in defaults.
+# It is NOT overridden by ``from superset_config import *`` (underscore prefix)
+# and is used to deep-merge partial user overrides so that unspecified token
+# fields gracefully fall back to the built-in values.
+_THEME_DEFAULT_BASE: Theme = {
     "token": {
         # Brand
         # Application name for window titles
@@ -1050,18 +1055,22 @@ THEME_DEFAULT: Theme = {
     "algorithm": "default",
 }
 
+THEME_DEFAULT: Theme = _THEME_DEFAULT_BASE
+
 # Dark theme configuration - foundation for dark mode
 # Inherits all tokens from THEME_DEFAULT and adds dark algorithm
 # Set to None to disable dark mode
-THEME_DARK: Optional[Theme] = {
-    **THEME_DEFAULT,
+_THEME_DARK_BASE: Theme = {
+    **_THEME_DEFAULT_BASE,
     "token": {
-        **THEME_DEFAULT["token"],
+        **_THEME_DEFAULT_BASE["token"],
         # Darker selection color for dark mode
         "colorEditorSelection": "#5c4d1a",
     },
     "algorithm": "dark",
 }
+
+THEME_DARK: Optional[Theme] = _THEME_DARK_BASE
 
 
 def sync_theme_logo_href(

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -52,6 +52,7 @@ from superset import (
     is_feature_enabled,
     security_manager,
 )
+from superset.config import _THEME_DARK_BASE, _THEME_DEFAULT_BASE
 from superset.connectors.sqla import models
 from superset.daos.theme import ThemeDAO
 from superset.db_engine_specs import get_available_engine_specs
@@ -375,9 +376,18 @@ def get_theme_bootstrap_data() -> dict[str, Any]:
     # Check if UI theme administration is enabled
     enable_ui_admin = app.config.get("ENABLE_UI_THEME_ADMINISTRATION", False)
 
-    # Get config themes to use as fallback
+    # Get config themes, deep-merging partial user overrides with built-in defaults
+    # so that unspecified token fields fall back gracefully.
     config_theme_default = get_config_value("THEME_DEFAULT")
+    if config_theme_default:
+        config_theme_default = _merge_theme_dicts(
+            dict(_THEME_DEFAULT_BASE), dict(config_theme_default)
+        )
     config_theme_dark = get_config_value("THEME_DARK")
+    if config_theme_dark:
+        config_theme_dark = _merge_theme_dicts(
+            dict(_THEME_DARK_BASE), dict(config_theme_dark)
+        )
 
     if enable_ui_admin:
         # Try to load themes from database

--- a/tests/unit_tests/views/test_base_theme_helpers.py
+++ b/tests/unit_tests/views/test_base_theme_helpers.py
@@ -358,10 +358,10 @@ class TestGetThemeBootstrapData:
 
         result = get_theme_bootstrap_data()
 
-        # Verify
+        # Verify user overrides are applied (merged with base defaults)
         assert result["theme"]["enableUiThemeAdministration"] is False
-        assert result["theme"]["default"] == {"token": {"colorPrimary": "#config1"}}
-        assert result["theme"]["dark"] == {"token": {"colorPrimary": "#config2"}}
+        assert result["theme"]["default"]["token"]["colorPrimary"] == "#config1"
+        assert result["theme"]["dark"]["token"]["colorPrimary"] == "#config2"
 
     @patch("superset.views.base.app")
     @patch("superset.views.base.get_config_value")
@@ -466,10 +466,10 @@ class TestGetThemeBootstrapData:
 
         result = get_theme_bootstrap_data()
 
-        # Should fall back to config themes
+        # Should fall back to config themes (merged with base defaults)
         assert result["theme"]["enableUiThemeAdministration"] is True
-        assert result["theme"]["default"] == {"token": {"colorPrimary": "#config1"}}
-        assert result["theme"]["dark"] == {"token": {"colorPrimary": "#config2"}}
+        assert result["theme"]["default"]["token"]["colorPrimary"] == "#config1"
+        assert result["theme"]["dark"]["token"]["colorPrimary"] == "#config2"
 
     @patch("superset.views.base.app")
     @patch("superset.views.base.get_config_value")
@@ -505,8 +505,8 @@ class TestGetThemeBootstrapData:
         with patch("superset.views.base.logger") as mock_logger:
             result = get_theme_bootstrap_data()
 
-            # Should fall back to config theme and log error
-            assert result["theme"]["default"] == {"token": {"colorPrimary": "#config1"}}
+            # Should fall back to config theme (merged with base defaults)
+            assert result["theme"]["default"]["token"]["colorPrimary"] == "#config1"
             mock_logger.error.assert_called_once()
 
     @patch("superset.views.base.app")
@@ -530,6 +530,64 @@ class TestGetThemeBootstrapData:
         assert result["theme"]["enableUiThemeAdministration"] is False
         assert result["theme"]["default"] == {}
         assert result["theme"]["dark"] == {}
+
+    @patch("superset.views.base.app")
+    @patch("superset.views.base.get_config_value")
+    def test_partial_theme_override_preserves_base_tokens(
+        self, mock_get_config, mock_app
+    ):
+        """Regression test for #40375: partial THEME_DEFAULT override must
+        preserve unspecified token fields from the built-in defaults so the
+        frontend does not crash on undefined values."""
+        from superset.config import _THEME_DARK_BASE, _THEME_DEFAULT_BASE
+
+        mock_app.config = MagicMock()
+        mock_app.config.get.side_effect = lambda k, d=None: {
+            "ENABLE_UI_THEME_ADMINISTRATION": False,
+        }.get(k, d)
+
+        # Simulate a minimal user override in superset_config.py
+        partial_default = {
+            "token": {"colorPrimary": "#ff0000"},
+            "algorithm": "default",
+        }
+        partial_dark = {
+            "token": {"colorPrimary": "#00ff00"},
+            "algorithm": "dark",
+        }
+        mock_get_config.side_effect = lambda k: {
+            "THEME_DEFAULT": partial_default,
+            "THEME_DARK": partial_dark,
+        }.get(k)
+
+        result = get_theme_bootstrap_data()
+
+        default_theme = result["theme"]["default"]
+        dark_theme = result["theme"]["dark"]
+
+        # User overrides must be applied
+        assert default_theme["token"]["colorPrimary"] == "#ff0000"
+        assert dark_theme["token"]["colorPrimary"] == "#00ff00"
+
+        # All built-in base tokens must still be present
+        for key in _THEME_DEFAULT_BASE["token"]:
+            assert key in default_theme["token"], (
+                f"Missing base token '{key}' in default theme after partial override"
+            )
+        for key in _THEME_DARK_BASE["token"]:
+            assert key in dark_theme["token"], (
+                f"Missing base token '{key}' in dark theme after partial override"
+            )
+
+        # Spot-check a few critical fields that caused the original crash
+        assert (
+            default_theme["token"]["fontFamily"]
+            == (_THEME_DEFAULT_BASE["token"]["fontFamily"])
+        )
+        assert (
+            default_theme["token"]["colorLink"]
+            == (_THEME_DEFAULT_BASE["token"]["colorLink"])
+        )
 
 
 class TestBrandAppNameFallback:


### PR DESCRIPTION
### SUMMARY

Fixes a white-screen regression where a **partial** `THEME_DEFAULT` (or `THEME_DARK`) override in `superset_config.py` crashes the frontend.

**Root cause:** PR #35220 populated `THEME_DEFAULT` with ~22 token fields (`fontFamily`, `colorLink`, etc.). Because Superset loads user config via `from superset_config import *`, defining `THEME_DEFAULT` in `superset_config.py` *replaces the entire dict* rather than merging. An operator who sets only a couple of tokens (e.g. just `colorPrimary`) silently drops all the others. The frontend then calls `.startsWith()` on an undefined field like `fontFamily` and dies with a blank white screen.

**The fix:**
1. `superset/config.py` — introduce private `_THEME_DEFAULT_BASE` / `_THEME_DARK_BASE` constants holding the built-in defaults. The underscore prefix means they survive `from superset_config import *` (star-imports skip underscore-prefixed names), so the built-in baseline is always available even when the operator overrides `THEME_DEFAULT`. `THEME_DEFAULT` / `THEME_DARK` are aliased to them.
2. `superset/views/base.py` — in `get_theme_bootstrap_data()`, deep-merge the user's config theme on top of these base constants using the existing `_merge_theme_dicts()` helper, so unspecified token fields fall back to the built-in values.
3. `tests/unit_tests/views/test_base_theme_helpers.py` — adds a regression test (`test_partial_theme_override_preserves_base_tokens`) and updates a few existing assertions whose expected output legitimately changes now that config themes are merged with the base.

**Note on a subtle behavior change:** config themes are now **always** deep-merged over the built-in base — even a full replacement. This is more correct (you can no longer accidentally drop required tokens), but it does mean a *deliberately* minimal theme will get base tokens merged back in. Operators who want to clear a token should set it explicitly rather than omitting it.

### BEFORE/AFTER

**Before:** Setting a partial override in `superset_config.py`, e.g.

```python
THEME_DEFAULT = {"token": {"colorPrimary": "#ff0000"}, "algorithm": "default"}
```

...renders a blank white screen (`Cannot read properties of undefined (reading 'startsWith')`).

**After:** The partial override is deep-merged over the built-in defaults. `/login` and the rest of the app render correctly, with `colorPrimary` applied and all other tokens (`fontFamily`, `colorLink`, etc.) intact.

### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/views/test_base_theme_helpers.py -v
```

All 38 tests pass, including the new `test_partial_theme_override_preserves_base_tokens` regression test.

Manual:
1. Add a partial `THEME_DEFAULT` override (only `colorPrimary`) to `superset_config.py`.
2. Start Superset and load `/login`.
3. Before this fix: white screen. After: the page renders with the custom primary color and intact default fonts/tokens.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #40375
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Adopted from [abdul-haizelabs/superset#6](https://github.com/abdul-haizelabs/superset/pull/6). Original work by Devin (app/devin-ai-integration) on the Haize Labs fork; adopted, typing-cleaned, and rebased onto current `master` by @rusackas. Co-authorship preserved in the commit trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
