### PR TITLE
fix(sqllab): truncate long tab names in the overflow ("...") dropdown

### DIFF
--- a/superset-frontend/src/SqlLab/SqlLabGlobalStyles.tsx
+++ b/superset-frontend/src/SqlLab/SqlLabGlobalStyles.tsx
@@ -20,6 +20,11 @@
 import { Global } from '@emotion/react';
 import { css } from '@apache-superset/core/theme';
 
+// Class applied to the SQL Lab tab bar's overflow ("...") dropdown so its menu
+// items truncate long tab names. The dropdown is portaled to the body, outside
+// the tabs' emotion scope, so it is styled here via a global rule.
+export const SQLLAB_TAB_OVERFLOW_POPUP_CLASS = 'sqllab-tab-overflow-popup';
+
 export const SqlLabGlobalStyles = () => (
   <Global
     styles={theme => css`
@@ -29,6 +34,31 @@ export const SqlLabGlobalStyles = () => (
           ${theme.sizeUnit * 125}px
         ); // Set a min height so the gutter is always visible when resizing
         overflow: hidden;
+      }
+
+      // The tab label is a flex node (icon menu + title + status icon). antd's
+      // overflow dropdown styles each menu item for a plain-text label, so the
+      // nested flex defeats its ellipsis and very long names render blank. Cap
+      // the item width and let the title truncate inside it.
+      .${SQLLAB_TAB_OVERFLOW_POPUP_CLASS} {
+        .ant-tabs-dropdown-menu-item {
+          max-width: ${theme.sizeUnit * 80}px;
+        }
+        .ant-tabs-dropdown-menu-item > span {
+          min-width: 0;
+          overflow: hidden;
+        }
+        [data-test='sql-editor-tab-header'] {
+          min-width: 0;
+          width: 100%;
+        }
+        [data-test='sql-editor-tab-title'] {
+          flex: 1;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       }
     `}
   />

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -55,315 +55,303 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
     ...(store && { store }),
   });
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('SqlEditorTabHeader', () => {
-  test('renders name', () => {
-    const { queryByText } = setup(defaultQueryEditor, mockStore(initialState));
-    expect(queryByText(defaultQueryEditor.name)).toBeInTheDocument();
-    expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
-    expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
-  });
+// Renders the header and opens its "..." dropdown menu, returning the store so
+// each test can assert on the actions it dispatches.
+const openTabDropdown = () => {
+  const store = mockStore(initialState);
+  const { getByTestId } = setup(defaultQueryEditor, store);
+  userEvent.click(getByTestId('dropdown-trigger'));
+  return store;
+};
 
-  test('exposes the name on a dedicated node the overflow dropdown can truncate', () => {
-    // The overflow ("...") menu reuses this label and styles the title node by
-    // its data-test to keep very long names from rendering blank.
-    const { getByTestId } = setup(defaultQueryEditor, mockStore(initialState));
-    expect(getByTestId('sql-editor-tab-title')).toHaveTextContent(
-      defaultQueryEditor.name,
-    );
-  });
+test('renders name', () => {
+  const { queryByText } = setup(defaultQueryEditor, mockStore(initialState));
+  expect(queryByText(defaultQueryEditor.name)).toBeInTheDocument();
+  expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
+  expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
+});
 
-  test('renders name from unsaved changes', () => {
-    const expectedTitle = 'updated title';
-    const { queryByText } = setup(
-      defaultQueryEditor,
-      mockStore({
-        ...initialState,
-        sqlLab: {
-          ...initialState.sqlLab,
-          unsavedQueryEditor: {
-            id: defaultQueryEditor.id,
-            name: expectedTitle,
-          },
-        },
-      }),
-    );
-    expect(queryByText(expectedTitle)).toBeInTheDocument();
-    expect(queryByText(defaultQueryEditor.name)).not.toBeInTheDocument();
-    expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
-    expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
-  });
+test('exposes the name on a dedicated node the overflow dropdown can truncate', () => {
+  // The overflow ("...") menu reuses this label and styles the title node by
+  // its data-test to keep very long names from rendering blank.
+  const { getByTestId } = setup(defaultQueryEditor, mockStore(initialState));
+  expect(getByTestId('sql-editor-tab-title')).toHaveTextContent(
+    defaultQueryEditor.name,
+  );
+});
 
-  test('renders current name for unrelated unsaved changes', () => {
-    const unrelatedTitle = 'updated title';
-    const { queryByText } = setup(
-      defaultQueryEditor,
-      mockStore({
-        ...initialState,
-        sqlLab: {
-          ...initialState.sqlLab,
-          unsavedQueryEditor: {
-            id: `${defaultQueryEditor.id}-other`,
-            name: unrelatedTitle,
-          },
-        },
-      }),
-    );
-    expect(queryByText(defaultQueryEditor.name)).toBeInTheDocument();
-    expect(queryByText(unrelatedTitle)).not.toBeInTheDocument();
-    expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
-    expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
-  });
-
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('with dropdown menus', () => {
-    let store = mockStore();
-    beforeEach(async () => {
-      store = mockStore(initialState);
-      const { getByTestId } = setup(defaultQueryEditor, store);
-      const dropdown = getByTestId('dropdown-trigger');
-
-      userEvent.click(dropdown);
-    });
-
-    test('should dispatch removeQueryEditor action', async () => {
-      await waitFor(() =>
-        expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
-      );
-
-      fireEvent.click(screen.getByTestId('close-tab-menu-option'));
-
-      const actions = store.getActions();
-      await waitFor(() =>
-        expect(actions[0]).toEqual({
-          type: REMOVE_QUERY_EDITOR,
-          queryEditor: defaultQueryEditor,
-        }),
-      );
-    });
-
-    test('should dispatch queryEditorSetTitle action', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      const expectedTitle = 'typed text';
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
-
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: expectedTitle } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      const actions = store.getActions();
-      await waitFor(() =>
-        expect(actions[0]).toEqual({
-          type: QUERY_EDITOR_SET_TITLE,
+test('renders name from unsaved changes', () => {
+  const expectedTitle = 'updated title';
+  const { queryByText } = setup(
+    defaultQueryEditor,
+    mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        unsavedQueryEditor: {
+          id: defaultQueryEditor.id,
           name: expectedTitle,
-          queryEditor: expect.objectContaining({
-            id: defaultQueryEditor.id,
-          }),
-        }),
-      );
-    });
+        },
+      },
+    }),
+  );
+  expect(queryByText(expectedTitle)).toBeInTheDocument();
+  expect(queryByText(defaultQueryEditor.name)).not.toBeInTheDocument();
+  expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
+  expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
+});
 
-    test('prefills the rename input with the current tab name', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+test('renders current name for unrelated unsaved changes', () => {
+  const unrelatedTitle = 'updated title';
+  const { queryByText } = setup(
+    defaultQueryEditor,
+    mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        unsavedQueryEditor: {
+          id: `${defaultQueryEditor.id}-other`,
+          name: unrelatedTitle,
+        },
+      },
+    }),
+  );
+  expect(queryByText(defaultQueryEditor.name)).toBeInTheDocument();
+  expect(queryByText(unrelatedTitle)).not.toBeInTheDocument();
+  expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
+  expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
+});
 
-      const input = await screen.findByTestId('rename-tab-input');
-      expect(input).toHaveValue(defaultQueryEditor.name);
-    });
+test('should dispatch removeQueryEditor action', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
+  );
 
-    test('focuses the rename input when the modal opens', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  fireEvent.click(screen.getByTestId('close-tab-menu-option'));
 
-      const input = await screen.findByTestId('rename-tab-input');
-      await waitFor(() => expect(input).toHaveFocus());
-    });
+  const actions = store.getActions();
+  await waitFor(() =>
+    expect(actions[0]).toEqual({
+      type: REMOVE_QUERY_EDITOR,
+      queryEditor: defaultQueryEditor,
+    }),
+  );
+});
 
-    test('disables Save when the input is empty or whitespace', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+test('should dispatch queryEditorSetTitle action', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  const expectedTitle = 'typed text';
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: '   ' } });
-      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-    });
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: expectedTitle } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    test('does not dispatch or dismiss on Enter when the input is empty', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  const actions = store.getActions();
+  await waitFor(() =>
+    expect(actions[0]).toEqual({
+      type: QUERY_EDITOR_SET_TITLE,
+      name: expectedTitle,
+      queryEditor: expect.objectContaining({
+        id: defaultQueryEditor.id,
+      }),
+    }),
+  );
+});
 
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: '   ' } });
-      fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, charCode: 13 });
+test('prefills the rename input with the current tab name', async () => {
+  openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      const dispatchedTitleChange = store
-        .getActions()
-        .some(action => action.type === QUERY_EDITOR_SET_TITLE);
-      expect(dispatchedTitleChange).toBe(false);
-      // the modal must stay open so the user can correct the name,
-      // mirroring the disabled Save button rather than dismissing like Escape
-      expect(screen.queryByRole('dialog')).toBeInTheDocument();
-    });
+  const input = await screen.findByTestId('rename-tab-input');
+  expect(input).toHaveValue(defaultQueryEditor.name);
+});
 
-    test('does not dispatch a title change when the modal is cancelled', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+test('focuses the rename input when the modal opens', async () => {
+  openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: 'discarded text' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  const input = await screen.findByTestId('rename-tab-input');
+  await waitFor(() => expect(input).toHaveFocus());
+});
 
-      expect(store.getActions()).toEqual([]);
-    });
+test('disables Save when the input is empty or whitespace', async () => {
+  openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-    test('does not dispatch a title change when dismissed with the close button', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: '   ' } });
+  expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+});
 
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: 'discarded text' } });
-      fireEvent.click(screen.getByTestId('close-modal-btn'));
+test('does not dispatch or dismiss on Enter when the input is empty', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      expect(store.getActions()).toEqual([]);
-    });
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: '   ' } });
+  fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, charCode: 13 });
 
-    test('returns focus to the tab header after the modal is cancelled', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  const dispatchedTitleChange = store
+    .getActions()
+    .some(action => action.type === QUERY_EDITOR_SET_TITLE);
+  expect(dispatchedTitleChange).toBe(false);
+  // the modal must stay open so the user can correct the name,
+  // mirroring the disabled Save button rather than dismissing like Escape
+  expect(screen.queryByRole('dialog')).toBeInTheDocument();
+});
 
-      await screen.findByTestId('rename-tab-input');
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+test('does not dispatch a title change when the modal is cancelled', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      await waitFor(() =>
-        expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
-      );
-    });
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: 'discarded text' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    test('returns focus to the tab header after a successful rename', async () => {
-      await waitFor(() =>
-        expect(
-          screen.getByTestId('rename-tab-menu-option'),
-        ).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  expect(store.getActions()).toEqual([]);
+});
 
-      const input = await screen.findByTestId('rename-tab-input');
-      fireEvent.change(input, { target: { value: 'renamed tab' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+test('does not dispatch a title change when dismissed with the close button', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-      await waitFor(() =>
-        expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
-      );
-    });
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: 'discarded text' } });
+  fireEvent.click(screen.getByTestId('close-modal-btn'));
 
-    test('should dispatch removeAllOtherQueryEditors action', async () => {
-      await waitFor(() =>
-        expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('close-all-other-menu-option'));
+  expect(store.getActions()).toEqual([]);
+});
 
-      const actions = store.getActions();
-      await waitFor(() =>
-        expect(actions).toEqual([
-          {
-            type: REMOVE_QUERY_EDITOR,
-            queryEditor: initialState.sqlLab.queryEditors[1],
-          },
-          {
-            type: REMOVE_QUERY_EDITOR,
-            queryEditor: initialState.sqlLab.queryEditors[2],
-          },
-        ]),
-      );
-    });
+test('returns focus to the tab header after the modal is cancelled', async () => {
+  openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-    test('should dispatch cloneQueryToNewTab action', async () => {
-      await waitFor(() =>
-        expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
-      );
-      fireEvent.click(screen.getByTestId('clone-tab-menu-option'));
+  await screen.findByTestId('rename-tab-input');
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-      const actions = store.getActions();
-      await waitFor(() =>
-        expect(actions[0]).toEqual({
-          type: ADD_QUERY_EDITOR,
-          queryEditor: expect.objectContaining({
-            name: `Copy of ${defaultQueryEditor.name}`,
-            sql: defaultQueryEditor.sql,
-            autorun: false,
-          }),
-        }),
-      );
-    });
-  });
+  await waitFor(() =>
+    expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
+  );
+});
 
-  test('does not leak tab-editing keystrokes from the rename input to the surrounding tabs', async () => {
-    const onContainerKeyDown = jest.fn();
-    const store = mockStore(initialState);
-    render(
-      <div onKeyDown={onContainerKeyDown}>
-        <SqlEditorTabHeader queryEditor={defaultQueryEditor} />
-      </div>,
-      { useRedux: true, store },
-    );
+test('returns focus to the tab header after a successful rename', async () => {
+  openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
 
-    userEvent.click(screen.getByTestId('dropdown-trigger'));
-    await waitFor(() =>
-      expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
-    );
-    fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
-    const input = await screen.findByTestId('rename-tab-input');
+  const input = await screen.findByTestId('rename-tab-input');
+  fireEvent.change(input, { target: { value: 'renamed tab' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    // The modal portals over the editable-card tabs, whose keyboard handler would
-    // otherwise remove, navigate, or activate a tab (and swallow Space). None of
-    // these keys should escape the modal to the surrounding container.
-    [
-      'Delete',
-      'Backspace',
-      'ArrowLeft',
-      'ArrowRight',
-      'Home',
-      'End',
-      ' ',
-    ].forEach(key => fireEvent.keyDown(input, { key }));
-    expect(onContainerKeyDown).not.toHaveBeenCalled();
+  await waitFor(() =>
+    expect(screen.getByTestId('sql-editor-tab-header')).toHaveFocus(),
+  );
+});
 
-    // Escape (close) and Tab (focus trap) must still reach the Modal.
-    fireEvent.keyDown(input, { key: 'Tab' });
-    fireEvent.keyDown(input, { key: 'Escape' });
-    const reached = onContainerKeyDown.mock.calls.map(call => call[0].key);
-    expect(reached).toEqual(expect.arrayContaining(['Tab', 'Escape']));
-  });
+test('should dispatch removeAllOtherQueryEditors action', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('close-all-other-menu-option'));
+
+  const actions = store.getActions();
+  await waitFor(() =>
+    expect(actions).toEqual([
+      {
+        type: REMOVE_QUERY_EDITOR,
+        queryEditor: initialState.sqlLab.queryEditors[1],
+      },
+      {
+        type: REMOVE_QUERY_EDITOR,
+        queryEditor: initialState.sqlLab.queryEditors[2],
+      },
+    ]),
+  );
+});
+
+test('should dispatch cloneQueryToNewTab action', async () => {
+  const store = openTabDropdown();
+  await waitFor(() =>
+    expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('clone-tab-menu-option'));
+
+  const actions = store.getActions();
+  await waitFor(() =>
+    expect(actions[0]).toEqual({
+      type: ADD_QUERY_EDITOR,
+      queryEditor: expect.objectContaining({
+        name: `Copy of ${defaultQueryEditor.name}`,
+        sql: defaultQueryEditor.sql,
+        autorun: false,
+      }),
+    }),
+  );
+});
+
+test('does not leak tab-editing keystrokes from the rename input to the surrounding tabs', async () => {
+  const onContainerKeyDown = jest.fn();
+  const store = mockStore(initialState);
+  render(
+    <div onKeyDown={onContainerKeyDown}>
+      <SqlEditorTabHeader queryEditor={defaultQueryEditor} />
+    </div>,
+    { useRedux: true, store },
+  );
+
+  userEvent.click(screen.getByTestId('dropdown-trigger'));
+  await waitFor(() =>
+    expect(screen.getByTestId('rename-tab-menu-option')).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+  const input = await screen.findByTestId('rename-tab-input');
+
+  // The modal portals over the editable-card tabs, whose keyboard handler would
+  // otherwise remove, navigate, or activate a tab (and swallow Space). None of
+  // these keys should escape the modal to the surrounding container.
+  [
+    'Delete',
+    'Backspace',
+    'ArrowLeft',
+    'ArrowRight',
+    'Home',
+    'End',
+    ' ',
+  ].forEach(key => fireEvent.keyDown(input, { key }));
+  expect(onContainerKeyDown).not.toHaveBeenCalled();
+
+  // Escape (close) and Tab (focus trap) must still reach the Modal.
+  fireEvent.keyDown(input, { key: 'Tab' });
+  fireEvent.keyDown(input, { key: 'Escape' });
+  const reached = onContainerKeyDown.mock.calls.map(call => call[0].key);
+  expect(reached).toEqual(expect.arrayContaining(['Tab', 'Escape']));
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -64,6 +64,15 @@ describe('SqlEditorTabHeader', () => {
     expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
   });
 
+  test('exposes the name on a dedicated node the overflow dropdown can truncate', () => {
+    // The overflow ("...") menu reuses this label and styles the title node by
+    // its data-test to keep very long names from rendering blank.
+    const { getByTestId } = setup(defaultQueryEditor, mockStore(initialState));
+    expect(getByTestId('sql-editor-tab-title')).toHaveTextContent(
+      defaultQueryEditor.name,
+    );
+  });
+
   test('renders name from unsaved changes', () => {
     const expectedTitle = 'updated title';
     const { queryByText } = setup(

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -245,7 +245,7 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
           />
         }
       />
-      <TabTitle>{qe.name}</TabTitle>{' '}
+      <TabTitle data-test="sql-editor-tab-title">{qe.name}</TabTitle>{' '}
       <StatusIcon
         className="status-icon"
         iconSize="m"

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
@@ -263,7 +263,7 @@ function TabbedSqlEditors({
       hideAdd={offline}
       onTabClick={onTabClicked}
       onEdit={handleEdit}
-      more={{ overlayClassName: SQLLAB_TAB_OVERFLOW_POPUP_CLASS }}
+      popupClassName={SQLLAB_TAB_OVERFLOW_POPUP_CLASS}
       type={queryEditors?.length === 0 ? 'card' : 'editable-card'}
       addIcon={
         <Tooltip

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
@@ -29,6 +29,7 @@ import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { detectOS } from 'src/utils/common';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
 import { Icons } from '@superset-ui/core/components/Icons';
+import { SQLLAB_TAB_OVERFLOW_POPUP_CLASS } from 'src/SqlLab/SqlLabGlobalStyles';
 import SqlEditor from '../SqlEditor';
 import SqlEditorTabHeader from '../SqlEditorTabHeader';
 
@@ -262,6 +263,7 @@ function TabbedSqlEditors({
       hideAdd={offline}
       onTabClick={onTabClicked}
       onEdit={handleEdit}
+      more={{ overlayClassName: SQLLAB_TAB_OVERFLOW_POPUP_CLASS }}
       type={queryEditors?.length === 0 ? 'card' : 'editable-card'}
       addIcon={
         <Tooltip


### PR DESCRIPTION
### SUMMARY

When a SQL Lab tab has a very long name and the tab bar collapses tabs into the overflow ("...") dropdown, the dropdown entries render **blank**, so overflowed tabs become unreachable.

The tab `label` is a flex node (`SqlEditorTabHeader`: icon menu + title + status icon), not plain text. antd styles each overflow menu item for a plain-text label (`overflow:hidden` + `text-overflow:ellipsis` on the item, `flex:1` on its `> span`). The nested flex `TabTitleWrapper` defeats that ellipsis and, with no width bound, an extremely long name overflows the item and gets clipped out of view.

Fix: scope a style to the overflow dropdown (via the tabs `more` `overlayClassName`) that caps the menu-item width and lets the title truncate inside it. The dropdown is portaled to `body`, outside the tabs' emotion scope, so the rule lives in `SqlLabGlobalStyles`. The tab bar itself is untouched.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: overflow dropdown rows for long-named tabs show empty space (no name).

<img width="1155" height="185" alt="image" src="https://github.com/user-attachments/assets/e55204c2-97eb-4a95-b195-af494cdc535f" />

After: each row shows the name truncated with an ellipsis, e.g. `AAAAAAAA…`, with the menu icon and status dot still visible.

<img width="1275" height="138" alt="image" src="https://github.com/user-attachments/assets/0b2741fb-e300-4cc6-8f4b-3b058c214fc7" />


### TESTING INSTRUCTIONS

1. Open SQL Lab.
2. Rename a tab to a very long string (200+ chars) and/or open enough tabs to force overflow.
3. Click the "..." overflow control at the right of the tab bar.
4. Each hidden tab now lists its name (truncated with an ellipsis) and clicking switches to it.

Unit: `npm run test -- src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [x] Changes UI — SQL Lab tab overflow dropdown only
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

https://claude.ai/code/session_015i9w3EMM6EY647fa6SBBSS