### PR TITLE
fix(a11y): propagate tooltip string as aria-label on IconTooltip button

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/IconTooltip/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/IconTooltip/index.tsx
@@ -45,6 +45,7 @@ export const IconTooltip = forwardRef<HTMLElement, IconTooltipProps>(
         }}
         buttonStyle="link"
         className={`IconTooltip ${className}`}
+        aria-label={tooltip ?? undefined}
       >
         {children}
       </Button>


### PR DESCRIPTION
## Summary

`IconTooltip` renders a link-style `<Button>` that typically contains only an icon child (e.g. `<Icons.EyeOutlined />`). The `tooltip` prop — a human-readable string like `"View SQL"` or `"Show SQL"` — was displayed as a hover tooltip but was **never set as `aria-label` on the button**, so screen readers announced the icon's auto-generated name (`"eye"`, `"edit"`, etc.) instead of the actual action description.

### WCAG violation

**WCAG 2.1 SC 4.1.2 — Name, Role, Value — Level A**
> For all user interface components, the name … can be programmatically determined.

A button whose only accessible name is a generic icon label (`"eye"`) rather than its action (`"View SQL"`) violates this rule.

### What changed

`packages/superset-ui-core/src/components/IconTooltip/index.tsx` — 1 line added:

```tsx
<Button
  ...
  aria-label={tooltip ?? undefined}
>
```

All three call sites gain correct accessible names automatically:
- `SqlLab/components/ShowSQL` — button labelled with `tooltipText` (e.g. `"Show SQL"`)
- `SqlLab/components/ExploreCtasResultsButton` — button labelled `"Explore"`
- `explore/components/controls/CollectionControl` — button labelled with its tooltip string

### Behavior unchanged

No visual change. The Tooltip overlay continues to appear on hover/focus. The only difference is what screen readers announce.

### Test plan

- [ ] Tab to a `ShowSQL` eye icon in SQL Lab; verify a screen reader announces `"Show SQL"` (or the configured tooltip text) rather than `"eye"`.
- [ ] Tab to an Explore button in a CTAS result; verify the screen reader announces `"Explore"`.
- [ ] Verify the hover tooltip still appears visually.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)