### PR TITLE
fix(mcp): document select_columns valid fields and URL scheme for preview tools

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -2231,7 +2231,14 @@ class URLPreview(BaseModel):
     """URL-based preview format."""
 
     type: Literal["url"] = "url"
-    preview_url: str = Field(..., description="Explore URL for opening the chart")
+    preview_url: str = Field(
+        ...,
+        description=(
+            "Explore URL for opening the chart. "
+            "The scheme matches the configured instance URL "
+            "(HTTPS in production/staging, HTTP in local development)."
+        ),
+    )
     width: int = Field(..., description="Requested Explore viewport width in pixels")
     height: int = Field(..., description="Requested Explore viewport height in pixels")
     supports_interaction: bool = Field(

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1432,6 +1432,10 @@ async def get_chart_preview(
     """Get chart preview by ID or UUID.
 
     Returns preview URL or formatted content (ascii, table, vega_lite).
+
+    When format includes 'url', the returned preview_url uses the same scheme
+    as the configured instance URL (HTTPS in production/staging, HTTP in local
+    development).
     """
     await ctx.info(
         "Starting chart preview generation: identifier=%s, format=%s, width=%s, "

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -128,7 +128,9 @@ def update_chart_preview(  # noqa: C901
     - Iterating on chart design without creating permanent charts
     - Testing different configurations
 
-    Returns new form_data_key, preview images, and explore URL.
+    Returns new form_data_key, preview images, and explore URL. The explore_url
+    scheme matches the configured instance URL (HTTPS in production/staging,
+    HTTP in local development).
     """
     start_time = time.time()
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -369,10 +369,17 @@ class GetDatasetInfoRequest(MetadataCacheControl):
         Field(
             default_factory=lambda: list(DEFAULT_GET_DATASET_INFO_COLUMNS),
             description=(
-                "Top-level fields to include in the response. Defaults to a lean "
-                "set that excludes verbose fields like params, template_params, "
-                "extra, tags, certification_details. Pass an explicit list to "
-                "override (e.g. ['id','table_name','columns'] for minimal output)."
+                "Top-level fields to include in the response. "
+                "Default set: 'id', 'table_name', 'schema', 'database_name', "
+                "'database_id', 'uuid', 'is_virtual', 'description', "
+                "'main_dttm_col', 'sql', 'url', 'columns', 'metrics'. "
+                "Additional available fields: 'certified_by', "
+                "'certification_details', 'changed_on', 'changed_on_humanized', "
+                "'created_on', 'created_on_humanized', 'tags', 'schema_perm', "
+                "'offset', 'cache_timeout', 'params', 'template_params', "
+                "'extra', 'is_favorite'. "
+                "Pass an explicit list to select only what you need "
+                "(e.g. ['id', 'table_name', 'columns', 'metrics'])."
             ),
         ),
     ]

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -74,6 +74,15 @@ async def get_dataset_info(
     (pre-defined saved metrics). When building chart configs, use saved_metric=true
     for metrics — do not treat them as columns. See instructions for details.
 
+    The select_columns parameter controls which top-level fields are returned.
+    Default fields: 'id', 'table_name', 'schema', 'database_name', 'database_id',
+    'uuid', 'is_virtual', 'description', 'main_dttm_col', 'sql', 'url',
+    'columns', 'metrics'.
+    Additional fields available on request: 'certified_by', 'certification_details',
+    'changed_on', 'changed_on_humanized', 'created_on', 'created_on_humanized',
+    'tags', 'schema_perm', 'offset', 'cache_timeout', 'params', 'template_params',
+    'extra', 'is_favorite'.
+
     Example usage:
     ```json
     {
@@ -85,6 +94,14 @@ async def get_dataset_info(
     ```json
     {
         "identifier": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+    }
+    ```
+
+    Or to fetch only columns metadata:
+    ```json
+    {
+        "identifier": 123,
+        "select_columns": ["columns"]
     }
     ```
     """

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -105,7 +105,8 @@ async def generate_explore_link(
     Only use generate_chart when user EXPLICITLY requests to save/create a
     permanent chart.
 
-    Returns explore URL for immediate use.
+    Returns explore URL for immediate use. The URL scheme matches the configured
+    instance URL (HTTPS in production/staging, HTTP in local development).
     """
     chart_type = request.config.chart_type if request.config else "none"
     await ctx.info(

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -94,6 +94,8 @@ def open_sql_lab_with_context(
     """Generate SQL Lab URL with pre-populated sql and context.
 
     Pass the sql parameter to pre-fill the editor. Returns URL for direct navigation.
+    The URL scheme matches the configured instance URL (HTTPS in production/staging,
+    HTTP in local development).
     """
     try:
         from superset.daos.database import DatabaseDAO


### PR DESCRIPTION
## Summary

- **`get_dataset_info` / `select_columns`**: The field description did not list which values are valid. Updated both `GetDatasetInfoRequest.select_columns` and the function docstring to enumerate the default set and all additional available field names so the model can construct a working call from the schema alone.

- **URL scheme for preview/link tools**: `get_chart_preview`, `generate_explore_link`, `update_chart_preview`, and `open_sql_lab_with_context` did not document the URL scheme of their returned URLs. Added a note that the scheme mirrors the configured instance URL (HTTPS in production/staging, HTTP in local development). Also updated `URLPreview.preview_url` field description.

## Testing

- Changes are docstring/schema description only — no logic changes
- Pre-commit passes