### PR TITLE
chore(deps): stop Dependabot from opening Babel 8 major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,13 @@ updates:
       # and confirm the issue https://github.com/apache/superset/issues/39600 is fixed
       - dependency-name: "react-checkbox-tree"
         update-types: ["version-update:semver-major"]
+      # Babel 8 (7.x -> 8.x) is blocked on the surrounding ecosystem: @emotion/babel-plugin
+      # (NodePath#hoist), babel-plugin-jsx-remove-data-test-id (t.jSXOpeningElement), and
+      # ts-jest all rely on Babel APIs removed in v8 and have not shipped Babel 8 support.
+      # Ignore the coordinated major bump until the ecosystem catches up; it must be done
+      # as a single manual upgrade anyway. TODO: remove when Babel 8 support is viable.
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
     directory: "/superset-frontend/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### SUMMARY

Stops Dependabot from re-opening the ~17 individual `@babel/*` 7.x → 8.x major-bump PRs by ignoring `version-update:semver-major` for `@babel/*` in the frontend npm config.

The Babel 8 upgrade is blocked on the surrounding ecosystem, which still relies on Babel APIs removed in v8 and has not shipped Babel 8 support:

- **`@emotion/babel-plugin`** — calls the removed `NodePath#hoist` (and is required for the `css` prop; latest release is still Babel-7-only).
- **`babel-plugin-jsx-remove-data-test-id`** — calls the removed `t.jSXOpeningElement` builder (unmaintained since 2022).
- **`ts-jest`** — peer-caps `@babel/core` at `< 8`.

The attempt in #41510 confirmed this requires patching multiple unmaintained plugins plus chasing ESM-transform fallout — a stack of workarounds, not a clean upgrade. Babel 8 must be adopted atomically as a single manual upgrade once the ecosystem catches up; the ignore clause is annotated with a TODO to remove it then.

### TESTING INSTRUCTIONS

N/A — Dependabot config only. The ignore rule takes effect on Dependabot's next scan.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related: #41510 (closed Babel 8 attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
