### PR TITLE
fix(chart-explore): allow Save (Overwrite) after editing chart properties

### DIFF
--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.test.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.test.tsx
@@ -47,3 +47,11 @@ test('should pass removeToast to the Toast component', async () => {
   fireEvent.click(getAllByTestId('close-button')[0]);
   await waitFor(() => expect(removeToast).toHaveBeenCalledTimes(1));
 });
+
+test('presenter container does not capture pointer events over its empty area', () => {
+  const { container } = setup();
+  const presenter = container.querySelector('#toast-presenter');
+  // The container spans a tall fixed region; its empty area must let clicks
+  // pass through to underlying controls (e.g. the Explore Save button).
+  expect(presenter).toHaveStyle('pointer-events: none');
+});

--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -39,6 +39,11 @@ const StyledToastPresenter = styled.div<VisualProps>(
 
     height: calc(100vh - 100px);
 
+    /* The container spans a tall region on the right edge of the screen.
+       Let clicks pass through its empty area so it doesn't block underlying
+       controls (e.g. the Explore Save button); toasts re-enable pointer events. */
+    pointer-events: none;
+
     display: flex;
     flex-direction: ${position === 'bottom' ? 'column-reverse' : 'column'};
     align-items: stretch;
@@ -107,6 +112,8 @@ const StyledToastPresenter = styled.div<VisualProps>(
       transition:
         transform ${theme.motionDurationMid},
         opacity ${theme.motionDurationMid};
+      /* Off-screen/hidden toasts must not capture clicks; only visible ones do. */
+      pointer-events: none;
       &:after {
         content: '';
         position: absolute;
@@ -125,6 +132,7 @@ const StyledToastPresenter = styled.div<VisualProps>(
     .toast--visible {
       opacity: 1;
       transform: translateY(0);
+      pointer-events: auto;
     }
   `,
 );

--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -265,6 +265,14 @@ test('disables overwrite option for non-owner', () => {
   expect(getByRole('radio', { name: 'Save (Overwrite)' })).toBeDisabled();
 });
 
+test('enables and selects overwrite option for owner', () => {
+  // Owners is a normalized array of user IDs, matching the current user
+  const { getByRole } = setup();
+  const overwriteRadio = getByRole('radio', { name: 'Save (Overwrite)' });
+  expect(overwriteRadio).toBeEnabled();
+  expect(overwriteRadio).toBeChecked();
+});
+
 test('updates slice name and selected dashboard', async () => {
   const dashboardId = mockEvent.value;
   const saveDataset = jest.fn().mockResolvedValue(undefined);

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -18,7 +18,7 @@
  */
 
 import exploreReducer, { ExploreState } from './exploreReducer';
-import { setStashFormData } from '../actions/exploreActions';
+import { setStashFormData, sliceUpdated } from '../actions/exploreActions';
 import { QueryFormData } from '@superset-ui/core';
 
 test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
@@ -51,4 +51,50 @@ test('skips updates when the field is already updated on SET_STASH_FORM_DATA', (
   >[1];
   const newState = exploreReducer(initialState, restoreAction);
   expect(newState).toBe(initialState);
+});
+
+test('normalizes API owner objects to id array on SLICE_UPDATED', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+    slice: { slice_id: 1, owners: [1] },
+  } as ExploreState;
+  // The chart API returns owners as objects: {id, first_name, last_name}
+  const action = sliceUpdated({
+    slice_id: 1,
+    slice_name: 'My chart',
+    owners: [{ id: 5, first_name: 'Superset', last_name: 'Admin' }],
+  } as never) as Parameters<typeof exploreReducer>[1];
+  const newState = exploreReducer(initialState, action);
+  expect(newState.slice?.owners).toEqual([5]);
+  expect(newState.metadata?.owners).toEqual(['Superset Admin']);
+});
+
+test('normalizes select control owners ({value, label}) on SLICE_UPDATED', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+    slice: { slice_id: 1, owners: [1] },
+  } as ExploreState;
+  const action = sliceUpdated({
+    slice_id: 1,
+    owners: [{ value: 7, label: 'Jane Doe' }],
+  } as never) as Parameters<typeof exploreReducer>[1];
+  const newState = exploreReducer(initialState, action);
+  expect(newState.slice?.owners).toEqual([7]);
+  expect(newState.metadata?.owners).toEqual(['Jane Doe']);
+});
+
+test('keeps numeric owner ids on SLICE_UPDATED', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+    slice: { slice_id: 1, owners: [1] },
+  } as ExploreState;
+  const action = sliceUpdated({
+    slice_id: 1,
+    owners: [3, 4],
+  } as never) as Parameters<typeof exploreReducer>[1];
+  const newState = exploreReducer(initialState, action);
+  expect(newState.slice?.owners).toEqual([3, 4]);
 });

--- a/superset-frontend/src/explore/reducers/exploreReducer.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.ts
@@ -152,9 +152,13 @@ interface SetStashFormDataAction {
   isHidden: boolean;
 }
 
-// Owner can be either a number (user ID) or an object with value/label
-// This handles both Slice format (number[]) and select control format ({value, label}[])
-type OwnerItem = number | { value: number; label: string };
+// Owner can be a number (user ID), a select control option ({value, label}),
+// or an API entity object ({id, first_name, last_name}). This handles the Slice
+// format (number[]), select control format, and the raw chart API response format.
+type OwnerItem =
+  | number
+  | { value: number; label: string }
+  | { id: number; first_name?: string; last_name?: string };
 
 interface SliceUpdatedAction {
   type: typeof actions.SLICE_UPDATED;
@@ -601,11 +605,20 @@ export default function exploreReducer(
     },
     [actions.SLICE_UPDATED]() {
       const typedAction = action as SliceUpdatedAction;
-      // Handle owners that can be either number[] or Array<{value, label}>
-      const getOwnerId = (owner: OwnerItem): number =>
-        typeof owner === 'number' ? owner : owner.value;
-      const getOwnerLabel = (owner: OwnerItem): string | null =>
-        typeof owner === 'number' ? null : owner.label;
+      // Handle owners in number[], {value, label}[], or API {id, first_name, ...}[] form
+      const getOwnerId = (owner: OwnerItem): number => {
+        if (typeof owner === 'number') return owner;
+        return 'value' in owner ? owner.value : owner.id;
+      };
+      const getOwnerLabel = (owner: OwnerItem): string | null => {
+        if (typeof owner === 'number') return null;
+        if ('value' in owner) return owner.label;
+        const name = [owner.first_name, owner.last_name]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+        return name || null;
+      };
       return {
         ...state,
         slice: {


### PR DESCRIPTION
### SUMMARY

Fixes two bugs in the Chart Explore "Edit chart properties" → "Save (Overwrite)" flow.

**1. "Save (Overwrite)" incorrectly disabled after editing chart properties**

After editing a chart's properties (e.g. adding a Description) and saving, the **Save (Overwrite)** option in the Save modal became disabled, forcing users into "Save as..." instead of overwriting the chart they own.

Root cause: `PropertiesModal` passes the raw chart API response into the `sliceUpdated` action, whose `owners` is an array of objects (`{ id, first_name, last_name }`). The `exploreReducer` `SLICE_UPDATED` handler only normalized `number` and `{ value, label }` owner shapes, so it read `owner.value` (`undefined`) on the API objects and turned `slice.owners` into `[undefined]`. `SaveModal.canOverwriteSlice()` then failed its `owners.includes(userId)` check and disabled the overwrite radio.

Fix (`exploreReducer.ts`): extended `OwnerItem` and the `getOwnerId`/`getOwnerLabel` helpers to also handle the API entity shape (`{ id, first_name, last_name }`), so `slice.owners` stays a clean `number[]` regardless of the caller.

**2. Toast overlay blocks the Save button**

While the "Chart properties updated" success toast was visible (4s), the Explore **Save** button in the header could not be clicked until the toast disappeared.

Root cause: `StyledToastPresenter` is `position: fixed; right: 0; height: calc(100vh - 100px)` with a high `z-index` — a tall invisible column over the top-right where the Save button lives. With no `pointer-events` rule, its empty/transparent area intercepted all clicks in that region for as long as a toast was mounted.

Fix (`ToastPresenter.tsx`): set `pointer-events: none` on the container and hidden toasts, and `pointer-events: auto` on visible toasts — clicks pass through the empty area while visible toasts (and their close button) remain interactive.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- Before/After GIFs go here -->

**Before:**
<img width="800" height="509" alt="ezgif-5b85d7d2b755edbd" src="https://github.com/user-attachments/assets/35c1815a-689c-4b33-8919-d6a3c88d9f8e" />



**After:**
<img width="800" height="509" alt="ezgif-1c2dcd94eb52736c" src="https://github.com/user-attachments/assets/699642dc-02fa-4ac9-a13f-ecc58edd50f2" />


### TESTING INSTRUCTIONS

Automated:
```bash
cd superset-frontend
npm run test -- src/explore/reducers/exploreReducer.test.ts
npm run test -- src/explore/components/SaveModal.test.tsx
npm run test -- src/components/MessageToasts/ToastPresenter.test.tsx
```

Manual (owner of a chart):
1. Open a chart you own in Explore.
2. Menu → **Edit chart properties** → add a Description → **Save**.
3. As soon as the "Chart properties updated" toast appears, click **Save** in the header — it should be clickable immediately (bug 2).
4. In the Save modal, **Save (Overwrite)** should be enabled and pre-selected (bug 1); overwriting succeeds.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
