### PR TITLE
fix(i18n): skip unparseable catalogs when building translation index

### DIFF
--- a/scripts/translations/build_translation_index.py
+++ b/scripts/translations/build_translation_index.py
@@ -88,10 +88,12 @@ def build_index(translations_dir: Path) -> dict[str, Any]:
         po_path = translations_dir / lang / "LC_MESSAGES" / "messages.po"
         try:
             cat = polib.pofile(str(po_path))
-        except OSError as exc:
-            # A single malformed catalog (e.g. an unescaped quote) shouldn't
-            # block backfilling every other language. Skip it with a loud
-            # warning so the corrupt file gets fixed separately.
+        except (OSError, UnicodeDecodeError) as exc:
+            # A single malformed catalog shouldn't block backfilling every
+            # other language. polib raises OSError on syntax errors (e.g. an
+            # unescaped quote) and UnicodeDecodeError on bad encoding; skip
+            # either with a loud warning so the corrupt file gets fixed
+            # separately.
             print(
                 f"WARNING: skipping {lang} — could not parse {po_path}: {exc}",
                 file=sys.stderr,

--- a/scripts/translations/build_translation_index.py
+++ b/scripts/translations/build_translation_index.py
@@ -86,7 +86,17 @@ def build_index(translations_dir: Path) -> dict[str, Any]:
 
     for lang in langs:
         po_path = translations_dir / lang / "LC_MESSAGES" / "messages.po"
-        cat = polib.pofile(str(po_path))
+        try:
+            cat = polib.pofile(str(po_path))
+        except OSError as exc:
+            # A single malformed catalog (e.g. an unescaped quote) shouldn't
+            # block backfilling every other language. Skip it with a loud
+            # warning so the corrupt file gets fixed separately.
+            print(
+                f"WARNING: skipping {lang} — could not parse {po_path}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         for entry in cat:
             if not entry.msgid:
                 continue  # skip header entry

--- a/tests/unit_tests/scripts/translations/build_translation_index_test.py
+++ b/tests/unit_tests/scripts/translations/build_translation_index_test.py
@@ -267,6 +267,30 @@ def test_build_index_skips_unparseable_catalog(tmp_path: Path) -> None:
     assert index["Hello"]["fr"] is None
 
 
+def test_build_index_skips_catalog_with_bad_encoding(tmp_path: Path) -> None:
+    """
+    A catalog with invalid encoding raises ``UnicodeDecodeError`` (not
+    ``OSError``) from ``polib.pofile``. It must be skipped like any other
+    unparseable file rather than crashing the whole index build.
+    """
+    root = tmp_path / "translations"
+    _write_po(
+        root / "es" / "LC_MESSAGES" / "messages.po",
+        [polib.POEntry(msgid="Hello", msgstr="Hola")],
+    )
+    bad_po = root / "fr" / "LC_MESSAGES" / "messages.po"
+    bad_po.parent.mkdir(parents=True, exist_ok=True)
+    # Declares UTF-8 but contains a byte that isn't valid UTF-8.
+    bad_po.write_bytes(
+        b'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=UTF-8\\n"\n\n'
+        b'msgid "Hello"\nmsgstr "Bonjour \xff"\n'
+    )
+
+    index = build_translation_index.build_index(root)
+    assert index["Hello"]["es"] == "Hola"
+    assert index["Hello"]["fr"] is None
+
+
 def test_build_index_skips_header_entry(tmp_path: Path) -> None:
     """
     The .po header entry has an empty msgid by convention. It must not be

--- a/tests/unit_tests/scripts/translations/build_translation_index_test.py
+++ b/tests/unit_tests/scripts/translations/build_translation_index_test.py
@@ -242,6 +242,31 @@ def test_build_index_skips_languages_without_messages_po(tmp_path: Path) -> None
     assert index == {"Hello": {"es": "Hola"}}
 
 
+def test_build_index_skips_unparseable_catalog(tmp_path: Path) -> None:
+    """
+    A single malformed catalog must not block indexing every other language.
+    The corrupt file is skipped (with a warning) while valid languages are
+    still indexed.
+    """
+    root = tmp_path / "translations"
+    _write_po(
+        root / "es" / "LC_MESSAGES" / "messages.po",
+        [polib.POEntry(msgid="Hello", msgstr="Hola")],
+    )
+    bad_po = root / "fr" / "LC_MESSAGES" / "messages.po"
+    bad_po.parent.mkdir(parents=True, exist_ok=True)
+    bad_po.write_text(
+        'msgid "Hello"\nmsgstr "Bonjour"\nthis is not valid po syntax\n',
+        encoding="utf-8",
+    )
+
+    index = build_translation_index.build_index(root)
+    # The valid language is still indexed; the corrupt one contributes no
+    # translations (it surfaces as a null slot, never as parsed text).
+    assert index["Hello"]["es"] == "Hola"
+    assert index["Hello"]["fr"] is None
+
+
 def test_build_index_skips_header_entry(tmp_path: Path) -> None:
     """
     The .po header entry has an empty msgid by convention. It must not be


### PR DESCRIPTION
### SUMMARY

`build_translation_index.py` calls `polib.pofile()` on every language catalog with no error handling, so a single malformed `.po` (e.g. an unescaped quote) raises and aborts the entire index build. That blocks the AI translation backfill for *every* language, not just the broken one.

This skips an unparseable catalog with a loud `WARNING` and continues, matching the resilience already present in `check_translation_regression.py` (which warns-and-skips catalogs that won't compile). The corrupt file still needs fixing separately, but it no longer takes the whole index down with it.

(Surfaced while running the backfill tooling: `ro/LC_MESSAGES/messages.po` currently fails to parse, which is what exposed this. The `ro` corruption itself is fixed in a separate PR.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (developer tooling)

### TESTING INSTRUCTIONS

With a malformed catalog present (e.g. an unescaped `"` in any `messages.po`):

```bash
python scripts/translations/build_translation_index.py
```

Before: traceback, no index written. After: `WARNING: skipping <lang> …` and the index is written for all parseable languages.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
