### PR TITLE
fix(frontend): finish sentence-case conversion for time range buttons

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -817,9 +817,7 @@ export function exploreJSON(
             ),
         );
         (queriesResponse as QueryData[]).forEach(response => {
-          const { warning } = response as QueryData & {
-            warning?: string | null;
-          };
+          const { warning } = response as { warning?: string | null };
           if (warning) {
             dispatch(addWarningToast(warning, { noDuplicate: true }));
           }

--- a/superset-frontend/src/components/ListView/Filters/TimeRange.tsx
+++ b/superset-frontend/src/components/ListView/Filters/TimeRange.tsx
@@ -249,7 +249,7 @@ function TimeRangeFilter(
       <Divider />
       <div className="footer">
         <Button buttonStyle="secondary" cta key="cancel" onClick={onClose}>
-          {t('CANCEL')}
+          {t('Cancel')}
         </Button>
         <Button
           buttonStyle="primary"
@@ -281,7 +281,7 @@ function TimeRangeFilter(
             onClose();
           }}
         >
-          {t('APPLY')}
+          {t('Apply')}
         </Button>
       </div>
     </ContentWrapper>


### PR DESCRIPTION
Follow-up to #40435.

That PR converted most ALL CAPS button labels to sentence case but missed the time range filter popover in the ListView filters (different component from the explore `DateFilterLabel` that #40435 did fix). This finishes the job.

### Changes
- `components/ListView/Filters/TimeRange.tsx`: `CANCEL` -> `Cancel`, `APPLY` -> `Apply` (matches the sentence-case convention used everywhere else for these buttons).
- `components/Chart/chartAction.ts`: dropped a redundant `QueryData &` from a type assertion. The `response` is already inferred as `QueryData`, so re-asserting it in the intersection was redundant; `response as { warning?: string | null }` is enough.

The existing `TimeRange.test.tsx` queries these buttons with case-insensitive regex (`/cancel/i`, `/apply/i`), so no test changes are needed.

### Test plan
- [ ] Time range filter popover (list views): verify Cancel/Apply buttons render correctly
- [ ] `jest` passes on `TimeRange.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
