### PR TITLE
fix(deck.gl): use interval notation for Polygon legend bucket labels

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import type { ReactElement } from 'react';
+import Legend from './Legend';
+
+const renderWithTheme = (component: ReactElement) =>
+  render(<ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>);
+
+test('formats interval-notation labels while preserving brackets', () => {
+  renderWithTheme(
+    <Legend
+      format=",.2f"
+      categories={{
+        '[1, 81)': { enabled: true, color: [0, 0, 0] },
+        '[81, 212)': { enabled: true, color: [0, 0, 0] },
+        '[212, 369]': { enabled: true, color: [0, 0, 0] },
+      }}
+    />,
+  );
+
+  expect(screen.getByText('[1.00, 81.00)')).toBeInTheDocument();
+  expect(screen.getByText('[81.00, 212.00)')).toBeInTheDocument();
+  expect(screen.getByText('[212.00, 369.00]')).toBeInTheDocument();
+});
+
+test('still formats legacy "a - b" delimiter labels', () => {
+  renderWithTheme(
+    <Legend
+      format=",.1f"
+      categories={{
+        '0 - 100000': { enabled: true, color: [0, 0, 0] },
+        '100001 - 200000': { enabled: true, color: [0, 0, 0] },
+      }}
+    />,
+  );
+
+  expect(screen.getByText('0.0 - 100,000.0')).toBeInTheDocument();
+  expect(screen.getByText('100,001.0 - 200,000.0')).toBeInTheDocument();
+});
+
+test('leaves labels untouched when no format is provided', () => {
+  renderWithTheme(
+    <Legend
+      format={null}
+      categories={{ '[1, 81)': { enabled: true, color: [0, 0, 0] } }}
+    />,
+  );
+
+  expect(screen.getByText('[1, 81)')).toBeInTheDocument();
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -59,6 +59,33 @@ const StyledLegend = styled.div`
 
 const categoryDelimiter = ' - ';
 
+const OPENING_BRACKETS = '[(';
+const CLOSING_BRACKETS = '])';
+
+// Recognize half-open interval labels like "[1, 81)" or "[81, 212]" emitted by
+// getBuckets: brackets on the ends, two comma-separated bounds in between.
+// Returns the parsed pieces, or null when the label isn't interval notation.
+const parseInterval = (label: string) => {
+  const open = label[0];
+  const close = label[label.length - 1];
+  if (!OPENING_BRACKETS.includes(open) || !CLOSING_BRACKETS.includes(close)) {
+    return null;
+  }
+
+  const bounds = label.slice(1, -1).split(',');
+  if (bounds.length !== 2) {
+    return null;
+  }
+
+  const lower = bounds[0].trim();
+  const upper = bounds[1].trim();
+  if (!lower || !upper) {
+    return null;
+  }
+
+  return { open, lower, upper, close };
+};
+
 export type LegendProps = {
   format: string | null;
   forceCategorical?: boolean;
@@ -91,13 +118,13 @@ const Legend = ({
       return k;
     }
 
-    // Interval-notation labels, e.g. "[1, 81)" or "[81, 212]". Format each
-    // numeric bound while preserving the brackets and separator.
-    const intervalMatch = k.match(/^([[(])\s*(.+?)\s*,\s*(.+?)\s*([\])])$/);
-    if (intervalMatch) {
-      const [, openBracket, lower, upper, closeBracket] = intervalMatch;
+    // Format each numeric bound of an interval label while preserving the
+    // brackets and separator, e.g. "[1, 81)" -> "[1.00, 81.00)".
+    const interval = parseInterval(k);
+    if (interval) {
+      const { open, lower, upper, close } = interval;
 
-      return `${openBracket}${format(lower)}, ${format(upper)}${closeBracket}`;
+      return `${open}${format(lower)}, ${format(upper)}${close}`;
     }
 
     if (k.includes(categoryDelimiter)) {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -91,6 +91,15 @@ const Legend = ({
       return k;
     }
 
+    // Interval-notation labels, e.g. "[1, 81)" or "[81, 212]". Format each
+    // numeric bound while preserving the brackets and separator.
+    const intervalMatch = k.match(/^([[(])\s*(.+?)\s*,\s*(.+?)\s*([\])])$/);
+    if (intervalMatch) {
+      const [, openBracket, lower, upper, closeBracket] = intervalMatch;
+
+      return `${openBracket}${format(lower)}, ${format(upper)}${closeBracket}`;
+    }
+
     if (k.includes(categoryDelimiter)) {
       const values = k.split(categoryDelimiter);
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
@@ -16,10 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { JsonObject, QueryFormData } from '@superset-ui/core';
 import {
   getColorBreakpointsBuckets,
   getBreakPoints,
   getBuckets,
+  BucketsWithColorScale,
 } from './utils';
 import { ColorBreakpointType } from './types';
 
@@ -494,7 +496,7 @@ describe('getBreakPoints', () => {
 });
 
 describe('getBuckets', () => {
-  const accessor = (d: any) => d.value;
+  const accessor = (d: JsonObject) => d.value;
 
   const buildFeatures = (values: number[]) => values.map(value => ({ value }));
 
@@ -503,7 +505,7 @@ describe('getBuckets', () => {
     // "1 - 81", "81 - 212", "212 - 369" where each interior breakpoint
     // (81, 212) appeared in two adjacent labels, reading as overlapping
     // ranges. Labels should instead form a clean, non-overlapping partition.
-    const fd: any = {
+    const fd: QueryFormData & BucketsWithColorScale = {
       break_points: ['1', '81', '212', '369'],
       num_buckets: '3',
       linear_color_scheme: ['#000000', '#ffffff'],

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
@@ -506,6 +506,8 @@ describe('getBuckets', () => {
     // (81, 212) appeared in two adjacent labels, reading as overlapping
     // ranges. Labels should instead form a clean, non-overlapping partition.
     const fd: QueryFormData & BucketsWithColorScale = {
+      datasource: '1__table',
+      viz_type: 'deck_polygon',
       break_points: ['1', '81', '212', '369'],
       num_buckets: '3',
       linear_color_scheme: ['#000000', '#ffffff'],

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.test.ts
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getColorBreakpointsBuckets, getBreakPoints } from './utils';
+import {
+  getColorBreakpointsBuckets,
+  getBreakPoints,
+  getBuckets,
+} from './utils';
 import { ColorBreakpointType } from './types';
 
 describe('getColorBreakpointsBuckets', () => {
@@ -485,6 +489,43 @@ describe('getBreakPoints', () => {
         expect(firstBp).toBeLessThanOrEqual(minValue);
         expect(lastBp).toBeGreaterThanOrEqual(maxValue);
       }
+    });
+  });
+});
+
+describe('getBuckets', () => {
+  const accessor = (d: any) => d.value;
+
+  const buildFeatures = (values: number[]) => values.map(value => ({ value }));
+
+  test('produces non-overlapping bucket labels (no shared endpoints)', () => {
+    // With break points [1, 81, 212, 369] the legacy behavior produced
+    // "1 - 81", "81 - 212", "212 - 369" where each interior breakpoint
+    // (81, 212) appeared in two adjacent labels, reading as overlapping
+    // ranges. Labels should instead form a clean, non-overlapping partition.
+    const fd: any = {
+      break_points: ['1', '81', '212', '369'],
+      num_buckets: '3',
+      linear_color_scheme: ['#000000', '#ffffff'],
+      opacity: 100,
+      metric: 'count',
+    };
+    const features = buildFeatures([1, 50, 100, 200, 300, 369]);
+
+    const buckets = getBuckets(fd, features, accessor);
+    const labels = Object.keys(buckets);
+
+    // Three buckets for four breakpoints
+    expect(labels).toHaveLength(3);
+
+    // Interval notation: half-open everywhere except the last bucket, which
+    // is closed so the maximum value is included.
+    expect(labels).toEqual(['[1, 81)', '[81, 212)', '[212, 369]']);
+
+    // No numeric endpoint should appear as both an upper bound of one bucket
+    // and a lower bound of the next in an ambiguous "a - b" form.
+    labels.forEach(label => {
+      expect(label).not.toMatch(/^\d+(\.\d+)?\s-\s\d+(\.\d+)?$/);
     });
   });
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
@@ -200,8 +200,15 @@ export function getBuckets(
     string,
     { color: Color | undefined; enabled: boolean }
   > = {};
+  const lastBucketIndex = breakPoints.length - 2;
   breakPoints.slice(1).forEach((_, i) => {
-    const range = `${breakPoints[i]} - ${breakPoints[i + 1]}`;
+    // Use half-open interval notation so adjacent buckets don't share an
+    // ambiguous endpoint. This mirrors the d3 `scaleThreshold` binning used
+    // for coloring, where each breakpoint is a half-open cut point. The final
+    // bucket is closed on the right so the maximum value is included.
+    const isLastBucket = i === lastBucketIndex;
+    const closingBracket = isLastBucket ? ']' : ')';
+    const range = `[${breakPoints[i]}, ${breakPoints[i + 1]}${closingBracket}`;
     const mid =
       0.5 * (parseFloat(breakPoints[i]) + parseFloat(breakPoints[i + 1]));
     // fix polygon doesn't show


### PR DESCRIPTION
### SUMMARY

The deck.gl Polygon legend builds each bucket label by pairing adjacent breakpoints as `a - b`, so every interior breakpoint shows up in two labels — e.g. `1 - 81`, `81 - 212`, `212 - 369`, where `81` and `212` each appear twice and the ranges read as overlapping. The binning itself is fine (coloring uses d3 `scaleThreshold`, which is half-open, so a value of exactly `81` lands in exactly one bucket); it's only the label text that's ambiguous.

This swaps `getBuckets` over to half-open interval notation — `[1, 81)`, `[81, 212)`, `[212, 369]` — with the final bucket closed on the right so the max value is still included. That matches what the color scale actually does and reads as a clean, non-overlapping partition. As the issue notes, just incrementing the lower bound (`82 - 212`) doesn't generalize, since breakpoints and values can be fractional — interval notation sidesteps that.

The `Legend` formatter learned to recognize interval-notation keys so it still number-formats each bound (via the chart's d3 format) while preserving the brackets. The legacy `a - b` delimiter path is untouched, so the manual color-breakpoints legend keeps formatting as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: `1 - 81`, `81 - 212`, `212 - 369` (shared endpoints)
After: `[1, 81)`, `[81, 212)`, `[212, 369]` (clean partition)

### TESTING INSTRUCTIONS

1. Create a deck.gl Polygon chart with a numeric metric.
2. Leave Bucket break points empty (use the default Number of buckets).
3. Check the legend — bins now read as `[a, b)` intervals with no shared endpoints, and number formatting still applies to each bound.

Unit tests cover it too: `getBuckets` asserts the non-overlapping interval labels, and a new `Legend.test.tsx` pins both the interval formatting and the legacy `a - b` path.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #40786
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API