### PR TITLE
fix(dashboard): suppress favorite status error toast on 404

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -502,6 +502,29 @@ describe('dashboardState actions', () => {
 
       expect(dispatch).not.toHaveBeenCalled();
     });
+
+    test('does NOT dispatch a danger toast on 404 error when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest
+        .spyOn(SupersetClient, 'get')
+        .mockRejectedValue(
+          new Response(JSON.stringify({ message: 'Not found' }), {
+            status: 404,
+          }),
+        );
+
+      await fetchFaveStar(id)(dispatch, getState);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
   });
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -525,6 +525,37 @@ describe('dashboardState actions', () => {
 
       expect(dispatch).not.toHaveBeenCalled();
     });
+
+    test('dispatches a danger toast on a non-404 error Response when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest
+        .spyOn(SupersetClient, 'get')
+        .mockRejectedValue(
+          new Response(JSON.stringify({ message: 'Server error' }), {
+            status: 500,
+          }),
+        );
+
+      await fetchFaveStar(id)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          type: ADD_TOAST,
+          payload: expect.objectContaining({
+            toastType: ToastType.Danger,
+          }),
+        }),
+      );
+    });
   });
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -177,12 +177,11 @@ export function fetchFaveStar(id: number) {
           );
         }
       })
-      .catch(async error => {
-        const { status } = await getClientErrorObject(error);
-        // A 404 means the favorite status isn't available to this user
-        // (a non-owner viewing a draft dashboard, or a dashboard deleted
-        // after navigation) — swallow it silently instead of alarming them.
-        if (status === 404) {
+      .catch(error => {
+        // A 404 means the favorite status isn't available to this user (a
+        // non-owner viewing a draft dashboard, or a dashboard deleted after
+        // navigation) — swallow it silently instead of alarming them.
+        if (error instanceof Response && error.status === 404) {
           return;
         }
         // Only show the error if this is still the current dashboard (prevents

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -177,10 +177,16 @@ export function fetchFaveStar(id: number) {
           );
         }
       })
-      .catch(() => {
-        // Only show error if this is still the current dashboard
-        // This prevents error toasts from appearing for dashboards the user
-        // has already navigated away from (e.g., deleted dashboards)
+      .catch(async error => {
+        const { status } = await getClientErrorObject(error);
+        // A 404 means the favorite status isn't available to this user
+        // (a non-owner viewing a draft dashboard, or a dashboard deleted
+        // after navigation) — swallow it silently instead of alarming them.
+        if (status === 404) {
+          return;
+        }
+        // Only show the error if this is still the current dashboard (prevents
+        // toasts for dashboards the user already navigated away from).
         const currentId = getState().dashboardInfo?.id;
         if (currentId === id) {
           dispatch(


### PR DESCRIPTION
### SUMMARY

When a non-owner user opens a draft dashboard by direct URL, the `GET /api/v1/dashboard/favorite_status/` endpoint correctly returns 404 (draft dashboard visibility is owner/admin-only at the API layer). However, `fetchFaveStar`'s `.catch` handler treated every error uniformly and surfaced a danger toast: *"There was an issue fetching the favorite status of this dashboard."*

A 404 here means "favorite status isn't available to this user" — it is not an error worth alarming the user about. This also covers the case where a dashboard is deleted after navigation began.

**Fix:** In `fetchFaveStar`'s `.catch`, detect the 404 with an `error instanceof Response && error.status === 404` type guard (the client rejects HTTP failures with the raw `Response`, which carries `.status`). On a 404, return silently instead of dispatching the danger toast. Non-404 errors (network failures, 500s) continue to toast when the dashboard ID still matches, preserving the existing `currentId === id` race-condition guard.

Related: #33007 (closed unmerged) addressed the same symptom for the deleted-dashboard case. This PR covers both the draft-non-owner case and the deleted case with the same 404 check.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Non-owner loads a draft dashboard → red danger toast appears on load.
**After:** No toast. The 404 from `favorite_status` is silently swallowed.

### TESTING INSTRUCTIONS

1. As an admin, create a dashboard and leave it in draft (unpublished) state.
2. As a non-admin user who is NOT the dashboard owner, navigate directly to the dashboard URL.
3. **Before this fix:** a red danger toast "There was an issue fetching the favorite status of this dashboard." appears.
4. **After this fix:** no toast appears.
5. Verify that genuine network errors still produce the toast on a published dashboard.

Automated: `cd superset-frontend && npm run test -- src/dashboard/actions/dashboardState.test.ts`
- `does NOT dispatch a danger toast on 404 error when the dashboard ID still matches` (the fix)
- `dispatches a danger toast on a non-404 error Response when the dashboard ID still matches` (non-404 still toasts)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
