### PR TITLE
fix(dashboard): surface size, limit, and config key in oversized dashboard error

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -551,18 +551,18 @@ Adjust `retention_period_days` to control how long query rows are kept. Companio
 
 ## Dashboard Layout Size Limit
 
-Each dashboard stores its layout (the position, size, and nesting of every chart, row, and tab) as a JSON blob in the metadata database. Superset caps the size of this blob with `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT`, which defaults to `65535` bytes:
+Each dashboard stores its layout (the position, size, and nesting of every chart, row, and tab) as a JSON blob in the metadata database. Superset caps the length of this serialized blob with `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT`, which defaults to `65535`:
 
 ```python
 SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 65535
 ```
 
-The default of 65535 (2¹⁶ − 1) comes from the historical maximum size of a MySQL `TEXT` column. When the serialized layout reaches this limit, the editor blocks the save and reports the current size, the limit, and this setting's name. A warning is shown once the layout passes 90% of the limit.
+This is a Python-level cap (65535 is 2¹⁶ − 1), independent of the database column capacity — the `position_json` column is a `MEDIUMTEXT`, which holds far more. When the serialized layout reaches this limit, the editor blocks the save and reports the current length, the limit, and this setting's name. A warning is shown once the layout passes 90% of the limit.
 
-Large dashboards — for example, many charts spread across nested tabs — can exceed the default. If your metadata database uses a column type that supports larger values (such as PostgreSQL `text` or MySQL `MEDIUMTEXT`/`LONGTEXT`), you can safely raise the limit:
+Large dashboards — for example, many charts spread across nested tabs — can exceed the default. Because the underlying column comfortably stores larger values, you can safely raise the limit:
 
 ```python
-SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 131072  # 128 KB
+SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 131072  # double the default
 ```
 
 Alternatively, split a very large dashboard into several smaller ones. Note that this check is enforced when saving layout edits in the UI; a dashboard imported from a ZIP with an oversized layout will load and render, but cannot be edited and re-saved until the limit is raised.

--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -549,6 +549,24 @@ CELERY_BEAT_SCHEDULE = {
 
 Adjust `retention_period_days` to control how long query rows are kept. Companion opt-in tasks (`prune_logs`, `prune_tasks`) exist for pruning the logs and tasks tables; see the commented-out examples in `superset/config.py`. Without enabling these tasks, the metadata database will grow unbounded over time.
 
+## Dashboard Layout Size Limit
+
+Each dashboard stores its layout (the position, size, and nesting of every chart, row, and tab) as a JSON blob in the metadata database. Superset caps the size of this blob with `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT`, which defaults to `65535` bytes:
+
+```python
+SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 65535
+```
+
+The default of 65535 (2¹⁶ − 1) comes from the historical maximum size of a MySQL `TEXT` column. When the serialized layout reaches this limit, the editor blocks the save and reports the current size, the limit, and this setting's name. A warning is shown once the layout passes 90% of the limit.
+
+Large dashboards — for example, many charts spread across nested tabs — can exceed the default. If your metadata database uses a column type that supports larger values (such as PostgreSQL `text` or MySQL `MEDIUMTEXT`/`LONGTEXT`), you can safely raise the limit:
+
+```python
+SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 131072  # 128 KB
+```
+
+Alternatively, split a very large dashboard into several smaller ones. Note that this check is enforced when saving layout edits in the UI; a dashboard imported from a ZIP with an oversized layout will load and render, but cannot be edited and re-saved until the limit is raised.
+
 :::resources
 - [Blog: Feature Flags in Apache Superset](https://preset.io/blog/feature-flags-in-apache-superset-and-preset/)
 :::

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -559,7 +559,7 @@ test('should block saving and surface the size, limit, and config key when the l
       common: {
         conf: {
           ...editableState.dashboardInfo.common.conf,
-          // any non-empty layout serializes to more than 1 byte
+          // any non-empty layout serializes to more than 1 character
           SUPERSET_DASHBOARD_POSITION_DATA_LIMIT: 1,
         },
       },
@@ -571,7 +571,7 @@ test('should block saving and surface the size, limit, and config key when the l
   expect(addDangerToast).toHaveBeenCalledTimes(1);
   const message = addDangerToast.mock.calls[0][0];
   expect(message).toContain('too large to save');
-  expect(message).toContain('the limit is 1 bytes');
+  expect(message).toContain('the limit is 1');
   expect(message).toContain('SUPERSET_DASHBOARD_POSITION_DATA_LIMIT');
 });
 

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -547,6 +547,34 @@ test('should save', () => {
   expect(onSave).toHaveBeenCalledTimes(1);
 });
 
+test('should block saving and surface the size, limit, and config key when the layout exceeds the limit', () => {
+  const oversizedState = {
+    ...editableState,
+    dashboardState: {
+      ...editableState.dashboardState,
+      hasUnsavedChanges: true,
+    },
+    dashboardInfo: {
+      ...editableState.dashboardInfo,
+      common: {
+        conf: {
+          ...editableState.dashboardInfo.common.conf,
+          // any non-empty layout serializes to more than 1 byte
+          SUPERSET_DASHBOARD_POSITION_DATA_LIMIT: 1,
+        },
+      },
+    },
+  };
+  setup(oversizedState);
+  userEvent.click(screen.getByText('Save'));
+  expect(onSave).not.toHaveBeenCalled();
+  expect(addDangerToast).toHaveBeenCalledTimes(1);
+  const message = addDangerToast.mock.calls[0][0];
+  expect(message).toContain('too large to save');
+  expect(message).toContain('the limit is 1 bytes');
+  expect(message).toContain('SUPERSET_DASHBOARD_POSITION_DATA_LIMIT');
+});
+
 test('should NOT render the "Draft" status', () => {
   const publishedState = {
     ...initialState,

--- a/superset-frontend/src/dashboard/components/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/index.tsx
@@ -468,7 +468,7 @@ const Header = (): JSX.Element => {
     if (positionJSONLength >= limit) {
       boundActionCreators.addDangerToast(
         t(
-          'Your dashboard is too large to save: the layout is %s bytes but the limit is %s bytes. Reduce the dashboard size (for example, split it into multiple dashboards) or raise the SUPERSET_DASHBOARD_POSITION_DATA_LIMIT config setting.',
+          'Your dashboard is too large to save: the serialized layout length is %s but the limit is %s. Reduce the dashboard size (for example, split it into multiple dashboards) or raise the SUPERSET_DASHBOARD_POSITION_DATA_LIMIT config setting.',
           positionJSONLength.toLocaleString(),
           limit.toLocaleString(),
         ),

--- a/superset-frontend/src/dashboard/components/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/index.tsx
@@ -468,7 +468,9 @@ const Header = (): JSX.Element => {
     if (positionJSONLength >= limit) {
       boundActionCreators.addDangerToast(
         t(
-          'Your dashboard is too large. Please reduce its size before saving it.',
+          'Your dashboard is too large to save: the layout is %s bytes but the limit is %s bytes. Reduce the dashboard size (for example, split it into multiple dashboards) or raise the SUPERSET_DASHBOARD_POSITION_DATA_LIMIT config setting.',
+          positionJSONLength.toLocaleString(),
+          limit.toLocaleString(),
         ),
       );
     } else {


### PR DESCRIPTION
### SUMMARY

When a dashboard's serialized layout exceeds `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT` (default `65535` bytes), saving layout edits is blocked in the UI with a generic toast:

> Your dashboard is too large. Please reduce its size before saving it.

This gives the user no indication of *how* large the layout is, what the limit is, or how to change it — leading to lengthy debugging (see #41528, where a programmatically-imported 120-chart dashboard hit the wall after importing fine).

This PR:

1. **Improves the error message** to include the actual layout size, the configured limit, and the name of the config setting to raise — the values are already in scope at the check site (`positionJSONLength` and `limit`), so this is a small, self-contained change:

   > Your dashboard is too large to save: the layout is 74,960 bytes but the limit is 65,535 bytes. Reduce the dashboard size (for example, split it into multiple dashboards) or raise the SUPERSET_DASHBOARD_POSITION_DATA_LIMIT config setting.

2. **Documents `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT`** in the configuration reference — it was previously undocumented. The note covers the default, the historical MySQL `TEXT` rationale, when/how to raise it, and the fact that an imported oversized dashboard renders but can't be re-saved until the limit is raised.

The reporter (@Hamidcha-Mosaab) offered to take the error-message change; this folds it together with the docs gap they also identified, and credit goes to them for the thorough write-up.

### BEFORE/AFTER

**Before:** `Your dashboard is too large. Please reduce its size before saving it.`

**After:** `Your dashboard is too large to save: the layout is 74,960 bytes but the limit is 65,535 bytes. Reduce the dashboard size (for example, split it into multiple dashboards) or raise the SUPERSET_DASHBOARD_POSITION_DATA_LIMIT config setting.`

### TESTING INSTRUCTIONS

1. Set a small `SUPERSET_DASHBOARD_POSITION_DATA_LIMIT` (e.g. `1`) in `superset_config.py`, or build a dashboard whose layout exceeds the default.
2. Open the dashboard in Edit mode, move/resize a chart, and click **Save**.
3. The error toast now reports the actual size, the limit, and the config key.

Unit test added in `Header.test.tsx` covering the oversized-layout path (blocks save, surfaces size/limit/config key).

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #41528
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)