### PR TITLE
fix(sqllab): preserve query history after tab migration

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -1843,14 +1843,14 @@ describe('async actions', () => {
           {
             ...query,
             id: 'previewOne',
-            sqlEditorId: oldQueryEditor.id,
-            inLocalStorage: true,
+            sqlEditorId: null,
+            isDataPreview: true,
           },
           {
             ...query,
             id: 'previewTwo',
-            sqlEditorId: oldQueryEditor.id,
-            inLocalStorage: true,
+            sqlEditorId: null,
+            isDataPreview: true,
           },
           {
             ...query,
@@ -1897,16 +1897,6 @@ describe('async actions', () => {
           },
           {
             type: actions.MIGRATE_QUERY,
-            queryId: 'previewOne',
-            queryEditorId: '1',
-          },
-          {
-            type: actions.MIGRATE_QUERY,
-            queryId: 'previewTwo',
-            queryEditorId: '1',
-          },
-          {
-            type: actions.MIGRATE_QUERY,
             queryId: 'runningQuery',
             queryEditorId: '1',
           },
@@ -1917,7 +1907,7 @@ describe('async actions', () => {
             expect(store.getActions()).toEqual(expectedActions);
             expect(
               fetchMock.callHistory.calls(updateTabStateEndpoint),
-            ).toHaveLength(4);
+            ).toHaveLength(2);
 
             // query editor has 2 tables loaded in the schema viewer
             expect(

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -1852,6 +1852,18 @@ describe('async actions', () => {
             sqlEditorId: oldQueryEditor.id,
             inLocalStorage: true,
           },
+          {
+            ...query,
+            id: 'runningQuery',
+            sqlEditorId: oldQueryEditor.id,
+            state: 'running',
+          },
+          {
+            ...query,
+            id: 'unrelatedQuery',
+            sqlEditorId: 'other-editor',
+            state: 'running',
+          },
         ];
         const store = mockStore({
           sqlLab: {
@@ -1893,6 +1905,11 @@ describe('async actions', () => {
             queryId: 'previewTwo',
             queryEditorId: '1',
           },
+          {
+            type: actions.MIGRATE_QUERY,
+            queryId: 'runningQuery',
+            queryEditorId: '1',
+          },
         ];
         return store
           .dispatch(actions.syncQueryEditor(oldQueryEditor))
@@ -1900,7 +1917,7 @@ describe('async actions', () => {
             expect(store.getActions()).toEqual(expectedActions);
             expect(
               fetchMock.callHistory.calls(updateTabStateEndpoint),
-            ).toHaveLength(3);
+            ).toHaveLength(4);
 
             // query editor has 2 tables loaded in the schema viewer
             expect(

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -689,8 +689,8 @@ export function syncQueryEditor(
       (table: Table) =>
         table.inLocalStorage && table.queryEditorId === queryEditor.id,
     );
-    const localStorageQueries = Object.values(queries).filter(
-      query => query.inLocalStorage && query.sqlEditorId === queryEditor.id,
+    const queriesToMigrate = Object.values(queries).filter(
+      query => query.sqlEditorId === queryEditor.id && !query.isDataPreview,
     );
     return SupersetClient.post({
       endpoint: '/tabstateview/',
@@ -712,7 +712,7 @@ export function syncQueryEditor(
           ...localStorageTables.map((table: Table) =>
             migrateTable(table, newQueryEditor.tabViewId!, dispatch),
           ),
-          ...localStorageQueries.map((query: Query) =>
+          ...queriesToMigrate.map((query: Query) =>
             migrateQuery(query.id, newQueryEditor.tabViewId!, dispatch),
           ),
         ]);


### PR DESCRIPTION
### SUMMARY
Fixes the SQL Lab query history pane becoming empty after running a query in a new tab from Query History.

When a new SQL Lab tab is created locally and then persisted to the backend, the editor id changes from the temporary local id to the backend tab id. `syncQueryEditor` only migrated queries that were marked as `inLocalStorage`, so a just-started query from an autorun cloned tab could stay attached to the old local editor id. The Query History pane then filtered by the backend tab id and no longer found the query.

This updates tab sync to migrate all non-preview queries attached to the local editor id, and adds regression coverage for a running query that is not marked `inLocalStorage`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A. Behavior-only SQL Lab state fix.

### TESTING INSTRUCTIONS
1. Enable SQL Lab backend persistence.
2. Open SQL > Query History.
3. Click Run query in a new tab for an existing query.
4. Confirm the new SQL Lab tab keeps showing the query in the Query History pane after the tab is saved to the backend.

Automated/local checks run:
- `npm run test -- src/SqlLab/actions/sqlLab.test.ts --runTestsByPath`
- `npm run lint -- src/SqlLab/actions/sqlLab.ts src/SqlLab/actions/sqlLab.test.ts`
- `pre-commit run --files superset-frontend/src/SqlLab/actions/sqlLab.ts superset-frontend/src/SqlLab/actions/sqlLab.test.ts`
- `git diff --check`

Note: `pre-commit run --all-files` was run before pushing, but this local worktree did not complete green because of unrelated baseline/environment blockers outside this diff, including existing mypy/ruff failures in unrelated Python files and missing local all-files tooling/build prerequisites (`yarn`, `helm-docs`, and package build artifacts before local package build).

### ADDITIONAL INFORMATION
- [ ] Has associated issue: Shortcut SC-105345 / PPR-1271
- [x] Required feature flags: `SQLLAB_BACKEND_PERSISTENCE`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
