### PR TITLE
fix(semantic layers): time comparison with 1 row

### DIFF
--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -165,6 +165,18 @@ def get_results(query_object: QueryObject) -> QueryResult:
             for metric in metric_names:
                 offset_col_name = TIME_COMPARISON.join([metric, time_offset])
                 main_df[offset_col_name] = np.nan
+        elif not join_keys:
+            # No dimensions to join on — this is an aggregate-only query
+            # (e.g. ``metrics: ["Orders Count"]`` with empty ``columns``),
+            # which produces a single-row DataFrame. ``pandas.merge`` on an
+            # empty ``on=`` list crashes with ``IndexError`` deep in the
+            # join-indexer code, so we lift the offset metric values from
+            # the first row of ``offset_df`` straight onto ``main_df``.
+            for metric in metric_names:
+                offset_col_name = TIME_COMPARISON.join([metric, time_offset])
+                main_df[offset_col_name] = (
+                    offset_df[metric].iloc[0] if metric in offset_df else np.nan
+                )
         else:
             # Rename metric columns with time offset suffix
             # Format: "{metric_name}__{time_offset}"

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -1507,6 +1507,53 @@ def test_get_results_with_multiple_time_offsets(
     pd.testing.assert_frame_equal(result.df, expected_df)
 
 
+def test_get_results_with_time_offset_and_no_dimensions(
+    mock_datasource: MagicMock,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Aggregate-only queries (no dimensions) with a time offset should not
+    crash. Regression for ``IndexError: list index out of range`` inside
+    pandas, which fired when ``main_df.merge(..., on=[])`` was attempted
+    because the empty ``columns`` list left no join keys.
+    """
+    # Aggregate without group-by produces a single row per query.
+    main_df = pd.DataFrame({"total_sales": [1000.0]})
+    offset_df = pd.DataFrame({"total_sales": [950.0]})
+
+    mock_main_result = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="SELECT SUM(amount)")],
+        results=pa.Table.from_pandas(main_df.copy()),
+    )
+    mock_offset_result = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="SELECT SUM(amount)")],
+        results=pa.Table.from_pandas(offset_df.copy()),
+    )
+    mock_datasource.implementation.get_table = mocker.Mock(
+        side_effect=[mock_main_result, mock_offset_result]
+    )
+
+    query_object = ValidatedQueryObject(
+        datasource=mock_datasource,
+        from_dttm=datetime(2025, 10, 15),
+        to_dttm=datetime(2025, 10, 22),
+        metrics=["total_sales"],
+        columns=[],
+        granularity="order_date",
+        time_offsets=["1 day ago"],
+    )
+
+    # No exception, and the offset value rides alongside the main one.
+    result = get_results(query_object)
+    expected_df = pd.DataFrame(
+        {
+            "total_sales": [1000.0],
+            "total_sales__1 day ago": [950.0],
+        }
+    )
+    pd.testing.assert_frame_equal(result.df, expected_df)
+
+
 def test_get_results_with_empty_offset_result(
     mock_datasource: MagicMock,
     mocker: MockerFixture,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix time comparison on semantic views when there's a single row.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1728" height="1080" alt="Screenshot 2026-06-29 at 5 59 48 PM" src="https://github.com/user-attachments/assets/db41c4de-d981-4cbd-bc69-0553a88097cf" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
