### PR TITLE
chore(frontend): enforce TypeScript-only source files

### DIFF
--- a/superset-frontend/scripts/check-custom-rules.js
+++ b/superset-frontend/scripts/check-custom-rules.js
@@ -633,6 +633,35 @@ function processFile(filepath) {
 }
 
 /**
+ * Application source trees that must be authored in TypeScript. Matches the
+ * top-level `src/` directory as well as each package/plugin `src/` directory.
+ */
+const TS_ONLY_SOURCE_PATTERN =
+  /^(src|packages\/[^/]+\/src|plugins\/[^/]+\/src)\//;
+
+/**
+ * Enforce the TypeScript-only frontend convention: no `.js`/`.jsx` files may be
+ * added under the application source trees (including test files). Build
+ * artifacts and root-level config files (e.g. `.storybook/preview.jsx`,
+ * `webpack.config.js`) live outside these trees and are intentionally allowed.
+ *
+ * @param {string[]} candidateFiles paths relative to `superset-frontend/`
+ */
+function checkTypeScriptOnlySource(candidateFiles) {
+  candidateFiles.forEach(file => {
+    if (TS_ONLY_SOURCE_PATTERN.test(file) && /\.(js|jsx)$/.test(file)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `${RED}✗${RESET} ${file}: frontend source must be TypeScript. ` +
+          `Rename to .ts/.tsx (the codebase is mid-migration to full ` +
+          `TypeScript; no new .js/.jsx files in src/).`,
+      );
+      errorCount += 1;
+    }
+  });
+}
+
+/**
  * Main function
  */
 function main() {
@@ -665,6 +694,22 @@ function main() {
     /\/theme\/utils/, // Theme utility functions legitimately work with colors
     /packages\/superset-ui-core\/src\/color\/index\.ts/, // Core brand color constants
   ];
+
+  // Enforce TypeScript-only source. Run this on the raw file list (before the
+  // ignore patterns below strip out tests/stories) so that e.g. a new
+  // `*.test.jsx` is still rejected.
+  const tsOnlyCandidates =
+    args.length === 0
+      ? glob.sync('{src,packages/*/src,plugins/*/src}/**/*.{js,jsx}', {
+          ignore: [
+            '**/node_modules/**',
+            '**/esm/**',
+            '**/lib/**',
+            '**/dist/**',
+          ],
+        })
+      : args.map(f => f.replace(/^superset-frontend\//, ''));
+  checkTypeScriptOnlySource(tsOnlyCandidates);
 
   // If no files specified, check all
   if (files.length === 0) {
@@ -706,21 +751,22 @@ function main() {
   if (files.length === 0) {
     // eslint-disable-next-line no-console
     console.log('No files to check.');
-    return;
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Checking ${files.length} files for Superset custom rules...\n`,
+    );
+
+    files.forEach(file => {
+      // Resolve the file path
+      const resolvedPath = path.resolve(file);
+      if (fs.existsSync(resolvedPath)) {
+        processFile(resolvedPath);
+      } else if (fs.existsSync(file)) {
+        processFile(file);
+      }
+    });
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`Checking ${files.length} files for Superset custom rules...\n`);
-
-  files.forEach(file => {
-    // Resolve the file path
-    const resolvedPath = path.resolve(file);
-    if (fs.existsSync(resolvedPath)) {
-      processFile(resolvedPath);
-    } else if (fs.existsSync(file)) {
-      processFile(file);
-    }
-  });
 
   // eslint-disable-next-line no-console
   console.log(`\n${errorCount} errors, ${warningCount} warnings`);
@@ -740,4 +786,5 @@ module.exports = {
   checkNoFaIcons,
   checkI18nTemplates,
   checkUntranslatedStrings,
+  checkTypeScriptOnlySource,
 };


### PR DESCRIPTION
### SUMMARY

The frontend is mid-migration to full TypeScript, and every file under the application source trees (`src/`, `packages/*/src/`, `plugins/*/src/`) is already `.ts`/`.tsx` — but nothing actually **enforced** it. A new `.js`/`.jsx` file (including tests) could slip through review, which is exactly what happened on #37131 (a `useExploreAdditionalActionsMenu.test.jsx` that only got caught by an AI reviewer).

I looked at the obvious lever first — oxlint's `react/jsx-filename-extension` — but it isn't a good fit:
- It only flags JSX in the wrong extension, so a plain `.js` file with no JSX slips through.
- It scans the whole frontend, so tightening it to `.tsx`-only would false-positive on legitimate config files like `.storybook/preview.jsx` and the root `*.config.js` files.

Instead this adds a small, **scoped** check to `scripts/check-custom-rules.js` — which is already wired into pre-commit (`custom rules (frontend)`) and `npm run lint:full`. It fails when a `.js`/`.jsx` file is added under the three application source trees, **including test files**. Root-level configs (`webpack.config.js`, `.storybook/preview.jsx`, etc.) and build artifacts (`lib/`, `esm/`, `dist/`) live outside those trees and are intentionally left alone.

The check runs on the raw staged-file list (before the existing color/i18n ignore patterns strip out tests/stories), so `*.test.jsx` is correctly rejected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (lint tooling).

### TESTING INSTRUCTIONS

```bash
cd superset-frontend

# Passes on the current tree (0 .js/.jsx in source trees):
node scripts/check-custom-rules.js

# Rejected (exit 1), including test files:
node scripts/check-custom-rules.js src/components/Foo/Foo.test.jsx
node scripts/check-custom-rules.js packages/superset-ui-core/src/Bar.jsx

# Allowed (exit 0):
node scripts/check-custom-rules.js src/components/Foo/Foo.test.tsx
node scripts/check-custom-rules.js webpack.config.js .storybook/preview.jsx
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)