### PR TITLE
fix(mcp): escape LIKE wildcards in find_users to prevent user enumeration

### DIFF
--- a/superset/mcp_service/system/tool/find_users.py
+++ b/superset/mcp_service/system/tool/find_users.py
@@ -65,7 +65,7 @@ async def find_users(request: FindUsersRequest, ctx: Context) -> FindUsersRespon
     )
 
     user_model = security_manager.user_model
-    needle = f"%{escape_like(request.query.strip())}%"
+    needle: str = f"%{escape_like(request.query.strip())}%"
 
     with event_logger.log_context(action="mcp.find_users.query"):
         query = (

--- a/superset/mcp_service/system/tool/find_users.py
+++ b/superset/mcp_service/system/tool/find_users.py
@@ -64,17 +64,25 @@ async def find_users(request: FindUsersRequest, ctx: Context) -> FindUsersRespon
     )
 
     user_model = security_manager.user_model
-    needle = f"%{request.query.strip()}%"
+    # Escape LIKE metacharacters so a query of "%" or "_" cannot enumerate all
+    # users. Backslash must be doubled first to avoid double-escaping.
+    escaped = (
+        request.query.strip()
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+    needle = f"%{escaped}%"
 
     with event_logger.log_context(action="mcp.find_users.query"):
         query = (
             db.session.query(user_model)
             .filter(
                 or_(
-                    user_model.username.ilike(needle),
-                    user_model.first_name.ilike(needle),
-                    user_model.last_name.ilike(needle),
-                    user_model.email.ilike(needle),
+                    user_model.username.ilike(needle, escape="\\"),
+                    user_model.first_name.ilike(needle, escape="\\"),
+                    user_model.last_name.ilike(needle, escape="\\"),
+                    user_model.email.ilike(needle, escape="\\"),
                 )
             )
             .order_by(user_model.username.asc())

--- a/superset/mcp_service/system/tool/find_users.py
+++ b/superset/mcp_service/system/tool/find_users.py
@@ -29,6 +29,7 @@ from superset.mcp_service.system.schemas import (
     FindUsersResponse,
     UserMatch,
 )
+from superset.mcp_service.utils.sanitization import escape_like
 
 logger = logging.getLogger(__name__)
 
@@ -64,15 +65,7 @@ async def find_users(request: FindUsersRequest, ctx: Context) -> FindUsersRespon
     )
 
     user_model = security_manager.user_model
-    # Escape LIKE metacharacters so a query of "%" or "_" cannot enumerate all
-    # users. Backslash must be doubled first to avoid double-escaping.
-    escaped = (
-        request.query.strip()
-        .replace("\\", "\\\\")
-        .replace("%", "\\%")
-        .replace("_", "\\_")
-    )
-    needle = f"%{escaped}%"
+    needle = f"%{escape_like(request.query.strip())}%"
 
     with event_logger.log_context(action="mcp.find_users.query"):
         query = (

--- a/superset/mcp_service/utils/__init__.py
+++ b/superset/mcp_service/utils/__init__.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from superset.mcp_service.utils.sanitization import (
+    escape_like as escape_like,
     escape_llm_context_delimiters as escape_llm_context_delimiters,
     sanitize_for_llm_context as sanitize_for_llm_context,
 )

--- a/superset/mcp_service/utils/sanitization.py
+++ b/superset/mcp_service/utils/sanitization.py
@@ -550,3 +550,13 @@ def sanitize_sql_expression(  # noqa: C901
     _check_dangerous_stored_procedures(value, field_name)
 
     return value
+
+
+def escape_like(value: str) -> str:
+    """Escape SQL LIKE metacharacters in *value*, using backslash as the escape char.
+
+    Pair the result with escape="\\" in every .ilike() / .like()
+    call so the database treats \\, \\%, and \\_ as literals.
+    Backslash is doubled first to prevent double-escaping.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/tests/unit_tests/mcp_service/system/tool/test_find_users.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_find_users.py
@@ -255,3 +255,84 @@ async def test_list_charts_passes_changed_by_fk_filter_to_dao(mock_list, mcp_ser
     forwarded_filters = mock_list.call_args.kwargs.get("column_operators")
     assert forwarded_filters is not None
     assert any(getattr(f, "col", None) == "changed_by_fk" for f in forwarded_filters)
+
+
+# ---------------------------------------------------------------------------
+# LIKE wildcard escaping tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_users_escapes_percent_wildcard(mcp_server):
+    """query='%' must not enumerate all users; the LIKE pattern must be escaped."""
+    session, _ = _patch_user_query([])
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_") as mock_or,
+    ):
+        mock_db.session = session
+        user_model = MagicMock()
+        mock_sm.user_model = user_model
+        mock_or.return_value = MagicMock()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("find_users", {"request": {"query": "%"}})
+
+    data = json.loads(result.content[0].text)
+    assert data["count"] == 0
+    # Needle must be "%\%%" (escaped %) not "%%%" (all-rows wildcard)
+    ilike_call = user_model.username.ilike.call_args
+    assert ilike_call is not None
+    assert ilike_call.args[0] == "%\\%%"
+    assert ilike_call.kwargs.get("escape") == "\\"
+
+
+@pytest.mark.asyncio
+async def test_find_users_escapes_underscore_wildcard(mcp_server):
+    """query='_' must not match single-character strings via SQL LIKE wildcard."""
+    session, _ = _patch_user_query([])
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_") as mock_or,
+    ):
+        mock_db.session = session
+        user_model = MagicMock()
+        mock_sm.user_model = user_model
+        mock_or.return_value = MagicMock()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("find_users", {"request": {"query": "_"}})
+
+    data = json.loads(result.content[0].text)
+    assert data["count"] == 0
+    ilike_call = user_model.username.ilike.call_args
+    assert ilike_call is not None
+    assert ilike_call.args[0] == "%\\_%"
+    assert ilike_call.kwargs.get("escape") == "\\"
+
+
+@pytest.mark.asyncio
+async def test_find_users_escapes_literal_backslash(mcp_server):
+    """A literal backslash in the query must be doubled in the LIKE pattern."""
+    session, _ = _patch_user_query([])
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_") as mock_or,
+    ):
+        mock_db.session = session
+        user_model = MagicMock()
+        mock_sm.user_model = user_model
+        mock_or.return_value = MagicMock()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("find_users", {"request": {"query": "\\"}})
+
+    data = json.loads(result.content[0].text)
+    assert data["count"] == 0
+    ilike_call = user_model.username.ilike.call_args
+    assert ilike_call is not None
+    assert ilike_call.args[0] == "%\\\\%"
+    assert ilike_call.kwargs.get("escape") == "\\"

--- a/tests/unit_tests/mcp_service/utils/test_sanitization.py
+++ b/tests/unit_tests/mcp_service/utils/test_sanitization.py
@@ -1024,3 +1024,44 @@ def test_sanitize_sql_expression_allows_url_scheme_in_string_literal():
     sanitize_sql_expression = _sanitize_sql()
     expr = "COUNT(CASE WHEN url LIKE 'javascript:%' THEN 1 END)"
     assert sanitize_sql_expression(expr, "sql_expression") == expr
+
+
+# ---------------------------------------------------------------------------
+# escape_like
+# ---------------------------------------------------------------------------
+
+
+def test_escape_like_plain_text():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("maxime") == "maxime"
+
+
+def test_escape_like_percent():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("%") == "\\%"
+
+
+def test_escape_like_underscore():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("_") == "\\_"
+
+
+def test_escape_like_backslash():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("\\") == "\\\\"
+
+
+def test_escape_like_mixed():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("a%b_c\\") == "a\\%b\\_c\\\\"
+
+
+def test_escape_like_empty_string():
+    from superset.mcp_service.utils.sanitization import escape_like
+
+    assert escape_like("") == ""


### PR DESCRIPTION
## Summary

- The `find_users` MCP tool was building its LIKE pattern directly from raw user input, so `query="%"` matched every row in the users table — directly contradicting the docstring claim that the tool does not enumerate the full user directory.
- Escape backslash first (to avoid double-escaping), then `%`, then `_`, before wrapping in the surrounding `%…%` wildcards.
- Pass `escape="\\"` to every `.ilike()` call so the database treats the escape sequences as literals.
- Add unit tests for `query="%"`, `query="_"`, and a query containing a literal backslash.

## Test plan

- [ ] `pytest tests/unit_tests/mcp_service/system/tool/test_find_users.py` — 16 tests, all pass
- [ ] Verify `query="%"` produces needle `%\%%` with `escape="\\"` (not `%%%`)
- [ ] Verify `query="_"` produces needle `%\_%` with `escape="\\"` (not `%_%`)
- [ ] Verify `query="\\"` produces needle `%\\%` with `escape="\\"`