### PR TITLE
chore(ci): correct setup-python pin version comment to v6.2.0

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
         echo "python-version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
     - name: Set up Python ${{ steps.set-python-version.outputs.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
         cache: ${{ inputs.cache }}

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/setup-supersetbot/
 
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
### SUMMARY

The `actions/setup-python` step in our composite backend setup action (and the `bump-python-package` workflow) is pinned to commit `a309ff8b426b58ec0e2a45f0f869d46889d02405`, but the inline version comment read `# v6`.

That commit actually corresponds to release tag **v6.2.0**. The floating `# v6` tag points at a different commit (`ece7cb06…`, currently v6.3.0). zizmor's `ref-version-mismatch` rule flags this because the human-readable comment misrepresents the exact pinned version, which makes audits and Dependabot bumps harder to reason about.

This PR updates both occurrences of the comment to the truthful `# v6.2.0`. The pinned SHA is unchanged, so runtime behavior is identical — this is purely a documentation/accuracy fix to satisfy the supply-chain pin convention.

Resolves code-scanning alert #2549.

### BEFORE/AFTER

Before:
```yaml
uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
```
After:
```yaml
uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
```

### TESTING INSTRUCTIONS

`pre-commit run --files .github/actions/setup-backend/action.yml .github/workflows/bump-python-package.yml` passes, including the `zizmor (GHA security audit)` hook.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
