### PR TITLE
fix(datasource): allow Gamma to load combined datasource list

### DIFF
--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -45,6 +45,9 @@ logger = logging.getLogger(__name__)
 class DatasourceRestApi(BaseSupersetApi):
     allow_browser_login = True
     class_permission_name = "Datasource"
+    method_permission_name = {
+        "combined_list": "read",
+    }
     resource_name = "datasource"
     openapi_spec_tag = "Datasources"
 

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -339,12 +339,6 @@ class TestDatasourceApi(SupersetTestCase):
         run_mock,
         can_access_mock,
     ):
-        security_manager.add_permission_view_menu("can_combined_list", "Datasource")
-        perm = security_manager.find_permission_view_menu(
-            "can_combined_list", "Datasource"
-        )
-        admin_role = security_manager.find_role("Admin")
-        security_manager.add_permission_role(admin_role, perm)
         can_access_mock.side_effect = [True, True]
         run_mock.side_effect = ValueError("Invalid order column: invalid")
         self.login(ADMIN_USERNAME)
@@ -364,12 +358,6 @@ class TestDatasourceApi(SupersetTestCase):
         run_mock,
         can_access_mock,
     ):
-        security_manager.add_permission_view_menu("can_combined_list", "Datasource")
-        perm = security_manager.find_permission_view_menu(
-            "can_combined_list", "Datasource"
-        )
-        admin_role = security_manager.find_role("Admin")
-        security_manager.add_permission_role(admin_role, perm)
         can_access_mock.return_value = True
         run_mock.return_value = {"count": 1, "result": []}
         self.login(ADMIN_USERNAME)
@@ -383,3 +371,19 @@ class TestDatasourceApi(SupersetTestCase):
         run_mock.assert_called_once()
         _, kwargs = run_mock.call_args
         assert kwargs == {}
+
+    @patch("superset.datasource.api.GetCombinedDatasourceListCommand.run")
+    def test_combined_list_gamma_uses_read_permission(self, run_mock):
+        run_mock.return_value = {"count": 0, "result": []}
+        self.login(GAMMA_USERNAME)
+
+        rv = self.client.get(
+            "api/v1/datasource/?q="
+            "(order_column:changed_on_delta_humanized,"
+            "order_direction:desc,page:0,page_size:25)"
+        )
+
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response == {"count": 0, "result": []}
+        run_mock.assert_called_once()


### PR DESCRIPTION
### SUMMARY

Fixes a 403 for Gamma users opening the Dataset List page, likely caused by #37815.

The Dataset List page calls `GET /api/v1/datasource/`, which is served by `DatasourceRestApi.combined_list`. Because the endpoint did not define `method_permission_name`, FAB protected it as `can_combined_list` on `Datasource`. Gamma has `can_read` on `Datasource`, but not `can_combined_list`, so the page failed with 403.

This maps `combined_list` to `read`, so the route uses `can_read` on `Datasource`, matching the endpoint’s read-only list semantics and its internal `can_read` checks for Dataset/SemanticView access.

Also removes test-only `can_combined_list` grants that masked the issue and adds a Gamma regression test for the Dataset List request.

### BEFORE
Currently a user with only Gamma role but with adequate datasource perms gets a 403 on the dataset list view:
<img width="1464" height="844" alt="image" src="https://github.com/user-attachments/assets/6648b4fe-1b77-449f-80d0-cd1f57a9010f" />

### AFTER
With the fix, the dataset list view now renders datasets as expected:
<img width="1480" height="877" alt="image" src="https://github.com/user-attachments/assets/85df6062-8a06-487c-a098-5694949a1918" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
