### PR TITLE
chore(ci): pin @action-validator versions in GHA validator workflow

### DIFF
--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -37,7 +37,9 @@ jobs:
           node-version: "20"
 
       - name: Install Dependencies
-        run: npm install -g @action-validator/core @action-validator/cli --save-dev
+        # Versions are pinned to avoid ad-hoc, unpinned package installs
+        # (zizmor adhoc-packages). Bump deliberately when upgrading.
+        run: npm install -g @action-validator/core@0.6.0 @action-validator/cli@0.6.0
 
       - name: Run Script
         run: bash .github/workflows/github-action-validator.sh


### PR DESCRIPTION
### SUMMARY

The `Validate All GitHub Actions` workflow installs `@action-validator/core` and `@action-validator/cli` without pinning versions:

```yaml
run: npm install -g @action-validator/core @action-validator/cli --save-dev
```

This is flagged by zizmor's [`adhoc-packages`](https://docs.zizmor.sh/audits/#adhoc-packages) audit (GitHub code-scanning alert #2557): installing unpinned packages at workflow runtime is a supply-chain risk, since a compromised or mutated upstream release would be pulled in silently on every run.

This pins both packages to their pinned version (`0.6.0`) and drops the no-op `--save-dev` flag, which does nothing for a global (`-g`) install with no local `package.json`.

```yaml
run: npm install -g @action-validator/core@0.6.0 @action-validator/cli@0.6.0
```

Resolves code-scanning alert #2557.

### BEFORE/AFTER

Before: zizmor reports an `adhoc-packages` note on `.github/workflows/github-action-validator.yml:40`.
After: packages are version-pinned; the finding is resolved. Local `pre-commit run` (including the zizmor hook) passes.

### TESTING INSTRUCTIONS

CI-only change. The `Validate All GitHub Actions` workflow continues to install the action-validator tooling and run the validation script; behavior is unchanged aside from pinning the installed versions.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)