### PR TITLE
feat(reports): add XLSX (Excel) attachments for Alerts & Reports

### DIFF
--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -135,7 +135,7 @@ Superset sends an HTTP POST with `Content-Type: application/json`:
 }
 ```
 
-When a report includes file attachments (CSV, PDF, or PNG screenshots), the request is sent as `multipart/form-data` instead. In that case, each top-level payload field (`name`, `text`, `description`, `url`) becomes its own form field, and nested structures like `header` are serialized as a JSON-encoded string in their own field. Every attachment is added as a repeated form field named `files`:
+When a report includes file attachments (CSV, Excel, PDF, or PNG screenshots), the request is sent as `multipart/form-data` instead. In that case, each top-level payload field (`name`, `text`, `description`, `url`) becomes its own form field, and nested structures like `header` are serialized as a JSON-encoded string in their own field. Every attachment is added as a repeated form field named `files`:
 
 ```
 POST /webhook HTTP/1.1

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -807,6 +807,29 @@ test('does not show screenshot width when csv is selected', async () => {
   expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
 });
 
+test('does not show screenshot width when Excel is selected', async () => {
+  render(<AlertReportModal {...generateMockedProps(false, true, false)} />, {
+    useRedux: true,
+  });
+  userEvent.click(screen.getByTestId('contents-panel'));
+  await screen.findByText(/test chart/i);
+  const contentTypeSelector = screen.getByRole('combobox', {
+    name: /select content type/i,
+  });
+  await comboboxSelect(contentTypeSelector, 'Chart', () =>
+    screen.getByText(/select chart/i),
+  );
+  const reportFormatSelector = screen.getByRole('combobox', {
+    name: /select format/i,
+  });
+  await comboboxSelect(
+    reportFormatSelector,
+    'Excel',
+    () => screen.getAllByText(/Send as Excel/i)[0],
+  );
+  expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+});
+
 test('clearing the chart selection resets the combobox value', async () => {
   render(<AlertReportModal {...generateMockedProps(false, true, false)} />, {
     useRedux: true,

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -232,6 +232,10 @@ const FORMAT_OPTIONS = {
     label: t('Send as CSV'),
     value: 'CSV',
   },
+  xlsx: {
+    label: t('Send as Excel'),
+    value: 'XLSX',
+  },
   txt: {
     label: t('Send as text'),
     value: 'TEXT',
@@ -2407,7 +2411,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   </StyledInputContainer>
                   <StyledInputContainer
                     css={
-                      ['PDF', 'TEXT', 'CSV'].includes(reportFormat) &&
+                      ['PDF', 'TEXT', 'CSV', 'XLSX'].includes(reportFormat) &&
                       noMarginBottom
                     }
                   >
@@ -2433,7 +2437,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                                     chartVizType,
                                   )
                                 ? Object.values(FORMAT_OPTIONS)
-                                : ['pdf', 'png', 'csv'].map(
+                                : ['pdf', 'png', 'csv', 'xlsx'].map(
                                     key =>
                                       FORMAT_OPTIONS[key as FORMAT_OPTIONS_KEY],
                                   )

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -284,6 +284,10 @@ function ReportModal({
               label: t('Formatted CSV attached in email'),
               value: NotificationFormats.CSV,
             },
+            {
+              label: t('Formatted Excel attached in email'),
+              value: NotificationFormats.XLSX,
+            },
           ]}
         />
       </div>

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -34,6 +34,7 @@ export enum NotificationFormats {
   Text = 'TEXT',
   PNG = 'PNG',
   CSV = 'CSV',
+  XLSX = 'XLSX',
 }
 export interface ReportObject {
   id?: number;

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -197,6 +197,12 @@ class ReportScheduleCsvFailedError(CommandException):
     message = _("Report Schedule execution failed when generating a csv.")
 
 
+class ReportScheduleXlsxFailedError(CommandException):
+    """Raised when generating the Excel (xlsx) attachment for a report fails."""
+
+    message = _("Report Schedule execution failed when generating an Excel file.")
+
+
 class ReportScheduleDataFrameFailedError(CommandException):
     message = _("Report Schedule execution failed when generating a dataframe.")
 
@@ -308,6 +314,13 @@ class ReportScheduleScreenshotTimeout(CommandException):
 class ReportScheduleCsvTimeout(CommandException):
     status = 408
     message = _("A timeout occurred while generating a csv.")
+
+
+class ReportScheduleXlsxTimeout(CommandException):
+    """Raised when generating the Excel (xlsx) attachment for a report times out."""
+
+    status: int = 408
+    message = _("A timeout occurred while generating an Excel file.")
 
 
 class ReportScheduleDataFrameTimeout(CommandException):

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -52,6 +52,8 @@ from superset.commands.report.exceptions import (
     ReportScheduleTargetDashboardDeletedError,
     ReportScheduleUnexpectedError,
     ReportScheduleWorkingTimeoutError,
+    ReportScheduleXlsxFailedError,
+    ReportScheduleXlsxTimeout,
 )
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.daos.report import (
@@ -293,6 +295,7 @@ class BaseReportState:
         if self._report_schedule.chart:
             if result_format in {
                 ChartDataResultFormat.CSV,
+                ChartDataResultFormat.XLSX,
                 ChartDataResultFormat.JSON,
             }:
                 return get_url_path(
@@ -698,30 +701,51 @@ class BaseReportState:
                 raise URLError(response.getcode())
         return content or None
 
-    def _get_csv_data(self) -> bytes:
+    def _get_data(self, result_format: ChartDataResultFormat) -> bytes:
+        """
+        Fetch tabular chart data (CSV or Excel) as raw bytes.
+
+        Both formats are produced by the chart data export endpoint, so the
+        bytes are fetched the same way and only differ by ``result_format``.
+        This reuses the export path's post-processing and index handling,
+        keeping report output consistent with a chart's manual export.
+        """
+        timeout_error: type[CommandException]
+        failed_error: type[CommandException]
+        if result_format == ChartDataResultFormat.XLSX:
+            label, timeout_error, failed_error = (
+                "Excel",
+                ReportScheduleXlsxTimeout,
+                ReportScheduleXlsxFailedError,
+            )
+        else:
+            label, timeout_error, failed_error = (
+                "CSV",
+                ReportScheduleCsvTimeout,
+                ReportScheduleCsvFailedError,
+            )
+
         start_time = datetime.utcnow()
         user, username = resolve_executor_user(self._report_schedule)
         auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(user)
 
         if self._report_schedule.chart.query_context is None:
             logger.warning("No query context found, taking a screenshot to generate it")
-            self._update_query_context()
+            self._update_query_context(failed_error)
             db.session.refresh(self._report_schedule.chart)
 
         try:
             if self._report_schedule.chart.query_context is None:
-                url = self._get_url(result_format=ChartDataResultFormat.CSV)
-                csv_data = get_chart_csv_data(
+                url = self._get_url(result_format=result_format)
+                data = get_chart_csv_data(
                     chart_url=url,
                     auth_cookies=auth_cookies,
                     timeout=app.config["ALERT_REPORTS_CSV_REQUEST_TIMEOUT"],
                 )
             else:
-                request_payload = self._get_chart_data_request_payload(
-                    ChartDataResultFormat.CSV
-                )
+                request_payload = self._get_chart_data_request_payload(result_format)
                 url = get_url_path("ChartDataRestApi.data")
-                csv_data = self._post_chart_data(
+                data = self._post_chart_data(
                     chart_url=url,
                     auth_cookies=auth_cookies,
                     request_payload=request_payload,
@@ -729,7 +753,8 @@ class BaseReportState:
                 )
             elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
             logger.info(
-                "CSV data generation from %s as user %s took %.2fs - execution_id: %s",
+                "%s data generation from %s as user %s took %.2fs - execution_id: %s",
+                label,
                 url,
                 username,
                 elapsed_seconds,
@@ -738,24 +763,24 @@ class BaseReportState:
         except SoftTimeLimitExceeded as ex:
             elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
             logger.warning(
-                "CSV generation timeout after %.2fs - execution_id: %s",
+                "%s generation timeout after %.2fs - execution_id: %s",
+                label,
                 elapsed_seconds,
                 self._execution_id,
             )
-            raise ReportScheduleCsvTimeout() from ex
+            raise timeout_error() from ex
         except Exception as ex:
             elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
             logger.exception(
-                "CSV generation failed after %.2fs - execution_id: %s",
+                "%s generation failed after %.2fs - execution_id: %s",
+                label,
                 elapsed_seconds,
                 self._execution_id,
             )
-            raise ReportScheduleCsvFailedError(
-                f"Failed generating csv {str(ex)}"
-            ) from ex
-        if not csv_data:
-            raise ReportScheduleCsvFailedError()
-        return csv_data
+            raise failed_error(f"Failed generating {label.lower()} {str(ex)}") from ex
+        if not data:
+            raise failed_error()
+        return data
 
     def _get_embedded_data(self) -> pd.DataFrame:
         """
@@ -807,14 +832,18 @@ class BaseReportState:
             raise ReportScheduleCsvFailedError()
         return dataframe
 
-    def _update_query_context(self) -> None:
+    def _update_query_context(
+        self,
+        failed_error: type[CommandException] = ReportScheduleCsvFailedError,
+    ) -> None:
         """
         Update chart query context.
 
-        To load CSV data from the endpoint the chart must have been saved
+        To load data from the endpoint the chart must have been saved
         with its query context. For charts without saved query context we
         get a screenshot to force the chart to produce and save the query
-        context.
+        context. ``failed_error`` lets the caller surface a format-specific
+        failure (e.g. Excel vs CSV) when the screenshot fallback fails.
         """
         try:
             self._get_screenshots()
@@ -822,7 +851,7 @@ class BaseReportState:
             ReportScheduleScreenshotFailedError,
             ReportScheduleScreenshotTimeout,
         ) as ex:
-            raise ReportScheduleCsvFailedError(
+            raise failed_error(
                 "Unable to fetch data because the chart has no query context "
                 "saved, and an error occurred when fetching it via a screenshot. "
                 "Please try loading the chart and saving it again."
@@ -870,7 +899,8 @@ class BaseReportState:
 
         :raises: ReportScheduleScreenshotFailedError
         """
-        csv_data = None
+        csv_data: bytes | None = None
+        xlsx_data: bytes | None = None
         screenshot_data = []
         pdf_data = None
         embedded_data = None
@@ -892,11 +922,16 @@ class BaseReportState:
                     error_text = "Unexpected missing pdf"
             elif (
                 self._report_schedule.chart
-                and self._report_schedule.report_format == ReportDataFormat.CSV
+                and self._report_schedule.report_format in ReportDataFormat.tabular()
             ):
-                csv_data = self._get_csv_data()
-                if not csv_data:
-                    error_text = "Unexpected missing csv file"
+                if self._report_schedule.report_format == ReportDataFormat.XLSX:
+                    xlsx_data = self._get_data(ChartDataResultFormat.XLSX)
+                    if not xlsx_data:
+                        error_text = "Unexpected missing Excel file"
+                else:
+                    csv_data = self._get_data(ChartDataResultFormat.CSV)
+                    if not csv_data:
+                        error_text = "Unexpected missing csv file"
             if error_text:
                 return NotificationContent(
                     name=sanitize_title(self._report_schedule.name),
@@ -932,6 +967,7 @@ class BaseReportState:
             pdf=pdf_data,
             description=self._report_schedule.description,
             csv=csv_data,
+            xlsx=xlsx_data,
             embedded_data=embedded_data,
             header_data=header_data,
         )
@@ -1377,7 +1413,7 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
             # user (find_user -> None) so the state machine still runs and its
             # error envelope writes the ERROR execution-log row and sends the
             # editor notification. The dedicated ReportScheduleExecutorNotFoundError
-            # guard lives at the content sites (_get_screenshots / _get_csv_data /
+            # guard lives at the content sites (_get_screenshots / _get_data /
             # _get_embedded_data), which raise inside that envelope. Guarding here
             # instead would surface the executor error above the state machine,
             # suppressing both the log row and the editor notification. The

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -83,7 +83,13 @@ class ReportDataFormat(StrEnum):
     PDF = "PDF"
     PNG = "PNG"
     CSV = "CSV"
+    XLSX = "XLSX"
     TEXT = "TEXT"
+
+    @classmethod
+    def tabular(cls: type["ReportDataFormat"]) -> set["ReportDataFormat"]:
+        """Formats produced from tabular chart data via the chart export path."""
+        return {cls.CSV, cls.XLSX}
 
 
 class ReportCreationMethod(StrEnum):

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -28,6 +28,7 @@ class NotificationContent:
     name: str
     header_data: HeaderDataType  # this is optional to account for error states
     csv: Optional[bytes] = None  # bytes for csv file
+    xlsx: Optional[bytes] = None  # bytes for Excel file
     pdf: Optional[bytes] = None  # bytes for PDF file
     screenshots: Optional[list[bytes]] = None  # bytes for a list of screenshots
     text: Optional[str] = None

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -205,9 +205,13 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             </html>
             """
         )
-        csv_data = None
+        # CSV and Excel are mutually exclusive (a report has a single format),
+        # so at most one tabular attachment is present in the data dict.
+        attachment_data: dict[str, bytes] | None = None
         if self._content.csv:
-            csv_data = {__("%(name)s.csv", name=self._name): self._content.csv}
+            attachment_data = {__("%(name)s.csv", name=self._name): self._content.csv}
+        elif self._content.xlsx:
+            attachment_data = {__("%(name)s.xlsx", name=self._name): self._content.xlsx}
 
         pdf_data = None
         if self._content.pdf:
@@ -217,7 +221,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             body=body,
             images=images,
             pdf=pdf_data,
-            data=csv_data,
+            data=attachment_data,
             header_data=self._content.header_data,
         )
 

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -82,6 +82,8 @@ class SlackNotification(SlackMixin, BaseNotification):  # pylint: disable=too-fe
     ) -> tuple[Union[str, None], Sequence[Union[str, IOBase, bytes]]]:
         if self._content.csv:
             return ("csv", [self._content.csv])
+        if self._content.xlsx:
+            return ("xlsx", [self._content.xlsx])
         if self._content.screenshots:
             return ("png", self._content.screenshots)
         if self._content.pdf:

--- a/superset/reports/notifications/slackv2.py
+++ b/superset/reports/notifications/slackv2.py
@@ -120,6 +120,8 @@ class SlackV2Notification(SlackMixin, BaseNotification):  # pylint: disable=too-
     ) -> tuple[Union[str, None], Sequence[Union[str, IOBase, bytes]]]:
         if self._content.csv:
             return ("csv", [self._content.csv])
+        if self._content.xlsx:
+            return ("xlsx", [self._content.xlsx])
         if self._content.screenshots:
             return ("png", self._content.screenshots)
         if self._content.pdf:

--- a/superset/reports/notifications/webhook.py
+++ b/superset/reports/notifications/webhook.py
@@ -80,6 +80,18 @@ class WebhookNotification(BaseNotification):
         files = []
         if self._content.csv:
             files.append(("files", ("report.csv", self._content.csv, "text/csv")))
+        if self._content.xlsx:
+            files.append(
+                (
+                    "files",
+                    (
+                        "report.xlsx",
+                        self._content.xlsx,
+                        "application/vnd.openxmlformats-officedocument."
+                        "spreadsheetml.sheet",
+                    ),
+                )
+            )
         if self._content.pdf:
             files.append(
                 ("files", ("report.pdf", self._content.pdf, "application/pdf"))

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -105,6 +106,7 @@ from tests.integration_tests.reports.utils import (
     reset_key_values,
     SCREENSHOT_FILE,
     TEST_ID,
+    XLSX_FILE,
 )
 from tests.integration_tests.test_app import app
 
@@ -257,6 +259,20 @@ def create_report_email_chart_with_csv():
 
 
 @pytest.fixture
+def create_report_email_chart_with_xlsx() -> Iterator[ReportSchedule]:
+    """Email report schedule on a chart with the XLSX (Excel) attachment format."""
+    chart = db.session.query(Slice).first()
+    chart.query_context = '{"mock": "query_context"}'
+    report_schedule = create_report_notification(
+        email_target="target@email.com",
+        chart=chart,
+        report_format=ReportDataFormat.XLSX,
+    )
+    yield report_schedule
+    cleanup_report_schedule(report_schedule)
+
+
+@pytest.fixture
 def create_report_email_chart_with_text():
     chart = db.session.query(Slice).first()
     chart.query_context = '{"mock": "query_context"}'
@@ -338,6 +354,21 @@ def create_report_slack_chart_with_csv():
         slack_channel="slack_channel",
         chart=chart,
         report_format=ReportDataFormat.CSV,
+    )
+    yield report_schedule
+
+    cleanup_report_schedule(report_schedule)
+
+
+@pytest.fixture
+def create_report_slack_chart_with_xlsx() -> Iterator[ReportSchedule]:
+    """Slack report schedule on a chart with the XLSX (Excel) attachment format."""
+    chart = db.session.query(Slice).first()
+    chart.query_context = '{"mock": "query_context"}'
+    report_schedule = create_report_notification(
+        slack_channel="slack_channel",
+        chart=chart,
+        report_format=ReportDataFormat.XLSX,
     )
     yield report_schedule
 
@@ -984,6 +1015,50 @@ def test_email_chart_report_schedule_with_csv(
         # Assert the email csv file
         smtp_images = email_mock.call_args[1]["data"]
         assert smtp_images[list(smtp_images.keys())[0]] == CSV_FILE
+        # Assert logs are correct
+        assert_log(ReportState.SUCCESS)
+
+
+@pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices",
+    "create_report_email_chart_with_xlsx",
+)
+@patch("superset.utils.csv.urllib.request.urlopen")
+@patch("superset.utils.csv.urllib.request.OpenerDirector.open")
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.utils.csv.get_chart_csv_data")
+def test_email_chart_report_schedule_with_xlsx(
+    xlsx_mock: Mock,
+    email_mock: Mock,
+    mock_open: Mock,
+    mock_urlopen: Mock,
+    create_report_email_chart_with_xlsx: ReportSchedule,
+) -> None:
+    """
+    ExecuteReport Command: Test chart email report schedule with Excel
+    """
+    # setup xlsx mock
+    response = Mock()
+    mock_open.return_value = response
+    mock_urlopen.return_value = response
+    mock_urlopen.return_value.getcode.return_value = 200
+    response.read.return_value = XLSX_FILE
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_report_email_chart_with_xlsx.id, datetime.utcnow()
+        ).run()
+
+        notification_targets = get_target_from_report_schedule(
+            create_report_email_chart_with_xlsx
+        )
+        # Assert the email smtp address
+        assert email_mock.call_args[0][0] == notification_targets[0]
+        # Assert the Excel attachment is sent with an .xlsx filename
+        attachments = email_mock.call_args[1]["data"]
+        attachment_name = list(attachments.keys())[0]
+        assert attachment_name.endswith(".xlsx")
+        assert attachments[attachment_name] == XLSX_FILE
         # Assert logs are correct
         assert_log(ReportState.SUCCESS)
 
@@ -1648,6 +1723,56 @@ def test_slack_chart_report_schedule_with_csv(
         assert (
             slack_client_mock_class.return_value.files_upload.call_args[1]["file"]
             == CSV_FILE
+        )
+
+        # Assert logs are correct
+        assert_log(ReportState.SUCCESS)
+
+
+@pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices", "create_report_slack_chart_with_xlsx"
+)
+@patch("superset.reports.notifications.slack.should_use_v2_api", return_value=False)
+@patch("superset.reports.notifications.slack.get_slack_client")
+@patch("superset.utils.csv.urllib.request.urlopen")
+@patch("superset.utils.csv.urllib.request.OpenerDirector.open")
+@patch("superset.utils.csv.get_chart_csv_data")
+def test_slack_chart_report_schedule_with_xlsx(
+    xlsx_mock: Mock,
+    mock_open: Mock,
+    mock_urlopen: Mock,
+    slack_client_mock_class: Mock,
+    slack_should_use_v2_api_mock: Mock,
+    create_report_slack_chart_with_xlsx: ReportSchedule,
+) -> None:
+    """
+    ExecuteReport Command: Test chart slack report V1 schedule with Excel
+    """
+    # setup xlsx mock
+    response = Mock()
+    mock_open.return_value = response
+    mock_urlopen.return_value = response
+    mock_urlopen.return_value.getcode.return_value = 200
+    response.read.return_value = XLSX_FILE
+
+    notification_targets = get_target_from_report_schedule(
+        create_report_slack_chart_with_xlsx
+    )
+
+    channel_name = notification_targets[0]
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_report_slack_chart_with_xlsx.id, datetime.utcnow()
+        ).run()
+
+        assert (
+            slack_client_mock_class.return_value.files_upload.call_args[1]["channels"]
+            == channel_name
+        )
+        assert (
+            slack_client_mock_class.return_value.files_upload.call_args[1]["file"]
+            == XLSX_FILE
         )
 
         # Assert logs are correct

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -44,6 +44,9 @@ from tests.integration_tests.utils import read_fixture
 
 TEST_ID = str(uuid4())
 CSV_FILE = read_fixture("trends.csv")
+# Reports fetch tabular data as opaque bytes from the (mocked) chart export
+# endpoint, so any distinct non-empty payload is sufficient for Excel tests.
+XLSX_FILE: bytes = b"PK\x03\x04 mock xlsx bytes"
 SCREENSHOT_FILE = read_fixture("sample.png")
 DEFAULT_OWNER_EMAIL = "admin@fab.org"
 

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -17,7 +17,8 @@
 
 import json  # noqa: TID251
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
 from urllib.error import URLError
 from uuid import UUID, uuid4
 
@@ -37,6 +38,8 @@ from superset.commands.report.exceptions import (
     ReportScheduleStateNotFoundError,
     ReportScheduleUnexpectedError,
     ReportScheduleWorkingTimeoutError,
+    ReportScheduleXlsxFailedError,
+    ReportScheduleXlsxTimeout,
 )
 from superset.commands.report.execute import (
     BaseReportState,
@@ -1416,7 +1419,7 @@ def test_screenshot_width_calculation(
 
 def _executor_report_state(mocker: MockerFixture) -> BaseReportState:
     report_schedule = create_report_schedule(mocker)
-    # _get_csv_data/_get_embedded_data build a chart-data URL from chart_id
+    # _get_data/_get_embedded_data build a chart-data URL from chart_id
     # before resolving the executor; give it a concrete value so URL building
     # succeeds and the executor resolution is actually reached.
     report_schedule.chart_id = 1
@@ -1429,11 +1432,18 @@ def _executor_report_state(mocker: MockerFixture) -> BaseReportState:
 
 
 @pytest.mark.parametrize(
-    "method_name",
-    ["_get_screenshots", "_get_csv_data", "_get_embedded_data"],
+    ("method_name", "method_args"),
+    [
+        ("_get_screenshots", ()),
+        ("_get_data", (ChartDataResultFormat.CSV,)),
+        ("_get_embedded_data", ()),
+    ],
 )
 def test_get_content_raises_when_executor_user_missing(
-    app: SupersetApp, mocker: MockerFixture, method_name: str
+    app: SupersetApp,
+    mocker: MockerFixture,
+    method_name: str,
+    method_args: tuple[Any, ...],
 ) -> None:
     """
     When the configured executor user cannot be resolved
@@ -1460,7 +1470,37 @@ def test_get_content_raises_when_executor_user_missing(
         mock_sm.find_user = mocker.MagicMock(return_value=None)
 
         with pytest.raises(ReportScheduleExecutorNotFoundError, match="ghost_user"):
-            getattr(report_state, method_name)()
+            getattr(report_state, method_name)(*method_args)
+
+
+def test_get_data_xlsx_wraps_soft_time_limit_as_xlsx_timeout(
+    app: SupersetApp, mocker: MockerFixture
+) -> None:
+    """
+    A ``SoftTimeLimitExceeded`` during XLSX fetch surfaces as
+    ``ReportScheduleXlsxTimeout`` (not the CSV timeout class), so Excel report
+    timeouts are classified under the format-specific error.
+    """
+    from celery.exceptions import SoftTimeLimitExceeded
+
+    app.config.update({"ALERT_REPORTS_CSV_REQUEST_TIMEOUT": 60})
+    report_state = _executor_report_state(mocker)
+    # Non-None query context so _get_data skips the screenshot fallback and
+    # reaches the get_chart_csv_data call this test drives to time out.
+    report_state._report_schedule.chart.query_context = '{"mock": "qc"}'
+
+    mocker.patch(
+        "superset.commands.report.execute.resolve_executor_user",
+        return_value=(mocker.MagicMock(), "executor"),
+    )
+    mocker.patch("superset.commands.report.execute.machine_auth_provider_factory")
+    mocker.patch(
+        "superset.commands.report.execute.get_chart_csv_data",
+        side_effect=SoftTimeLimitExceeded(),
+    )
+
+    with pytest.raises(ReportScheduleXlsxTimeout):
+        report_state._get_data(ChartDataResultFormat.XLSX)
 
 
 def test_executor_not_found_error_message_without_username() -> None:
@@ -1757,6 +1797,22 @@ def test_update_query_context_wraps_screenshot_failure(mocker: MockerFixture) ->
         state._update_query_context()
 
 
+def test_update_query_context_wraps_screenshot_failure_xlsx(
+    mocker: MockerFixture,
+) -> None:
+    """_update_query_context surfaces the caller's error class (XLSX, not CSV)."""
+    schedule = mocker.Mock(spec=ReportSchedule)
+    state = BaseReportState(schedule, datetime.utcnow(), uuid4())
+    state._report_schedule = schedule
+    mocker.patch.object(
+        state,
+        "_get_screenshots",
+        side_effect=ReportScheduleScreenshotFailedError("boom"),
+    )
+    with pytest.raises(ReportScheduleXlsxFailedError, match="query context"):
+        state._update_query_context(ReportScheduleXlsxFailedError)
+
+
 def test_update_query_context_wraps_screenshot_timeout(mocker: MockerFixture) -> None:
     """_update_query_context wraps ScreenshotTimeout as CsvFailedError."""
     schedule = mocker.Mock(spec=ReportSchedule)
@@ -1876,10 +1932,27 @@ def test_get_notification_content_csv_format(mock_ff, mocker: MockerFixture) -> 
     state = _make_notification_state(
         mocker, report_format=ReportDataFormat.CSV, has_chart=True
     )
-    mocker.patch.object(state, "_get_csv_data", return_value=b"col1,col2\n1,2")
+    mocker.patch.object(state, "_get_data", return_value=b"col1,col2\n1,2")
 
     content = state._get_notification_content()
     assert content.csv == b"col1,col2\n1,2"
+    assert content.xlsx is None
+
+
+@patch("superset.commands.report.execute.feature_flag_manager")
+def test_get_notification_content_xlsx_format(
+    mock_ff: MagicMock, mocker: MockerFixture
+) -> None:
+    """XLSX-format reports populate ``NotificationContent.xlsx`` (not ``csv``)."""
+    mock_ff.is_feature_enabled.return_value = False
+    state = _make_notification_state(
+        mocker, report_format=ReportDataFormat.XLSX, has_chart=True
+    )
+    mocker.patch.object(state, "_get_data", return_value=b"xlsx_bytes")
+
+    content = state._get_notification_content()
+    assert content.xlsx == b"xlsx_bytes"
+    assert content.csv is None
 
 
 @patch("superset.commands.report.execute.feature_flag_manager")

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -1251,7 +1251,7 @@ def test_get_csv_data_posts_prepared_chart_data_payload(
         return_value=b"csv-data",
     )
 
-    assert report_state._get_csv_data() == b"csv-data"
+    assert report_state._get_data(ChartDataResultFormat.CSV) == b"csv-data"
 
     get_url_path.assert_called_once_with("ChartDataRestApi.data")
     post_chart_data.assert_called_once()
@@ -1313,7 +1313,7 @@ def test_get_csv_data_keeps_screenshot_fallback_without_query_context(
     )
     post_chart_data = mocker.patch.object(report_state, "_post_chart_data")
 
-    assert report_state._get_csv_data() == b"csv-data"
+    assert report_state._get_data(ChartDataResultFormat.CSV) == b"csv-data"
 
     update_query_context.assert_called_once()
     refresh.assert_called_once_with(report_state._report_schedule.chart)
@@ -1486,7 +1486,7 @@ def test_get_data_xlsx_wraps_soft_time_limit_as_xlsx_timeout(
     app.config.update({"ALERT_REPORTS_CSV_REQUEST_TIMEOUT": 60})
     report_state = _executor_report_state(mocker)
     # Non-None query context so _get_data skips the screenshot fallback and
-    # reaches the get_chart_csv_data call this test drives to time out.
+    # reaches the _post_chart_data call this test drives to time out.
     report_state._report_schedule.chart.query_context = '{"mock": "qc"}'
 
     mocker.patch(
@@ -1494,8 +1494,9 @@ def test_get_data_xlsx_wraps_soft_time_limit_as_xlsx_timeout(
         return_value=(mocker.MagicMock(), "executor"),
     )
     mocker.patch("superset.commands.report.execute.machine_auth_provider_factory")
-    mocker.patch(
-        "superset.commands.report.execute.get_chart_csv_data",
+    mocker.patch.object(
+        report_state,
+        "_post_chart_data",
         side_effect=SoftTimeLimitExceeded(),
     )
 

--- a/tests/unit_tests/reports/model_test.py
+++ b/tests/unit_tests/reports/model_test.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from superset.reports.models import ReportSchedule
+from superset.reports.models import ReportDataFormat, ReportSchedule
 
 
 def test_get_native_filters_params():
@@ -748,3 +748,10 @@ def test_generate_native_filter_time_empty_id():
     assert "" in result
     assert result[""]["id"] == ""
     assert warning is None
+
+
+def test_tabular_returns_csv_and_xlsx():
+    """
+    Test the ``tabular`` method.
+    """
+    assert ReportDataFormat.tabular() == {ReportDataFormat.CSV, ReportDataFormat.XLSX}

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -144,3 +144,35 @@ def test_email_subject_with_datetime() -> None:
         subject = notification._get_subject()
     assert datetime_pattern not in subject
     assert frozen_now.strftime(datetime_pattern) in subject
+
+
+def test_email_content_with_xlsx_attachment() -> None:
+    """Email content attaches xlsx bytes under an ``.xlsx`` filename."""
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.email import EmailNotification
+
+    content = NotificationContent(
+        name="test report",
+        xlsx=b"xlsx_content",
+        header_data={
+            "notification_format": "XLSX",
+            "notification_type": "Report",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+            "slack_channels": None,
+            "execution_id": "test-execution-id",
+        },
+    )
+    email_content = EmailNotification(
+        recipient=ReportRecipients(type=ReportRecipientType.EMAIL), content=content
+    )._get_content()
+
+    assert email_content.data is not None
+    attachment_name = list(email_content.data.keys())[0]
+    assert attachment_name.endswith(".xlsx")
+    assert email_content.data[attachment_name] == b"xlsx_content"

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -160,7 +160,7 @@ def test_email_content_with_xlsx_attachment() -> None:
         header_data={
             "notification_format": "XLSX",
             "notification_type": "Report",
-            "owners": [1],
+            "editors": [1],
             "notification_source": None,
             "chart_id": None,
             "dashboard_id": None,

--- a/tests/unit_tests/reports/notifications/slack_tests.py
+++ b/tests/unit_tests/reports/notifications/slack_tests.py
@@ -179,6 +179,84 @@ def test_get_inline_files_with_screenshots(mock_header_data) -> None:
 
     assert result == ("png", [b"screenshot1", b"screenshot2"])
 
+
+def test_get_inline_files_with_csv(mock_header_data: HeaderDataType) -> None:
+    """
+    Test the _get_inline_files function to ensure it returns the correct tuple
+    when content has a CSV attachment
+    """
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification
+
+    content = NotificationContent(
+        name="test alert",
+        header_data=mock_header_data,
+        csv=b"csv_content",
+    )
+    slack_notification = SlackNotification(
+        recipient=ReportRecipients(
+            type=ReportRecipientType.SLACK,
+            recipient_config_json='{"target": "some_channel"}',
+        ),
+        content=content,
+    )
+
+    result = slack_notification._get_inline_files()
+
+    assert result == ("csv", [b"csv_content"])
+
+
+def test_get_inline_files_with_xlsx(mock_header_data: HeaderDataType) -> None:
+    """
+    Test the _get_inline_files function to ensure it returns the correct tuple
+    when content has an Excel attachment
+    """
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification
+
+    content = NotificationContent(
+        name="test alert",
+        header_data=mock_header_data,
+        xlsx=b"xlsx_content",
+    )
+    slack_notification = SlackNotification(
+        recipient=ReportRecipients(
+            type=ReportRecipientType.SLACK,
+            recipient_config_json='{"target": "some_channel"}',
+        ),
+        content=content,
+    )
+
+    result = slack_notification._get_inline_files()
+
+    assert result == ("xlsx", [b"xlsx_content"])
+
+
+def test_get_inline_files_with_xlsx_slackv2(mock_header_data: HeaderDataType) -> None:
+    """SlackV2 _get_inline_files returns the xlsx tuple when content has Excel."""
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slackv2 import SlackV2Notification
+
+    content = NotificationContent(
+        name="test alert",
+        header_data=mock_header_data,
+        xlsx=b"xlsx_content",
+    )
+    slack_notification = SlackV2Notification(
+        recipient=ReportRecipients(
+            type=ReportRecipientType.SLACKV2,
+            recipient_config_json='{"target": "some_channel"}',
+        ),
+        content=content,
+    )
+
+    result = slack_notification._get_inline_files()
+
+    assert result == ("xlsx", [b"xlsx_content"])
+
     # Ensure _get_inline_files function returns None when content has no screenshots or csv  # noqa: E501
 
 

--- a/tests/unit_tests/reports/notifications/webhook_tests.py
+++ b/tests/unit_tests/reports/notifications/webhook_tests.py
@@ -171,6 +171,37 @@ def test_get_files_includes_all_content_types(mock_header_data) -> None:
     assert mime_types.count("image/png") == 2
 
 
+def test_get_files_includes_xlsx(mock_header_data: HeaderDataType) -> None:
+    """_get_files attaches xlsx bytes as report.xlsx with the spreadsheet MIME type."""
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+
+    xlsx_bytes: bytes = b"PK\x03\x04 mock xlsx bytes"
+
+    content = NotificationContent(
+        name="file test",
+        header_data=mock_header_data,
+        xlsx=xlsx_bytes,
+        description="xlsx files test",
+    )
+    webhook_notification = WebhookNotification(
+        recipient=ReportRecipients(
+            type=ReportRecipientType.WEBHOOK,
+            recipient_config_json='{"target": "https://webhook.com"}',
+        ),
+        content=content,
+    )
+    files = webhook_notification._get_files()
+
+    assert len(files) == 1
+    file_name, file_bytes, mime_type = files[0][1]
+    assert file_name == "report.xlsx"
+    assert file_bytes == xlsx_bytes
+    assert mime_type == (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
 def test_get_files_empty_when_no_content(mock_header_data) -> None:
     """
     Test that _get_files returns empty list when no files present


### PR DESCRIPTION
### SUMMARY

Adds **Excel (`.xlsx`)** as an attachment format for chart-based Alerts & Reports, alongside the existing CSV / PNG / PDF / text options. Users can now pick **"Send as Excel"** in the report/alert modal and receive a formatted spreadsheet
by email or Slack.

This picks up and finalizes the long-stalled #19810, which was closed in Nov 2025 due to inactivity. It resolves the two issues that blocked the original:

1. **Spurious index column** — the original generated the workbook by re-parsing the CSV into a DataFrame and writing it locally, which produced an extra index column. This implementation instead fetches the **pre-rendered XLSX from the chart data export endpoint** (`result_format=xlsx`), so it reuses the exact same post-processing, `include_index` logic, and the formula-injection-safe `superset.utils.excel.df_to_excel` path as a chart's normal "Export to Excel" — no spurious column, and no duplicated logic.
2. **Unified data fetching** — per maintainer feedback on the original PR, CSV and XLSX now share a single `_get_data(result_format)` method instead of separate per-format methods.

**Key changes**
- `ReportDataFormat`: add `XLSX` + a `tabular()` helper (`{CSV, XLSX}`).
- `BaseReportState._get_data(result_format)`: unified CSV/XLSX byte fetch; adds `ReportScheduleXlsx{Failed,Timeout}Error`.
- `NotificationContent.xlsx`; email attaches `<name>.xlsx`; Slack v1 + v2 upload xlsx.
- Frontend: `NotificationFormats.XLSX` and a "Send as Excel" option in both `AlertReportModal` and the `ReportModal`.
- Docs: list Excel among report attachment formats.

XLSX availability mirrors CSV (chart-based reports only). No new feature flag, config key (the existing `EXCEL_EXPORT` config is reused), or DB migration is required.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- Please attach a screenshot of the report/alert modal's "Content format" dropdown showing the new "Send as Excel" option, and (optionally) the received .xlsx email attachment. -->
<img width="378" height="557" alt="image" src="https://github.com/user-attachments/assets/4a44c468-ae1a-438c-bcb4-4f0731911f42" />


### TESTING INSTRUCTIONS

Automated:
- Unit: `pytest tests/unit_tests/commands/report/execute_test.py tests/unit_tests/reports/notifications/`
- Integration: `pytest tests/integration_tests/reports/commands_tests.py -k "csv or xlsx"`
- Frontend: `npm run test -- AlertReportModal` and `npm run test -- ReportModal`

Manual:
1. Enable the **Alerts & Reports** feature and have a worker/beat running.
2. Create a **Report** on a chart, set **Content format → Send as Excel**, add an
   email recipient, and trigger it.
3. Confirm the email contains a valid `<report name>.xlsx` that opens in
   Excel/LibreOffice with the expected data and **no extra leading index column**.
4. Repeat with a Slack recipient and confirm the `.xlsx` file is uploaded.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
