### PR TITLE
fix: show truncation notice when table list exceeds API page limit (#40407)

### DIFF
--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -82,6 +82,13 @@ const TableLabel = styled.span`
   }
 `;
 
+const TruncationNotice = styled.div`
+  ${({ theme }) => `
+    color: ${theme.colorTextSecondary};
+    margin-top: ${theme.sizeUnit}px;
+  `}
+`;
+
 interface TableSelectorProps {
   clearable?: boolean;
   database?: DatabaseObject | null;
@@ -339,6 +346,11 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       <>
         <StyledFormLabel>{label}</StyledFormLabel>
         {renderSelectRow(select, refreshLabel)}
+        {data?.hasMore && (
+          <TruncationNotice>
+            {t('Some tables are not shown. Refine your search.')}
+          </TruncationNotice>
+        )}
       </>
     );
   }


### PR DESCRIPTION
### SUMMARY
The `useTables` hook already computes a `hasMore` flag (`json.count > json.result.length`), but it was never consumed by `TableSelector`. When a database schema has more tables than the API page limit, users saw a truncated list with no indication that tables were missing.

### BEFORE
No indication when the table list is truncated.

### AFTER
A helper message appears below the table selector when `hasMore` is true:
> "Some tables are not shown. Refine your search."

### CHANGES
- `superset-frontend/src/components/TableSelector/index.tsx` — Added `TruncationNotice` styled component and conditional rendering of the message when `data?.hasMore` is true.

### TESTING INSTRUCTIONS
1. Connect a database schema with 100+ tables
2. Open SQL Lab, select that database and schema
3. Observe the helper message below the table selector informing users that the list is truncated

### ADDITIONAL INFORMATION
Closes #40407