### PR TITLE
fix(deck.gl): apply categorical scatterplot colors in Multiple Layers chart

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import { getCategories } from './CategoricalDeckGLContainer';
+import { addColorToFeatures } from './utils/addColor';
+import { COLOR_SCHEME_TYPES } from './utilities/utils';
+
+// Record every (label, sliceId) pair the categorical color scale is asked to
+// resolve, so we can assert the legend and point-color paths key the scale on
+// the same slice id.
+const scaleCalls: [string, number | undefined][] = [];
+jest.mock('@superset-ui/core', () => {
+  const actual = jest.requireActual('@superset-ui/core');
+  return {
+    ...actual,
+    CategoricalColorNamespace: {
+      ...actual.CategoricalColorNamespace,
+      getScale: () => (value: string, sliceId?: number) => {
+        scaleCalls.push([value, sliceId]);
+        return value === 'A' ? '#ff0000' : '#00ff00';
+      },
+    },
+  };
+});
+
+test('legend and point colors resolve from the same slice_id', () => {
+  const fd = {
+    datasource: '1__table',
+    viz_type: 'deck_scatter',
+    color_scheme_type: COLOR_SCHEME_TYPES.categorical_palette,
+    color_scheme: 'supersetColors',
+    dimension: 'category',
+    slice_id: 42,
+    color_picker: { r: 0, g: 0, b: 0, a: 1 },
+  } as unknown as QueryFormData;
+  const data = [{ cat_color: 'A' }, { cat_color: 'B' }];
+
+  const categories = getCategories(fd, data);
+  const features = addColorToFeatures(data, fd);
+
+  // Both the legend path (getCategories) and the point-color path
+  // (addColorToFeatures) key the color scale on the same slice id.
+  expect(scaleCalls.length).toBeGreaterThan(0);
+  scaleCalls.forEach(([, sliceId]) => {
+    expect(sliceId).toBe(42);
+  });
+
+  // The legend swatch for each category matches the resolved point color.
+  expect(categories.A.color).toEqual(features[0].color);
+  expect(categories.B.color).toEqual(features[1].color);
+  expect(features[0].color).not.toEqual(features[1].color);
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -70,7 +70,7 @@ function getCategories(fd: QueryFormData, data: JsonObject[]) {
       if (d.cat_color != null && !categories.hasOwnProperty(d.cat_color)) {
         let color;
         if (fd.dimension) {
-          color = hexToRGB(colorFn(d.cat_color, fd.sliceId), c.a * 255);
+          color = hexToRGB(colorFn(d.cat_color, fd.slice_id), c.a * 255);
         } else {
           color = fixedColor;
         }

--- a/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -47,11 +47,11 @@ import {
   DeckGLContainerStyledWrapper,
 } from './DeckGLContainer';
 import { GetLayerType } from './factory';
-import { ColorBreakpointType, ColorType, Point } from './types';
+import { Point } from './types';
 import { TooltipProps } from './components/Tooltip';
 import { COLOR_SCHEME_TYPES, ColorSchemeType } from './utilities/utils';
 import { getColorBreakpointsBuckets } from './utils';
-import { DEFAULT_DECKGL_COLOR } from './utilities/Shared_DeckGL';
+import { addColorToFeatures } from './utils/addColor';
 
 const { getScale } = CategoricalColorNamespace;
 
@@ -150,80 +150,7 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
       data: JsonObject[],
       fd: QueryFormData,
       selectedColorScheme: ColorSchemeType,
-    ) => {
-      const appliedScheme = fd.color_scheme;
-      const colorFn = getScale(appliedScheme);
-      let color: ColorType;
-
-      switch (selectedColorScheme) {
-        case COLOR_SCHEME_TYPES.fixed_color: {
-          color = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
-          const colorArray = [color.r, color.g, color.b, color.a * 255];
-
-          return data.map(d => ({ ...d, color: colorArray }));
-        }
-        case COLOR_SCHEME_TYPES.categorical_palette: {
-          if (!fd.dimension) {
-            const fallbackColor = fd.color_picker || {
-              r: 0,
-              g: 0,
-              b: 0,
-              a: 1,
-            };
-            const colorArray = [
-              fallbackColor.r,
-              fallbackColor.g,
-              fallbackColor.b,
-              fallbackColor.a * 255,
-            ];
-            return data.map(d => ({ ...d, color: colorArray }));
-          }
-
-          return data.map(d => ({
-            ...d,
-            color: hexToRGB(colorFn(d.cat_color, fd.slice_id)),
-          }));
-        }
-        case COLOR_SCHEME_TYPES.color_breakpoints: {
-          const defaultBreakpointColor = fd.default_breakpoint_color
-            ? [
-                fd.default_breakpoint_color.r,
-                fd.default_breakpoint_color.g,
-                fd.default_breakpoint_color.b,
-                fd.default_breakpoint_color.a * 255,
-              ]
-            : [
-                DEFAULT_DECKGL_COLOR.r,
-                DEFAULT_DECKGL_COLOR.g,
-                DEFAULT_DECKGL_COLOR.b,
-                DEFAULT_DECKGL_COLOR.a * 255,
-              ];
-          return data.map(d => {
-            const breakpointForPoint: ColorBreakpointType =
-              fd.color_breakpoints?.find(
-                (breakpoint: ColorBreakpointType) =>
-                  d.metric >= breakpoint.minValue &&
-                  d.metric <= breakpoint.maxValue,
-              );
-
-            if (breakpointForPoint) {
-              const pointColor = [
-                breakpointForPoint.color.r,
-                breakpointForPoint.color.g,
-                breakpointForPoint.color.b,
-                breakpointForPoint.color.a * 255,
-              ];
-              return { ...d, color: pointColor };
-            }
-
-            return { ...d, color: defaultBreakpointColor };
-          });
-        }
-        default: {
-          return [];
-        }
-      }
-    },
+    ) => addColorToFeatures(data, fd, selectedColorScheme),
     [],
   );
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -55,7 +55,7 @@ import { addColorToFeatures } from './utils/addColor';
 
 const { getScale } = CategoricalColorNamespace;
 
-function getCategories(fd: QueryFormData, data: JsonObject[]) {
+export function getCategories(fd: QueryFormData, data: JsonObject[]) {
   const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
   const fixedColor = [c.r, c.g, c.b, 255 * c.a];
   const appliedScheme = fd.color_scheme;

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
@@ -26,9 +26,16 @@ import DeckMulti from './Multi';
 
 // Capture the layers handed to the DeckGL container so we can inspect the
 // per-feature colors that were resolved for each sublayer.
-const mockLayerCapture: { layers: any[] } = { layers: [] };
+interface CapturedDataPoint {
+  color: number[];
+}
+interface CapturedLayer {
+  id?: string;
+  props: { data: CapturedDataPoint[] };
+}
+const mockLayerCapture: { layers: CapturedLayer[] } = { layers: [] };
 jest.mock('../DeckGLContainer', () => ({
-  DeckGLContainerStyledWrapper: ({ layers }: any) => {
+  DeckGLContainerStyledWrapper: ({ layers }: { layers?: CapturedLayer[] }) => {
     mockLayerCapture.layers = layers || [];
     return <div data-test="deckgl-container">DeckGL Container Mock</div>;
   },
@@ -127,16 +134,16 @@ test('applies categorical scatterplot colors to sublayers in the multi chart', a
     expect(mockLayerCapture.layers.length).toBeGreaterThan(0);
   });
 
-  const scatterLayer = mockLayerCapture.layers.find((layer: any) =>
+  const scatterLayer = mockLayerCapture.layers.find((layer: CapturedLayer) =>
     layer?.id?.startsWith('scatter-layer-'),
   );
   expect(scatterLayer).toBeDefined();
 
-  const { data } = scatterLayer.props;
+  const { data } = (scatterLayer as CapturedLayer).props;
   expect(data).toHaveLength(2);
 
   // Both points must carry a resolved RGBA color...
-  data.forEach((d: any) => {
+  data.forEach((d: CapturedDataPoint) => {
     expect(Array.isArray(d.color)).toBe(true);
     expect(d.color).toHaveLength(4);
   });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { DatasourceType, SupersetClient } from '@superset-ui/core';
+import DeckMulti from './Multi';
+
+// Capture the layers handed to the DeckGL container so we can inspect the
+// per-feature colors that were resolved for each sublayer.
+const mockLayerCapture: { layers: any[] } = { layers: [] };
+jest.mock('../DeckGLContainer', () => ({
+  DeckGLContainerStyledWrapper: ({ layers }: any) => {
+    mockLayerCapture.layers = layers || [];
+    return <div data-test="deckgl-container">DeckGL Container Mock</div>;
+  },
+}));
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  SupersetClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockStore = configureStore({
+  reducer: {
+    dataMask: () => ({}),
+  },
+});
+
+const renderWithProviders = (component: React.ReactElement) =>
+  render(
+    <Provider store={mockStore}>
+      <ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>
+    </Provider>,
+  );
+
+const SCATTER_SLICE_ID = 1;
+
+const props = {
+  formData: {
+    datasource: '1__table',
+    viz_type: 'deck_multi',
+    deck_slices: [SCATTER_SLICE_ID],
+    autozoom: false,
+    map_style: 'mapbox://styles/mapbox/light-v9',
+  },
+  payload: {
+    data: {
+      slices: [
+        {
+          slice_id: SCATTER_SLICE_ID,
+          form_data: {
+            viz_type: 'deck_scatter',
+            datasource: '1__table',
+            slice_id: SCATTER_SLICE_ID,
+            // categorical color configuration coming from the saved scatter chart
+            color_scheme_type: 'categorical_palette',
+            color_scheme: 'supersetColors',
+            dimension: 'category',
+          },
+        },
+      ],
+      features: {
+        deck_scatter: [],
+      },
+      mapboxApiKey: 'test-key',
+    },
+  },
+  setControlValue: jest.fn(),
+  viewport: { longitude: 0, latitude: 0, zoom: 1 },
+  onAddFilter: jest.fn(),
+  height: 600,
+  width: 800,
+  datasource: {
+    id: 1,
+    type: DatasourceType.Table,
+    name: 'test_datasource',
+    columns: [],
+    metrics: [],
+    columnFormats: {},
+    currencyFormats: {},
+    verboseMap: {},
+  },
+  onSelect: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLayerCapture.layers = [];
+  // The scatter sublayer query returns features tagged with a category column.
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      data: {
+        features: [
+          { position: [0, 0], radius: 1, cat_color: 'A' },
+          { position: [1, 1], radius: 1, cat_color: 'B' },
+        ],
+      },
+    },
+  });
+});
+
+test('applies categorical scatterplot colors to sublayers in the multi chart', async () => {
+  renderWithProviders(<DeckMulti {...props} />);
+
+  await waitFor(() => {
+    expect(mockLayerCapture.layers.length).toBeGreaterThan(0);
+  });
+
+  const scatterLayer = mockLayerCapture.layers.find((layer: any) =>
+    layer?.id?.startsWith('scatter-layer-'),
+  );
+  expect(scatterLayer).toBeDefined();
+
+  const { data } = scatterLayer.props;
+  expect(data).toHaveLength(2);
+
+  // Both points must carry a resolved RGBA color...
+  data.forEach((d: any) => {
+    expect(Array.isArray(d.color)).toBe(true);
+    expect(d.color).toHaveLength(4);
+  });
+
+  // ...and the two distinct categories must NOT share the same color. Before
+  // the fix, categorical colors were dropped in the Multiple Layers chart and
+  // every point fell back to the same default color.
+  expect(data[0].color).not.toEqual(data[1].color);
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
@@ -31,7 +31,11 @@ interface CapturedDataPoint {
 }
 interface CapturedLayer {
   id?: string;
-  props: { data: CapturedDataPoint[] };
+  props: {
+    data: CapturedDataPoint[];
+    getSourceColor?: (d: Record<string, unknown>) => number[];
+    getTargetColor?: (d: Record<string, unknown>) => number[];
+  };
 }
 const mockLayerCapture: { layers: CapturedLayer[] } = { layers: [] };
 jest.mock('../DeckGLContainer', () => ({
@@ -127,9 +131,7 @@ beforeEach(() => {
   });
 });
 
-test('applies categorical scatterplot colors to sublayers in the multi chart', async () => {
-  renderWithProviders(<DeckMulti {...props} />);
-
+const expectDistinctCategoricalColors = async () => {
   await waitFor(() => {
     expect(mockLayerCapture.layers.length).toBeGreaterThan(0);
   });
@@ -152,4 +154,92 @@ test('applies categorical scatterplot colors to sublayers in the multi chart', a
   // the fix, categorical colors were dropped in the Multiple Layers chart and
   // every point fell back to the same default color.
   expect(data[0].color).not.toEqual(data[1].color);
+};
+
+test('applies categorical scatterplot colors to sublayers in the multi chart', async () => {
+  renderWithProviders(<DeckMulti {...props} />);
+
+  await expectDistinctCategoricalColors();
+});
+
+test('applies categorical colors to scatter subslices saved before the color_scheme_type control existed', async () => {
+  // Charts saved before the color_scheme_type control existed lack the key in
+  // stored params; the scatter default (categorical_palette) must be resolved
+  // so they keep per-category colors.
+  const legacyProps = {
+    ...props,
+    payload: {
+      ...props.payload,
+      data: {
+        ...props.payload.data,
+        slices: [
+          {
+            slice_id: SCATTER_SLICE_ID,
+            form_data: {
+              viz_type: 'deck_scatter',
+              datasource: '1__table',
+              slice_id: SCATTER_SLICE_ID,
+              color_scheme: 'supersetColors',
+              dimension: 'category',
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  renderWithProviders(<DeckMulti {...legacyProps} />);
+
+  await expectDistinctCategoricalColors();
+});
+
+test('keeps fixed source and target colors for arc subslices saved before the color_scheme_type control existed', async () => {
+  // Legacy arcs default to fixed_color, where the layer reads the source and
+  // target pickers directly; resolving the default must not stamp a single
+  // per-feature color over the target color.
+  const ARC_SLICE_ID = 2;
+  const arcProps = {
+    ...props,
+    formData: { ...props.formData, deck_slices: [ARC_SLICE_ID] },
+    payload: {
+      ...props.payload,
+      data: {
+        ...props.payload.data,
+        slices: [
+          {
+            slice_id: ARC_SLICE_ID,
+            form_data: {
+              viz_type: 'deck_arc',
+              datasource: '1__table',
+              slice_id: ARC_SLICE_ID,
+              color_picker: { r: 10, g: 20, b: 30, a: 1 },
+              target_color_picker: { r: 40, g: 50, b: 60, a: 1 },
+            },
+          },
+        ],
+        features: { deck_arc: [] },
+      },
+    },
+  };
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      data: {
+        features: [{ sourcePosition: [0, 0], targetPosition: [1, 1] }],
+      },
+    },
+  });
+
+  renderWithProviders(<DeckMulti {...arcProps} />);
+
+  await waitFor(() => {
+    expect(mockLayerCapture.layers.length).toBeGreaterThan(0);
+  });
+
+  const arcLayer = mockLayerCapture.layers.find(
+    (layer: CapturedLayer) => layer?.id === `path-layer-${ARC_SLICE_ID}`,
+  );
+  expect(arcLayer).toBeDefined();
+
+  expect(arcLayer?.props.getSourceColor?.({})).toEqual([10, 20, 30, 255]);
+  expect(arcLayer?.props.getTargetColor?.({})).toEqual([40, 50, 60, 255]);
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -50,6 +50,7 @@ import {
 } from '../DeckGLContainer';
 import { getExploreLongUrl } from '../utils/explore';
 import { addColorToFeatures } from '../utils/addColor';
+import { COLOR_SCHEME_TYPES, ColorSchemeType } from '../utilities/utils';
 import layerGenerators from '../layers';
 import fitViewport, { Viewport } from '../utils/fitViewport';
 import { getMapboxApiKey } from '../utils/mapbox';
@@ -99,17 +100,15 @@ const MultiWrapper = styled.div<{ height: number; width: number }>`
   width: ${({ width }) => width}px;
 `;
 
-// Layer types that resolve a per-feature color from the form data's color
-// scheme (categorical palette, fixed color or breakpoints). When rendered on
-// their own these layers get their colors from CategoricalDeckGLContainer; in
-// the Multiple Layers chart we need to apply the same resolution here so the
-// configured categorical colors are preserved instead of falling back to the
-// default point color.
-const COLOR_AWARE_LAYER_TYPES = new Set([
-  'deck_scatter',
-  'deck_path',
-  'deck_arc',
-]);
+// Default color_scheme_type per color-aware layer type, matching each control
+// panel. Sub-slices arrive as raw saved form data without control-default
+// hydration, so charts saved before this control existed need the default
+// resolved here to keep their configured colors.
+const COLOR_AWARE_LAYER_DEFAULTS: Record<string, ColorSchemeType> = {
+  deck_scatter: COLOR_SCHEME_TYPES.categorical_palette,
+  deck_path: COLOR_SCHEME_TYPES.fixed_color,
+  deck_arc: COLOR_SCHEME_TYPES.fixed_color,
+};
 
 const selectDataMask = createSelector(
   (state: { dataMask?: DataMaskState }) => state.dataMask,
@@ -240,30 +239,34 @@ const DeckMulti = (props: DeckMultiProps) => {
   const createLayerFromData = useCallback(
     (subslice: JsonObject, json: JsonObject): Layer => {
       const { form_data: subsliceFormData } = subslice;
+      const defaultColorSchemeType =
+        COLOR_AWARE_LAYER_DEFAULTS[subsliceFormData.viz_type];
+      let layerFormData = subsliceFormData;
       let payload = json;
 
-      // Resolve per-feature categorical/fixed/breakpoint colors for layers that
-      // would otherwise get them from CategoricalDeckGLContainer when rendered
-      // standalone. Without this, scatterplot categorical colors are dropped in
-      // the Multiple Layers chart and fall back to the default point color.
-      if (
-        COLOR_AWARE_LAYER_TYPES.has(subsliceFormData.viz_type) &&
-        subsliceFormData.color_scheme_type &&
-        Array.isArray(json?.data?.features)
-      ) {
-        payload = {
-          ...json,
-          data: {
-            ...json.data,
-            features: addColorToFeatures(json.data.features, subsliceFormData),
-          },
+      // Resolve per-feature colors as CategoricalDeckGLContainer does when
+      // the layer renders standalone.
+      if (defaultColorSchemeType) {
+        layerFormData = {
+          ...subsliceFormData,
+          color_scheme_type:
+            subsliceFormData.color_scheme_type ?? defaultColorSchemeType,
         };
+        if (Array.isArray(json?.data?.features)) {
+          payload = {
+            ...json,
+            data: {
+              ...json.data,
+              features: addColorToFeatures(json.data.features, layerFormData),
+            },
+          };
+        }
       }
 
       return (
         // @ts-expect-error TODO(hainenber): define proper type for `form_data.viz_type` and call signature for functions in layerGenerators.
-        layerGenerators[subsliceFormData.viz_type]({
-          formData: subsliceFormData,
+        layerGenerators[layerFormData.viz_type]({
+          formData: layerFormData,
           payload,
           setTooltip,
           datasource: props.datasource,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -49,6 +49,7 @@ import {
   DeckGLContainerStyledWrapper,
 } from '../DeckGLContainer';
 import { getExploreLongUrl } from '../utils/explore';
+import { addColorToFeatures } from '../utils/addColor';
 import layerGenerators from '../layers';
 import fitViewport, { Viewport } from '../utils/fitViewport';
 import { getMapboxApiKey } from '../utils/mapbox';
@@ -97,6 +98,18 @@ const MultiWrapper = styled.div<{ height: number; width: number }>`
   height: ${({ height }) => height}px;
   width: ${({ width }) => width}px;
 `;
+
+// Layer types that resolve a per-feature color from the form data's color
+// scheme (categorical palette, fixed color or breakpoints). When rendered on
+// their own these layers get their colors from CategoricalDeckGLContainer; in
+// the Multiple Layers chart we need to apply the same resolution here so the
+// configured categorical colors are preserved instead of falling back to the
+// default point color.
+const COLOR_AWARE_LAYER_TYPES = new Set([
+  'deck_scatter',
+  'deck_path',
+  'deck_arc',
+]);
 
 const selectDataMask = createSelector(
   (state: { dataMask?: DataMaskState }) => state.dataMask,
@@ -225,15 +238,39 @@ const DeckMulti = (props: DeckMultiProps) => {
   );
 
   const createLayerFromData = useCallback(
-    (subslice: JsonObject, json: JsonObject): Layer =>
-      // @ts-expect-error TODO(hainenber): define proper type for `form_data.viz_type` and call signature for functions in layerGenerators.
-      layerGenerators[subslice.form_data.viz_type]({
-        formData: subslice.form_data,
-        payload: json,
-        setTooltip,
-        datasource: props.datasource,
-        onSelect: props.onSelect,
-      }),
+    (subslice: JsonObject, json: JsonObject): Layer => {
+      const { form_data: subsliceFormData } = subslice;
+      let payload = json;
+
+      // Resolve per-feature categorical/fixed/breakpoint colors for layers that
+      // would otherwise get them from CategoricalDeckGLContainer when rendered
+      // standalone. Without this, scatterplot categorical colors are dropped in
+      // the Multiple Layers chart and fall back to the default point color.
+      if (
+        COLOR_AWARE_LAYER_TYPES.has(subsliceFormData.viz_type) &&
+        subsliceFormData.color_scheme_type &&
+        Array.isArray(json?.data?.features)
+      ) {
+        payload = {
+          ...json,
+          data: {
+            ...json.data,
+            features: addColorToFeatures(json.data.features, subsliceFormData),
+          },
+        };
+      }
+
+      return (
+        // @ts-expect-error TODO(hainenber): define proper type for `form_data.viz_type` and call signature for functions in layerGenerators.
+        layerGenerators[subsliceFormData.viz_type]({
+          formData: subsliceFormData,
+          payload,
+          setTooltip,
+          datasource: props.datasource,
+          onSelect: props.onSelect,
+        })
+      );
+    },
     [props.onSelect, props.datasource, setTooltip],
   );
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import { addColorToFeatures } from './addColor';
+import { COLOR_SCHEME_TYPES } from '../utilities/utils';
+
+const baseFormData = {
+  datasource: '1__table',
+  viz_type: 'deck_scatter',
+} as unknown as QueryFormData;
+
+test('assigns distinct colors per category for a categorical palette', () => {
+  const features = [{ cat_color: 'A' }, { cat_color: 'B' }, { cat_color: 'A' }];
+  const result = addColorToFeatures(features, {
+    ...baseFormData,
+    color_scheme_type: COLOR_SCHEME_TYPES.categorical_palette,
+    color_scheme: 'supersetColors',
+    dimension: 'category',
+    slice_id: 1,
+  } as unknown as QueryFormData);
+
+  // Each feature gets a resolved RGBA color
+  result.forEach(d => {
+    expect(Array.isArray(d.color)).toBe(true);
+    expect(d.color).toHaveLength(4);
+  });
+  // Same category resolves to the same color, different categories differ
+  expect(result[0].color).toEqual(result[2].color);
+  expect(result[0].color).not.toEqual(result[1].color);
+});
+
+test('falls back to the fixed color picker when no dimension is set', () => {
+  const features = [{ cat_color: 'A' }, { cat_color: 'B' }];
+  const result = addColorToFeatures(features, {
+    ...baseFormData,
+    color_scheme_type: COLOR_SCHEME_TYPES.categorical_palette,
+    color_picker: { r: 10, g: 20, b: 30, a: 1 },
+  } as unknown as QueryFormData);
+
+  result.forEach(d => {
+    expect(d.color).toEqual([10, 20, 30, 255]);
+  });
+});
+
+test('applies the fixed color scheme to every feature', () => {
+  const features = [{ cat_color: 'A' }, { cat_color: 'B' }];
+  const result = addColorToFeatures(features, {
+    ...baseFormData,
+    color_scheme_type: COLOR_SCHEME_TYPES.fixed_color,
+    color_picker: { r: 1, g: 2, b: 3, a: 0.5 },
+  } as unknown as QueryFormData);
+
+  result.forEach(d => {
+    expect(d.color).toEqual([1, 2, 3, 127.5]);
+  });
+});
+
+test('returns features unchanged for an unrecognized color scheme', () => {
+  const features = [{ cat_color: 'A' }];
+  const result = addColorToFeatures(features, {
+    ...baseFormData,
+    color_scheme_type: 'something_else',
+  } as unknown as QueryFormData);
+
+  expect(result).toEqual(features);
+  expect(result[0].color).toBeUndefined();
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.test.ts
@@ -71,6 +71,26 @@ test('applies the fixed color scheme to every feature', () => {
   });
 });
 
+test('assigns breakpoint colors by metric and falls back to the default', () => {
+  const features = [{ metric: 5 }, { metric: 50 }, { metric: 500 }];
+  const result = addColorToFeatures(features, {
+    ...baseFormData,
+    color_scheme_type: COLOR_SCHEME_TYPES.color_breakpoints,
+    color_breakpoints: [
+      { minValue: 0, maxValue: 10, color: { r: 1, g: 2, b: 3, a: 1 } },
+      { minValue: 11, maxValue: 100, color: { r: 4, g: 5, b: 6, a: 0.5 } },
+    ],
+    default_breakpoint_color: { r: 7, g: 8, b: 9, a: 1 },
+  } as unknown as QueryFormData);
+
+  // Metric inside the first breakpoint range
+  expect(result[0].color).toEqual([1, 2, 3, 255]);
+  // Metric inside the second breakpoint range (alpha scaled to 0-255)
+  expect(result[1].color).toEqual([4, 5, 6, 127.5]);
+  // Metric outside every range falls back to the default breakpoint color
+  expect(result[2].color).toEqual([7, 8, 9, 255]);
+});
+
 test('returns features unchanged for an unrecognized color scheme', () => {
   const features = [{ cat_color: 'A' }];
   const result = addColorToFeatures(features, {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.ts
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  CategoricalColorNamespace,
+  JsonObject,
+  QueryFormData,
+} from '@superset-ui/core';
+import { hexToRGB } from './colors';
+import { ColorBreakpointType } from '../types';
+import { COLOR_SCHEME_TYPES, ColorSchemeType } from '../utilities/utils';
+import { DEFAULT_DECKGL_COLOR } from '../utilities/Shared_DeckGL';
+
+const { getScale } = CategoricalColorNamespace;
+
+/**
+ * Resolve the per-feature color for a deck.gl layer based on the form data's
+ * color scheme configuration. This mirrors the categorical/fixed/breakpoint
+ * color logic that `CategoricalDeckGLContainer` applies when a layer is
+ * rendered on its own, so that it can be reused when layers are composed
+ * inside the deck.gl Multiple Layers chart.
+ *
+ * Features whose color scheme is not recognized are returned unchanged so the
+ * layer's own fallback color logic can take over.
+ */
+export function addColorToFeatures(
+  data: JsonObject[],
+  fd: QueryFormData,
+  selectedColorScheme: ColorSchemeType = fd.color_scheme_type,
+): JsonObject[] {
+  const appliedScheme = fd.color_scheme;
+  const colorFn = getScale(appliedScheme);
+
+  switch (selectedColorScheme) {
+    case COLOR_SCHEME_TYPES.fixed_color: {
+      const color = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
+      const colorArray = [color.r, color.g, color.b, color.a * 255];
+
+      return data.map(d => ({ ...d, color: colorArray }));
+    }
+    case COLOR_SCHEME_TYPES.categorical_palette: {
+      if (!fd.dimension) {
+        const fallbackColor = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
+        const colorArray = [
+          fallbackColor.r,
+          fallbackColor.g,
+          fallbackColor.b,
+          fallbackColor.a * 255,
+        ];
+        return data.map(d => ({ ...d, color: colorArray }));
+      }
+
+      return data.map(d => ({
+        ...d,
+        color: hexToRGB(colorFn(d.cat_color, fd.slice_id)),
+      }));
+    }
+    case COLOR_SCHEME_TYPES.color_breakpoints: {
+      const defaultBreakpointColor = fd.default_breakpoint_color
+        ? [
+            fd.default_breakpoint_color.r,
+            fd.default_breakpoint_color.g,
+            fd.default_breakpoint_color.b,
+            fd.default_breakpoint_color.a * 255,
+          ]
+        : [
+            DEFAULT_DECKGL_COLOR.r,
+            DEFAULT_DECKGL_COLOR.g,
+            DEFAULT_DECKGL_COLOR.b,
+            DEFAULT_DECKGL_COLOR.a * 255,
+          ];
+      return data.map(d => {
+        const breakpointForPoint: ColorBreakpointType =
+          fd.color_breakpoints?.find(
+            (breakpoint: ColorBreakpointType) =>
+              d.metric >= breakpoint.minValue &&
+              d.metric <= breakpoint.maxValue,
+          );
+
+        if (breakpointForPoint) {
+          const pointColor = [
+            breakpointForPoint.color.r,
+            breakpointForPoint.color.g,
+            breakpointForPoint.color.b,
+            breakpointForPoint.color.a * 255,
+          ];
+          return { ...d, color: pointColor };
+        }
+
+        return { ...d, color: defaultBreakpointColor };
+      });
+    }
+    default:
+      return data;
+  }
+}
+
+export default addColorToFeatures;

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/addColor.ts
@@ -109,5 +109,3 @@ export function addColorToFeatures(
       return data;
   }
 }
-
-export default addColorToFeatures;


### PR DESCRIPTION
### SUMMARY

Fixes #20459.

When a deck.gl scatterplot configured with a categorical point color is added to a deck.gl **Multiple Layers** chart, the points all rendered in the default/fallback color even though the legend still showed the configured categorical palette. So the legend and the map disagreed.

Root cause: a standalone scatterplot (and path/arc) chart resolves its per-feature colors inside `CategoricalDeckGLContainer` (its `addColor` step), which maps each `cat_color` through the categorical color scale before handing the data to the layer. The Multiple Layers chart, however, builds its sublayers by calling the raw `getLayer` functions directly in `Multi.tsx` (`createLayerFromData`), bypassing that container entirely. Without the color resolution step, the scatter `getLayer` just falls back to the fixed `color_picker` color, so the categorical colors were dropped.

The fix extracts the color-resolution logic into a small shared util, `addColorToFeatures`, and:
- reuses it inside `CategoricalDeckGLContainer`, and
- applies it to color-aware sublayers (`deck_scatter`, `deck_path`, `deck_arc`) in the Multiple Layers chart before the layer is built, so the configured categorical/fixed/breakpoint colors are preserved.

Non color-aware layers and layers without a `color_scheme_type` are left untouched, so this is scoped to the layers that actually consume per-feature colors.

Two small, intentional behavior shifts for **standalone** categorical charts (both low risk):
- The unknown-`color_scheme_type` branch returns features unchanged (layer fallback color) instead of dropping every feature (blank map). This branch is unreachable for saved charts — `color_scheme_type` defaults to `categorical_palette` and the control isn't clearable — and the new behavior is pinned by a test.
- `getCategories` keys the legend color scale on `fd.slice_id` (the canonical snake_case `form_data` key, matching the point-color path) instead of `fd.sliceId`, which was `undefined` in practice. Legend swatches and point colors resolve from the same slice namespace; pinned by `CategoricalDeckGLContainer.test.tsx`.

### TESTING INSTRUCTIONS

1. Create a deck.gl Scatterplot chart and set Point Color to a Categorical color over some dimension. Save it.
2. Create a deck.gl Multiple Layers chart and add the scatterplot above.
3. Run it: the points on the map now match the categorical colors shown in the legend (previously they all rendered in the default color).

Automated, test-first:
- `Multi.color.test.tsx` pins the bug — it asserts two points with different categories get different resolved colors in the Multiple Layers chart. It fails on `master` (both points come back `[0,0,0,255]`) and passes with this change.
- `addColor.test.ts` covers the extracted util (categorical/fixed/fallback/breakpoint/unknown-scheme cases).
- `CategoricalDeckGLContainer.test.tsx` asserts the legend and point-color paths key the color scale on the same `slice_id` and produce matching colors per category.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #20459
- [x] Changes UI
