### PR TITLE
fix(sunburst): make "Show Null Values" non-breaking and cover all layers

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -186,7 +186,9 @@ export default function transformProps(
     showLabels,
     showLabelsThreshold,
     showTotal,
-    showNullValues,
+    // Default to true so charts saved before this control existed keep
+    // showing null values instead of silently hiding them on upgrade.
+    showNullValues = true,
     sliceId,
   } = formData;
   const {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -96,7 +96,7 @@ export function treeBuilder(
   // secondaryValue/value ratio for coloring and tooltips.
   return filterNullNames
     ? nodes.filter(
-        node => node.name !== null && !(node.children && !node.children.length),
+        node => node.name !== null && node.children?.length !== 0,
       )
     : nodes;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -91,6 +91,12 @@ export function treeBuilder(
     [] as TreeNode[],
   );
   // Filter at every level so single-level charts and root nodes are covered,
-  // not just nested children.
-  return filterNullNames ? nodes.filter(node => node.name !== null) : nodes;
+  // not just nested children. A parent whose children were all null-filtered
+  // is dropped too: keeping it would leave a zero-value arc that yields a NaN
+  // secondaryValue/value ratio for coloring and tooltips.
+  return filterNullNames
+    ? nodes.filter(
+        node => node.name !== null && !(node.children && !node.children.length),
+      )
+    : nodes;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -40,7 +40,7 @@ export function treeBuilder(
 ): TreeNode[] {
   const [curGroupBy, ...restGroupby] = groupBy;
   const curData = _groupBy(data, curGroupBy);
-  return transform(
+  const nodes = transform(
     curData,
     (result, value, key) => {
       const name = curData[key][0][curGroupBy]!;
@@ -59,6 +59,9 @@ export function treeBuilder(
           result.push(item);
         });
       } else {
+        // Children are already null-filtered by the recursive call, so the
+        // parent's value/secondaryValue exclude hidden nulls. This keeps the
+        // parent arc sized to its visible children (no empty gap).
         const children = treeBuilder(
           value,
           restGroupby,
@@ -76,12 +79,9 @@ export function treeBuilder(
               0,
             )
           : metricValue;
-        const validChildren = filterNullNames
-          ? children.filter(child => child.name !== null)
-          : children;
         result.push({
           name,
-          children: validChildren,
+          children,
           value: metricValue,
           secondaryValue,
           groupBy: curGroupBy,
@@ -90,4 +90,7 @@ export function treeBuilder(
     },
     [] as TreeNode[],
   );
+  // Filter at every level so single-level charts and root nodes are covered,
+  // not just nested children.
+  return filterNullNames ? nodes.filter(node => node.name !== null) : nodes;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
@@ -51,3 +51,49 @@ test('series label has no textBorderColor or textBorderWidth', () => {
   expect(series.label).not.toHaveProperty('textBorderColor');
   expect(series.label).not.toHaveProperty('textBorderWidth');
 });
+
+const nullValueProps = (showNullValues?: boolean) =>
+  new ChartProps({
+    formData: {
+      colorScheme: 'bnbColors',
+      datasource: '3__table',
+      columns: ['category'],
+      metric: 'sum__value',
+      ...(showNullValues === undefined ? {} : { showNullValues }),
+    },
+    width: 800,
+    height: 600,
+    queriesData: [
+      {
+        data: [
+          { category: 'A', sum__value: 10 },
+          { category: 'B', sum__value: 20 },
+          { category: null, sum__value: 5 },
+        ],
+      },
+    ],
+    theme: supersetTheme,
+  });
+
+const seriesValues = (props: ChartProps) =>
+  (
+    (transformProps(props as EchartsSunburstChartProps).echartOptions as any)
+      .series[0].data as { value: number }[]
+  )
+    .map(node => node.value)
+    .sort((a, b) => a - b);
+
+// Charts saved before the "Show Null Values" control existed have no
+// `showNullValues` in form data; they must keep showing nulls (non-breaking).
+test('keeps null values when showNullValues is unset (legacy charts)', () => {
+  expect(seriesValues(nullValueProps(undefined))).toEqual([5, 10, 20]);
+});
+
+test('keeps null values when showNullValues is true', () => {
+  expect(seriesValues(nullValueProps(true))).toEqual([5, 10, 20]);
+});
+
+// Single-column sunburst: the toggle must actually drop the null node.
+test('removes null values when showNullValues is false', () => {
+  expect(seriesValues(nullValueProps(false))).toEqual([10, 20]);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
@@ -21,6 +21,13 @@ import { supersetTheme } from '@apache-superset/core/theme';
 import { EchartsSunburstChartProps } from '../../src/Sunburst/types';
 import transformProps from '../../src/Sunburst/transformProps';
 
+type SunburstSeries = {
+  label?: Record<string, unknown>;
+  data: { value: number }[];
+};
+const firstSeries = (echartOptions: unknown) =>
+  (echartOptions as { series: SunburstSeries[] }).series[0];
+
 const formData = {
   colorScheme: 'bnbColors',
   datasource: '3__table',
@@ -47,7 +54,7 @@ test('series label has no textBorderColor or textBorderWidth', () => {
   const { echartOptions } = transformProps(
     chartProps as EchartsSunburstChartProps,
   );
-  const series = (echartOptions as any).series[0];
+  const series = firstSeries(echartOptions);
   expect(series.label).not.toHaveProperty('textBorderColor');
   expect(series.label).not.toHaveProperty('textBorderWidth');
 });
@@ -75,13 +82,12 @@ const nullValueProps = (showNullValues?: boolean) =>
     theme: supersetTheme,
   });
 
-const seriesValues = (props: ChartProps) =>
-  (
-    (transformProps(props as EchartsSunburstChartProps).echartOptions as any)
-      .series[0].data as { value: number }[]
-  )
-    .map(node => node.value)
+const seriesValues = (props: ChartProps) => {
+  const { echartOptions } = transformProps(props as EchartsSunburstChartProps);
+  return firstSeries(echartOptions)
+    .data.map(node => node.value)
     .sort((a, b) => a - b);
+};
 
 // Charts saved before the "Show Null Values" control existed have no
 // `showNullValues` in form data; they must keep showing nulls (non-breaking).

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -621,4 +621,29 @@ describe('test treeBuilder', () => {
       },
     ]);
   });
+
+  // A parent whose children are all null must be dropped, not kept as a
+  // zero-value arc: a retained `value: 0` node yields NaN for the
+  // secondaryValue/value ratio used in linear coloring and tooltips.
+  test('filtering drops parents left with no children', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'keep', bar: 'a', count: 2, count2: 3 },
+        { foo: 'drop', bar: null, count: 5, count2: 7 },
+      ],
+      ['foo', 'bar'],
+      'count',
+      'count2',
+      true,
+    );
+    expect(tree).toEqual([
+      {
+        children: [{ groupBy: 'bar', name: 'a', secondaryValue: 3, value: 2 }],
+        groupBy: 'foo',
+        name: 'keep',
+        secondaryValue: 3,
+        value: 2,
+      },
+    ]);
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -394,7 +394,7 @@ describe('test treeBuilder', () => {
     ]);
   });
 
-  test('filter null values', () => {
+  test('filter null values in a nested layer (parent total excludes hidden nulls)', () => {
     const tree = treeBuilder(
       [
         ...data,
@@ -426,6 +426,8 @@ describe('test treeBuilder', () => {
         value: 2,
       },
       {
+        // The null `bar` child is removed AND its value is excluded from the
+        // parent total, so the arc stays sized to its visible children (no gap).
         children: [
           {
             groupBy: 'bar',
@@ -436,8 +438,8 @@ describe('test treeBuilder', () => {
         ],
         groupBy: 'foo',
         name: 'a-2',
-        secondaryValue: 4,
-        value: 4,
+        secondaryValue: 2,
+        value: 2,
       },
       {
         children: [
@@ -507,6 +509,114 @@ describe('test treeBuilder', () => {
         groupBy: 'foo',
         name: 'd-1',
         secondaryValue: 2,
+        value: 2,
+      },
+    ]);
+  });
+
+  // Regression: a single-level (single column) sunburst previously never
+  // filtered, because filtering only happened in the multi-level branch.
+  test('single-level: shows null nodes when filtering is off', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'a', count: 2, count2: 3 },
+        { foo: null, count: 5, count2: 7 },
+      ],
+      ['foo'],
+      'count',
+    );
+    expect(tree).toEqual([
+      { groupBy: 'foo', name: 'a', secondaryValue: 2, value: 2 },
+      { groupBy: 'foo', name: null, secondaryValue: 5, value: 5 },
+    ]);
+  });
+
+  test('single-level: removes null nodes when filtering is on', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'a', count: 2, count2: 3 },
+        { foo: null, count: 5, count2: 7 },
+      ],
+      ['foo'],
+      'count',
+      undefined,
+      true,
+    );
+    expect(tree).toEqual([
+      { groupBy: 'foo', name: 'a', secondaryValue: 2, value: 2 },
+    ]);
+  });
+
+  // Regression: a null in the *root* (first) column previously slipped through
+  // because the top-level result array was never filtered.
+  test('multi-level: shows null root node when filtering is off', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'a-1', bar: 'a', count: 2, count2: 3 },
+        { foo: null, bar: 'x', count: 5, count2: 7 },
+      ],
+      ['foo', 'bar'],
+      'count',
+    );
+    expect(tree).toEqual([
+      {
+        children: [{ groupBy: 'bar', name: 'a', secondaryValue: 2, value: 2 }],
+        groupBy: 'foo',
+        name: 'a-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [{ groupBy: 'bar', name: 'x', secondaryValue: 5, value: 5 }],
+        groupBy: 'foo',
+        name: null,
+        secondaryValue: 5,
+        value: 5,
+      },
+    ]);
+  });
+
+  test('multi-level: removes null root node (and its subtree) when filtering is on', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'a-1', bar: 'a', count: 2, count2: 3 },
+        { foo: null, bar: 'x', count: 5, count2: 7 },
+      ],
+      ['foo', 'bar'],
+      'count',
+      undefined,
+      true,
+    );
+    expect(tree).toEqual([
+      {
+        children: [{ groupBy: 'bar', name: 'a', secondaryValue: 2, value: 2 }],
+        groupBy: 'foo',
+        name: 'a-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+    ]);
+  });
+
+  // With a secondary metric, the parent's secondaryValue must also exclude the
+  // hidden null child rather than leaving a stale (inflated) total.
+  test('filtering excludes hidden nulls from secondary-metric totals', () => {
+    const tree = treeBuilder(
+      [
+        { foo: 'p', bar: 'a', count: 2, count2: 3 },
+        { foo: 'p', bar: null, count: 2, count2: 7 },
+      ],
+      ['foo', 'bar'],
+      'count',
+      'count2',
+      true,
+    );
+    expect(tree).toEqual([
+      {
+        children: [{ groupBy: 'bar', name: 'a', secondaryValue: 3, value: 2 }],
+        groupBy: 'foo',
+        name: 'p',
+        secondaryValue: 3,
         value: 2,
       },
     ]);


### PR DESCRIPTION
### SUMMARY

Follow-up to #31477 (cc @gerbermichi 🙏), which added the **Show Null Values** control to the Sunburst chart. That PR shipped the feature, but a couple of touch-ups flagged in review never made it in. This finishes them off and, importantly, makes the change **non-breaking for charts that already exist**.

Three distinct issues:

**1. Legacy charts silently stopped showing nulls (the breaking part).**
A chart saved before this control existed has no `showNullValues` key in its form data, so it read as `undefined`. Since `transformProps` passes `!showNullValues` to `treeBuilder`, `!undefined === true` forced filtering **on** — hiding null slices that used to render, which is the *opposite* of the control's `default: true`. New chart created today → shows nulls; identical chart saved last week → silently hides them after upgrade. Fixed by defaulting `showNullValues = true` in the destructure so legacy form data preserves the old behavior.

**2. Single-level and root-level nulls slipped through.**
The filter only ran inside the multi-level (`else`) branch, applied to a node's `children`. So:
- a single-column sunburst never filtered at all (every node is built in the leaf branch), and
- a `null` in the **root** column was never removed (the top-level array has no parent to filter it).

Now the filter is applied once at the end of every recursion level, covering roots, leaves, and nested children uniformly.

**3. Hidden nulls left an empty gap in the ring.**
Children were filtered *after* the parent reduced over them, so the parent arc kept the hidden null's value while one outer slice vanished — an angular gap. Children are now filtered *before* the reduce, so a parent's `value`/`secondaryValue` always match its visible children.

### Scenarios — what is and isn't a behavior change

| Chart | Before this PR | After this PR |
|---|---|---|
| No null values | unchanged | unchanged |
| New chart (default "show") | shows nulls | shows nulls |
| **Legacy multi-level chart with inner-layer nulls** | #31477 silently hid them | **shows them again** (regression fixed) |
| Legacy single-level chart with nulls | toggle was inert | shows nulls by default; toggle now works |
| Legacy multi-level chart with root nulls | root null slipped through | shows by default; toggle now removes it |
| Any chart with "Show Null Values" unchecked | partially worked / left gaps | nulls removed cleanly, no gap |

Net effect: the only *existing* charts that rendered differently under #31477 were multi-level sunbursts with nulls in a non-root layer (they lost those slices). This PR restores them and makes the toggle behave consistently everywhere.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — logic/behavior fix. Covered by unit tests below.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npx jest plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts`
- New/updated tests cover: legacy `undefined` default keeps nulls; single-level filtering on/off; root-level filtering on/off; nested filtering excludes hidden nulls from parent totals (incl. secondary metric).
- Manual: create a sunburst with a single column containing nulls, and a multi-column one with nulls at the root and inner layers; toggle **Show Null Values** and confirm nulls appear/disappear at every level with no gaps.

### ADDITIONAL INFORMATION

- [x] Changes UI (behavior of an existing control)
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)