### PR TITLE
fix(dashboard): remeasure chart description height after markdown render

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -656,34 +656,35 @@ test('should pass chartStackTrace to ChartContainer so dashboard chart errors st
   );
 });
 
-describe('Chart Description with ResizeObserver', () => {
-  let mockResizeObserver: jest.Mock;
-  let observeMock: jest.Mock;
-  let disconnectMock: jest.Mock;
-  let getComputedStyleSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    observeMock = jest.fn();
-    disconnectMock = jest.fn();
-    mockResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: observeMock,
-      disconnect: disconnectMock,
-    }));
-    global.ResizeObserver = mockResizeObserver as any;
-
-    getComputedStyleSpy = jest
-      .spyOn(window, 'getComputedStyle')
-      .mockReturnValue({
-        getPropertyValue: () => '',
-      } as unknown as CSSStyleDeclaration);
+function installResizeObserverMock() {
+  const observeMock = jest.fn();
+  const disconnectMock = jest.fn();
+  let observerCallback: ResizeObserverCallback | undefined;
+  const mockResizeObserver = jest.fn().mockImplementation(callback => {
+    observerCallback = callback;
+    return { observe: observeMock, disconnect: disconnectMock };
   });
+  global.ResizeObserver = mockResizeObserver as any;
 
-  afterEach(() => {
-    delete (global as any).ResizeObserver;
-    getComputedStyleSpy.mockRestore();
-  });
+  const getComputedStyleSpy = jest
+    .spyOn(window, 'getComputedStyle')
+    .mockReturnValue({
+      getPropertyValue: () => '',
+    } as unknown as CSSStyleDeclaration);
 
-  test('A chart description configured to start expanded is visible after initial render', () => {
+  return {
+    observeMock,
+    getObserverCallback: () => observerCallback,
+    restore: () => {
+      delete (global as any).ResizeObserver;
+      getComputedStyleSpy.mockRestore();
+    },
+  };
+}
+
+test('A chart description configured to start expanded is visible after initial render', () => {
+  const { observeMock, restore } = installResizeObserverMock();
+  try {
     const { container } = setup(
       {},
       {
@@ -695,15 +696,14 @@ describe('Chart Description with ResizeObserver', () => {
     );
     expect(container.querySelector('.slice_description')).toBeInTheDocument();
     expect(observeMock).toHaveBeenCalled();
-  });
+  } finally {
+    restore();
+  }
+});
 
-  test('The description height is correctly updated after asynchronous markdown rendering completes', () => {
-    let observerCallback: ResizeObserverCallback | undefined;
-    mockResizeObserver.mockImplementation(callback => {
-      observerCallback = callback;
-      return { observe: observeMock, disconnect: disconnectMock };
-    });
-
+test('The description height is correctly updated after asynchronous markdown rendering completes', () => {
+  const { getObserverCallback, restore } = installResizeObserverMock();
+  try {
     const { container } = setup(
       { height: 300 },
       {
@@ -726,13 +726,14 @@ describe('Chart Description with ResizeObserver', () => {
     ) as HTMLElement;
     expect(descriptionEl).toBeInTheDocument();
 
+    const observerCallback = getObserverCallback();
     if (observerCallback) {
       Object.defineProperty(descriptionEl, 'offsetHeight', {
         value: 100,
         configurable: true,
       });
       act(() => {
-        observerCallback!(
+        observerCallback(
           [{ target: descriptionEl } as unknown as ResizeObserverEntry],
           {} as ResizeObserver,
         );
@@ -745,15 +746,14 @@ describe('Chart Description with ResizeObserver', () => {
       10,
     );
     expect(chartHeight).toBe(300 - 22 - 100);
-  });
+  } finally {
+    restore();
+  }
+});
 
-  test('The ResizeObserver callback updates the measured height', () => {
-    let observerCallback: ResizeObserverCallback | undefined;
-    mockResizeObserver.mockImplementation(callback => {
-      observerCallback = callback;
-      return { observe: observeMock, disconnect: disconnectMock };
-    });
-
+test('The ResizeObserver callback updates the measured height', () => {
+  const { getObserverCallback, restore } = installResizeObserverMock();
+  try {
     const { container } = setup(
       { height: 400 },
       {
@@ -776,13 +776,14 @@ describe('Chart Description with ResizeObserver', () => {
     ) as HTMLElement;
     expect(descriptionEl).toBeInTheDocument();
 
+    const observerCallback = getObserverCallback();
     if (observerCallback) {
       Object.defineProperty(descriptionEl, 'offsetHeight', {
         value: 200,
         configurable: true,
       });
       act(() => {
-        observerCallback!(
+        observerCallback(
           [{ target: descriptionEl } as unknown as ResizeObserverEntry],
           {} as ResizeObserver,
         );
@@ -795,9 +796,14 @@ describe('Chart Description with ResizeObserver', () => {
       10,
     );
     expect(chartHeight).toBe(400 - 22 - 200);
-  });
+  } finally {
+    restore();
+  }
+});
 
-  test('Existing expand/collapse behavior continues to work', () => {
+test('Existing expand/collapse behavior continues to work', () => {
+  const { restore } = installResizeObserverMock();
+  try {
     const collapsedSetup = setup(
       {},
       {
@@ -823,5 +829,7 @@ describe('Chart Description with ResizeObserver', () => {
     expect(
       expandedSetup.container.querySelector('.slice_description'),
     ).toBeInTheDocument();
-  });
+  } finally {
+    restore();
+  }
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { fireEvent, render } from 'spec/helpers/testing-library';
+import { act, fireEvent, render } from 'spec/helpers/testing-library';
 import { FeatureFlag, VizType } from '@superset-ui/core';
 import * as redux from 'redux';
 
@@ -654,4 +654,174 @@ test('should pass chartStackTrace to ChartContainer so dashboard chart errors st
     'chartStackTrace',
     stackTrace,
   );
+});
+
+describe('Chart Description with ResizeObserver', () => {
+  let mockResizeObserver: jest.Mock;
+  let observeMock: jest.Mock;
+  let disconnectMock: jest.Mock;
+  let getComputedStyleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    observeMock = jest.fn();
+    disconnectMock = jest.fn();
+    mockResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: observeMock,
+      disconnect: disconnectMock,
+    }));
+    global.ResizeObserver = mockResizeObserver as any;
+
+    getComputedStyleSpy = jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValue({
+        getPropertyValue: () => '',
+      } as unknown as CSSStyleDeclaration);
+  });
+
+  afterEach(() => {
+    delete (global as any).ResizeObserver;
+    getComputedStyleSpy.mockRestore();
+  });
+
+  test('A chart description configured to start expanded is visible after initial render', () => {
+    const { container } = setup(
+      {},
+      {
+        dashboardState: {
+          ...defaultState.dashboardState,
+          expandedSlices: { [queryId]: true },
+        },
+      },
+    );
+    expect(container.querySelector('.slice_description')).toBeInTheDocument();
+    expect(observeMock).toHaveBeenCalled();
+  });
+
+  test('The description height is correctly updated after asynchronous markdown rendering completes', () => {
+    let observerCallback: ResizeObserverCallback | undefined;
+    mockResizeObserver.mockImplementation(callback => {
+      observerCallback = callback;
+      return { observe: observeMock, disconnect: disconnectMock };
+    });
+
+    const { container } = setup(
+      { height: 300 },
+      {
+        charts: {
+          ...defaultState.charts,
+          [queryId]: {
+            ...defaultState.charts[queryId],
+            chartStatus: 'loading',
+          },
+        },
+        dashboardState: {
+          ...defaultState.dashboardState,
+          expandedSlices: { [queryId]: true },
+        },
+      },
+    );
+
+    const descriptionEl = container.querySelector(
+      '.slice_description',
+    ) as HTMLElement;
+    expect(descriptionEl).toBeInTheDocument();
+
+    if (observerCallback) {
+      Object.defineProperty(descriptionEl, 'offsetHeight', {
+        value: 100,
+        configurable: true,
+      });
+      act(() => {
+        observerCallback!(
+          [{ target: descriptionEl } as unknown as ResizeObserverEntry],
+          {} as ResizeObserver,
+        );
+      });
+    }
+
+    const chartHeight = parseInt(
+      container.querySelector<HTMLDivElement>('.dashboard-chart > div[style]')!
+        .style.height,
+      10,
+    );
+    expect(chartHeight).toBe(300 - 22 - 100);
+  });
+
+  test('The ResizeObserver callback updates the measured height', () => {
+    let observerCallback: ResizeObserverCallback | undefined;
+    mockResizeObserver.mockImplementation(callback => {
+      observerCallback = callback;
+      return { observe: observeMock, disconnect: disconnectMock };
+    });
+
+    const { container } = setup(
+      { height: 400 },
+      {
+        charts: {
+          ...defaultState.charts,
+          [queryId]: {
+            ...defaultState.charts[queryId],
+            chartStatus: 'loading',
+          },
+        },
+        dashboardState: {
+          ...defaultState.dashboardState,
+          expandedSlices: { [queryId]: true },
+        },
+      },
+    );
+
+    const descriptionEl = container.querySelector(
+      '.slice_description',
+    ) as HTMLElement;
+    expect(descriptionEl).toBeInTheDocument();
+
+    if (observerCallback) {
+      Object.defineProperty(descriptionEl, 'offsetHeight', {
+        value: 200,
+        configurable: true,
+      });
+      act(() => {
+        observerCallback!(
+          [{ target: descriptionEl } as unknown as ResizeObserverEntry],
+          {} as ResizeObserver,
+        );
+      });
+    }
+
+    const chartHeight = parseInt(
+      container.querySelector<HTMLDivElement>('.dashboard-chart > div[style]')!
+        .style.height,
+      10,
+    );
+    expect(chartHeight).toBe(400 - 22 - 200);
+  });
+
+  test('Existing expand/collapse behavior continues to work', () => {
+    const collapsedSetup = setup(
+      {},
+      {
+        dashboardState: {
+          ...defaultState.dashboardState,
+          expandedSlices: { [queryId]: false },
+        },
+      },
+    );
+    expect(
+      collapsedSetup.container.querySelector('.slice_description'),
+    ).not.toBeInTheDocument();
+
+    const expandedSetup = setup(
+      {},
+      {
+        dashboardState: {
+          ...defaultState.dashboardState,
+          expandedSlices: { [queryId]: true },
+        },
+      },
+    );
+    expect(
+      expandedSetup.container.querySelector('.slice_description'),
+    ).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -323,11 +323,35 @@ const Chart = (props: ChartProps) => {
   );
 
   useLayoutEffect(() => {
-    if (isExpanded && descriptionRef.current) {
-      setDescriptionHeight(descriptionRef.current.offsetHeight);
-    } else {
+    if (!isExpanded || !descriptionRef.current) {
       setDescriptionHeight(0);
+      return undefined;
     }
+
+    let isDescriptionHeightSet = false;
+    const initialHeight = descriptionRef.current.offsetHeight;
+    if (initialHeight > 0) {
+      setDescriptionHeight(initialHeight);
+      isDescriptionHeightSet = true;
+    }
+
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === descriptionRef.current) {
+          const height = (entry.target as HTMLElement).offsetHeight;
+          if (height > 0 || !isDescriptionHeightSet) {
+            setDescriptionHeight(height);
+            isDescriptionHeightSet = true;
+          }
+        }
+      }
+    });
+
+    observer.observe(descriptionRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
   }, [isExpanded]);
 
   useEffect(

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -31,7 +31,7 @@ import type { ChartCustomization, JsonObject } from '@superset-ui/core';
 import { VizType } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
-import { debounce } from 'lodash-es';
+import debounce from 'lodash/debounce';
 import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -31,7 +31,7 @@ import type { ChartCustomization, JsonObject } from '@superset-ui/core';
 import { VizType } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -335,23 +335,27 @@ const Chart = (props: ChartProps) => {
       isDescriptionHeightSet = true;
     }
 
-    const observer = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        if (entry.target === descriptionRef.current) {
-          const height = (entry.target as HTMLElement).offsetHeight;
-          if (height > 0 || !isDescriptionHeightSet) {
-            setDescriptionHeight(height);
-            isDescriptionHeightSet = true;
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          if (entry.target === descriptionRef.current) {
+            const height = (entry.target as HTMLElement).offsetHeight;
+            if (height > 0 || !isDescriptionHeightSet) {
+              setDescriptionHeight(height);
+              isDescriptionHeightSet = true;
+            }
           }
         }
-      }
-    });
+      });
 
-    observer.observe(descriptionRef.current);
+      observer.observe(descriptionRef.current);
 
-    return () => {
-      observer.disconnect();
-    };
+      return () => {
+        observer.disconnect();
+      };
+    }
+
+    return undefined;
   }, [isExpanded]);
 
   useEffect(


### PR DESCRIPTION
### SUMMARY

This PR fixes a regression affecting expanded chart descriptions on dashboards.

The root cause was that the description container's height could be measured before the asynchronously rendered markdown content had finished laying out. In that case, the initial measurement could be `0`, causing a chart description configured to start expanded via `expanded_slices` to remain visually collapsed.

This change re-measures the description height after the markdown content has finished rendering, ensuring that expanded descriptions reflect their actual rendered height.

### BEFORE

When a dashboard was configured with a chart in `expanded_slices`:

```json
{
  "expanded_slices": {
    "123": true
  }
}
```

the chart description could remain visually collapsed on the initial dashboard load because its height was measured before the markdown content finished rendering.

### AFTER

Once the markdown content has finished rendering, the description height is re-measured, allowing chart descriptions configured in `expanded_slices` to render expanded as expected on the initial dashboard load.

### TESTING

Added regression coverage verifying that:

- chart descriptions configured to start expanded are measured correctly after rendering;
- description height is updated after asynchronous markdown layout;
- existing expand/collapse behavior continues to work as expected.

Fixes #40373