### PR TITLE
fix(dashboard): restore page scrolling

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.test.tsx
@@ -32,11 +32,7 @@ fetchMock.put('glob:*/api/v1/dashboard/*/colors*', {});
 fetchMock.post('glob:*/superset/log/?*', {});
 
 jest.mock('@visx/responsive', () => ({
-  ParentSize: ({
-    children,
-  }: {
-    children: (props: { width: number }) => JSX.Element;
-  }) => children({ width: 800 }),
+  useParentSize: () => ({ parentRef: { current: null }, width: 800 }),
 }));
 
 jest.mock('src/dashboard/containers/DashboardGrid', () => ({

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -38,7 +38,7 @@ import {
   NativeFilterType,
   getLabelsColorMap,
 } from '@superset-ui/core';
-import { ParentSize } from '@visx/responsive';
+import { useParentSize } from '@visx/responsive';
 import Tabs from '@superset-ui/core/components/Tabs';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
 import {
@@ -374,9 +374,13 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
     [activeKey, childIds, dashboardLayout, handleFocus, renderTabBar, tabIndex],
   );
 
+  // Hook form, not <ParentSize>: @visx 4.0.0's component clips content taller
+  // than the viewport, which breaks dashboard page scrolling.
+  const { parentRef, width } = useParentSize();
+
   return (
-    <div className="grid-container" data-test="grid-container">
-      <ParentSize>{renderParentSizeChildren}</ParentSize>
+    <div className="grid-container" data-test="grid-container" ref={parentRef}>
+      {renderParentSizeChildren({ width })}
     </div>
   );
 };

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -123,13 +123,24 @@ const contentCss = css`
   position: relative;
 `;
 
-/**
- * Renders the main content area. When the chat panel is open in panel mode,
- * wraps <Layout> and <ChatPanelContent> in a Splitter so they sit side-by-side
- * with a lazy drag bar (blue preview line, resize committed on mouseup).
- * The full <Layout> tree lives inside the first panel so its internal flex
- * context is preserved — SQL Lab, Explore, and other pages are unaffected.
- */
+// Chat panel mode locks the shell (content scrolls inside its panel); every
+// other state page-scrolls so the navbar hides on scroll.
+const lockedShellCss = css`
+  height: 100vh;
+  overflow: hidden;
+`;
+
+const pageScrollShellCss = css`
+  min-height: 100vh;
+`;
+
+const pageScrollContentCss = css`
+  display: flex;
+  flex-direction: column;
+`;
+
+// Renders the app shell and picks the scroll model: in chat panel mode <Layout>
+// sits in a Splitter beside the chat panel; otherwise the page scrolls normally.
 const AppContent = () => {
   const isAuthenticated =
     isUser(bootstrapData.user) && !bootstrapData.user.isAnonymous;
@@ -145,23 +156,14 @@ const AppContent = () => {
   );
 
   const layoutContent = (
-    <Layout css={layoutCss}>
-      <Layout.Content css={contentCss}>
+    <Layout css={isPanelOpen ? layoutCss : undefined}>
+      <Layout.Content css={isPanelOpen ? contentCss : pageScrollContentCss}>
         <RouteSwitch />
       </Layout.Content>
     </Layout>
   );
 
-  if (!isPanelOpen) {
-    return (
-      <>
-        {layoutContent}
-        {hasChatExtension && <ChatFloatingHost />}
-      </>
-    );
-  }
-
-  return (
+  const content = isPanelOpen ? (
     <Splitter
       lazy
       onResizeEnd={sizes => {
@@ -194,6 +196,21 @@ const AppContent = () => {
         <ChatPanelHost />
       </Splitter.Panel>
     </Splitter>
+  ) : (
+    <>
+      {layoutContent}
+      {hasChatExtension && <ChatFloatingHost />}
+    </>
+  );
+
+  return (
+    <Flex vertical css={isPanelOpen ? lockedShellCss : pageScrollShellCss}>
+      <Menu
+        data={bootstrapData.common.menu_data}
+        isFrontendRoute={isFrontendRoute}
+      />
+      <ExtensionsStartup>{content}</ExtensionsStartup>
+    </Flex>
   );
 };
 
@@ -202,21 +219,7 @@ const App = () => (
     <ScrollToTop />
     <LocationPathnameLogger />
     <RootContextProviders>
-      <Flex
-        vertical
-        css={css`
-          height: 100vh;
-          overflow: hidden;
-        `}
-      >
-        <Menu
-          data={bootstrapData.common.menu_data}
-          isFrontendRoute={isFrontendRoute}
-        />
-        <ExtensionsStartup>
-          <AppContent />
-        </ExtensionsStartup>
-      </Flex>
+      <AppContent />
       <ToastContainer />
     </RootContextProviders>
   </Router>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Restores page scrolling on dashboards: a dashboard taller than the browser window was clipped with no scrollbar, leaving every chart below the fold completely unreachable. The same change also restores the top navbar's hide-on-scroll behavior, which had been silently disabled across the entire app.

Two independent regressions combined to cause this:
**1. `@visx/responsive` 3.12.0 --> 4.0.0 (#41239)**
In 4.0.0, the `<ParentSize>` component renders its children inside an absolutely-positioned, `overflow: hidden` wrapper (`position: absolute; inset: 0`). `DashboardContainer` renders the dashboard grid inside `<ParentSize>`, so any dashboard taller than the measured area was clipped and could no longer grow the document, removing the page scrollbar entirely.

*Fix:* use the `useParentSize` hook instead of the `<ParentSize>` component, so the resize observer attaches to the grid container itself and the grid renders in normal document flow. We only ever consumed `width`, so behavior is otherwise
identical.

**2. Unconditional app-shell inner-scroll (#41205, SIP-214 chat panel)**
The chat panel switched the app shell to a viewport-locked, inner-scroll layout (`height: 100vh; overflow: hidden` on the shell, `overflow-y: auto` on the content) **unconditionally**. That layout is only required for the chat panel's split view,
but because it always applied, the navbar stopped hiding on scroll, even when no chat extension was present.

*Fix:* scope the `viewport-locked/inner-scroll` shell to chat **panel** mode only. In every other state (no chat extension, chat closed, or chat in floating mode) the shell page-scrolls exactly as before, so the navbar hides on scroll again. The chat
panel's split-view behavior is unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:**
[screen-capture (6).webm](https://github.com/user-attachments/assets/853f07f1-37de-4486-9367-72e17f417df7)

**After:**
[screen-capture (5).webm](https://github.com/user-attachments/assets/81bddd42-60ba-466e-a500-211465e3f258)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Dashboard page-scroll (core fix):
1. Open a dashboard taller than the browser window (for example "FCC New Coder Survey 2018" from the bundled examples).
2. Scroll down. Expected: the whole page scrolls, every below-fold chart is reachable, the top navbar hides as you scroll, and the dashboard header stays pinned to the top.
3. Regression check: confirm Explore and SQL Lab still scroll/behave as before.

Chat panel (only if `ENABLE_EXTENSIONS` is on and a chat extension is registered):
4. Open the chat in panel mode: the shell switches to split view, the navbar stays fixed, and the dashboard scrolls inside its panel next to the chat. Close it: page-scroll and navbar hide-on-scroll return.
5. Switch the chat to floating mode: the page scrolls normally (navbar hides) with the chat floating on top.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API