### PR TITLE
fix: apply object access checks in tag bulk_create and update commands

### DIFF
--- a/superset/commands/tag/create.py
+++ b/superset/commands/tag/create.py
@@ -21,7 +21,11 @@ from typing import Any
 from superset import security_manager
 from superset.commands.base import BaseCommand, CreateMixin
 from superset.commands.tag.exceptions import TagCreateFailedError, TagInvalidError
-from superset.commands.tag.utils import to_object_model, to_object_type
+from superset.commands.tag.utils import (
+    current_user_can_modify_object,
+    to_object_model,
+    to_object_type,
+)
 from superset.daos.tag import TagDAO
 from superset.exceptions import SupersetSecurityException
 from superset.tags.models import ObjectType, TagType
@@ -133,16 +137,14 @@ class CreateCustomTagWithRelationshipsCommand(CreateMixin, BaseCommand):
                 continue
 
             try:
-                if model := to_object_model(object_type, obj_id):
-                    try:
-                        security_manager.raise_for_ownership(model)
-                    except SupersetSecurityException:
-                        if (
-                            not model.created_by
-                            or model.created_by != security_manager.current_user
-                        ):
-                            # skip the object if the user doesn't have access
-                            self._skipped_tagged_objects.add((obj_type, obj_id))
+                # Look the object up bypassing the access base filter, so an
+                # object the user cannot access resolves to a model and is
+                # checked here. Without skip_base_filter it returns None for an
+                # inaccessible object and the tag write would pass through
+                # unchecked. Skip objects the user has no access to.
+                model = to_object_model(object_type, obj_id, skip_base_filter=True)
+                if model and not current_user_can_modify_object(model):
+                    self._skipped_tagged_objects.add((obj_type, obj_id))
             except Exception as e:
                 exceptions.append(TagInvalidError(str(e)))
 

--- a/superset/commands/tag/update.py
+++ b/superset/commands/tag/update.py
@@ -22,7 +22,11 @@ from flask_appbuilder.models.sqla import Model
 from superset import db
 from superset.commands.base import BaseCommand, UpdateMixin
 from superset.commands.tag.exceptions import TagInvalidError, TagNotFoundError
-from superset.commands.tag.utils import to_object_type
+from superset.commands.tag.utils import (
+    current_user_can_modify_object,
+    to_object_model,
+    to_object_type,
+)
 from superset.daos.tag import TagDAO
 from superset.tags.models import Tag
 from superset.utils.decorators import transaction
@@ -59,13 +63,24 @@ class UpdateTagCommand(UpdateMixin, BaseCommand):
 
         # Validate object_id
         if objects_to_tag := self._properties.get("objects_to_tag"):
-            # Validate object type
-            for obj_type, _ in objects_to_tag:
+            accessible_objects = []
+            for obj_type, obj_id in objects_to_tag:
                 object_type = to_object_type(obj_type)
+                # Validate object type
                 if not object_type:
                     exceptions.append(
                         TagInvalidError(f"invalid object type {object_type}")
                     )
+                    continue
+                # Only tag objects the user can access; skip the rest, matching
+                # the single-object and bulk-create tag paths. Look up bypassing
+                # the access base filter so an inaccessible object reaches the
+                # check instead of resolving to None and being written unchecked.
+                model = to_object_model(object_type, obj_id, skip_base_filter=True)
+                if model and not current_user_can_modify_object(model):
+                    continue
+                accessible_objects.append([obj_type, obj_id])
+            self._properties["objects_to_tag"] = accessible_objects
 
         if exceptions:
             raise TagInvalidError(exceptions=exceptions)

--- a/superset/commands/tag/utils.py
+++ b/superset/commands/tag/utils.py
@@ -17,9 +17,11 @@
 
 from typing import Any, Optional, Union
 
+from superset import security_manager
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
 from superset.daos.query import SavedQueryDAO
+from superset.exceptions import SupersetSecurityException
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import SavedQuery
@@ -50,3 +52,22 @@ def to_object_model(
 
         return DatasetDAO.find_by_id(object_id, skip_base_filter=skip_base_filter)
     return None
+
+
+def current_user_can_modify_object(model: Any) -> bool:
+    """Whether the current user may create/modify tag relationships on ``model``.
+
+    Mirrors the ownership check the bulk-create path already applies (owner or
+    admin via ``raise_for_ownership``, or the object's creator), so the
+    tag-update path enforces the same boundary. Look the model up with
+    ``skip_base_filter=True`` before calling this, so an object the user cannot
+    access reaches the check instead of resolving to ``None`` and being written
+    without any check.
+    """
+    try:
+        security_manager.raise_for_ownership(model)
+        return True
+    except SupersetSecurityException:
+        return bool(
+            model.created_by and model.created_by == security_manager.current_user
+        )

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -41,7 +41,11 @@ from superset.tags.models import (
 )
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
-from tests.integration_tests.constants import ADMIN_USERNAME, ALPHA_USERNAME
+from tests.integration_tests.constants import (
+    ADMIN_USERNAME,
+    ALPHA_USERNAME,
+    GAMMA_USERNAME,
+)
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
@@ -823,8 +827,11 @@ class TestTagApi(InsertChartMixin, SupersetTestCase):
 
         assert rv.status_code == 200
         result = rv.json["result"]
-        assert len(result["objects_tagged"]) == 2
-        assert len(result["objects_skipped"]) == 1
+        # Alpha owns only alpha_dash, so only that is tagged; the World Bank
+        # dashboard and chart it does not own are skipped (objects the caller
+        # cannot modify are not tagged, including via the bulk-create path).
+        assert len(result["objects_tagged"]) == 1
+        assert len(result["objects_skipped"]) == 2
 
     def test_create_tag_mysql_compatibility(self) -> None:
         """
@@ -869,4 +876,71 @@ class TestTagApi(InsertChartMixin, SupersetTestCase):
 
         # Cleanup
         db.session.delete(created_tag)
+        db.session.commit()
+
+    def test_bulk_create_and_update_skip_inaccessible_objects(self):
+        """A non-owner with the Tag write permission must not create tag
+        relationships on a dashboard they cannot access, via either bulk_create
+        or PUT /tag/<id>. The single-object path already enforced this; these two
+        paths must too (object is looked up bypassing the access base filter, so
+        an inaccessible object is checked instead of silently passing through)."""
+        admin = self.get_user(ADMIN_USERNAME)
+        victim = Dashboard(
+            dashboard_title="tag_access_victim_dashboard",
+            slug="tag-access-victim",
+            published=False,
+            owners=[admin],
+        )
+        db.session.add(victim)
+        db.session.commit()
+        vid = victim.id
+
+        self.login(GAMMA_USERNAME)
+
+        # bulk_create must skip the inaccessible dashboard.
+        self.client.post(
+            "api/v1/tag/bulk_create",
+            json={
+                "tags": [
+                    {"name": "tag_access_bulk", "objects_to_tag": [["dashboard", vid]]}
+                ]
+            },
+        )
+        bulk_rows = (
+            db.session.query(TaggedObject)
+            .join(Tag)
+            .filter(TaggedObject.object_id == vid, Tag.name == "tag_access_bulk")
+            .count()
+        )
+        assert bulk_rows == 0, "bulk_create tagged a dashboard the user cannot access"
+
+        # PUT /tag/<id> must skip the inaccessible dashboard too. Create the tag
+        # without a (denied) relationship first, then attempt to attach the victim.
+        put_tag = Tag(name="tag_access_put", type=TagType.custom)
+        db.session.add(put_tag)
+        db.session.commit()
+        put_tag_id = put_tag.id
+        self.client.put(
+            f"api/v1/tag/{put_tag_id}",
+            json={"name": "tag_access_put", "objects_to_tag": [["dashboard", vid]]},
+        )
+        put_rows = (
+            db.session.query(TaggedObject)
+            .filter(TaggedObject.object_id == vid, TaggedObject.tag_id == put_tag_id)
+            .count()
+        )
+        assert put_rows == 0, "tag update tagged a dashboard the user cannot access"
+
+        # Cleanup
+        db.session.query(TaggedObject).filter(
+            TaggedObject.tag_id.in_(
+                db.session.query(Tag.id).filter(
+                    Tag.name.in_(["tag_access_bulk", "tag_access_put"])
+                )
+            )
+        ).delete(synchronize_session=False)
+        db.session.query(Tag).filter(
+            Tag.name.in_(["tag_access_bulk", "tag_access_put"])
+        ).delete(synchronize_session=False)
+        db.session.query(Dashboard).filter(Dashboard.id == vid).delete()
         db.session.commit()


### PR DESCRIPTION
### SUMMARY

Tag relationships can be created through three command paths: the single-object `CreateCustomTagCommand`, the bulk `CreateCustomTagWithRelationshipsCommand`, and `UpdateTagCommand`. The single-object path already checks that the caller may modify the target object before creating the relationship (added in #40333).

This PR factors that check into a shared `current_user_can_modify_object` helper in `commands/tag/utils.py` and applies it across all three paths so they enforce one consistent ownership boundary. Objects are looked up with `skip_base_filter=True` so the explicit ownership check decides which objects are tagged.

### TESTING INSTRUCTIONS

`pytest tests/integration_tests/tags/api_tests.py`

Adds `test_bulk_create_and_update_skip_inaccessible_objects`: an object owned by another user is skipped by a non-owner's `bulk_create` and `update` calls.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API