### PR TITLE
chore(ci): correct actions/cache pin comment to actual version v5.0.5

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -63,7 +63,7 @@ jobs:
           yarn install --immutable
 
       - name: Cache pre-commit environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-v2-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache npm
         if: env.HAS_TAGS
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -70,7 +70,7 @@ jobs:
         run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache npm
         if: env.HAS_TAGS
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: npm-cache # use this to check for `cache-hit` (`steps.npm-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
### SUMMARY

The `actions/cache` action is pinned by SHA `27d5ce7f107fe9357f9df03efb73ab90386fccae` in three workflow steps, but the trailing comment reads `# v5`. That SHA actually corresponds to tag **v5.0.5**; the floating `v5` tag points to a different commit (`caa2961...`). The comment therefore misrepresents the pinned version.

This updates the comment to the truthful version (`# v5.0.5`) so it matches the pinned commit. No SHA change, so runtime behavior is identical.

Affected files:
- `.github/workflows/release.yml` (2 steps)
- `.github/workflows/pre-commit.yml` (1 step)

Resolves code-scanning alert #2553 (zizmor `ref-version-mismatch`).

### BEFORE/AFTER

Before: `uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5`
After: `uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`

### TESTING INSTRUCTIONS

`pre-commit run --files .github/workflows/release.yml .github/workflows/pre-commit.yml` — zizmor passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)