### PR TITLE
chore(codeowners): add translation maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 
 # Notify translation maintainers of changes to translations
 
-/superset/translations/ @sfirke @rusackas
+/superset/translations/ @sfirke @rusackas @villebro @sadpandajoe @hainenber
 
 # Notify PMC members of changes to extension-related files
 


### PR DESCRIPTION
### SUMMARY

Adds @villebro, @sadpandajoe, and @hainenber as code owners for the translations directory (`/superset/translations/`), alongside the existing owners @sfirke and @rusackas. This ensures they're automatically requested for review on translation-related changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CODEOWNERS-only change.

### TESTING INSTRUCTIONS

No functional changes. GitHub validates CODEOWNERS syntax automatically; the listed handles are existing committers.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)