### PR TITLE
chore(ci): scope zizmor adhoc-packages on setup-supersetbot action

### DIFF
--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -17,6 +17,7 @@ runs:
     - name: Install supersetbot from npm
       if: ${{ inputs.from-npm == 'true' }}
       shell: bash
+      # zizmor: ignore[adhoc-packages] - installing the supersetbot CLI globally is the sole purpose of this action; there is no lockfile-based install path for a global CLI tool
       run: npm install -g supersetbot
 
     - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -31,6 +32,7 @@ runs:
       if: ${{ inputs.from-npm == 'false' }}
       shell: bash
       working-directory: supersetbot
+      # zizmor: ignore[adhoc-packages] - installs the locally packed supersetbot tarball built from the trusted apache-superset/supersetbot checkout; no lockfile applies to a global CLI install
       run: |
         # simple trick to install globally with dependencies
         npm pack


### PR DESCRIPTION
### SUMMARY

Resolves code-scanning alert #2556 (and the sibling finding on the same action), both flagged by zizmor's `adhoc-packages` audit on `.github/actions/setup-supersetbot/action.yml`.

The composite action's sole purpose is to install the `supersetbot` CLI globally, either:
- from npm (`npm install -g supersetbot`), or
- from a locally packed tarball built via `npm pack` of the trusted `apache-superset/supersetbot` checkout (`npm install -g ./supersetbot*.tgz`).

A globally installed CLI tool has no lockfile/manifest-based install path, so `adhoc-packages` (a `note`-level supply-chain reproducibility audit) is a justified false positive here. This adds scoped, commented `# zizmor: ignore[adhoc-packages]` suppressions, matching the existing convention already used in `tag-release.yml`, `welcome-new-users.yml`, and other workflows.

Per `SECURITY.md`, this is operator/CI tooling and does not grant any principal a capability outside the role/capability matrix; the suppression is documented so the rationale is auditable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```
uvx zizmor@latest --persona auditor .github/actions/setup-supersetbot/action.yml
# -> No findings to report. Good job! (2 ignored)
```

The repo's own `zizmor (GHA security audit)` pre-commit hook also passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)