### PR TITLE
fix(bigquery): quote dotted STRUCT columns per-segment in drill to detail

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3354,11 +3354,16 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 # multi-part identifiers (e.g. a BigQuery STRUCT field registered
                 # with a dotted ``column_name`` such as ``a.b.c``) are quoted per
                 # segment, matching the chart/groupby selection path above.
-                # Routing these through ``quote()`` + sqlglot normalization below
-                # can instead quote the whole dotted path as one identifier
-                # (e.g. ``a.b.c`` becomes a single quoted name rather than the
-                # correct per-segment form), which breaks drill to detail /
-                # samples queries on nested columns (SC-111745).
+                # Without this, a registered string column falls through to the
+                # ``quote()`` + ``_process_select_expression`` (sqlglot
+                # ``sanitize_clause``) path below, which re-serializes the merged
+                # identifier into a table-qualified form that no longer matches
+                # ``quoted_columns_by_name`` and is emitted via ``literal_column``
+                # as a single quoted name — breaking drill to detail / samples
+                # queries on nested columns (SC-111745).
+                # The guard fires for every registered physical column, not only
+                # dotted ones; that is intentional — for a plain name like ``id``
+                # the resolved column produces SQL identical to the fallback path.
                 if isinstance(selected, str) and selected in columns_by_name:
                     select_exprs.append(
                         self.convert_tbl_column_to_sqla_col(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3355,9 +3355,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 # with a dotted ``column_name`` such as ``a.b.c``) are quoted per
                 # segment, matching the chart/groupby selection path above.
                 # Routing these through ``quote()`` + sqlglot normalization below
-                # can collapse the dotted path into a single quoted identifier
-                # (e.g. ```a.b`.`c```), which breaks drill to detail / samples
-                # queries on nested columns (SC-111745).
+                # can instead quote the whole dotted path as one identifier
+                # (e.g. ``a.b.c`` becomes a single quoted name rather than the
+                # correct per-segment form), which breaks drill to detail /
+                # samples queries on nested columns (SC-111745).
                 if isinstance(selected, str) and selected in columns_by_name:
                     select_exprs.append(
                         self.convert_tbl_column_to_sqla_col(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3350,6 +3350,23 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 select_exprs.append(outer)
         elif columns:
             for selected in columns:
+                # Resolve a known column directly to its ``TableColumn`` so that
+                # multi-part identifiers (e.g. a BigQuery STRUCT field registered
+                # with a dotted ``column_name`` such as ``a.b.c``) are quoted per
+                # segment, matching the chart/groupby selection path above.
+                # Routing these through ``quote()`` + sqlglot normalization below
+                # can collapse the dotted path into a single quoted identifier
+                # (e.g. ```a.b`.`c```), which breaks drill to detail / samples
+                # queries on nested columns (SC-111745).
+                if isinstance(selected, str) and selected in columns_by_name:
+                    select_exprs.append(
+                        self.convert_tbl_column_to_sqla_col(
+                            columns_by_name[selected],
+                            label=selected,
+                            template_processor=template_processor,
+                        )
+                    )
+                    continue
                 if is_adhoc_column(selected):
                     _sql = selected["sqlExpression"]
                     _column_label = selected["label"]

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3251,4 +3251,7 @@ def test_get_sqla_query_dotted_struct_column_bigquery(
     # The dotted STRUCT path must be quoted per-segment so BigQuery resolves the
     # nested field, and must not appear as a single merged identifier.
     assert "`forecasts`.`original`.`total_cost`" in sql
+    # ```forecasts.original``` is a substring of the broken form
+    # ```forecasts.original`.`total_cost``` (the regression), so this negative
+    # assertion catches the actual failure mode, not just an exact-string match.
     assert "`forecasts.original`" not in sql

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3193,3 +3193,62 @@ def test_process_sql_expression_no_gate_when_denylists_empty(
         template_processor=None,
     )
     assert result is not None
+
+
+def test_get_sqla_query_dotted_struct_column_bigquery(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    SC-111745: a BigQuery STRUCT field registered with a dotted ``column_name``
+    (e.g. ``forecasts.original.total_cost``) must be quoted per-segment in the
+    drill-to-detail / samples SELECT (e.g. ```forecasts`.`original`.`total_cost```),
+    not collapsed into a single quoted identifier (```forecasts.original```),
+    which BigQuery rejects with "Unrecognized name".
+    """
+    bigquery = pytest.importorskip("sqlalchemy_bigquery")
+
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.models.core import Database
+
+    SqlaTable.metadata.create_all(session.get_bind())
+
+    dialect = bigquery.BigQueryDialect()
+
+    @contextmanager
+    def fake_engine(*args, **kwargs):
+        engine = MagicMock()
+        engine.dialect = dialect
+        yield engine
+
+    database = Database(database_name="bq", sqlalchemy_uri="bigquery://project")
+    mocker.patch.object(database, "get_sqla_engine", new=fake_engine)
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="orders",
+        columns=[
+            TableColumn(column_name="id", type="INTEGER"),
+            TableColumn(column_name="forecasts.original.total_cost", type="FLOAT"),
+        ],
+    )
+
+    # Mirror the drill-to-detail / samples path: select physical columns with no
+    # groupby/metrics so the column-selection branch in ``get_sqla_query`` runs.
+    sqlaq = table.get_sqla_query(
+        columns=["id", "forecasts.original.total_cost"],
+        is_timeseries=False,
+        row_limit=100,
+    )
+    sql = str(
+        sqlaq.sqla_query.compile(
+            dialect=dialect,
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    # The dotted STRUCT path must be quoted per-segment so BigQuery resolves the
+    # nested field, and must not appear as a single merged identifier.
+    assert "`forecasts`.`original`.`total_cost`" in sql
+    assert "`forecasts.original`" not in sql


### PR DESCRIPTION
### SUMMARY

Drill to Detail / samples queries over a **physical BigQuery dataset** failed with `400 ... Unrecognized name: \`forecasts.original\`` when a column was a nested `STRUCT` field registered with a dotted `column_name` (e.g. `forecasts.original.total_cost`). The chart itself rendered fine — only Drill to Detail / samples broke.

**Root cause:** In `ExploreMixin.get_sqla_query` (`superset/models/helpers.py`), the column-selection branch (`elif columns:`) routed plain string columns through `quote()` + sqlglot normalization. For a dotted name that collapses the path into a **single** quoted identifier (`` `forecasts.original` ``), which BigQuery reads as one flat column name. The chart/groupby selection path instead resolves the `TableColumn` and builds `sa.column(column_name)`, which BigQuery quotes **per-segment** (`` `forecasts`.`original`.`total_cost` ``) and resolves correctly.

```
sa.column("a.b.c")  →  `a`.`b`.`c`   ✅
quote("a.b.c")      →  `a.b.c`       ❌
```

**Fix:** In the `elif columns:` branch, short-circuit known columns — when `selected in columns_by_name`, resolve directly via `convert_tbl_column_to_sqla_col` (the same helper the chart selection path uses) before falling back to the `quote()`/normalize path. Non-dotted columns, adhoc columns, and virtual datasets are unaffected (same helper, same labels; the short-circuit only triggers for registered physical columns).

The filter path was already correct (it resolves via `columns_by_name.get()` + `convert_tbl_column_to_sqla_col`), so no change was needed there.

Fixes [SC-111745](https://app.shortcut.com/preset/story/111745).

### TESTING INSTRUCTIONS

- New unit test `test_get_sqla_query_dotted_struct_column_bigquery` (`tests/unit_tests/models/helpers_test.py`) asserts the dotted STRUCT path is quoted per-segment (`` `forecasts`.`original`.`total_cost` ``) and that the merged identifier (`` `forecasts.original` ``) does **not** appear, using the real BigQuery dialect (`importorskip`).
- Full `helpers_test.py` (73 tests) passes — no regressions.
- Manual repro: build an Interactive Table over a physical BigQuery dataset with a nested STRUCT column registered as a dotted name, right-click → Drill to detail. Previously 400'd; now returns detail rows.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related earlier report: PCS-2360 / PPR-442 covers Drill to Detail on a nested `ARRAY<STRUCT>` failing with a *different* error; that variant is not addressed here.
