### PR TITLE
fix(i18n): key translation-regression check on per-msgid transitions

### DIFF
--- a/scripts/translations/check_translation_regression.py
+++ b/scripts/translations/check_translation_regression.py
@@ -20,21 +20,31 @@ Check that source-code changes don't cause translation regressions.
 
 What counts as a regression
 ---------------------------
-A regression is an *existing translation that a source change invalidated*.
-The check keys on the **increase in fuzzy entries** rather than a drop in the
-translated count, because a count drop happens identically for a benign
-*deletion* and a real *rename*, so it cannot distinguish the two — whereas a
-``#, fuzzy`` marker unambiguously flags a stranded translation.
+A regression is an *existing translation that a source change invalidated*:
+a message that was a **confirmed, non-fuzzy translation** in the baseline and
+is **fuzzy** after the PR. The check keys on this per-``msgid`` transition
+rather than on the aggregate count of fuzzy entries, because a bare count
+cannot tell apart two changes that move the fuzzy total by the same amount:
+
+* ``translated -> fuzzy`` — a reworded source string stranded a real
+  translation. **This is the regression.**
+* ``untranslated -> fuzzy`` — an empty ``msgstr`` was filled with a fuzzy
+  (unconfirmed) guess, e.g. an AI backfill committed as ``#, fuzzy``. No
+  existing translation was lost, so this is **not** a regression and must
+  pass.
+
+Keying on the per-entry transition lets a backfill PR commit fuzzy guesses for
+previously-untranslated strings (the ja/fi catalog backfills) without tripping
+the check, while still catching a genuine invalidation even when the same PR
+also adds new strings (which a count-delta heuristic would let mask it).
 
 Note ``babel_update.sh`` runs ``pybabel update`` with ``--no-fuzzy-matching``,
 so *adding* (or renaming) a source string does **not** auto-generate a fuzzy
 guess against an unrelated existing translation — new strings land as cleanly
-untranslated (empty ``msgstr``). This deliberately avoids the prior behaviour
-where *every* PR that merely added a translatable string tripped this check on
-spurious fuzzies. As a result the check now guards against ``#, fuzzy`` entries
-that arrive another way — e.g. a committed ``.po`` edit — rather than ones the
-update step synthesises. *Deleting* a string is still not a regression: with
-``--ignore-obsolete`` it is simply dropped and no fuzzy is created.
+untranslated (empty ``msgstr``). The fuzzies this check sees therefore arrive
+another way — typically a committed ``.po`` edit. *Deleting* a string is still
+not a regression: with ``--ignore-obsolete`` it is simply dropped and no fuzzy
+is created.
 
 Usage
 -----
@@ -127,28 +137,72 @@ def count_stats(po_file: Path) -> dict[str, int]:
     }
 
 
+def entry_keys(po_file: Path) -> dict[str, list[str]]:
+    """Return per-``msgid`` key sets for a .po file.
+
+    ``translated_keys`` lists the non-fuzzy, non-obsolete entries with a
+    populated ``msgstr`` — confirmed translations a source reword could strand.
+    ``fuzzy_keys`` lists the non-obsolete entries carrying the ``fuzzy`` flag
+    (however they arrived — a committed backfill guess or a real invalidation).
+
+    A key combines ``msgctxt`` and ``msgid`` (gettext's own identity rule) so
+    context-disambiguated entries stay distinct. The header entry (empty
+    ``msgid``) is ignored. The regression check compares the baseline's
+    ``translated_keys`` against the PR's ``fuzzy_keys``: their intersection is
+    exactly the set of confirmed translations the PR turned fuzzy.
+
+    Raises:
+        OSError: if ``polib`` cannot read or parse the file. As with a msgfmt
+            failure, a catalog we cannot parse is surfaced rather than silently
+            counted as empty.
+    """
+    import polib  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    translated_keys: list[str] = []
+    fuzzy_keys: list[str] = []
+    for entry in polib.pofile(str(po_file)):
+        if entry.obsolete or not entry.msgid:
+            continue
+        key = f"{entry.msgctxt}\x04{entry.msgid}" if entry.msgctxt else entry.msgid
+        if "fuzzy" in entry.flags:
+            fuzzy_keys.append(key)
+        elif (
+            all(entry.msgstr_plural.values())
+            if entry.msgid_plural
+            else bool(entry.msgstr)
+        ):
+            translated_keys.append(key)
+    return {"translated_keys": translated_keys, "fuzzy_keys": fuzzy_keys}
+
+
 def get_counts(
     translations_dir: Path,
     failures: Optional[set[str]] = None,
-) -> dict[str, dict[str, int]]:
+) -> dict[str, dict[str, object]]:
     """Count translated/fuzzy entries for every ``.po`` file in a directory.
 
+    Each language maps to ``{"translated", "fuzzy", "translated_keys",
+    "fuzzy_keys"}`` — aggregate counts (for the human-readable summary) plus the
+    per-``msgid`` key sets the regression check actually keys on.
+
     If ``failures`` is provided, the name of each language whose ``.po`` file
-    is present on disk but could not be counted (msgfmt non-zero exit, or
-    unparseable output) is added to it. Such a language is deliberately absent
-    from the returned mapping — but, unlike a language whose catalog was simply
-    deleted, it must not be mistaken for an intentional removal: a caller that
-    cares about the distinction (see :func:`cmd_compare`) can inspect
-    ``failures`` and treat it as a hard error.
+    is present on disk but could not be counted (msgfmt non-zero exit,
+    unparseable output, or a polib parse error) is added to it. Such a language
+    is deliberately absent from the returned mapping — but, unlike a language
+    whose catalog was simply deleted, it must not be mistaken for an intentional
+    removal: a caller that cares about the distinction (see :func:`cmd_compare`)
+    can inspect ``failures`` and treat it as a hard error.
     """
-    counts: dict[str, dict[str, int]] = {}
+    counts: dict[str, dict[str, object]] = {}
     for po_file in sorted(translations_dir.glob("*/LC_MESSAGES/messages.po")):
         lang = po_file.parent.parent.name
         if lang in SKIP_LANGS:
             continue
         try:
-            counts[lang] = count_stats(po_file)
-        except (subprocess.CalledProcessError, RuntimeError) as exc:
+            stats: dict[str, object] = dict(count_stats(po_file))
+            stats.update(entry_keys(po_file))
+            counts[lang] = stats
+        except (subprocess.CalledProcessError, RuntimeError, OSError) as exc:
             # A malformed .po file (msgfmt non-zero exit, or stderr we
             # can't parse) is a real problem worth seeing, but it shouldn't
             # take the whole regression check down with it — that would
@@ -164,42 +218,73 @@ def get_counts(
     return counts
 
 
-def _normalize(entry: object) -> dict[str, int]:
-    """Coerce a baseline entry into ``{"translated", "fuzzy"}``.
+def _normalize(entry: object) -> dict[str, object]:
+    """Coerce a baseline entry into ``{"translated", "fuzzy", *_keys}``.
 
-    Tolerates the legacy baseline format where each language mapped directly to
-    an integer translated count (no fuzzy data); such entries contribute a
-    fuzzy baseline of 0.
+    ``translated_keys``/``fuzzy_keys`` are the per-``msgid`` sets the check
+    keys on. They are ``None`` (not ``[]``) when the baseline predates the
+    per-entry format — an absent set means "unknown", which routes
+    :func:`cmd_compare` to the coarse aggregate fallback, whereas an empty list
+    is a known-empty set. Legacy formats — a ``{"translated", "fuzzy"}`` dict
+    with no key sets, or a bare integer translated count — are both tolerated.
     """
     if isinstance(entry, dict):
         return {
             "translated": int(entry.get("translated", 0)),
             "fuzzy": int(entry.get("fuzzy", 0)),
+            "translated_keys": (
+                list(entry["translated_keys"]) if "translated_keys" in entry else None
+            ),
+            "fuzzy_keys": (
+                list(entry["fuzzy_keys"]) if "fuzzy_keys" in entry else None
+            ),
         }
     if isinstance(entry, int):
-        return {"translated": entry, "fuzzy": 0}
+        return {
+            "translated": entry,
+            "fuzzy": 0,
+            "translated_keys": None,
+            "fuzzy_keys": None,
+        }
     raise TypeError(f"Unsupported baseline entry: {entry!r}")
 
 
-def build_regression_report(regressions: list[tuple[str, int, int]]) -> str:
+def _key_list(stats: dict[str, object], field: str) -> Optional[list[str]]:
+    """Return ``stats[field]`` as a list of keys, or ``None`` if unavailable.
+
+    A missing or non-list value reads as "unknown" so the caller can fall back
+    to the aggregate comparison instead of treating it as an empty key set.
+    """
+    value = stats.get(field)
+    return list(value) if isinstance(value, list) else None
+
+
+def _count(stats: dict[str, object], field: str) -> int:
+    """Return ``stats[field]`` as an int count, defaulting to 0."""
+    value = stats.get(field, 0)
+    return value if isinstance(value, int) else 0
+
+
+def build_regression_report(regressions: list[tuple[str, int, int, int]]) -> str:
     """Build a markdown report for posting as a PR comment.
 
-    Each regression tuple is ``(lang, before_fuzzy, after_fuzzy)``.
+    Each regression tuple is ``(lang, before_fuzzy, after_fuzzy, invalidated)``
+    where ``invalidated`` is the number of confirmed translations the PR turned
+    fuzzy.
     """
-    rows = "\n".join(
-        f"| `{lang}` | {b} | {a} | +{a - b} |" for lang, b, a in regressions
-    )
-    affected = ", ".join(f"`{lang}`" for lang, _, _ in regressions)
+    rows = "\n".join(f"| `{lang}` | {n} |" for lang, _b, _a, n in regressions)
+    affected = ", ".join(f"`{lang}`" for lang, *_ in regressions)
     return (
         "## ⚠️ Translation Regression Detected\n\n"
         f"A source change in this PR renamed or reworded strings, invalidating "
         f"existing translations (they are now `#, fuzzy`) in {affected}. Please "
         f"resolve the affected `.po` files before merging.\n\n"
-        "_Note: intentionally **deleting** a translatable string is not a "
-        "regression and is not flagged here — only translations invalidated by "
-        "a renamed/reworded source string are._\n\n"
-        "| Language | Fuzzy before | Fuzzy after | New |\n"
-        "|----------|-------------:|------------:|----:|\n"
+        "_Note: neither intentionally **deleting** a translatable string nor "
+        "filling a previously-**untranslated** entry with a fuzzy guess (e.g. an "
+        "AI backfill) is a regression — only a confirmed translation that a "
+        "renamed/reworded source string turned fuzzy is flagged here._\n\n"
+        "| Language | Invalidated translations |\n"
+        "|----------|-------------------------:|\n"
         f"{rows}\n\n"
         "### How to fix\n\n"
         "**1. Install dependencies** (if not already set up):\n\n"
@@ -231,6 +316,41 @@ def cmd_count(translations_dir: Path) -> None:
     print(json.dumps(counts, indent=2))
 
 
+def _detect_regressions(
+    before: dict[str, dict[str, object]],
+    after: dict[str, dict[str, object]],
+) -> list[tuple[str, int, int, int]]:
+    """Return ``(lang, before_fuzzy, after_fuzzy, invalidated)`` per regressed lang.
+
+    A regression is a key in the baseline's ``translated_keys`` that is fuzzy
+    after the PR — a confirmed translation a source reword stranded. Filling a
+    previously-untranslated entry with a fuzzy guess (backfill) is therefore not
+    flagged (its key was absent from the baseline's translated set), and neither
+    is deleting a string (with ``--ignore-obsolete`` it drops, creating no
+    fuzzy). When per-entry key data is unavailable (a legacy baseline, or a
+    catalog whose key set could not be read), fall back to the coarse rule: any
+    net increase in the aggregate fuzzy count.
+    """
+    regressions: list[tuple[str, int, int, int]] = []
+    for lang, before_stats in sorted(before.items()):
+        after_stats = after.get(lang)
+        if after_stats is None:
+            # Catalog absent from `after`: an intentional deletion (a
+            # present-but-uncountable catalog was already caught by the caller).
+            continue
+        b_fuzzy = _count(before_stats, "fuzzy")
+        a_fuzzy = _count(after_stats, "fuzzy")
+        before_translated = before_stats.get("translated_keys")
+        after_fuzzy = _key_list(after_stats, "fuzzy_keys")
+        if isinstance(before_translated, list) and after_fuzzy is not None:
+            invalidated = set(after_fuzzy) & set(before_translated)
+            if invalidated:
+                regressions.append((lang, b_fuzzy, a_fuzzy, len(invalidated)))
+        elif a_fuzzy > b_fuzzy:
+            regressions.append((lang, b_fuzzy, a_fuzzy, a_fuzzy - b_fuzzy))
+    return regressions
+
+
 def cmd_compare(
     before_path: str,
     translations_dir: Path,
@@ -259,23 +379,12 @@ def cmd_compare(
         )
         sys.exit(1)
 
-    # A regression is an *increase* in fuzzy entries: the PR's source diff
-    # renamed/reworded strings, leaving their committed translations stranded.
-    # A plain drop in the translated count is NOT used — deleting a string
-    # lowers it identically to a rename but is a legitimate change, and with
-    # `pybabel update --ignore-obsolete` a deletion creates no fuzzy entry.
-    regressions: list[tuple[str, int, int]] = []
-    for lang, before_stats in sorted(before.items()):
-        after_stats = after.get(lang, {"translated": 0, "fuzzy": 0})
-        if after_stats["fuzzy"] > before_stats["fuzzy"]:
-            regressions.append((lang, before_stats["fuzzy"], after_stats["fuzzy"]))
-
-    if regressions:
+    if regressions := _detect_regressions(before, after):
         print("Translation regression detected!\n")
-        for lang, b, a in regressions:
+        for lang, _b, _a, n in regressions:
             print(
-                f"  {lang}: {a - b} translation(s) invalidated "
-                f"(fuzzy {b} -> {a}) by a renamed/reworded source string"
+                f"  {lang}: {n} confirmed translation(s) invalidated "
+                f"(now fuzzy) by a renamed/reworded source string"
             )
         print(
             "\nResolve the newly-fuzzy entries in the affected .po files "
@@ -290,14 +399,16 @@ def cmd_compare(
     # All good — print a summary so it's easy to read in CI logs.
     print("No translation regressions.\n")
     for lang in sorted(after):
-        before_stats = before.get(lang, {"translated": 0, "fuzzy": 0})
+        before_stats: dict[str, object] = before.get(lang, {})
         after_stats = after[lang]
-        t_delta = after_stats["translated"] - before_stats["translated"]
-        f_delta = after_stats["fuzzy"] - before_stats["fuzzy"]
+        b_translated = _count(before_stats, "translated")
+        a_translated = _count(after_stats, "translated")
+        b_fuzzy = _count(before_stats, "fuzzy")
+        a_fuzzy = _count(after_stats, "fuzzy")
         print(
-            f"  {lang}: translated {before_stats['translated']} -> "
-            f"{after_stats['translated']} ({t_delta:+d}), fuzzy "
-            f"{before_stats['fuzzy']} -> {after_stats['fuzzy']} ({f_delta:+d})"
+            f"  {lang}: translated {b_translated} -> {a_translated} "
+            f"({a_translated - b_translated:+d}), fuzzy "
+            f"{b_fuzzy} -> {a_fuzzy} ({a_fuzzy - b_fuzzy:+d})"
         )
 
 

--- a/tests/unit_tests/scripts/translations/check_translation_regression_test.py
+++ b/tests/unit_tests/scripts/translations/check_translation_regression_test.py
@@ -157,6 +157,166 @@ def test_writes_report_on_regression(tmp_path: Path) -> None:
     assert "deleting" in body.lower()
 
 
+def test_backfilling_untranslated_strings_as_fuzzy_is_not_a_regression(
+    tmp_path: Path,
+) -> None:
+    # The ja/fi backfill case: previously-empty msgstrs are filled with fuzzy
+    # guesses. The aggregate fuzzy count rises (0 -> 2) but no *confirmed*
+    # translation was lost — the new fuzzy keys were untranslated in the
+    # baseline — so the per-msgid check must let it pass.
+    before = {
+        "ja": {
+            "translated": 10,
+            "fuzzy": 0,
+            "translated_keys": ["A", "B"],
+            "fuzzy_keys": [],
+        }
+    }
+    after = {
+        "ja": {
+            "translated": 10,
+            "fuzzy": 2,
+            "translated_keys": ["A", "B"],
+            "fuzzy_keys": ["C", "D"],
+        }
+    }
+    _compare(tmp_path, before, after)  # no SystemExit
+
+
+def test_invalidating_a_confirmed_translation_is_a_regression(tmp_path: Path) -> None:
+    # A key that was a confirmed (non-fuzzy) translation in the baseline is
+    # fuzzy after the PR -> a reworded source stranded it.
+    before = {
+        "fr": {
+            "translated": 2,
+            "fuzzy": 0,
+            "translated_keys": ["A", "B"],
+            "fuzzy_keys": [],
+        }
+    }
+    after = {
+        "fr": {
+            "translated": 1,
+            "fuzzy": 1,
+            "translated_keys": ["A"],
+            "fuzzy_keys": ["B"],
+        }
+    }
+    with pytest.raises(SystemExit) as exc:
+        _compare(tmp_path, before, after)
+    assert exc.value.code == 1
+
+
+def test_preexisting_fuzzy_staying_fuzzy_is_not_a_regression(tmp_path: Path) -> None:
+    # `B` was already fuzzy on the base branch and stays fuzzy: it was never a
+    # confirmed translation, so the PR did not invalidate anything.
+    before = {
+        "de": {
+            "translated": 1,
+            "fuzzy": 1,
+            "translated_keys": ["A"],
+            "fuzzy_keys": ["B"],
+        }
+    }
+    after = {
+        "de": {
+            "translated": 1,
+            "fuzzy": 1,
+            "translated_keys": ["A"],
+            "fuzzy_keys": ["B"],
+        }
+    }
+    _compare(tmp_path, before, after)  # no SystemExit
+
+
+def test_a_real_regression_is_caught_even_alongside_a_backfill(tmp_path: Path) -> None:
+    # The same PR both backfills empties as fuzzy (X, Y) and strands a confirmed
+    # translation (C). The aggregate fuzzy delta (+3) cannot separate these; the
+    # per-msgid check still catches C.
+    before = {
+        "ja": {
+            "translated": 3,
+            "fuzzy": 0,
+            "translated_keys": ["A", "B", "C"],
+            "fuzzy_keys": [],
+        }
+    }
+    after = {
+        "ja": {
+            "translated": 2,
+            "fuzzy": 3,
+            "translated_keys": ["A", "B"],
+            "fuzzy_keys": ["C", "X", "Y"],
+        }
+    }
+    with pytest.raises(SystemExit) as exc:
+        _compare(tmp_path, before, after)
+    assert exc.value.code == 1
+
+
+def test_report_counts_only_invalidated_msgids(tmp_path: Path) -> None:
+    # B and C were confirmed translations now turned fuzzy; D is a backfill of a
+    # previously-untranslated key. The report must count 2, not 3.
+    before_file = tmp_path / "before.json"
+    before_file.write_text(
+        json.dumps(
+            {
+                "ja": {
+                    "translated": 3,
+                    "fuzzy": 0,
+                    "translated_keys": ["A", "B", "C"],
+                    "fuzzy_keys": [],
+                }
+            }
+        )
+    )
+    report = tmp_path / "report.md"
+    after = {
+        "ja": {
+            "translated": 1,
+            "fuzzy": 3,
+            "translated_keys": ["A"],
+            "fuzzy_keys": ["B", "C", "D"],
+        }
+    }
+    with patch.object(check_translation_regression, "get_counts", return_value=after):
+        with pytest.raises(SystemExit):
+            check_translation_regression.cmd_compare(
+                str(before_file), tmp_path, str(report)
+            )
+    body = report.read_text(encoding="utf-8")
+    assert "| `ja` | 2 |" in body
+
+
+def test_entry_keys_classifies_translated_fuzzy_and_context(tmp_path: Path) -> None:
+    po = tmp_path / "messages.po"
+    po.write_text(
+        'msgid ""\n'
+        'msgstr ""\n'
+        '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+        "\n"
+        'msgid "confirmed"\n'
+        'msgstr "ok"\n'
+        "\n"
+        "#, fuzzy\n"
+        'msgid "guess"\n'
+        'msgstr "maybe"\n'
+        "\n"
+        'msgid "still empty"\n'
+        'msgstr ""\n'
+        "\n"
+        'msgctxt "ctx"\n'
+        'msgid "confirmed"\n'
+        'msgstr "ok in context"\n',
+        encoding="utf-8",
+    )
+    keys = check_translation_regression.entry_keys(po)
+    # The header (empty msgid) and the untranslated entry are excluded; the
+    # context-qualified "confirmed" stays distinct from the plain one.
+    assert keys["translated_keys"] == ["confirmed", "ctx\x04confirmed"]
+    assert keys["fuzzy_keys"] == ["guess"]
+
+
 def test_count_stats_parses_translated_and_fuzzy() -> None:
     stderr = (
         "3731 translated messages, 1009 fuzzy translations, 175 untranslated messages."


### PR DESCRIPTION
### SUMMARY

The translation-regression check (`scripts/translations/check_translation_regression.py`) keyed on the **aggregate per-language fuzzy count**: any net increase in `#, fuzzy` entries was reported as a regression. That count is too coarse to tell apart two changes that move the fuzzy total identically:

- `translated -> fuzzy` — a reworded source string stranded a confirmed translation. **This is the real regression.**
- `untranslated -> fuzzy` — an empty `msgstr` was filled with a fuzzy guess (an AI backfill committed as `#, fuzzy`). **No existing translation was lost — not a regression.**

It also can't catch a genuine `translated -> fuzzy` invalidation when the same PR happens to add new strings (the deltas cancel in aggregate), and — because the baseline is re-extracted on the base branch — its fuzzy totals for heavily-fuzzy catalogs are not even stable run-to-run, so unrelated PRs get flagged with drifting numbers.

This change makes the check compare **per-`msgid`** instead. `--count` now records each language's `translated_keys` / `fuzzy_keys` sets; a regression is a key that was a confirmed (non-fuzzy) translation in the baseline and is fuzzy after the PR (`baseline.translated_keys ∩ after.fuzzy_keys`). Backfills (`untranslated -> fuzzy`) and deletions no longer trip the check, while a real invalidation is still caught even alongside additions. Legacy baselines without the key sets fall back to the prior aggregate rule.

**Why now:** two PRs this week were false-flagged by the aggregate rule — an AI backfill PR (committing fuzzy guesses for previously-untranslated strings) and a frontend-only PR that changes no strings at all but still got a `fi`/`th` "regression" because those backfilled catalogs sit at ~4,800 fuzzy and the baseline count wobbles between runs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI tooling)

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/scripts/translations/check_translation_regression_test.py
```

17 tests pass (11 pre-existing + 6 new). The new cases cover: a backfill (`untranslated -> fuzzy`) passing, a real `translated -> fuzzy` invalidation failing, a pre-existing fuzzy staying fuzzy passing, a real regression caught alongside a backfill, the report counting only invalidated msgids, and `entry_keys` classification (incl. `msgctxt` disambiguation). `ruff` and `mypy` are clean.

End-to-end against real catalogs: recording a baseline then flipping an `untranslated -> fuzzy` entry passes (exit 0), while a `translated -> fuzzy` flip fails (exit 1).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
