### PR TITLE
feat(tags): add favorites filter to Tags list view

### DIFF
--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -129,6 +129,7 @@ export enum ListViewFilterOperator {
   Between = 'between',
   DashboardIsFav = 'dashboard_is_favorite',
   ChartIsFav = 'chart_is_favorite',
+  TagIsFav = 'tag_is_favorite',
   ChartIsCertified = 'chart_is_certified',
   DashboardIsCertified = 'dashboard_is_certified',
   DatasetIsCertified = 'dataset_is_certified',

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -35,6 +35,7 @@ import {
   ListView,
   ModifiedInfo,
   ListViewFilterOperator as FilterOperator,
+  type ListViewFilter,
   type ListViewFilters,
   type ListViewProps,
 } from 'src/components';
@@ -260,6 +261,23 @@ function TagList(props: TagListProps) {
     [userId, canDelete, refreshData, addSuccessToast, addDangerToast],
   );
 
+  const favoritesFilter: ListViewFilter = useMemo(
+    () => ({
+      Header: t('Favorite'),
+      key: 'favorite',
+      id: 'id',
+      urlDisplay: 'favorite',
+      input: 'select',
+      operator: FilterOperator.TagIsFav,
+      unfilteredLabel: t('Any'),
+      selects: [
+        { label: t('Yes'), value: true },
+        { label: t('No'), value: false },
+      ],
+    }),
+    [],
+  );
+
   const filters: ListViewFilters = useMemo(() => {
     const filters_list = [
       {
@@ -269,6 +287,7 @@ function TagList(props: TagListProps) {
         operator: FilterOperator.Contains,
         inputName: 'tag_list_search',
       },
+      ...(userId ? [favoritesFilter] : []),
       {
         Header: t('Modified by'),
         key: 'changed_by',
@@ -291,7 +310,7 @@ function TagList(props: TagListProps) {
       },
     ] as ListViewFilters;
     return filters_list;
-  }, [addDangerToast, props.user]);
+  }, [addDangerToast, props.user, userId, favoritesFilter]);
 
   const sortTypes = [
     {

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -40,7 +40,7 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.tag import TagDAO
 from superset.exceptions import MissingUserContextException
 from superset.extensions import event_logger
-from superset.tags.filters import UserCreatedTagTypeFilter
+from superset.tags.filters import TagFavoriteFilter, UserCreatedTagTypeFilter
 from superset.tags.models import ObjectType, Tag
 from superset.tags.schemas import (
     delete_tags_schema,
@@ -120,7 +120,19 @@ class TagRestApi(BaseSupersetModelRestApi):
     }
     allowed_rel_fields = {"created_by", "changed_by"}
 
-    search_filters = {"type": [UserCreatedTagTypeFilter]}
+    search_columns = [
+        "id",
+        "name",
+        "type",
+        "description",
+        "created_by",
+        "changed_by",
+    ]
+
+    search_filters = {
+        "type": [UserCreatedTagTypeFilter],
+        "id": [TagFavoriteFilter],
+    }
 
     add_model_schema = TagPostSchema()
     edit_model_schema = TagPutSchema()

--- a/superset/tags/filters.py
+++ b/superset/tags/filters.py
@@ -22,11 +22,12 @@ from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import Query
 
 from superset.connectors.sqla.models import SqlaTable
-from superset.extensions import db
+from superset.extensions import db, security_manager
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.sql_lab import Query as SqllabQuery
-from superset.tags.models import Tag, TagType
+from superset.tags.models import Tag, TagType, user_favorite_tag_table
+from superset.utils.core import get_user_id
 from superset.views.base import BaseFilter
 
 
@@ -46,6 +47,31 @@ class UserCreatedTagTypeFilter(BaseFilter):  # pylint: disable=too-few-public-me
         if value is False:
             return query.filter(Tag.type != TagType.custom)
         return query
+
+
+class TagFavoriteFilter(BaseFilter):  # pylint: disable=too-few-public-methods
+    """
+    Custom filter for the GET list that filters tags the current user has
+    favorited or not.
+
+    Tag favorites are stored in the dedicated ``user_favorite_tag_table`` M2M
+    table rather than in ``FavStar``, so this filter cannot reuse
+    ``BaseFavoriteFilter`` (which queries ``FavStar``).
+    """
+
+    name = _("Is favorite")
+    arg_name = "tag_is_favorite"
+
+    def apply(self, query: Query, value: Any) -> Query:
+        # If anonymous user filter nothing
+        if security_manager.current_user is None:
+            return query
+        users_favorite_query = db.session.query(
+            user_favorite_tag_table.c.tag_id
+        ).filter(user_favorite_tag_table.c.user_id == get_user_id())
+        if value:
+            return query.filter(Tag.id.in_(users_favorite_query))
+        return query.filter(~Tag.id.in_(users_favorite_query))
 
 
 class BaseTagNameFilter(BaseFilter):  # pylint: disable=too-few-public-methods

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -602,6 +602,46 @@ class TestTagApi(InsertChartMixin, SupersetTestCase):
         assert association_row is None
 
     @pytest.mark.usefixtures("create_tags")
+    def test_get_list_tag_filtered_by_favorite(self):
+        """
+        Tag API: Test get list filtered by the ``tag_is_favorite`` filter
+        returns only the tags the current user has (or has not) favorited.
+        """
+        self.login(ADMIN_USERNAME)
+        # favorite a single tag for the current (admin) user
+        favorited_tag = db.session.query(Tag).first()
+        rv = self.client.post(
+            f"api/v1/tag/{favorited_tag.id}/favorites/", follow_redirects=True
+        )
+        assert rv.status_code == 200
+
+        # value=True returns only the favorited tag
+        query = {
+            "filters": [{"col": "id", "opr": "tag_is_favorite", "value": True}],
+        }
+        uri = f"api/v1/tag/?{parse.urlencode({'q': rison.dumps(query)})}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["count"] == 1
+        assert data["result"][0]["id"] == favorited_tag.id
+
+        # value=False returns every other tag
+        query["filters"][0]["value"] = False
+        uri = f"api/v1/tag/?{parse.urlencode({'q': rison.dumps(query)})}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["count"] == TAGS_FIXTURE_COUNT - 1
+        assert favorited_tag.id not in {tag["id"] for tag in data["result"]}
+
+        # cleanup the favorite association
+        rv = self.client.delete(
+            f"api/v1/tag/{favorited_tag.id}/favorites/", follow_redirects=True
+        )
+        assert rv.status_code == 200
+
+    @pytest.mark.usefixtures("create_tags")
     def test_add_tag_not_found(self):
         self.login(ADMIN_USERNAME)
         uri = "api/v1/tag/123/favorites/"  # noqa: F541


### PR DESCRIPTION
### SUMMARY

Adds a **"Favorite"** filter to the **Tags** list view, mirroring the pattern (and ordering) already used by the Charts and Dashboards CRUD list views. Users can now filter the Tags list to show only their favorited tags (or only non-favorited).

**Frontend**
- `ListView/types.ts`: added `TagIsFav = 'tag_is_favorite'` to the `ListViewFilterOperator` enum.
- `pages/Tags/index.tsx`: added a memoized `favoritesFilter` (Yes/No select, `operator: TagIsFav`), included in the filters array guarded by `userId`. The Tags list has no Owner/Certified filters, so it's placed between **Name** and **Modified by** — consistent with where Charts/Dashboards put Favorite (after owner-type filters, before "Modified by").

**Backend**
- `tags/filters.py`: new `TagFavoriteFilter`. Note tag favorites are stored in `user_favorite_tag_table` (a dedicated M2M table), **not** in `FavStar` — so this deliberately does **not** subclass `BaseFavoriteFilter`. It builds a subquery of favorited tag ids for the current user (anonymous users pass through unfiltered), mirroring `TagDAO.favorited_ids`.
- `tags/api.py`: registered `TagFavoriteFilter` under the `"id"` key in `search_filters` and added an explicit `search_columns` list including `id`.

A companion PR fixes the (separate) bug where the Tags favorite star did not toggle: apache/superset#41460

### TESTING INSTRUCTIONS

1. Favorite one or more tags in Settings → Tags (requires apache/superset#41460 for the star to toggle in the UI, or favorite via the API).
2. Use the new **Favorite** filter → "Yes" shows only favorited tags, "No" shows the rest.

New integration test `tests/integration_tests/tags/api_tests.py::test_get_list_tag_filtered_by_favorite` asserts `tag_is_favorite=True/False` returns the correct tags for the current user.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime warnings (e.g., Compatibility warnings, Deprecation warnings, Spark workers crashing)