### PR TITLE
fix(sqllab): show non-ASCII text in array/JSON columns instead of \uXXXX escapes

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -60,7 +60,11 @@ def dedup(l: list[str], suffix: str = "__", case_sensitive: bool = True) -> list
 
 
 def stringify(obj: Any) -> str:
-    return json.dumps(obj, default=json.json_iso_dttm_ser)
+    # ensure_ascii=False so non-ASCII characters in array/struct/JSON column
+    # values (e.g. Cyrillic or CJK text from array_agg) render verbatim in the
+    # result grid instead of as \uXXXX escape sequences. This only affects the
+    # query result payload, not metadata persisted to the database.
+    return json.dumps(obj, default=json.json_iso_dttm_ser, ensure_ascii=False)
 
 
 def stringify_values(array: NDArray[Any]) -> NDArray[Any]:

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -195,6 +195,7 @@ def dumps(  # pylint: disable=too-many-arguments
     separators: Union[tuple[str, str], None] = None,
     cls: Union[type[simplejson.JSONEncoder], None] = None,
     encoding: Optional[str] = "utf-8",
+    ensure_ascii: bool = True,
 ) -> str:
     """
     Dumps object to compatible JSON format
@@ -207,6 +208,9 @@ def dumps(  # pylint: disable=too-many-arguments
     :param indent: when set elements and object members will be pretty-printed
     :param separators: when specified dumps will use (item_separator, key_separator)
     :param cls: custom `JSONEncoder` subclass
+    :param ensure_ascii: when set to False non-ASCII characters are kept verbatim
+        instead of being escaped to ``\\uXXXX`` sequences. Defaults to True so the
+        escaped output stays safe for narrow charset columns (e.g. MySQL ``utf8``).
     :returns: String object in the JSON compatible form
     """
 
@@ -220,6 +224,7 @@ def dumps(  # pylint: disable=too-many-arguments
         "separators": separators,
         "cls": cls,
         "encoding": encoding,
+        "ensure_ascii": ensure_ascii,
     }
     try:
         results_string = simplejson.dumps(obj, **dumps_kwargs)

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -522,6 +522,37 @@ def test_clickhouse_json_column_in_pa_table_is_valid_json() -> None:
     assert parsed1 == {"e": 5}
 
 
+def test_stringify_values_preserves_non_ascii_characters() -> None:
+    """
+    Non-ASCII text inside array/struct/JSON column values (e.g. the Cyrillic and
+    CJK strings produced by ``array_agg``) must render verbatim in the result
+    grid, not as ``\\uXXXX`` escape sequences. Regression test for #19388 and
+    #22904, where such values were displayed as "unicode gibberish".
+    """
+    data = np.array(
+        [
+            ["Лонгсливы", "Свитшоты"],
+            {"city": "北京", "country": "中国"},
+            "你好，世界！",
+        ],
+        dtype=object,
+    )
+    result = stringify_values(data)
+
+    # Array and dict values keep their characters intact and stay valid JSON
+    assert result[0] == '["Лонгсливы", "Свитшоты"]'
+    assert result[1] == '{"city": "北京", "country": "中国"}'
+    assert result[2] == "你好，世界！"
+
+    # No escape sequences leak through
+    assert "\\u" not in result[0]
+    assert "\\u" not in result[1]
+
+    # Still round-trips through a JSON parser
+    assert superset_json.loads(result[0]) == ["Лонгсливы", "Свитшоты"]
+    assert superset_json.loads(result[1]) == {"city": "北京", "country": "中国"}
+
+
 def test_stringify_values_non_serializable_dict_falls_back_to_str() -> None:
     """
     When a dict/list contains a value that json.dumps cannot serialize (e.g. bytes),

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -417,14 +417,14 @@ def test_format_timedelta():
     )
 
 
-def test_dumps_escapes_non_ascii_by_default():
+def test_dumps_escapes_non_ascii_by_default() -> None:
     # Default ensure_ascii=True keeps output safe for narrow charset columns
     # (e.g. MySQL utf8) by escaping non-ASCII characters to \uXXXX sequences.
     assert json.dumps("Hello, world!") == '"Hello, world!"'
     assert json.dumps("Привет") == '"\\u041f\\u0440\\u0438\\u0432\\u0435\\u0442"'
 
 
-def test_dumps_preserves_unicode_when_ensure_ascii_false():
+def test_dumps_preserves_unicode_when_ensure_ascii_false() -> None:
     # Opt-in ensure_ascii=False renders non-ASCII characters verbatim.
     assert json.dumps("Hello, world!", ensure_ascii=False) == '"Hello, world!"'
     assert json.dumps("Привет, мир!", ensure_ascii=False) == '"Привет, мир!"'

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -415,3 +415,17 @@ def test_format_timedelta():
         json.format_timedelta(timedelta(0) - timedelta(days=16, hours=4, minutes=3))
         == "-16 days, 4:03:00"
     )
+
+
+def test_dumps_escapes_non_ascii_by_default():
+    # Default ensure_ascii=True keeps output safe for narrow charset columns
+    # (e.g. MySQL utf8) by escaping non-ASCII characters to \uXXXX sequences.
+    assert json.dumps("Hello, world!") == '"Hello, world!"'
+    assert json.dumps("Привет") == '"\\u041f\\u0440\\u0438\\u0432\\u0435\\u0442"'
+
+
+def test_dumps_preserves_unicode_when_ensure_ascii_false():
+    # Opt-in ensure_ascii=False renders non-ASCII characters verbatim.
+    assert json.dumps("Hello, world!", ensure_ascii=False) == '"Hello, world!"'
+    assert json.dumps("Привет, мир!", ensure_ascii=False) == '"Привет, мир!"'
+    assert json.dumps("你好，世界！", ensure_ascii=False) == '"你好，世界！"'


### PR DESCRIPTION
### SUMMARY

Non-ASCII text inside **array / struct / JSON column values** (e.g. the CJK and Cyrillic strings produced by `array_agg`) was displayed as `\uXXXX` escape sequences in SQL Lab, Explore, and on dashboards — the "unicode gibberish" reported in #19388 and #22904. Plain string columns were never affected; only nested values that get JSON-serialized for the result grid.

The fix is deliberately narrow:

- `superset.utils.json.dumps` gains an opt-in `ensure_ascii: bool = True` parameter. The default is unchanged, so metadata serialization keeps escaping non-ASCII for narrow charset columns (notably MySQL `utf8`/utf8mb3). In particular the `position_json` emoji-escaping from #39737 stays intact.
- Only the result-set `stringify` path (`superset/result_set.py`) opts into `ensure_ascii=False`. That is the single, DRY chokepoint through which array/struct values flow to SQL Lab, Explore and dashboards. It affects the query result payload only — never anything persisted to the metadata database.

This avoids the breaking change / MySQL charset migration that a global `ensure_ascii=False` would have required, and it leaves no regression against the #39737 emoji-truncation guard.

This **supersedes #33720** (same goal, narrower implementation), whose author appears to be MIA. Credit to @Quatters, retained as co-author on the commit.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before (array_agg of Cyrillic text in SQL Lab):

```
["Лонгсливы", "Свитшоты"]
```

After:

```
["Лонгсливы", "Свитшоты"]
```

### TESTING INSTRUCTIONS

Automated (unit):

```bash
pytest tests/unit_tests/result_set_test.py tests/unit_tests/utils/json_tests.py
```

`test_stringify_values_preserves_non_ascii_characters` reproduces both linked issues and fails without the fix. The #39737 emoji tests (`tests/integration_tests/dashboards/test_update_emoji.py`) remain green since the metadata path is untouched.

Manual:
1. Point Superset at a Postgres analytics DB containing non-ASCII text.
2. In SQL Lab, run a query that wraps the text in `array_agg(...)` (or select an array/JSON column).
3. Confirm the result grid shows the characters verbatim, not `\uXXXX`.
4. Repeat via Explore / a dashboard table chart.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Closes #19388, Closes #22904
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)