### PR TITLE
fix(tags): make favorite star toggle in Tags list view

### DIFF
--- a/superset-frontend/src/pages/Tags/Tags.test.tsx
+++ b/superset-frontend/src/pages/Tags/Tags.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import TagList from 'src/pages/Tags';
+
+const mockUser = {
+  userId: 1,
+  firstName: 'Test',
+  lastName: 'User',
+};
+
+const mockTags = [
+  {
+    id: 1,
+    name: 'Test Tag',
+    changed_on_delta_humanized: '1 day ago',
+    changed_by: { first_name: 'Test', last_name: 'User', id: 1 },
+  },
+];
+
+const ENDPOINTS = {
+  INFO: 'glob:*/api/v1/tag/_info*',
+  TAGS: 'glob:*/api/v1/tag/?*',
+  FAVORITE_STATUS: 'glob:*/api/v1/tag/favorite_status/*',
+  FAVORITES: 'glob:*/api/v1/tag/1/favorites/',
+  RELATED_CHANGED_BY: 'glob:*/api/v1/tag/related/changed_by*',
+  CATCH_ALL: 'glob:*',
+};
+
+const setupMocks = (initialFavorite = false) => {
+  fetchMock.get(ENDPOINTS.INFO, {
+    permissions: ['can_read', 'can_write'],
+  });
+  fetchMock.get(ENDPOINTS.TAGS, {
+    result: mockTags,
+    count: mockTags.length,
+  });
+  fetchMock.get(ENDPOINTS.FAVORITE_STATUS, {
+    result: [{ id: 1, value: initialFavorite }],
+  });
+  fetchMock.post(ENDPOINTS.FAVORITES, {});
+  fetchMock.delete(ENDPOINTS.FAVORITES, {});
+  fetchMock.get(ENDPOINTS.RELATED_CHANGED_BY, { result: [], count: 0 });
+  fetchMock.get(ENDPOINTS.CATCH_ALL, { result: [], count: 0 });
+};
+
+const renderTagList = () => {
+  const store = configureStore({
+    reducer: { user: (state = mockUser) => state },
+    preloadedState: { user: mockUser },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  });
+  return render(
+    <Provider store={store}>
+      <BrowserRouter>
+        <QueryParamProvider adapter={ReactRouter5Adapter}>
+          <TagList user={mockUser} />
+        </QueryParamProvider>
+      </BrowserRouter>
+    </Provider>,
+  );
+};
+
+afterEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+});
+
+test('reflects the fetched favorite status on the star icon', async () => {
+  setupMocks(true);
+  renderTagList();
+
+  // The star fills to reflect the favorite status loaded from the API.
+  await waitFor(
+    () => expect(screen.getByLabelText('starred')).toBeInTheDocument(),
+    { timeout: 5000 },
+  );
+});
+
+test('toggles the favorite star and updates the icon on click', async () => {
+  setupMocks(false);
+  renderTagList();
+
+  // Initially unstarred per the favorite_status response.
+  await waitFor(
+    () => expect(screen.getByLabelText('unstarred')).toBeInTheDocument(),
+    { timeout: 5000 },
+  );
+
+  fireEvent.click(screen.getByTestId('fave-unfave-icon'));
+
+  // The POST to favorite the tag fires...
+  await waitFor(() =>
+    expect(fetchMock.callHistory.called(ENDPOINTS.FAVORITES)).toBe(true),
+  );
+
+  // ...and the cell re-renders with the filled star (regression guard for the
+  // stale columns useMemo that omitted saveFavoriteStatus/favoriteStatus).
+  await waitFor(
+    () => expect(screen.getByLabelText('starred')).toBeInTheDocument(),
+    { timeout: 5000 },
+  );
+});

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -257,7 +257,15 @@ function TagList(props: TagListProps) {
         id: QueryObjectColumns.ChangedBy,
       },
     ],
-    [userId, canDelete, refreshData, addSuccessToast, addDangerToast],
+    [
+      userId,
+      canDelete,
+      refreshData,
+      addSuccessToast,
+      addDangerToast,
+      saveFavoriteStatus,
+      favoriteStatus,
+    ],
   );
 
   const filters: ListViewFilters = useMemo(() => {


### PR DESCRIPTION
### SUMMARY

In the **Tags** list view (Settings → Tags), the favorite star did not respond to clicks — no visual feedback, and the tag was never marked as favorite.

**Root cause:** in `superset-frontend/src/pages/Tags/index.tsx`, the `columns` `useMemo` dependency array omitted `saveFavoriteStatus` and `favoriteStatus`. The `FaveStar` cell is rendered with `saveFaveStar={saveFavoriteStatus}` and `isStarred={favoriteStatus[id]}`, but because those values were missing from the deps, the memoized columns held a stale closure — the cell never re-rendered when favorite status loaded or changed. `ChartList`'s equivalent `useMemo` includes both in its deps; the `useFavoriteStatus('tag', …)` hook was already wired correctly, and the backend tag-favorite endpoints already work.

**Fix:** add `saveFavoriteStatus` and `favoriteStatus` to the columns `useMemo` deps (matching `ChartList`'s convention).

This PR is intentionally scoped to the broken star toggle only. A companion PR adds the favorites *filter* to the Tags list: apache/superset#41461

### TESTING INSTRUCTIONS

1. Go to Settings → Tags.
2. Click the star next to any tag → it fills and the tag is favorited (persists on reload).
3. Click again → it unfavorites.

New tests in `superset-frontend/src/pages/Tags/Tags.test.tsx` cover that the star reflects fetched favorite status and updates on click. Verified the tests fail when the deps fix is reverted (genuine regression guard) and pass with it.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime warnings (e.g., Compatibility warnings, Deprecation warnings, Spark workers crashing)
