### PR TITLE
chore(ci): correct setup-python pin comment to match v6.2.0

### DIFF
--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/setup-supersetbot/
 
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
### SUMMARY

zizmor's `ref-version-mismatch` rule flags `.github/workflows/bump-python-package.yml:43`: the `actions/setup-python` step is pinned to SHA `a309ff8b426b58ec0e2a45f0f869d46889d02405`, but the inline comment reads `# v6`. That SHA actually resolves to tag **v6.2.0**, so the comment was imprecise/misleading.

This updates the comment to `# v6.2.0` so it truthfully reflects the pinned commit. No behavior change — the SHA (the thing actually used) is unchanged; only the comment is corrected. This also matches the rest of the workflows in the repo, which pin with full semver comments (e.g. `# v6.0.3`, `# v6.4.0`).

Resolves code-scanning alert #2550.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

`pre-commit run --files .github/workflows/bump-python-package.yml` passes, including the `zizmor (GHA security audit)` hook. The code-scanning alert should clear once the workflow is re-scanned.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)