### PR TITLE
fix(semantic layers): guards for zero rows

### DIFF
--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -121,6 +121,7 @@ def get_results(query_object: QueryObject) -> QueryResult:
     # Step 2: Execute the main query (first in the list)
     main_query = queries[0]
     main_result = dispatcher(main_query)
+    main_result = _coerce_empty_result(main_result, main_query)
 
     main_df = stringify_extension_columns(main_result.results).to_pandas()
 
@@ -152,6 +153,7 @@ def get_results(query_object: QueryObject) -> QueryResult:
     ):
         # Execute the offset query
         result = dispatcher(offset_query)
+        result = _coerce_empty_result(result, offset_query)
 
         # Add this query's requests to the collection
         all_requests.extend(result.requests)
@@ -204,6 +206,32 @@ def get_results(query_object: QueryObject) -> QueryResult:
         semantic_result,
         query_object,
         duration,
+    )
+
+
+def _coerce_empty_result(
+    semantic_result: SemanticResult,
+    query: SemanticQuery,
+) -> SemanticResult:
+    """
+    Guard against ``SemanticResult.results is None``.
+
+    Some semantic-layer driver implementations return ``None`` when a query
+    produces zero rows (for example, ``snowflake.connector``'s
+    ``fetch_arrow_all`` does this). Downstream consumers expect an Arrow table,
+    so build an empty one with the columns implied by the query's dimensions
+    and metrics.
+    """
+    if semantic_result.results is not None:
+        return semantic_result
+
+    columns = {
+        **{dim.name: pa.array([], type=dim.type) for dim in query.dimensions},
+        **{metric.name: pa.array([], type=metric.type) for metric in query.metrics},
+    }
+    return SemanticResult(
+        requests=semantic_result.requests,
+        results=pa.table(columns),
     )
 
 

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -1694,6 +1694,37 @@ def test_get_results_with_multiple_dimensions(
     pd.testing.assert_frame_equal(result.df, expected_df)
 
 
+def test_get_results_handles_none_results(
+    mock_datasource: MagicMock,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Some semantic-layer driver implementations return ``SemanticResult(results=None)``
+    when a query produces zero rows (for example, ``snowflake.connector``'s
+    ``fetch_arrow_all``). ``get_results`` must coerce that to an empty Arrow table
+    rather than crashing on ``None.to_pandas()``.
+    """
+    mock_result = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="SELECT 1")],
+        results=None,
+    )
+    mock_datasource.implementation.get_table = mocker.Mock(return_value=mock_result)
+
+    query_object = ValidatedQueryObject(
+        datasource=mock_datasource,
+        from_dttm=datetime(2025, 10, 15),
+        to_dttm=datetime(2025, 10, 22),
+        metrics=["total_sales"],
+        columns=["category"],
+    )
+
+    result = get_results(query_object)
+
+    assert result.df is not None
+    assert result.df.empty
+    assert set(result.df.columns) == {"category", "total_sales"}
+
+
 def test_get_results_no_datasource() -> None:
     """
     Test that get_results raises error when datasource is missing.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A small fix for when a query on a semantic view returns no rows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
