### PR TITLE
chore(ci): prune orphaned showtime labels in daily cleanup

### DIFF
--- a/.github/workflows/showtime-cleanup.yml
+++ b/.github/workflows/showtime-cleanup.yml
@@ -24,13 +24,14 @@ jobs:
 
     permissions:
       contents: read
+      issues: write        # delete orphaned showtime label definitions (label CRUD is the issues API)
       pull-requests: write
 
     steps:
       - name: Install Superset Showtime
         run: pip install superset-showtime
 
-      - name: Cleanup expired environments
+      - name: Cleanup expired environments and orphaned labels
         run: |
-          echo "Cleaning up environments respecting TTL labels"
-          python -m showtime cleanup --respect-ttl
+          echo "Cleaning up environments respecting TTL labels, and pruning orphaned 🎪 labels"
+          python -m showtime cleanup --respect-ttl --force


### PR DESCRIPTION
### SUMMARY

[Superset Showtime](https://github.com/mistercrunch/superset-showtime) stores per-PR ephemeral-environment state in GitHub **labels** (e.g. `🎪 <sha> 🚦 running`). When that state no longer applies, the label is removed from the PR — but GitHub never deletes the repo-level label *definition*, so orphaned `🎪` definitions pile up forever (currently ~1,200 of ~2,400 labels in this repo).

[superset-showtime#15](https://github.com/preset-io/superset-showtime/pull/15) moved the orphaned-label pruning into the `showtime cleanup` CLI itself (the right home — reusable, tested, shared across every repo that uses Showtime), and it shipped in **Showtime 0.7.1** on PyPI. This PR is the tiny apache-side change needed to *activate* that behavior in our existing scheduled cleanup job:

- **`issues: write`** permission — GitHub label CRUD goes through the Issues API; without it the deletes 403.
- **`--force`** — in #15 the label-deletion path is gated behind a confirmation prompt unless `--force` is passed, which would hang/fail in non-interactive CI.

The job already `pip install`s `superset-showtime` unpinned, so it picks up the new CLI automatically. The cleanup schedule is unchanged (every 6 hours) — pruning just rides along on the existing run.

#### History
This supersedes #41459, which implemented the same pruning rule as a standalone in-repo `github-script` workflow. That approach works with zero dependency on a Showtime release, so the branch is kept as a fallback, but landing the logic in the tool is the better outcome.

### TESTING INSTRUCTIONS

**Actions → 🎪 Showtime Cleanup → Run workflow.** Confirm the run prunes orphaned `🎪` label definitions (SHA-bearing, zero-attachment) while leaving control labels (`⌛`/`⚡`/`🔒`) and still-attached labels intact.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
