### PR TITLE
fix(slack): fix indented triple-quoted string in v1 API deprecation warning

### DIFF
--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -194,9 +194,9 @@ def should_use_v2_api() -> bool:
     except SlackApiError:
         # use the v1 api but warn with a deprecation message
         logger.warning(
-            """Your current Slack scopes are missing `channels:read`. Please add
-            this to your Slack app in order to continue using the v1 API. Support
-            for the old Slack API will be removed in Superset version 6.0.0."""
+            "Your current Slack scopes are missing `channels:read`. Please add "
+            "this to your Slack app in order to continue using the v1 API. Support "
+            "for the old Slack API will be removed in Superset version 6.0.0."
         )
         return False
 


### PR DESCRIPTION
### What was the deprecation warning?

`should_use_v2_api()` in `superset/utils/slack.py` logged a warning using a triple-quoted string. Because the string was written inside an indented `except` block, Python included the code-level indentation in the message — each continuation line got 12 leading spaces. Production logs showed:

```
Your current Slack scopes are missing `channels:read`. Please add
            this to your Slack app in order to continue using the v1 API. Support
            for the old Slack API will be removed in Superset version 6.0.0.
```

### What was changed?

Replaced the triple-quoted string with adjacent string literals so the message renders as a single clean line:

```
Your current Slack scopes are missing `channels:read`. Please add this to your Slack app in order to continue using the v1 API. Support for the old Slack API will be removed in Superset version 6.0.0.
```

No logic change. Same words, no whitespace artifact.

### No-behavior-change note

This is a log message formatting fix only. `should_use_v2_api()` returns exactly the same values in all paths. No imports added or removed.

### Test plan

- [ ] Confirm no pre-commit failures: `pre-commit run --files superset/utils/slack.py`
- [ ] Confirm the message logs cleanly by checking the `logger.warning` call manually or via existing Slack notification tests