### PR TITLE
fix(mixed-chart): preserve order_desc and series_limit_metric in buildQuery

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -82,7 +82,18 @@ export default function buildQuery(formData: QueryFormData) {
           flattenOperator(fd, queryObject),
         ],
       } as QueryObject;
-      return [normalizeOrderBy(tmpQueryObject)];
+      // Preserve `order_desc` and `series_limit_metric` on the query object and
+      // only normalize `orderby`. `normalizeOrderBy` strips those two fields from
+      // its result, but the backend series-limit subquery reads `order_desc`
+      // directly to pick the top-N series, so dropping it makes the sort
+      // direction silently ignored for the displayed result. Mirrors the
+      // single-query Timeseries chart's buildQuery.
+      return [
+        {
+          ...tmpQueryObject,
+          orderby: normalizeOrderBy(tmpQueryObject).orderby,
+        },
+      ];
     }),
   );
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -106,7 +106,8 @@ test('should compile query object A', () => {
     row_offset: undefined,
     series_columns: ['foo'],
     series_limit: 5,
-    series_limit_metric: undefined,
+    series_limit_metric: 'count',
+    order_desc: true,
     group_others_when_limit_reached: false,
     url_params: {},
     custom_params: {},
@@ -167,6 +168,7 @@ test('should compile query object B', () => {
     series_columns: [],
     series_limit: 0,
     series_limit_metric: undefined,
+    order_desc: false,
     group_others_when_limit_reached: false,
     url_params: {},
     custom_params: {},
@@ -373,4 +375,36 @@ test('ensure correct pivot columns', () => {
       },
     },
   });
+});
+
+test('preserves order_desc and series_limit_metric for both queries', () => {
+  // Regression for sc-107146: toggling "Sort Descending" off in a Mixed Chart
+  // updated the displayed SQL but not the rendered result. The backend
+  // series-limit subquery picks the top-N series from `order_desc`, so dropping
+  // it (as `normalizeOrderBy` does) made the sort direction silently ignored.
+  const ascendingFormData = {
+    ...formDataMixedChart,
+    order_desc: false,
+    order_desc_b: false,
+    timeseries_limit_metric_b: 'count',
+  };
+  const { queries } = buildQuery(ascendingFormData);
+
+  // Query A: ascending sort by its explicit sort metric must survive.
+  expect(queries[0]).toEqual(
+    expect.objectContaining({
+      order_desc: false,
+      series_limit_metric: 'count',
+      orderby: [['count', true]],
+    }),
+  );
+
+  // Query B: the `_b` query must independently keep its own direction/metric.
+  expect(queries[1]).toEqual(
+    expect.objectContaining({
+      order_desc: false,
+      series_limit_metric: 'count',
+      orderby: [['count', true]],
+    }),
+  );
 });


### PR DESCRIPTION
### SUMMARY

In a **Mixed Chart** (`mixed_timeseries`), changing **"Sort Query By"** or toggling **"Sort Descending"** updated the displayed SQL ("View query") but did **not** change the rendered result.

Root cause is in the frontend query builder. `MixedTimeseries/buildQuery.ts` returned the full output of `normalizeOrderBy(tmpQueryObject)`. `normalizeOrderBy` deletes `order_desc` and `series_limit_metric` from the object it returns, re-adding only `orderby`. The backend main query reads `orderby` (so the displayed SQL looks correct), but the **series-limit subquery** that decides *which* top-N series to show reads `order_desc` and `series_limit_metric` directly (`superset/models/helpers.py`: `direction = sa.desc if order_desc else sa.asc`, and `_get_series_orderby` reads `series_limit_metric`). With those two fields stripped, the backend `QueryObject` defaults `order_desc` to `True`, so the same top-N series were always selected → the result never changed.

The fix mirrors what the single-query **Timeseries** chart already does: spread the query object and override only `orderby`, preserving `order_desc` and `series_limit_metric`.

```js
// MixedTimeseries/buildQuery.ts
return [
  {
    ...tmpQueryObject,
    orderby: normalizeOrderBy(tmpQueryObject).orderby,
  },
];
```

This applies symmetrically to Query A and Query B.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual chrome change. The behavior change is that the rendered series now respond to the sort controls (see Testing Instructions).

### TESTING INSTRUCTIONS

1. Create a Mixed Chart (Mixed Timeseries) on a dataset with a dimension that produces more series than the series limit (e.g. group by a high-cardinality column with **Series limit** set to a small N).
2. Set **"Sort Query By"** to a metric and toggle **"Sort Descending"** on, then off.
3. **Before this fix:** the displayed SQL changes but the rendered top-N series stay the same.
4. **After this fix:** the rendered top-N series change to honor the chosen sort metric and direction, for both Query A and Query B.

Automated coverage (`plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts`):
- Updated "should compile query object A/B" to assert `order_desc` and `series_limit_metric` are preserved.
- Added a regression test, `preserves order_desc and series_limit_metric for both queries`, asserting the sc-107146 ascending-sort repro keeps `order_desc: false` + `series_limit_metric` for both queries. Reverting only the source fix fails this test.

Run: `npm run test -- plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

#### Reviewer / QA note — expected behavior change on existing saved charts

Preserving `series_limit_metric` changes the series-limit subquery's ORDER BY **column**, not just its direction. Previously the field was stripped, so the backend fell back to ordering the top-N prequery by the main metric; with the fix it orders by the chosen **"Sort Query By"** metric (`helpers.py` `_get_series_orderby`). This is the intended correctness fix, but **existing saved Mixed Charts may render a different (correct) top-N series set with no user action**. Please don't mistake this for a regression during QA.
