### PR TITLE
chore: replace deprecated datetime.utcnow()/utcfromtimestamp()

### DIFF
--- a/superset/commands/logs/prune.py
+++ b/superset/commands/logs/prune.py
@@ -16,7 +16,7 @@
 # under the License.
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import sqlalchemy as sa
 
@@ -65,10 +65,12 @@ class LogPruneCommand(BaseCommand):
 
         # Select all IDs that need to be deleted
         # Log.dttm is stored as a naive UTC datetime (no tzinfo), so compute
-        # the cutoff with utcnow() to avoid a naive/aware mismatch that raises
+        # the cutoff as a naive UTC datetime to avoid a naive/aware mismatch that raises
         # on PostgreSQL ("operator does not exist: timestamp without time zone").
         select_stmt = sa.select(Log.id).where(
-            Log.dttm < datetime.utcnow() - timedelta(days=self.retention_period_days)
+            Log.dttm
+            < datetime.now(timezone.utc).replace(tzinfo=None)
+            - timedelta(days=self.retention_period_days)
         )
 
         # Optionally limited by max_rows_per_run

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -571,7 +571,7 @@ class BaseReportState:
                         "Screenshot failed; aborting to avoid sending a partial report"
                     )
                 imges.append(imge)
-            elapsed_seconds = (
+            elapsed_seconds: float = (
                 datetime.now(timezone.utc).replace(tzinfo=None) - start_time
             ).total_seconds()
             logger.info(
@@ -767,7 +767,7 @@ class BaseReportState:
                     request_payload=request_payload,
                     timeout=app.config["ALERT_REPORTS_CSV_REQUEST_TIMEOUT"],
                 )
-            elapsed_seconds = (
+            elapsed_seconds: float = (
                 datetime.now(timezone.utc).replace(tzinfo=None) - start_time
             ).total_seconds()
             logger.info(
@@ -824,7 +824,7 @@ class BaseReportState:
                 auth_cookies,
                 timeout=app.config["ALERT_REPORTS_CSV_REQUEST_TIMEOUT"],
             )
-            elapsed_seconds = (
+            elapsed_seconds: float = (
                 datetime.now(timezone.utc).replace(tzinfo=None) - start_time
             ).total_seconds()
             logger.info(
@@ -1476,7 +1476,7 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
                     self._execution_id, self._model, self._scheduled_dttm
                 ).run()
 
-            elapsed_seconds = (
+            elapsed_seconds: float = (
                 datetime.now(timezone.utc).replace(tzinfo=None) - start_time
             ).total_seconds()
             logger.info(

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -19,7 +19,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Sequence
 from contextlib import closing
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, TYPE_CHECKING, Union
 from urllib.error import URLError
 from uuid import UUID
@@ -136,7 +136,7 @@ class BaseReportState:
     ) -> None:
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._start_dttm = datetime.utcnow()
+        self._start_dttm = datetime.now(timezone.utc).replace(tzinfo=None)
         self._execution_id = execution_id
         self._filter_warnings: list[str] = []
 
@@ -166,7 +166,9 @@ class BaseReportState:
             self._report_schedule.last_value_row_json = None
 
         self._report_schedule.last_state = state
-        self._report_schedule.last_eval_dttm = datetime.utcnow()
+        self._report_schedule.last_eval_dttm = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        )
 
     def update_report_schedule_slack_v2(self) -> None:
         """
@@ -232,7 +234,7 @@ class BaseReportState:
             log = ReportExecutionLog(
                 scheduled_dttm=self._scheduled_dttm,
                 start_dttm=self._start_dttm,
-                end_dttm=datetime.utcnow(),
+                end_dttm=datetime.now(timezone.utc).replace(tzinfo=None),
                 value=self._report_schedule.last_value,
                 value_row_json=self._report_schedule.last_value_row_json,
                 state=self._report_schedule.last_state,
@@ -522,7 +524,7 @@ class BaseReportState:
         Get chart or dashboard screenshots
         :raises: ReportScheduleScreenshotFailedError
         """
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
 
         user, _ = resolve_executor_user(self._report_schedule)
 
@@ -569,14 +571,18 @@ class BaseReportState:
                         "Screenshot failed; aborting to avoid sending a partial report"
                     )
                 imges.append(imge)
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.info(
                 "Screenshot capture took %.2fs - execution_id: %s",
                 elapsed_seconds,
                 self._execution_id,
             )
         except SoftTimeLimitExceeded as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.warning(
                 "Screenshot timeout after %.2fs - execution_id: %s",
                 elapsed_seconds,
@@ -584,7 +590,9 @@ class BaseReportState:
             )
             raise ReportScheduleScreenshotTimeout() from ex
         except Exception as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.error(
                 "Screenshot failed after %.2fs - execution_id: %s",
                 elapsed_seconds,
@@ -733,7 +741,7 @@ class BaseReportState:
                 ReportScheduleCsvFailedError,
             )
 
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
         user, username = resolve_executor_user(self._report_schedule)
         auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(user)
 
@@ -759,7 +767,9 @@ class BaseReportState:
                     request_payload=request_payload,
                     timeout=app.config["ALERT_REPORTS_CSV_REQUEST_TIMEOUT"],
                 )
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.info(
                 "%s data generation from %s as user %s took %.2fs - execution_id: %s",
                 label,
@@ -769,7 +779,9 @@ class BaseReportState:
                 self._execution_id,
             )
         except SoftTimeLimitExceeded as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.warning(
                 "%s generation timeout after %.2fs - execution_id: %s",
                 label,
@@ -778,7 +790,9 @@ class BaseReportState:
             )
             raise timeout_error() from ex
         except Exception as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.exception(
                 "%s generation failed after %.2fs - execution_id: %s",
                 label,
@@ -794,7 +808,7 @@ class BaseReportState:
         """
         Return data as a Pandas dataframe, to embed in notifications as a table.
         """
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
 
         url = self._get_url(result_format=ChartDataResultFormat.JSON)
         user, username = resolve_executor_user(self._report_schedule)
@@ -810,7 +824,9 @@ class BaseReportState:
                 auth_cookies,
                 timeout=app.config["ALERT_REPORTS_CSV_REQUEST_TIMEOUT"],
             )
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.info(
                 "DataFrame generation from %s as user %s took %.2fs - execution_id: %s",
                 url,
@@ -819,7 +835,9 @@ class BaseReportState:
                 self._execution_id,
             )
         except SoftTimeLimitExceeded as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.warning(
                 "DataFrame generation timeout after %.2fs - execution_id: %s",
                 elapsed_seconds,
@@ -827,7 +845,9 @@ class BaseReportState:
             )
             raise ReportScheduleDataFrameTimeout() from ex
         except Exception as ex:
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.error(
                 "DataFrame generation failed after %.2fs - execution_id: %s",
                 elapsed_seconds,
@@ -1086,7 +1106,7 @@ class BaseReportState:
         return (
             last_success is not None
             and self._report_schedule.grace_period
-            and datetime.utcnow()
+            and datetime.now(timezone.utc).replace(tzinfo=None)
             - timedelta(seconds=self._report_schedule.grace_period)
             < last_success.end_dttm
         )
@@ -1103,7 +1123,7 @@ class BaseReportState:
         return (
             last_success is not None
             and self._report_schedule.grace_period
-            and datetime.utcnow()
+            and datetime.now(timezone.utc).replace(tzinfo=None)
             - timedelta(seconds=self._report_schedule.grace_period)
             < last_success.end_dttm
         )
@@ -1120,7 +1140,7 @@ class BaseReportState:
         return (
             self._report_schedule.working_timeout is not None
             and self._report_schedule.last_eval_dttm is not None
-            and datetime.utcnow()
+            and datetime.now(timezone.utc).replace(tzinfo=None)
             - timedelta(seconds=self._report_schedule.working_timeout)
             > last_working.end_dttm
         )
@@ -1236,7 +1256,10 @@ class ReportWorkingState(BaseReportState):
                 self._report_schedule
             )
             elapsed_seconds = (
-                (datetime.utcnow() - last_working.end_dttm).total_seconds()
+                (
+                    datetime.now(timezone.utc).replace(tzinfo=None)
+                    - last_working.end_dttm
+                ).total_seconds()
                 if last_working
                 else None
             )
@@ -1434,7 +1457,7 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
             )
             user = security_manager.find_user(username)
 
-            start_time = datetime.utcnow()
+            start_time = datetime.now(timezone.utc).replace(tzinfo=None)
             with override_user(user):
                 # Pre-commit any permalink rows before the state machine's
                 # @transaction() opens. When called inside a transaction,
@@ -1453,7 +1476,9 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
                     self._execution_id, self._model, self._scheduled_dttm
                 ).run()
 
-            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            elapsed_seconds = (
+                datetime.now(timezone.utc).replace(tzinfo=None) - start_time
+            ).total_seconds()
             logger.info(
                 "Report execution as user %s completed in %.2fs - execution_id: %s",
                 username,

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -136,7 +136,7 @@ class BaseReportState:
     ) -> None:
         self._report_schedule = report_schedule
         self._scheduled_dttm = scheduled_dttm
-        self._start_dttm = datetime.now(timezone.utc).replace(tzinfo=None)
+        self._start_dttm: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
         self._execution_id = execution_id
         self._filter_warnings: list[str] = []
 
@@ -524,7 +524,7 @@ class BaseReportState:
         Get chart or dashboard screenshots
         :raises: ReportScheduleScreenshotFailedError
         """
-        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_time: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
 
         user, _ = resolve_executor_user(self._report_schedule)
 
@@ -741,7 +741,7 @@ class BaseReportState:
                 ReportScheduleCsvFailedError,
             )
 
-        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_time: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
         user, username = resolve_executor_user(self._report_schedule)
         auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(user)
 
@@ -808,7 +808,7 @@ class BaseReportState:
         """
         Return data as a Pandas dataframe, to embed in notifications as a table.
         """
-        start_time = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_time: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
 
         url = self._get_url(result_format=ChartDataResultFormat.JSON)
         user, username = resolve_executor_user(self._report_schedule)
@@ -1457,7 +1457,7 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
             )
             user = security_manager.find_user(username)
 
-            start_time = datetime.now(timezone.utc).replace(tzinfo=None)
+            start_time: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
             with override_user(user):
                 # Pre-commit any permalink rows before the state machine's
                 # @transaction() opens. When called inside a transaction,

--- a/superset/commands/report/log_prune.py
+++ b/superset/commands/report/log_prune.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -41,7 +41,7 @@ class AsyncPruneReportScheduleLogCommand(BaseCommand):
 
         for report_schedule in db.session.query(ReportSchedule).all():
             if report_schedule.log_retention is not None:
-                from_date = datetime.utcnow() - timedelta(
+                from_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
                     days=report_schedule.log_retention
                 )
                 try:

--- a/superset/commands/report/log_prune.py
+++ b/superset/commands/report/log_prune.py
@@ -41,9 +41,9 @@ class AsyncPruneReportScheduleLogCommand(BaseCommand):
 
         for report_schedule in db.session.query(ReportSchedule).all():
             if report_schedule.log_retention is not None:
-                from_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
-                    days=report_schedule.log_retention
-                )
+                from_date: datetime = datetime.now(timezone.utc).replace(
+                    tzinfo=None
+                ) - timedelta(days=report_schedule.log_retention)
                 try:
                     row_count = ReportScheduleDAO.bulk_delete_logs(
                         report_schedule,

--- a/superset/daos/log.py
+++ b/superset/daos/log.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import humanize
@@ -142,7 +142,7 @@ class LogDAO(BaseDAO[Log]):
                     "item_title": item_title,
                     "time": datetime_to_epoch(log.dttm),
                     "time_delta_humanized": humanize.naturaltime(
-                        datetime.utcnow() - log.dttm
+                        datetime.now(timezone.utc).replace(tzinfo=None) - log.dttm
                     ),
                 }
             )

--- a/superset/daos/query.py
+++ b/superset/daos/query.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Union
 
 from superset import sql_lab
@@ -48,7 +48,9 @@ class QueryDAO(BaseDAO[Query]):
     @staticmethod
     def get_queries_changed_after(last_updated_ms: Union[float, int]) -> list[Query]:
         # UTC date time, same that is stored in the DB.
-        last_updated_dt = datetime.utcfromtimestamp(last_updated_ms / 1000)
+        last_updated_dt = datetime.fromtimestamp(
+            last_updated_ms / 1000, timezone.utc
+        ).replace(tzinfo=None)
 
         return (
             db.session.query(Query)

--- a/superset/daos/query.py
+++ b/superset/daos/query.py
@@ -48,7 +48,7 @@ class QueryDAO(BaseDAO[Query]):
     @staticmethod
     def get_queries_changed_after(last_updated_ms: Union[float, int]) -> list[Query]:
         # UTC date time, same that is stored in the DB.
-        last_updated_dt = datetime.fromtimestamp(
+        last_updated_dt: datetime = datetime.fromtimestamp(
             last_updated_ms / 1000, timezone.utc
         ).replace(tzinfo=None)
 

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import Any, Callable
 
@@ -73,7 +73,7 @@ def set_and_log_cache(
     if timeout == CACHE_DISABLED_TIMEOUT:
         return
     try:
-        dttm = datetime.utcnow().isoformat().split(".")[0]
+        dttm = datetime.now(timezone.utc).replace(tzinfo=None).isoformat().split(".")[0]
         value = {**cache_value, "dttm": dttm}
         cache_instance.set(cache_key, value, timeout=timeout)
         stats_logger = app.config["STATS_LOGGER"]
@@ -226,7 +226,7 @@ def etag_cache(  # noqa: C901
 
             # Check if the cache is stale. Default the content_changed_time to now
             # if we don't know when it was last modified.
-            content_changed_time = datetime.utcnow()
+            content_changed_time = datetime.now(timezone.utc).replace(tzinfo=None)
             if get_last_modified:
                 content_changed_time = get_last_modified(*args, **kwargs)
                 if (

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -226,7 +226,9 @@ def etag_cache(  # noqa: C901
 
             # Check if the cache is stale. Default the content_changed_time to now
             # if we don't know when it was last modified.
-            content_changed_time = datetime.now(timezone.utc).replace(tzinfo=None)
+            content_changed_time: datetime = datetime.now(timezone.utc).replace(
+                tzinfo=None
+            )
             if get_last_modified:
                 content_changed_time = get_last_modified(*args, **kwargs)
                 if (

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -73,7 +73,9 @@ def set_and_log_cache(
     if timeout == CACHE_DISABLED_TIMEOUT:
         return
     try:
-        dttm = datetime.now(timezone.utc).replace(tzinfo=None).isoformat().split(".")[0]
+        dttm: str = (
+            datetime.now(timezone.utc).replace(tzinfo=None).isoformat().split(".")[0]
+        )
         value = {**cache_value, "dttm": dttm}
         cache_instance.set(cache_key, value, timeout=timeout)
         stats_logger = app.config["STATS_LOGGER"]

--- a/superset/utils/dates.py
+++ b/superset/utils/dates.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytz
 
@@ -31,4 +31,4 @@ def datetime_to_epoch(dttm: datetime) -> float:
 
 
 def now_as_float() -> float:
-    return datetime_to_epoch(datetime.utcnow())
+    return datetime_to_epoch(datetime.now(timezone.utc).replace(tzinfo=None))


### PR DESCRIPTION
### SUMMARY

Python 3.12 deprecated `datetime.utcnow()` and `datetime.utcfromtimestamp()`. This sweeps all production occurrences under `superset/` (8 files, ~29 call sites) and replaces them with **behavior-preserving** equivalents:

```
datetime.utcnow()            → datetime.now(timezone.utc).replace(tzinfo=None)
datetime.utcfromtimestamp(x) → datetime.fromtimestamp(x, timezone.utc).replace(tzinfo=None)
```

The values stay **naive UTC**, exactly as before. This is a deliberate choice — and the key difference from the earlier #37538, which switched to *aware* datetimes. Superset stores naive UTC datetimes in the metadata DB, so switching to aware values would raise naive/aware comparison errors (e.g. the `Log.dttm` prune query on PostgreSQL — see the existing comment in `superset/commands/logs/prune.py`) and would change `isoformat()`/cache-key output. Keeping the values naive makes this a pure no-op refactor that just removes the deprecation.

`superset/security/session_invalidation.py` already uses `datetime.now(timezone.utc)` and is intentionally left unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no functional or UI change.

### TESTING INSTRUCTIONS

No behavior change; the produced datetime values are identical to before (naive UTC), so existing tests cover these paths. `pre-commit` (ruff, ruff-format, mypy, pylint) passes on all changed files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Scope is limited to production code under `superset/` to keep the diff easy to verify as a no-op. Test files under `tests/` still use the deprecated calls and can be migrated in a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)