### PR TITLE
fix(table): exclude metricSqlExpressions from ownState→extra_form_data spread

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -1166,8 +1166,12 @@ function mapStateToProps(state: ExploreRootState) {
 
   const slice_id = form_data.slice_id ?? slice?.slice_id ?? 0; // 0 - unsaved chart
 
-  // exclude clientView from extra_form_data; keep other ownState pieces
-  const ownStateForQuery = omit(dataMask[slice_id]?.ownState, ['clientView']);
+  // exclude clientView and metricSqlExpressions from extra_form_data;
+  // metricSqlExpressions is runtime-only and must not be serialised to chart params
+  const ownStateForQuery = omit(dataMask[slice_id]?.ownState, [
+    'clientView',
+    'metricSqlExpressions',
+  ]);
 
   form_data.extra_form_data = mergeExtraFormData(
     { ...form_data.extra_form_data },


### PR DESCRIPTION
### SUMMARY

AG Grid table plugin was serialising `metricSqlExpressions` — a full mapping of every datasource metric and calculated column to its SQL expression — into chart params on save, causing 927 MB param payloads on large datasources.

**Root cause:**

In `ExploreViewContainer/mapStateToProps`, all `ownState` fields (except `clientView`) are spread into `form_data.extra_form_data`:

```ts
const ownStateForQuery = omit(dataMask[slice_id]?.ownState, ['clientView']);
form_data.extra_form_data = mergeExtraFormData({ ...form_data.extra_form_data }, { ...ownStateForQuery });
```

When the AG Grid plugin wrote `metricSqlExpressions` into `ownState` (to pass datasource-level SQL expressions to `buildQuery` for filter resolution), it landed in `extra_form_data` and was then serialised into `params` on save.

**Fix:**

Add `metricSqlExpressions` to the `omit` list so it is excluded from the `ownState → extra_form_data` spread:

```ts
const ownStateForQuery = omit(dataMask[slice_id]?.ownState, [
  'clientView',
  'metricSqlExpressions',
]);
```

`metricSqlExpressions` remains in `ownState` in memory (it is never serialised to params after this omit). `buildQuery` continues to read it from `ownState` exactly as before — no behaviour change, no lifecycle coupling.

**What this does not change:**
- Filter resolution in `buildQuery` — reads `ownState.metricSqlExpressions` as before
- The AG Grid plugin's `ownState` shape — no plugin changes needed
- Backward compatibility — existing saved charts with `metricSqlExpressions` in params will continue to work (those fields are simply ignored on load)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — params size fix, no visual change.

### TESTING INSTRUCTIONS

1. Open a chart using the AG Grid table plugin with a datasource that has many saved metrics (SQL expressions)
2. Apply a column filter — verify the filter works correctly (metric label → SQL resolution still works)
3. Save the chart — verify the `params` field in the `slices` table no longer contains `metricSqlExpressions`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API