### PR TITLE
fix(explore): let chart owners overwrite when owners come through as objects

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -359,9 +359,9 @@ test('enables overwrite option for admin non-editor', () => {
 });
 
 test('enables overwrite option for owner when owners are objects', () => {
-  // The Slice type declares `owners: { id: number }[]`, and the explore
-  // bootstrap can deliver owners in object form. A chart owner must still be
-  // able to overwrite their own chart in that case.
+  // The Slice type declares `owners` as `number[]`, but the explore
+  // bootstrap can deliver owners as `{ id: number }` objects at runtime.
+  // A chart owner must still be able to overwrite their own chart in that case.
   const { getByRole } = setup(
     {},
     mockStore({

--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -358,6 +358,27 @@ test('enables overwrite option for admin non-editor', () => {
   expect(getByRole('radio', { name: 'Save (Overwrite)' })).toBeEnabled();
 });
 
+test('enables overwrite option for owner when owners are objects', () => {
+  // The Slice type declares `owners: { id: number }[]`, and the explore
+  // bootstrap can deliver owners in object form. A chart owner must still be
+  // able to overwrite their own chart in that case.
+  const { getByRole } = setup(
+    {},
+    mockStore({
+      ...initialState,
+      explore: {
+        ...initialState.explore,
+        slice: {
+          ...initialState.explore.slice,
+          owners: [{ id: 1 }],
+        },
+      },
+      user: { userId: 1 },
+    }),
+  );
+  expect(getByRole('radio', { name: 'Save (Overwrite)' })).toBeEnabled();
+});
+
 test('updates slice name and selected dashboard', async () => {
   const dashboardId = mockEvent.value;
   const saveDataset = jest.fn().mockResolvedValue(undefined);

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -228,6 +228,21 @@ const SaveModal = ({
   const history = useHistory();
   const theme = useTheme();
 
+  const isCurrentUserOwner = useCallback((): boolean => {
+    const userId = user?.userId;
+    if (userId === undefined) {
+      return false;
+    }
+    // Owners can arrive either as plain ids (number) or as objects depending on
+    // where the slice was hydrated from (bootstrap vs. SLICE_UPDATED reducer),
+    // so normalize to the numeric id before comparing.
+    return Boolean(
+      slice?.owners?.some((owner: number | { id?: number }) =>
+        typeof owner === 'number' ? owner === userId : owner?.id === userId,
+      ),
+    );
+  }, [slice, user]);
+
   const canOverwriteSlice = useCallback((): boolean => {
     const userSubjects = getBootstrapData()?.common?.user_subjects ?? [];
     const canEditSlice = Boolean(
@@ -238,10 +253,13 @@ const SaveModal = ({
 
     return (
       !!slice &&
-      (can_overwrite || isUserAdmin(user) || canEditSlice) &&
+      (can_overwrite ||
+        isUserAdmin(user) ||
+        canEditSlice ||
+        isCurrentUserOwner()) &&
       !slice?.is_managed_externally
     );
-  }, [can_overwrite, slice, user]);
+  }, [can_overwrite, slice, user, isCurrentUserOwner]);
 
   const [newSliceName, setNewSliceName] = useState<string | undefined>(
     sliceName,

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -233,9 +233,9 @@ const SaveModal = ({
     if (userId === undefined) {
       return false;
     }
-    // Owners can arrive either as plain ids (number) or as objects depending on
-    // where the slice was hydrated from (bootstrap vs. SLICE_UPDATED reducer),
-    // so normalize to the numeric id before comparing.
+    // The Slice type declares `owners` as `number[]`, but the explore
+    // bootstrap payload can carry owners as API `Owner` objects (`{ id }`)
+    // instead, so normalize to the numeric id before comparing.
     return Boolean(
       slice?.owners?.some((owner: number | { id?: number }) =>
         typeof owner === 'number' ? owner === userId : owner?.id === userId,


### PR DESCRIPTION
### SUMMARY

The Save chart modal disables **Save (Overwrite)** for users who actually own the chart, forcing them into **Save as...**. That's the path behind the duplicate/stale-chart mess in #38911.

`canOverwriteSlice()` was checking `slice.owners.includes(user.userId)`. But `Slice.owners` is typed as `{ id: number }[]`, and the Explore bootstrap can hand us owners in object form — so `includes()` against a numeric `userId` never matches. Admins squeaked by on the `isUserAdmin` branch, but plain owners didn't, which is exactly the reporter's scenario.

Fix is just to normalize the owner id before comparing, so it works whether owners arrive as plain ids or as `{ id }` objects. Pulled the check out into a little `isCurrentUserOwner()` helper to keep `canOverwriteSlice()` readable.

### TESTING INSTRUCTIONS

1. As a non-admin user who owns a chart, open it in Explore and tweak something (e.g. a description).
2. Hit Save — **Save (Overwrite)** should be enabled and selected by default rather than disabled.

Also added a unit test that pins the object-shaped-owners case (it fails on master, passes here).

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38911
- [x] Changes UI