### PR TITLE
fix(a11y): add aria-label to ActionButton span role=button

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
@@ -41,7 +41,7 @@ export const ActionButton = ({
     <span
       role="button"
       tabIndex={0}
-      aria-label={label}
+      aria-label={typeof tooltip === 'string' ? tooltip : label}
       css={css`
         cursor: pointer;
         color: ${theme.colorIcon};

--- a/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
@@ -41,6 +41,7 @@ export const ActionButton = ({
     <span
       role="button"
       tabIndex={0}
+      aria-label={label}
       css={css`
         cursor: pointer;
         color: ${theme.colorIcon};


### PR DESCRIPTION
## Summary

`ActionButton` is used throughout Superset list views to render icon-only row actions (edit, delete, export, etc.). It renders a `<span role="button" tabIndex={0}>` containing only an icon, but never sets an accessible name on that element.

### WCAG rule violated

**WCAG 2.1 SC 4.1.2 — Name, Role, Value (Level A)**

> For all user interface components, the name and role can be programmatically determined.

Without `aria-label`, screen readers attempt to derive an accessible name from the icon's SVG content, which typically produces an empty or meaningless string. Users navigating by keyboard or assistive technology cannot determine what each action button does.

### What changed

One line in `ActionButton/index.tsx`:

```diff
 <span
   role="button"
   tabIndex={0}
+  aria-label={typeof tooltip === 'string' ? tooltip : label}
   ...
 >
   {icon}
 </span>
```

**Why `tooltip` and not `label`?**

Call sites consistently use `label` for internal test identifiers (e.g. `'edit-action'`, `'delete-action'`) and `tooltip` for the translatable, user-facing string (e.g. `t('Edit query')`). Using `label` directly would announce `"edit-action, button"` to screen readers instead of the correct `"Edit query, button"`.

The expression `typeof tooltip === 'string' ? tooltip : label` uses the human-readable tooltip text when available (always a translated string at list-view call sites), falling back to `label` for the rare cases where no tooltip is provided or tooltip is a ReactElement.

### Behavior unchanged

Visual rendering, click handling, and keyboard interaction are identical. Only the screen-reader-announced name changes (from empty/SVG-derived to the human-readable action label already defined by callers).

### Test plan

1. Tab to any list view (Dashboards, Charts, Datasets, Saved Queries, etc.) and navigate to the action buttons column.
2. Activate a screen reader (e.g. VoiceOver on macOS, NVDA on Windows).
3. Focus an action button. Confirm the screen reader announces the action name (e.g. "Edit query, button", "Delete query, button") rather than empty or SVG-derived content.
4. Confirm click and keyboard (Enter/Space) behavior is unchanged.

---

*Automated accessibility fix — part of the [Automated Accessibility Fixes](https://app.shortcut.com/preset/epic/111841) initiative.*