### PR TITLE
fix(ag-grid): cover gradient conditional formatting for ranged operators

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.gradient.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.gradient.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getColorFunction } from '../../src/utils/getColorFormatters';
+import { Comparator } from '../../src/types';
+
+// Regression guard for #107917 / upstream #36098: bounded-range conditional
+// formatting operators must render a gradient (opacity proportional to where
+// the value falls in the range), not a flat color, when "Use gradient" is on.
+const VALUES = [1, 10, 30, 50, 60];
+const BOUNDED_OPERATORS = [
+  Comparator.Between, // < x <
+  Comparator.BetweenOrEqual, // <= x <=
+  Comparator.BetweenOrLeftEqual, // <= x <
+  Comparator.BetweenOrRightEqual, // < x <=
+];
+
+test.each(BOUNDED_OPERATORS)(
+  'bounded operator %s renders a gradient across the range',
+  operator => {
+    const fn = getColorFunction(
+      {
+        operator,
+        targetValueLeft: 1,
+        targetValueRight: 60,
+        colorScheme: '#FF0000',
+        useGradient: true,
+      } as any,
+      VALUES,
+    );
+    const low = fn(10);
+    const mid = fn(30);
+    const high = fn(50);
+    // All three must be distinct -> a real gradient, not a flat fill.
+    expect(new Set([low, mid, high]).size).toBe(3);
+  },
+);
+
+test('bounded operator works with string-typed bounds (form inputs)', () => {
+  const fn = getColorFunction(
+    {
+      operator: Comparator.Between,
+      targetValueLeft: '1',
+      targetValueRight: '60',
+      colorScheme: '#FF0000',
+      useGradient: true,
+    } as any,
+    VALUES,
+  );
+  expect(fn(10)).not.toEqual(fn(50));
+});
+
+test('useGradient=false produces a solid color for bounded operators', () => {
+  const fn = getColorFunction(
+    {
+      operator: Comparator.Between,
+      targetValueLeft: 1,
+      targetValueRight: 60,
+      colorScheme: '#FF0000',
+      useGradient: false,
+    } as any,
+    VALUES,
+  );
+  expect(fn(10)).toEqual(fn(50));
+  expect(fn(30)).toEqual('#FF0000');
+});


### PR DESCRIPTION
### SUMMARY

This is a follow-up on reports that custom conditional formatting with **Use gradient** enabled rendered a flat color for the ranged operators (`< x <`, `≤ x ≤`, `≤ x <`, `< x ≤`) while single-bound operators worked fine.

Digging into `getColorFunction`, the gradient computation is actually correct for all four ranged operators on current master — values across the defined range get distinct, proportional opacities, for both numeric and string-typed bounds (which is what form inputs produce). I couldn't reproduce a flat fill at the color-computation layer.

Rather than change behavior that's already correct, I'm adding tests that lock this in so the ranged-operator gradients can't silently regress again. If a flat-color issue is still observable in practice, it's likely further up in the control/save path rather than in the color math, and this gives us a clear baseline to bisect from.

### TESTING INSTRUCTIONS

`npm run test -- packages/superset-ui-chart-controls/test/utils/getColorFormatters.gradient.test.ts`

The tests assert that each ranged operator produces three distinct opacities across the range (a real gradient), that string-typed bounds behave the same as numeric, and that turning gradient off yields a solid color.

### ADDITIONAL INFORMATION

- [ ] Changes UI
