### PR TITLE
fix(mcp): set .embedded on update_dashboard test mocks

### DIFF
--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -81,6 +81,11 @@ def _mock_dashboard(
     dashboard.slices = []
     dashboard.owners = []
     dashboard.tags = []
+    # Real dashboards expose ``embedded`` as a (possibly empty) list; the
+    # shared dashboard_serializer reads ``dashboard.embedded[0].uuid`` behind
+    # an ``if dashboard.embedded`` guard. Without this, Mock returns a truthy
+    # auto-Mock that passes the guard and then fails to subscript.
+    dashboard.embedded = []
     return dashboard
 
 


### PR DESCRIPTION
### SUMMARY

Master's Python-Unit CI is red. Five tests in `tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py` fail with:

```
fastmcp.exceptions.ToolError: Error calling tool 'update_dashboard': 'Mock' object is not subscriptable
```

The cause is the shared `dashboard_serializer` in `superset/mcp_service/dashboard/schemas.py`. #41195 added:

```python
embedded_uuid=str(dashboard.embedded[0].uuid) if dashboard.embedded else None,
```

That production code is fine: a real `dashboard.embedded` is an empty list when the dashboard isn't embedded, so the guard short-circuits. The problem is that `update_dashboard` routes through the same serializer, and the test mocks in `test_update_dashboard.py` never set `.embedded`. Mock hands back a truthy auto-Mock, the `if dashboard.embedded` guard passes, and `dashboard.embedded[0]` blows up. #41195 only updated the `get_dashboard_info` mocks in `test_dashboard_tools.py`, not these.

Fix is test-only: I set `embedded = []` on the shared `_mock_dashboard` builder so it matches the not-embedded production case. No production code changes; the guard in `schemas.py` is correct as-is. I checked the sibling tool tests and they don't reach this serializer line, so nothing else needed touching.

References #41195.

### BEFORE/AFTER

Before: `Python-Unit` red, 5 failures in `test_update_dashboard.py`.
After: `pytest tests/unit_tests/mcp_service/dashboard/tool/` passes (117 passed locally).

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
