### PR TITLE
fix(async): derive async channel from guest token for embedded RLS queries (closes #31492)

### DIFF
--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -16,10 +16,12 @@
 # under the License.
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, TYPE_CHECKING
 
 import jwt
 from flask import Flask, Request, request, Response, session
@@ -31,6 +33,9 @@ from superset.async_events.cache_backend import (
 )
 from superset.utils import json
 from superset.utils.core import get_user_id
+
+if TYPE_CHECKING:
+    from superset.security.guest_token import GuestUser
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +173,17 @@ class AsyncQueryManager:
     def register_request_handlers(self, app: Flask) -> None:
         @app.after_request
         def validate_session(response: Response) -> Response:
+            # pylint: disable=import-outside-toplevel
+            from superset import security_manager
+
+            # Guest users (embedded dashboards) are typically loaded from a
+            # third-party context where session cookies are unreliable, so the
+            # async channel is derived deterministically from the guest token
+            # in `parse_channel_id_from_request` and the JWT cookie is not
+            # required.
+            if security_manager.get_current_guest_user_if_guest():
+                return response
+
             user_id = get_user_id()
 
             reset_token = (
@@ -206,7 +222,44 @@ class AsyncQueryManager:
 
             return response
 
+    def get_guest_user_channel_id(self, guest_user: GuestUser) -> str:
+        """
+        Derive a deterministic async channel ID for a guest user.
+
+        Embedded guest sessions cannot reliably rely on the async-token cookie
+        because cross-origin cookies are blocked or stripped by modern browsers
+        when running inside a third-party iframe. Using an HMAC over stable
+        guest-token claims yields a per-token channel that the chart data
+        request, the celery worker, and the polling endpoint can all derive
+        without needing a cookie. The HMAC is keyed with the configured JWT
+        secret so the value is unguessable to outside callers.
+        """
+        token = guest_user.guest_token
+        # ``iat`` uniquely identifies a guest token issuance, so it provides
+        # per-token isolation while remaining stable across the lifetime of a
+        # single embedded session.
+        message = json.dumps(
+            {
+                "user": token.get("user"),
+                "resources": token.get("resources"),
+                "iat": token.get("iat"),
+                "exp": token.get("exp"),
+                "aud": token.get("aud"),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        digest = hmac.new(
+            self._jwt_secret.encode("utf-8"), message, hashlib.sha256
+        ).hexdigest()
+        return f"guest-{digest}"
+
     def parse_channel_id_from_request(self, req: Request) -> str:
+        # pylint: disable=import-outside-toplevel
+        from superset import security_manager
+
+        if guest_user := security_manager.get_current_guest_user_if_guest():
+            return self.get_guest_user_channel_id(guest_user)
+
         token = req.cookies.get(self._jwt_cookie_name)
         if not token:
             raise AsyncQueryTokenException("Token not preset")

--- a/tests/unit_tests/async_events/async_query_manager_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_tests.py
@@ -46,7 +46,15 @@ def async_query_manager():
 
 def set_current_as_guest_user():
     g.user = security_manager.get_guest_user_from_token(
-        {"user": {}, "resources": [{"type": "dashboard", "id": "some-uuid"}]}
+        {
+            "user": {},
+            "resources": [{"type": "dashboard", "id": "some-uuid"}],
+            "rls_rules": [{"clause": '"STATEID" = 3'}],
+            "iat": 1700000000.0,
+            "exp": 1700000300.0,
+            "aud": "http://0.0.0.0:8080/",
+            "type": "guest",
+        }
     )
 
 
@@ -145,6 +153,75 @@ def test_parse_channel_id_from_request_bad_jwt(async_query_manager):
         async_query_manager.parse_channel_id_from_request(request)
 
 
+@mock.patch("superset.is_feature_enabled")
+def test_parse_channel_id_from_request_as_guest_user_no_cookie(
+    is_feature_enabled_mock, async_query_manager
+):
+    """
+    Embedded guest sessions cannot rely on the async-token cookie because
+    cross-origin cookies are blocked or stripped by modern browsers when the
+    dashboard is rendered inside a third-party iframe. The channel id must
+    therefore be derived from the guest token rather than the cookie.
+    """
+    is_feature_enabled_mock.return_value = True
+    set_current_as_guest_user()
+
+    request = Mock()
+    request.cookies = {}
+
+    channel_id = async_query_manager.parse_channel_id_from_request(request)
+    assert channel_id.startswith("guest-")
+
+
+@mock.patch("superset.is_feature_enabled")
+def test_parse_channel_id_from_request_as_guest_user_is_deterministic(
+    is_feature_enabled_mock, async_query_manager
+):
+    """
+    The same guest token (including its RLS rules) must yield the same channel
+    id across requests. Otherwise the chart-data submission and the polling
+    endpoint would write to and read from different streams, returning 401s
+    even though the work was scheduled correctly.
+    """
+    is_feature_enabled_mock.return_value = True
+    set_current_as_guest_user()
+
+    request = Mock()
+    request.cookies = {}
+
+    first = async_query_manager.parse_channel_id_from_request(request)
+    second = async_query_manager.parse_channel_id_from_request(request)
+    assert first == second
+
+
+@mock.patch("superset.is_feature_enabled")
+def test_parse_channel_id_from_request_as_guest_user_differs_per_token(
+    is_feature_enabled_mock, async_query_manager
+):
+    """Different guest tokens must produce different channel ids."""
+    is_feature_enabled_mock.return_value = True
+
+    set_current_as_guest_user()
+    request = Mock()
+    request.cookies = {}
+    first = async_query_manager.parse_channel_id_from_request(request)
+
+    g.user = security_manager.get_guest_user_from_token(
+        {
+            "user": {"username": "other"},
+            "resources": [{"type": "dashboard", "id": "another-uuid"}],
+            "rls_rules": [{"clause": '"STATEID" = 4'}],
+            "iat": 1700000000.0,
+            "exp": 1700000300.0,
+            "aud": "http://0.0.0.0:8080/",
+            "type": "guest",
+        }
+    )
+    second = async_query_manager.parse_channel_id_from_request(request)
+
+    assert first != second
+
+
 @mark.parametrize(
     "cache_type, cache_backend",
     [
@@ -174,8 +251,13 @@ def test_submit_chart_data_job_as_guest_user(
             "channel_id": "test_channel_id",
             "errors": [],
             "guest_token": {
-                "resources": [{"id": "some-uuid", "type": "dashboard"}],
                 "user": {},
+                "resources": [{"type": "dashboard", "id": "some-uuid"}],
+                "rls_rules": [{"clause": '"STATEID" = 3'}],
+                "iat": 1700000000.0,
+                "exp": 1700000300.0,
+                "aud": "http://0.0.0.0:8080/",
+                "type": "guest",
             },
             "job_id": ANY,
             "result_url": None,
@@ -219,8 +301,13 @@ def test_submit_explore_json_job_as_guest_user(
             "channel_id": "test_channel_id",
             "errors": [],
             "guest_token": {
-                "resources": [{"id": "some-uuid", "type": "dashboard"}],
                 "user": {},
+                "resources": [{"type": "dashboard", "id": "some-uuid"}],
+                "rls_rules": [{"clause": '"STATEID" = 3'}],
+                "iat": 1700000000.0,
+                "exp": 1700000300.0,
+                "aud": "http://0.0.0.0:8080/",
+                "type": "guest",
             },
             "job_id": ANY,
             "result_url": None,


### PR DESCRIPTION
### SUMMARY

Adopts **anandraiin3/superset#23** (originally authored via the Devin AI bot — credit to **@anandraiin3**). This brings the fix onto current `apache/superset` master with the touched code re-verified against master's `async_query_manager`.

Closes #31492 ("Getting error when using RLS filtering in Guest token when `GLOBAL_ASYNC_QUERIES` is enabled").

When `GLOBAL_ASYNC_QUERIES` is enabled and an embedded dashboard is loaded with a guest token that contains `rls_rules`, every chart and filter request fails with `Not authorized` (HTTP 401) and the frontend surfaces:

> This session has encountered an interruption, and some controls may not work as intended. If you are the developer of this app, please check that the guest token is being generated correctly.

#### Root cause

The async-query path identifies a client through a server-issued `async-token` JWT cookie, created in `validate_session` and read back in `parse_channel_id_from_request` for both `POST /api/v1/chart/data` (scheduling the celery job) and `GET /api/v1/async_event/` (polling for completion events). For embedded dashboards the page renders inside a third-party iframe, so the `async-token` cookie is unreliable: modern browsers strip it for cross-site contexts or never set it (depending on `SameSite`/third-party-cookie settings). Subsequent polling requests typically arrive without it, which makes `parse_channel_id_from_request` raise `AsyncQueryTokenException` → 401. The error surfaces most often when RLS rules are present because the per-token cache key prevents a sync cache-hit shortcut from masking the cookie issue.

#### Fix

For requests that arrive with a guest user attached (`security_manager.get_current_guest_user_if_guest()`), the channel id is derived deterministically from stable claims of the guest token (`user`, `resources`, `iat`, `exp`, `aud`) using HMAC-SHA256 keyed with `GLOBAL_ASYNC_QUERIES_JWT_SECRET`:

- Removes the dependency on a third-party cookie inside the embedded iframe.
- Yields the same channel id for the chart-data POST, the celery worker, and the polling endpoint, so events written to `async-events-<channel>` are readable by the same guest session.
- Stays unguessable to outside callers because the digest is keyed with the existing JWT secret.
- Leaves the cookie path completely untouched for non-guest (regular) users.

`validate_session` also short-circuits for guest users so it does not pointlessly issue an `async-token` cookie that would either fail to be set or never be sent back.

Files changed:
- `superset/async_events/async_query_manager.py` — new `get_guest_user_channel_id` helper; `parse_channel_id_from_request` and `validate_session` branch on `get_current_guest_user_if_guest()`.
- `tests/unit_tests/async_events/async_query_manager_tests.py` — guest-user fixture mirrors the realistic guest-token payload from the bug report (RLS rules, `iat`/`exp`/`aud`/`type`); three new tests cover the new code path.

#### Security note (reviewer aid)

The channel id is the sole authz boundary for `GET /api/v1/async_event/`. The HMAC is keyed with the same `GLOBAL_ASYNC_QUERIES_JWT_SECRET` that protects the cookie JWT, so the derived channel is equally unguessable. The guest token signature/expiry is already validated before this code runs, and a guest can only derive their own channel (channel scope == token scope). No privilege escalation found.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change. The user-visible effect is that embedded dashboards with `rls_rules` and `GLOBAL_ASYNC_QUERIES=True` no longer return 401 on chart and filter APIs.

### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/async_events/async_query_manager_tests.py -v
```

The new tests `test_parse_channel_id_from_request_as_guest_user_no_cookie`, `test_parse_channel_id_from_request_as_guest_user_is_deterministic`, and `test_parse_channel_id_from_request_as_guest_user_differs_per_token` cover the regression directly. The pre-existing guest-token tests continue to pass and now exercise a guest-token payload that matches the one in the issue.

Manual reproduction (matches the issue):

1. Set `FEATURE_FLAGS = {"EMBEDDED_SUPERSET": True, "GLOBAL_ASYNC_QUERIES": True}` and configure the celery worker + Redis as documented.
2. Mint a guest token whose payload includes `rls_rules` (e.g. `[{"clause": "\"STATEID\" = 3"}]`) for an embedded dashboard.
3. Load the dashboard in an iframe on a different origin from Superset.
4. **Before this PR**: every `POST /api/v1/chart/data` and `GET /api/v1/async_event/` returns 401 with `Not authorized`, and the embedded SDK surfaces the "session has encountered an interruption" toast.
5. **After this PR**: chart-data requests return 202 with a job id, the polling endpoint streams completion events, and the dashboard renders normally with the RLS predicate applied.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #31492
- [x] Required feature flags: `EMBEDDED_SUPERSET`, `GLOBAL_ASYNC_QUERIES` (existing flags; no new flags introduced)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Adopted from anandraiin3/superset#23, originally authored via the Devin AI bot. Credit to **@anandraiin3**.
