### PR TITLE
fix(databend): support configuring Databend via individual parameters

### DIFF
--- a/superset/db_engine_specs/databend.py
+++ b/superset/db_engine_specs/databend.py
@@ -370,12 +370,19 @@ class DatabendEngineSpec(BasicParametersMixin, DatabendBaseEngineSpec):
         return f"{label}_{hash_from_str(label)[:6]}"
 
 
-# Backwards-compatible alias. Previously there were two separate specs
-# (a legacy ``DatabendEngineSpec`` without parameter support and a
-# ``DatabendConnectEngineSpec`` with it), both registered under the
-# ``databend`` engine. Because neither declared distinct ``drivers``,
-# ``get_engine_spec`` resolved to the first-defined (legacy) spec, which
-# lacks ``parameters_schema``/``build_sqlalchemy_uri`` and broke the
-# "configure via individual parameters" flow. They are now merged into a
-# single spec; this alias keeps existing imports working.
-DatabendConnectEngineSpec: type[DatabendEngineSpec] = DatabendEngineSpec
+def __getattr__(name: str) -> Any:
+    # Backwards-compatible alias. Previously there were two separate specs
+    # (a legacy ``DatabendEngineSpec`` without parameter support and a
+    # ``DatabendConnectEngineSpec`` with it), both registered under the
+    # ``databend`` engine. Because neither declared distinct ``drivers``,
+    # ``get_engine_spec`` resolved to the first-defined (legacy) spec, which
+    # lacks ``parameters_schema``/``build_sqlalchemy_uri`` and broke the
+    # "configure via individual parameters" flow. They are now merged into a
+    # single spec.
+    #
+    # The alias is exposed via module-level ``__getattr__`` (PEP 562) rather
+    # than a class binding so that ``load_engine_specs`` -- which iterates
+    # ``module.__dict__`` -- does not collect the same spec twice.
+    if name == "DatabendConnectEngineSpec":
+        return DatabendEngineSpec
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/superset/db_engine_specs/databend.py
+++ b/superset/db_engine_specs/databend.py
@@ -152,47 +152,6 @@ class DatabendBaseEngineSpec(BaseEngineSpec):
         return None
 
 
-class DatabendEngineSpec(DatabendBaseEngineSpec):
-    """Engine spec for databend_sqlalchemy connector (legacy)"""
-
-    engine = "databend"
-    engine_name = "Databend (legacy)"  # Internal name for legacy connector
-    _function_names: list[str] = []
-
-    _show_functions_column = "name"
-    supports_file_upload = False
-
-    # Note: Primary metadata is in DatabendConnectEngineSpec which provides
-    # the native connection UI. This spec exists for backwards compatibility.
-
-    @classmethod
-    def get_dbapi_exception_mapping(cls) -> dict[type[Exception], type[Exception]]:
-        return {NewConnectionError: SupersetDBAPIDatabaseError}
-
-    @classmethod
-    def get_dbapi_mapped_exception(cls, exception: Exception) -> Exception:
-        new_exception = cls.get_dbapi_exception_mapping().get(type(exception))
-        if new_exception == SupersetDBAPIDatabaseError:
-            return SupersetDBAPIDatabaseError("Connection failed")
-        if not new_exception:
-            return exception
-        return new_exception(str(exception))
-
-    @classmethod
-    def get_function_names(cls, database: Database) -> list[str]:
-        if cls._function_names:
-            return cls._function_names
-        try:
-            names = database.get_df("SELECT name FROM system.functions;")[
-                "name"
-            ].tolist()
-            cls._function_names = names
-            return names
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.exception("Error retrieving system.functions: %s", str(ex))
-            return []
-
-
 class DatabendParametersSchema(Schema):
     username = fields.String(allow_none=True, metadata={"description": __("Username")})
     password = fields.String(allow_none=True, metadata={"description": __("Password")})
@@ -218,8 +177,13 @@ class DatabendParametersSchema(Schema):
     )
 
 
-class DatabendConnectEngineSpec(BasicParametersMixin, DatabendEngineSpec):
-    """Engine spec for databend with native connection UI (recommended)"""
+class DatabendEngineSpec(BasicParametersMixin, DatabendBaseEngineSpec):
+    """Engine spec for Databend with native connection UI.
+
+    Databend has a single connector (``databend-sqlalchemy``), so this single
+    spec supports both SQLAlchemy URI and individual-parameter (dynamic form)
+    configuration. Both styles resolve to the ``databend`` SQLAlchemy backend.
+    """
 
     engine = "databend"
     engine_name = "Databend"
@@ -227,14 +191,14 @@ class DatabendConnectEngineSpec(BasicParametersMixin, DatabendEngineSpec):
     default_driver = "databend"
     _function_names: list[str] = []
 
+    _show_functions_column = "name"
+    supports_file_upload = False
+
     sqlalchemy_uri_placeholder = (
         "databend://user:password@host[:port][/dbname][?secure=value&=value...]"
     )
     parameters_schema = DatabendParametersSchema()
     encryption_parameters = {"secure": "true"}
-
-    # Note: Inherits metadata from DatabendEngineSpec. This spec provides
-    # the native connection UI experience in Superset.
 
     metadata = {
         "description": (
@@ -264,7 +228,7 @@ class DatabendConnectEngineSpec(BasicParametersMixin, DatabendEngineSpec):
 
     @classmethod
     def get_dbapi_exception_mapping(cls) -> dict[type[Exception], type[Exception]]:
-        return {}
+        return {NewConnectionError: SupersetDBAPIDatabaseError}
 
     @classmethod
     def get_dbapi_mapped_exception(cls, exception: Exception) -> Exception:
@@ -404,3 +368,14 @@ class DatabendConnectEngineSpec(BasicParametersMixin, DatabendEngineSpec):
         :return: Conditionally mutated label
         """
         return f"{label}_{hash_from_str(label)[:6]}"
+
+
+# Backwards-compatible alias. Previously there were two separate specs
+# (a legacy ``DatabendEngineSpec`` without parameter support and a
+# ``DatabendConnectEngineSpec`` with it), both registered under the
+# ``databend`` engine. Because neither declared distinct ``drivers``,
+# ``get_engine_spec`` resolved to the first-defined (legacy) spec, which
+# lacks ``parameters_schema``/``build_sqlalchemy_uri`` and broke the
+# "configure via individual parameters" flow. They are now merged into a
+# single spec; this alias keeps existing imports working.
+DatabendConnectEngineSpec = DatabendEngineSpec

--- a/superset/db_engine_specs/databend.py
+++ b/superset/db_engine_specs/databend.py
@@ -378,4 +378,4 @@ class DatabendEngineSpec(BasicParametersMixin, DatabendBaseEngineSpec):
 # lacks ``parameters_schema``/``build_sqlalchemy_uri`` and broke the
 # "configure via individual parameters" flow. They are now merged into a
 # single spec; this alias keeps existing imports working.
-DatabendConnectEngineSpec = DatabendEngineSpec
+DatabendConnectEngineSpec: type[DatabendEngineSpec] = DatabendEngineSpec

--- a/tests/unit_tests/db_engine_specs/test_databend.py
+++ b/tests/unit_tests/db_engine_specs/test_databend.py
@@ -60,6 +60,43 @@ def test_convert_dttm(
     assert_convert_dttm(spec, target_type, expected_result, dttm)
 
 
+def test_get_engine_spec_supports_parameters() -> None:
+    """
+    Regression test: configuring Databend via individual parameters must
+    resolve to an engine spec that supports the dynamic form.
+
+    Previously two specs were registered under engine ``databend`` and neither
+    declared a distinct ``drivers`` set, so ``get_engine_spec`` resolved to the
+    first-defined legacy spec, which lacked ``parameters_schema`` /
+    ``build_sqlalchemy_uri``. This made the "configure via individual
+    parameters" flow fail with:
+        Engine spec "InvalidEngine" does not support being configured via
+        individual parameters.
+    """
+    from superset.db_engine_specs import get_engine_spec
+    from superset.db_engine_specs.databend import (
+        DatabendConnectEngineSpec,
+        DatabendEngineSpec,
+    )
+
+    # Both with and without an explicit driver, the resolved spec must support
+    # configuration via individual parameters.
+    for driver in (None, "databend"):
+        spec = get_engine_spec("databend", driver)
+        assert hasattr(spec, "parameters_schema"), (
+            f"resolved spec {spec.__name__} (driver={driver!r}) is missing "
+            "parameters_schema"
+        )
+        assert hasattr(spec, "build_sqlalchemy_uri"), (
+            f"resolved spec {spec.__name__} (driver={driver!r}) is missing "
+            "build_sqlalchemy_uri"
+        )
+
+    # The legacy alias must point to the same merged spec for backwards
+    # compatibility.
+    assert DatabendConnectEngineSpec is DatabendEngineSpec
+
+
 def test_execute_connection_error() -> None:
     from urllib3.exceptions import NewConnectionError
 


### PR DESCRIPTION
### SUMMARY

  Connecting to Databend through the dynamic form (individual parameters such
  as host/port/username/password) fails with:

  > Engine spec "InvalidEngine" does not support being configured via individual parameters.

  Connecting via a full SQLAlchemy URI / DSN works fine.

  #### Root cause

  `superset/db_engine_specs/databend.py` defined two engine specs that both
  use `engine = "databend"`:

  - `DatabendEngineSpec` (legacy) — extends `BaseEngineSpec`, has **no**
    `parameters_schema` / `build_sqlalchemy_uri`.
  - `DatabendConnectEngineSpec` — extends `BasicParametersMixin`, **has**
    `parameters_schema`.

  When configuring via parameters, DatabaseParametersSchemaMixin calls
  get_engine_spec("databend", "databend"). supports_backend() returns
  True ignoring the driver whenever a spec declares no drivers
  (base.py). Since neither Databend spec declares drivers,
  get_engine_spec resolves to the first-defined spec — the legacy one,
  which has no parameters_schema, triggering the InvalidEngine error in
  superset/databases/schemas.py.

  DSN connections are unaffected because they don't hit the parameter
  validation branch.

  Unlike ClickHouse (clickhouse vs clickhousedb) or Databricks
  (pyhive/pyodbc/databricks-connector), Databend has a single connector
  (databend-sqlalchemy, driver name databend), so the two specs can't be
  disambiguated by engine name or drivers. They are redundant and conflict.

  Fix

  Merge the two specs into a single full-featured `DatabendEngineSpec`
  (extends `BasicParametersMixin`, retaining the legacy DBAPI exception
  mapping and `get_function_names`), and keep `DatabendConnectEngineSpec` as
  a backwards-compatible alias.

  BEFORE/AFTER

  Before: configuring Databend via the dynamic parameters form returns
  HTTP 422 with the InvalidEngine error.

  After: the dynamic parameters form resolves to a spec with
  parameters_schema/build_sqlalchemy_uri and the connection succeeds.

  TESTING INSTRUCTIONS

  - pytest tests/unit_tests/db_engine_specs/test_databend.py
  - Manual: add a Databend database via the UI using individual parameters
    (host/port/username/password) and confirm the connection test passes.

  ADDITIONAL INFORMATION

  - Has associated issue
  - Required feature flags: n/a
  - Changes UI: no (backend-only)
  - [ ]Includes DB Migration
  - Introduces new feature or API
  - Removes existing feature or API