### PR TITLE
fix(mcp): add AliasChoices to chart/dashboard/dataset request schemas

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -306,6 +306,8 @@ class GetChartInfoRequest(BaseModel):
     current chart configuration from cache.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: Annotated[
         int | str | None,
         Field(
@@ -314,6 +316,7 @@ class GetChartInfoRequest(BaseModel):
                 "Chart identifier - can be numeric ID or UUID string. "
                 "Optional when form_data_key is provided (for unsaved charts)."
             ),
+            validation_alias=AliasChoices("identifier", "id", "chart_id"),
         ),
     ]
     form_data_key: str | None = Field(
@@ -1935,6 +1938,8 @@ class ChartRequestNormalizerMixin(BaseModel):
 class ListChartsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheControl):
     """Request schema for list_charts with clear, unambiguous types."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     filters: Annotated[
         List[ChartFilter],
         Field(
@@ -1950,6 +1955,7 @@ class ListChartsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheControl)
             default_factory=list,
             description="List of columns to select. Defaults to common columns if not "
             "specified.",
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
 
@@ -2127,6 +2133,8 @@ class GenerateChartRequest(ChartRequestNormalizerMixin, QueryCacheControl):
 
 
 class GenerateExploreLinkRequest(ChartRequestNormalizerMixin, FormDataCacheControl):
+    model_config = ConfigDict(populate_by_name=True)
+
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
     config: ChartConfig | None = Field(
         None,
@@ -2141,7 +2149,11 @@ class GenerateExploreLinkRequest(ChartRequestNormalizerMixin, FormDataCacheContr
 class UpdateChartRequest(ChartRequestNormalizerMixin, QueryCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
-    identifier: int | str = Field(..., description="Chart ID or UUID")
+    identifier: int | str = Field(
+        ...,
+        description="Chart ID or UUID",
+        validation_alias=AliasChoices("identifier", "id", "chart_id"),
+    )
     config: ChartConfig | None = Field(
         None,
         description="Chart configuration. Optional; omit to only update chart_name.",
@@ -2186,6 +2198,8 @@ class UpdateChartRequest(ChartRequestNormalizerMixin, QueryCacheControl):
 
 
 class UpdateChartPreviewRequest(ChartRequestNormalizerMixin, FormDataCacheControl):
+    model_config = ConfigDict(populate_by_name=True)
+
     form_data_key: str | None = Field(
         None,
         description=(
@@ -2213,12 +2227,15 @@ class GetChartDataRequest(QueryCacheControl):
     the current chart configuration from cache.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: int | str | None = Field(
         default=None,
         description=(
             "Chart identifier (ID, UUID). "
             "Optional when form_data_key is provided (for unsaved charts)."
         ),
+        validation_alias=AliasChoices("identifier", "id", "chart_id"),
     )
     form_data_key: str | None = Field(
         default=None,
@@ -2343,12 +2360,15 @@ class GetChartPreviewRequest(QueryCacheControl):
     using the current chart configuration from cache.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: int | str | None = Field(
         default=None,
         description=(
             "Chart identifier (ID, UUID). "
             "Optional when form_data_key is provided (for unsaved charts)."
         ),
+        validation_alias=AliasChoices("identifier", "id", "chart_id"),
     )
     form_data_key: str | None = Field(
         default=None,
@@ -2562,12 +2582,15 @@ class GetChartSqlRequest(BaseModel):
     to get the SQL for the unsaved chart state from the Explore view.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: int | str | None = Field(
         default=None,
         description=(
             "Chart identifier - can be numeric ID or UUID string. "
             "Optional when form_data_key is provided (for unsaved charts)."
         ),
+        validation_alias=AliasChoices("identifier", "id", "chart_id"),
     )
     form_data_key: str | None = Field(
         default=None,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -347,6 +347,7 @@ class GetChartInfoRequest(BaseModel):
                 "set that excludes 'form_data' (the full chart config, can be 50KB+). "
                 "Add 'form_data' explicitly when you need the raw chart configuration."
             ),
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
 

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -195,6 +195,8 @@ class DashboardFilter(ColumnOperator):
 class ListDashboardsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheControl):
     """Request schema for list_dashboards with clear, unambiguous types."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     filters: Annotated[
         List[DashboardFilter],
         Field(
@@ -210,6 +212,7 @@ class ListDashboardsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheCont
             default_factory=list,
             description="List of columns to select. Defaults to common columns "
             "if not specified.",
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
 
@@ -321,10 +324,15 @@ class GetDashboardInfoRequest(MetadataCacheControl):
     in a dashboard but the URL contains a permalink_key.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: Annotated[
         int | str,
         Field(
-            description="Dashboard identifier - can be numeric ID, UUID string, or slug"
+            description=(
+                "Dashboard identifier - can be numeric ID, UUID string, or slug"
+            ),
+            validation_alias=AliasChoices("identifier", "id", "dashboard_id"),
         ),
     ]
     permalink_key: str | None = Field(
@@ -568,10 +576,18 @@ class DashboardList(BaseModel):
 class AddChartToDashboardRequest(BaseModel):
     """Request schema for adding a chart to an existing dashboard."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     dashboard_id: int = Field(
-        ..., description="ID of the dashboard to add the chart to"
+        ...,
+        description="ID of the dashboard to add the chart to",
+        validation_alias=AliasChoices("dashboard_id", "dashboard", "id"),
     )
-    chart_id: int = Field(..., description="ID of the chart to add to the dashboard")
+    chart_id: int = Field(
+        ...,
+        description="ID of the chart to add to the dashboard",
+        validation_alias=AliasChoices("chart_id", "chart"),
+    )
     target_tab: str | None = Field(
         None,
         min_length=1,

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -355,6 +355,7 @@ class GetDashboardInfoRequest(MetadataCacheControl):
                 "to override, e.g. ['id','dashboard_title','charts'] for minimal "
                 "output, or add 'css' to include raw dashboard CSS."
             ),
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -400,6 +400,7 @@ class GetDatasetInfoRequest(MetadataCacheControl):
                 "Pass an explicit list to select only what you need "
                 "(e.g. ['id', 'table_name', 'columns', 'metrics'])."
             ),
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
     column_fields: Annotated[

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, List, Literal
 
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -262,6 +263,8 @@ class DatasetList(BaseModel):
 class ListDatasetsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheControl):
     """Request schema for list_datasets with clear, unambiguous types."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     filters: Annotated[
         List[DatasetFilter],
         Field(
@@ -277,6 +280,7 @@ class ListDatasetsRequest(EditedByMeMixin, CreatedByMeMixin, MetadataCacheContro
             default_factory=list,
             description="List of columns to select. Defaults to common columns if not "
             "specified.",
+            validation_alias=AliasChoices("select_columns", "columns"),
         ),
     ]
     search: Annotated[
@@ -370,9 +374,14 @@ DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS: List[str] = [
 class GetDatasetInfoRequest(MetadataCacheControl):
     """Request schema for get_dataset_info with support for ID or UUID."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: Annotated[
         int | str,
-        Field(description="Dataset identifier - can be numeric ID or UUID string"),
+        Field(
+            description="Dataset identifier - can be numeric ID or UUID string",
+            validation_alias=AliasChoices("identifier", "id", "dataset_id"),
+        ),
     ]
     select_columns: Annotated[
         List[str],

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -28,10 +28,16 @@ from superset.mcp_service.chart.schemas import (
     FilterConfig,
     GenerateChartRequest,
     GenerateChartResponse,
+    GetChartDataRequest,
+    GetChartInfoRequest,
+    GetChartPreviewRequest,
+    GetChartSqlRequest,
+    ListChartsRequest,
     MixedTimeseriesChartConfig,
     PieChartConfig,
     PivotTableChartConfig,
     TableChartConfig,
+    UpdateChartRequest,
     XYChartConfig,
 )
 
@@ -1137,3 +1143,46 @@ class TestSqlMetricLlmContextWrapping:
         assert "<UNTRUSTED-CONTENT>" in metric["label"]
         assert metric["expressionType"] == "SQL"
         assert "<UNTRUSTED-CONTENT>" not in metric["optionName"]
+
+
+class TestRequestSchemaAliasChoices:
+    """Test that LLM-friendly field name variants are accepted on the
+    chart MCP tool request schemas, so callers sending 'id'/'chart_id'
+    instead of 'identifier' (or 'columns' instead of 'select_columns')
+    don't silently have the field dropped."""
+
+    def test_get_chart_info_identifier_id_alias(self) -> None:
+        req = GetChartInfoRequest.model_validate({"id": 42})
+        assert req.identifier == 42
+
+    def test_get_chart_info_identifier_chart_id_alias(self) -> None:
+        req = GetChartInfoRequest.model_validate({"chart_id": 42})
+        assert req.identifier == 42
+
+    def test_get_chart_info_identifier_still_works(self) -> None:
+        req = GetChartInfoRequest.model_validate({"identifier": 42})
+        assert req.identifier == 42
+
+    def test_get_chart_data_identifier_id_alias(self) -> None:
+        req = GetChartDataRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_get_chart_preview_identifier_id_alias(self) -> None:
+        req = GetChartPreviewRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_get_chart_sql_identifier_id_alias(self) -> None:
+        req = GetChartSqlRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_update_chart_identifier_id_alias(self) -> None:
+        req = UpdateChartRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_update_chart_identifier_chart_id_alias(self) -> None:
+        req = UpdateChartRequest.model_validate({"chart_id": 7})
+        assert req.identifier == 7
+
+    def test_list_charts_select_columns_columns_alias(self) -> None:
+        req = ListChartsRequest.model_validate({"columns": ["id", "slice_name"]})
+        assert req.select_columns == ["id", "slice_name"]

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -1163,16 +1163,34 @@ class TestRequestSchemaAliasChoices:
         req = GetChartInfoRequest.model_validate({"identifier": 42})
         assert req.identifier == 42
 
+    def test_get_chart_info_select_columns_columns_alias(self) -> None:
+        req = GetChartInfoRequest.model_validate(
+            {"id": 42, "columns": ["id", "slice_name"]}
+        )
+        assert req.select_columns == ["id", "slice_name"]
+
     def test_get_chart_data_identifier_id_alias(self) -> None:
         req = GetChartDataRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_get_chart_data_identifier_chart_id_alias(self) -> None:
+        req = GetChartDataRequest.model_validate({"chart_id": 7})
         assert req.identifier == 7
 
     def test_get_chart_preview_identifier_id_alias(self) -> None:
         req = GetChartPreviewRequest.model_validate({"id": 7})
         assert req.identifier == 7
 
+    def test_get_chart_preview_identifier_chart_id_alias(self) -> None:
+        req = GetChartPreviewRequest.model_validate({"chart_id": 7})
+        assert req.identifier == 7
+
     def test_get_chart_sql_identifier_id_alias(self) -> None:
         req = GetChartSqlRequest.model_validate({"id": 7})
+        assert req.identifier == 7
+
+    def test_get_chart_sql_identifier_chart_id_alias(self) -> None:
+        req = GetChartSqlRequest.model_validate({"chart_id": 7})
         assert req.identifier == 7
 
     def test_update_chart_identifier_id_alias(self) -> None:

--- a/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
@@ -31,10 +31,13 @@ from superset.mcp_service.dashboard.schemas import (
     _extract_cross_filters_enabled,
     _extract_native_filters,
     _safe_user_label,
+    AddChartToDashboardRequest,
     dashboard_serializer,
     DuplicateDashboardRequest,
     DuplicateDashboardResponse,
     GenerateDashboardRequest,
+    GetDashboardInfoRequest,
+    ListDashboardsRequest,
     serialize_chart_summary,
     serialize_dashboard_object,
     UpdateDashboardRequest,
@@ -904,3 +907,40 @@ class TestDuplicateDashboardResponse:
         """A null error stays null rather than being wrapped."""
         resp = DuplicateDashboardResponse(dashboard_url="http://host/d/1/")
         assert resp.error is None
+
+
+class TestRequestSchemaAliasChoices:
+    """Test that LLM-friendly field name variants are accepted on the
+    dashboard MCP tool request schemas, so callers sending 'id'/'dashboard_id'
+    instead of 'identifier' (or 'columns' instead of 'select_columns')
+    don't silently have the field dropped."""
+
+    def test_get_dashboard_info_identifier_id_alias(self) -> None:
+        req = GetDashboardInfoRequest.model_validate({"id": 42})
+        assert req.identifier == 42
+
+    def test_get_dashboard_info_identifier_dashboard_id_alias(self) -> None:
+        req = GetDashboardInfoRequest.model_validate({"dashboard_id": 42})
+        assert req.identifier == 42
+
+    def test_get_dashboard_info_identifier_still_works(self) -> None:
+        req = GetDashboardInfoRequest.model_validate({"identifier": 42})
+        assert req.identifier == 42
+
+    def test_list_dashboards_select_columns_columns_alias(self) -> None:
+        req = ListDashboardsRequest.model_validate(
+            {"columns": ["id", "dashboard_title"]}
+        )
+        assert req.select_columns == ["id", "dashboard_title"]
+
+    def test_add_chart_to_dashboard_dashboard_alias(self) -> None:
+        req = AddChartToDashboardRequest.model_validate({"dashboard": 1, "chart_id": 2})
+        assert req.dashboard_id == 1
+
+    def test_add_chart_to_dashboard_id_alias(self) -> None:
+        req = AddChartToDashboardRequest.model_validate({"id": 1, "chart_id": 2})
+        assert req.dashboard_id == 1
+
+    def test_add_chart_to_dashboard_chart_alias(self) -> None:
+        req = AddChartToDashboardRequest.model_validate({"dashboard_id": 1, "chart": 2})
+        assert req.chart_id == 2

--- a/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
@@ -927,6 +927,12 @@ class TestRequestSchemaAliasChoices:
         req = GetDashboardInfoRequest.model_validate({"identifier": 42})
         assert req.identifier == 42
 
+    def test_get_dashboard_info_select_columns_columns_alias(self) -> None:
+        req = GetDashboardInfoRequest.model_validate(
+            {"id": 42, "columns": ["id", "dashboard_title"]}
+        )
+        assert req.select_columns == ["id", "dashboard_title"]
+
     def test_list_dashboards_select_columns_columns_alias(self) -> None:
         req = ListDashboardsRequest.model_validate(
             {"columns": ["id", "dashboard_title"]}

--- a/tests/unit_tests/mcp_service/dataset/test_dataset_schemas.py
+++ b/tests/unit_tests/mcp_service/dataset/test_dataset_schemas.py
@@ -43,6 +43,12 @@ class TestRequestSchemaAliasChoices:
         req = GetDatasetInfoRequest.model_validate({"identifier": 42})
         assert req.identifier == 42
 
+    def test_get_dataset_info_select_columns_columns_alias(self) -> None:
+        req = GetDatasetInfoRequest.model_validate(
+            {"id": 42, "columns": ["id", "table_name"]}
+        )
+        assert req.select_columns == ["id", "table_name"]
+
     def test_list_datasets_select_columns_columns_alias(self) -> None:
         req = ListDatasetsRequest.model_validate({"columns": ["id", "table_name"]})
         assert req.select_columns == ["id", "table_name"]

--- a/tests/unit_tests/mcp_service/dataset/test_dataset_schemas.py
+++ b/tests/unit_tests/mcp_service/dataset/test_dataset_schemas.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for MCP dataset schema validation.
+"""
+
+from superset.mcp_service.dataset.schemas import (
+    GetDatasetInfoRequest,
+    ListDatasetsRequest,
+)
+
+
+class TestRequestSchemaAliasChoices:
+    """Test that LLM-friendly field name variants are accepted on the
+    dataset MCP tool request schemas, so callers sending 'id'/'dataset_id'
+    instead of 'identifier' (or 'columns' instead of 'select_columns')
+    don't silently have the field dropped."""
+
+    def test_get_dataset_info_identifier_id_alias(self) -> None:
+        req = GetDatasetInfoRequest.model_validate({"id": 42})
+        assert req.identifier == 42
+
+    def test_get_dataset_info_identifier_dataset_id_alias(self) -> None:
+        req = GetDatasetInfoRequest.model_validate({"dataset_id": 42})
+        assert req.identifier == 42
+
+    def test_get_dataset_info_identifier_still_works(self) -> None:
+        req = GetDatasetInfoRequest.model_validate({"identifier": 42})
+        assert req.identifier == 42
+
+    def test_list_datasets_select_columns_columns_alias(self) -> None:
+        req = ListDatasetsRequest.model_validate({"columns": ["id", "table_name"]})
+        assert req.select_columns == ["id", "table_name"]


### PR DESCRIPTION
## Summary
- LLM-driven MCP callers commonly send field name variants like `id` instead of `identifier`, or `columns` instead of `select_columns`. Pydantic silently drops unrecognized keys and falls back to field defaults, so these requests behaved as if the field was never sent at all.
- Adds `validation_alias=AliasChoices(...)` plus `model_config = ConfigDict(populate_by_name=True)` to the chart, dashboard, and dataset MCP request schemas that were missing them, following the existing pattern already used by `OpenSqlLabRequest` and `GenerateDashboardRequest`.
- Affected schemas: `GetChartInfoRequest`, `ListChartsRequest`, `GenerateExploreLinkRequest`, `UpdateChartRequest`, `UpdateChartPreviewRequest`, `GetChartDataRequest`, `GetChartPreviewRequest`, `GetChartSqlRequest`, `ListDashboardsRequest`, `GetDashboardInfoRequest`, `AddChartToDashboardRequest`, `ListDatasetsRequest`, `GetDatasetInfoRequest`.

## Test plan
- [x] `ruff format` / `ruff check` clean on all changed files
- [x] `mypy` and `pylint` pre-commit hooks pass on all changed files
- [x] Added unit tests covering each new alias (`id`/`chart_id`/`dashboard_id`/`dataset_id` → `identifier`, `columns` → `select_columns`, `dashboard`/`chart` → `dashboard_id`/`chart_id`) in `test_chart_schemas.py`, `test_dashboard_schemas.py`, and a new `test_dataset_schemas.py`
- [ ] CI test suite (could not run the full pytest suite locally — `mysqlclient` failed to build in this sandbox due to missing native libs)