### PR TITLE
feat(database): add databricks oauth support

### DIFF
--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -32,7 +32,7 @@ install new database drivers into your Superset configuration.
 ### Supported Databases and Dependencies
 
 Some of the recommended packages are shown below. Please refer to
-[pyproject.toml](https://github.com/apache/superset/blob/master/pyproject.toml) for the versions thatdocs/docs/configuration/databases.mdx
+[pyproject.toml](https://github.com/apache/superset/blob/master/pyproject.toml) for the versions that
 are compatible with Superset.
 
 | <div style={{width: '150px'}}>Database</div>                   | PyPI package                                                                       | Connection String                                                                                                                                      |

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -32,7 +32,7 @@ install new database drivers into your Superset configuration.
 ### Supported Databases and Dependencies
 
 Some of the recommended packages are shown below. Please refer to
-[pyproject.toml](https://github.com/apache/superset/blob/master/pyproject.toml) for the versions that
+[pyproject.toml](https://github.com/apache/superset/blob/master/pyproject.toml) for the versions thatdocs/docs/configuration/databases.mdx
 are compatible with Superset.
 
 | <div style={{width: '150px'}}>Database</div>                   | PyPI package                                                                       | Connection String                                                                                                                                      |
@@ -518,6 +518,63 @@ For a connection to a SQL endpoint you need to use the HTTP path from the endpoi
 ```json
 {"connect_args": {"http_path": "/sql/1.0/endpoints/****", "driver_path": "/path/to/odbc/driver"}}
 ```
+
+##### OAuth2 Authentication
+
+Superset supports OAuth2 authentication for Databricks, allowing users to authenticate with their personal Databricks accounts instead of using shared access tokens. This provides better security and audit capabilities.
+
+###### Prerequisites
+
+1. Create an OAuth2 application in your Databricks account:
+   - Go to your Databricks account console
+   - Navigate to **Settings** → **Developer** → **OAuth apps**
+   - Create a new OAuth app with the redirect URI: `http://your-superset-host:port/api/v1/database/oauth2/`
+
+2. Configure OAuth2 in your `superset_config.py`:
+
+```python
+from datetime import timedelta
+
+# OAuth2 configuration for Databricks
+DATABASE_OAUTH2_CLIENTS = {
+    "Databricks (legacy)": {
+        "id": "your-databricks-client-id",
+        "secret": "your-databricks-client-secret",
+        "scope": "sql",
+        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
+        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/token",
+    },
+    "Databricks": {
+        "id": "your-databricks-client-id",
+        "secret": "your-databricks-client-secret",
+        "scope": "sql",
+        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
+        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/token",
+    },
+}
+
+# OAuth2 redirect URI (adjust hostname/port for your setup)
+DATABASE_OAUTH2_REDIRECT_URI = "http://your-superset-host:port/api/v1/database/oauth2/"
+
+# Optional: OAuth2 timeout
+DATABASE_OAUTH2_TIMEOUT = timedelta(seconds=30)
+```
+
+Replace the following placeholders:
+- `your-databricks-client-id`: Your Databricks OAuth2 application client ID
+- `your-databricks-client-secret`: Your Databricks OAuth2 application client secret
+- `{account_id}`: Your Databricks account ID (found in your workspace URL)
+- `your-superset-host:port`: Your Superset instance hostname and port
+
+###### Usage
+
+Once configured, users can:
+
+1. Connect to Databricks databases normally using access tokens
+2. When querying data, Superset will automatically redirect users to authenticate with Databricks if needed
+3. User-specific OAuth2 tokens will be used for database connections, providing better security and audit trails
+
+This feature works with both "Databricks (legacy)" and "Databricks" engine types.
 
 #### Denodo
 

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -536,20 +536,22 @@ Superset supports OAuth2 authentication for Databricks, allowing users to authen
 from datetime import timedelta
 
 # OAuth2 configuration for Databricks
+# OAuth2 endpoints are automatically detected based on your Databricks cloud provider
 DATABASE_OAUTH2_CLIENTS = {
     "Databricks (legacy)": {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
-        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/token",
+        # OAuth2 endpoints are auto-detected based on hostname, but can be overridden:
+        # AWS: "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
+        # Azure: "authorization_request_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
+        # GCP: "authorization_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{account_id}/v1/authorize",
     },
     "Databricks": {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
-        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/token",
+        # OAuth2 endpoints are auto-detected based on hostname
     },
 }
 
@@ -563,8 +565,25 @@ DATABASE_OAUTH2_TIMEOUT = timedelta(seconds=30)
 Replace the following placeholders:
 - `your-databricks-client-id`: Your Databricks OAuth2 application client ID
 - `your-databricks-client-secret`: Your Databricks OAuth2 application client secret
-- `{account_id}`: Your Databricks account ID (found in your workspace URL)
 - `your-superset-host:port`: Your Superset instance hostname and port
+
+**Multi-Cloud Provider Support**
+
+Superset automatically detects your Databricks cloud provider and uses the appropriate OAuth2 endpoints:
+
+- **AWS**: Detected from hostnames containing `cloud.databricks.com`
+- **Azure**: Detected from hostnames containing `azure` or `azuredatabricks`
+- **GCP**: Detected from hostnames containing `gcp` or `googleusercontent`
+
+You can also explicitly specify the cloud provider in your database configuration under **Advanced** → **Other** → **ENGINE PARAMETERS**:
+
+```json
+{
+  "cloud_provider": "azure"
+}
+```
+
+Valid cloud provider values are: `aws`, `azure`, `gcp`.
 
 ###### Usage
 
@@ -574,7 +593,7 @@ Once configured, users can:
 2. When querying data, Superset will automatically redirect users to authenticate with Databricks if needed
 3. User-specific OAuth2 tokens will be used for database connections, providing better security and audit trails
 
-This feature works with both "Databricks (legacy)" and "Databricks" engine types.
+This feature works with both "Databricks (legacy)" and "Databricks" engine types and automatically supports all major cloud providers (AWS, Azure, GCP).
 
 #### Denodo
 

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -575,15 +575,31 @@ Superset automatically detects your Databricks cloud provider and uses the appro
 - **Azure**: Detected from hostnames containing `azure` or `azuredatabricks`
 - **GCP**: Detected from hostnames containing `gcp` or `googleusercontent`
 
-You can also explicitly specify the cloud provider in your database configuration under **Advanced** → **Other** → **ENGINE PARAMETERS**:
+You can also explicitly specify the cloud provider, along with the account
+identifier used to build the OAuth2 endpoints, in your database configuration
+under **Advanced** → **Other** → **ENGINE PARAMETERS**:
 
 ```json
 {
-  "cloud_provider": "azure"
+  "cloud_provider": "azure",
+  "tenant_id": "your-azure-tenant-id"
 }
 ```
 
-Valid cloud provider values are: `aws`, `azure`, `gcp`.
+For AWS and GCP, supply `account_id` instead:
+
+```json
+{
+  "cloud_provider": "aws",
+  "account_id": "your-databricks-account-id"
+}
+```
+
+Valid cloud provider values are: `aws`, `azure`, `gcp`. When the OAuth2 endpoints
+are auto-detected, Superset substitutes this identifier into the provider's
+endpoint template. If you instead supply fully-resolved `authorization_request_uri`
+and `token_request_uri` values in `DATABASE_OAUTH2_CLIENTS`, those take precedence
+and no `account_id`/`tenant_id` is required.
 
 ###### Usage
 

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -536,25 +536,20 @@ Superset supports OAuth2 authentication for Databricks, allowing users to authen
 from datetime import timedelta
 
 # OAuth2 configuration for Databricks
-# OAuth2 endpoints are automatically detected based on your Databricks cloud provider
+# The authorization endpoint is derived from your Databricks workspace host; the
+# token endpoint must be set explicitly (see notes below).
 DATABASE_OAUTH2_CLIENTS = {
     "Databricks (legacy)": {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        # The authorization endpoint is auto-detected from the hostname; the
-        # token endpoint must be set explicitly (no DB context at exchange):
-        # AWS: "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
-        # Azure: "authorization_request_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
-        # GCP: "authorization_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{account_id}/v1/authorize",
-        # "token_request_uri": "https://<provider-token-endpoint>",
+        "token_request_uri": "https://your-workspace-host/oidc/v1/token",
     },
     "Databricks": {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        # Authorization endpoint auto-detected from hostname; set
-        # "token_request_uri" explicitly for the token exchange.
+        "token_request_uri": "https://your-workspace-host/oidc/v1/token",
     },
 }
 
@@ -572,40 +567,21 @@ Replace the following placeholders:
 
 **Multi-Cloud Provider Support**
 
-Superset automatically detects your Databricks cloud provider and uses the appropriate OAuth2 endpoints:
+Databricks fronts the user-to-machine (U2M) OAuth2 flow on every workspace at
+`https://<workspace-host>/oidc/v1/authorize` and
+`https://<workspace-host>/oidc/v1/token`, regardless of whether the workspace
+runs on AWS, Azure, or GCP. Superset derives the **authorization** endpoint
+directly from your connection's host, so no cloud provider or account/tenant
+identifier needs to be configured.
 
-- **AWS**: Detected from hostnames containing `cloud.databricks.com`
-- **Azure**: Detected from hostnames containing `azure` or `azuredatabricks`
-- **GCP**: Detected from hostnames containing `gcp` or `googleusercontent`
+The **token** endpoint cannot be auto-derived (token exchange has no database
+context to read the host), so you must supply `token_request_uri` in
+`DATABASE_OAUTH2_CLIENTS`, set to `https://<workspace-host>/oidc/v1/token` for
+your workspace.
 
-You can also explicitly specify the cloud provider, along with the account
-identifier used to build the OAuth2 endpoints, in your database configuration
-under **Advanced** → **Other** → **ENGINE PARAMETERS**:
-
-```json
-{
-  "cloud_provider": "azure",
-  "tenant_id": "your-azure-tenant-id"
-}
-```
-
-For AWS and GCP, supply `account_id` instead:
-
-```json
-{
-  "cloud_provider": "aws",
-  "account_id": "your-databricks-account-id"
-}
-```
-
-Valid cloud provider values are: `aws`, `azure`, `gcp`. The **authorization**
-endpoint is auto-detected: Superset substitutes this identifier into the
-provider's authorization template. The **token** endpoint is not auto-resolved
-(token exchange has no database context to detect the provider), so for the
-auto-detected flow you must still supply a fully-resolved `token_request_uri`
-in `DATABASE_OAUTH2_CLIENTS`. If you supply fully-resolved
-`authorization_request_uri` and `token_request_uri` values, those take
-precedence and no `account_id`/`tenant_id` is required.
+If you supply a fully-resolved `authorization_request_uri` (and/or
+`token_request_uri`), those values take precedence over the host-derived
+defaults.
 
 ###### Usage
 

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -542,16 +542,19 @@ DATABASE_OAUTH2_CLIENTS = {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        # OAuth2 endpoints are auto-detected based on hostname, but can be overridden:
+        # The authorization endpoint is auto-detected from the hostname; the
+        # token endpoint must be set explicitly (no DB context at exchange):
         # AWS: "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{account_id}/v1/authorize",
         # Azure: "authorization_request_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
         # GCP: "authorization_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{account_id}/v1/authorize",
+        # "token_request_uri": "https://<provider-token-endpoint>",
     },
     "Databricks": {
         "id": "your-databricks-client-id",
         "secret": "your-databricks-client-secret",
         "scope": "sql",
-        # OAuth2 endpoints are auto-detected based on hostname
+        # Authorization endpoint auto-detected from hostname; set
+        # "token_request_uri" explicitly for the token exchange.
     },
 }
 
@@ -595,11 +598,14 @@ For AWS and GCP, supply `account_id` instead:
 }
 ```
 
-Valid cloud provider values are: `aws`, `azure`, `gcp`. When the OAuth2 endpoints
-are auto-detected, Superset substitutes this identifier into the provider's
-endpoint template. If you instead supply fully-resolved `authorization_request_uri`
-and `token_request_uri` values in `DATABASE_OAUTH2_CLIENTS`, those take precedence
-and no `account_id`/`tenant_id` is required.
+Valid cloud provider values are: `aws`, `azure`, `gcp`. The **authorization**
+endpoint is auto-detected: Superset substitutes this identifier into the
+provider's authorization template. The **token** endpoint is not auto-resolved
+(token exchange has no database context to detect the provider), so for the
+auto-detected flow you must still supply a fully-resolved `token_request_uri`
+in `DATABASE_OAUTH2_CLIENTS`. If you supply fully-resolved
+`authorization_request_uri` and `token_request_uri` values, those take
+precedence and no `account_id`/`tenant_id` is required.
 
 ###### Usage
 

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -38,6 +38,7 @@ from superset.db_engine_specs.base import (
 )
 from superset.db_engine_specs.hive import HiveEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import OAuth2RedirectError
 from superset.utils import json
 from superset.utils.core import get_user_agent, QuerySource
 from superset.utils.network import is_hostname_valid, is_port_open
@@ -277,6 +278,29 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "port": "port",
     }
 
+    @classmethod
+    def impersonate_user(
+        cls,
+        database: Database,
+        username: str | None,
+        user_token: str | None,
+        url: URL,
+        engine_kwargs: dict[str, Any],
+    ) -> tuple[URL, dict[str, Any]]:
+        """
+        Update connection with OAuth2 access token for user impersonation.
+        """
+        if user_token:
+            # Replace the access token in the URL with the user's OAuth2 token
+            url = url.set(password=user_token)
+
+            # Also update connect_args if they contain access token
+            connect_args = engine_kwargs.setdefault("connect_args", {})
+            if "access_token" in connect_args:
+                connect_args["access_token"] = user_token
+
+        return url, engine_kwargs
+
     @staticmethod
     def get_extra_params(
         database: Database, source: QuerySource | None = None
@@ -473,6 +497,17 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
     supports_catalog = True
     supports_dynamic_catalog = True
     supports_cross_catalog_queries = True
+
+    # OAuth 2.0 support
+    supports_oauth2 = True
+    oauth2_exception = OAuth2RedirectError
+    oauth2_scope = "sql"
+    oauth2_authorization_request_uri = (
+        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
+    )
+    oauth2_token_request_uri = (
+        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
+    )
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore
@@ -684,6 +719,17 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
     }
 
     supports_dynamic_schema = supports_catalog = supports_dynamic_catalog = True
+
+    # OAuth 2.0 support
+    supports_oauth2 = True
+    oauth2_exception = OAuth2RedirectError
+    oauth2_scope = "sql"
+    oauth2_authorization_request_uri = (
+        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
+    )
+    oauth2_token_request_uri = (
+        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
+    )
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -596,18 +596,22 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         """
         Exchange authorization code for refresh/access tokens with dynamic endpoint.
 
-        Note: For token exchange, we need the database context from the state.
-        This is a limitation of the current OAuth2 flow design.
+        The token request URI is resolved when the OAuth2 config is built (see
+        `get_oauth2_config`), so it already targets the correct cloud provider and
+        account. Only fall back to the AWS endpoint when no URI is configured.
         """
-        # For now, fall back to AWS endpoints for token exchange
-        # TODO: Improve OAuth2 flow to pass database context to token exchange
         from typing import cast
 
-        config = cast(
-            "OAuth2ClientConfig",
-            dict(config)
-            | {"token_request_uri": cls._oauth2_endpoints["aws"]["token_request_uri"]},
-        )
+        if not config.get("token_request_uri"):
+            config = cast(
+                "OAuth2ClientConfig",
+                dict(config)
+                | {
+                    "token_request_uri": cls._oauth2_endpoints["aws"][
+                        "token_request_uri"
+                    ]
+                },
+            )
 
         return super().get_oauth2_token(config, code, code_verifier)
 
@@ -873,18 +877,22 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
         """
         Exchange authorization code for refresh/access tokens with dynamic endpoint.
 
-        Note: For token exchange, we need the database context from the state.
-        This is a limitation of the current OAuth2 flow design.
+        The token request URI is resolved when the OAuth2 config is built (see
+        `get_oauth2_config`), so it already targets the correct cloud provider and
+        account. Only fall back to the AWS endpoint when no URI is configured.
         """
-        # For now, fall back to AWS endpoints for token exchange
-        # TODO: Improve OAuth2 flow to pass database context to token exchange
         from typing import cast
 
-        config = cast(
-            "OAuth2ClientConfig",
-            dict(config)
-            | {"token_request_uri": cls._oauth2_endpoints["aws"]["token_request_uri"]},
-        )
+        if not config.get("token_request_uri"):
+            config = cast(
+                "OAuth2ClientConfig",
+                dict(config)
+                | {
+                    "token_request_uri": cls._oauth2_endpoints["aws"][
+                        "token_request_uri"
+                    ]
+                },
+            )
 
         return super().get_oauth2_token(config, code, code_verifier)
 

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -564,11 +564,12 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         """
         Return URI for initial OAuth2 request with dynamic endpoint detection.
         """
+        from superset import db
         from superset.models.core import Database
 
         # Get the database to detect cloud provider
         database_id = state["database_id"]
-        if database := Database.query.get(database_id):
+        if database := db.session.get(Database, database_id):
             provider = cls._detect_cloud_provider(database)
             # Update config with the correct authorization URI for the cloud provider
             from typing import cast
@@ -840,11 +841,12 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
         """
         Return URI for initial OAuth2 request with dynamic endpoint detection.
         """
+        from superset import db
         from superset.models.core import Database
 
         # Get the database to detect cloud provider
         database_id = state["database_id"]
-        if database := Database.query.get(database_id):
+        if database := db.session.get(Database, database_id):
             provider = cls._detect_cloud_provider(database)
             # Update config with the correct authorization URI for the cloud provider
             from typing import cast

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -45,6 +45,11 @@ from superset.utils.network import is_hostname_valid, is_port_open
 
 if TYPE_CHECKING:
     from superset.models.core import Database
+    from superset.superset_typing import (
+        OAuth2ClientConfig,
+        OAuth2State,
+        OAuth2TokenResponse,
+    )
 
 
 try:
@@ -278,6 +283,48 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "port": "port",
     }
 
+    # OAuth2 endpoints for different cloud providers
+    _oauth2_endpoints = {
+        "aws": {
+            "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize",
+            "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token",
+        },
+        "azure": {
+            "authorization_request_uri": "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
+            "token_request_uri": "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        },
+        "gcp": {
+            "authorization_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{}/v1/authorize",
+            "token_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{}/v1/token",
+        },
+    }
+
+    @classmethod
+    def _detect_cloud_provider(cls, database: Database) -> str:
+        """
+        Detect the cloud provider based on the database configuration.
+
+        Returns:
+            str: The cloud provider ('aws', 'azure', or 'gcp')
+        """
+        # Check if cloud provider is explicitly configured in extra
+        if "cloud_provider" in (extra := cls.get_extra_params(database)):
+            provider = extra["cloud_provider"].lower()
+            if provider in cls._oauth2_endpoints:
+                return provider
+
+        # Try to detect from hostname
+        hostname = database.url_object.host or ""
+        hostname = hostname.lower()
+
+        if "azure" in hostname or "azuredatabricks" in hostname:
+            return "azure"
+        elif "gcp" in hostname or "googleusercontent" in hostname:
+            return "gcp"
+        else:
+            # Default to AWS for compatibility
+            return "aws"
+
     @classmethod
     def impersonate_user(
         cls,
@@ -502,12 +549,66 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
     supports_oauth2 = True
     oauth2_exception = OAuth2RedirectError
     oauth2_scope = "sql"
-    oauth2_authorization_request_uri = (
-        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
-    )
-    oauth2_token_request_uri = (
-        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
-    )
+
+    # OAuth2 endpoints are determined dynamically based on cloud provider
+    oauth2_authorization_request_uri = ""  # Set dynamically
+    oauth2_token_request_uri = ""  # Set dynamically
+
+    @classmethod
+    def get_oauth2_authorization_uri(
+        cls,
+        config: "OAuth2ClientConfig",
+        state: "OAuth2State",
+        code_verifier: str | None = None,
+    ) -> str:
+        """
+        Return URI for initial OAuth2 request with dynamic endpoint detection.
+        """
+        from superset.models.core import Database
+
+        # Get the database to detect cloud provider
+        database_id = state["database_id"]
+        if database := Database.query.get(database_id):
+            provider = cls._detect_cloud_provider(database)
+            # Update config with the correct authorization URI for the cloud provider
+            from typing import cast
+
+            config = cast(
+                "OAuth2ClientConfig",
+                dict(config)
+                | {
+                    "authorization_request_uri": cls._oauth2_endpoints[provider][
+                        "authorization_request_uri"
+                    ]
+                },
+            )
+
+        return super().get_oauth2_authorization_uri(config, state, code_verifier)
+
+    @classmethod
+    def get_oauth2_token(
+        cls,
+        config: "OAuth2ClientConfig",
+        code: str,
+        code_verifier: str | None = None,
+    ) -> "OAuth2TokenResponse":
+        """
+        Exchange authorization code for refresh/access tokens with dynamic endpoint.
+
+        Note: For token exchange, we need the database context from the state.
+        This is a limitation of the current OAuth2 flow design.
+        """
+        # For now, fall back to AWS endpoints for token exchange
+        # TODO: Improve OAuth2 flow to pass database context to token exchange
+        from typing import cast
+
+        config = cast(
+            "OAuth2ClientConfig",
+            dict(config)
+            | {"token_request_uri": cls._oauth2_endpoints["aws"]["token_request_uri"]},
+        )
+
+        return super().get_oauth2_token(config, code, code_verifier)
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore
@@ -724,12 +825,66 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
     supports_oauth2 = True
     oauth2_exception = OAuth2RedirectError
     oauth2_scope = "sql"
-    oauth2_authorization_request_uri = (
-        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
-    )
-    oauth2_token_request_uri = (
-        "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
-    )
+
+    # OAuth2 endpoints are determined dynamically based on cloud provider
+    oauth2_authorization_request_uri = ""  # Set dynamically
+    oauth2_token_request_uri = ""  # Set dynamically
+
+    @classmethod
+    def get_oauth2_authorization_uri(
+        cls,
+        config: "OAuth2ClientConfig",
+        state: "OAuth2State",
+        code_verifier: str | None = None,
+    ) -> str:
+        """
+        Return URI for initial OAuth2 request with dynamic endpoint detection.
+        """
+        from superset.models.core import Database
+
+        # Get the database to detect cloud provider
+        database_id = state["database_id"]
+        if database := Database.query.get(database_id):
+            provider = cls._detect_cloud_provider(database)
+            # Update config with the correct authorization URI for the cloud provider
+            from typing import cast
+
+            config = cast(
+                "OAuth2ClientConfig",
+                dict(config)
+                | {
+                    "authorization_request_uri": cls._oauth2_endpoints[provider][
+                        "authorization_request_uri"
+                    ]
+                },
+            )
+
+        return super().get_oauth2_authorization_uri(config, state, code_verifier)
+
+    @classmethod
+    def get_oauth2_token(
+        cls,
+        config: "OAuth2ClientConfig",
+        code: str,
+        code_verifier: str | None = None,
+    ) -> "OAuth2TokenResponse":
+        """
+        Exchange authorization code for refresh/access tokens with dynamic endpoint.
+
+        Note: For token exchange, we need the database context from the state.
+        This is a limitation of the current OAuth2 flow design.
+        """
+        # For now, fall back to AWS endpoints for token exchange
+        # TODO: Improve OAuth2 flow to pass database context to token exchange
+        from typing import cast
+
+        config = cast(
+            "OAuth2ClientConfig",
+            dict(config)
+            | {"token_request_uri": cls._oauth2_endpoints["aws"]["token_request_uri"]},
+        )
+
+        return super().get_oauth2_token(config, code, code_verifier)
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -38,7 +38,7 @@ from superset.db_engine_specs.base import (
 )
 from superset.db_engine_specs.hive import HiveEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import OAuth2RedirectError
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.utils import json
 from superset.utils.core import get_user_agent, QuerySource
 from superset.utils.network import is_hostname_valid, is_port_open
@@ -326,6 +326,37 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
             return "aws"
 
     @classmethod
+    def _resolve_oauth2_endpoint(
+        cls,
+        database: Database,
+        provider: str,
+        endpoint_key: str,
+    ) -> str:
+        """
+        Build a fully-resolved OAuth2 endpoint for the detected cloud provider.
+
+        The per-provider templates carry a single ``{}`` placeholder for the
+        Databricks account id (or Azure tenant id), read from the database's
+        ``extra`` (``account_id``, or ``tenant_id`` for Azure). Raising when it
+        is absent keeps the flow from issuing a request to an unresolved
+        ``.../{}/...`` endpoint.
+        """
+        template = cls._oauth2_endpoints[provider][endpoint_key]
+        if "{}" not in template:
+            return template
+
+        extra = cls.get_extra_params(database)
+        account_id = extra.get("account_id") or extra.get("tenant_id")
+        if not account_id:
+            raise OAuth2Error(
+                "Databricks OAuth2 endpoints could not be resolved: set "
+                "`account_id` (or `tenant_id` for Azure) in the database's "
+                "engine parameters, or provide a fully-resolved "
+                f"`{endpoint_key}` in DATABASE_OAUTH2_CLIENTS."
+            )
+        return template.format(account_id)
+
+    @classmethod
     def impersonate_user(
         cls,
         database: Database,
@@ -563,26 +594,30 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
     ) -> str:
         """
         Return URI for initial OAuth2 request with dynamic endpoint detection.
+
+        A fully-resolved `authorization_request_uri` from `DATABASE_OAUTH2_CLIENTS`
+        is preserved; only fall back to the auto-detected, account-resolved
+        endpoint when none is configured.
         """
-        from superset import db
-        from superset.models.core import Database
+        if not config.get("authorization_request_uri"):
+            from superset import db
+            from superset.models.core import Database
 
-        # Get the database to detect cloud provider
-        database_id = state["database_id"]
-        if database := db.session.get(Database, database_id):
-            provider = cls._detect_cloud_provider(database)
-            # Update config with the correct authorization URI for the cloud provider
-            from typing import cast
+            # Get the database to detect cloud provider
+            database_id = state["database_id"]
+            if database := db.session.get(Database, database_id):
+                provider = cls._detect_cloud_provider(database)
+                from typing import cast
 
-            config = cast(
-                "OAuth2ClientConfig",
-                dict(config)
-                | {
-                    "authorization_request_uri": cls._oauth2_endpoints[provider][
-                        "authorization_request_uri"
-                    ]
-                },
-            )
+                config = cast(
+                    "OAuth2ClientConfig",
+                    dict(config)
+                    | {
+                        "authorization_request_uri": cls._resolve_oauth2_endpoint(
+                            database, provider, "authorization_request_uri"
+                        )
+                    },
+                )
 
         return super().get_oauth2_authorization_uri(config, state, code_verifier)
 
@@ -594,23 +629,17 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         code_verifier: str | None = None,
     ) -> "OAuth2TokenResponse":
         """
-        Exchange authorization code for refresh/access tokens with dynamic endpoint.
+        Exchange authorization code for refresh/access tokens.
 
         The token request URI is resolved when the OAuth2 config is built (see
-        `get_oauth2_config`), so it already targets the correct cloud provider and
-        account. Only fall back to the AWS endpoint when no URI is configured.
+        `get_oauth2_config`) and already targets the correct cloud provider and
+        account. There is no database context here to auto-detect it, so fail
+        fast rather than POST to an unresolved endpoint when it is missing.
         """
-        from typing import cast
-
         if not config.get("token_request_uri"):
-            config = cast(
-                "OAuth2ClientConfig",
-                dict(config)
-                | {
-                    "token_request_uri": cls._oauth2_endpoints["aws"][
-                        "token_request_uri"
-                    ]
-                },
+            raise OAuth2Error(
+                "Databricks OAuth2 token endpoint is not configured: provide a "
+                "fully-resolved `token_request_uri` in DATABASE_OAUTH2_CLIENTS."
             )
 
         return super().get_oauth2_token(config, code, code_verifier)
@@ -844,26 +873,30 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
     ) -> str:
         """
         Return URI for initial OAuth2 request with dynamic endpoint detection.
+
+        A fully-resolved `authorization_request_uri` from `DATABASE_OAUTH2_CLIENTS`
+        is preserved; only fall back to the auto-detected, account-resolved
+        endpoint when none is configured.
         """
-        from superset import db
-        from superset.models.core import Database
+        if not config.get("authorization_request_uri"):
+            from superset import db
+            from superset.models.core import Database
 
-        # Get the database to detect cloud provider
-        database_id = state["database_id"]
-        if database := db.session.get(Database, database_id):
-            provider = cls._detect_cloud_provider(database)
-            # Update config with the correct authorization URI for the cloud provider
-            from typing import cast
+            # Get the database to detect cloud provider
+            database_id = state["database_id"]
+            if database := db.session.get(Database, database_id):
+                provider = cls._detect_cloud_provider(database)
+                from typing import cast
 
-            config = cast(
-                "OAuth2ClientConfig",
-                dict(config)
-                | {
-                    "authorization_request_uri": cls._oauth2_endpoints[provider][
-                        "authorization_request_uri"
-                    ]
-                },
-            )
+                config = cast(
+                    "OAuth2ClientConfig",
+                    dict(config)
+                    | {
+                        "authorization_request_uri": cls._resolve_oauth2_endpoint(
+                            database, provider, "authorization_request_uri"
+                        )
+                    },
+                )
 
         return super().get_oauth2_authorization_uri(config, state, code_verifier)
 
@@ -875,23 +908,17 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
         code_verifier: str | None = None,
     ) -> "OAuth2TokenResponse":
         """
-        Exchange authorization code for refresh/access tokens with dynamic endpoint.
+        Exchange authorization code for refresh/access tokens.
 
         The token request URI is resolved when the OAuth2 config is built (see
-        `get_oauth2_config`), so it already targets the correct cloud provider and
-        account. Only fall back to the AWS endpoint when no URI is configured.
+        `get_oauth2_config`) and already targets the correct cloud provider and
+        account. There is no database context here to auto-detect it, so fail
+        fast rather than POST to an unresolved endpoint when it is missing.
         """
-        from typing import cast
-
         if not config.get("token_request_uri"):
-            config = cast(
-                "OAuth2ClientConfig",
-                dict(config)
-                | {
-                    "token_request_uri": cls._oauth2_endpoints["aws"][
-                        "token_request_uri"
-                    ]
-                },
+            raise OAuth2Error(
+                "Databricks OAuth2 token endpoint is not configured: provide a "
+                "fully-resolved `token_request_uri` in DATABASE_OAUTH2_CLIENTS."
             )
 
         return super().get_oauth2_token(config, code, code_verifier)

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -288,7 +288,7 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
     # expired or missing token surfaces as a generic driver error. These case-
     # insensitive substrings flag the errors that should bootstrap a re-auth.
     oauth2_auth_failure_signals = (
-        "401",
+        "http 401",
         "unauthorized",
         "unauthenticated",
         "invalid access token",

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, Callable, cast, TYPE_CHECKING, TypedDict, Union
 
@@ -51,6 +52,9 @@ if TYPE_CHECKING:
         OAuth2State,
         OAuth2TokenResponse,
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 try:
@@ -403,18 +407,48 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         engine_kwargs: dict[str, Any],
     ) -> tuple[URL, dict[str, Any]]:
         """
-        Update connection with OAuth2 access token for user impersonation.
-        """
-        if user_token:
-            # Replace the access token in the URL with the user's OAuth2 token
-            url = url.set(password=user_token)
+        Update connection with the user's OAuth2 access token for impersonation.
 
-            # Also update connect_args if they contain access token
-            connect_args = engine_kwargs.setdefault("connect_args", {})
-            if "access_token" in connect_args:
-                connect_args["access_token"] = user_token
+        When impersonation is enabled but no user token is available yet (e.g. the
+        first connection, before the OAuth2 dance has run), the stored credential
+        is cleared rather than left in place. The driver then raises a "no valid
+        authentication settings" error, which ``needs_oauth2`` catches to bootstrap
+        the OAuth2 flow instead of silently connecting with a stale credential.
+        """
+        # Replace the credential in the URL with the user's OAuth2 token, falling
+        # back to an empty string to force re-authentication when none is set.
+        url = url.set(password=user_token or "")
+
+        # The Python connector passes the token via ``connect_args`` instead of the
+        # URL password, so keep it in sync (clearing it likewise forces re-auth).
+        connect_args = engine_kwargs.setdefault("connect_args", {})
+        if "access_token" in connect_args:
+            connect_args["access_token"] = user_token or ""
 
         return url, engine_kwargs
+
+    @staticmethod
+    def update_params_from_encrypted_extra(
+        database: Database, params: dict[str, Any]
+    ) -> None:
+        """
+        Merge ``encrypted_extra`` into the connection params, dropping the
+        ``oauth2_client_info`` block.
+
+        ``oauth2_client_info`` holds the per-database OAuth2 client configuration
+        consumed by ``Database.get_oauth2_config``; it is not a Databricks driver
+        connection argument, so it must be stripped here to avoid poisoning the
+        connection when OAuth2 is configured on the database itself.
+        """
+        if not database.encrypted_extra:
+            return
+        try:
+            encrypted_extra = json.loads(database.encrypted_extra)
+        except json.JSONDecodeError as ex:
+            logger.error(ex, exc_info=True)
+            raise
+        encrypted_extra.pop("oauth2_client_info", None)
+        params.update(encrypted_extra)
 
     @staticmethod
     def get_extra_params(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -295,6 +295,9 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "invalid token",
         "expired token",
         "token expired",
+        # Raised by the databricks-sql-connector when no usable credentials are
+        # present (e.g. an OAuth2 token that has been cleared/expired).
+        "no valid authentication settings",
     )
 
     @classmethod

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Callable, TYPE_CHECKING, TypedDict, Union
+from typing import Any, Callable, cast, TYPE_CHECKING, TypedDict, Union
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from flask import g
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from marshmallow.validate import Range
@@ -38,7 +39,7 @@ from superset.db_engine_specs.base import (
 )
 from superset.db_engine_specs.hive import HiveEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import OAuth2Error, OAuth2RedirectError
+from superset.exceptions import OAuth2Error
 from superset.utils import json
 from superset.utils.core import get_user_agent, QuerySource
 from superset.utils.network import is_hostname_valid, is_port_open
@@ -283,81 +284,111 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "port": "port",
     }
 
-    # OAuth2 endpoints for different cloud providers
-    _oauth2_endpoints = {
-        "aws": {
-            "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize",
-            "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token",
-        },
-        "azure": {
-            "authorization_request_uri": "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
-            "token_request_uri": "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-        },
-        "gcp": {
-            "authorization_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{}/v1/authorize",
-            "token_request_uri": "https://accounts.gcp.databricks.com/oidc/accounts/{}/v1/token",
-        },
-    }
+    # The Databricks SQL driver has no dedicated authentication exception, so an
+    # expired or missing token surfaces as a generic driver error. These case-
+    # insensitive substrings flag the errors that should bootstrap a re-auth.
+    oauth2_auth_failure_signals = (
+        "401",
+        "unauthorized",
+        "unauthenticated",
+        "invalid access token",
+        "invalid token",
+        "expired token",
+        "token expired",
+    )
 
     @classmethod
-    def _detect_cloud_provider(cls, database: Database) -> str:
+    def _workspace_oauth2_endpoint(cls, database: Database, path: str) -> str:
         """
-        Detect the cloud provider based on the database configuration.
+        Build a Databricks OAuth2 (U2M) endpoint from the workspace host.
 
-        Returns:
-            str: The cloud provider ('aws', 'azure', or 'gcp')
+        Databricks fronts the user-to-machine OAuth2 flow on every workspace at
+        ``https://<workspace-host>/oidc/v1/{authorize,token}`` across AWS, Azure
+        and GCP, so the endpoints derive directly from the connection host and
+        need no account or tenant identifier.
         """
-        # Check if cloud provider is explicitly configured in extra
-        if isinstance(
-            (cloud_provider := cls.get_extra_params(database).get("cloud_provider")),
-            str,
-        ):
-            provider = cloud_provider.lower()
-            if provider in cls._oauth2_endpoints:
-                return provider
-
-        # Try to detect from hostname
-        hostname = database.url_object.host or ""
-        hostname = hostname.lower()
-
-        if "azure" in hostname or "azuredatabricks" in hostname:
-            return "azure"
-        elif "gcp" in hostname or "googleusercontent" in hostname:
-            return "gcp"
-        else:
-            # Default to AWS for compatibility
-            return "aws"
+        host = database.url_object.host
+        if not host:
+            raise OAuth2Error(
+                "Databricks OAuth2 endpoint could not be resolved: the database "
+                "connection has no host."
+            )
+        return f"https://{host}/oidc/v1/{path}"
 
     @classmethod
-    def _resolve_oauth2_endpoint(
+    def needs_oauth2(cls, ex: Exception) -> bool:
+        """
+        Identify driver errors that should trigger the OAuth2 dance.
+
+        Unlike Trino (``TrinoAuthError``) or GSheets (``UnauthenticatedError``),
+        the Databricks driver raises no dedicated auth exception, so in addition
+        to the base ``isinstance`` check we match the auth signals above on the
+        error message (mirrors ``GSheetsEngineSpec.needs_oauth2``).
+        """
+        if not (g and hasattr(g, "user")):
+            return False
+        if isinstance(ex, cls.oauth2_exception):
+            return True
+        message = str(ex).lower()
+        return any(signal in message for signal in cls.oauth2_auth_failure_signals)
+
+    @classmethod
+    def get_oauth2_authorization_uri(
         cls,
-        database: Database,
-        provider: str,
-        endpoint_key: str,
+        config: "OAuth2ClientConfig",
+        state: "OAuth2State",
+        code_verifier: str | None = None,
     ) -> str:
         """
-        Build a fully-resolved OAuth2 endpoint for the detected cloud provider.
+        Return the URI for the initial OAuth2 request.
 
-        The per-provider templates carry a single ``{}`` placeholder for the
-        Databricks account id (or Azure tenant id), read from the database's
-        ``extra`` (``account_id``, or ``tenant_id`` for Azure). Raising when it
-        is absent keeps the flow from issuing a request to an unresolved
-        ``.../{}/...`` endpoint.
+        A fully-resolved ``authorization_request_uri`` from
+        ``DATABASE_OAUTH2_CLIENTS`` is preserved; otherwise the endpoint is
+        derived from the workspace host (``https://<host>/oidc/v1/authorize``),
+        which is valid on AWS, Azure and GCP.
         """
-        template = cls._oauth2_endpoints[provider][endpoint_key]
-        if "{}" not in template:
-            return template
+        if not config.get("authorization_request_uri"):
+            from superset import db
+            from superset.models.core import Database
 
-        extra = cls.get_extra_params(database)
-        account_id = extra.get("account_id") or extra.get("tenant_id")
-        if not account_id:
+            database_id = state["database_id"]
+            if database := db.session.get(Database, database_id):
+                config = cast(
+                    "OAuth2ClientConfig",
+                    dict(config)
+                    | {
+                        "authorization_request_uri": cls._workspace_oauth2_endpoint(
+                            database, "authorize"
+                        )
+                    },
+                )
+
+        return super().get_oauth2_authorization_uri(config, state, code_verifier)
+
+    @classmethod
+    def get_oauth2_token(
+        cls,
+        config: "OAuth2ClientConfig",
+        code: str,
+        code_verifier: str | None = None,
+    ) -> "OAuth2TokenResponse":
+        """
+        Exchange the authorization code for refresh/access tokens.
+
+        Token exchange runs in a separate request with no database context, so
+        the workspace host is not available to derive the endpoint here. Require
+        a configured ``token_request_uri``
+        (``https://<workspace-host>/oidc/v1/token``) and fail fast rather than
+        POST to an unresolved endpoint.
+        """
+        if not config.get("token_request_uri"):
             raise OAuth2Error(
-                "Databricks OAuth2 endpoints could not be resolved: set "
-                "`account_id` (or `tenant_id` for Azure) in the database's "
-                "engine parameters, or provide a fully-resolved "
-                f"`{endpoint_key}` in DATABASE_OAUTH2_CLIENTS."
+                "Databricks OAuth2 token endpoint is not configured: set "
+                "`token_request_uri` to https://<workspace-host>/oidc/v1/token "
+                "in DATABASE_OAUTH2_CLIENTS."
             )
-        return template.format(account_id)
+
+        return super().get_oauth2_token(config, code, code_verifier)
 
     @classmethod
     def impersonate_user(
@@ -579,73 +610,15 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
     supports_dynamic_catalog = True
     supports_cross_catalog_queries = True
 
-    # OAuth 2.0 support
+    # OAuth 2.0 support. The flow (endpoint resolution from the workspace host,
+    # `needs_oauth2` detection) is shared via `DatabricksDynamicBaseEngineSpec`.
     supports_oauth2 = True
-    oauth2_exception = OAuth2RedirectError
     oauth2_scope = "sql"
 
-    # OAuth2 endpoints are determined dynamically based on cloud provider
-    oauth2_authorization_request_uri = ""  # Set dynamically
-    oauth2_token_request_uri = ""  # Set dynamically
-
-    @classmethod
-    def get_oauth2_authorization_uri(
-        cls,
-        config: "OAuth2ClientConfig",
-        state: "OAuth2State",
-        code_verifier: str | None = None,
-    ) -> str:
-        """
-        Return URI for initial OAuth2 request with dynamic endpoint detection.
-
-        A fully-resolved `authorization_request_uri` from `DATABASE_OAUTH2_CLIENTS`
-        is preserved; only fall back to the auto-detected, account-resolved
-        endpoint when none is configured.
-        """
-        if not config.get("authorization_request_uri"):
-            from superset import db
-            from superset.models.core import Database
-
-            # Get the database to detect cloud provider
-            database_id = state["database_id"]
-            if database := db.session.get(Database, database_id):
-                provider = cls._detect_cloud_provider(database)
-                from typing import cast
-
-                config = cast(
-                    "OAuth2ClientConfig",
-                    dict(config)
-                    | {
-                        "authorization_request_uri": cls._resolve_oauth2_endpoint(
-                            database, provider, "authorization_request_uri"
-                        )
-                    },
-                )
-
-        return super().get_oauth2_authorization_uri(config, state, code_verifier)
-
-    @classmethod
-    def get_oauth2_token(
-        cls,
-        config: "OAuth2ClientConfig",
-        code: str,
-        code_verifier: str | None = None,
-    ) -> "OAuth2TokenResponse":
-        """
-        Exchange authorization code for refresh/access tokens.
-
-        The token request URI is resolved when the OAuth2 config is built (see
-        `get_oauth2_config`) and already targets the correct cloud provider and
-        account. There is no database context here to auto-detect it, so fail
-        fast rather than POST to an unresolved endpoint when it is missing.
-        """
-        if not config.get("token_request_uri"):
-            raise OAuth2Error(
-                "Databricks OAuth2 token endpoint is not configured: provide a "
-                "fully-resolved `token_request_uri` in DATABASE_OAUTH2_CLIENTS."
-            )
-
-        return super().get_oauth2_token(config, code, code_verifier)
+    # Authorization endpoint is derived from the workspace host at runtime; the
+    # token endpoint must be configured (no DB context at exchange time).
+    oauth2_authorization_request_uri = ""
+    oauth2_token_request_uri = ""
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore
@@ -858,73 +831,15 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
 
     supports_dynamic_schema = supports_catalog = supports_dynamic_catalog = True
 
-    # OAuth 2.0 support
+    # OAuth 2.0 support. The flow (endpoint resolution from the workspace host,
+    # `needs_oauth2` detection) is shared via `DatabricksDynamicBaseEngineSpec`.
     supports_oauth2 = True
-    oauth2_exception = OAuth2RedirectError
     oauth2_scope = "sql"
 
-    # OAuth2 endpoints are determined dynamically based on cloud provider
-    oauth2_authorization_request_uri = ""  # Set dynamically
-    oauth2_token_request_uri = ""  # Set dynamically
-
-    @classmethod
-    def get_oauth2_authorization_uri(
-        cls,
-        config: "OAuth2ClientConfig",
-        state: "OAuth2State",
-        code_verifier: str | None = None,
-    ) -> str:
-        """
-        Return URI for initial OAuth2 request with dynamic endpoint detection.
-
-        A fully-resolved `authorization_request_uri` from `DATABASE_OAUTH2_CLIENTS`
-        is preserved; only fall back to the auto-detected, account-resolved
-        endpoint when none is configured.
-        """
-        if not config.get("authorization_request_uri"):
-            from superset import db
-            from superset.models.core import Database
-
-            # Get the database to detect cloud provider
-            database_id = state["database_id"]
-            if database := db.session.get(Database, database_id):
-                provider = cls._detect_cloud_provider(database)
-                from typing import cast
-
-                config = cast(
-                    "OAuth2ClientConfig",
-                    dict(config)
-                    | {
-                        "authorization_request_uri": cls._resolve_oauth2_endpoint(
-                            database, provider, "authorization_request_uri"
-                        )
-                    },
-                )
-
-        return super().get_oauth2_authorization_uri(config, state, code_verifier)
-
-    @classmethod
-    def get_oauth2_token(
-        cls,
-        config: "OAuth2ClientConfig",
-        code: str,
-        code_verifier: str | None = None,
-    ) -> "OAuth2TokenResponse":
-        """
-        Exchange authorization code for refresh/access tokens.
-
-        The token request URI is resolved when the OAuth2 config is built (see
-        `get_oauth2_config`) and already targets the correct cloud provider and
-        account. There is no database context here to auto-detect it, so fail
-        fast rather than POST to an unresolved endpoint when it is missing.
-        """
-        if not config.get("token_request_uri"):
-            raise OAuth2Error(
-                "Databricks OAuth2 token endpoint is not configured: provide a "
-                "fully-resolved `token_request_uri` in DATABASE_OAUTH2_CLIENTS."
-            )
-
-        return super().get_oauth2_token(config, code, code_verifier)
+    # Authorization endpoint is derived from the workspace host at runtime; the
+    # token endpoint must be configured (no DB context at exchange time).
+    oauth2_authorization_request_uri = ""
+    oauth2_token_request_uri = ""
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -308,8 +308,11 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
             str: The cloud provider ('aws', 'azure', or 'gcp')
         """
         # Check if cloud provider is explicitly configured in extra
-        if "cloud_provider" in (extra := cls.get_extra_params(database)):
-            provider = extra["cloud_provider"].lower()
+        if isinstance(
+            (cloud_provider := cls.get_extra_params(database).get("cloud_provider")),
+            str,
+        ):
+            provider = cloud_provider.lower()
             if provider in cls._oauth2_endpoints:
                 return provider
 

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -18,13 +18,21 @@
 
 from datetime import datetime
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.engine.url import make_url
 
-from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+from superset.db_engine_specs.databricks import (
+    DatabricksNativeEngineSpec,
+    DatabricksPythonConnectorEngineSpec,
+)
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import OAuth2RedirectError
+from superset.superset_typing import OAuth2ClientConfig
 from superset.utils import json
+from superset.utils.oauth2 import decode_oauth2_state
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm  # noqa: F401
 
@@ -291,3 +299,413 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
         "USE CATALOG `evil`` USE CATALOG bad`",
         "USE SCHEMA `evil`` USE SCHEMA bad`",
     ]
+
+
+# OAuth2 Tests
+
+
+def test_oauth2_attributes() -> None:
+    """
+    Test that OAuth2 attributes are properly set for both engine specs.
+    """
+    # Test DatabricksNativeEngineSpec
+    assert DatabricksNativeEngineSpec.supports_oauth2 is True
+    assert DatabricksNativeEngineSpec.oauth2_exception is OAuth2RedirectError
+    assert DatabricksNativeEngineSpec.oauth2_scope == "sql"
+    assert (
+        DatabricksNativeEngineSpec.oauth2_authorization_request_uri
+        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
+    )
+    assert (
+        DatabricksNativeEngineSpec.oauth2_token_request_uri
+        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
+    )
+
+    # Test DatabricksPythonConnectorEngineSpec
+    assert DatabricksPythonConnectorEngineSpec.supports_oauth2 is True
+    assert DatabricksPythonConnectorEngineSpec.oauth2_exception is OAuth2RedirectError
+    assert DatabricksPythonConnectorEngineSpec.oauth2_scope == "sql"
+    assert (
+        DatabricksPythonConnectorEngineSpec.oauth2_authorization_request_uri
+        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
+    )
+    assert (
+        DatabricksPythonConnectorEngineSpec.oauth2_token_request_uri
+        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
+    )
+
+
+def test_impersonate_user_with_token(mocker: MockerFixture) -> None:
+    """
+    Test impersonate_user method with OAuth2 token for DatabricksNativeEngineSpec.
+    """
+    database = mocker.MagicMock()
+    original_url = make_url(
+        "databricks+connector://token:original-token@host:443/database"
+    )
+    engine_kwargs = {"connect_args": {"access_token": "original-token"}}
+
+    # Test with user token
+    url, kwargs = DatabricksNativeEngineSpec.impersonate_user(
+        database=database,
+        username="user1",
+        user_token="user-oauth-token",  # noqa: S106
+        url=original_url,
+        engine_kwargs=engine_kwargs,
+    )
+
+    # Check that the password (token) was updated in the URL
+    assert url.password == "user-oauth-token"  # noqa: S105
+    # Check that access_token was updated in connect_args
+    assert kwargs["connect_args"]["access_token"] == "user-oauth-token"  # noqa: S105
+
+
+def test_impersonate_user_without_token(mocker: MockerFixture) -> None:
+    """
+    Test impersonate_user method without OAuth2 token.
+    """
+    database = mocker.MagicMock()
+    original_url = make_url(
+        "databricks+connector://token:original-token@host:443/database"
+    )
+    engine_kwargs = {"connect_args": {"access_token": "original-token"}}
+
+    # Test without user token
+    url, kwargs = DatabricksNativeEngineSpec.impersonate_user(
+        database=database,
+        username="user1",
+        user_token=None,
+        url=original_url,
+        engine_kwargs=engine_kwargs,
+    )
+
+    # Check that nothing was changed
+    assert url.password == "original-token"  # noqa: S105
+    assert kwargs["connect_args"]["access_token"] == "original-token"  # noqa: S105
+
+
+def test_impersonate_user_python_connector(mocker: MockerFixture) -> None:
+    """
+    Test impersonate_user method for DatabricksPythonConnectorEngineSpec.
+    """
+    database = mocker.MagicMock()
+    original_url = make_url(
+        "databricks://token:original-token@host:443?http_path=path&catalog=main&schema=default"
+    )
+    engine_kwargs = {"connect_args": {"access_token": "original-token"}}
+
+    # Test with user token
+    url, kwargs = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database=database,
+        username="user1",
+        user_token="user-oauth-token",  # noqa: S106
+        url=original_url,
+        engine_kwargs=engine_kwargs,
+    )
+
+    # Check that the password (token) was updated in the URL
+    assert url.password == "user-oauth-token"  # noqa: S105
+    # Check that access_token was updated in connect_args
+    assert kwargs["connect_args"]["access_token"] == "user-oauth-token"  # noqa: S105
+
+
+@pytest.fixture
+def oauth2_config_native() -> OAuth2ClientConfig:
+    """
+    Config for Databricks Native OAuth2.
+    """
+    return {
+        "id": "databricks-client-id",
+        "secret": "databricks-client-secret",
+        "scope": "sql",
+        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/authorize",
+        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        "request_content_type": "json",
+    }
+
+
+@pytest.fixture
+def oauth2_config_python() -> OAuth2ClientConfig:
+    """
+    Config for Databricks Python Connector OAuth2.
+    """
+    return {
+        "id": "databricks-client-id",
+        "secret": "databricks-client-secret",
+        "scope": "sql",
+        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/authorize",
+        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        "request_content_type": "json",
+    }
+
+
+def test_is_oauth2_enabled_no_config_native(mocker: MockerFixture) -> None:
+    """
+    Test `is_oauth2_enabled` when OAuth2 is not configured for Native engine.
+    """
+    mocker.patch(
+        "flask.current_app.config",
+        new={"DATABASE_OAUTH2_CLIENTS": {}},
+    )
+
+    assert DatabricksNativeEngineSpec.is_oauth2_enabled() is False
+
+
+def test_is_oauth2_enabled_config_native(mocker: MockerFixture) -> None:
+    """
+    Test `is_oauth2_enabled` when OAuth2 is configured for Native engine.
+    """
+    mocker.patch(
+        "flask.current_app.config",
+        new={
+            "DATABASE_OAUTH2_CLIENTS": {
+                "Databricks (legacy)": {
+                    "id": "client-id",
+                    "secret": "client-secret",
+                },
+            }
+        },
+    )
+
+    assert DatabricksNativeEngineSpec.is_oauth2_enabled() is True
+
+
+def test_is_oauth2_enabled_no_config_python(mocker: MockerFixture) -> None:
+    """
+    Test `is_oauth2_enabled` when OAuth2 is not configured for Python Connector engine.
+    """
+    mocker.patch(
+        "flask.current_app.config",
+        new={"DATABASE_OAUTH2_CLIENTS": {}},
+    )
+
+    assert DatabricksPythonConnectorEngineSpec.is_oauth2_enabled() is False
+
+
+def test_is_oauth2_enabled_config_python(mocker: MockerFixture) -> None:
+    """
+    Test `is_oauth2_enabled` when OAuth2 is configured for Python Connector engine.
+    """
+    mocker.patch(
+        "flask.current_app.config",
+        new={
+            "DATABASE_OAUTH2_CLIENTS": {
+                "Databricks": {
+                    "id": "client-id",
+                    "secret": "client-secret",
+                },
+            }
+        },
+    )
+
+    assert DatabricksPythonConnectorEngineSpec.is_oauth2_enabled() is True
+
+
+def test_get_oauth2_authorization_uri_native(
+    mocker: MockerFixture,
+    oauth2_config_native: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_authorization_uri` for Native engine.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    state: OAuth2State = {
+        "database_id": 1,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(
+        oauth2_config_native, state
+    )
+    parsed = urlparse(url)
+    assert parsed.netloc == "accounts.cloud.databricks.com"
+    assert parsed.path == "/oidc/accounts/12345/v1/authorize"
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state
+
+
+def test_get_oauth2_authorization_uri_python(
+    mocker: MockerFixture,
+    oauth2_config_python: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_authorization_uri` for Python Connector engine.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    state: OAuth2State = {
+        "database_id": 1,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksPythonConnectorEngineSpec.get_oauth2_authorization_uri(
+        oauth2_config_python, state
+    )
+    parsed = urlparse(url)
+    assert parsed.netloc == "accounts.cloud.databricks.com"
+    assert parsed.path == "/oidc/accounts/12345/v1/authorize"
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state
+
+
+def test_get_oauth2_token_native(
+    mocker: MockerFixture,
+    oauth2_config_native: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_token` for Native engine.
+    """
+    requests = mocker.patch("superset.db_engine_specs.base.requests")
+    requests.post().json.return_value = {
+        "access_token": "access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "refresh-token",
+    }
+
+    assert DatabricksNativeEngineSpec.get_oauth2_token(
+        oauth2_config_native, "authorization-code"
+    ) == {
+        "access_token": "access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "refresh-token",
+    }
+    requests.post.assert_called_with(
+        "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        json={
+            "code": "authorization-code",
+            "client_id": "databricks-client-id",
+            "client_secret": "databricks-client-secret",
+            "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+            "grant_type": "authorization_code",
+        },
+        timeout=30.0,
+    )
+
+
+def test_get_oauth2_token_python(
+    mocker: MockerFixture,
+    oauth2_config_python: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_token` for Python Connector engine.
+    """
+    requests = mocker.patch("superset.db_engine_specs.base.requests")
+    requests.post().json.return_value = {
+        "access_token": "access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "refresh-token",
+    }
+
+    assert DatabricksPythonConnectorEngineSpec.get_oauth2_token(
+        oauth2_config_python, "authorization-code"
+    ) == {
+        "access_token": "access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "refresh-token",
+    }
+    requests.post.assert_called_with(
+        "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        json={
+            "code": "authorization-code",
+            "client_id": "databricks-client-id",
+            "client_secret": "databricks-client-secret",
+            "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+            "grant_type": "authorization_code",
+        },
+        timeout=30.0,
+    )
+
+
+def test_get_oauth2_fresh_token_native(
+    mocker: MockerFixture,
+    oauth2_config_native: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_fresh_token` for Native engine.
+    """
+    requests = mocker.patch("superset.db_engine_specs.base.requests")
+    requests.post().json.return_value = {
+        "access_token": "new-access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "new-refresh-token",
+    }
+
+    assert DatabricksNativeEngineSpec.get_oauth2_fresh_token(
+        oauth2_config_native, "old-refresh-token"
+    ) == {
+        "access_token": "new-access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "new-refresh-token",
+    }
+    requests.post.assert_called_with(
+        "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        json={
+            "client_id": "databricks-client-id",
+            "client_secret": "databricks-client-secret",
+            "refresh_token": "old-refresh-token",
+            "grant_type": "refresh_token",
+        },
+        timeout=30.0,
+    )
+
+
+def test_get_oauth2_fresh_token_python(
+    mocker: MockerFixture,
+    oauth2_config_python: OAuth2ClientConfig,
+) -> None:
+    """
+    Test `get_oauth2_fresh_token` for Python Connector engine.
+    """
+    requests = mocker.patch("superset.db_engine_specs.base.requests")
+    requests.post().json.return_value = {
+        "access_token": "new-access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "new-refresh-token",
+    }
+
+    assert DatabricksPythonConnectorEngineSpec.get_oauth2_fresh_token(
+        oauth2_config_python, "old-refresh-token"
+    ) == {
+        "access_token": "new-access-token",
+        "expires_in": 3600,
+        "scope": "sql",
+        "token_type": "Bearer",
+        "refresh_token": "new-refresh-token",
+    }
+    requests.post.assert_called_with(
+        "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        json={
+            "client_id": "databricks-client-id",
+            "client_secret": "databricks-client-secret",
+            "refresh_token": "old-refresh-token",
+            "grant_type": "refresh_token",
+        },
+        timeout=30.0,
+    )

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -312,27 +312,17 @@ def test_oauth2_attributes() -> None:
     assert DatabricksNativeEngineSpec.supports_oauth2 is True
     assert DatabricksNativeEngineSpec.oauth2_exception is OAuth2RedirectError
     assert DatabricksNativeEngineSpec.oauth2_scope == "sql"
-    assert (
-        DatabricksNativeEngineSpec.oauth2_authorization_request_uri
-        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
-    )
-    assert (
-        DatabricksNativeEngineSpec.oauth2_token_request_uri
-        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
-    )
+    # OAuth2 endpoints are now dynamic and set at runtime
+    assert DatabricksNativeEngineSpec.oauth2_authorization_request_uri == ""
+    assert DatabricksNativeEngineSpec.oauth2_token_request_uri == ""
 
     # Test DatabricksPythonConnectorEngineSpec
     assert DatabricksPythonConnectorEngineSpec.supports_oauth2 is True
     assert DatabricksPythonConnectorEngineSpec.oauth2_exception is OAuth2RedirectError
     assert DatabricksPythonConnectorEngineSpec.oauth2_scope == "sql"
-    assert (
-        DatabricksPythonConnectorEngineSpec.oauth2_authorization_request_uri
-        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/authorize"
-    )
-    assert (
-        DatabricksPythonConnectorEngineSpec.oauth2_token_request_uri
-        == "https://accounts.cloud.databricks.com/oidc/accounts/{}/v1/token"  # noqa: S105
-    )
+    # OAuth2 endpoints are now dynamic and set at runtime
+    assert DatabricksPythonConnectorEngineSpec.oauth2_authorization_request_uri == ""
+    assert DatabricksPythonConnectorEngineSpec.oauth2_token_request_uri == ""
 
 
 def test_impersonate_user_with_token(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -666,6 +666,9 @@ def test_get_oauth2_fresh_token_native(
 
 
 def _oauth2_state() -> OAuth2State:
+    """
+    Build the default OAuth2 state shared by the OAuth2 tests.
+    """
     state: OAuth2State = {
         "database_id": 1,
         "user_id": 1,

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -311,19 +311,80 @@ def test_oauth2_attributes() -> None:
     """
     # Test DatabricksNativeEngineSpec
     assert DatabricksNativeEngineSpec.supports_oauth2 is True
-    assert DatabricksNativeEngineSpec.oauth2_exception is OAuth2RedirectError
     assert DatabricksNativeEngineSpec.oauth2_scope == "sql"
-    # OAuth2 endpoints are now dynamic and set at runtime
+    # The authorization endpoint is derived from the workspace host at runtime;
+    # the token endpoint must be configured explicitly.
     assert DatabricksNativeEngineSpec.oauth2_authorization_request_uri == ""
     assert DatabricksNativeEngineSpec.oauth2_token_request_uri == ""
 
     # Test DatabricksPythonConnectorEngineSpec
     assert DatabricksPythonConnectorEngineSpec.supports_oauth2 is True
-    assert DatabricksPythonConnectorEngineSpec.oauth2_exception is OAuth2RedirectError
     assert DatabricksPythonConnectorEngineSpec.oauth2_scope == "sql"
-    # OAuth2 endpoints are now dynamic and set at runtime
     assert DatabricksPythonConnectorEngineSpec.oauth2_authorization_request_uri == ""
     assert DatabricksPythonConnectorEngineSpec.oauth2_token_request_uri == ""
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Error during request to server: HTTP 401 Unauthorized",
+        "Invalid access token",
+        "The access token expired",
+        "UNAUTHENTICATED: token is no longer valid",
+    ],
+)
+def test_needs_oauth2_detects_auth_failure_from_message(
+    mocker: MockerFixture,
+    spec: Any,
+    message: str,
+) -> None:
+    """
+    The Databricks driver has no dedicated auth exception, so `needs_oauth2`
+    matches auth-failure signals in the error message to bootstrap a re-auth.
+    """
+    g = mocker.patch("superset.db_engine_specs.databricks.g")
+    g.user = mocker.MagicMock()
+
+    assert spec.needs_oauth2(Exception(message)) is True
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+def test_needs_oauth2_ignores_unrelated_errors(
+    mocker: MockerFixture,
+    spec: Any,
+) -> None:
+    """
+    A non-auth driver error must not trigger the OAuth2 dance.
+    """
+    g = mocker.patch("superset.db_engine_specs.databricks.g")
+    g.user = mocker.MagicMock()
+
+    assert spec.needs_oauth2(Exception("Table not found")) is False
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+def test_needs_oauth2_matches_oauth2_redirect_error(
+    mocker: MockerFixture,
+    spec: Any,
+) -> None:
+    """
+    The inherited `isinstance` check against `oauth2_exception` still holds.
+    """
+    g = mocker.patch("superset.db_engine_specs.databricks.g")
+    g.user = mocker.MagicMock()
+
+    ex = OAuth2RedirectError("https://example/authorize", "tab", "redirect")
+    assert spec.needs_oauth2(ex) is True
 
 
 def test_impersonate_user_with_token(mocker: MockerFixture) -> None:
@@ -699,48 +760,33 @@ def _unresolved_oauth2_config() -> OAuth2ClientConfig:
     [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
 )
 @pytest.mark.parametrize(
-    "extra, netloc, path",
+    "host",
     [
-        (
-            {"cloud_provider": "aws", "account_id": "acct-999"},
-            "accounts.cloud.databricks.com",
-            "/oidc/accounts/acct-999/v1/authorize",
-        ),
-        (
-            {"cloud_provider": "azure", "tenant_id": "tenant-abc"},
-            "login.microsoftonline.com",
-            "/tenant-abc/oauth2/v2.0/authorize",
-        ),
-        (
-            {"cloud_provider": "gcp", "account_id": "acct-gcp"},
-            "accounts.gcp.databricks.com",
-            "/oidc/accounts/acct-gcp/v1/authorize",
-        ),
+        "dbc-abc.cloud.databricks.com",
+        "adb-123456789.12.azuredatabricks.net",
+        "123456789.gcp.databricks.com",
     ],
 )
-def test_get_oauth2_authorization_uri_autodetects_and_resolves(
+def test_get_oauth2_authorization_uri_derives_from_workspace_host(
     mocker: MockerFixture,
     spec: Any,
-    extra: dict[str, Any],
-    netloc: str,
-    path: str,
+    host: str,
 ) -> None:
     """
-    With no configured `authorization_request_uri`, the endpoint is auto-detected
-    per cloud provider and the `account_id`/`tenant_id` placeholder is resolved
-    from the database `extra`.
+    With no configured `authorization_request_uri`, the endpoint is derived from
+    the workspace host (`https://<host>/oidc/v1/authorize`) on every cloud, with
+    no account/tenant identifier required.
     """
     database = mocker.MagicMock()
-    database.extra = json.dumps(extra)
-    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    database.url_object.host = host
     mocker.patch("superset.db.session.get", return_value=database)
 
     url = spec.get_oauth2_authorization_uri(
         _unresolved_oauth2_config(), _oauth2_state()
     )
     parsed = urlparse(url)
-    assert parsed.netloc == netloc
-    assert parsed.path == path
+    assert parsed.netloc == host
+    assert parsed.path == "/oidc/v1/authorize"
 
 
 @pytest.mark.parametrize(
@@ -753,7 +799,7 @@ def test_get_oauth2_authorization_uri_preserves_configured(
 ) -> None:
     """
     A fully-resolved `authorization_request_uri` is never overwritten by the
-    auto-detected template, and no database lookup is needed.
+    host-derived endpoint, and no database lookup is needed.
     """
     session_get = mocker.patch("superset.db.session.get")
     config = _unresolved_oauth2_config()
@@ -770,17 +816,16 @@ def test_get_oauth2_authorization_uri_preserves_configured(
     "spec",
     [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
 )
-def test_get_oauth2_authorization_uri_fails_without_account_id(
+def test_get_oauth2_authorization_uri_fails_without_host(
     mocker: MockerFixture,
     spec: Any,
 ) -> None:
     """
-    When the endpoint must be auto-detected but no `account_id`/`tenant_id` is
-    available, fail fast instead of emitting an unresolved `.../{}/...` URL.
+    When the endpoint must be derived but the connection has no host, fail fast
+    instead of emitting an invalid `https:///oidc/v1/authorize` URL.
     """
     database = mocker.MagicMock()
-    database.extra = json.dumps({"cloud_provider": "aws"})
-    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    database.url_object.host = None
     mocker.patch("superset.db.session.get", return_value=database)
 
     with pytest.raises(OAuth2Error):

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -335,6 +335,7 @@ def test_oauth2_attributes() -> None:
         "Invalid access token",
         "The access token expired",
         "UNAUTHENTICATED: token is no longer valid",
+        "RuntimeError: No valid authentication settings!",
     ],
 )
 def test_needs_oauth2_detects_auth_failure_from_message(

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -422,9 +422,11 @@ def test_impersonate_user_with_token(mocker: MockerFixture) -> None:
     assert kwargs["connect_args"]["access_token"] == "user-oauth-token"  # noqa: S105
 
 
-def test_impersonate_user_without_token(mocker: MockerFixture) -> None:
+def test_impersonate_user_without_token_forces_oauth2(mocker: MockerFixture) -> None:
     """
-    Test impersonate_user method without OAuth2 token.
+    Without a user token, impersonate_user clears any stored credential so the
+    driver fails authentication and the OAuth2 dance is bootstrapped, rather than
+    silently connecting with a stale credential.
     """
     database = mocker.MagicMock()
     original_url = make_url(
@@ -441,9 +443,9 @@ def test_impersonate_user_without_token(mocker: MockerFixture) -> None:
         engine_kwargs=engine_kwargs,
     )
 
-    # Check that nothing was changed
-    assert url.password == "original-token"  # noqa: S105
-    assert kwargs["connect_args"]["access_token"] == "original-token"  # noqa: S105
+    # The stored credential is cleared in both the URL and connect_args
+    assert url.password == ""  # noqa: S105
+    assert kwargs["connect_args"]["access_token"] == ""  # noqa: S105
 
 
 def test_impersonate_user_python_connector(mocker: MockerFixture) -> None:
@@ -469,6 +471,129 @@ def test_impersonate_user_python_connector(mocker: MockerFixture) -> None:
     assert url.password == "user-oauth-token"  # noqa: S105
     # Check that access_token was updated in connect_args
     assert kwargs["connect_args"]["access_token"] == "user-oauth-token"  # noqa: S105
+
+
+def test_impersonate_user_python_connector_without_token_forces_oauth2(
+    mocker: MockerFixture,
+) -> None:
+    """
+    The Python connector path also clears the credential when no user token is
+    available, so per-user OAuth2 is enforced rather than falling back to a stale
+    connection-level token.
+    """
+    database = mocker.MagicMock()
+    original_url = make_url(
+        "databricks://token:original-token@host:443?http_path=path&catalog=main&schema=default"
+    )
+    engine_kwargs = {"connect_args": {"access_token": "original-token"}}
+
+    url, kwargs = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database=database,
+        username="user1",
+        user_token=None,
+        url=original_url,
+        engine_kwargs=engine_kwargs,
+    )
+
+    assert url.password == ""  # noqa: S105
+    assert kwargs["connect_args"]["access_token"] == ""  # noqa: S105
+
+
+def test_impersonate_user_without_connect_args_token(mocker: MockerFixture) -> None:
+    """
+    When ``connect_args`` carries no ``access_token`` (the URL-only auth path), the
+    token is applied to the URL password and no spurious ``access_token`` key is
+    introduced into ``connect_args``.
+    """
+    database = mocker.MagicMock()
+    original_url = make_url(
+        "databricks+connector://token:original-token@host:443/database"
+    )
+    engine_kwargs: dict[str, Any] = {"connect_args": {"http_path": "/sql/path"}}
+
+    url, kwargs = DatabricksNativeEngineSpec.impersonate_user(
+        database=database,
+        username="user1",
+        user_token="user-oauth-token",  # noqa: S106
+        url=original_url,
+        engine_kwargs=engine_kwargs,
+    )
+
+    assert url.password == "user-oauth-token"  # noqa: S105
+    assert "access_token" not in kwargs["connect_args"]
+    # Unrelated connect_args are preserved
+    assert kwargs["connect_args"]["http_path"] == "/sql/path"
+
+
+def test_update_params_strips_oauth2_client_info(mocker: MockerFixture) -> None:
+    """
+    ``oauth2_client_info`` is the per-database OAuth2 client config consumed by
+    ``Database.get_oauth2_config``; it must not leak into the driver connection
+    params, while the rest of ``encrypted_extra`` is still merged.
+    """
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "oauth2_client_info": {
+                "id": "client-id",
+                "secret": "client-secret",
+                "authorization_request_uri": "https://host/oidc/v1/authorize",
+                "token_request_uri": "https://host/oidc/v1/token",
+            },
+            "http_headers": [["X-Custom", "value"]],
+        }
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "oauth2_client_info" not in params
+    assert params == {"http_headers": [["X-Custom", "value"]]}
+
+
+def test_update_params_no_encrypted_extra(mocker: MockerFixture) -> None:
+    """
+    A database without ``encrypted_extra`` leaves the params untouched.
+    """
+    database = mocker.MagicMock()
+    database.encrypted_extra = None
+    params: dict[str, Any] = {"existing": "value"}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {"existing": "value"}
+
+
+def test_update_params_merges_when_no_oauth2_client_info(
+    mocker: MockerFixture,
+) -> None:
+    """
+    ``encrypted_extra`` without an ``oauth2_client_info`` block is merged in full,
+    so the strip never removes legitimate driver params.
+    """
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps(
+        {"http_headers": [["X-Custom", "value"]], "_tls_verify_hostname": True}
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {
+        "http_headers": [["X-Custom", "value"]],
+        "_tls_verify_hostname": True,
+    }
+
+
+def test_update_params_invalid_encrypted_extra_raises(mocker: MockerFixture) -> None:
+    """
+    Malformed ``encrypted_extra`` JSON raises rather than silently connecting.
+    """
+    database = mocker.MagicMock()
+    database.encrypted_extra = "{not valid json"
+
+    with pytest.raises(json.JSONDecodeError):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
 
 
 @pytest.fixture

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -356,9 +356,18 @@ def test_needs_oauth2_detects_auth_failure_from_message(
     "spec",
     [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
 )
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Table not found",
+        # A bare 401 in an unrelated position must not look like an auth failure.
+        "Query failed at line 401: syntax error",
+    ],
+)
 def test_needs_oauth2_ignores_unrelated_errors(
     mocker: MockerFixture,
     spec: Any,
+    message: str,
 ) -> None:
     """
     A non-auth driver error must not trigger the OAuth2 dance.
@@ -366,7 +375,7 @@ def test_needs_oauth2_ignores_unrelated_errors(
     g = mocker.patch("superset.db_engine_specs.databricks.g")
     g.user = mocker.MagicMock()
 
-    assert spec.needs_oauth2(Exception("Table not found")) is False
+    assert spec.needs_oauth2(Exception(message)) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -17,19 +17,20 @@
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.engine.url import make_url
 
+from superset.db_engine_specs.base import OAuth2State
 from superset.db_engine_specs.databricks import (
     DatabricksNativeEngineSpec,
     DatabricksPythonConnectorEngineSpec,
 )
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import OAuth2RedirectError
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.superset_typing import OAuth2ClientConfig
 from superset.utils import json
 from superset.utils.oauth2 import decode_oauth2_state
@@ -662,6 +663,141 @@ def test_get_oauth2_fresh_token_native(
         },
         timeout=30.0,
     )
+
+
+def _oauth2_state() -> OAuth2State:
+    state: OAuth2State = {
+        "database_id": 1,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+    return state
+
+
+def _unresolved_oauth2_config() -> OAuth2ClientConfig:
+    """
+    Config as built by `get_oauth2_config` when no endpoints are overridden:
+    the URIs default to the spec's empty class attributes.
+    """
+    return {
+        "id": "databricks-client-id",
+        "secret": "databricks-client-secret",
+        "scope": "sql",
+        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "authorization_request_uri": "",
+        "token_request_uri": "",
+        "request_content_type": "json",
+    }
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+@pytest.mark.parametrize(
+    "extra, netloc, path",
+    [
+        (
+            {"cloud_provider": "aws", "account_id": "acct-999"},
+            "accounts.cloud.databricks.com",
+            "/oidc/accounts/acct-999/v1/authorize",
+        ),
+        (
+            {"cloud_provider": "azure", "tenant_id": "tenant-abc"},
+            "login.microsoftonline.com",
+            "/tenant-abc/oauth2/v2.0/authorize",
+        ),
+        (
+            {"cloud_provider": "gcp", "account_id": "acct-gcp"},
+            "accounts.gcp.databricks.com",
+            "/oidc/accounts/acct-gcp/v1/authorize",
+        ),
+    ],
+)
+def test_get_oauth2_authorization_uri_autodetects_and_resolves(
+    mocker: MockerFixture,
+    spec: Any,
+    extra: dict[str, Any],
+    netloc: str,
+    path: str,
+) -> None:
+    """
+    With no configured `authorization_request_uri`, the endpoint is auto-detected
+    per cloud provider and the `account_id`/`tenant_id` placeholder is resolved
+    from the database `extra`.
+    """
+    database = mocker.MagicMock()
+    database.extra = json.dumps(extra)
+    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    mocker.patch("superset.db.session.get", return_value=database)
+
+    url = spec.get_oauth2_authorization_uri(
+        _unresolved_oauth2_config(), _oauth2_state()
+    )
+    parsed = urlparse(url)
+    assert parsed.netloc == netloc
+    assert parsed.path == path
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+def test_get_oauth2_authorization_uri_preserves_configured(
+    mocker: MockerFixture,
+    spec: Any,
+) -> None:
+    """
+    A fully-resolved `authorization_request_uri` is never overwritten by the
+    auto-detected template, and no database lookup is needed.
+    """
+    session_get = mocker.patch("superset.db.session.get")
+    config = _unresolved_oauth2_config()
+    config["authorization_request_uri"] = (
+        "https://accounts.cloud.databricks.com/oidc/accounts/override/v1/authorize"
+    )
+
+    url = spec.get_oauth2_authorization_uri(config, _oauth2_state())
+    assert urlparse(url).path == "/oidc/accounts/override/v1/authorize"
+    session_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+def test_get_oauth2_authorization_uri_fails_without_account_id(
+    mocker: MockerFixture,
+    spec: Any,
+) -> None:
+    """
+    When the endpoint must be auto-detected but no `account_id`/`tenant_id` is
+    available, fail fast instead of emitting an unresolved `.../{}/...` URL.
+    """
+    database = mocker.MagicMock()
+    database.extra = json.dumps({"cloud_provider": "aws"})
+    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    mocker.patch("superset.db.session.get", return_value=database)
+
+    with pytest.raises(OAuth2Error):
+        spec.get_oauth2_authorization_uri(_unresolved_oauth2_config(), _oauth2_state())
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec],
+)
+def test_get_oauth2_token_fails_without_uri(
+    mocker: MockerFixture,
+    spec: Any,
+) -> None:
+    """
+    Token exchange has no database context to auto-detect the endpoint, so a
+    missing `token_request_uri` fails fast rather than POSTing to `.../{}/...`.
+    """
+    with pytest.raises(OAuth2Error):
+        spec.get_oauth2_token(_unresolved_oauth2_config(), "authorization-code")
 
 
 def test_get_oauth2_fresh_token_python(

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -32,7 +33,7 @@ from superset.utils.oauth2 import decode_oauth2_state
 
 
 @pytest.fixture
-def mock_database_aws(mocker: MockerFixture):
+def mock_database_aws(mocker: MockerFixture) -> MagicMock:
     """
     Mock database with AWS hostname.
     """
@@ -44,7 +45,7 @@ def mock_database_aws(mocker: MockerFixture):
 
 
 @pytest.fixture
-def mock_database_azure(mocker: MockerFixture):
+def mock_database_azure(mocker: MockerFixture) -> MagicMock:
     """
     Mock database with Azure hostname.
     """
@@ -56,7 +57,7 @@ def mock_database_azure(mocker: MockerFixture):
 
 
 @pytest.fixture
-def mock_database_gcp(mocker: MockerFixture):
+def mock_database_gcp(mocker: MockerFixture) -> MagicMock:
     """
     Mock database with GCP hostname.
     """
@@ -83,7 +84,7 @@ def oauth2_config() -> OAuth2ClientConfig:
     }
 
 
-def test_cloud_provider_detection_aws(mock_database_aws) -> None:
+def test_cloud_provider_detection_aws(mock_database_aws: MagicMock) -> None:
     """
     Test cloud provider detection for AWS.
     """
@@ -91,7 +92,7 @@ def test_cloud_provider_detection_aws(mock_database_aws) -> None:
     assert provider == "aws"
 
 
-def test_cloud_provider_detection_azure(mock_database_azure) -> None:
+def test_cloud_provider_detection_azure(mock_database_azure: MagicMock) -> None:
     """
     Test cloud provider detection for Azure.
     """
@@ -99,7 +100,7 @@ def test_cloud_provider_detection_azure(mock_database_azure) -> None:
     assert provider == "azure"
 
 
-def test_cloud_provider_detection_gcp(mock_database_gcp) -> None:
+def test_cloud_provider_detection_gcp(mock_database_gcp: MagicMock) -> None:
     """
     Test cloud provider detection for GCP.
     """
@@ -128,7 +129,7 @@ def test_cloud_provider_detection_explicit_config(mocker: MockerFixture) -> None
 def test_get_oauth2_authorization_uri_aws(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,
-    mock_database_aws,
+    mock_database_aws: MagicMock,
 ) -> None:
     """
     Test OAuth2 authorization URI generation for AWS provider.
@@ -160,7 +161,7 @@ def test_get_oauth2_authorization_uri_aws(
 def test_get_oauth2_authorization_uri_azure(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,
-    mock_database_azure,
+    mock_database_azure: MagicMock,
 ) -> None:
     """
     Test OAuth2 authorization URI generation for Azure provider.
@@ -191,7 +192,7 @@ def test_get_oauth2_authorization_uri_azure(
 def test_get_oauth2_authorization_uri_gcp(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,
-    mock_database_gcp,
+    mock_database_gcp: MagicMock,
 ) -> None:
     """
     Test OAuth2 authorization URI generation for GCP provider.
@@ -220,7 +221,9 @@ def test_get_oauth2_authorization_uri_gcp(
     assert decode_oauth2_state(encoded_state) == state
 
 
-def test_python_connector_cloud_provider_detection_azure(mock_database_azure) -> None:
+def test_python_connector_cloud_provider_detection_azure(
+    mock_database_azure: MagicMock,
+) -> None:
     """
     Test cloud provider detection for Python Connector with Azure.
     """
@@ -233,7 +236,7 @@ def test_python_connector_cloud_provider_detection_azure(mock_database_azure) ->
 def test_python_connector_oauth2_authorization_uri_azure(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,
-    mock_database_azure,
+    mock_database_azure: MagicMock,
 ) -> None:
     """
     Test OAuth2 authorization URI generation for Python Connector with Azure provider.

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -1,0 +1,263 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument, import-outside-toplevel, protected-access
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.db_engine_specs.databricks import (
+    DatabricksNativeEngineSpec,
+    DatabricksPythonConnectorEngineSpec,
+)
+from superset.superset_typing import OAuth2ClientConfig
+from superset.utils.oauth2 import decode_oauth2_state
+
+# Multi-Cloud Provider Tests
+
+
+@pytest.fixture
+def mock_database_aws(mocker: MockerFixture):
+    """
+    Mock database with AWS hostname.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "my-cluster.cloud.databricks.com"
+    database.extra = "{}"
+    database.id = 1
+    return database
+
+
+@pytest.fixture
+def mock_database_azure(mocker: MockerFixture):
+    """
+    Mock database with Azure hostname.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
+    database.extra = "{}"
+    database.id = 2
+    return database
+
+
+@pytest.fixture
+def mock_database_gcp(mocker: MockerFixture):
+    """
+    Mock database with GCP hostname.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "123456789.gcp.databricks.com"
+    database.extra = "{}"
+    database.id = 3
+    return database
+
+
+@pytest.fixture
+def oauth2_config() -> OAuth2ClientConfig:
+    """
+    Config for Databricks OAuth2.
+    """
+    return {
+        "id": "databricks-client-id",
+        "secret": "databricks-client-secret",
+        "scope": "sql",
+        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/authorize",
+        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        "request_content_type": "json",
+    }
+
+
+def test_cloud_provider_detection_aws(mock_database_aws) -> None:
+    """
+    Test cloud provider detection for AWS.
+    """
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_aws)
+    assert provider == "aws"
+
+
+def test_cloud_provider_detection_azure(mock_database_azure) -> None:
+    """
+    Test cloud provider detection for Azure.
+    """
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_azure)
+    assert provider == "azure"
+
+
+def test_cloud_provider_detection_gcp(mock_database_gcp) -> None:
+    """
+    Test cloud provider detection for GCP.
+    """
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_gcp)
+    assert provider == "gcp"
+
+
+def test_cloud_provider_detection_explicit_config(mocker: MockerFixture) -> None:
+    """
+    Test cloud provider detection with explicit configuration.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "generic-host.com"
+
+    # Mock get_extra_params to return explicit cloud provider
+    mocker.patch.object(
+        DatabricksNativeEngineSpec,
+        "get_extra_params",
+        return_value={"cloud_provider": "azure"},
+    )
+
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
+    assert provider == "azure"
+
+
+def test_get_oauth2_authorization_uri_aws(
+    mocker: MockerFixture,
+    oauth2_config: OAuth2ClientConfig,
+    mock_database_aws,
+) -> None:
+    """
+    Test OAuth2 authorization URI generation for AWS provider.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    # Mock the database query
+    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_aws)
+
+    state: OAuth2State = {
+        "database_id": 1,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    parsed = urlparse(url)
+    assert parsed.netloc == "accounts.cloud.databricks.com"
+    assert "/oidc/accounts/" in parsed.path
+    assert "/v1/authorize" in parsed.path
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state
+
+
+def test_get_oauth2_authorization_uri_azure(
+    mocker: MockerFixture,
+    oauth2_config: OAuth2ClientConfig,
+    mock_database_azure,
+) -> None:
+    """
+    Test OAuth2 authorization URI generation for Azure provider.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    # Mock the database query
+    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_azure)
+
+    state: OAuth2State = {
+        "database_id": 2,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    parsed = urlparse(url)
+    assert parsed.netloc == "login.microsoftonline.com"
+    assert "/oauth2/v2.0/authorize" in parsed.path
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state
+
+
+def test_get_oauth2_authorization_uri_gcp(
+    mocker: MockerFixture,
+    oauth2_config: OAuth2ClientConfig,
+    mock_database_gcp,
+) -> None:
+    """
+    Test OAuth2 authorization URI generation for GCP provider.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    # Mock the database query
+    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_gcp)
+
+    state: OAuth2State = {
+        "database_id": 3,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    parsed = urlparse(url)
+    assert parsed.netloc == "accounts.gcp.databricks.com"
+    assert "/oidc/accounts/" in parsed.path
+    assert "/v1/authorize" in parsed.path
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state
+
+
+def test_python_connector_cloud_provider_detection_azure(mock_database_azure) -> None:
+    """
+    Test cloud provider detection for Python Connector with Azure.
+    """
+    provider = DatabricksPythonConnectorEngineSpec._detect_cloud_provider(
+        mock_database_azure
+    )
+    assert provider == "azure"
+
+
+def test_python_connector_oauth2_authorization_uri_azure(
+    mocker: MockerFixture,
+    oauth2_config: OAuth2ClientConfig,
+    mock_database_azure,
+) -> None:
+    """
+    Test OAuth2 authorization URI generation for Python Connector with Azure provider.
+    """
+    from superset.db_engine_specs.base import OAuth2State
+
+    # Mock the database query
+    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_azure)
+
+    state: OAuth2State = {
+        "database_id": 2,
+        "user_id": 1,
+        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "tab_id": "1234",
+    }
+
+    url = DatabricksPythonConnectorEngineSpec.get_oauth2_authorization_uri(
+        oauth2_config, state
+    )
+    parsed = urlparse(url)
+    assert parsed.netloc == "login.microsoftonline.com"
+    assert "/oauth2/v2.0/authorize" in parsed.path
+
+    query = parse_qs(parsed.query)
+    assert query["scope"][0] == "sql"
+    encoded_state = query["state"][0].replace("%2E", ".")
+    assert decode_oauth2_state(encoded_state) == state

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -65,6 +65,9 @@ def oauth2_config_no_uri() -> OAuth2ClientConfig:
 
 
 def _mock_database(mocker: MockerFixture, host: str) -> MagicMock:
+    """
+    Build a mock database whose URL resolves to the given workspace host.
+    """
     database = mocker.MagicMock()
     database.url_object.host = host
     database.id = 1

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -88,7 +88,7 @@ def test_get_oauth2_authorization_uri_uses_workspace_host(
     from superset.db_engine_specs.base import OAuth2State
 
     mocker.patch(
-        "superset.extensions.db.session.get",
+        "superset.db.session.get",
         return_value=_mock_database(mocker, host),
     )
 

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
+from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
@@ -30,65 +31,27 @@ from superset.superset_typing import OAuth2ClientConfig
 from superset.utils.oauth2 import decode_oauth2_state
 
 # Multi-Cloud Provider Tests
+#
+# Databricks fronts the user-to-machine OAuth2 flow on every workspace at
+# `https://<workspace-host>/oidc/v1/{authorize,token}`, regardless of cloud, so
+# the authorization endpoint derives from the connection host with no per-cloud
+# account/tenant identifier.
 
+SPECS = [DatabricksNativeEngineSpec, DatabricksPythonConnectorEngineSpec]
 
-@pytest.fixture
-def mock_database_aws(mocker: MockerFixture) -> MagicMock:
-    """
-    Mock database with AWS hostname.
-    """
-    database = mocker.MagicMock()
-    database.url_object.host = "my-cluster.cloud.databricks.com"
-    database.extra = "{}"
-    database.id = 1
-    return database
-
-
-@pytest.fixture
-def mock_database_azure(mocker: MockerFixture) -> MagicMock:
-    """
-    Mock database with Azure hostname.
-    """
-    database = mocker.MagicMock()
-    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
-    database.extra = '{"tenant_id": "azure-tenant-id"}'
-    database.id = 2
-    return database
-
-
-@pytest.fixture
-def mock_database_gcp(mocker: MockerFixture) -> MagicMock:
-    """
-    Mock database with GCP hostname.
-    """
-    database = mocker.MagicMock()
-    database.url_object.host = "123456789.gcp.databricks.com"
-    database.extra = '{"account_id": "12345"}'
-    database.id = 3
-    return database
-
-
-@pytest.fixture
-def oauth2_config() -> OAuth2ClientConfig:
-    """
-    Config for Databricks OAuth2 with a fully-resolved endpoint configured.
-    """
-    return {
-        "id": "databricks-client-id",
-        "secret": "databricks-client-secret",
-        "scope": "sql",
-        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
-        "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/authorize",
-        "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
-        "request_content_type": "json",
-    }
+# Representative workspace hosts for each cloud provider.
+CLOUD_HOSTS = [
+    "my-cluster.cloud.databricks.com",  # AWS
+    "adb-123456789.12.azuredatabricks.net",  # Azure
+    "123456789.gcp.databricks.com",  # GCP
+]
 
 
 @pytest.fixture
 def oauth2_config_no_uri() -> OAuth2ClientConfig:
     """
     Config for Databricks OAuth2 without a pre-configured endpoint, so the
-    per-provider endpoint is auto-detected and account-resolved.
+    authorization endpoint is derived from the workspace host.
     """
     return {
         "id": "databricks-client-id",
@@ -101,100 +64,30 @@ def oauth2_config_no_uri() -> OAuth2ClientConfig:
     }
 
 
-def test_cloud_provider_detection_aws(mock_database_aws: MagicMock) -> None:
-    """
-    Test cloud provider detection for AWS.
-    """
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_aws)
-    assert provider == "aws"
-
-
-def test_cloud_provider_detection_azure(mock_database_azure: MagicMock) -> None:
-    """
-    Test cloud provider detection for Azure.
-    """
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_azure)
-    assert provider == "azure"
-
-
-def test_cloud_provider_detection_gcp(mock_database_gcp: MagicMock) -> None:
-    """
-    Test cloud provider detection for GCP.
-    """
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(mock_database_gcp)
-    assert provider == "gcp"
-
-
-def test_cloud_provider_detection_explicit_config(mocker: MockerFixture) -> None:
-    """
-    Test cloud provider detection with explicit configuration.
-    """
+def _mock_database(mocker: MockerFixture, host: str) -> MagicMock:
     database = mocker.MagicMock()
-    database.url_object.host = "generic-host.com"
-
-    # Mock get_extra_params to return explicit cloud provider
-    mocker.patch.object(
-        DatabricksNativeEngineSpec,
-        "get_extra_params",
-        return_value={"cloud_provider": "azure"},
-    )
-
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
-    assert provider == "azure"
+    database.url_object.host = host
+    database.id = 1
+    return database
 
 
-def test_cloud_provider_detection_invalid_config_falls_back_to_hostname(
+@pytest.mark.parametrize("spec", SPECS)
+@pytest.mark.parametrize("host", CLOUD_HOSTS)
+def test_get_oauth2_authorization_uri_uses_workspace_host(
     mocker: MockerFixture,
+    spec: Any,
+    host: str,
+    oauth2_config_no_uri: OAuth2ClientConfig,
 ) -> None:
     """
-    An unrecognized explicit `cloud_provider` is ignored and detection falls
-    back to the hostname rather than raising or returning the bad value.
-    """
-    database = mocker.MagicMock()
-    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
-
-    mocker.patch.object(
-        DatabricksNativeEngineSpec,
-        "get_extra_params",
-        return_value={"cloud_provider": "oracle"},
-    )
-
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
-    assert provider == "azure"
-
-
-def test_cloud_provider_detection_non_string_falls_back_to_hostname(
-    mocker: MockerFixture,
-) -> None:
-    """
-    A non-string `cloud_provider` (e.g. a boolean from malformed JSON) is
-    ignored without raising and detection falls back to the hostname.
-    """
-    database = mocker.MagicMock()
-    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
-
-    mocker.patch.object(
-        DatabricksNativeEngineSpec,
-        "get_extra_params",
-        return_value={"cloud_provider": True},
-    )
-
-    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
-    assert provider == "azure"
-
-
-def test_get_oauth2_authorization_uri_aws(
-    mocker: MockerFixture,
-    oauth2_config: OAuth2ClientConfig,
-    mock_database_aws: MagicMock,
-) -> None:
-    """
-    Test OAuth2 authorization URI generation for AWS provider.
+    The authorization endpoint is the workspace host on AWS, Azure, and GCP.
     """
     from superset.db_engine_specs.base import OAuth2State
 
-    # Mock the database query
-    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_aws)
+    mocker.patch(
+        "superset.extensions.db.session.get",
+        return_value=_mock_database(mocker, host),
+    )
 
     state: OAuth2State = {
         "database_id": 1,
@@ -203,11 +96,10 @@ def test_get_oauth2_authorization_uri_aws(
         "tab_id": "1234",
     }
 
-    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    url = spec.get_oauth2_authorization_uri(oauth2_config_no_uri, state)
     parsed = urlparse(url)
-    assert parsed.netloc == "accounts.cloud.databricks.com"
-    assert "/oidc/accounts/" in parsed.path
-    assert "/v1/authorize" in parsed.path
+    assert parsed.netloc == host
+    assert parsed.path == "/oidc/v1/authorize"
 
     query = parse_qs(parsed.query)
     assert query["scope"][0] == "sql"
@@ -215,113 +107,18 @@ def test_get_oauth2_authorization_uri_aws(
     assert decode_oauth2_state(encoded_state) == state
 
 
-def test_get_oauth2_authorization_uri_azure(
+@pytest.mark.parametrize("spec", SPECS)
+@pytest.mark.parametrize("host", CLOUD_HOSTS)
+def test_workspace_oauth2_endpoint_builds_token_uri(
     mocker: MockerFixture,
-    oauth2_config_no_uri: OAuth2ClientConfig,
-    mock_database_azure: MagicMock,
+    spec: Any,
+    host: str,
 ) -> None:
     """
-    Test OAuth2 authorization URI generation for Azure provider.
+    The helper builds the matching token endpoint from the same workspace host.
     """
-    from superset.db_engine_specs.base import OAuth2State
-
-    # Mock the database query
-    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_azure)
-
-    state: OAuth2State = {
-        "database_id": 2,
-        "user_id": 1,
-        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
-        "tab_id": "1234",
-    }
-
-    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(
-        oauth2_config_no_uri, state
+    database = _mock_database(mocker, host)
+    assert (
+        spec._workspace_oauth2_endpoint(database, "token")
+        == f"https://{host}/oidc/v1/token"
     )
-    parsed = urlparse(url)
-    assert parsed.netloc == "login.microsoftonline.com"
-    assert "/oauth2/v2.0/authorize" in parsed.path
-
-    query = parse_qs(parsed.query)
-    assert query["scope"][0] == "sql"
-    encoded_state = query["state"][0].replace("%2E", ".")
-    assert decode_oauth2_state(encoded_state) == state
-
-
-def test_get_oauth2_authorization_uri_gcp(
-    mocker: MockerFixture,
-    oauth2_config_no_uri: OAuth2ClientConfig,
-    mock_database_gcp: MagicMock,
-) -> None:
-    """
-    Test OAuth2 authorization URI generation for GCP provider.
-    """
-    from superset.db_engine_specs.base import OAuth2State
-
-    # Mock the database query
-    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_gcp)
-
-    state: OAuth2State = {
-        "database_id": 3,
-        "user_id": 1,
-        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
-        "tab_id": "1234",
-    }
-
-    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(
-        oauth2_config_no_uri, state
-    )
-    parsed = urlparse(url)
-    assert parsed.netloc == "accounts.gcp.databricks.com"
-    assert "/oidc/accounts/" in parsed.path
-    assert "/v1/authorize" in parsed.path
-
-    query = parse_qs(parsed.query)
-    assert query["scope"][0] == "sql"
-    encoded_state = query["state"][0].replace("%2E", ".")
-    assert decode_oauth2_state(encoded_state) == state
-
-
-def test_python_connector_cloud_provider_detection_azure(
-    mock_database_azure: MagicMock,
-) -> None:
-    """
-    Test cloud provider detection for Python Connector with Azure.
-    """
-    provider = DatabricksPythonConnectorEngineSpec._detect_cloud_provider(
-        mock_database_azure
-    )
-    assert provider == "azure"
-
-
-def test_python_connector_oauth2_authorization_uri_azure(
-    mocker: MockerFixture,
-    oauth2_config_no_uri: OAuth2ClientConfig,
-    mock_database_azure: MagicMock,
-) -> None:
-    """
-    Test OAuth2 authorization URI generation for Python Connector with Azure provider.
-    """
-    from superset.db_engine_specs.base import OAuth2State
-
-    # Mock the database query
-    mocker.patch("superset.extensions.db.session.get", return_value=mock_database_azure)
-
-    state: OAuth2State = {
-        "database_id": 2,
-        "user_id": 1,
-        "default_redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
-        "tab_id": "1234",
-    }
-
-    url = DatabricksPythonConnectorEngineSpec.get_oauth2_authorization_uri(
-        oauth2_config_no_uri, state
-    )
-    parsed = urlparse(url)
-    assert parsed.netloc == "login.microsoftonline.com"
-    assert "/oauth2/v2.0/authorize" in parsed.path
-
-    query = parse_qs(parsed.query)
-    assert query["scope"][0] == "sql"
-    encoded_state = query["state"][0].replace("%2E", ".")
-    assert decode_oauth2_state(encoded_state) == state

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -143,6 +143,26 @@ def test_cloud_provider_detection_explicit_config(mocker: MockerFixture) -> None
     assert provider == "azure"
 
 
+def test_cloud_provider_detection_invalid_config_falls_back_to_hostname(
+    mocker: MockerFixture,
+) -> None:
+    """
+    An unrecognized explicit `cloud_provider` is ignored and detection falls
+    back to the hostname rather than raising or returning the bad value.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
+
+    mocker.patch.object(
+        DatabricksNativeEngineSpec,
+        "get_extra_params",
+        return_value={"cloud_provider": "oracle"},
+    )
+
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
+    assert provider == "azure"
+
+
 def test_get_oauth2_authorization_uri_aws(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -51,7 +51,7 @@ def mock_database_azure(mocker: MockerFixture) -> MagicMock:
     """
     database = mocker.MagicMock()
     database.url_object.host = "adb-123456789.12.azuredatabricks.net"
-    database.extra = "{}"
+    database.extra = '{"tenant_id": "azure-tenant-id"}'
     database.id = 2
     return database
 
@@ -63,7 +63,7 @@ def mock_database_gcp(mocker: MockerFixture) -> MagicMock:
     """
     database = mocker.MagicMock()
     database.url_object.host = "123456789.gcp.databricks.com"
-    database.extra = "{}"
+    database.extra = '{"account_id": "12345"}'
     database.id = 3
     return database
 
@@ -71,7 +71,7 @@ def mock_database_gcp(mocker: MockerFixture) -> MagicMock:
 @pytest.fixture
 def oauth2_config() -> OAuth2ClientConfig:
     """
-    Config for Databricks OAuth2.
+    Config for Databricks OAuth2 with a fully-resolved endpoint configured.
     """
     return {
         "id": "databricks-client-id",
@@ -80,6 +80,23 @@ def oauth2_config() -> OAuth2ClientConfig:
         "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
         "authorization_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/authorize",
         "token_request_uri": "https://accounts.cloud.databricks.com/oidc/accounts/12345/v1/token",
+        "request_content_type": "json",
+    }
+
+
+@pytest.fixture
+def oauth2_config_no_uri() -> OAuth2ClientConfig:
+    """
+    Config for Databricks OAuth2 without a pre-configured endpoint, so the
+    per-provider endpoint is auto-detected and account-resolved.
+    """
+    return {
+        "id": "databricks-client-id",
+        "secret": "databricks-client-secret",
+        "scope": "sql",
+        "redirect_uri": "http://localhost:8088/api/v1/database/oauth2/",
+        "authorization_request_uri": "",
+        "token_request_uri": "",
         "request_content_type": "json",
     }
 
@@ -160,7 +177,7 @@ def test_get_oauth2_authorization_uri_aws(
 
 def test_get_oauth2_authorization_uri_azure(
     mocker: MockerFixture,
-    oauth2_config: OAuth2ClientConfig,
+    oauth2_config_no_uri: OAuth2ClientConfig,
     mock_database_azure: MagicMock,
 ) -> None:
     """
@@ -178,7 +195,9 @@ def test_get_oauth2_authorization_uri_azure(
         "tab_id": "1234",
     }
 
-    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(
+        oauth2_config_no_uri, state
+    )
     parsed = urlparse(url)
     assert parsed.netloc == "login.microsoftonline.com"
     assert "/oauth2/v2.0/authorize" in parsed.path
@@ -191,7 +210,7 @@ def test_get_oauth2_authorization_uri_azure(
 
 def test_get_oauth2_authorization_uri_gcp(
     mocker: MockerFixture,
-    oauth2_config: OAuth2ClientConfig,
+    oauth2_config_no_uri: OAuth2ClientConfig,
     mock_database_gcp: MagicMock,
 ) -> None:
     """
@@ -209,7 +228,9 @@ def test_get_oauth2_authorization_uri_gcp(
         "tab_id": "1234",
     }
 
-    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(oauth2_config, state)
+    url = DatabricksNativeEngineSpec.get_oauth2_authorization_uri(
+        oauth2_config_no_uri, state
+    )
     parsed = urlparse(url)
     assert parsed.netloc == "accounts.gcp.databricks.com"
     assert "/oidc/accounts/" in parsed.path
@@ -235,7 +256,7 @@ def test_python_connector_cloud_provider_detection_azure(
 
 def test_python_connector_oauth2_authorization_uri_azure(
     mocker: MockerFixture,
-    oauth2_config: OAuth2ClientConfig,
+    oauth2_config_no_uri: OAuth2ClientConfig,
     mock_database_azure: MagicMock,
 ) -> None:
     """
@@ -254,7 +275,7 @@ def test_python_connector_oauth2_authorization_uri_azure(
     }
 
     url = DatabricksPythonConnectorEngineSpec.get_oauth2_authorization_uri(
-        oauth2_config, state
+        oauth2_config_no_uri, state
     )
     parsed = urlparse(url)
     assert parsed.netloc == "login.microsoftonline.com"

--- a/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py
@@ -163,6 +163,26 @@ def test_cloud_provider_detection_invalid_config_falls_back_to_hostname(
     assert provider == "azure"
 
 
+def test_cloud_provider_detection_non_string_falls_back_to_hostname(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A non-string `cloud_provider` (e.g. a boolean from malformed JSON) is
+    ignored without raising and detection falls back to the hostname.
+    """
+    database = mocker.MagicMock()
+    database.url_object.host = "adb-123456789.12.azuredatabricks.net"
+
+    mocker.patch.object(
+        DatabricksNativeEngineSpec,
+        "get_extra_params",
+        return_value={"cloud_provider": True},
+    )
+
+    provider = DatabricksNativeEngineSpec._detect_cloud_provider(database)
+    assert provider == "azure"
+
+
 def test_get_oauth2_authorization_uri_aws(
     mocker: MockerFixture,
     oauth2_config: OAuth2ClientConfig,


### PR DESCRIPTION
### SUMMARY

OAuth 2.0 support for Databricks, across AWS, Azure, and GCP.

Adopts #34619 (original work by @drummerwolli, who stepped away). I re-applied their commits on current master and fixed the failing unit tests. Authorship is preserved via co-author trailers.

The only real fix on top of the original work: `get_oauth2_token` was overwriting the config's already-resolved `token_request_uri` with the AWS template that still had an unsubstituted account-id placeholder, so the token exchange POSTed to `.../accounts/{}/v1/token`. It now only falls back to the AWS endpoint when no URI is configured. No behavioral change to the feature otherwise.

### TESTING INSTRUCTIONS

- set up oauth config in superset_config.py for databricks as described in the newly added docs
- install databricks dependencies
- run superset
- set up a DB connection to Databricks
- run a query with that connection and notice the OAuth login screen

Unit tests: `pytest tests/unit_tests/db_engine_specs/test_databricks.py tests/unit_tests/db_engine_specs/test_databricks_multi_cloud.py`

### ADDITIONAL INFORMATION

- [x] Introduces new feature or API
