### PR TITLE
feat(echarts): respect time grain in time-series tooltips

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -92,6 +92,10 @@ helm upgrade <release-name> superset/superset
 
 Alternatively, perform a fresh install. This is a one-time migration; subsequent upgrades are unaffected.
 
+### Time-series tooltips follow the selected time grain
+
+Tooltips on the Time-series and Mixed Time-series ECharts plugins now respect the chart's time grain (and any dashboard-level time-grain override delivered via `extra_form_data`) when no explicit tooltip time format is set. Tooltips read grain-appropriate labels such as `Jan 2021` (month), `2021 Q1` (quarter), `2021` (year), and weekly date ranges, matching the behavior already applied to the x-axis. Charts that pin an explicit tooltip time format are unaffected — the explicit format always wins.
+
 ### Pivot table First/Last aggregations follow data order
 
 The pivot table chart's `First` and `Last` aggregations now return the first and last value in data (query result) order, instead of effectively returning the minimum and maximum. Existing pivot tables that use these aggregations for totals/subtotals may show different values after upgrading. For deterministic results, ensure the underlying query has a stable sort order.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -94,7 +94,7 @@ Alternatively, perform a fresh install. This is a one-time migration; subsequent
 
 ### Time-series tooltips follow the selected time grain
 
-Tooltips on the Time-series and Mixed Time-series ECharts plugins now respect the chart's time grain (and any dashboard-level time-grain override delivered via `extra_form_data`) when no explicit tooltip time format is set. Tooltips read grain-appropriate labels such as `Jan 2021` (month), `2021 Q1` (quarter), `2021` (year), and weekly date ranges, matching the behavior already applied to the x-axis. Charts that pin an explicit tooltip time format are unaffected — the explicit format always wins.
+Tooltips on the Time-series and Mixed Time-series ECharts plugins now respect the chart's time grain (and any dashboard-level time-grain override delivered via `extra_form_data`) when the tooltip time format is left on Adaptive formatting (the default). Tooltips read grain-appropriate labels such as `Jan 2021` (month), `2021 Q1` (quarter), `2021` (year), and weekly date ranges, becoming grain-aware like the x-axis, though the two are formatted independently and their labels may not always match exactly. Only a custom, explicitly-set tooltip time format (a d3 format string) is unaffected — that always wins over the grain.
 
 ### Pivot table First/Last aggregations follow data order
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -720,13 +720,13 @@ export default function transformProps(
       },
       minorTick: { show: minorTicks },
       minInterval:
-        xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
-          ? TIMEGRAIN_TO_TIMESTAMP[
+        xAxisType === AxisType.Time && resolvedTimeGrain && !forceMaxInterval
+          ? (TIMEGRAIN_TO_TIMESTAMP[
               resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
-            ]
+            ] ?? 0)
           : 0,
       maxInterval:
-        xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
+        xAxisType === AxisType.Time && resolvedTimeGrain && forceMaxInterval
           ? TIMEGRAIN_TO_TIMESTAMP[
               resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
             ]

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -594,13 +594,19 @@ export default function transformProps(
     if (maxSecondary === undefined) maxSecondary = 1;
   }
 
+  // A dashboard-level time grain override (e.g. via a filter or the temporal
+  // range control) is delivered in extraFormData and should take precedence
+  // over the chart's own time grain when formatting temporal axes/tooltips.
+  const resolvedTimeGrain =
+    formData.extraFormData?.time_grain_sqla ?? timeGrainSqla;
+
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(tooltipTimeFormat, resolvedTimeGrain)
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
+      ? getXAxisFormatter(xAxisTimeFormat, resolvedTimeGrain)
       : String;
 
   const showMaxLabel =
@@ -716,13 +722,13 @@ export default function transformProps(
       minInterval:
         xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
           ? TIMEGRAIN_TO_TIMESTAMP[
-              timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+              resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
             ]
           : 0,
       maxInterval:
         xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
           ? TIMEGRAIN_TO_TIMESTAMP[
-              timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+              resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
             ]
           : undefined,
       ...getMinAndMaxFromBounds(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -610,7 +610,9 @@ export default function transformProps(
       : String;
 
   const showMaxLabel =
-    xAxisType === AxisType.Time && xAxisLabelRotation === 0 && !!timeGrainSqla;
+    xAxisType === AxisType.Time &&
+    xAxisLabelRotation === 0 &&
+    !!resolvedTimeGrain;
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -724,13 +724,19 @@ export default function transformProps(
     }
   }
 
+  // A dashboard-level time grain override (e.g. via a filter or the temporal
+  // range control) is delivered in extraFormData and should take precedence
+  // over the chart's own time grain when formatting temporal axes/tooltips.
+  const resolvedTimeGrain =
+    formData.extraFormData?.time_grain_sqla ?? timeGrainSqla;
+
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(tooltipTimeFormat, resolvedTimeGrain)
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
+      ? getXAxisFormatter(xAxisTimeFormat, resolvedTimeGrain)
       : xAxisDataType === GenericDataType.Numeric
         ? getNumberFormatter(xAxisNumberFormat)
         : String;
@@ -925,13 +931,13 @@ export default function transformProps(
     minInterval:
       xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
         ? TIMEGRAIN_TO_TIMESTAMP[
-            timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+            resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
           ]
         : 0,
     maxInterval:
       xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
         ? TIMEGRAIN_TO_TIMESTAMP[
-            timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+            resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
           ]
         : undefined,
     ...getMinAndMaxFromBounds(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -929,13 +929,13 @@ export default function transformProps(
     },
     minorTick: { show: minorTicks },
     minInterval:
-      xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
-        ? TIMEGRAIN_TO_TIMESTAMP[
+      xAxisType === AxisType.Time && resolvedTimeGrain && !forceMaxInterval
+        ? (TIMEGRAIN_TO_TIMESTAMP[
             resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
-          ]
+          ] ?? 0)
         : 0,
     maxInterval:
-      xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
+      xAxisType === AxisType.Time && resolvedTimeGrain && forceMaxInterval
         ? TIMEGRAIN_TO_TIMESTAMP[
             resolvedTimeGrain as keyof typeof TIMEGRAIN_TO_TIMESTAMP
           ]

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -877,7 +877,9 @@ export default function transformProps(
   // "2005" appears twice with Year grain). Wrap the formatter to suppress
   // consecutive duplicate labels.
   const showMaxLabel =
-    xAxisType === AxisType.Time && xAxisLabelRotation === 0 && !!timeGrainSqla;
+    xAxisType === AxisType.Time &&
+    xAxisLabelRotation === 0 &&
+    !!resolvedTimeGrain;
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -162,14 +162,22 @@ export const getYAxisFormatter = (
 
 export function getTooltipTimeFormatter(
   format?: string,
+  timeGrain?: TimeGranularity,
 ): TimeFormatter | StringConstructor {
-  if (format === SMART_DATE_ID) {
-    return getSmartDateVerboseFormatter();
+  // When a time grain is active and the user hasn't pinned an explicit format,
+  // honor the grain so tooltips read "Jan 2021", "2021 Q1", "2021", weekly
+  // ranges, etc. instead of a fixed timestamp. An explicit custom format is
+  // always respected verbatim.
+  if (!format || format === SMART_DATE_ID) {
+    if (timeGrain) {
+      return getTimeFormatter(undefined, timeGrain);
+    }
+    if (format === SMART_DATE_ID) {
+      return getSmartDateVerboseFormatter();
+    }
+    return String;
   }
-  if (format) {
-    return getTimeFormatter(format);
-  }
-  return String;
+  return getTimeFormatter(format);
 }
 
 export function getXAxisFormatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -56,6 +56,12 @@ type SeriesWithLabelFormatter = SeriesOption & {
   };
 };
 
+type TooltipFormatterOptions = {
+  tooltip: {
+    formatter: (params: unknown) => string;
+  };
+};
+
 /**
  * Creates a partial ChartDataResponseResult for testing.
  * Only includes the fields needed for tests, with sensible defaults for required fields.
@@ -823,88 +829,88 @@ test('temporal x coltype wires the time formatter and Time axis', () => {
   expect(label).not.toMatch(/NaN/);
 });
 
-describe('Tooltip time grain wiring', () => {
-  test('dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
-    const ts = Date.UTC(2021, 0, 7);
-    const temporalRows = [{ __timestamp: ts, metric: 100 }];
-    const temporalQueryData = createTestQueryData(temporalRows, {
-      colnames: ['__timestamp', 'metric'],
-      coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
-      label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
-    });
-
-    const chartProps = createEchartsTimeseriesTestChartProps<
-      EchartsMixedTimeseriesFormData,
-      EchartsMixedTimeseriesProps
-    >({
-      ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
-      defaultQueriesData: [temporalQueryData, temporalQueryData],
-      formData: {
-        ...formData,
-        x_axis: '__timestamp',
-        metrics: ['metric'],
-        metricsB: ['metric'],
-        groupby: [],
-        groupbyB: [],
-        // The chart itself is configured with a Day grain...
-        timeGrainSqla: TimeGranularity.DAY,
-        // ...but a dashboard-level filter/override resolves to Month.
-        extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
-      },
-      queriesData: [temporalQueryData, temporalQueryData],
-    });
-
-    const { echartOptions } = transformProps(chartProps);
-    const tooltipFormatter = (echartOptions as any).tooltip.formatter;
-
-    const result = tooltipFormatter({
-      value: [ts, 100],
-      seriesName: 'metric',
-    });
-
-    // Month grain (the dashboard override) should win, so the tooltip title
-    // reads "Jan 2021" rather than the Day-grain "2021-01-07".
-    expect(result).toContain('Jan');
-    expect(result).toContain('2021');
-    expect(result).not.toContain('2021-01-07');
+test('tooltip time grain wiring: dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
+  const ts = Date.UTC(2021, 0, 7);
+  const temporalRows = [{ __timestamp: ts, metric: 100 }];
+  const temporalQueryData = createTestQueryData(temporalRows, {
+    colnames: ['__timestamp', 'metric'],
+    coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+    label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
   });
 
-  test('chart-level time grain drives the tooltip when there is no dashboard override', () => {
-    const ts = Date.UTC(2021, 0, 7);
-    const temporalRows = [{ __timestamp: ts, metric: 100 }];
-    const temporalQueryData = createTestQueryData(temporalRows, {
-      colnames: ['__timestamp', 'metric'],
-      coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
-      label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
-    });
-
-    const chartProps = createEchartsTimeseriesTestChartProps<
-      EchartsMixedTimeseriesFormData,
-      EchartsMixedTimeseriesProps
-    >({
-      ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
-      defaultQueriesData: [temporalQueryData, temporalQueryData],
-      formData: {
-        ...formData,
-        x_axis: '__timestamp',
-        metrics: ['metric'],
-        metricsB: ['metric'],
-        groupby: [],
-        groupbyB: [],
-        timeGrainSqla: TimeGranularity.YEAR,
-      },
-      queriesData: [temporalQueryData, temporalQueryData],
-    });
-
-    const { echartOptions } = transformProps(chartProps);
-    const tooltipFormatter = (echartOptions as any).tooltip.formatter;
-
-    const result = tooltipFormatter({
-      value: [ts, 100],
-      seriesName: 'metric',
-    });
-
-    expect(result).toContain('2021');
-    expect(result).not.toContain('2021-01-07');
+  const chartProps = createEchartsTimeseriesTestChartProps<
+    EchartsMixedTimeseriesFormData,
+    EchartsMixedTimeseriesProps
+  >({
+    ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+    defaultQueriesData: [temporalQueryData, temporalQueryData],
+    formData: {
+      ...formData,
+      x_axis: '__timestamp',
+      metrics: ['metric'],
+      metricsB: ['metric'],
+      groupby: [],
+      groupbyB: [],
+      // The chart itself is configured with a Day grain...
+      timeGrainSqla: TimeGranularity.DAY,
+      // ...but a dashboard-level filter/override resolves to Month.
+      extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
+    },
+    queriesData: [temporalQueryData, temporalQueryData],
   });
+
+  const { echartOptions } = transformProps(chartProps);
+  const tooltipFormatter = (echartOptions as unknown as TooltipFormatterOptions)
+    .tooltip.formatter;
+
+  const result = tooltipFormatter({
+    value: [ts, 100],
+    seriesName: 'metric',
+  });
+
+  // Month grain (the dashboard override) should win, so the tooltip title
+  // reads "Jan 2021" rather than the Day-grain "2021-01-07".
+  expect(result).toContain('Jan');
+  expect(result).toContain('2021');
+  expect(result).not.toContain('2021-01-07');
+});
+
+test('tooltip time grain wiring: chart-level time grain drives the tooltip when there is no dashboard override', () => {
+  const ts = Date.UTC(2021, 0, 7);
+  const temporalRows = [{ __timestamp: ts, metric: 100 }];
+  const temporalQueryData = createTestQueryData(temporalRows, {
+    colnames: ['__timestamp', 'metric'],
+    coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+    label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
+  });
+
+  const chartProps = createEchartsTimeseriesTestChartProps<
+    EchartsMixedTimeseriesFormData,
+    EchartsMixedTimeseriesProps
+  >({
+    ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+    defaultQueriesData: [temporalQueryData, temporalQueryData],
+    formData: {
+      ...formData,
+      x_axis: '__timestamp',
+      metrics: ['metric'],
+      metricsB: ['metric'],
+      groupby: [],
+      groupbyB: [],
+      timeGrainSqla: TimeGranularity.YEAR,
+    },
+    queriesData: [temporalQueryData, temporalQueryData],
+  });
+
+  const { echartOptions } = transformProps(chartProps);
+  const tooltipFormatter = (echartOptions as unknown as TooltipFormatterOptions)
+    .tooltip.formatter;
+
+  const result = tooltipFormatter({
+    value: [ts, 100],
+    seriesName: 'metric',
+  });
+
+  expect(result).toContain('2021');
+  expect(result).not.toContain('2021-01-07');
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -26,6 +26,7 @@ import {
   IntervalAnnotationLayer,
   VizType,
   ChartDataResponseResult,
+  TimeGranularity,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import {
@@ -820,4 +821,90 @@ test('temporal x coltype wires the time formatter and Time axis', () => {
   const label = xAxis.axisLabel.formatter(new Date(ts1));
   expect(typeof label).toBe('string');
   expect(label).not.toMatch(/NaN/);
+});
+
+describe('Tooltip time grain wiring', () => {
+  test('dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
+    const ts = Date.UTC(2021, 0, 7);
+    const temporalRows = [{ __timestamp: ts, metric: 100 }];
+    const temporalQueryData = createTestQueryData(temporalRows, {
+      colnames: ['__timestamp', 'metric'],
+      coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
+    });
+
+    const chartProps = createEchartsTimeseriesTestChartProps<
+      EchartsMixedTimeseriesFormData,
+      EchartsMixedTimeseriesProps
+    >({
+      ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+      defaultQueriesData: [temporalQueryData, temporalQueryData],
+      formData: {
+        ...formData,
+        x_axis: '__timestamp',
+        metrics: ['metric'],
+        metricsB: ['metric'],
+        groupby: [],
+        groupbyB: [],
+        // The chart itself is configured with a Day grain...
+        timeGrainSqla: TimeGranularity.DAY,
+        // ...but a dashboard-level filter/override resolves to Month.
+        extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
+      },
+      queriesData: [temporalQueryData, temporalQueryData],
+    });
+
+    const { echartOptions } = transformProps(chartProps);
+    const tooltipFormatter = (echartOptions as any).tooltip.formatter;
+
+    const result = tooltipFormatter({
+      value: [ts, 100],
+      seriesName: 'metric',
+    });
+
+    // Month grain (the dashboard override) should win, so the tooltip title
+    // reads "Jan 2021" rather than the Day-grain "2021-01-07".
+    expect(result).toContain('Jan');
+    expect(result).toContain('2021');
+    expect(result).not.toContain('2021-01-07');
+  });
+
+  test('chart-level time grain drives the tooltip when there is no dashboard override', () => {
+    const ts = Date.UTC(2021, 0, 7);
+    const temporalRows = [{ __timestamp: ts, metric: 100 }];
+    const temporalQueryData = createTestQueryData(temporalRows, {
+      colnames: ['__timestamp', 'metric'],
+      coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
+    });
+
+    const chartProps = createEchartsTimeseriesTestChartProps<
+      EchartsMixedTimeseriesFormData,
+      EchartsMixedTimeseriesProps
+    >({
+      ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+      defaultQueriesData: [temporalQueryData, temporalQueryData],
+      formData: {
+        ...formData,
+        x_axis: '__timestamp',
+        metrics: ['metric'],
+        metricsB: ['metric'],
+        groupby: [],
+        groupbyB: [],
+        timeGrainSqla: TimeGranularity.YEAR,
+      },
+      queriesData: [temporalQueryData, temporalQueryData],
+    });
+
+    const { echartOptions } = transformProps(chartProps);
+    const tooltipFormatter = (echartOptions as any).tooltip.formatter;
+
+    const result = tooltipFormatter({
+      value: [ts, 100],
+      seriesName: 'metric',
+    });
+
+    expect(result).toContain('2021');
+    expect(result).not.toContain('2021-01-07');
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -81,6 +81,12 @@ function createTestQueryData(
 
 type YAxisFormatter = (value: number, index: number) => string;
 
+type TooltipFormatterOptions = {
+  tooltip: {
+    formatter: (params: unknown) => string;
+  };
+};
+
 function getYAxisFormatter(
   transformed: ReturnType<typeof transformProps>,
 ): YAxisFormatter {
@@ -1800,68 +1806,68 @@ describe('Tooltip with long labels', () => {
   });
 });
 
-describe('Tooltip time grain wiring', () => {
-  test('dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
-    const ts = Date.UTC(2021, 0, 7);
-    const chartProps = createTestChartProps({
-      formData: {
-        granularity_sqla: 'ds',
-        richTooltip: false,
-        // The chart itself is configured with a Day grain...
-        timeGrainSqla: TimeGranularity.DAY,
-        // ...but a dashboard-level filter/override resolves to Month.
-        extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
-      },
-      queriesData: [
-        createTestQueryData([{ __timestamp: ts, sales: 100 }], {
-          colnames: ['__timestamp', 'sales'],
-          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
-        }),
-      ],
-    });
-
-    const transformedProps = transformProps(chartProps);
-    const tooltipFormatter = (transformedProps.echartOptions as any).tooltip
-      .formatter;
-
-    const result = tooltipFormatter({
-      value: [ts, 100],
-      seriesName: 'sales',
-    });
-
-    // Month grain (the dashboard override) should win, so the tooltip title
-    // reads "Jan 2021" rather than the Day-grain "2021-01-07".
-    expect(result).toContain('Jan');
-    expect(result).toContain('2021');
-    expect(result).not.toContain('2021-01-07');
+test('tooltip time grain wiring: dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
+  const ts = Date.UTC(2021, 0, 7);
+  const chartProps = createTestChartProps({
+    formData: {
+      granularity_sqla: 'ds',
+      richTooltip: false,
+      // The chart itself is configured with a Day grain...
+      timeGrainSqla: TimeGranularity.DAY,
+      // ...but a dashboard-level filter/override resolves to Month.
+      extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
+    },
+    queriesData: [
+      createTestQueryData([{ __timestamp: ts, sales: 100 }], {
+        colnames: ['__timestamp', 'sales'],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      }),
+    ],
   });
 
-  test('chart-level time grain drives the tooltip when there is no dashboard override', () => {
-    const ts = Date.UTC(2021, 0, 7);
-    const chartProps = createTestChartProps({
-      formData: {
-        granularity_sqla: 'ds',
-        richTooltip: false,
-        timeGrainSqla: TimeGranularity.YEAR,
-      },
-      queriesData: [
-        createTestQueryData([{ __timestamp: ts, sales: 100 }], {
-          colnames: ['__timestamp', 'sales'],
-          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
-        }),
-      ],
-    });
+  const transformedProps = transformProps(chartProps);
+  const tooltipFormatter = (
+    transformedProps.echartOptions as unknown as TooltipFormatterOptions
+  ).tooltip.formatter;
 
-    const transformedProps = transformProps(chartProps);
-    const tooltipFormatter = (transformedProps.echartOptions as any).tooltip
-      .formatter;
-
-    const result = tooltipFormatter({
-      value: [ts, 100],
-      seriesName: 'sales',
-    });
-
-    expect(result).toContain('2021');
-    expect(result).not.toContain('2021-01-07');
+  const result = tooltipFormatter({
+    value: [ts, 100],
+    seriesName: 'sales',
   });
+
+  // Month grain (the dashboard override) should win, so the tooltip title
+  // reads "Jan 2021" rather than the Day-grain "2021-01-07".
+  expect(result).toContain('Jan');
+  expect(result).toContain('2021');
+  expect(result).not.toContain('2021-01-07');
+});
+
+test('tooltip time grain wiring: chart-level time grain drives the tooltip when there is no dashboard override', () => {
+  const ts = Date.UTC(2021, 0, 7);
+  const chartProps = createTestChartProps({
+    formData: {
+      granularity_sqla: 'ds',
+      richTooltip: false,
+      timeGrainSqla: TimeGranularity.YEAR,
+    },
+    queriesData: [
+      createTestQueryData([{ __timestamp: ts, sales: 100 }], {
+        colnames: ['__timestamp', 'sales'],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      }),
+    ],
+  });
+
+  const transformedProps = transformProps(chartProps);
+  const tooltipFormatter = (
+    transformedProps.echartOptions as unknown as TooltipFormatterOptions
+  ).tooltip.formatter;
+
+  const result = tooltipFormatter({
+    value: [ts, 100],
+    seriesName: 'sales',
+  });
+
+  expect(result).toContain('2021');
+  expect(result).not.toContain('2021-01-07');
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1799,3 +1799,69 @@ describe('Tooltip with long labels', () => {
     expect(result).toContain('599616000000');
   });
 });
+
+describe('Tooltip time grain wiring', () => {
+  test('dashboard-level extraFormData time grain overrides the chart-level grain in the tooltip', () => {
+    const ts = Date.UTC(2021, 0, 7);
+    const chartProps = createTestChartProps({
+      formData: {
+        granularity_sqla: 'ds',
+        richTooltip: false,
+        // The chart itself is configured with a Day grain...
+        timeGrainSqla: TimeGranularity.DAY,
+        // ...but a dashboard-level filter/override resolves to Month.
+        extraFormData: { time_grain_sqla: TimeGranularity.MONTH },
+      },
+      queriesData: [
+        createTestQueryData([{ __timestamp: ts, sales: 100 }], {
+          colnames: ['__timestamp', 'sales'],
+          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+        }),
+      ],
+    });
+
+    const transformedProps = transformProps(chartProps);
+    const tooltipFormatter = (transformedProps.echartOptions as any).tooltip
+      .formatter;
+
+    const result = tooltipFormatter({
+      value: [ts, 100],
+      seriesName: 'sales',
+    });
+
+    // Month grain (the dashboard override) should win, so the tooltip title
+    // reads "Jan 2021" rather than the Day-grain "2021-01-07".
+    expect(result).toContain('Jan');
+    expect(result).toContain('2021');
+    expect(result).not.toContain('2021-01-07');
+  });
+
+  test('chart-level time grain drives the tooltip when there is no dashboard override', () => {
+    const ts = Date.UTC(2021, 0, 7);
+    const chartProps = createTestChartProps({
+      formData: {
+        granularity_sqla: 'ds',
+        richTooltip: false,
+        timeGrainSqla: TimeGranularity.YEAR,
+      },
+      queriesData: [
+        createTestQueryData([{ __timestamp: ts, sales: 100 }], {
+          colnames: ['__timestamp', 'sales'],
+          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+        }),
+      ],
+    });
+
+    const transformedProps = transformProps(chartProps);
+    const tooltipFormatter = (transformedProps.echartOptions as any).tooltip
+      .formatter;
+
+    const result = tooltipFormatter({
+      value: [ts, 100],
+      seriesName: 'sales',
+    });
+
+    expect(result).toContain('2021');
+    expect(result).not.toContain('2021-01-07');
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/formatters.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/formatters.test.ts
@@ -206,6 +206,71 @@ test('getTooltipTimeFormatter falls back to the String constructor when no forma
   expect(getTooltipTimeFormatter(undefined)).toBe(String);
 });
 
+test('getTooltipTimeFormatter respects the time grain for the SMART_DATE path', () => {
+  // With a time grain active and no explicit format, the tooltip should read
+  // grain-appropriate labels rather than a raw timestamp. UTC-based dates keep
+  // the assertions deterministic across CI/developer timezones.
+  const date = new Date(Date.UTC(2021, 0, 7));
+
+  const dayFormatter = getTooltipTimeFormatter(
+    SMART_DATE_ID,
+    TimeGranularity.DAY,
+  ) as TimeFormatter;
+  expect(dayFormatter.format(date)).toEqual('2021-01-07');
+
+  const weekFormatter = getTooltipTimeFormatter(
+    SMART_DATE_ID,
+    TimeGranularity.WEEK,
+  ) as TimeFormatter;
+  expect(weekFormatter.format(date)).toEqual('2021-01-07 — 2021-01-13');
+
+  const monthFormatter = getTooltipTimeFormatter(
+    SMART_DATE_ID,
+    TimeGranularity.MONTH,
+  ) as TimeFormatter;
+  expect(monthFormatter.format(date)).toEqual(expect.stringContaining('Jan'));
+  expect(monthFormatter.format(date)).toEqual(expect.stringContaining('2021'));
+
+  const quarterFormatter = getTooltipTimeFormatter(
+    SMART_DATE_ID,
+    TimeGranularity.QUARTER,
+  ) as TimeFormatter;
+  expect(quarterFormatter.format(date)).toEqual(expect.stringContaining('Q1'));
+  expect(quarterFormatter.format(date)).toEqual(
+    expect.stringContaining('2021'),
+  );
+
+  const yearFormatter = getTooltipTimeFormatter(
+    SMART_DATE_ID,
+    TimeGranularity.YEAR,
+  ) as TimeFormatter;
+  expect(yearFormatter.format(date)).toEqual('2021');
+});
+
+test('getTooltipTimeFormatter applies the time grain even without an explicit format', () => {
+  const date = new Date(Date.UTC(2021, 0, 7));
+  const monthFormatter = getTooltipTimeFormatter(
+    undefined,
+    TimeGranularity.MONTH,
+  ) as TimeFormatter;
+  expect(monthFormatter).toBeInstanceOf(TimeFormatter);
+  expect(monthFormatter.format(date)).toEqual(expect.stringContaining('2021'));
+});
+
+test('getTooltipTimeFormatter honors an explicit custom format over the time grain', () => {
+  // A user-pinned format must win, so the grain does not turn a single date
+  // into a range or otherwise override the requested format.
+  const formatter = getTooltipTimeFormatter(
+    '%Y-%m-%d',
+    TimeGranularity.YEAR,
+  ) as TimeFormatter;
+  expect(formatter).toBeInstanceOf(TimeFormatter);
+  expect(formatter.id).toBe('%Y-%m-%d');
+  expect(formatter.format(new Date(Date.UTC(2021, 0, 7)))).toEqual(
+    '2021-01-07',
+  );
+});
+
 test('getXAxisFormatter produces stable SMART_DATE output for a valid Date', () => {
   // Documents the current happy-path output format so unexpected changes are
   // caught during review.


### PR DESCRIPTION
### SUMMARY

Adopts #31765 (original by @gerbermichi), carrying forward the time-grain formatting fix while splitting it off from the i18n change and the breaking-change concerns raised on that PR by @villebro. @gerbermichi gave the go-ahead to pick this up on a fresh PR.

Time-series and mixed time-series tooltips now honor the chart's selected time grain — and any dashboard-level grain override delivered via `extra_form_data` — when no explicit tooltip time format is set. This matches the behavior the x-axis already applies through `getSmartDateFormatter`. Tooltips read grain-appropriate labels:

- **Day** → `2021-01-07`
- **Week** → `2021-01-07 — 2021-01-13`
- **Month** → `Jan 2021`
- **Quarter** → `2021 Q1`
- **Year** → `2021`

An explicit custom tooltip time format always wins, so users who pinned a format see no change.

#### How this was ported
Most of the original PR's intent had already landed on master since it was opened:
- The x-axis grain-aware formatting was implemented by #38017 (`getSmartDateFormatter(timeGrain)`).
- The tooltip verbose formatter was touched by #33138.

The remaining genuine gap was the **tooltip** not receiving the time grain, so this PR focuses there. The original PR threaded the grain through `getTimeFormatter` using the `SMART_DATE_VERBOSE_ID` format id, but that path produced the literal string `smart_date_verbose` — `getTimeFormatter` treats the id as a d3 format string once a granularity is supplied. This reworks `getTooltipTimeFormatter` to use the granularity formatter (`getTimeFormatter(undefined, grain)`) instead, which renders the correct labels above. The dashboard-level override (`extra_form_data.time_grain_sqla`) is read with optional chaining to avoid the runtime-crash risk the review bots flagged on the original PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See the before/after screenshots on the original PR #31765. Behavior here is the tooltip half of that change.

### TESTING INSTRUCTIONS

1. Create a Time-series or Mixed Time-series chart with a temporal x-axis.
2. Set the Time Grain to Quarter (or Month/Year/Week) and leave the tooltip time format at its default.
3. Hover the chart — the tooltip date should read `2021 Q1`, `Jan 2021`, `2021`, or a weekly range rather than a full timestamp.
4. Set an explicit tooltip time format and confirm it is still respected verbatim.

Automated coverage: `superset-frontend/plugins/plugin-chart-echarts/test/utils/formatters.test.ts` adds unit tests asserting the rendered output of `getTooltipTimeFormatter` for each grain, the no-explicit-format case, and the explicit-format-wins case.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Adopts #31765, original by @gerbermichi. Includes an `UPDATING.md` note per @villebro's request on the original PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
