### PR TITLE
perf(frontend): migrate lodash imports to lodash-es for tree-shaking

### DIFF
--- a/superset-frontend/babel.config.js
+++ b/superset-frontend/babel.config.js
@@ -44,7 +44,6 @@ module.exports = {
     '@babel/preset-typescript',
   ],
   plugins: [
-    'lodash',
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-transform-export-namespace-from',
     ['@babel/plugin-transform-class-properties', { loose: true }],

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -25,6 +25,9 @@ module.exports = {
     '\\.(css|less|geojson)$': '<rootDir>/spec/__mocks__/mockExportObject.js',
     '\\.(gif|ttf|eot|png|jpg)$': '<rootDir>/spec/__mocks__/mockExportString.js',
     '\\.svg$': '<rootDir>/spec/__mocks__/svgrMock.tsx',
+    // lodash-es is ESM (type: module) which jest.mock cannot intercept; alias to
+    // the CJS lodash build (identical API) so module mocks work in tests.
+    '^lodash-es$': '<rootDir>/node_modules/lodash',
     '^src/(.*)$': '<rootDir>/src/$1',
     '^spec/(.*)$': '<rootDir>/spec/$1',
     // mapping plugins of superset-ui to source code

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -221,7 +221,6 @@
         "babel-loader": "^10.1.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
-        "babel-plugin-lodash": "^3.3.4",
         "baseline-browser-mapping": "^2.10.38",
         "cheerio": "1.2.0",
         "concurrently": "^10.0.3",
@@ -14736,20 +14735,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -37592,13 +37577,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/requireindex": {
       "version": "1.2.0",

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -109,6 +109,7 @@
         "json-bigint": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "mapbox-gl": "^3.25.0",
         "markdown-to-jsx": "^9.8.2",
         "match-sorter": "^8.3.0",
@@ -199,6 +200,7 @@
         "@types/jquery": "^4.0.1",
         "@types/js-levenshtein": "^1.1.3",
         "@types/json-bigint": "^1.0.4",
+        "@types/lodash-es": "^4.17.12",
         "@types/mousetrap": "^1.6.15",
         "@types/node": "^26.0.0",
         "@types/react": "^18.3.0",
@@ -44244,6 +44246,9 @@
       "name": "@apache-superset/core",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
       "devDependencies": {
         "@babel/cli": "^7.29.7",
         "@babel/core": "^7.29.7",
@@ -44286,6 +44291,7 @@
         "@apache-superset/core": "*",
         "@types/react": "*",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "tinycolor2": "*"
       },
       "peerDependencies": {
@@ -44333,6 +44339,7 @@
         "handlebars": "^4.7.9",
         "jed": "^1.1.1",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "math-expression-evaluator": "^2.0.7",
         "parse-ms": "^4.0.0",
         "re-resizable": "^6.11.2",
@@ -44796,6 +44803,7 @@
         "dompurify": "^3.4.11",
         "fast-safe-stringify": "^2.1.1",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "nvd3-fork": "^2.0.5",
         "prop-types": "^15.8.1",
         "urijs": "^1.19.11"
@@ -44818,6 +44826,7 @@
         "classnames": "^2.5.1",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "memoize-one": "^6.0.0",
         "react-table": "^7.8.0",
         "regenerator-runtime": "^0.14.1",
@@ -44856,7 +44865,8 @@
       "dependencies": {
         "@types/geojson": "^7946.0.16",
         "geojson": "^0.5.0",
-        "lodash": "^4.18.1"
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "@ant-design/icons": "^5.6.1",
@@ -44886,6 +44896,7 @@
         "acorn": "^8.17.0",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
@@ -44929,7 +44940,8 @@
       "dependencies": {
         "currencyformatter.js": "^1.0.5",
         "handlebars-group-by": "^1.0.1",
-        "just-handlebars-helpers": "^1.0.19"
+        "just-handlebars-helpers": "^1.0.19",
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -45010,6 +45022,7 @@
         "classnames": "^2.5.1",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "memoize-one": "^6.0.0",
         "react-table": "^7.8.0",
         "regenerator-runtime": "^0.14.1",
@@ -45049,7 +45062,8 @@
       "dependencies": {
         "@types/d3-scale": "^4.0.9",
         "d3-cloud": "^1.2.9",
-        "d3-scale": "^4.0.2"
+        "d3-scale": "^4.0.2",
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
         "@types/d3-cloud": "^1.2.9"
@@ -45098,6 +45112,7 @@
         "d3-scale": "^4.0.2",
         "handlebars": "^4.7.9",
         "lodash": "^4.18.1",
+        "lodash-es": "^4.17.21",
         "maplibre-gl": "^5.24.0",
         "mousetrap": "^1.6.5",
         "ngeohash": "^0.6.3",
@@ -45167,36 +45182,6 @@
       "version": "1.0.0",
       "extraneous": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/whatwg-url/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     }
   }
 }

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -239,7 +239,8 @@
     "use-query-params": "^2.2.2",
     "uuid": "^14.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "yargs": "^18.0.0"
+    "yargs": "^18.0.0",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@babel/cli": "^7.29.7",
@@ -372,7 +373,8 @@
     "webpack-dev-server": "^5.2.5",
     "webpack-manifest-plugin": "^6.0.1",
     "webpack-sources": "^3.5.0",
-    "webpack-visualizer-plugin2": "^2.0.0"
+    "webpack-visualizer-plugin2": "^2.0.0",
+    "@types/lodash-es": "^4.17.12"
   },
   "peerDependencies": {
     "ace-builds": "^1.41.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -303,7 +303,6 @@
     "babel-loader": "^10.1.1",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "baseline-browser-mapping": "^2.10.38",
     "cheerio": "1.2.0",
     "concurrently": "^10.0.3",

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -120,5 +120,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "lodash-es": "^4.17.21"
   }
 }

--- a/superset-frontend/packages/superset-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.tsx
@@ -25,7 +25,7 @@ import {
   CacheProvider as EmotionCacheProvider,
 } from '@emotion/react';
 import createCache from '@emotion/cache';
-import { noop, mergeWith } from 'lodash';
+import { noop, mergeWith } from 'lodash-es';
 import { GlobalStyles } from './GlobalStyles';
 import {
   AntdThemeConfig,

--- a/superset-frontend/packages/superset-core/src/utils/isBlank.ts
+++ b/superset-frontend/packages/superset-core/src/utils/isBlank.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty, isNaN, isNil, isString, trim } from 'lodash';
+import { isEmpty, isNaN, isNil, isString, trim } from 'lodash-es';
 
 /**
  * Checks if a value is null, undefined, NaN, or a whitespace-only string.

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -27,7 +27,8 @@
     "@apache-superset/core": "*",
     "@types/react": "*",
     "lodash": "^4.18.1",
-    "tinycolor2": "*"
+    "tinycolor2": "*",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/CertifiedIconWithTooltip.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/CertifiedIconWithTooltip.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { useTheme, styled } from '@apache-superset/core/theme';
 import { Tooltip } from '@superset-ui/core/components';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import {
   ensureIsArray,
   getMetricLabel,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -32,7 +32,7 @@
  * here's a list of the keys that are common to all controls, and as a result define the
  * control interface.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   getCategoricalSchemeRegistry,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import memoizeOne from 'memoize-one';
-import { isString, isBoolean } from 'lodash';
+import { isString, isBoolean } from 'lodash-es';
 import { isBlank } from '@apache-superset/core/utils';
 import { addAlpha, DataRecord } from '@superset-ui/core';
 import tinycolor from 'tinycolor2';

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/histogramOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/histogramOperator.test.ts
@@ -18,7 +18,7 @@
  */
 import { histogramOperator } from '@superset-ui/chart-controls';
 import { SqlaFormData, VizType } from '@superset-ui/core';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 const formData: SqlaFormData = {
   bins: 5,

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -66,7 +66,8 @@
     "reselect": "^5.2.0",
     "rison": "^0.1.1",
     "seedrandom": "^3.0.5",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@emotion/styled": "^11.14.1",

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorNamespace.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorNamespace.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import CategoricalColorScale from './CategoricalColorScale';
 import { ColorsLookup } from './types';
 import getCategoricalSchemeRegistry from './CategoricalSchemeRegistrySingleton';

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Dropdown } from 'antd';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'lodash-es';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { Tooltip } from '../Tooltip';
 import type { DropdownButtonProps } from './types';

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useRef, useCallback, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { css } from '@apache-superset/core/theme';
 import { Button } from '../Button';
 import { Select } from '../Select';

--- a/superset-frontend/packages/superset-ui-core/src/components/InfoTooltip/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/InfoTooltip/index.tsx
@@ -18,7 +18,7 @@
  */
 import { KeyboardEvent, useMemo } from 'react';
 import { SerializedStyles, CSSObject } from '@emotion/react';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { css, useTheme, getFontSize } from '@apache-superset/core/theme';
 import {

--- a/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
@@ -18,7 +18,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
-import { uniqWith } from 'lodash';
+import { uniqWith } from 'lodash-es';
 import { styled } from '@apache-superset/core/theme';
 import { Tooltip } from '../Tooltip';
 import { TooltipPlacement } from '../Tooltip/types';

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -24,7 +24,7 @@ import {
   useState,
   type ComponentType,
 } from 'react';
-import { isNil } from 'lodash';
+import { isNil } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
 import { Modal as AntdModal, ModalProps as AntdModalProps } from 'antd';

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -22,7 +22,7 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 // remark-gfm v4+ requires react-markdown v9+, which requires React 18.
 // Currently pinned to v3.0.1 for compatibility with react-markdown v8 and React 17.
 import remarkGfm from 'remark-gfm';
-import { cloneDeep, mergeWith } from 'lodash';
+import { cloneDeep, mergeWith } from 'lodash-es';
 import { FeatureFlag, isFeatureEnabled } from '../../utils';
 
 interface SafeMarkdownProps {

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -41,7 +41,7 @@ import {
   LabeledValue as AntdLabeledValue,
   RefSelectProps,
 } from 'antd/es/select';
-import { debounce, isEqual, uniq } from 'lodash';
+import { debounce, isEqual, uniq } from 'lodash-es';
 import { Constants, Icons } from '@superset-ui/core/components';
 import { Space } from '../Space';
 import {

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -37,7 +37,7 @@ import {
   LabeledValue as AntdLabeledValue,
   RefSelectProps,
 } from 'antd/es/select';
-import { debounce, isEqual, uniq } from 'lodash';
+import { debounce, isEqual, uniq } from 'lodash-es';
 import {
   dropDownRenderHelper,
   getOption,

--- a/superset-frontend/packages/superset-ui-core/src/components/TableView/TableView.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableView/TableView.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { memo, useEffect, useRef, useMemo, useCallback, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { styled } from '@apache-superset/core/theme';
 import { useFilters, useSortBy, useTable } from 'react-table';
 import { Empty } from '@superset-ui/core/components';

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import _JSONbig from 'json-bigint';
-import { cloneDeepWith } from 'lodash';
+import { cloneDeepWith } from 'lodash-es';
 
 import { ParseMethod, TextResponse, JsonResponse } from '../types';
 

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeOrderBy.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeOrderBy.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 
 import { QueryObject } from './types';
 

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 import {
   AdhocColumn,

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import rison from 'rison';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import {
   SupersetClient,
   getClientErrorObject,

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { ensureIsArray } from '../utils';
 import { customTimeRangeDecode } from './customTimeRangeDecode';
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/convertKeysToCamelCase.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/convertKeysToCamelCase.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { camelCase, isPlainObject, mapKeys } from 'lodash';
+import { camelCase, isPlainObject, mapKeys } from 'lodash-es';
 
 export default function convertKeysToCamelCase<T>(object: T) {
   if (object === null || object === undefined) {

--- a/superset-frontend/packages/superset-ui-core/src/utils/merge.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/merge.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { mergeWith } from 'lodash';
+import { mergeWith } from 'lodash-es';
 
 /**
  * Merges objects using lodash.mergeWith, but replaces arrays instead of concatenating them.

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { render } from '@testing-library/react';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { defaultSchema } from 'rehype-sanitize';
 import {
   getOverrideHtmlSchema,

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
@@ -36,7 +36,8 @@
     "nvd3-fork": "^2.0.5",
     "dompurify": "^3.4.11",
     "prop-types": "^15.8.1",
-    "urijs": "^1.19.11"
+    "urijs": "^1.19.11",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.ts
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { kebabCase, throttle } from 'lodash';
+import { kebabCase, throttle } from 'lodash-es';
 import d3 from 'd3';
 import utc from 'dayjs/plugin/utc';
 import nv from 'nvd3-fork';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
@@ -32,7 +32,8 @@
     "memoize-one": "^6.0.0",
     "react-table": "^7.8.0",
     "regenerator-runtime": "^0.14.1",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -50,7 +50,7 @@ import {
   JsonObject,
 } from '@superset-ui/core';
 import { SearchOutlined } from '@ant-design/icons';
-import { debounce, isEqual } from 'lodash';
+import { debounce, isEqual } from 'lodash-es';
 import Pagination from './components/Pagination';
 import SearchSelectDropdown from './components/SearchSelectDropdown';
 import { SearchOption, SortByItem } from '../types';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -24,7 +24,7 @@ import {
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 import {
   CellClickedEvent,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -38,7 +38,7 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
 import { updateTableOwnState } from './utils/externalAPIs';
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -55,7 +55,7 @@ import {
   withLabel,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
-import { isEmpty, last } from 'lodash';
+import { isEmpty, last } from 'lodash-es';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 
 /**

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -38,7 +38,7 @@ import {
   AgGridFilterModel,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
-import { isEmpty, isEqual, merge } from 'lodash';
+import { isEmpty, isEqual, merge } from 'lodash-es';
 import {
   ConditionalFormattingConfig,
   getColorFormatters,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/extent.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/extent.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { isNil } from 'lodash';
+import { isNil } from 'lodash-es';
 
 export default function extent<T = number | string | Date | undefined | null>(
   values: T[],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/getInitialFilterModel.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/getInitialFilterModel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import type { AgGridChartState } from '@superset-ui/core';
 
 const getInitialFilterModel = (

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@types/geojson": "^7946.0.16",
     "geojson": "^0.5.0",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
@@ -24,7 +24,7 @@ import { View } from 'ol';
 import BaseEvent from 'ol/events/Event';
 import { unByKey } from 'ol/Observable';
 import { toLonLat } from 'ol/proj';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { fitMapToCharts } from '../util/mapUtil';
 import { ChartLayer } from './ChartLayer';
 import { createLayer } from '../util/layerUtil';

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
@@ -22,7 +22,7 @@ import {
   convertKeysToCamelCase,
   DataRecord,
 } from '@superset-ui/core';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 import {
   LocationConfigMapping,
   SelectedChartConfig,

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -29,7 +29,8 @@
     "acorn": "^8.17.0",
     "d3-array": "^3.2.4",
     "lodash": "^4.18.1",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -29,7 +29,7 @@ import {
   DEFAULT_DATE_PATTERN,
   ColorSchemeEnum,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import {
   PopKPIComparisonSymbolStyleProps,
   PopKPIComparisonValueStyleProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -26,7 +26,7 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 
 export default function buildQuery(formData: QueryFormData) {
   const { cols: groupby, extra_form_data } = formData;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -25,7 +25,7 @@ import {
   sections,
   ColorSchemeEnum,
 } from '@superset-ui/chart-controls';
-import { noop } from 'lodash';
+import { noop } from 'lodash-es';
 import {
   headerFontSize,
   subheaderFontSize,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/useOverflowDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/useOverflowDetection.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useEffect, useRef, useState } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 export const useOverflowDetection = (flexGap: number) => {
   const symbolContainerRef = useRef<HTMLDivElement>(null);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -30,7 +30,7 @@ import type { EChartsCoreOption } from 'echarts/core';
 import type { GaugeSeriesOption } from 'echarts/charts';
 import type { GaugeDataItemOption } from 'echarts/types/src/chart/gauge/GaugeSeries';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
-import { range } from 'lodash';
+import { range } from 'lodash-es';
 import { parseNumbersList } from '../utils/controls';
 import {
   DEFAULT_FORM_DATA as DEFAULT_GAUGE_FORM_DATA,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -32,7 +32,7 @@ import {
 import { logging } from '@apache-superset/core/utils';
 import { GenericDataType } from '@apache-superset/core/common';
 import memoizeOne from 'memoize-one';
-import { maxBy, minBy } from 'lodash';
+import { maxBy, minBy } from 'lodash-es';
 import type { ComposeOption } from 'echarts/core';
 import type { HeatmapSeriesOption } from 'echarts/charts';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -20,7 +20,7 @@ import type { ComposeOption } from 'echarts/core';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { GridComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import {
   CategoricalColorNamespace,
   NumberFormats,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -18,7 +18,7 @@
  */
 import { t } from '@apache-superset/core/translation';
 import { ensureIsArray } from '@superset-ui/core';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import {
   ControlPanelsContainerProps,
   ControlPanelConfig,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { invert } from 'lodash';
+import { invert } from 'lodash-es';
 import {
   AnnotationLayer,
   AxisType,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { invert } from 'lodash';
+import { invert } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   AnnotationLayer,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 
 import {
   Annotation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -37,7 +37,7 @@ import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
 import type { LegendComponentOption } from 'echarts/components';
 import type { SeriesOption } from 'echarts';
-import { isEmpty, maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash';
+import { isEmpty, maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash-es';
 import {
   NULL_STRING,
   StackControlsValue,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/themeOverrides.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/themeOverrides.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { mergeWith, isPlainObject } from 'lodash';
+import { mergeWith, isPlainObject } from 'lodash-es';
 
 /**
  * Custom merge function for ECharts theme overrides.

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecord, DataRecordValue } from '@superset-ui/core';
-import { groupBy as _groupBy, transform } from 'lodash';
+import { groupBy as _groupBy, transform } from 'lodash-es';
 
 export type TreeNode = {
   name: DataRecordValue;
@@ -95,8 +95,6 @@ export function treeBuilder(
   // is dropped too: keeping it would leave a zero-value arc that yields a NaN
   // secondaryValue/value ratio for coloring and tooltips.
   return filterNullNames
-    ? nodes.filter(
-        node => node.name !== null && node.children?.length !== 0,
-      )
+    ? nodes.filter(node => node.name !== null && node.children?.length !== 0)
     : nodes;
 }

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "currencyformatter.js": "^1.0.5",
     "handlebars-group-by": "^1.0.1",
-    "just-handlebars-helpers": "^1.0.19"
+    "just-handlebars-helpers": "^1.0.19",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
@@ -22,7 +22,7 @@ import { SafeMarkdown } from '@superset-ui/core/components';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import Handlebars from 'handlebars';
 import { useMemo, useState } from 'react';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'lodash-es';
 import Helpers from 'just-handlebars-helpers';
 import HandlebarsGroupBy from 'handlebars-group-by';
 

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/consts.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/consts.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { Constants } from '@superset-ui/core/components';
 
 export const debounceFunc = debounce(

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/orderBy.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/orderBy.tsx
@@ -18,7 +18,7 @@
  */
 import { ControlSetItem, Dataset } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core/translation';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { isAggMode, isRawMode } from './shared';
 
 export const orderByControlSetItem: ControlSetItem = {

--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -32,7 +32,8 @@
     "memoize-one": "^6.0.0",
     "react-table": "^7.8.0",
     "regenerator-runtime": "^0.14.1",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -43,7 +43,7 @@ import {
   Row,
 } from 'react-table';
 import { matchSorter, rankings } from 'match-sorter';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { Flex, Space } from '@superset-ui/core/components';
 import GlobalFilter, { GlobalFilterProps } from './components/GlobalFilter';
 import SelectPageSize, {

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -75,7 +75,7 @@ import {
   PlusCircleOutlined,
   TableOutlined,
 } from '@ant-design/icons';
-import { isEmpty, debounce, isEqual } from 'lodash';
+import { isEmpty, debounce, isEqual } from 'lodash-es';
 import {
   ColorFormatters,
   getTextColorForBackground,

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -34,7 +34,7 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
 import { updateTableOwnState } from './DataTable/utils/externalAPIs';
 

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -57,7 +57,7 @@ import {
   withLabel,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
-import { isEmpty, last } from 'lodash';
+import { isEmpty, last } from 'lodash-es';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 
 function getQueryMode(controls: ControlStateMapping): QueryMode {

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -45,7 +45,7 @@ import {
   ColorSchemeEnum,
 } from '@superset-ui/chart-controls';
 
-import { isEmpty, merge } from 'lodash';
+import { isEmpty, merge } from 'lodash-es';
 import isEqualColumns from './utils/isEqualColumns';
 import DateWithFormatter from './utils/DateWithFormatter';
 import {

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/extent.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/extent.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { isNil } from 'lodash';
+import { isNil } from 'lodash-es';
 
 export default function extent<T = number | string | Date | undefined | null>(
   values: T[],

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -29,7 +29,7 @@ import {
   waitFor,
   within,
 } from '@superset-ui/core/spec';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import {
   QueryMode,
   TimeGranularity,

--- a/superset-frontend/plugins/plugin-chart-word-cloud/package.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@types/d3-scale": "^4.0.9",
     "d3-cloud": "^1.2.9",
-    "d3-scale": "^4.0.2"
+    "d3-scale": "^4.0.2",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -21,7 +21,7 @@ import cloudLayout from 'd3-cloud';
 import { scaleLinear } from 'd3-scale';
 import { seed, CategoricalColorNamespace } from '@superset-ui/core';
 import { SupersetTheme, withTheme } from '@apache-superset/core/theme';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 const seedRandom = seed('superset-ui');
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/ColorSchemeControl/index.tsx
@@ -27,7 +27,7 @@ import {
   CategoricalColorNamespace,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import { ControlHeader } from '@superset-ui/chart-controls';
 import {
   Tooltip,

--- a/superset-frontend/plugins/preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/preset-chart-deckgl/package.json
@@ -53,7 +53,8 @@
     "tinycolor2": "^1.6.0",
     "underscore": "^1.13.7",
     "urijs": "^1.19.11",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@types/mapbox__geojson-extent": "^1.0.3",

--- a/superset-frontend/plugins/preset-chart-deckgl/src/DeckGLContainer.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/DeckGLContainer.tsx
@@ -27,7 +27,7 @@ import {
   useState,
   isValidElement,
 } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { Map as MapLibreMap } from 'react-map-gl/maplibre';
 import { Map as MapboxMap } from 'react-map-gl/mapbox';
 import mapboxgl from 'mapbox-gl';

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -21,7 +21,7 @@
  */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { createSelector } from '@reduxjs/toolkit';
 import {
   AdhocFilter,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/factory.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/factory.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import type { Layer } from '@deck.gl/core';
 import { getMapboxApiKey } from './utils/mapbox';
 import {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
@@ -22,7 +22,7 @@ import { sanitizeHtml } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import Handlebars from 'handlebars';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'lodash-es';
 
 export interface HandlebarsRendererProps {
   templateSource: string;

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utilities/TooltipTemplateControl.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utilities/TooltipTemplateControl.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useCallback } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { useTheme } from '@apache-superset/core/theme';
 import { InfoTooltip, Constants } from '@superset-ui/core/components';

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -29,7 +29,7 @@ import {
   getClientErrorObject,
 } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
-import { invert, mapKeys } from 'lodash';
+import { invert, mapKeys } from 'lodash-es';
 
 import { now } from '@superset-ui/core/utils/dates';
 import {

--- a/superset-frontend/src/SqlLab/components/App/index.tsx
+++ b/superset-frontend/src/SqlLab/components/App/index.tsx
@@ -22,7 +22,7 @@ import { Redirect } from 'react-router-dom';
 import Mousetrap from 'mousetrap';
 import { t } from '@apache-superset/core/translation';
 import { css, styled } from '@apache-superset/core/theme';
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import {
   LOCALSTORAGE_MAX_USAGE_KB,
   LOCALSTORAGE_WARNING_THRESHOLD,

--- a/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useSelector } from 'react-redux';
-import { noop } from 'lodash';
+import { noop } from 'lodash-es';
 import type { SqlLabRootState } from 'src/SqlLab/types';
 import { css, styled } from '@apache-superset/core/theme';
 import { useComponentDidUpdate } from '@superset-ui/core';

--- a/superset-frontend/src/SqlLab/components/PopEditorTab/index.tsx
+++ b/superset-frontend/src/SqlLab/components/PopEditorTab/index.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
 import URI from 'urijs';
-import { pick } from 'lodash';
+import { pick } from 'lodash-es';
 import { useComponentDidUpdate } from '@superset-ui/core';
 import { Skeleton } from '@superset-ui/core/components';
 import useEffectEvent from 'src/hooks/useEffectEvent';

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
@@ -19,7 +19,7 @@
 import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 import rison from 'rison';
 import {
   SupersetClient,

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -19,7 +19,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useInView } from 'react-intersection-observer';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import { EmptyState, Skeleton } from '@superset-ui/core/components';
 import { t } from '@apache-superset/core/translation';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -31,7 +31,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
 import { useHistory } from 'react-router-dom';
-import { pick } from 'lodash';
+import { pick } from 'lodash-es';
 import {
   Button,
   ButtonGroup,

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -56,7 +56,7 @@ import {
 import { mountExploreUrl } from 'src/explore/exploreUtils';
 import { postFormData } from 'src/explore/exploreUtils/formData';
 import { URL_PARAMS } from 'src/constants';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { clearDatasetCache } from 'src/utils/cachedSupersetGet';
 
 interface QueryDatabase {

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -29,7 +29,7 @@ import {
 } from 'spec/helpers/testing-library';
 import ShareSqlLabQuery from 'src/SqlLab/components/ShareSqlLabQuery';
 import { initialState } from 'src/SqlLab/fixtures';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 const mockStore = configureStore([thunk]);
 const defaultProps = {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -49,7 +49,7 @@ import type {
   CursorPosition,
 } from 'src/SqlLab/types';
 import type { DatabaseObject } from 'src/features/databases/types';
-import { debounce, isEmpty } from 'lodash';
+import { debounce, isEmpty } from 'lodash-es';
 import Mousetrap from 'mousetrap';
 import {
   Button,

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -19,7 +19,7 @@
 import { useState, useEffect } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import {
   Badge,
   InfoTooltip,

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { pick } from 'lodash';
+import { pick } from 'lodash-es';
 import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { SqlLabRootState, QueryEditor } from 'src/SqlLab/types';

--- a/superset-frontend/src/SqlLab/middlewares/persistSqlLabStateEnhancer.ts
+++ b/superset-frontend/src/SqlLab/middlewares/persistSqlLabStateEnhancer.ts
@@ -18,7 +18,7 @@
  */
 import type { StoreEnhancer } from 'redux';
 import persistState from 'redux-localstorage';
-import { pickBy } from 'lodash';
+import { pickBy } from 'lodash-es';
 import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { filterUnsavedQueryEditorList } from 'src/SqlLab/components/EditorAutoSync';
 import type {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -18,7 +18,7 @@
  */
 import { normalizeTimestamp, QueryState } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
-import { isEqual, omit } from 'lodash';
+import { isEqual, omit } from 'lodash-es';
 import { shallowEqual } from 'react-redux';
 import { now } from '@superset-ui/core/utils/dates';
 import type { SqlLabRootState, QueryEditor, Table } from '../types';

--- a/superset-frontend/src/SqlLab/utils/reduxStateToLocalStorageHelper.ts
+++ b/superset-frontend/src/SqlLab/utils/reduxStateToLocalStorageHelper.ts
@@ -29,7 +29,7 @@ import type {
   Table,
 } from 'src/SqlLab/types';
 import type { ThunkDispatch } from 'redux-thunk';
-import { pick } from 'lodash';
+import { pick } from 'lodash-es';
 import { tableApiUtil } from 'src/hooks/apiResources/tables';
 import {
   BYTES_PER_CHAR,

--- a/superset-frontend/src/components/AlteredSliceTag/index.tsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useEffect, useMemo, useState, FC } from 'react';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import getControlsForVizType from 'src/utils/getControlsForVizType';
 import {

--- a/superset-frontend/src/components/Chart/ChartRenderer.tsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { snakeCase, cloneDeep } from 'lodash';
+import { snakeCase, cloneDeep } from 'lodash-es';
 import {
   useCallback,
   useEffect,

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -19,7 +19,7 @@
 
 import { useState } from 'react';
 import fetchMock from 'fetch-mock';
-import { omit, omitBy } from 'lodash';
+import { omit, omitBy } from 'lodash-es';
 import {
   render,
   screen,

--- a/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.test.tsx
@@ -37,11 +37,14 @@ import { DrillBySubmenu, DrillBySubmenuProps } from './DrillBySubmenu';
 
 const { form_data: defaultFormData } = chartQueries[sliceId];
 
-jest.mock('lodash/debounce', () => (fn: Function & { debounce: Function }) => {
-  // eslint-disable-next-line no-param-reassign
-  fn.debounce = jest.fn();
-  return fn;
-});
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fn: Function & { debounce: Function }) => {
+    // eslint-disable-next-line no-param-reassign
+    fn.debounce = jest.fn();
+    return fn;
+  },
+}));
 
 const defaultColumns = [
   { column_name: 'col1', groupby: true },

--- a/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
@@ -43,7 +43,7 @@ import {
   Popover,
   Icons,
 } from '@superset-ui/core/components';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { FixedSizeList as List } from 'react-window';
 import { InputRef } from 'antd';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';

--- a/superset-frontend/src/components/Chart/DrillDetail/utils.ts
+++ b/superset-frontend/src/components/Chart/DrillDetail/utils.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import {
   ensureIsArray,
   QueryFormData,

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -18,7 +18,7 @@
  */
 /* eslint camelcase: 0 */
 import { t } from '@apache-superset/core/translation';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import { HYDRATE_DASHBOARD } from 'src/dashboard/actions/hydrate';
 import { DatasourcesAction } from 'src/dashboard/actions/datasources';
 import { ChartState } from 'src/explore/types';

--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
@@ -24,7 +24,7 @@ import {
   useCallback,
   useMemo,
 } from 'react';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   Behavior,

--- a/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {
   DndContext,

--- a/superset-frontend/src/components/DynamicPlugins/index.tsx
+++ b/superset-frontend/src/components/DynamicPlugins/index.tsx
@@ -34,7 +34,7 @@ import {
   makeApi,
 } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
-import { omitBy } from 'lodash';
+import { omitBy } from 'lodash-es';
 import type { Plugin, PluginAction, PluginContextType } from './types';
 
 const metadataRegistry = getChartMetadataRegistry();

--- a/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
+++ b/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
@@ -26,7 +26,7 @@ import {
   type CSSProperties,
   type RefObject,
 } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { useTheme, styled, css } from '@apache-superset/core/theme';
 import {

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -34,7 +34,7 @@ import {
 } from 'use-query-params';
 
 import rison from 'rison';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import {
   ListViewFetchDataConfig as FetchDataConfig,
   ListViewFilter as Filter,

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -58,7 +58,7 @@ import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { safeStringify } from 'src/utils/safeStringify';
 import { logEvent } from 'src/logger/actions';
 import { LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA } from 'src/logger/LogUtils';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { navigateWithState, navigateTo } from 'src/utils/navigationUtils';
 import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';

--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -27,7 +27,7 @@ import {
 } from '@superset-ui/core';
 import { Dispatch } from 'redux';
 import { RootState } from 'src/dashboard/types';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { setDataMaskForFilterChangesComplete } from 'src/dataMask/actions';
 import { HYDRATE_DASHBOARD } from './hydrate';
 import {

--- a/superset-frontend/src/dashboard/components/ColorSchemeSelect.tsx
+++ b/superset-frontend/src/dashboard/components/ColorSchemeSelect.tsx
@@ -25,7 +25,7 @@ import {
   CategoricalScheme,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import { Select, Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import ColorSchemeLabel from 'src/explore/components/controls/ColorSchemeControl/ColorSchemeLabel';

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -30,7 +30,7 @@ import {
 } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import {
   ChartCustomizationConfiguration,
   ChartCustomizationType,

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
@@ -24,7 +24,7 @@ import { RootState } from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import { useDragDropManager } from 'react-dnd';
 import classNames from 'classnames';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 const StyledDiv = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -27,7 +27,7 @@ import {
 } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
-import { uniqWith } from 'lodash';
+import { uniqWith } from 'lodash-es';
 import cx from 'classnames';
 import { t } from '@apache-superset/core/translation';
 import {

--- a/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
+++ b/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
@@ -22,7 +22,7 @@ import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Menu, MenuItem } from '@superset-ui/core/components/Menu';
 import { t } from '@apache-superset/core/translation';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { URL_PARAMS } from 'src/constants';
 import { useShareMenuItems } from 'src/dashboard/components/menu/ShareMenuItems';
 import { useDownloadMenuItems } from 'src/dashboard/components/menu/DownloadMenuItems';

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import jsonStringify from 'json-stringify-pretty-compact';
 import {
   Form,

--- a/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
@@ -45,17 +45,17 @@ jest.mock('@superset-ui/core', () => ({
   ),
 }));
 
-jest.mock('lodash/debounce', () => {
-  const debounced = (fn: Function) => {
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fn: Function) => {
     const debouncedFn = ((...args: any[]) =>
       fn(...args)) as unknown as Function & {
       cancel: () => void;
     };
     debouncedFn.cancel = () => {};
     return debouncedFn;
-  };
-  return debounced;
-});
+  },
+}));
 
 const mockStore = configureStore({
   reducer: (state = { common: { locale: 'en' } }) => state,

--- a/superset-frontend/src/dashboard/components/SliceAdder.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.tsx
@@ -46,7 +46,7 @@ import {
   NEW_CHART_ID,
   NEW_COMPONENTS_SOURCE_ID,
 } from 'src/dashboard/util/constants';
-import { debounce, pickBy } from 'lodash';
+import { debounce, pickBy } from 'lodash-es';
 import { Dispatch } from 'redux';
 import { Slice } from 'src/dashboard/types';
 import { navigateTo } from 'src/utils/navigationUtils';

--- a/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
+++ b/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
@@ -18,7 +18,7 @@
  */
 import { FC, useEffect } from 'react';
 
-import { pick, pickBy } from 'lodash';
+import { pick, pickBy } from 'lodash-es';
 import { useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { DashboardContextForExplore } from 'src/types/DashboardContextForExplore';

--- a/superset-frontend/src/dashboard/components/dnd/handleHover.ts
+++ b/superset-frontend/src/dashboard/components/dnd/handleHover.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import { DropTargetMonitor } from 'react-dnd';
 import { DASHBOARD_ROOT_TYPE } from 'src/dashboard/util/componentTypes';
 import getDropPosition from 'src/dashboard/util/getDropPosition';

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -31,7 +31,7 @@ import type { ChartCustomization, JsonObject } from '@superset-ui/core';
 import { VizType } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -44,7 +44,7 @@ import {
 import { styled, SupersetTheme } from '@apache-superset/core/theme';
 import { useTheme } from '@emotion/react';
 import { useDispatch, useSelector } from 'react-redux';
-import { isEqual, isEqualWith } from 'lodash';
+import { isEqual, isEqualWith } from 'lodash-es';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ErrorAlert, ErrorMessageWithStackTrace } from 'src/components';
 import { Loading, Constants, Flex } from '@superset-ui/core/components';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/utils.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { Dispatch } from 'react';
 import {
   setFocusedNativeFilter,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -18,7 +18,7 @@
  */
 
 /* eslint-disable no-param-reassign */
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import {
   memo,
   useEffect,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -52,7 +52,7 @@ import {
 } from 'src/dashboard/actions/chartCustomizationActions';
 
 import { useImmer } from 'use-immer';
-import { isEmpty, isEqual, debounce } from 'lodash';
+import { isEmpty, isEqual, debounce } from 'lodash-es';
 import { getInitialDataMask } from 'src/dataMask/reducer';
 import { URL_PARAMS } from 'src/constants';
 import { applicationRoot } from 'src/utils/getBootstrapData';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -23,7 +23,7 @@ import {
   Filter,
   FilterState,
 } from '@superset-ui/core';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { areObjectsEqual } from 'src/reduxUtils';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -38,7 +38,7 @@ import {
 } from '@superset-ui/core';
 import { styled, useTheme, css } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
-import { debounce, isEqual } from 'lodash';
+import { debounce, isEqual } from 'lodash-es';
 import {
   forwardRef,
   useCallback,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { flatMapDeep } from 'lodash';
+import { flatMapDeep } from 'lodash-es';
 import type { FormInstance } from '@superset-ui/core/components';
 import { useState, useCallback } from 'react';
 import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { memo, useEffect, useCallback, useMemo, useState, useRef } from 'react';
-import { uniq, debounce } from 'lodash';
+import { uniq, debounce } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { ChartCustomizationType, NativeFilterType } from '@superset-ui/core';
 import { styled, css, useTheme } from '@apache-superset/core/theme';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useItemStateManager.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useItemStateManager.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useState, useCallback, useEffect } from 'react';
-import { uniq, isEmpty } from 'lodash';
+import { uniq, isEmpty } from 'lodash-es';
 import { FilterChangesType, FilterRemoval } from '../types';
 
 const DEFAULT_EMPTY_ARRAY: string[] = [];

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useModalSaveLogic.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useModalSaveLogic.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useMemo } from 'react';
-import { isEqual, sortBy } from 'lodash';
+import { isEqual, sortBy } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   Filter,

--- a/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.ts
+++ b/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.ts
@@ -19,7 +19,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
-import { last } from 'lodash';
+import { last } from 'lodash-es';
 import rison from 'rison';
 import { parse as parseContentDisposition } from 'content-disposition';
 import { t } from '@apache-superset/core/translation';

--- a/superset-frontend/src/dashboard/reducers/datasources.ts
+++ b/superset-frontend/src/dashboard/reducers/datasources.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { keyBy } from 'lodash';
+import { keyBy } from 'lodash-es';
 import { DatasourcesState } from 'src/dashboard/types';
 import {
   DatasourcesActionPayload,

--- a/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
+++ b/superset-frontend/src/dashboard/util/activeAllDashboardFilters.ts
@@ -22,7 +22,7 @@ import {
   JsonObject,
   PartialFilters,
 } from '@superset-ui/core';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import { ActiveFilters, ChartConfiguration } from '../types';
 
 export const getRelevantDataMask = (

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.ts
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { mapValues, flow, keyBy } from 'lodash/fp';
 import {
   JsonValue,

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -35,7 +35,7 @@ import {
 } from 'src/dashboard/types';
 import { getExtraFormData } from 'src/dashboard/components/nativeFilters/utils';
 import { isChartCustomization } from 'src/dashboard/components/nativeFilters/FiltersConfigModal/utils';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { areObjectsEqual } from 'src/reduxUtils';
 import {
   isSingleColumnDimensionChart,

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import {
   Behavior,
   getChartMetadataRegistry,

--- a/superset-frontend/src/dashboard/util/getDashboardUrl.ts
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { JsonObject } from '@superset-ui/core';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
 import serializeActiveFilterValues from './serializeActiveFilterValues';

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.ts
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { flow, keyBy, mapValues } from 'lodash/fp';
-import { flatMap, isEmpty } from 'lodash';
+import { flatMap, isEmpty } from 'lodash-es';
 
 import { CHART_TYPE, TAB_TYPE } from './componentTypes';
 import { getChartIdAndColumnFromFilterKey } from './getDashboardFilterKey';

--- a/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.ts
+++ b/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 
 import { DASHBOARD_ROOT_ID } from './constants';

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -45,7 +45,7 @@ import {
   migrateChartCustomizationArray,
   isLegacyChartCustomizationFormat,
 } from 'src/dashboard/util/migrateChartCustomization';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import {
   AnyDataMaskAction,
   CLEAR_DATA_MASK_STATE,

--- a/superset-frontend/src/embedded/utils.test.ts
+++ b/superset-frontend/src/embedded/utils.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataMaskStateWithId } from '@superset-ui/core';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { getDataMaskChangeTrigger, getChartDataPayloads } from './utils';
 import { RootState } from 'src/views/store';
 import * as chartStateConverter from 'src/dashboard/util/chartStateConverter';

--- a/superset-frontend/src/embedded/utils.ts
+++ b/superset-frontend/src/embedded/utils.ts
@@ -23,7 +23,7 @@ import {
   QueryFormData,
 } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash-es';
 import { NATIVE_FILTER_PREFIX } from 'src/dashboard/components/nativeFilters/FiltersConfigModal/utils';
 import {
   hasChartStateConverter,

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -26,7 +26,7 @@ import {
   SupersetClient,
 } from '@superset-ui/core';
 import { addSuccessToast } from 'src/components/MessageToasts/actions';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { Slice } from 'src/dashboard/types';
 import { Operators } from '../constants';
 import { buildV1ChartDataPayload } from '../exploreUtils';

--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ReactNode, useCallback, useState, useEffect } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import {
   ControlType,
   ControlComponentProps as BaseControlComponentProps,

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -59,7 +59,7 @@ import {
   sections,
 } from '@superset-ui/chart-controls';
 import { useSelector } from 'react-redux';
-import { kebabCase, isEqual } from 'lodash';
+import { kebabCase, isEqual } from 'lodash-es';
 
 import {
   Collapse,

--- a/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/FilterInput.test.tsx
@@ -19,9 +19,9 @@
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import { FilterInput } from '.';
 
-jest.mock('lodash/debounce', () => ({
-  __esModule: true,
-  default: (fuc: Function) => fuc,
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fuc: Function) => fuc,
 }));
 
 test('Render a FilterInput', async () => {

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -20,7 +20,7 @@ import { useMemo, useEffect, useRef, RefObject } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
 
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { Constants, Button, Icons, Input } from '@superset-ui/core/components';
 import { CopyToClipboard } from 'src/components';
 import {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -20,7 +20,7 @@ import { styled, css, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { GenericDataType } from '@apache-superset/core/common';
 import { useMemo } from 'react';
-import { zip } from 'lodash';
+import { zip } from 'lodash-es';
 import { Select, Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -104,9 +104,9 @@ jest.mock(
   }),
 );
 
-jest.mock('lodash/debounce', () => ({
-  __esModule: true,
-  default: (fuc: Function) => fuc,
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fuc: Function) => fuc,
 }));
 
 fetchMock.post('glob:*/api/v1/explore/form_data*', { key: KEY });

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -45,7 +45,7 @@ import {
 import { styled, css, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
-import { debounce, isEqual, isObjectLike, omit, pick } from 'lodash';
+import { debounce, isEqual, isObjectLike, omit, pick } from 'lodash-es';
 import { Resizable } from 're-resizable';
 import { useHistory } from 'react-router-dom';
 import { Tooltip } from '@superset-ui/core/components';

--- a/superset-frontend/src/explore/components/controls/BoundsControl.tsx
+++ b/superset-frontend/src/explore/components/controls/BoundsControl.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef, useState } from 'react';
 import { InputNumber } from '@superset-ui/core/components';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import ControlHeader from 'src/explore/components/ControlHeader';
 
 type ValueType = (number | null)[];

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
@@ -27,7 +27,7 @@ import {
   CategoricalColorNamespace,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import {
   Tooltip,

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ControlForm/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ControlForm/index.tsx
@@ -25,7 +25,7 @@ import {
 import { JsonObject, JsonValue } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { Constants } from '@superset-ui/core/components';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { ControlFormItemNode } from './ControlFormItem';
 
 export * from './ControlFormItem';

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -19,7 +19,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { isEmpty, isEqual, noop } from 'lodash';
+import { isEmpty, isEqual, noop } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   BinaryAdhocFilter,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
@@ -29,7 +29,7 @@ import {
 } from '@superset-ui/core';
 import { tn } from '@apache-superset/core/translation';
 import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
-import { isString } from 'lodash';
+import { isString } from 'lodash-es';
 import DndSelectLabel from 'src/explore/components/controls/DndColumnSelectControl/DndSelectLabel';
 import OptionWrapper from 'src/explore/components/controls/DndColumnSelectControl/OptionWrapper';
 import { DatasourcePanelDndItem } from 'src/explore/components/DatasourcePanel/types';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -22,7 +22,7 @@ import { t } from '@apache-superset/core/translation';
 import { AdhocColumn, QueryFormColumn, isAdhocColumn } from '@superset-ui/core';
 import { tn } from '@apache-superset/core/translation';
 import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import DndSelectLabel from 'src/explore/components/controls/DndColumnSelectControl/DndSelectLabel';
 import OptionWrapper from 'src/explore/components/controls/DndColumnSelectControl/OptionWrapper';
 import { OptionSelector } from 'src/explore/components/controls/DndColumnSelectControl/utils';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
@@ -24,7 +24,7 @@ import {
   MouseEvent as ReactMouseEvent,
 } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import {
   POPOVER_INITIAL_HEIGHT,
   POPOVER_INITIAL_WIDTH,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -36,7 +36,7 @@ import {
   Operators,
 } from 'src/explore/constants';
 import rison from 'rison';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 import { ExpressionTypes } from '../types';
 
 interface LayerOption {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
@@ -19,7 +19,7 @@
 import { useCallback, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { ensureIsArray, SupersetClient } from '@superset-ui/core';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import rison from 'rison';
 import { AdvancedDataTypesState, Props } from './index';
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.tsx
@@ -19,7 +19,7 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { ensureIsArray, usePrevious } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { Icons } from '@superset-ui/core/components/Icons';
 import {

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect, useRef, useMemo } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import {
   Input,
   Tooltip,

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -18,7 +18,7 @@
  */
 import { useState, useCallback, useRef, useEffect, ChangeEvent } from 'react';
 import { legacyValidateNumber, legacyValidateInteger } from '@superset-ui/core';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { Constants, Input } from '@superset-ui/core/components';
 

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ReactNode, useCallback, useEffect, useState } from 'react';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash-es';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import {
   parseDttmToDate,

--- a/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/TimeSeriesColumnControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/TimeSeriesColumnControl.test.tsx
@@ -19,11 +19,14 @@
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import TimeSeriesColumnControl from '.';
 
-jest.mock('lodash/debounce', () => (fn: Function & { cancel: Function }) => {
-  // eslint-disable-next-line no-param-reassign
-  fn.cancel = jest.fn();
-  return fn;
-});
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fn: Function & { cancel: Function }) => {
+    // eslint-disable-next-line no-param-reassign
+    fn.cancel = jest.fn();
+    return fn;
+  },
+}));
 
 test('renders with default props', () => {
   render(<TimeSeriesColumnControl />);

--- a/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { FC } from 'react';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { SupersetClient } from '@superset-ui/core';
 import { Button } from '@superset-ui/core/components';

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -27,7 +27,7 @@ import {
   JsonValue,
   SimpleAdhocFilter,
 } from '@superset-ui/core';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 
 const isControlValueCompatibleWithDatasource = (

--- a/superset-frontend/src/explore/controlUtils/getFormDataWithDashboardContext.ts
+++ b/superset-frontend/src/explore/controlUtils/getFormDataWithDashboardContext.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import {
   AdhocFilter,
   ensureIsArray,

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import {
   ensureIsArray,
   getChartControlPanelRegistry,

--- a/superset-frontend/src/explore/reducers/exploreReducer.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.ts
@@ -28,7 +28,7 @@ import {
   ControlStateMapping,
   Dataset,
 } from '@superset-ui/chart-controls';
-import { omit, pick } from 'lodash';
+import { omit, pick } from 'lodash-es';
 import { DYNAMIC_PLUGIN_CONTROLS_READY } from 'src/components/Chart/chartAction';
 import { getControlsState } from 'src/explore/store';
 import {

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelSwitch.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelSwitch.tsx
@@ -22,7 +22,7 @@ import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { Switch } from '@superset-ui/core/components/Switch';
 import { InfoTooltip } from '@superset-ui/core/components';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { infoTooltip, toggleStyle } from './styles';
 import { SwitchProps } from '../types';
 

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -63,7 +63,7 @@ import {
 } from 'src/views/CRUD/hooks';
 import { FileEncryptedExtraFields } from 'src/views/CRUD/types';
 import { useCommonConf } from 'src/features/databases/state';
-import { isEmpty, pick } from 'lodash';
+import { isEmpty, pick } from 'lodash-es';
 import { OnlyKeyWithType } from 'src/utils/types';
 import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
 import {

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -29,7 +29,7 @@ import rison from 'rison';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useQueryParams, BooleanParam } from 'use-query-params';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   SupersetClient,

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -27,7 +27,7 @@ import {
   useTheme,
 } from '@apache-superset/core/theme';
 import cx from 'classnames';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { Menu, MenuMode } from '@superset-ui/core/components/Menu';
 import {
   Button,

--- a/superset-frontend/src/features/reports/ReportModal/actions.ts
+++ b/superset-frontend/src/features/reports/ReportModal/actions.ts
@@ -24,7 +24,7 @@ import {
   addDangerToast,
   addSuccessToast,
 } from 'src/components/MessageToasts/actions';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { Dispatch, AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { ReportObject, ReportCreationMethod } from 'src/features/reports/types';

--- a/superset-frontend/src/features/reports/ReportModal/reducer.ts
+++ b/superset-frontend/src/features/reports/ReportModal/reducer.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import {
   SET_REPORT,
   ADD_REPORT,

--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -24,7 +24,7 @@ import {
   useMemo,
   ChangeEvent,
 } from 'react';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 import { t } from '@apache-superset/core/translation';
 import { Alert } from '@apache-superset/core/components';

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -28,7 +28,7 @@ import { styled, useTheme, css } from '@apache-superset/core/theme';
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { FilterBarOrientation } from 'src/dashboard/types';
 // import Metadata from '@superset-ui/core/components/Metadata';
-import { isNumber } from 'lodash';
+import { isNumber } from 'lodash-es';
 import { InputNumber } from '@superset-ui/core/components/Input';
 import Slider from '@superset-ui/core/components/Slider';
 import { FormItem, Tooltip, Icons } from '@superset-ui/core/components';

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -31,7 +31,7 @@ import {
 import { tn } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
-import { debounce, isUndefined } from 'lodash';
+import { debounce, isUndefined } from 'lodash-es';
 import { useImmerReducer } from 'use-immer';
 import {
   FormItem,

--- a/superset-frontend/src/hooks/apiResources/sqlEditorTabs.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlEditorTabs.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { pickBy } from 'lodash';
+import { pickBy } from 'lodash-es';
 import { QueryEditor, LatestQueryEditorVersion } from 'src/SqlLab/types';
 import { api, JsonResponse } from './queryApi';
 

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -29,7 +29,7 @@ import {
 import { css, styled } from '@apache-superset/core/theme';
 import { useState, useMemo, useCallback } from 'react';
 import rison from 'rison';
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'lodash-es';
 import { useSelector } from 'react-redux';
 import {
   createErrorHandler,

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -28,7 +28,7 @@ import { styled } from '@apache-superset/core/theme';
 import rison from 'rison';
 import { Collapse, ListViewCard } from '@superset-ui/core/components';
 import { User } from 'src/types/bootstrapTypes';
-import { reject } from 'lodash';
+import { reject } from 'lodash-es';
 import {
   dangerouslyGetItemDoNotUse,
   dangerouslySetItemDoNotUse,

--- a/superset-frontend/src/pages/SqlLab/SqlLab.test.tsx
+++ b/superset-frontend/src/pages/SqlLab/SqlLab.test.tsx
@@ -18,7 +18,7 @@
  */
 import fetchMock from 'fetch-mock';
 import { isValidElement } from 'react';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import {
   render,
   act,

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -19,7 +19,7 @@
 import { nanoid } from 'nanoid';
 import { compose } from 'redux';
 import persistState, { StorageAdapter } from 'redux-localstorage';
-import { isEqual, omitBy, omit, isEqualWith } from 'lodash';
+import { isEqual, omitBy, omit, isEqualWith } from 'lodash-es';
 import { ensureIsArray } from '@superset-ui/core';
 
 export function addToObject(

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -18,7 +18,7 @@
  */
 import { FormatLocaleDefinition } from 'd3-format';
 import { TimeLocaleDefinition } from 'd3-time-format';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'lodash-es';
 import { Languages } from 'src/features/home/LanguagePicker';
 import {
   AnyThemeConfig,

--- a/superset-frontend/src/utils/DebouncedMessageQueue.ts
+++ b/superset-frontend/src/utils/DebouncedMessageQueue.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 export interface DebouncedMessageQueueOptions<T> {
   callback?: (events: T[]) => void;

--- a/superset-frontend/src/utils/colorScheme.ts
+++ b/superset-frontend/src/utils/colorScheme.ts
@@ -23,7 +23,7 @@ import {
   getCategoricalSchemeRegistry,
   getLabelsColorMap,
 } from '@superset-ui/core';
-import { intersection, omit, pick } from 'lodash';
+import { intersection, omit, pick } from 'lodash-es';
 import { areObjectsEqual } from 'src/reduxUtils';
 
 const EMPTY_ARRAY: string[] = [];

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -18,7 +18,7 @@
  */
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { addWarningToast } from 'src/components/MessageToasts/actions';

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -18,7 +18,7 @@
  */
 import { SyntheticEvent } from 'react';
 import domToPdf from 'dom-to-pdf';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
 import { addWarningToast } from 'src/components/MessageToasts/actions';

--- a/superset-frontend/src/utils/getChartFormDiffs/index.ts
+++ b/superset-frontend/src/utils/getChartFormDiffs/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { DiffType } from 'src/types/DiffType';
 import { JsonObject } from '@superset-ui/core';
 import { sanitizeFormData } from '../sanitizeFormData';

--- a/superset-frontend/src/utils/sanitizeFormData/index.ts
+++ b/superset-frontend/src/utils/sanitizeFormData/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { JsonObject } from '@superset-ui/core';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 const TEMPORARY_CONTROLS: string[] = ['url_params'];
 

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -24,7 +24,7 @@ import {
 } from '@superset-ui/core';
 import Switchboard from '@superset-ui/switchboard';
 import rison from 'rison';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import {
   RESERVED_CHART_URL_PARAMS,
   RESERVED_DASHBOARD_URL_PARAMS,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -27,7 +27,7 @@ import {
 } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import Chart from 'src/types/Chart';
-import { intersection } from 'lodash';
+import { intersection } from 'lodash-es';
 import rison from 'rison';
 import type {
   ListViewFetchDataConfig as FetchDataConfig,


### PR DESCRIPTION
### SUMMARY

Migrates the frontend's bare lodash imports to **`lodash-es`** for native, method-level tree-shaking. `import { debounce } from 'lodash'` → `import { debounce } from 'lodash-es'` across **173 source files**.

`lodash` (the CommonJS build) doesn't tree-shake — importing a single method pulls in the whole library unless a build-time transform rewrites it. The repo relied on `babel-plugin-lodash` for that rewrite, but that plugin is **unmaintained and incompatible with Babel 8** (it calls the removed `path.hoist` API). `lodash-es` is the modern replacement: webpack tree-shakes it natively, no Babel plugin required.

This pairs with the Babel 8 upgrade (#41510), which removes `babel-plugin-lodash`. Doing the lodash-es migration here keeps the app's bundle lean without that plugin. The two PRs are independent and can merge in either order.

**Why this is low-risk:**
- The codemod only touches **named imports** (`import { x } from 'lodash'`), which map 1:1 to `lodash-es`. There were **zero** default (`import _ from 'lodash'`) or namespace (`import * as _`) imports — the shapes `lodash-es` doesn't support.
- `@types/lodash-es` provides the same type signatures as `@types/lodash`, so no type changes (`tsc --noEmit` clean).
- `lodash-es` is already in jest's `transformIgnorePatterns`.
- `lodash` is retained as a dependency for the handful of remaining per-method `lodash/x` imports and transitive consumers.
- `lodash-es` declared in every workspace manifest that imports it (plus `@types/lodash-es` at the root) for published-package correctness.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm ci
npm run build   # production webpack build
npm run test    # Jest unit suite
```

Validated locally: production webpack build compiles (pre-existing echarts/bundle-size warnings only), Jest unit suite passes, and `tsc --noEmit` reports no type errors from the change.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related: #41510 (Babel 8 upgrade, which removes `babel-plugin-lodash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
