### PR TITLE
fix(mcp): reject non-finite JWT exp instead of 500ing on int() overflow

### DIFF
--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -29,6 +29,7 @@ import asyncio
 import base64
 import html as html_module
 import logging
+import math
 import time
 from collections.abc import Callable
 from contextvars import ContextVar
@@ -599,6 +600,24 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                     _sanitize_for_log(client_id),
                 )
                 return None
+            # ``exp`` must be a finite real number. A non-numeric value would
+            # raise ``TypeError`` on the comparison below, and a non-finite
+            # float (e.g. ``inf`` parsed from a JSON ``1e309``) would overflow
+            # the ``int(exp)`` cast later, raising ``OverflowError``. Both are
+            # rejected here with a precise reason rather than escaping as a
+            # generic failure (or, for the overflow, an uncaught 500).
+            if (
+                not isinstance(exp, (int, float))
+                or isinstance(exp, bool)
+                or not math.isfinite(exp)
+            ):
+                reason = "Token has invalid expiration"
+                _jwt_failure_reason.set(reason)
+                logger.debug(
+                    "Token exp claim is not a finite number for client '%s'",
+                    _sanitize_for_log(client_id),
+                )
+                return None
             if exp < time.time():
                 reason = "Token expired"
                 _jwt_failure_reason.set(reason)
@@ -703,7 +722,14 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                 claims=dict(claims),
             )
 
-        except (ValueError, JoseError, KeyError, AttributeError, TypeError) as e:
+        except (
+            ValueError,
+            JoseError,
+            KeyError,
+            AttributeError,
+            TypeError,
+            OverflowError,
+        ) as e:
             reason = "Token validation failed"
             _jwt_failure_reason.set(reason)
             logger.debug("Token validation failed: %s", e)

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -408,6 +408,58 @@ async def test_token_without_expiration_rejected(hs256_verifier):
 
 
 @pytest.mark.asyncio
+async def test_non_finite_expiration_rejected(hs256_verifier):
+    """An infinite exp must be rejected cleanly, not crash on int() overflow.
+
+    A JSON ``1e309`` decodes to ``float('inf')``, which passes the
+    ``exp < time.time()`` expiry check and would later raise ``OverflowError``
+    on ``int(exp)`` — surfacing as a 500 instead of a 401. The finite-number
+    guard rejects it with a precise reason before that can happen.
+    """
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": float("inf"),
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    assert _jwt_failure_reason.get() == "Token has invalid expiration"
+
+
+@pytest.mark.asyncio
+async def test_non_numeric_expiration_rejected(hs256_verifier):
+    """A non-numeric exp must be rejected with the invalid-expiration reason.
+
+    Without the finite-number guard, ``exp < time.time()`` would raise
+    ``TypeError`` and degrade to the generic "Token validation failed" reason.
+    """
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": "2026-01-01",
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    assert _jwt_failure_reason.get() == "Token has invalid expiration"
+
+
+@pytest.mark.asyncio
 async def test_decode_error(hs256_verifier):
     """Token that fails to decode should report decode failure."""
     token = _make_token(


### PR DESCRIPTION
### SUMMARY

Follow-up to #39645 (which is being closed as superseded — its security
hardening already landed on master).

The `DetailedJWTVerifier` expiration check has an edge case that turns a bad
token into a server error. A JWT whose `exp` claim decodes to `float('inf')`
— e.g. a JSON `1e309` — passes both existing guards:

```python
exp = claims.get("exp")
if exp is None: ...          # inf is not None  → passes
if exp < time.time(): ...    # inf < now is False → passes (not "expired")
...
expires_at=int(exp),         # int(float('inf')) → OverflowError
```

`OverflowError` was not in the surrounding `except (ValueError, JoseError,
KeyError, AttributeError, TypeError)` tuple, so it escaped uncaught and
surfaced as a **500 instead of a 401**. (Note `nan` is already safe — `int(nan)`
raises `ValueError`, which *was* caught. This is specifically the infinity
overflow.)

**Fix (two layers):**
1. **Primary** — a finite-number guard at the expiration check rejects
   non-numeric and non-finite `exp` values with a precise
   `"Token has invalid expiration"` reason, consistent with this module's
   per-failure reason classification.
2. **Backstop** — `OverflowError` is added to the `except` tuple so no
   arithmetic overflow anywhere in that block can ever escape as a 500.

The fix was flagged by review bots (codeant-ai / Bito) on #39645 against the
pre-existing master code, and confirmed by the original author and a maintainer
in that thread.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/mcp_service/test_jwt_verifier.py`

Two new unit tests:
- `test_non_finite_expiration_rejected` — `exp = inf` returns `None` (401) with
  reason `"Token has invalid expiration"` and does not raise.
- `test_non_numeric_expiration_rejected` — a string `exp` is rejected with the
  same precise reason instead of degrading to the generic failure.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
