### PR TITLE
test(mcp): fix update_dashboard test mock for embedded_uuid

### DIFF
--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -81,6 +81,9 @@ def _mock_dashboard(
     dashboard.slices = []
     dashboard.owners = []
     dashboard.tags = []
+    # dashboard_serializer reads embedded[0].uuid when truthy (added in #41195);
+    # model it as an empty list so the serializer resolves embedded_uuid to None.
+    dashboard.embedded = []
     return dashboard
 
 


### PR DESCRIPTION
### SUMMARY

`#41195` added `embedded_uuid=str(dashboard.embedded[0].uuid) if dashboard.embedded else None` to the shared `dashboard_serializer` and updated the `get_dashboard_info` test mocks, but the `update_dashboard` test's `_mock_dashboard` helper was not updated. That helper builds a `Mock` with "EVERY field the serializer touches explicitly set" — except `.embedded`, which therefore resolved to an auto-`Mock` (truthy but not subscriptable). As a result the serializer hits `TypeError: 'Mock' object is not subscriptable` and **5 tests in `test_update_dashboard.py` fail on `master`**:

- `test_update_with_no_fields_is_noop`
- `test_update_title_and_slug_and_published`
- `test_update_description`
- `test_empty_slug_clears_slug`
- (plus one more in the same file)

This is a **test-only** gap. Product code is unaffected: on a real `Dashboard`, `.embedded` is a SQLAlchemy list relationship — empty → falsy → `embedded_uuid=None`; non-empty → `embedded[0].uuid` works.

The fix models `.embedded` as an empty list in `_mock_dashboard` (matching a dashboard with no embedded configuration), so the serializer resolves `embedded_uuid` to `None`, consistent with how `#41195` fixed the `get_dashboard_info` mocks.

### TESTING INSTRUCTIONS

```bash
python -m pytest tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py -q
```

Before: `5 failed, 3 passed`. After: `8 passed`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up to #41195 (test mocks only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)