### PR TITLE
fix(dashboard): let CSV exports use query cache instead of always force-querying

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -227,7 +227,10 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
         formData?.result_type === 'results');
 
     if (isDownloadQuery) {
-      moreProps.row_limit = Number(formDataCopy.row_limit) || 0;
+      moreProps.row_limit =
+        formDataCopy.row_limit != null
+          ? Number(formDataCopy.row_limit)
+          : undefined;
       moreProps.row_offset = 0;
     }
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -562,7 +562,6 @@ const Chart = (props: ChartProps) => {
             exportFormData as unknown as import('@superset-ui/core').QueryFormData,
           resultType,
           resultFormat: format,
-          force: true,
           ownState: exportOwnState,
           onStartStreamingExport: shouldUseStreaming
             ? (exportParams: JsonObject) => {


### PR DESCRIPTION
### SUMMARY

Two bugs combine to make Dashboard CSV/XLSX exports always re-execute the query instead of serving from cache, while the Explore page correctly hits the cache.

**Bug 1 — `Chart.tsx`**: The `exportChart()` call in the dashboard chart component hardcodes `force: true`, which tells the backend to bypass the cache entirely on every export. The Explore page does not set this flag, which is why it correctly uses the cache.

**Bug 2 — `buildQuery.ts`**: For download queries (`result_format: 'csv'` / `'xlsx'`), `row_limit` was coerced to `0` via `Number(formDataCopy.row_limit) || 0` when the chart has no explicit `row_limit`. Display queries leave `row_limit` as `undefined`. This produces a different cache key for the export request versus the display request that populated the cache, so the export always misses — even after fixing Bug 1.

Both fixes are required together:
- Removing `force: true` lets the backend consult the cache instead of always executing.
- Preserving `undefined` (instead of `0`) for a missing `row_limit` ensures the export query generates the same cache key as the display query that already populated the cache.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — backend cache behavior change with no UI change.

### TESTING INSTRUCTIONS

1. Open a dashboard containing a Table chart backed by a slow query.
2. Wait for the chart to finish loading (it will be cached at this point).
3. Use the chart's kebab menu → **Download → CSV**. With this fix the export should return immediately (from cache); without it, the query is re-executed from scratch.
4. Confirm the same behavior on the Explore page (should continue to work as before).
5. Verify that explicit `row_limit` values on the chart are still respected in the export.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API