### PR TITLE
docs: replace placeholder import in superset-ui-core README

### DIFF
--- a/superset-frontend/packages/superset-ui-core/README.md
+++ b/superset-frontend/packages/superset-ui-core/README.md
@@ -27,7 +27,7 @@ Description
 #### Example usage
 
 ```js
-import { xxx } from '@superset-ui/core';
+import { getNumberFormatter, t } from '@superset-ui/core';
 ```
 
 #### API


### PR DESCRIPTION
The @superset-ui/core README had a placeholder `import { xxx }` that
was never replaced with real content. Swapped it for a working example
using `getNumberFormatter` and `t`.

Closes #40403