### PR TITLE
fix(i18n): repair corrupted Romanian catalog so it parses again

### DIFF
--- a/superset/translations/ro/LC_MESSAGES/messages.po
+++ b/superset/translations/ro/LC_MESSAGES/messages.po
@@ -3164,9 +3164,6 @@ msgstr "Culoare după"
 msgid "Color for breakpoint"
 msgstr "Culoare pentru punct de întrerupere"
 
-msgid "Color Metric"
-msgstr "Indicator culoare"
-
 msgid "Color of the source location"
 msgstr "Culoarea locației sursă"
 
@@ -4644,7 +4641,7 @@ msgid "Deleted %(num)d theme"
 msgid_plural "Deleted %(num)d themes"
 msgstr[0] "Ștearsă %(num)d temă"
 msgstr[1] "Șterse %(num)d teme"
-msgstr[2] "Șterse %(num)d de teme""
+msgstr[2] "Șterse %(num)d de teme"
 
 #, python-format
 msgid "Deleted %s"
@@ -10218,7 +10215,7 @@ msgid "Saved expressions"
 msgstr "Expresii salvate"
 
 msgid "Saved metric"
-msgstr "Indicator salvat""
+msgstr "Indicator salvat"
 
 msgid "Saved queries"
 msgstr "Interogări salvate"
@@ -13422,7 +13419,7 @@ msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
 msgstr[0] "Aceasta a fost declanșată de:"
 msgstr[1] "Acestea pot fi declanșate de:"
-msgstr[2] "Acestea pot fi declanșate de către:""
+msgstr[2] "Acestea pot fi declanșate de către:"
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
@@ -14447,7 +14444,7 @@ msgstr ""
 "Vizualizează un indicator corelat pentru perechi de grupuri. Hartile "
 "termice (Heatmaps) excelează în evidențierea corelației sau a "
 "intensității dintre două grupuri. Culoarea este utilizată pentru a "
-"sublinia intensitatea legăturii dintre fiecare pereche de grupuri.""
+"sublinia intensitatea legăturii dintre fiecare pereche de grupuri."
 
 msgid ""
 "Visualize geospatial data like 3D buildings, landscapes, or objects in "


### PR DESCRIPTION
### SUMMARY

The Romanian catalog (`ro/LC_MESSAGES/messages.po`) is corrupted on `master` with hard syntax errors:

- **Four `msgstr` values end in a stray double quote**, e.g. `msgstr "Indicator salvat""`, `msgstr[2] "Șterse %(num)d de teme""`. The unescaped quote terminates the string early.
- **A duplicate `msgid "Color Metric"`** definition (identical `msgstr`).

`polib.pofile()` raises on the first of these, which is what broke the translation-index builder (it aborted the whole build on this one file), and `msgfmt`/`pybabel` reject it too. This removes the four stray quotes and the duplicate entry. The catalog now parses cleanly with `polib` and compiles with `pybabel`.

Found while running the AI backfill tooling — `ro` was silently excluded from every other language's translation context because it couldn't be parsed.

**Out of scope (intentionally):** with the syntax errors gone, strict `msgfmt --check-format` now surfaces a handful of pre-existing plural format-spec mismatches (`msgstr[0]` dropping the `%s`/`%(num)d` count). That's a separate, non-fatal class already present in `pl`, `pt_BR`, `zh`, and `zh_TW`, and is left for a dedicated cleanup rather than mixed into this corruption fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (translation catalog)

### TESTING INSTRUCTIONS

Before, this raises `OSError: unescaped double quote found`:

```bash
python -c "import polib; polib.pofile('superset/translations/ro/LC_MESSAGES/messages.po')"
```

After, it parses (4462 entries) and `pybabel compile -i superset/translations/ro/LC_MESSAGES/messages.po -o /tmp/ro.mo` no longer errors on syntax.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
