### PR TITLE
fix(mcp): document all 7 generate_chart chart_type values

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -105,19 +105,48 @@ async def generate_chart(  # noqa: C901
     - Set save_chart=True to permanently save the chart
     - LLM clients MUST display returned chart URL to users
     - Use numeric dataset ID or UUID (NOT schema.table_name format)
-    - MUST include chart_type in config (either 'xy' or 'table')
+    - MUST include chart_type in config (see the 7 valid values below)
 
     IMPORTANT: The 'chart_type' field in the config is a DISCRIMINATOR that determines
     which chart configuration schema to use. It MUST be included and MUST match the
-    other fields in your configuration:
+    other fields in your configuration. There are exactly 7 valid chart_type values
+    — NOT 'line', 'bar', 'mixed_timeseries', etc. Those are 'kind' values WITHIN
+    chart_type='xy' (see below), not chart_type values themselves:
 
-    - Use chart_type='xy' for charts with x and y axes (line, bar, area, scatter)
-      Required fields: x, y
+    - chart_type='xy' for line, bar, area, or scatter charts (x/y axes).
+      Required fields: x, y. Use 'kind' to pick line/bar/area/scatter
+      (default kind='line').
 
-    - Use chart_type='table' for tabular visualizations
+    - chart_type='table' for tabular visualizations.
       Required fields: columns
 
-    Example usage for XY chart:
+    - chart_type='pie' for pie or donut charts.
+      Required fields: dimension, metric
+
+    - chart_type='pivot_table' for interactive pivot tables.
+      Required fields: rows, metrics (columns is optional, for cross-tabs)
+
+    - chart_type='mixed_timeseries' for dual-series time charts (e.g. bar
+      + line on the same axis). Required fields: x, y (primary metrics),
+      y_secondary (secondary metrics)
+
+    - chart_type='handlebars' for custom HTML template charts.
+      Required fields: handlebars_template
+
+    - chart_type='big_number' for a single KPI/big-number display.
+      Required fields: metric
+
+    Quick lookup — natural-language ask -> chart_type (+ kind if applicable):
+    - "bar chart" / "line chart" / "area chart" / "scatter plot"
+      -> chart_type='xy', kind='bar'/'line'/'area'/'scatter'
+    - "pie chart" / "donut chart" -> chart_type='pie'
+    - "table" / "data grid" -> chart_type='table'
+    - "pivot table" / "cross-tab" -> chart_type='pivot_table'
+    - "compare two metrics over time" -> chart_type='mixed_timeseries'
+    - "single number" / "KPI" / "scorecard" -> chart_type='big_number'
+    - "custom HTML template" -> chart_type='handlebars'
+
+    Example usage for XY chart (bar/line/area/scatter):
     ```json
     {
         "dataset_id": 123,
@@ -141,6 +170,18 @@ async def generate_chart(  # noqa: C901
                 {"name": "quantity", "aggregate": "SUM"},
                 {"name": "revenue", "aggregate": "SUM", "label": "Total Revenue"}
             ]
+        }
+    }
+    ```
+
+    Example usage for Pie chart:
+    ```json
+    {
+        "dataset_id": 123,
+        "config": {
+            "chart_type": "pie",
+            "dimension": {"name": "product_category"},
+            "metric": {"name": "revenue", "aggregate": "SUM"}
         }
     }
     ```

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -294,14 +294,17 @@ MCP_RESPONSE_SIZE_CONFIG: Dict[str, Any] = {
 #
 # Summary Mode (include_schemas):
 # --------------------------------
-# When include_schemas=False (default), search results omit inputSchema
-# entirely and include a lightweight "parameters_hint" field listing
-# top-level parameter names (e.g. "page, page_size, search, filters").
-# This reduces per-search token cost by ~80% vs compact mode while still
-# conveying what parameters a tool accepts.  Full schemas remain available
-# when invoking the tool via call_tool.
-# - Set include_schemas=True to restore full inputSchema in search results.
-# - compact_schemas is ignored when include_schemas=False (no schema to
+# When include_schemas=False, search results omit inputSchema entirely and
+# include a lightweight "parameters_hint" field listing top-level parameter
+# names (e.g. "page, page_size, search, filters"). This reduces per-search
+# token cost by ~80% vs compact mode while still conveying what parameters
+# a tool accepts. Full schemas remain available when invoking the tool via
+# call_tool.
+# - include_schemas defaults to True: search results carry full inputSchema
+#   so LLMs can see structured/discriminated-union configs (e.g. chart
+#   generation) without a second round trip. Set include_schemas=False to
+#   switch to summary mode if search_tools response size becomes a problem
+#   again; compact_schemas is ignored when include_schemas=False (no schema to
 #   compact); max_description_length still applies in summary mode.
 # =============================================================================
 MCP_TOOL_SEARCH_CONFIG: Dict[str, Any] = {


### PR DESCRIPTION
### SUMMARY
The `generate_chart` MCP tool docstring only documented `chart_type='xy'` and `chart_type='table'`, even though the underlying `ChartConfig` discriminated union has supported 7 chart types (`xy`, `table`, `pie`, `pivot_table`, `mixed_timeseries`, `handlebars`, `big_number`) since #38375/#38402/#38403. LLM clients calling the tool with intuitive-but-wrong values (e.g. `chart_type='line'`, `chart_type='bar'`, `chart_type='pie'` without realizing it needed `dimension`/`metric`) hit raw Pydantic discriminator errors and looped through retries/`search_tools` until timing out.

This PR:
- Documents all 7 valid `chart_type` discriminator values directly in the tool docstring, with required fields for each.
- Adds a natural-language "quick lookup" table mapping common asks ("bar chart", "pie chart", "pivot table", "KPI", etc.) to the correct `chart_type` (+ `kind` for XY charts), clarifying that `line`/`bar`/`area`/`scatter` are `kind` values *within* `chart_type='xy'`, not `chart_type` values themselves.
- Adds a worked example for `chart_type='pie'`.
- Fixes a stale comment in `MCP_TOOL_SEARCH_CONFIG` that described `include_schemas=False` as the default; it has defaulted to `True` since #39732 (to keep discriminated-union configs visible to LLMs in `search_tools` results), but the comment still said otherwise.

No behavior change — docstring/comment only.

### TESTING INSTRUCTIONS
- `python -m py_compile superset/mcp_service/chart/tool/generate_chart.py superset/mcp_service/mcp_config.py`
- Existing unit tests under `tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py` continue to pass (no behavior touched).
- Manually inspect the new tool docstring via `get_chart_type_schema`/`search_tools` output for `generate_chart`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API