### PR TITLE
fix(ag-grid): show correct percentage metric value in summary row

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -652,13 +652,23 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         }
       }
 
+      // Preserve the percent-metric "contribution" post-processing so the
+      // summary row renames `metric` -> `%metric` the same way the data rows
+      // do. Without it the totals query returns `metric` while the grid reads
+      // `%metric`, leaving the summary row at 0.000% (#104600). The
+      // time-comparison operator is intentionally dropped from the aggregate
+      // totals query (orderby/order_desc are cleared below for the same reason).
+      const totalsPostProcessing = postProcessing.filter(
+        rule => rule?.operation === 'contribution',
+      );
+
       extraQueries.push({
         ...queryObject,
         columns: [],
         extras: totalsExtras, // Use extras with AG Grid WHERE removed
         row_limit: 0,
         row_offset: 0,
-        post_processing: [],
+        post_processing: totalsPostProcessing,
         order_desc: undefined, // we don't need orderby stuff here,
         orderby: undefined, // because this query will be used for get total aggregation.
       });

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -1363,4 +1363,33 @@ describe('plugin-chart-ag-grid-table', () => {
       expect(query.extras?.where || undefined).toBeUndefined();
     });
   });
+
+  describe('buildQuery - percent metric summary totals (#104600)', () => {
+    test('totals query keeps the contribution rename for percent metrics', () => {
+      const { queries } = buildQuery(
+        {
+          ...basicFormData,
+          metrics: ['revenue'],
+          percent_metrics: ['revenue'],
+          show_totals: true,
+        },
+        { ownState: {} },
+      );
+
+      // queries[0] is the data query; the summary/totals query is the extra
+      // aggregate query with no row limit.
+      const totalsQuery = queries.slice(1).find(q => q.row_limit === 0);
+      expect(totalsQuery).toBeDefined();
+
+      const contributionOp = (totalsQuery?.post_processing || []).find(
+        (op: any) => op?.operation === 'contribution',
+      );
+      // Regression: the totals query previously used post_processing: [] which
+      // dropped the metric -> %metric rename, leaving the summary row at 0.000%.
+      expect(contributionOp).toBeDefined();
+      expect((contributionOp as any)?.options?.rename_columns).toContain(
+        '%revenue',
+      );
+    });
+  });
 });


### PR DESCRIPTION
### SUMMARY

On an interactive table with a metric in **Percentage Metrics** and **Show Summary** enabled, the summary/footer row showed `0.000%` for the percentage column while the regular rows were correct.

The totals query was being built with an empty `post_processing` list. That dropped the `contribution` step that renames a percent-metric column from `metric` to `%metric`. The result was that the totals came back keyed under the original metric name, while the grid was reading the `%`-prefixed one — so it found nothing and rendered `0.000%`.

The fix keeps the percent-metric `contribution` (rename) step on the totals query, while still dropping the time-comparison operator and ordering that aren't needed for an aggregate-only query.

### TESTING INSTRUCTIONS

1. Open/create an interactive table on any dataset.
2. Add a metric to **Metrics** and the same metric to **Percentage Metrics**.
3. Enable **Show Summary** and update the chart.
4. The percentage column in the summary row should show a real aggregated value instead of `0.000%`.

Added a buildQuery test asserting the totals query keeps the contribution/rename op for percent metrics; the rest of the buildQuery suite still passes.

### ADDITIONAL INFORMATION

- [x] Changes UI
