### PR TITLE
fix(sql-lab): use function valueGetter for GridTable row numbers

### DIFF
--- a/superset-frontend/src/components/GridTable/index.tsx
+++ b/superset-frontend/src/components/GridTable/index.tsx
@@ -19,7 +19,12 @@
 import { useCallback, useMemo } from 'react';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ThemedAgGridReact } from '@superset-ui/core/components';
-import type { CellKeyDownEvent, Column, GridOptions } from 'ag-grid-community';
+import type {
+  CellKeyDownEvent,
+  Column,
+  GridOptions,
+  ValueGetterParams,
+} from 'ag-grid-community';
 import type { AgGridReactProps } from 'ag-grid-react';
 
 import copyTextToClipboard from 'src/utils/copy';
@@ -85,7 +90,8 @@ export function GridTable<RecordType extends object>({
       [
         {
           field: PIVOT_COL_ID,
-          valueGetter: 'node.rowIndex+1',
+          valueGetter: (params: ValueGetterParams) =>
+            (params.node?.rowIndex ?? 0) + 1,
           cellClass: 'row-number-col',
           cellStyle: {
             backgroundColor: theme.colorFillTertiary,


### PR DESCRIPTION
String expression value getters require CSP unsafe-eval under production Talisman settings. Use a function valueGetter so SQL Lab result row numbers render without relaxing script-src.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
