### PR TITLE
fix(semantic-layers): apply time-comparison offset to `TEMPORAL_RANGE` filters

### DIFF
--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -391,12 +391,14 @@ def _get_filters_from_query_object(
     filters.update(extras_filters)
 
     # 4. Add all other filters from query_object.filter
+    # ``TEMPORAL_RANGE`` filters are skipped when a time axis can be inferred —
+    # ``_get_time_filter`` is responsible for emitting the bounds and (when a
+    # ``time_offset`` is set) shifting them. Without this skip, the offset
+    # query would carry the original literal bounds via the TEMPORAL_RANGE
+    # pass-through and end up identical to the main query.
+    has_time_axis = _get_time_axis_column(query_object, all_dimensions) is not None
     for filter_ in query_object.filter:
-        # Skip temporal range filters - we're using inner bounds instead
-        if (
-            filter_.get("op") == FilterOperator.TEMPORAL_RANGE.value
-            and query_object.granularity
-        ):
+        if filter_.get("op") == FilterOperator.TEMPORAL_RANGE.value and has_time_axis:
             continue
 
         if converted_filters := _convert_query_object_filter(filter_, all_dimensions):
@@ -449,6 +451,55 @@ def _get_filters_from_extras(extras: dict[str, Any]) -> set[Filter]:
     return filters
 
 
+def _get_time_axis_column(
+    query_object: ValidatedQueryObject,
+    all_dimensions: dict[str, Dimension],
+) -> str | None:
+    """
+    Determine which selected column is the time-axis (the one a time offset
+    applies to).
+
+    Legacy time-series charts encode this as ``query_object.granularity``.
+    Modern x-axis charts leave that empty and put the temporal column in
+    ``query_object.columns`` instead. Aggregate-only charts that just use a
+    ``TEMPORAL_RANGE`` adhoc filter (e.g. for time comparisons) carry the
+    temporal column only in ``query_object.filter``; we fall back to that so
+    the offset-aware filter path can still find a column to shift.
+    """
+    if query_object.granularity:
+        return query_object.granularity
+
+    dimension_names = set(all_dimensions.keys())
+
+    def is_temporal(name: str) -> bool:
+        dim = all_dimensions.get(name)
+        return dim is not None and (
+            pa.types.is_timestamp(dim.type)
+            or pa.types.is_date(dim.type)
+            or pa.types.is_time(dim.type)
+        )
+
+    for column in query_object.columns or []:
+        try:
+            name = _normalize_column(column, dimension_names)
+        except ValueError:
+            continue
+        if is_temporal(name):
+            return name
+
+    # Last resort: a TEMPORAL_RANGE filter (the shape produced by adhoc
+    # time-range filters on aggregate-only charts) carries the temporal
+    # column name in its ``col`` field.
+    for filter_ in query_object.filter or []:
+        if filter_.get("op") != FilterOperator.TEMPORAL_RANGE.value:
+            continue
+        col = filter_.get("col")
+        if isinstance(col, str) and is_temporal(col):
+            return col
+
+    return None
+
+
 def _get_time_filter(
     query_object: ValidatedQueryObject,
     time_offset: str | None,
@@ -460,13 +511,18 @@ def _get_time_filter(
     This handles both regular queries and time offset queries, simplifying the
     complexity of from_dttm/to_dttm/inner_from_dttm/inner_to_dttm by using the
     same time bounds for both the main query and series limit subqueries.
+
+    The time column is resolved via ``_get_time_axis_column`` so that
+    aggregate-only charts that only reference the temporal column inside a
+    ``TEMPORAL_RANGE`` adhoc filter still get offset-aware bounds applied.
     """
     filters: set[Filter] = set()
 
-    if not query_object.granularity:
+    time_axis_column = _get_time_axis_column(query_object, all_dimensions)
+    if not time_axis_column:
         return filters
 
-    time_dimension = all_dimensions.get(query_object.granularity)
+    time_dimension = all_dimensions.get(time_axis_column)
     if not time_dimension:
         return filters
 

--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -390,15 +390,23 @@ def _get_filters_from_query_object(
     extras_filters = _get_filters_from_extras(query_object.extras)
     filters.update(extras_filters)
 
-    # 4. Add all other filters from query_object.filter
-    # ``TEMPORAL_RANGE`` filters are skipped when a time axis can be inferred —
-    # ``_get_time_filter`` is responsible for emitting the bounds and (when a
-    # ``time_offset`` is set) shifting them. Without this skip, the offset
-    # query would carry the original literal bounds via the TEMPORAL_RANGE
-    # pass-through and end up identical to the main query.
-    has_time_axis = _get_time_axis_column(query_object, all_dimensions) is not None
+    # 4. Add all other filters from query_object.filter.
+    # ``TEMPORAL_RANGE`` filters are skipped only when ``_get_time_filter``
+    # actually emitted bounds — that path takes over both the base range and
+    # the ``time_offset`` shift, so pass-through would duplicate the bounds
+    # (or, worse, ship the un-shifted literal bounds into the offset query).
+    # When it did not emit anything (e.g. an open-ended range like
+    # ``"2020-01-01 : "``, where ``_get_time_filter`` requires both
+    # ``from_dttm`` and ``to_dttm``), we fall through to
+    # ``_convert_query_object_filter``'s TEMPORAL_RANGE handler so the one-
+    # sided predicate still lands on the query instead of silently widening
+    # the scan.
+    time_bounds_emitted = bool(time_filters)
     for filter_ in query_object.filter:
-        if filter_.get("op") == FilterOperator.TEMPORAL_RANGE.value and has_time_axis:
+        if (
+            filter_.get("op") == FilterOperator.TEMPORAL_RANGE.value
+            and time_bounds_emitted
+        ):
             continue
 
         if converted_filters := _convert_query_object_filter(filter_, all_dimensions):
@@ -901,31 +909,32 @@ def _get_group_limit_filters(
 
     # Create separate filters for the group limit subquery
     filters: set[Filter] = set()
+    time_bounds_emitted = False
 
-    # Add time range filter using inner bounds
-    if query_object.granularity:
-        time_dimension = all_dimensions.get(query_object.granularity)
-        if (
-            time_dimension
-            and query_object.inner_from_dttm
-            and query_object.inner_to_dttm
-        ):
-            filters.update(
-                {
-                    Filter(
-                        type=PredicateType.WHERE,
-                        column=time_dimension,
-                        operator=Operator.GREATER_THAN_OR_EQUAL,
-                        value=query_object.inner_from_dttm,
-                    ),
-                    Filter(
-                        type=PredicateType.WHERE,
-                        column=time_dimension,
-                        operator=Operator.LESS_THAN,
-                        value=query_object.inner_to_dttm,
-                    ),
-                }
-            )
+    # Add time range filter using inner bounds. The temporal column is resolved
+    # via ``_get_time_axis_column`` so aggregate-only charts that carry the
+    # time column only in a ``TEMPORAL_RANGE`` adhoc filter still get the
+    # group-limit subquery scoped to the inner bounds instead of falling
+    # through to the outer bounds.
+    time_axis_column = _get_time_axis_column(query_object, all_dimensions)
+    if time_axis_column and (time_dimension := all_dimensions.get(time_axis_column)):
+        filters.update(
+            {
+                Filter(
+                    type=PredicateType.WHERE,
+                    column=time_dimension,
+                    operator=Operator.GREATER_THAN_OR_EQUAL,
+                    value=query_object.inner_from_dttm,
+                ),
+                Filter(
+                    type=PredicateType.WHERE,
+                    column=time_dimension,
+                    operator=Operator.LESS_THAN,
+                    value=query_object.inner_to_dttm,
+                ),
+            }
+        )
+        time_bounds_emitted = True
 
     # Add fetch values predicate if present
     if (
@@ -945,12 +954,14 @@ def _get_group_limit_filters(
     extras_filters = _get_filters_from_extras(query_object.extras)
     filters.update(extras_filters)
 
-    # Add all other non-temporal filters from query_object.filter
+    # Add all other non-temporal filters from query_object.filter. Skip
+    # ``TEMPORAL_RANGE`` only when the inner-bound filters were actually
+    # emitted — otherwise dropping the pass-through would silently widen the
+    # group-limit subquery to the full history.
     for filter_ in query_object.filter:
-        # Skip temporal range filters - we're using inner bounds instead
         if (
             filter_.get("op") == FilterOperator.TEMPORAL_RANGE.value
-            and query_object.granularity
+            and time_bounds_emitted
         ):
             continue
 

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -2995,20 +2995,22 @@ def test_get_group_limit_filters_granularity_missing_inner_to(
     assert result is None
 
 
-def test_get_group_limit_filters_no_granularity(
+def test_get_group_limit_filters_no_time_axis(
     mocker: MockerFixture,
 ) -> None:
     """
-    Test _get_group_limit_filters when granularity is None/empty.
-    This explicitly covers the branch 704->729 where granularity is Falsy.
+    Test _get_group_limit_filters when no time axis can be identified.
+
+    Without a granularity, temporal column in ``columns``, or a TEMPORAL_RANGE
+    filter, ``_get_time_axis_column`` returns ``None`` and the inner-bound
+    filters are not emitted.
     """
-    # Create dimensions
     category_dim = Dimension("category", "category", pa.utf8(), "category", "Category")
     all_dimensions = {"category": category_dim}
 
-    # Create mock query object with no granularity
     query_object = mocker.Mock()
-    query_object.granularity = None  # No granularity
+    query_object.granularity = None
+    query_object.columns = []
     query_object.inner_from_dttm = datetime(2025, 9, 22)
     query_object.inner_to_dttm = datetime(2025, 10, 22)
     query_object.extras = {}
@@ -3019,7 +3021,6 @@ def test_get_group_limit_filters_no_granularity(
 
     result = _get_group_limit_filters(query_object, all_dimensions)
 
-    # Should return None - no granularity means no time filters added
     assert result is None
 
 
@@ -3469,3 +3470,119 @@ def test_map_query_object_shifts_time_offset_via_temporal_range_filter(
     assert offset_lt == get_past_or_future("1 month ago", datetime(2020, 12, 31))
     assert offset_gte != main_gte
     assert offset_lt != main_lt
+
+
+def test_get_group_limit_filters_uses_time_axis_from_temporal_range(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression: the group-limit subquery used to gate its inner-bound time
+    filter and its ``TEMPORAL_RANGE`` skip on ``query_object.granularity``.
+    A modern aggregate-only chart carries the temporal column only inside a
+    ``TEMPORAL_RANGE`` adhoc filter, so under time comparison the group-limit
+    subquery either got no time bounds at all or picked up the *outer* bounds
+    via the pass-through — never the inner bounds. Now both paths resolve the
+    temporal column via ``_get_time_axis_column``.
+    """
+    order_date = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.timestamp("us"),
+        description="Order date",
+        definition="order_date",
+    )
+    status = Dimension(
+        id="orders.status",
+        name="status",
+        type=pa.utf8(),
+        description="Order status",
+        definition="status",
+    )
+    all_dimensions = {"order_date": order_date, "status": status}
+
+    datasource = mocker.Mock()
+    datasource.fetch_values_predicate = None
+
+    query_object = ValidatedQueryObject(
+        datasource=datasource,
+        from_dttm=datetime(2020, 1, 1),
+        to_dttm=datetime(2020, 12, 31),
+        inner_from_dttm=datetime(2019, 12, 1),
+        inner_to_dttm=datetime(2020, 11, 30),
+        metrics=["count"],
+        columns=["status"],
+        # granularity intentionally NOT set — the modern x_axis SV shape.
+        filters=[
+            {
+                "col": "order_date",
+                "op": FilterOperator.TEMPORAL_RANGE.value,
+                "val": "2020-01-01 : 2020-12-31",
+            }
+        ],
+    )
+
+    result = _get_group_limit_filters(query_object, all_dimensions)
+
+    assert result is not None
+    order_date_bounds = {
+        (f.operator, f.value)
+        for f in result
+        if f.column is not None and f.column.name == "order_date"
+    }
+    # Inner bounds — not the outer 2020-01-01 / 2020-12-31 — must be present,
+    # and the outer TEMPORAL_RANGE pass-through must be skipped.
+    assert order_date_bounds == {
+        (Operator.GREATER_THAN_OR_EQUAL, datetime(2019, 12, 1)),
+        (Operator.LESS_THAN, datetime(2020, 11, 30)),
+    }
+
+
+def test_get_filters_from_query_object_preserves_open_ended_temporal_range(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression: the ``TEMPORAL_RANGE`` skip in ``_get_filters_from_query_object``
+    must not drop one-sided ranges. ``_get_time_filter`` only emits bounds when
+    both ``from_dttm`` and ``to_dttm`` resolve, so an open-ended range like
+    ``"2020-01-01 : "`` needs to fall through to ``_convert_query_object_filter``
+    (which emits the single bounded predicate). Otherwise the query silently
+    widens the scan.
+    """
+    order_date = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.timestamp("us"),
+        description="Order date",
+        definition="order_date",
+    )
+    all_dimensions = {"order_date": order_date}
+
+    datasource = mocker.Mock()
+    datasource.fetch_values_predicate = None
+
+    query_object = ValidatedQueryObject(
+        datasource=datasource,
+        from_dttm=datetime(2020, 1, 1),
+        to_dttm=None,  # open-ended → ``_get_time_filter`` returns nothing
+        metrics=["count"],
+        columns=[],
+        filters=[
+            {
+                "col": "order_date",
+                "op": FilterOperator.TEMPORAL_RANGE.value,
+                "val": "2020-01-01 : ",
+            }
+        ],
+        extras={},
+    )
+
+    result = _get_filters_from_query_object(query_object, None, all_dimensions)
+
+    assert result == {
+        Filter(
+            type=PredicateType.WHERE,
+            column=order_date,
+            operator=Operator.GREATER_THAN_OR_EQUAL,
+            value=datetime(2020, 1, 1),
+        ),
+    }

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -51,6 +51,7 @@ from superset.semantic_layers.mapper import (
     _get_group_limit_filters,
     _get_group_limit_from_query_object,
     _get_order_from_query_object,
+    _get_time_axis_column,
     _get_time_bounds,
     _get_time_filter,
     _normalize_column,
@@ -3224,3 +3225,247 @@ def test_coerce_time_invalid_string_raises() -> None:
 def test_coerce_time_rejects_other_types() -> None:
     with pytest.raises(ValueError, match="Invalid time value"):
         _coerce_scalar_filter_value(123, _dim(pa.time64("us")))
+
+
+# ---------------------------------------------------------------------------
+# _get_time_axis_column — resolves the temporal column the offset applies to
+# ---------------------------------------------------------------------------
+
+
+def test_get_time_axis_column_returns_granularity_when_set(
+    mocker: MockerFixture,
+) -> None:
+    """Legacy path: ``granularity`` short-circuits the rest of the lookup."""
+    qo = mocker.Mock()
+    qo.granularity = "order_date"
+    assert _get_time_axis_column(qo, {}) == "order_date"
+
+
+def test_get_time_axis_column_finds_temporal_in_columns(
+    mocker: MockerFixture,
+) -> None:
+    """Modern x_axis path: first temporal dim from ``columns`` wins."""
+    all_dims = {
+        "category": Dimension(
+            id="products.category",
+            name="category",
+            type=pa.utf8(),
+            definition="category",
+        ),
+        "order_date": Dimension(
+            id="orders.order_date",
+            name="order_date",
+            type=pa.timestamp("us"),
+            definition="order_date",
+        ),
+    }
+    qo = mocker.Mock()
+    qo.granularity = None
+    qo.columns = ["category", "order_date"]
+    qo.filter = []
+    assert _get_time_axis_column(qo, all_dims) == "order_date"
+
+
+def test_get_time_axis_column_finds_temporal_in_temporal_range_filter(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Aggregate-only charts that only reference the temporal column inside a
+    ``TEMPORAL_RANGE`` adhoc filter (no granularity, empty ``columns``) are
+    still resolvable so the offset-aware filter path can shift the bounds.
+    """
+    all_dims = {
+        "order_date": Dimension(
+            id="orders.order_date",
+            name="order_date",
+            type=pa.timestamp("us"),
+            definition="order_date",
+        ),
+    }
+    qo = mocker.Mock()
+    qo.granularity = None
+    qo.columns = []
+    qo.filter = [
+        # A non-TEMPORAL_RANGE filter is skipped so the loop reaches the
+        # TEMPORAL_RANGE entry that follows it.
+        {"col": "status", "op": FilterOperator.EQUALS.value, "val": "completed"},
+        {
+            "col": "order_date",
+            "op": FilterOperator.TEMPORAL_RANGE.value,
+            "val": "2020-01-01 : 2020-12-31",
+        },
+    ]
+    assert _get_time_axis_column(qo, all_dims) == "order_date"
+
+
+def test_get_time_axis_column_ignores_temporal_range_on_non_temporal_col(
+    mocker: MockerFixture,
+) -> None:
+    """Defensive: a TEMPORAL_RANGE filter on a non-temporal column is not
+    used as the time axis (malformed payload)."""
+    all_dims = {
+        "category": Dimension(
+            id="products.category",
+            name="category",
+            type=pa.utf8(),
+            definition="category",
+        ),
+    }
+    qo = mocker.Mock()
+    qo.granularity = None
+    qo.columns = []
+    qo.filter = [
+        {
+            "col": "category",
+            "op": FilterOperator.TEMPORAL_RANGE.value,
+            "val": "2020-01-01 : 2020-12-31",
+        },
+    ]
+    assert _get_time_axis_column(qo, all_dims) is None
+
+
+def test_get_time_axis_column_returns_none_when_no_temporal_signal(
+    mocker: MockerFixture,
+) -> None:
+    """Without ``granularity``, a temporal column in ``columns``, or a
+    ``TEMPORAL_RANGE`` filter we return ``None`` and the caller skips."""
+    all_dims = {
+        "category": Dimension(
+            id="products.category",
+            name="category",
+            type=pa.utf8(),
+            definition="category",
+        ),
+    }
+    qo = mocker.Mock()
+    qo.granularity = None
+    qo.columns = ["category"]
+    qo.filter = []
+    assert _get_time_axis_column(qo, all_dims) is None
+
+
+def test_get_time_axis_column_skips_unparseable_adhoc_columns(
+    mocker: MockerFixture,
+) -> None:
+    """An adhoc column that ``_normalize_column`` rejects is silently skipped."""
+    all_dims = {
+        "order_date": Dimension(
+            id="orders.order_date",
+            name="order_date",
+            type=pa.timestamp("us"),
+            definition="order_date",
+        ),
+    }
+    qo = mocker.Mock()
+    qo.granularity = None
+    qo.filter = []
+    # First column is an adhoc dict without ``isColumnReference`` — raises in
+    # ``_normalize_column`` and the loop should keep going.
+    qo.columns = [
+        {"label": "unsupported", "sqlExpression": "lower(x)"},
+        "order_date",
+    ]
+    assert _get_time_axis_column(qo, all_dims) == "order_date"
+
+
+# ---------------------------------------------------------------------------
+# Time-offset application via TEMPORAL_RANGE adhoc filter
+# ---------------------------------------------------------------------------
+
+
+def test_map_query_object_shifts_time_offset_via_temporal_range_filter(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression: an aggregate-only modern SV chart that carries the time
+    column only inside a ``TEMPORAL_RANGE`` adhoc filter (no granularity, no
+    temporal entry in ``columns``) used to emit identical main + offset
+    queries because ``_get_time_filter`` short-circuited on empty granularity
+    and the TEMPORAL_RANGE filter was passed through verbatim. The fix
+    routes the time column through ``_get_time_axis_column`` so the offset
+    bounds are computed and the TEMPORAL_RANGE pass-through is skipped.
+    """
+    datasource = mocker.Mock()
+    order_date = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.timestamp("us"),
+        description="Order date",
+        definition="order_date",
+    )
+    status = Dimension(
+        id="orders.status",
+        name="status",
+        type=pa.utf8(),
+        description="Order status",
+        definition="status",
+    )
+    count_metric = Metric(
+        id="orders.count",
+        name="count",
+        type=pa.int64(),
+        definition="count",
+        description="Order count",
+    )
+    implementation = MockSemanticView(
+        dimensions={order_date, status},
+        metrics={count_metric},
+        features=frozenset(),
+    )
+    datasource.implementation = implementation
+    datasource.fetch_values_predicate = None
+
+    query_object = ValidatedQueryObject(
+        datasource=datasource,
+        from_dttm=datetime(2020, 1, 1),
+        to_dttm=datetime(2020, 12, 31),
+        metrics=["count"],
+        columns=["status"],
+        # granularity intentionally NOT set — the modern x_axis SV shape.
+        filters=[
+            {
+                "col": "order_date",
+                "op": FilterOperator.TEMPORAL_RANGE.value,
+                "val": "2020-01-01 : 2020-12-31",
+            }
+        ],
+        time_offsets=["1 month ago"],
+    )
+
+    queries = map_query_object(query_object)
+    assert len(queries) == 2
+    main_query, offset_query = queries[0], queries[1]
+
+    def time_filter_bounds(query: SemanticQuery) -> tuple[datetime, datetime]:
+        gte = next(
+            f.value
+            for f in query.filters
+            if f.column is not None
+            and f.column.name == "order_date"
+            and f.operator == Operator.GREATER_THAN_OR_EQUAL
+        )
+        lt = next(
+            f.value
+            for f in query.filters
+            if f.column is not None
+            and f.column.name == "order_date"
+            and f.operator == Operator.LESS_THAN
+        )
+        return gte, lt
+
+    main_gte, main_lt = time_filter_bounds(main_query)
+    offset_gte, offset_lt = time_filter_bounds(offset_query)
+
+    assert main_gte == datetime(2020, 1, 1)
+    assert main_lt == datetime(2020, 12, 31)
+
+    # The offset bounds are shifted backwards by one month on both ends.
+    # Compare against ``get_past_or_future`` rather than hand-rolled date math
+    # so the assertion doesn't entangle the regression with "1 month ago"
+    # quirks (e.g. Dec 31 − 1 month → Nov 30, not Dec 1).
+    from superset.utils.date_parser import get_past_or_future
+
+    assert offset_gte == get_past_or_future("1 month ago", datetime(2020, 1, 1))
+    assert offset_lt == get_past_or_future("1 month ago", datetime(2020, 12, 31))
+    assert offset_gte != main_gte
+    assert offset_lt != main_lt


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

On semantic-view charts with a time comparison (`time_compare`) but no `granularity` set — i.e. modern x-axis or aggregate-only charts where the temporal column is only referenced inside a `TEMPORAL_RANGE` adhoc filter — the offset query was emitted with the same date bounds as the main query, so the two metric values were always identical.

Three things in `superset/semantic_layers/mapper.py` collided to produce this:

- `_get_time_filter` short-circuited when `query_object.granularity` was empty, so the offset-aware bounds path was never reached.
- `_get_filters_from_query_object` only skipped the TEMPORAL_RANGE pass-through when `query_object.granularity` was set, so the original (un-shifted) bounds were forwarded verbatim to both queries.
- `_convert_query_object_filter`'s TEMPORAL_RANGE handler has no notion of `time_offset` — it just emits literal `gte`/`lt` filters from the input range.

Net effect: main and offset Cube requests were byte-for-byte identical → identical responses → time comparison was a no-op.

Fix introduces a new `_get_time_axis_column(query_object, all_dimensions)` helper that resolves the temporal column from any of three sources, in order: `query_object.granularity` → first temporal entry in `query_object.columns` → `col` of any TEMPORAL_RANGE filter in `query_object.filter`. Both `_get_time_filter` and the TEMPORAL_RANGE skip in `_get_filters_from_query_object` now consult this helper, so the offset-aware code path takes over and the TEMPORAL_RANGE pass-through is skipped whenever a time axis is identifiable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


1. On a semantic-view-backed chart in Explore, set a time-range adhoc filter (e.g. `2020-01-01 : 2020-12-31` on a temporal column) and enable `time_compare` with `1 month ago`. Run the chart.
2. Inspect the response's `query` field: the two `-- cube` blocks should differ — the offset block's `gte` should be shifted back by one month (e.g. `2019-12-01T00:00:00`) and its `lt` accordingly.
3. The `__1 month ago` metric column in the result should now diverge from the base metric column.
4. Backend regression: `pytest --cov=superset/semantic_layers/ ./tests/unit_tests/semantic_layers/ --cov-fail-under=100` — 352 tests, 100% coverage.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
