### PR TITLE
fix(async): include datasets and rev claims in guest channel HMAC

### DIFF
--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -245,6 +245,11 @@ class AsyncQueryManager:
                 "iat": token.get("iat"),
                 "exp": token.get("exp"),
                 "aud": token.get("aud"),
+                # ``datasets`` and ``rev`` are optional scope claims, so tokens
+                # that differ only in their dataset allowlist or revocation
+                # version still derive distinct channels.
+                "datasets": token.get("datasets"),
+                "rev": token.get("rev"),
             },
             sort_keys=True,
         ).encode("utf-8")

--- a/tests/unit_tests/async_events/async_query_manager_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_tests.py
@@ -222,6 +222,44 @@ def test_parse_channel_id_from_request_as_guest_user_differs_per_token(
     assert first != second
 
 
+@mock.patch("superset.is_feature_enabled")
+def test_parse_channel_id_from_request_as_guest_user_differs_per_scope(
+    is_feature_enabled_mock, async_query_manager
+):
+    """
+    Tokens that differ only in the optional ``datasets`` allowlist or ``rev``
+    revocation version must still derive distinct channel ids, otherwise two
+    differently scoped embedded sessions would collide on the same stream.
+    """
+    is_feature_enabled_mock.return_value = True
+
+    base_token = {
+        "user": {},
+        "resources": [{"type": "dashboard", "id": "some-uuid"}],
+        "rls_rules": [{"clause": '"STATEID" = 3'}],
+        "iat": 1700000000.0,
+        "exp": 1700000300.0,
+        "aud": "http://0.0.0.0:8080/",
+        "type": "guest",
+    }
+
+    request = Mock()
+    request.cookies = {}
+
+    g.user = security_manager.get_guest_user_from_token(dict(base_token))
+    baseline = async_query_manager.parse_channel_id_from_request(request)
+
+    g.user = security_manager.get_guest_user_from_token({**base_token, "datasets": [1]})
+    with_datasets = async_query_manager.parse_channel_id_from_request(request)
+
+    g.user = security_manager.get_guest_user_from_token({**base_token, "rev": 1})
+    with_rev = async_query_manager.parse_channel_id_from_request(request)
+
+    assert baseline != with_datasets
+    assert baseline != with_rev
+    assert with_datasets != with_rev
+
+
 @mark.parametrize(
     "cache_type, cache_backend",
     [


### PR DESCRIPTION
### SUMMARY

Follow-up to #41397.

That PR derives a deterministic async channel id for embedded guest sessions via an HMAC-SHA256 over the guest token claims (since cross-origin cookies can't be relied on inside a third-party iframe). The HMAC message covered `user`, `resources`, `iat`, `exp`, and `aud`, but left out the two optional `GuestToken` scope claims: `datasets` (the dataset allowlist) and `rev` (the revocation version).

As a result, two tokens that differ *only* in their dataset allowlist or revocation version would hash to the same channel and collide on the same async stream. This folds both claims into the HMAC message so differently scoped tokens derive distinct channels.

### BEFORE/AFTER

Before: channel id ignored `datasets` and `rev`, so tokens differing only in those scopes shared a channel.

After: `datasets` and `rev` are part of the HMAC message; such tokens get distinct channels.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/async_events/async_query_manager_tests.py`

Added `test_parse_channel_id_from_request_as_guest_user_differs_per_scope` covering tokens that differ only in `datasets` or `rev`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
