### PR TITLE
feat(mcp): add dashboard owner, role, and certification management tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -138,7 +138,7 @@ Dashboard Management:
 - remove_chart_from_dashboard: Remove a chart from an existing dashboard (requires write access)
 - restore_dashboard: Restore a soft-deleted dashboard from trash by ID/UUID (requires editor rights — owner or Admin; only applies to dashboards trashed under the SOFT_DELETE feature flag)
 - manage_dashboard_owners: Add/remove dashboard owners by explicit operation (requires write access; rejects changes that would leave zero owners)
-- manage_dashboard_roles: Add/remove dashboard RBAC access roles by explicit operation (requires write access; only affects access when DASHBOARD_RBAC is enabled)
+- manage_dashboard_roles: Add/remove dashboard access roles by explicit operation (requires write access; only affects access when ENABLE_VIEWERS is enabled)
 - manage_dashboard_certification: Set or clear a dashboard's certified_by/certification_details badge (requires write access)
 
 Annotation Layers:

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -137,6 +137,9 @@ Dashboard Management:
 - manage_native_filters: Add, update, remove, or reorder native filters on a dashboard (requires write access; supports filter_select and filter_time)
 - remove_chart_from_dashboard: Remove a chart from an existing dashboard (requires write access)
 - restore_dashboard: Restore a soft-deleted dashboard from trash by ID/UUID (requires editor rights — owner or Admin; only applies to dashboards trashed under the SOFT_DELETE feature flag)
+- manage_dashboard_owners: Add/remove dashboard owners by explicit operation (requires write access; rejects changes that would leave zero owners)
+- manage_dashboard_roles: Add/remove dashboard RBAC access roles by explicit operation (requires write access; only affects access when DASHBOARD_RBAC is enabled)
+- manage_dashboard_certification: Set or clear a dashboard's certified_by/certification_details badge (requires write access)
 
 Annotation Layers:
 - list_annotation_layers: List annotation layers with advanced filters (1-based pagination)
@@ -475,7 +478,8 @@ Input format:
 - Write tools (generate_chart, generate_dashboard, update_chart, duplicate_dashboard,
   create_dataset, create_virtual_dataset, update_dataset_metric, save_sql_query,
   add_chart_to_existing_dashboard, manage_native_filters, remove_chart_from_dashboard,
-  update_chart_preview) require write
+  update_chart_preview, manage_dashboard_owners, manage_dashboard_roles,
+  manage_dashboard_certification) require write
   permissions. These tools are only listed for users who have the necessary access.
   If a write tool does not appear in the tool list, the current user lacks write access.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate
@@ -483,7 +487,12 @@ Input format:
   or dashboards, and vice versa.
 - Do NOT disclose dashboard access lists, dashboard editors, chart editors, dataset
   editors, workspace admins, or other users' names, usernames, email addresses,
-  contact details, roles, admin status, editorship, or access-list information.
+  contact details, roles, admin status, editorship, or access-list information,
+  EXCEPT the owners/roles that manage_dashboard_owners/manage_dashboard_roles
+  return as confirmation of an editorship/access change the user explicitly
+  requested on that specific dashboard. Do NOT use that confirmation output to
+  answer a general "who owns/can access X" question, and do NOT proactively
+  call these tools just to look up current owners/roles.
 - Do NOT infer access-list answers from dashboard metadata such as published status,
   role restrictions, empty editor lists, or schema fields.
 - find_users is sanctioned ONLY for resolving a name the user supplied into a
@@ -751,6 +760,9 @@ from superset.mcp_service.dashboard.tool import (  # noqa: F401, E402
     get_dashboard_info,
     get_dashboard_layout,
     list_dashboards,
+    manage_dashboard_certification,
+    manage_dashboard_owners,
+    manage_dashboard_roles,
     manage_native_filters,
     remove_chart_from_dashboard,
     restore_dashboard,

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1296,6 +1296,17 @@ class ManageDashboardCertificationRequest(BaseModel):
             return v
         return sanitize_user_input(v, "certified_by", max_length=500, allow_empty=True)
 
+    @field_validator("certification_details")
+    @classmethod
+    def sanitize_certification_details(cls, v: str | None) -> str | None:
+        """Sanitize certification_details to prevent XSS; it renders in the
+        same CertifiedBadge tooltip as certified_by."""
+        if v is None or v == "":
+            return v
+        return sanitize_user_input(
+            v, "certification_details", max_length=5000, allow_empty=True
+        )
+
 
 class ManageDashboardCertificationResponse(BaseModel):
     """Response schema for ``manage_dashboard_certification``."""

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -103,7 +103,6 @@ from superset.mcp_service.system.schemas import (
     SubjectInfo,
     TagInfo,
 )
-from superset.mcp_service.user.schemas import UserInfo
 from superset.mcp_service.utils import (
     escape_llm_context_delimiters,
     sanitize_for_llm_context,
@@ -1091,6 +1090,11 @@ class ManageDashboardOwnersRequest(BaseModel):
     list with no safety guard, so an empty or partial list could silently
     orphan a dashboard), this tool takes explicit add/remove operations and
     rejects any change that would leave the dashboard with zero owners.
+
+    "Owners" here means USER-type entries in the dashboard's Subject-based
+    ``editors`` list (the ownership model apache/superset#38831 introduced,
+    replacing the legacy ``owners`` relationship). Any ROLE- or GROUP-type
+    editors already on the dashboard are left untouched by this tool.
     """
 
     identifier: int | str = Field(
@@ -1133,9 +1137,13 @@ class ManageDashboardOwnersRequest(BaseModel):
 class ManageDashboardOwnersResponse(BaseModel):
     """Response schema for ``manage_dashboard_owners``."""
 
-    owners: List[UserInfo] = Field(
+    owners: List[SubjectInfo] = Field(
         default_factory=list,
-        description="Full list of dashboard owners after the operation.",
+        description=(
+            "Full list of USER-type editor subjects (dashboard owners) "
+            "after the operation. Any ROLE/GROUP-type editors on the "
+            "dashboard are not included here."
+        ),
     )
     dashboard_url: str | None = Field(None, description="URL to view the dashboard")
     added_owner_ids: List[int] = Field(
@@ -1174,6 +1182,12 @@ class ManageDashboardRolesRequest(BaseModel):
 
     Unlike ``update_dashboard``'s dropped ``roles`` field (a full-replacement
     access-control list), this tool takes explicit add/remove operations.
+
+    "Roles" here means ROLE-type entries in the dashboard's Subject-based
+    ``viewers`` list (the access model apache/superset#38831 introduced,
+    replacing the legacy ``roles``/``DASHBOARD_RBAC`` relationship). Any
+    USER- or GROUP-type viewers already on the dashboard are left untouched
+    by this tool.
     """
 
     identifier: int | str = Field(
@@ -1215,9 +1229,13 @@ class ManageDashboardRolesRequest(BaseModel):
 class ManageDashboardRolesResponse(BaseModel):
     """Response schema for ``manage_dashboard_roles``."""
 
-    roles: List[RoleInfo] = Field(
+    roles: List[SubjectInfo] = Field(
         default_factory=list,
-        description="Full list of dashboard access roles after the operation.",
+        description=(
+            "Full list of ROLE-type viewer subjects (dashboard access "
+            "roles) after the operation. Any USER/GROUP-type viewers on "
+            "the dashboard are not included here."
+        ),
     )
     dashboard_url: str | None = Field(None, description="URL to view the dashboard")
     added_role_ids: List[int] = Field(
@@ -1228,13 +1246,13 @@ class ManageDashboardRolesResponse(BaseModel):
         default_factory=list,
         description="Role IDs actually removed by this call.",
     )
-    dashboard_rbac_enabled: bool = Field(
+    viewers_enabled: bool = Field(
         default=False,
         description=(
-            "Whether the DASHBOARD_RBAC feature flag is enabled on this "
-            "instance. When False, dashboard roles are stored but have no "
+            "Whether the ENABLE_VIEWERS feature flag is enabled on this "
+            "instance. When False, dashboard viewers are stored but have no "
             "effect on access control — access still follows normal "
-            "Superset permissions/ownership."
+            "Superset permissions/editorship."
         ),
     )
     warnings: List[str] = Field(

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1119,6 +1119,15 @@ class ManageDashboardOwnersRequest(BaseModel):
         ),
     )
 
+    @field_validator("identifier", mode="before")
+    @classmethod
+    def reject_bool_identifier(cls, value: object) -> object:
+        """bool is a subclass of int, so identifier=true would coerce to
+        dashboard ID 1 and mutate the wrong dashboard; reject it outright."""
+        if isinstance(value, bool):
+            raise ValueError("identifier must be an integer ID, UUID, or slug string")
+        return value
+
     @model_validator(mode="after")
     def _validate_operations(self) -> "ManageDashboardOwnersRequest":
         if not self.add_owner_ids and not self.remove_owner_ids:
@@ -1136,7 +1145,28 @@ class ManageDashboardOwnersRequest(BaseModel):
         return self
 
 
-class ManageDashboardOwnersResponse(BaseModel):
+class DashboardMutationErrorFields(BaseModel):
+    """Shared ``error``/``permission_denied`` fields for dashboard governance
+    mutation responses (owners/roles/certification), including the
+    validator that wraps ``error`` before it is exposed to LLM context.
+    """
+
+    error: str | None = Field(None, description="Error message, if operation failed")
+    permission_denied: bool = Field(
+        default=False,
+        description=("True when the user lacks edit rights on the target dashboard."),
+    )
+
+    @field_validator("error")
+    @classmethod
+    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
+        """Wrap error text before it is exposed to LLM context."""
+        if value is None:
+            return value
+        return sanitize_for_llm_context(value, field_path=("error",))
+
+
+class ManageDashboardOwnersResponse(DashboardMutationErrorFields):
     """Response schema for ``manage_dashboard_owners``."""
 
     owners: List[SubjectInfo] = Field(
@@ -1164,19 +1194,29 @@ class ManageDashboardOwnersResponse(BaseModel):
             "themselves."
         ),
     )
-    error: str | None = Field(None, description="Error message, if operation failed")
-    permission_denied: bool = Field(
-        default=False,
-        description=("True when the user lacks edit rights on the target dashboard."),
-    )
 
-    @field_validator("error")
+    @field_validator("owners", mode="after")
     @classmethod
-    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
-        """Wrap error text before it is exposed to LLM context."""
-        if value is None:
-            return value
-        return sanitize_for_llm_context(value, field_path=("error",))
+    def sanitize_owners_for_llm_context(
+        cls, value: List[SubjectInfo]
+    ) -> List[SubjectInfo]:
+        """Wrap owner labels before LLM exposure; owner display names are
+        user-controlled and render as plain text in this response, so an
+        unsanitized label could inject content into LLM context (CWE-79
+        analog for LLM-facing output). Entries that sanitize to an empty
+        label are dropped rather than surfaced with a blank identity."""
+        sanitized: List[SubjectInfo] = []
+        for subject in value:
+            if subject.label is None:
+                sanitized.append(subject)
+                continue
+            clean_label = sanitize_for_llm_context(
+                subject.label, field_path=("owners", "label")
+            )
+            if not clean_label:
+                continue
+            sanitized.append(subject.model_copy(update={"label": clean_label}))
+        return sanitized
 
 
 class ManageDashboardRolesRequest(BaseModel):
@@ -1213,6 +1253,15 @@ class ManageDashboardRolesRequest(BaseModel):
         ),
     )
 
+    @field_validator("identifier", mode="before")
+    @classmethod
+    def reject_bool_identifier(cls, value: object) -> object:
+        """bool is a subclass of int, so identifier=true would coerce to
+        dashboard ID 1 and mutate the wrong dashboard; reject it outright."""
+        if isinstance(value, bool):
+            raise ValueError("identifier must be an integer ID, UUID, or slug string")
+        return value
+
     @model_validator(mode="after")
     def _validate_operations(self) -> "ManageDashboardRolesRequest":
         if not self.add_role_ids and not self.remove_role_ids:
@@ -1228,7 +1277,7 @@ class ManageDashboardRolesRequest(BaseModel):
         return self
 
 
-class ManageDashboardRolesResponse(BaseModel):
+class ManageDashboardRolesResponse(DashboardMutationErrorFields):
     """Response schema for ``manage_dashboard_roles``."""
 
     roles: List[SubjectInfo] = Field(
@@ -1260,19 +1309,29 @@ class ManageDashboardRolesResponse(BaseModel):
     warnings: List[str] = Field(
         default_factory=list, description="Non-fatal advisory messages."
     )
-    error: str | None = Field(None, description="Error message, if operation failed")
-    permission_denied: bool = Field(
-        default=False,
-        description=("True when the user lacks edit rights on the target dashboard."),
-    )
 
-    @field_validator("error")
+    @field_validator("roles", mode="after")
     @classmethod
-    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
-        """Wrap error text before it is exposed to LLM context."""
-        if value is None:
-            return value
-        return sanitize_for_llm_context(value, field_path=("error",))
+    def sanitize_roles_for_llm_context(
+        cls, value: List[SubjectInfo]
+    ) -> List[SubjectInfo]:
+        """Wrap role labels before LLM exposure; role display names are
+        user-controlled and render as plain text in this response, so an
+        unsanitized label could inject content into LLM context (CWE-79
+        analog for LLM-facing output). Entries that sanitize to an empty
+        label are dropped rather than surfaced with a blank identity."""
+        sanitized: List[SubjectInfo] = []
+        for subject in value:
+            if subject.label is None:
+                sanitized.append(subject)
+                continue
+            clean_label = sanitize_for_llm_context(
+                subject.label, field_path=("roles", "label")
+            )
+            if not clean_label:
+                continue
+            sanitized.append(subject.model_copy(update={"label": clean_label}))
+        return sanitized
 
 
 class ManageDashboardCertificationRequest(BaseModel):
@@ -1347,7 +1406,7 @@ class ManageDashboardCertificationRequest(BaseModel):
         return sanitized
 
 
-class ManageDashboardCertificationResponse(BaseModel):
+class ManageDashboardCertificationResponse(DashboardMutationErrorFields):
     """Response schema for ``manage_dashboard_certification``."""
 
     certified_by: str | None = Field(
@@ -1364,19 +1423,6 @@ class ManageDashboardCertificationResponse(BaseModel):
     warnings: List[str] = Field(
         default_factory=list, description="Non-fatal advisory messages."
     )
-    error: str | None = Field(None, description="Error message, if operation failed")
-    permission_denied: bool = Field(
-        default=False,
-        description=("True when the user lacks edit rights on the target dashboard."),
-    )
-
-    @field_validator("error")
-    @classmethod
-    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
-        """Wrap error text before it is exposed to LLM context."""
-        if value is None:
-            return value
-        return sanitize_for_llm_context(value, field_path=("error",))
 
     @field_validator("certified_by", "certification_details")
     @classmethod

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -103,6 +103,7 @@ from superset.mcp_service.system.schemas import (
     SubjectInfo,
     TagInfo,
 )
+from superset.mcp_service.user.schemas import UserInfo
 from superset.mcp_service.utils import (
     escape_llm_context_delimiters,
     sanitize_for_llm_context,
@@ -1081,6 +1082,261 @@ class UpdateDashboardResponse(BaseModel):
             "title was altered by sanitization."
         ),
     )
+
+
+class ManageDashboardOwnersRequest(BaseModel):
+    """Request schema for explicit add/remove dashboard owner management.
+
+    Unlike ``update_dashboard``'s dropped ``owners`` field (a full-replacement
+    list with no safety guard, so an empty or partial list could silently
+    orphan a dashboard), this tool takes explicit add/remove operations and
+    rejects any change that would leave the dashboard with zero owners.
+    """
+
+    identifier: int | str = Field(
+        ...,
+        description=(
+            "Dashboard ID (integer), UUID, or slug. Same identifier shape "
+            "accepted by ``get_dashboard_info``."
+        ),
+    )
+    add_owner_ids: List[int] = Field(
+        default_factory=list,
+        description=(
+            "User IDs to add as dashboard owners. Discover IDs with ``find_users``."
+        ),
+    )
+    remove_owner_ids: List[int] = Field(
+        default_factory=list,
+        description=(
+            "User IDs to remove from dashboard owners. Rejected if it would "
+            "leave the dashboard with zero owners, or if an ID is not "
+            "currently an owner."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_operations(self) -> "ManageDashboardOwnersRequest":
+        if not self.add_owner_ids and not self.remove_owner_ids:
+            raise ValueError(
+                "At least one of add_owner_ids or remove_owner_ids is required."
+            )
+        overlap = sorted(set(self.add_owner_ids) & set(self.remove_owner_ids))
+        if overlap:
+            raise ValueError(
+                "User IDs cannot appear in both add_owner_ids and "
+                f"remove_owner_ids: {overlap}."
+            )
+        return self
+
+
+class ManageDashboardOwnersResponse(BaseModel):
+    """Response schema for ``manage_dashboard_owners``."""
+
+    owners: List[UserInfo] = Field(
+        default_factory=list,
+        description="Full list of dashboard owners after the operation.",
+    )
+    dashboard_url: str | None = Field(None, description="URL to view the dashboard")
+    added_owner_ids: List[int] = Field(
+        default_factory=list,
+        description="User IDs actually added as owners by this call.",
+    )
+    removed_owner_ids: List[int] = Field(
+        default_factory=list,
+        description="User IDs actually removed from owners by this call.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal advisory messages, e.g. that a non-admin caller was "
+            "automatically re-added as owner after trying to remove "
+            "themselves."
+        ),
+    )
+    error: str | None = Field(None, description="Error message, if operation failed")
+    permission_denied: bool = Field(
+        default=False,
+        description=("True when the user lacks edit rights on the target dashboard."),
+    )
+
+    @field_validator("error")
+    @classmethod
+    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
+        """Wrap error text before it is exposed to LLM context."""
+        if value is None:
+            return value
+        return sanitize_for_llm_context(value, field_path=("error",))
+
+
+class ManageDashboardRolesRequest(BaseModel):
+    """Request schema for explicit add/remove dashboard RBAC role management.
+
+    Unlike ``update_dashboard``'s dropped ``roles`` field (a full-replacement
+    access-control list), this tool takes explicit add/remove operations.
+    """
+
+    identifier: int | str = Field(
+        ...,
+        description=(
+            "Dashboard ID (integer), UUID, or slug. Same identifier shape "
+            "accepted by ``get_dashboard_info``."
+        ),
+    )
+    add_role_ids: List[int] = Field(
+        default_factory=list,
+        description=(
+            "Role IDs to grant dashboard access to. Discover IDs with ``list_roles``."
+        ),
+    )
+    remove_role_ids: List[int] = Field(
+        default_factory=list,
+        description=(
+            "Role IDs to revoke dashboard access from. Rejected if an ID is "
+            "not currently assigned to the dashboard."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_operations(self) -> "ManageDashboardRolesRequest":
+        if not self.add_role_ids and not self.remove_role_ids:
+            raise ValueError(
+                "At least one of add_role_ids or remove_role_ids is required."
+            )
+        overlap = sorted(set(self.add_role_ids) & set(self.remove_role_ids))
+        if overlap:
+            raise ValueError(
+                "Role IDs cannot appear in both add_role_ids and "
+                f"remove_role_ids: {overlap}."
+            )
+        return self
+
+
+class ManageDashboardRolesResponse(BaseModel):
+    """Response schema for ``manage_dashboard_roles``."""
+
+    roles: List[RoleInfo] = Field(
+        default_factory=list,
+        description="Full list of dashboard access roles after the operation.",
+    )
+    dashboard_url: str | None = Field(None, description="URL to view the dashboard")
+    added_role_ids: List[int] = Field(
+        default_factory=list,
+        description="Role IDs actually added by this call.",
+    )
+    removed_role_ids: List[int] = Field(
+        default_factory=list,
+        description="Role IDs actually removed by this call.",
+    )
+    dashboard_rbac_enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether the DASHBOARD_RBAC feature flag is enabled on this "
+            "instance. When False, dashboard roles are stored but have no "
+            "effect on access control — access still follows normal "
+            "Superset permissions/ownership."
+        ),
+    )
+    warnings: List[str] = Field(
+        default_factory=list, description="Non-fatal advisory messages."
+    )
+    error: str | None = Field(None, description="Error message, if operation failed")
+    permission_denied: bool = Field(
+        default=False,
+        description=("True when the user lacks edit rights on the target dashboard."),
+    )
+
+    @field_validator("error")
+    @classmethod
+    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
+        """Wrap error text before it is exposed to LLM context."""
+        if value is None:
+            return value
+        return sanitize_for_llm_context(value, field_path=("error",))
+
+
+class ManageDashboardCertificationRequest(BaseModel):
+    """Request schema for setting or clearing dashboard certification.
+
+    ``certified_by`` and ``certification_details`` are independent optional
+    fields: omit (None) to leave a field unchanged, pass an empty string to
+    clear it, or pass a value to set it — mirrors the ``slug``/``css``
+    clear-with-empty-string convention on ``update_dashboard``.
+    """
+
+    identifier: int | str = Field(
+        ...,
+        description=(
+            "Dashboard ID (integer), UUID, or slug. Same identifier shape "
+            "accepted by ``get_dashboard_info``."
+        ),
+    )
+    certified_by: str | None = Field(
+        None,
+        max_length=500,
+        description=(
+            "Person or team certifying this dashboard. Pass an empty string "
+            "to clear. Omit (None) to leave unchanged."
+        ),
+    )
+    certification_details: str | None = Field(
+        None,
+        max_length=5000,
+        description=(
+            "Details of the certification (why/how it was certified). Pass "
+            "an empty string to clear. Omit (None) to leave unchanged."
+        ),
+    )
+
+    @field_validator("certified_by")
+    @classmethod
+    def sanitize_certified_by(cls, v: str | None) -> str | None:
+        """Sanitize certified_by to prevent XSS; it renders as a UI badge."""
+        if v is None or v == "":
+            return v
+        return sanitize_user_input(v, "certified_by", max_length=500, allow_empty=True)
+
+
+class ManageDashboardCertificationResponse(BaseModel):
+    """Response schema for ``manage_dashboard_certification``."""
+
+    certified_by: str | None = Field(
+        None, description="Certifying person/team after the operation."
+    )
+    certification_details: str | None = Field(
+        None, description="Certification details after the operation."
+    )
+    dashboard_url: str | None = Field(None, description="URL to view the dashboard")
+    changed_fields: List[str] = Field(
+        default_factory=list,
+        description="Names of fields that were actually applied.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list, description="Non-fatal advisory messages."
+    )
+    error: str | None = Field(None, description="Error message, if operation failed")
+    permission_denied: bool = Field(
+        default=False,
+        description=("True when the user lacks edit rights on the target dashboard."),
+    )
+
+    @field_validator("error")
+    @classmethod
+    def sanitize_error_for_llm_context(cls, value: str | None) -> str | None:
+        """Wrap error text before it is exposed to LLM context."""
+        if value is None:
+            return value
+        return sanitize_for_llm_context(value, field_path=("error",))
+
+    @field_validator("certified_by", "certification_details")
+    @classmethod
+    def sanitize_output_for_llm_context(
+        cls, value: str | None, info: Any
+    ) -> str | None:
+        """Wrap dashboard-controlled certification text before LLM exposure."""
+        if value is None:
+            return value
+        return sanitize_for_llm_context(value, field_path=(info.field_name,))
 
 
 class GenerateDashboardResponse(BaseModel):

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1128,6 +1128,15 @@ class ManageDashboardOwnersRequest(BaseModel):
             raise ValueError("identifier must be an integer ID, UUID, or slug string")
         return value
 
+    @field_validator("add_owner_ids", "remove_owner_ids", mode="before")
+    @classmethod
+    def reject_bool_owner_ids(cls, value: object) -> object:
+        """bool is a subclass of int, so a `true`/`false` list element would
+        coerce to owner ID 1/0 and add/remove the wrong owner; reject it."""
+        if isinstance(value, list) and any(isinstance(item, bool) for item in value):
+            raise ValueError("owner ID list items must be integers, not booleans")
+        return value
+
     @model_validator(mode="after")
     def _validate_operations(self) -> "ManageDashboardOwnersRequest":
         if not self.add_owner_ids and not self.remove_owner_ids:
@@ -1262,6 +1271,15 @@ class ManageDashboardRolesRequest(BaseModel):
             raise ValueError("identifier must be an integer ID, UUID, or slug string")
         return value
 
+    @field_validator("add_role_ids", "remove_role_ids", mode="before")
+    @classmethod
+    def reject_bool_role_ids(cls, value: object) -> object:
+        """bool is a subclass of int, so a `true`/`false` list element would
+        coerce to role ID 1/0 and grant/revoke the wrong role; reject it."""
+        if isinstance(value, list) and any(isinstance(item, bool) for item in value):
+            raise ValueError("role ID list items must be integers, not booleans")
+        return value
+
     @model_validator(mode="after")
     def _validate_operations(self) -> "ManageDashboardRolesRequest":
         if not self.add_role_ids and not self.remove_role_ids:
@@ -1366,6 +1384,15 @@ class ManageDashboardCertificationRequest(BaseModel):
             "an empty string to clear. Omit (None) to leave unchanged."
         ),
     )
+
+    @field_validator("identifier", mode="before")
+    @classmethod
+    def reject_bool_identifier(cls, value: object) -> object:
+        """bool is a subclass of int, so identifier=true would coerce to
+        dashboard ID 1 and mutate the wrong dashboard; reject it outright."""
+        if isinstance(value, bool):
+            raise ValueError("identifier must be an integer ID, UUID, or slug string")
+        return value
 
     @field_validator("certified_by")
     @classmethod

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1104,13 +1104,13 @@ class ManageDashboardOwnersRequest(BaseModel):
             "accepted by ``get_dashboard_info``."
         ),
     )
-    add_owner_ids: List[int] = Field(
+    add_owner_ids: list[int] = Field(
         default_factory=list,
         description=(
             "User IDs to add as dashboard owners. Discover IDs with ``find_users``."
         ),
     )
-    remove_owner_ids: List[int] = Field(
+    remove_owner_ids: list[int] = Field(
         default_factory=list,
         description=(
             "User IDs to remove from dashboard owners. Rejected if it would "
@@ -1178,7 +1178,7 @@ class DashboardMutationErrorFields(BaseModel):
 class ManageDashboardOwnersResponse(DashboardMutationErrorFields):
     """Response schema for ``manage_dashboard_owners``."""
 
-    owners: List[SubjectInfo] = Field(
+    owners: list[SubjectInfo] = Field(
         default_factory=list,
         description=(
             "Full list of USER-type editor subjects (dashboard owners) "
@@ -1187,15 +1187,15 @@ class ManageDashboardOwnersResponse(DashboardMutationErrorFields):
         ),
     )
     dashboard_url: str | None = Field(None, description="URL to view the dashboard")
-    added_owner_ids: List[int] = Field(
+    added_owner_ids: list[int] = Field(
         default_factory=list,
         description="User IDs actually added as owners by this call.",
     )
-    removed_owner_ids: List[int] = Field(
+    removed_owner_ids: list[int] = Field(
         default_factory=list,
         description="User IDs actually removed from owners by this call.",
     )
-    warnings: List[str] = Field(
+    warnings: list[str] = Field(
         default_factory=list,
         description=(
             "Non-fatal advisory messages, e.g. that a non-admin caller was "
@@ -1207,14 +1207,14 @@ class ManageDashboardOwnersResponse(DashboardMutationErrorFields):
     @field_validator("owners", mode="after")
     @classmethod
     def sanitize_owners_for_llm_context(
-        cls, value: List[SubjectInfo]
-    ) -> List[SubjectInfo]:
+        cls, value: list[SubjectInfo]
+    ) -> list[SubjectInfo]:
         """Wrap owner labels before LLM exposure; owner display names are
         user-controlled and render as plain text in this response, so an
         unsanitized label could inject content into LLM context (CWE-79
         analog for LLM-facing output). Entries that sanitize to an empty
         label are dropped rather than surfaced with a blank identity."""
-        sanitized: List[SubjectInfo] = []
+        sanitized: list[SubjectInfo] = []
         for subject in value:
             if subject.label is None:
                 sanitized.append(subject)
@@ -1248,13 +1248,13 @@ class ManageDashboardRolesRequest(BaseModel):
             "accepted by ``get_dashboard_info``."
         ),
     )
-    add_role_ids: List[int] = Field(
+    add_role_ids: list[int] = Field(
         default_factory=list,
         description=(
             "Role IDs to grant dashboard access to. Discover IDs with ``list_roles``."
         ),
     )
-    remove_role_ids: List[int] = Field(
+    remove_role_ids: list[int] = Field(
         default_factory=list,
         description=(
             "Role IDs to revoke dashboard access from. Rejected if an ID is "
@@ -1298,7 +1298,7 @@ class ManageDashboardRolesRequest(BaseModel):
 class ManageDashboardRolesResponse(DashboardMutationErrorFields):
     """Response schema for ``manage_dashboard_roles``."""
 
-    roles: List[SubjectInfo] = Field(
+    roles: list[SubjectInfo] = Field(
         default_factory=list,
         description=(
             "Full list of ROLE-type viewer subjects (dashboard access "
@@ -1307,11 +1307,11 @@ class ManageDashboardRolesResponse(DashboardMutationErrorFields):
         ),
     )
     dashboard_url: str | None = Field(None, description="URL to view the dashboard")
-    added_role_ids: List[int] = Field(
+    added_role_ids: list[int] = Field(
         default_factory=list,
         description="Role IDs actually added by this call.",
     )
-    removed_role_ids: List[int] = Field(
+    removed_role_ids: list[int] = Field(
         default_factory=list,
         description="Role IDs actually removed by this call.",
     )
@@ -1324,21 +1324,21 @@ class ManageDashboardRolesResponse(DashboardMutationErrorFields):
             "Superset permissions/editorship."
         ),
     )
-    warnings: List[str] = Field(
+    warnings: list[str] = Field(
         default_factory=list, description="Non-fatal advisory messages."
     )
 
     @field_validator("roles", mode="after")
     @classmethod
     def sanitize_roles_for_llm_context(
-        cls, value: List[SubjectInfo]
-    ) -> List[SubjectInfo]:
+        cls, value: list[SubjectInfo]
+    ) -> list[SubjectInfo]:
         """Wrap role labels before LLM exposure; role display names are
         user-controlled and render as plain text in this response, so an
         unsanitized label could inject content into LLM context (CWE-79
         analog for LLM-facing output). Entries that sanitize to an empty
         label are dropped rather than surfaced with a blank identity."""
-        sanitized: List[SubjectInfo] = []
+        sanitized: list[SubjectInfo] = []
         for subject in value:
             if subject.label is None:
                 sanitized.append(subject)
@@ -1443,11 +1443,11 @@ class ManageDashboardCertificationResponse(DashboardMutationErrorFields):
         None, description="Certification details after the operation."
     )
     dashboard_url: str | None = Field(None, description="URL to view the dashboard")
-    changed_fields: List[str] = Field(
+    changed_fields: list[str] = Field(
         default_factory=list,
         description="Names of fields that were actually applied.",
     )
-    warnings: List[str] = Field(
+    warnings: list[str] = Field(
         default_factory=list, description="Non-fatal advisory messages."
     )
 

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1219,7 +1219,7 @@ class ManageDashboardOwnersResponse(DashboardMutationErrorFields):
             if subject.label is None:
                 sanitized.append(subject)
                 continue
-            clean_label = sanitize_for_llm_context(
+            clean_label: str = sanitize_for_llm_context(
                 subject.label, field_path=("owners", "label")
             )
             if not clean_label:
@@ -1343,7 +1343,7 @@ class ManageDashboardRolesResponse(DashboardMutationErrorFields):
             if subject.label is None:
                 sanitized.append(subject)
                 continue
-            clean_label = sanitize_for_llm_context(
+            clean_label: str = sanitize_for_llm_context(
                 subject.label, field_path=("roles", "label")
             )
             if not clean_label:

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1125,7 +1125,9 @@ class ManageDashboardOwnersRequest(BaseModel):
             raise ValueError(
                 "At least one of add_owner_ids or remove_owner_ids is required."
             )
-        overlap = sorted(set(self.add_owner_ids) & set(self.remove_owner_ids))
+        overlap: list[int] = sorted(
+            set(self.add_owner_ids) & set(self.remove_owner_ids)
+        )
         if overlap:
             raise ValueError(
                 "User IDs cannot appear in both add_owner_ids and "
@@ -1217,7 +1219,7 @@ class ManageDashboardRolesRequest(BaseModel):
             raise ValueError(
                 "At least one of add_role_ids or remove_role_ids is required."
             )
-        overlap = sorted(set(self.add_role_ids) & set(self.remove_role_ids))
+        overlap: list[int] = sorted(set(self.add_role_ids) & set(self.remove_role_ids))
         if overlap:
             raise ValueError(
                 "Role IDs cannot appear in both add_role_ids and "
@@ -1312,7 +1314,18 @@ class ManageDashboardCertificationRequest(BaseModel):
         """Sanitize certified_by to prevent XSS; it renders as a UI badge."""
         if v is None or v == "":
             return v
-        return sanitize_user_input(v, "certified_by", max_length=500, allow_empty=True)
+        sanitized: str | None = sanitize_user_input(
+            v, "certified_by", max_length=500, allow_empty=True
+        )
+        if not sanitized:
+            # Empty string means "clear the field", so an input that
+            # sanitizes down to nothing (HTML-only or whitespace-only) must
+            # not silently erase an existing certification.
+            raise ValueError(
+                "certified_by has no content left after sanitization; pass "
+                'an explicit empty string ("") to clear the field.'
+            )
+        return sanitized
 
     @field_validator("certification_details")
     @classmethod
@@ -1321,9 +1334,17 @@ class ManageDashboardCertificationRequest(BaseModel):
         same CertifiedBadge tooltip as certified_by."""
         if v is None or v == "":
             return v
-        return sanitize_user_input(
+        sanitized: str | None = sanitize_user_input(
             v, "certification_details", max_length=5000, allow_empty=True
         )
+        if not sanitized:
+            # Same guard as certified_by: only an explicit "" may clear.
+            raise ValueError(
+                "certification_details has no content left after "
+                'sanitization; pass an explicit empty string ("") to clear '
+                "the field."
+            )
+        return sanitized
 
 
 class ManageDashboardCertificationResponse(BaseModel):

--- a/superset/mcp_service/dashboard/tool/__init__.py
+++ b/superset/mcp_service/dashboard/tool/__init__.py
@@ -23,6 +23,9 @@ from .get_dashboard_datasets import get_dashboard_datasets
 from .get_dashboard_info import get_dashboard_info
 from .get_dashboard_layout import get_dashboard_layout
 from .list_dashboards import list_dashboards
+from .manage_dashboard_certification import manage_dashboard_certification
+from .manage_dashboard_owners import manage_dashboard_owners
+from .manage_dashboard_roles import manage_dashboard_roles
 from .manage_native_filters import manage_native_filters
 from .remove_chart_from_dashboard import remove_chart_from_dashboard
 from .restore_dashboard import restore_dashboard
@@ -36,6 +39,9 @@ __all__ = [
     "generate_dashboard",
     "duplicate_dashboard",
     "add_chart_to_existing_dashboard",
+    "manage_dashboard_certification",
+    "manage_dashboard_owners",
+    "manage_dashboard_roles",
     "manage_native_filters",
     "remove_chart_from_dashboard",
     "restore_dashboard",

--- a/superset/mcp_service/dashboard/tool/governance_utils.py
+++ b/superset/mcp_service/dashboard/tool/governance_utils.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Shared helpers for the dashboard governance tools
+(``manage_dashboard_owners`` / ``manage_dashboard_roles`` /
+``manage_dashboard_certification``).
+
+``update_dashboard`` keeps its own variant of the lookup/authorization
+helper because its not-found contract differs — it returns a
+``DashboardError`` carrying an ``error_type`` rather than the tool's own
+response schema; unifying that shape is left to a follow-up.
+"""
+
+import logging
+from typing import Any, TypeVar
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,
+    DashboardNotFoundError,
+)
+from superset.exceptions import SupersetSecurityException
+from superset.mcp_service.dashboard.schemas import DashboardMutationErrorFields
+from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+ResponseT = TypeVar("ResponseT", bound=DashboardMutationErrorFields)
+
+
+def find_and_authorize_dashboard(
+    identifier: int | str,
+    response_cls: type[ResponseT],
+) -> tuple[Any, ResponseT | None]:
+    """Return (dashboard, None) on success or (None, error_response) on failure.
+
+    ``response_cls`` is the calling tool's response schema; every failure
+    mode is reported through it so the caller has a single pre-condition
+    branch. Mirrors the helper in ``update_dashboard``: avoids ImportError
+    before Flask app initialisation by co-locating the imports it needs
+    with the call site rather than importing them at module load time.
+    """
+    from superset import security_manager
+    from superset.daos.dashboard import DashboardDAO
+
+    try:
+        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except DashboardAccessDeniedError:
+        # get_by_id_or_slug re-checks view access and raises access-denied
+        # for dashboards the caller cannot see; surface it as the
+        # structured permission_denied response instead of an unhandled
+        # error.
+        return None, response_cls(
+            permission_denied=True,
+            error=(
+                "You do not have permission to access this dashboard. "
+                "Ask the user to grant access; do not retry."
+            ),
+        )
+    except DashboardNotFoundError:
+        return None, response_cls(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+    except SQLAlchemyError:
+        logger.exception("Database error looking up dashboard %r", identifier)
+        return None, response_cls(
+            error="Failed to look up dashboard due to a database error.",
+        )
+
+    if dashboard is None:
+        return None, response_cls(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    try:
+        security_manager.raise_for_editorship(dashboard)
+    except SupersetSecurityException:
+        return None, response_cls(
+            permission_denied=True,
+            error=(
+                f"You don't have permission to edit dashboard "
+                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
+            ),
+        )
+
+    return dashboard, None
+
+
+def dashboard_url(dashboard: Any) -> str:
+    """Build the user-facing dashboard URL, preferring slug over id."""
+    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"

--- a/superset/mcp_service/dashboard/tool/governance_utils.py
+++ b/superset/mcp_service/dashboard/tool/governance_utils.py
@@ -27,7 +27,7 @@ response schema; unifying that shape is left to a follow-up.
 """
 
 import logging
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -39,6 +39,9 @@ from superset.exceptions import SupersetSecurityException
 from superset.mcp_service.dashboard.schemas import DashboardMutationErrorFields
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 
+if TYPE_CHECKING:
+    from superset.models.dashboard import Dashboard
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 ResponseT = TypeVar("ResponseT", bound=DashboardMutationErrorFields)
@@ -47,7 +50,7 @@ ResponseT = TypeVar("ResponseT", bound=DashboardMutationErrorFields)
 def find_and_authorize_dashboard(
     identifier: int | str,
     response_cls: type[ResponseT],
-) -> tuple[Any, ResponseT | None]:
+) -> tuple["Dashboard | None", ResponseT | None]:
     """Return (dashboard, None) on success or (None, error_response) on failure.
 
     ``response_cls`` is the calling tool's response schema; every failure
@@ -60,7 +63,7 @@ def find_and_authorize_dashboard(
     from superset.daos.dashboard import DashboardDAO
 
     try:
-        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+        dashboard: Dashboard | None = DashboardDAO.get_by_id_or_slug(identifier)
     except DashboardAccessDeniedError:
         # get_by_id_or_slug re-checks view access and raises access-denied
         # for dashboards the caller cannot see; surface it as the
@@ -98,10 +101,20 @@ def find_and_authorize_dashboard(
                 f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
             ),
         )
+    except SQLAlchemyError:
+        # raise_for_editorship re-queries the dashboard's editor
+        # relationship, so a broken session here is just as possible as in
+        # the lookup above.
+        logger.exception(
+            "Database error checking editorship for dashboard %r", identifier
+        )
+        return None, response_cls(
+            error="Failed to verify dashboard edit permission due to a database error.",
+        )
 
     return dashboard, None
 
 
-def dashboard_url(dashboard: Any) -> str:
+def dashboard_url(dashboard: "Dashboard") -> str:
     """Build the user-facing dashboard URL, preferring slug over id."""
     return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -25,85 +25,22 @@ edits.
 """
 
 import logging
-from typing import Any
 
 from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import (
-    DashboardAccessDeniedError,
-    DashboardNotFoundError,
-)
-from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
     ManageDashboardCertificationRequest,
     ManageDashboardCertificationResponse,
 )
-from superset.mcp_service.utils.url_utils import get_superset_base_url
+from superset.mcp_service.dashboard.tool.governance_utils import (
+    dashboard_url,
+    find_and_authorize_dashboard,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-def _find_and_authorize_dashboard(
-    identifier: int | str,
-) -> tuple[Any, ManageDashboardCertificationResponse | None]:
-    """Return (dashboard, None) on success or (None, error_response) on failure.
-
-    Mirrors the helper in ``update_dashboard``: avoids ImportError before
-    Flask app initialisation by co-locating the imports it needs with the
-    call site rather than importing them at module load time.
-    """
-    from superset import security_manager
-    from superset.daos.dashboard import DashboardDAO
-
-    try:
-        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
-    except DashboardAccessDeniedError:
-        # get_by_id_or_slug re-checks view access and raises access-denied
-        # for dashboards the caller cannot see; surface it as the
-        # structured permission_denied response instead of an unhandled
-        # error.
-        return None, ManageDashboardCertificationResponse(
-            permission_denied=True,
-            error=(
-                "You do not have permission to access this dashboard. "
-                "Ask the user to grant access; do not retry."
-            ),
-        )
-    except DashboardNotFoundError:
-        return None, ManageDashboardCertificationResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-    except SQLAlchemyError:
-        logger.exception("Database error looking up dashboard %r", identifier)
-        return None, ManageDashboardCertificationResponse(
-            error="Failed to look up dashboard due to a database error.",
-        )
-
-    if dashboard is None:
-        return None, ManageDashboardCertificationResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-
-    try:
-        security_manager.raise_for_editorship(dashboard)
-    except SupersetSecurityException:
-        return None, ManageDashboardCertificationResponse(
-            permission_denied=True,
-            error=(
-                f"You don't have permission to edit dashboard "
-                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
-            ),
-        )
-
-    return dashboard, None
-
-
-def _dashboard_url(dashboard: Any) -> str:
-    """Build the user-facing dashboard URL, preferring slug over id."""
-    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 @tool(
@@ -137,7 +74,9 @@ def manage_dashboard_certification(
     """
     ctx.info(f"Managing dashboard certification: identifier={request.identifier}")
 
-    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    dashboard, auth_error = find_and_authorize_dashboard(
+        request.identifier, ManageDashboardCertificationResponse
+    )
     if auth_error is not None:
         return auth_error
 
@@ -145,7 +84,7 @@ def manage_dashboard_certification(
         return ManageDashboardCertificationResponse(
             certified_by=dashboard.certified_by,
             certification_details=dashboard.certification_details,
-            dashboard_url=_dashboard_url(dashboard),
+            dashboard_url=dashboard_url(dashboard),
             changed_fields=[],
             warnings=["No fields provided; dashboard unchanged."],
         )
@@ -209,7 +148,7 @@ def manage_dashboard_certification(
     return ManageDashboardCertificationResponse(
         certified_by=final_certified_by,
         certification_details=final_certification_details,
-        dashboard_url=_dashboard_url(dashboard),
+        dashboard_url=dashboard_url(dashboard),
         changed_fields=changed_fields,
         warnings=warnings,
     )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -1,0 +1,189 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Manage dashboard certification FastMCP tool
+
+Sets or clears the ``certified_by`` / ``certification_details`` badge
+fields. Split out from the generic ``update_dashboard`` tool because
+certification is a distinct governance concern from layout/theme/metadata
+edits.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.exceptions import SupersetSecurityException
+from superset.extensions import db, event_logger
+from superset.mcp_service.dashboard.schemas import (
+    ManageDashboardCertificationRequest,
+    ManageDashboardCertificationResponse,
+)
+from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+logger = logging.getLogger(__name__)
+
+
+def _find_and_authorize_dashboard(
+    identifier: int | str,
+) -> tuple[Any, ManageDashboardCertificationResponse | None]:
+    """Return (dashboard, None) on success or (None, error_response) on failure.
+
+    Mirrors the helper in ``update_dashboard``: avoids ImportError before
+    Flask app initialisation by co-locating the imports it needs with the
+    call site rather than importing them at module load time.
+    """
+    from superset import security_manager
+    from superset.daos.dashboard import DashboardDAO
+
+    try:
+        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except (DashboardNotFoundError, SQLAlchemyError):
+        return None, ManageDashboardCertificationResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    if dashboard is None:
+        return None, ManageDashboardCertificationResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    try:
+        security_manager.raise_for_ownership(dashboard)
+    except SupersetSecurityException:
+        return None, ManageDashboardCertificationResponse(
+            permission_denied=True,
+            error=(
+                f"You don't have permission to edit dashboard "
+                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
+            ),
+        )
+
+    return dashboard, None
+
+
+def _dashboard_url(dashboard: Any) -> str:
+    """Build the user-facing dashboard URL, preferring slug over id."""
+    return (
+        f"{get_superset_base_url()}/superset/dashboard/"
+        f"{dashboard.slug or dashboard.id}/"
+    )
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dashboard",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Manage dashboard certification",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+def manage_dashboard_certification(
+    request: ManageDashboardCertificationRequest, ctx: Context
+) -> ManageDashboardCertificationResponse:
+    """
+    Set or clear a dashboard's certification badge.
+
+    ``certified_by`` and ``certification_details`` are independent optional
+    fields: omit (None) to leave a field unchanged, pass an empty string to
+    clear it, or pass a value to set it. Certification surfaces as a badge
+    next to the dashboard title in the UI.
+
+    Example::
+
+        manage_dashboard_certification(request={
+            "identifier": 42,
+            "certified_by": "Data Platform Team",
+            "certification_details": "Verified against source-of-truth metrics.",
+        })
+    """
+    ctx.info(f"Managing dashboard certification: identifier={request.identifier}")
+
+    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    if auth_error is not None:
+        return auth_error
+
+    if request.certified_by is None and request.certification_details is None:
+        return ManageDashboardCertificationResponse(
+            certified_by=dashboard.certified_by,
+            certification_details=dashboard.certification_details,
+            dashboard_url=_dashboard_url(dashboard),
+            changed_fields=[],
+            warnings=["No fields provided; dashboard unchanged."],
+        )
+
+    changed_fields: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        with event_logger.log_context(
+            action="mcp.manage_dashboard_certification.apply"
+        ):
+            if request.certified_by is not None:
+                dashboard.certified_by = request.certified_by or None
+                changed_fields.append("certified_by")
+
+            if request.certification_details is not None:
+                dashboard.certification_details = request.certification_details or None
+                changed_fields.append("certification_details")
+
+            db.session.commit()  # pylint: disable=consider-using-transaction
+            try:
+                db.session.refresh(dashboard)
+            except SQLAlchemyError:
+                logger.warning(
+                    "Dashboard %s certification updated but refresh failed; "
+                    "continuing with current values",
+                    dashboard.id,
+                    exc_info=True,
+                )
+                warnings.append(
+                    "Dashboard updated but post-update refresh failed; "
+                    "returned values may not reflect database state."
+                )
+
+    except SQLAlchemyError as db_err:
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling",
+                exc_info=True,
+            )
+        logger.error("Dashboard certification update failed: %s", db_err, exc_info=True)
+        return ManageDashboardCertificationResponse(
+            error="Failed to update dashboard certification due to a database error.",
+        )
+
+    ctx.info(
+        f"Dashboard {dashboard.id} certification updated: changed={changed_fields}"
+    )
+
+    return ManageDashboardCertificationResponse(
+        certified_by=dashboard.certified_by,
+        certification_details=dashboard.certification_details,
+        dashboard_url=_dashboard_url(dashboard),
+        changed_fields=changed_fields,
+        warnings=warnings,
+    )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -40,7 +40,7 @@ from superset.mcp_service.dashboard.schemas import (
 )
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _find_and_authorize_dashboard(
@@ -83,10 +83,7 @@ def _find_and_authorize_dashboard(
 
 def _dashboard_url(dashboard: Any) -> str:
     """Build the user-facing dashboard URL, preferring slug over id."""
-    return (
-        f"{get_superset_base_url()}/superset/dashboard/"
-        f"{dashboard.slug or dashboard.id}/"
-    )
+    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 @tool(

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -68,7 +68,7 @@ def _find_and_authorize_dashboard(
         )
 
     try:
-        security_manager.raise_for_ownership(dashboard)
+        security_manager.raise_for_editorship(dashboard)
     except SupersetSecurityException:
         return None, ManageDashboardCertificationResponse(
             permission_denied=True,

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -152,17 +152,26 @@ def manage_dashboard_certification(
 
     changed_fields: list[str] = []
     warnings: list[str] = []
+    # Captured before commit so the final response never has to dereference
+    # `dashboard` post-commit: SQLAlchemy expires ORM attributes on commit,
+    # and a failed `refresh()` below would otherwise leave a later
+    # `dashboard.certified_by`/`certification_details` read free to raise an
+    # unhandled `SQLAlchemyError` from a broken session.
+    final_certified_by = dashboard.certified_by
+    final_certification_details = dashboard.certification_details
 
     try:
         with event_logger.log_context(
             action="mcp.manage_dashboard_certification.apply"
         ):
             if request.certified_by is not None:
-                dashboard.certified_by = request.certified_by or None
+                final_certified_by = request.certified_by or None
+                dashboard.certified_by = final_certified_by
                 changed_fields.append("certified_by")
 
             if request.certification_details is not None:
-                dashboard.certification_details = request.certification_details or None
+                final_certification_details = request.certification_details or None
+                dashboard.certification_details = final_certification_details
                 changed_fields.append("certification_details")
 
             db.session.commit()  # pylint: disable=consider-using-transaction
@@ -198,8 +207,8 @@ def manage_dashboard_certification(
     )
 
     return ManageDashboardCertificationResponse(
-        certified_by=dashboard.certified_by,
-        certification_details=dashboard.certification_details,
+        certified_by=final_certified_by,
+        certification_details=final_certification_details,
         dashboard_url=_dashboard_url(dashboard),
         changed_fields=changed_fields,
         warnings=warnings,

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -72,9 +72,14 @@ def _find_and_authorize_dashboard(
                 "Ask the user to grant access; do not retry."
             ),
         )
-    except (DashboardNotFoundError, SQLAlchemyError):
+    except DashboardNotFoundError:
         return None, ManageDashboardCertificationResponse(
             error=f"Dashboard not found: {identifier!r}",
+        )
+    except SQLAlchemyError:
+        logger.exception("Database error looking up dashboard %r", identifier)
+        return None, ManageDashboardCertificationResponse(
+            error="Failed to look up dashboard due to a database error.",
         )
 
     if dashboard is None:

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -31,7 +31,10 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,
+    DashboardNotFoundError,
+)
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
@@ -57,6 +60,18 @@ def _find_and_authorize_dashboard(
 
     try:
         dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except DashboardAccessDeniedError:
+        # get_by_id_or_slug re-checks view access and raises access-denied
+        # for dashboards the caller cannot see; surface it as the
+        # structured permission_denied response instead of an unhandled
+        # error.
+        return None, ManageDashboardCertificationResponse(
+            permission_denied=True,
+            error=(
+                "You do not have permission to access this dashboard. "
+                "Ask the user to grant access; do not retry."
+            ),
+        )
     except (DashboardNotFoundError, SQLAlchemyError):
         return None, ManageDashboardCertificationResponse(
             error=f"Dashboard not found: {identifier!r}",

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -79,6 +79,7 @@ def manage_dashboard_certification(
     )
     if auth_error is not None:
         return auth_error
+    assert dashboard is not None  # narrows for mypy
 
     if request.certified_by is None and request.certification_details is None:
         return ManageDashboardCertificationResponse(
@@ -96,8 +97,8 @@ def manage_dashboard_certification(
     # and a failed `refresh()` below would otherwise leave a later
     # `dashboard.certified_by`/`certification_details` read free to raise an
     # unhandled `SQLAlchemyError` from a broken session.
-    final_certified_by = dashboard.certified_by
-    final_certification_details = dashboard.certification_details
+    final_certified_by: str | None = dashboard.certified_by
+    final_certification_details: str | None = dashboard.certification_details
 
     try:
         with event_logger.log_context(

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -174,12 +174,17 @@ def _compute_new_owner_ids(
 
 def _apply_owner_change(
     dashboard: Any, new_owner_ids: list[int]
-) -> ManageDashboardOwnersResponse | None:
+) -> tuple[list[Any] | None, ManageDashboardOwnersResponse | None]:
     """Resolve the new owner user IDs to USER-type Subjects and persist.
 
     Mutates ``dashboard.editors`` in place on success — replacing the
     USER-type entries while preserving any ROLE/GROUP-type editors. Returns
-    an error response on failure, or ``None`` on success.
+    ``(resolved_owner_subjects, None)`` on success — captured before commit
+    so callers never need to dereference ``dashboard.editors`` post-commit
+    (SQLAlchemy expires ORM attributes on commit, and a failed
+    ``refresh()`` would otherwise leave a later ``dashboard.editors`` read
+    free to raise an unhandled ``SQLAlchemyError`` from a broken session) —
+    or ``(None, error_response)`` on failure.
     """
     from superset.commands.utils import populate_subject_list
     from superset.subjects.utils import get_or_create_user_subject
@@ -192,7 +197,7 @@ def _apply_owner_change(
             for user_id in new_owner_ids:
                 subject = get_or_create_user_subject(user_id)
                 if subject is None:
-                    return ManageDashboardOwnersResponse(
+                    return None, ManageDashboardOwnersResponse(
                         error=(
                             f"User ID {user_id} does not exist. Use "
                             "find_users to resolve valid user IDs."
@@ -208,7 +213,7 @@ def _apply_owner_change(
                     field_name="editors",
                 )
             except SubjectsNotFoundValidationError:
-                return ManageDashboardOwnersResponse(
+                return None, ManageDashboardOwnersResponse(
                     error=(
                         "One or more user IDs could not be resolved to "
                         "owners. Use find_users to resolve valid user IDs."
@@ -236,11 +241,11 @@ def _apply_owner_change(
                 exc_info=True,
             )
         logger.error("Dashboard owners update failed: %s", db_err, exc_info=True)
-        return ManageDashboardOwnersResponse(
+        return None, ManageDashboardOwnersResponse(
             error="Failed to update dashboard owners due to a database error.",
         )
 
-    return None
+    return resolved_owner_subjects, None
 
 
 def _build_owner_warnings(
@@ -351,10 +356,16 @@ def manage_dashboard_owners(
             ],
         )
 
-    if (apply_error := _apply_owner_change(dashboard, new_owner_ids)) is not None:
+    resolved_owner_subjects, apply_error = _apply_owner_change(dashboard, new_owner_ids)
+    if apply_error is not None:
         return apply_error
+    assert resolved_owner_subjects is not None  # narrows for mypy
 
-    final_owner_ids = set(_owner_user_ids(dashboard))
+    final_owner_ids = {
+        subject.user_id
+        for subject in resolved_owner_subjects
+        if subject.type == SubjectType.USER
+    }
     warnings = _build_owner_warnings(final_owner_ids, new_owner_ids)
 
     # True deltas against the PRE-call state — not just membership in the
@@ -384,7 +395,7 @@ def manage_dashboard_owners(
     return ManageDashboardOwnersResponse(
         owners=[
             info
-            for subject in dashboard.editors
+            for subject in resolved_owner_subjects
             if subject.type == SubjectType.USER
             and (info := serialize_subject_object(subject)) is not None
         ],

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -51,7 +51,7 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.subjects.exceptions import SubjectsNotFoundValidationError
 from superset.subjects.types import SubjectType
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _find_and_authorize_dashboard(
@@ -94,10 +94,7 @@ def _find_and_authorize_dashboard(
 
 def _dashboard_url(dashboard: Any) -> str:
     """Build the user-facing dashboard URL, preferring slug over id."""
-    return (
-        f"{get_superset_base_url()}/superset/dashboard/"
-        f"{dashboard.slug or dashboard.id}/"
-    )
+    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 def _owner_user_ids(dashboard: Any) -> list[int]:

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -20,8 +20,16 @@ Manage dashboard owners FastMCP tool
 
 Adds/removes dashboard owners via explicit operations, guarding against the
 "empty owners" footgun that the generic ``update_dashboard`` tool
-deliberately does not expose (a full-replacement ``owners`` list has no
-"keep >=1 owner" guard in ``UpdateDashboardCommand``).
+deliberately does not expose (a full-replacement ``owners``/``editors`` list
+has no "keep >=1 owner" guard of its own — ``populate_subject_list``'s
+``ensure_no_lockout`` only re-adds the CALLER, it does not prevent an admin
+from emptying the list outright).
+
+"Owners" are modeled as USER-type entries in the dashboard's Subject-based
+``editors`` list (apache/superset#38831 replaced the legacy ``owners``
+relationship with a unified Subject model covering User/Role/Group). Any
+ROLE- or GROUP-type editors already on the dashboard are preserved
+untouched by this tool.
 """
 
 import logging
@@ -32,15 +40,16 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.dashboard.exceptions import DashboardNotFoundError
-from superset.commands.exceptions import OwnersNotFoundValidationError
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
     ManageDashboardOwnersRequest,
     ManageDashboardOwnersResponse,
 )
-from superset.mcp_service.user.schemas import serialize_user_object
+from superset.mcp_service.system.schemas import serialize_subject_object
 from superset.mcp_service.utils.url_utils import get_superset_base_url
+from superset.subjects.exceptions import SubjectsNotFoundValidationError
+from superset.subjects.types import SubjectType
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +79,7 @@ def _find_and_authorize_dashboard(
         )
 
     try:
-        security_manager.raise_for_ownership(dashboard)
+        security_manager.raise_for_editorship(dashboard)
     except SupersetSecurityException:
         return None, ManageDashboardOwnersResponse(
             permission_denied=True,
@@ -89,6 +98,22 @@ def _dashboard_url(dashboard: Any) -> str:
         f"{get_superset_base_url()}/superset/dashboard/"
         f"{dashboard.slug or dashboard.id}/"
     )
+
+
+def _owner_user_ids(dashboard: Any) -> list[int]:
+    """User IDs behind the dashboard's USER-type editor subjects."""
+    return [
+        subject.user_id
+        for subject in dashboard.editors
+        if subject.type == SubjectType.USER
+    ]
+
+
+def _other_editors(dashboard: Any) -> list[Any]:
+    """Non-USER-type editors (ROLE/GROUP subjects), preserved untouched."""
+    return [
+        subject for subject in dashboard.editors if subject.type != SubjectType.USER
+    ]
 
 
 def _compute_new_owner_ids(
@@ -133,28 +158,47 @@ def _compute_new_owner_ids(
 def _apply_owner_change(
     dashboard: Any, new_owner_ids: list[int]
 ) -> ManageDashboardOwnersResponse | None:
-    """Resolve and persist the new owner list.
+    """Resolve the new owner user IDs to USER-type Subjects and persist.
 
-    Mutates ``dashboard.owners`` in place on success. Returns an error
-    response on failure, or ``None`` on success.
+    Mutates ``dashboard.editors`` in place on success — replacing the
+    USER-type entries while preserving any ROLE/GROUP-type editors. Returns
+    an error response on failure, or ``None`` on success.
     """
-    from superset.commands.utils import populate_owner_list
+    from superset.commands.utils import populate_subject_list
+    from superset.subjects.utils import get_or_create_user_subject
 
     try:
         with event_logger.log_context(action="mcp.manage_dashboard_owners.apply"):
+            other_editors = _other_editors(dashboard)
+
+            new_subject_ids: list[int] = []
+            for user_id in new_owner_ids:
+                subject = get_or_create_user_subject(user_id)
+                if subject is None:
+                    return ManageDashboardOwnersResponse(
+                        error=(
+                            f"User ID {user_id} does not exist. Use "
+                            "find_users to resolve valid user IDs."
+                        ),
+                    )
+                new_subject_ids.append(subject.id)
+
             try:
-                resolved_owners = populate_owner_list(
-                    new_owner_ids, default_to_user=False
+                resolved_owner_subjects = populate_subject_list(
+                    new_subject_ids,
+                    default_to_user=False,
+                    ensure_no_lockout=True,
+                    field_name="editors",
                 )
-            except OwnersNotFoundValidationError:
+            except SubjectsNotFoundValidationError:
                 return ManageDashboardOwnersResponse(
                     error=(
-                        "One or more user IDs do not exist. Use find_users "
-                        "to resolve valid user IDs."
+                        "One or more user IDs could not be resolved to "
+                        "owners. Use find_users to resolve valid user IDs."
                     ),
                 )
 
-            dashboard.owners = resolved_owners
+            dashboard.editors = other_editors + resolved_owner_subjects
             db.session.commit()  # pylint: disable=consider-using-transaction
             try:
                 db.session.refresh(dashboard)
@@ -188,7 +232,8 @@ def _build_owner_warnings(
     """Flag when the resolver re-added an ID that was not requested.
 
     Happens when a non-admin caller tries to remove themselves —
-    ``populate_owner_list``'s self-protection re-adds them.
+    ``populate_subject_list``'s ``ensure_no_lockout`` self-protection
+    re-adds their USER subject.
     """
     auto_added = final_owner_ids - set(new_owner_ids)
     if not auto_added:
@@ -221,16 +266,24 @@ def manage_dashboard_owners(
     a full-replacement list — only ``add_owner_ids``/``remove_owner_ids`` —
     and rejects any change that would leave the dashboard with zero owners.
 
+    Owners are the USER-type entries in the dashboard's Subject-based
+    ``editors`` list. Any ROLE- or GROUP-type editors already on the
+    dashboard are left untouched.
+
     A non-admin caller who removes themselves is automatically re-added
-    (mirrors the REST ``UpdateDashboardCommand`` self-protection) unless an
-    ``EXTRA_OWNERS_RESOLVER`` is configured on the instance; the response's
-    ``warnings`` reports when this happens.
+    (mirrors the same self-protection ``update_dashboard``'s editorship
+    check relies on) unless an ``EXTRA_EDITORS_RESOLVER`` is configured on
+    the instance; the response's ``warnings`` reports when this happens.
 
     Privacy: the returned ``owners`` list is sanctioned only as confirmation
     of the add/remove operation the caller explicitly requested on this
     dashboard. Do not use it to answer "who owns X" for a dashboard the
     caller did not ask to modify, and do not call this tool merely to look
     up current owners — those remain off-limits per the server instructions.
+    A request that has no effective change (e.g. "adding" an ID that is
+    already an owner) returns an empty ``owners`` list rather than the full
+    current set, so this tool cannot be used as a disguised directory
+    lookup.
 
     Example::
 
@@ -249,33 +302,77 @@ def manage_dashboard_owners(
     if auth_error is not None:
         return auth_error
 
-    current_owner_ids = [owner.id for owner in dashboard.owners]
+    try:
+        current_owner_ids = _owner_user_ids(dashboard)
+    except SQLAlchemyError as db_err:
+        logger.error(
+            "Failed to load owners for dashboard %s: %s",
+            request.identifier,
+            db_err,
+            exc_info=True,
+        )
+        return ManageDashboardOwnersResponse(
+            error="Failed to load dashboard owners due to a database error.",
+        )
+
     new_owner_ids, compute_error = _compute_new_owner_ids(current_owner_ids, request)
     if compute_error is not None:
         return compute_error
     assert new_owner_ids is not None  # narrows for mypy; empty list errors above
 
+    # No-op short-circuit: skip the DB write and, more importantly, the full
+    # owners list in the response. The owners list is only sanctioned as
+    # confirmation of an actual change (see docstring); returning it for a
+    # request that changes nothing would let a caller enumerate owners via
+    # a disguised no-op (e.g. "add" an ID that is already an owner).
+    if set(new_owner_ids) == set(current_owner_ids):
+        ctx.info(f"Dashboard {dashboard.id} owners unchanged; no-op request.")
+        return ManageDashboardOwnersResponse(
+            dashboard_url=_dashboard_url(dashboard),
+            warnings=[
+                "No effective change: requested owners already match the current state."
+            ],
+        )
+
     if (apply_error := _apply_owner_change(dashboard, new_owner_ids)) is not None:
         return apply_error
 
-    final_owner_ids = {owner.id for owner in dashboard.owners}
+    final_owner_ids = set(_owner_user_ids(dashboard))
     warnings = _build_owner_warnings(final_owner_ids, new_owner_ids)
+
+    # True deltas against the PRE-call state — not just membership in the
+    # request — so a redundant add/remove (already-satisfied, or reverted by
+    # ensure_no_lockout self-protection) is never reported or disclosed as a
+    # change.
+    added_owner_ids = sorted(
+        (final_owner_ids & set(request.add_owner_ids)) - set(current_owner_ids)
+    )
+    removed_owner_ids = sorted(
+        (set(request.remove_owner_ids) & set(current_owner_ids)) - final_owner_ids
+    )
+
+    if not added_owner_ids and not removed_owner_ids:
+        warnings.append(
+            "No effective change: the requested owners already matched the "
+            "final state after resolution."
+        )
+        ctx.info(f"Dashboard {dashboard.id} owners unchanged after resolution.")
+        return ManageDashboardOwnersResponse(
+            dashboard_url=_dashboard_url(dashboard),
+            warnings=warnings,
+        )
 
     ctx.info(f"Dashboard {dashboard.id} owners updated: {sorted(final_owner_ids)}")
 
     return ManageDashboardOwnersResponse(
         owners=[
             info
-            for owner in dashboard.owners
-            if (info := serialize_user_object(owner, include_sensitive=False))
-            is not None
+            for subject in dashboard.editors
+            if subject.type == SubjectType.USER
+            and (info := serialize_subject_object(subject)) is not None
         ],
         dashboard_url=_dashboard_url(dashboard),
-        added_owner_ids=sorted(final_owner_ids & set(request.add_owner_ids)),
-        removed_owner_ids=[
-            owner_id
-            for owner_id in request.remove_owner_ids
-            if owner_id not in final_owner_ids
-        ],
+        added_owner_ids=added_owner_ids,
+        removed_owner_ids=removed_owner_ids,
         warnings=warnings,
     )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -39,7 +39,10 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,
+    DashboardNotFoundError,
+)
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
@@ -68,6 +71,18 @@ def _find_and_authorize_dashboard(
 
     try:
         dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except DashboardAccessDeniedError:
+        # get_by_id_or_slug re-checks view access and raises access-denied
+        # for dashboards the caller cannot see; surface it as the
+        # structured permission_denied response instead of an unhandled
+        # error.
+        return None, ManageDashboardOwnersResponse(
+            permission_denied=True,
+            error=(
+                "You do not have permission to access this dashboard. "
+                "Ask the user to grant access; do not retry."
+            ),
+        )
     except (DashboardNotFoundError, SQLAlchemyError):
         return None, ManageDashboardOwnersResponse(
             error=f"Dashboard not found: {identifier!r}",

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -39,82 +39,20 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import (
-    DashboardAccessDeniedError,
-    DashboardNotFoundError,
-)
-from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
     ManageDashboardOwnersRequest,
     ManageDashboardOwnersResponse,
 )
+from superset.mcp_service.dashboard.tool.governance_utils import (
+    dashboard_url,
+    find_and_authorize_dashboard,
+)
 from superset.mcp_service.system.schemas import serialize_subject_object
-from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.subjects.exceptions import SubjectsNotFoundValidationError
 from superset.subjects.types import SubjectType
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-def _find_and_authorize_dashboard(
-    identifier: int | str,
-) -> tuple[Any, ManageDashboardOwnersResponse | None]:
-    """Return (dashboard, None) on success or (None, error_response) on failure.
-
-    Mirrors the helper in ``update_dashboard``: avoids ImportError before
-    Flask app initialisation by co-locating the imports it needs with the
-    call site rather than importing them at module load time.
-    """
-    from superset import security_manager
-    from superset.daos.dashboard import DashboardDAO
-
-    try:
-        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
-    except DashboardAccessDeniedError:
-        # get_by_id_or_slug re-checks view access and raises access-denied
-        # for dashboards the caller cannot see; surface it as the
-        # structured permission_denied response instead of an unhandled
-        # error.
-        return None, ManageDashboardOwnersResponse(
-            permission_denied=True,
-            error=(
-                "You do not have permission to access this dashboard. "
-                "Ask the user to grant access; do not retry."
-            ),
-        )
-    except DashboardNotFoundError:
-        return None, ManageDashboardOwnersResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-    except SQLAlchemyError:
-        logger.exception("Database error looking up dashboard %r", identifier)
-        return None, ManageDashboardOwnersResponse(
-            error="Failed to look up dashboard due to a database error.",
-        )
-
-    if dashboard is None:
-        return None, ManageDashboardOwnersResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-
-    try:
-        security_manager.raise_for_editorship(dashboard)
-    except SupersetSecurityException:
-        return None, ManageDashboardOwnersResponse(
-            permission_denied=True,
-            error=(
-                f"You don't have permission to edit dashboard "
-                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
-            ),
-        )
-
-    return dashboard, None
-
-
-def _dashboard_url(dashboard: Any) -> str:
-    """Build the user-facing dashboard URL, preferring slug over id."""
-    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 def _owner_user_ids(dashboard: Any) -> list[int]:
@@ -320,7 +258,9 @@ def manage_dashboard_owners(
         f"add={request.add_owner_ids} remove={request.remove_owner_ids}"
     )
 
-    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    dashboard, auth_error = find_and_authorize_dashboard(
+        request.identifier, ManageDashboardOwnersResponse
+    )
     if auth_error is not None:
         return auth_error
 
@@ -347,10 +287,18 @@ def manage_dashboard_owners(
     # confirmation of an actual change (see docstring); returning it for a
     # request that changes nothing would let a caller enumerate owners via
     # a disguised no-op (e.g. "add" an ID that is already an owner).
+    #
+    # A self-removal-only request from a non-admin is deliberately NOT
+    # detected here even though ensure_no_lockout will revert it: whether
+    # the caller is actually re-added depends on resolution-time state
+    # (admin status, EXTRA_EDITORS_RESOLVER) that populate_subject_list
+    # owns, and predicting it here would duplicate that logic. That rare
+    # path is allowed to commit a redundant (state-preserving) write and is
+    # caught by the post-resolution no-op check further down.
     if set(new_owner_ids) == set(current_owner_ids):
         ctx.info(f"Dashboard {dashboard.id} owners unchanged; no-op request.")
         return ManageDashboardOwnersResponse(
-            dashboard_url=_dashboard_url(dashboard),
+            dashboard_url=dashboard_url(dashboard),
             warnings=[
                 "No effective change: requested owners already match the current state."
             ],
@@ -386,7 +334,7 @@ def manage_dashboard_owners(
         )
         ctx.info(f"Dashboard {dashboard.id} owners unchanged after resolution.")
         return ManageDashboardOwnersResponse(
-            dashboard_url=_dashboard_url(dashboard),
+            dashboard_url=dashboard_url(dashboard),
             warnings=warnings,
         )
 
@@ -399,7 +347,7 @@ def manage_dashboard_owners(
             if subject.type == SubjectType.USER
             and (info := serialize_subject_object(subject)) is not None
         ],
-        dashboard_url=_dashboard_url(dashboard),
+        dashboard_url=dashboard_url(dashboard),
         added_owner_ids=added_owner_ids,
         removed_owner_ids=removed_owner_ids,
         warnings=warnings,

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -33,7 +33,7 @@ untouched by this tool.
 """
 
 import logging
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
@@ -52,10 +52,14 @@ from superset.mcp_service.system.schemas import serialize_subject_object
 from superset.subjects.exceptions import SubjectsNotFoundValidationError
 from superset.subjects.types import SubjectType
 
+if TYPE_CHECKING:
+    from superset.models.dashboard import Dashboard
+    from superset.subjects.models import Subject
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _owner_user_ids(dashboard: Any) -> list[int]:
+def _owner_user_ids(dashboard: "Dashboard") -> list[int]:
     """User IDs behind the dashboard's USER-type editor subjects."""
     return [
         subject.user_id
@@ -64,7 +68,7 @@ def _owner_user_ids(dashboard: Any) -> list[int]:
     ]
 
 
-def _other_editors(dashboard: Any) -> list[Any]:
+def _other_editors(dashboard: "Dashboard") -> list["Subject"]:
     """Non-USER-type editors (ROLE/GROUP subjects), preserved untouched."""
     return [
         subject for subject in dashboard.editors if subject.type != SubjectType.USER
@@ -111,18 +115,19 @@ def _compute_new_owner_ids(
 
 
 def _apply_owner_change(
-    dashboard: Any, new_owner_ids: list[int]
-) -> tuple[list[Any] | None, ManageDashboardOwnersResponse | None]:
+    dashboard: "Dashboard", new_owner_ids: list[int]
+) -> tuple[set[int] | None, list[Any] | None, ManageDashboardOwnersResponse | None]:
     """Resolve the new owner user IDs to USER-type Subjects and persist.
 
     Mutates ``dashboard.editors`` in place on success — replacing the
     USER-type entries while preserving any ROLE/GROUP-type editors. Returns
-    ``(resolved_owner_subjects, None)`` on success — captured before commit
-    so callers never need to dereference ``dashboard.editors`` post-commit
-    (SQLAlchemy expires ORM attributes on commit, and a failed
-    ``refresh()`` would otherwise leave a later ``dashboard.editors`` read
-    free to raise an unhandled ``SQLAlchemyError`` from a broken session) —
-    or ``(None, error_response)`` on failure.
+    ``(final_owner_ids, owners_response, None)`` on success — both captured
+    before commit so callers never need to dereference the resolved Subject
+    objects (or ``dashboard.editors``) post-commit: SQLAlchemy expires ORM
+    attributes on commit, and either a failed ``refresh()`` below or a
+    later attribute read on an expired Subject would otherwise be free to
+    raise an unhandled ``SQLAlchemyError`` from a broken session — or
+    ``(None, None, error_response)`` on failure.
     """
     from superset.commands.utils import populate_subject_list
     from superset.subjects.utils import get_or_create_user_subject
@@ -135,10 +140,18 @@ def _apply_owner_change(
             for user_id in new_owner_ids:
                 subject = get_or_create_user_subject(user_id)
                 if subject is None:
-                    return None, ManageDashboardOwnersResponse(
-                        error=(
-                            f"User ID {user_id} does not exist. Use "
-                            "find_users to resolve valid user IDs."
+                    # Roll back any Subject rows already flushed by earlier
+                    # iterations of this loop so this all-or-nothing request
+                    # never leaves an uncommitted partial sync behind.
+                    db.session.rollback()  # pylint: disable=consider-using-transaction
+                    return (
+                        None,
+                        None,
+                        ManageDashboardOwnersResponse(
+                            error=(
+                                f"User ID {user_id} does not exist. Use "
+                                "find_users to resolve valid user IDs."
+                            ),
                         ),
                     )
                 new_subject_ids.append(subject.id)
@@ -151,12 +164,30 @@ def _apply_owner_change(
                     field_name="editors",
                 )
             except SubjectsNotFoundValidationError:
-                return None, ManageDashboardOwnersResponse(
-                    error=(
-                        "One or more user IDs could not be resolved to "
-                        "owners. Use find_users to resolve valid user IDs."
+                db.session.rollback()  # pylint: disable=consider-using-transaction
+                return (
+                    None,
+                    None,
+                    ManageDashboardOwnersResponse(
+                        error=(
+                            "One or more user IDs could not be resolved to "
+                            "owners. Use find_users to resolve valid user IDs."
+                        ),
                     ),
                 )
+
+            # Captured before commit — see docstring.
+            final_owner_ids = {
+                subject.user_id
+                for subject in resolved_owner_subjects
+                if subject.type == SubjectType.USER
+            }
+            owners_response = [
+                info
+                for subject in resolved_owner_subjects
+                if subject.type == SubjectType.USER
+                and (info := serialize_subject_object(subject)) is not None
+            ]
 
             dashboard.editors = other_editors + resolved_owner_subjects
             db.session.commit()  # pylint: disable=consider-using-transaction
@@ -179,11 +210,15 @@ def _apply_owner_change(
                 exc_info=True,
             )
         logger.error("Dashboard owners update failed: %s", db_err, exc_info=True)
-        return None, ManageDashboardOwnersResponse(
-            error="Failed to update dashboard owners due to a database error.",
+        return (
+            None,
+            None,
+            ManageDashboardOwnersResponse(
+                error="Failed to update dashboard owners due to a database error.",
+            ),
         )
 
-    return resolved_owner_subjects, None
+    return final_owner_ids, owners_response, None
 
 
 def _build_owner_warnings(
@@ -263,6 +298,7 @@ def manage_dashboard_owners(
     )
     if auth_error is not None:
         return auth_error
+    assert dashboard is not None  # narrows for mypy
 
     try:
         current_owner_ids = _owner_user_ids(dashboard)
@@ -304,16 +340,14 @@ def manage_dashboard_owners(
             ],
         )
 
-    resolved_owner_subjects, apply_error = _apply_owner_change(dashboard, new_owner_ids)
+    final_owner_ids, owners_response, apply_error = _apply_owner_change(
+        dashboard, new_owner_ids
+    )
     if apply_error is not None:
         return apply_error
-    assert resolved_owner_subjects is not None  # narrows for mypy
+    assert final_owner_ids is not None  # narrows for mypy
+    assert owners_response is not None  # narrows for mypy
 
-    final_owner_ids = {
-        subject.user_id
-        for subject in resolved_owner_subjects
-        if subject.type == SubjectType.USER
-    }
     warnings = _build_owner_warnings(final_owner_ids, new_owner_ids)
 
     # True deltas against the PRE-call state — not just membership in the
@@ -341,12 +375,7 @@ def manage_dashboard_owners(
     ctx.info(f"Dashboard {dashboard.id} owners updated: {sorted(final_owner_ids)}")
 
     return ManageDashboardOwnersResponse(
-        owners=[
-            info
-            for subject in resolved_owner_subjects
-            if subject.type == SubjectType.USER
-            and (info := serialize_subject_object(subject)) is not None
-        ],
+        owners=owners_response,
         dashboard_url=dashboard_url(dashboard),
         added_owner_ids=added_owner_ids,
         removed_owner_ids=removed_owner_ids,

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -83,9 +83,14 @@ def _find_and_authorize_dashboard(
                 "Ask the user to grant access; do not retry."
             ),
         )
-    except (DashboardNotFoundError, SQLAlchemyError):
+    except DashboardNotFoundError:
         return None, ManageDashboardOwnersResponse(
             error=f"Dashboard not found: {identifier!r}",
+        )
+    except SQLAlchemyError:
+        logger.exception("Database error looking up dashboard %r", identifier)
+        return None, ManageDashboardOwnersResponse(
+            error="Failed to look up dashboard due to a database error.",
         )
 
     if dashboard is None:

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_owners.py
@@ -1,0 +1,281 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Manage dashboard owners FastMCP tool
+
+Adds/removes dashboard owners via explicit operations, guarding against the
+"empty owners" footgun that the generic ``update_dashboard`` tool
+deliberately does not expose (a full-replacement ``owners`` list has no
+"keep >=1 owner" guard in ``UpdateDashboardCommand``).
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.exceptions import OwnersNotFoundValidationError
+from superset.exceptions import SupersetSecurityException
+from superset.extensions import db, event_logger
+from superset.mcp_service.dashboard.schemas import (
+    ManageDashboardOwnersRequest,
+    ManageDashboardOwnersResponse,
+)
+from superset.mcp_service.user.schemas import serialize_user_object
+from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+logger = logging.getLogger(__name__)
+
+
+def _find_and_authorize_dashboard(
+    identifier: int | str,
+) -> tuple[Any, ManageDashboardOwnersResponse | None]:
+    """Return (dashboard, None) on success or (None, error_response) on failure.
+
+    Mirrors the helper in ``update_dashboard``: avoids ImportError before
+    Flask app initialisation by co-locating the imports it needs with the
+    call site rather than importing them at module load time.
+    """
+    from superset import security_manager
+    from superset.daos.dashboard import DashboardDAO
+
+    try:
+        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except (DashboardNotFoundError, SQLAlchemyError):
+        return None, ManageDashboardOwnersResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    if dashboard is None:
+        return None, ManageDashboardOwnersResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    try:
+        security_manager.raise_for_ownership(dashboard)
+    except SupersetSecurityException:
+        return None, ManageDashboardOwnersResponse(
+            permission_denied=True,
+            error=(
+                f"You don't have permission to edit dashboard "
+                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
+            ),
+        )
+
+    return dashboard, None
+
+
+def _dashboard_url(dashboard: Any) -> str:
+    """Build the user-facing dashboard URL, preferring slug over id."""
+    return (
+        f"{get_superset_base_url()}/superset/dashboard/"
+        f"{dashboard.slug or dashboard.id}/"
+    )
+
+
+def _compute_new_owner_ids(
+    current_owner_ids: list[int], request: ManageDashboardOwnersRequest
+) -> tuple[list[int] | None, ManageDashboardOwnersResponse | None]:
+    """Apply add/remove operations and validate the result.
+
+    Returns ``(new_owner_ids, None)`` on success or ``(None, error_response)``
+    when a removal targets a non-owner or the result would be empty.
+    """
+    unknown_removals = sorted(set(request.remove_owner_ids) - set(current_owner_ids))
+    if unknown_removals:
+        return None, ManageDashboardOwnersResponse(
+            error=(
+                f"Cannot remove user IDs that are not currently owners: "
+                f"{unknown_removals}. Current owner IDs: "
+                f"{sorted(current_owner_ids)}."
+            ),
+        )
+
+    new_owner_ids = [
+        owner_id
+        for owner_id in current_owner_ids
+        if owner_id not in request.remove_owner_ids
+    ]
+    for owner_id in request.add_owner_ids:
+        if owner_id not in new_owner_ids:
+            new_owner_ids.append(owner_id)
+
+    if not new_owner_ids:
+        return None, ManageDashboardOwnersResponse(
+            error=(
+                "Cannot remove all owners; a dashboard must have at least "
+                "one owner. To transfer ownership, add the new owner in the "
+                "same call as removing the last existing one."
+            ),
+        )
+
+    return new_owner_ids, None
+
+
+def _apply_owner_change(
+    dashboard: Any, new_owner_ids: list[int]
+) -> ManageDashboardOwnersResponse | None:
+    """Resolve and persist the new owner list.
+
+    Mutates ``dashboard.owners`` in place on success. Returns an error
+    response on failure, or ``None`` on success.
+    """
+    from superset.commands.utils import populate_owner_list
+
+    try:
+        with event_logger.log_context(action="mcp.manage_dashboard_owners.apply"):
+            try:
+                resolved_owners = populate_owner_list(
+                    new_owner_ids, default_to_user=False
+                )
+            except OwnersNotFoundValidationError:
+                return ManageDashboardOwnersResponse(
+                    error=(
+                        "One or more user IDs do not exist. Use find_users "
+                        "to resolve valid user IDs."
+                    ),
+                )
+
+            dashboard.owners = resolved_owners
+            db.session.commit()  # pylint: disable=consider-using-transaction
+            try:
+                db.session.refresh(dashboard)
+            except SQLAlchemyError:
+                logger.warning(
+                    "Dashboard %s owners updated but refresh failed; "
+                    "continuing with current values",
+                    dashboard.id,
+                    exc_info=True,
+                )
+
+    except SQLAlchemyError as db_err:
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling",
+                exc_info=True,
+            )
+        logger.error("Dashboard owners update failed: %s", db_err, exc_info=True)
+        return ManageDashboardOwnersResponse(
+            error="Failed to update dashboard owners due to a database error.",
+        )
+
+    return None
+
+
+def _build_owner_warnings(
+    final_owner_ids: set[int], new_owner_ids: list[int]
+) -> list[str]:
+    """Flag when the resolver re-added an ID that was not requested.
+
+    Happens when a non-admin caller tries to remove themselves —
+    ``populate_owner_list``'s self-protection re-adds them.
+    """
+    auto_added = final_owner_ids - set(new_owner_ids)
+    if not auto_added:
+        return []
+    return [
+        f"User ID(s) {sorted(auto_added)} were automatically re-added as "
+        "owner(s): non-admin callers cannot remove themselves from the "
+        "owners list."
+    ]
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dashboard",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Manage dashboard owners",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+def manage_dashboard_owners(
+    request: ManageDashboardOwnersRequest, ctx: Context
+) -> ManageDashboardOwnersResponse:
+    """
+    Add or remove dashboard owners with explicit, safe operations.
+
+    Owners can edit the dashboard, manage its charts, and delete it. Unlike
+    ``update_dashboard``'s dropped ``owners`` field, this tool never accepts
+    a full-replacement list — only ``add_owner_ids``/``remove_owner_ids`` —
+    and rejects any change that would leave the dashboard with zero owners.
+
+    A non-admin caller who removes themselves is automatically re-added
+    (mirrors the REST ``UpdateDashboardCommand`` self-protection) unless an
+    ``EXTRA_OWNERS_RESOLVER`` is configured on the instance; the response's
+    ``warnings`` reports when this happens.
+
+    Privacy: the returned ``owners`` list is sanctioned only as confirmation
+    of the add/remove operation the caller explicitly requested on this
+    dashboard. Do not use it to answer "who owns X" for a dashboard the
+    caller did not ask to modify, and do not call this tool merely to look
+    up current owners — those remain off-limits per the server instructions.
+
+    Example::
+
+        manage_dashboard_owners(request={
+            "identifier": 42,
+            "add_owner_ids": [7],
+            "remove_owner_ids": [3],
+        })
+    """
+    ctx.info(
+        f"Managing dashboard owners: identifier={request.identifier} "
+        f"add={request.add_owner_ids} remove={request.remove_owner_ids}"
+    )
+
+    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    if auth_error is not None:
+        return auth_error
+
+    current_owner_ids = [owner.id for owner in dashboard.owners]
+    new_owner_ids, compute_error = _compute_new_owner_ids(current_owner_ids, request)
+    if compute_error is not None:
+        return compute_error
+    assert new_owner_ids is not None  # narrows for mypy; empty list errors above
+
+    if (apply_error := _apply_owner_change(dashboard, new_owner_ids)) is not None:
+        return apply_error
+
+    final_owner_ids = {owner.id for owner in dashboard.owners}
+    warnings = _build_owner_warnings(final_owner_ids, new_owner_ids)
+
+    ctx.info(f"Dashboard {dashboard.id} owners updated: {sorted(final_owner_ids)}")
+
+    return ManageDashboardOwnersResponse(
+        owners=[
+            info
+            for owner in dashboard.owners
+            if (info := serialize_user_object(owner, include_sensitive=False))
+            is not None
+        ],
+        dashboard_url=_dashboard_url(dashboard),
+        added_owner_ids=sorted(final_owner_ids & set(request.add_owner_ids)),
+        removed_owner_ids=[
+            owner_id
+            for owner_id in request.remove_owner_ids
+            if owner_id not in final_owner_ids
+        ],
+        warnings=warnings,
+    )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -38,7 +38,10 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,
+    DashboardNotFoundError,
+)
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
@@ -66,6 +69,18 @@ def _find_and_authorize_dashboard(
 
     try:
         dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except DashboardAccessDeniedError:
+        # get_by_id_or_slug re-checks view access and raises access-denied
+        # for dashboards the caller cannot see; surface it as the
+        # structured permission_denied response instead of an unhandled
+        # error.
+        return None, ManageDashboardRolesResponse(
+            permission_denied=True,
+            error=(
+                "You do not have permission to access this dashboard. "
+                "Ask the user to grant access; do not retry."
+            ),
+        )
     except (DashboardNotFoundError, SQLAlchemyError):
         return None, ManageDashboardRolesResponse(
             error=f"Dashboard not found: {identifier!r}",

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -222,7 +222,7 @@ def manage_dashboard_roles(
 
     return ManageDashboardRolesResponse(
         roles=[
-            info
+            info.model_copy(update={"permissions": None})
             for role in dashboard.roles
             if (info := serialize_role_object(role)) is not None
         ],

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -278,6 +278,19 @@ def manage_dashboard_roles(
                     ),
                 )
 
+            # Captured before commit so the final response never has to
+            # dereference `dashboard.viewers` post-commit: SQLAlchemy
+            # expires ORM attributes on commit, and a failed `refresh()`
+            # below would otherwise leave a later `dashboard.viewers` read
+            # free to raise an unhandled `SQLAlchemyError` from a broken
+            # session.
+            final_role_ids = resolved_role_ids
+            roles_response = [
+                info
+                for subject in resolved_role_subjects
+                if (info := serialize_subject_object(subject)) is not None
+            ]
+
             dashboard.viewers = other_viewers + resolved_role_subjects
             db.session.commit()  # pylint: disable=consider-using-transaction
             try:
@@ -304,16 +317,10 @@ def manage_dashboard_roles(
             error="Failed to update dashboard roles due to a database error.",
         )
 
-    final_role_ids = set(_viewer_role_ids(dashboard))
     ctx.info(f"Dashboard {dashboard.id} roles updated: {sorted(final_role_ids)}")
 
     return ManageDashboardRolesResponse(
-        roles=[
-            info
-            for subject in dashboard.viewers
-            if subject.type == SubjectType.ROLE
-            and (info := serialize_subject_object(subject)) is not None
-        ],
+        roles=roles_response,
         dashboard_url=_dashboard_url(dashboard),
         # True deltas against the PRE-call state — not just membership in
         # the request — so a role that was already assigned (or already

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -49,7 +49,7 @@ from superset.mcp_service.system.schemas import serialize_subject_object
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.subjects.types import SubjectType
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _find_and_authorize_dashboard(
@@ -92,10 +92,7 @@ def _find_and_authorize_dashboard(
 
 def _dashboard_url(dashboard: Any) -> str:
     """Build the user-facing dashboard URL, preferring slug over id."""
-    return (
-        f"{get_superset_base_url()}/superset/dashboard/"
-        f"{dashboard.slug or dashboard.id}/"
-    )
+    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 def _viewer_role_ids(dashboard: Any) -> list[int]:
@@ -116,12 +113,13 @@ def _other_viewers(dashboard: Any) -> list[Any]:
 
 def _compute_new_role_ids(
     dashboard: Any, request: ManageDashboardRolesRequest, viewers_enabled: bool
-) -> tuple[list[int] | None, ManageDashboardRolesResponse | None]:
+) -> tuple[list[int] | None, list[int] | None, ManageDashboardRolesResponse | None]:
     """Load current viewer roles and apply add/remove operations.
 
-    Returns ``(new_role_ids, None)`` on success or ``(None, error_response)``
-    when the initial lazy-load fails or a removal targets an unassigned
-    role.
+    Returns ``(current_role_ids, new_role_ids, None)`` on success or
+    ``(None, None, error_response)`` when the initial lazy-load fails or a
+    removal targets an unassigned role. The pre-call ``current_role_ids``
+    is returned so the caller can report true added/removed deltas.
     """
     try:
         current_role_ids = _viewer_role_ids(dashboard)
@@ -132,19 +130,27 @@ def _compute_new_role_ids(
             db_err,
             exc_info=True,
         )
-        return None, ManageDashboardRolesResponse(
-            viewers_enabled=viewers_enabled,
-            error="Failed to load dashboard roles due to a database error.",
+        return (
+            None,
+            None,
+            ManageDashboardRolesResponse(
+                viewers_enabled=viewers_enabled,
+                error="Failed to load dashboard roles due to a database error.",
+            ),
         )
 
     unknown_removals = sorted(set(request.remove_role_ids) - set(current_role_ids))
     if unknown_removals:
-        return None, ManageDashboardRolesResponse(
-            viewers_enabled=viewers_enabled,
-            error=(
-                f"Cannot remove role IDs that are not currently assigned: "
-                f"{unknown_removals}. Current role IDs: "
-                f"{sorted(current_role_ids)}."
+        return (
+            None,
+            None,
+            ManageDashboardRolesResponse(
+                viewers_enabled=viewers_enabled,
+                error=(
+                    f"Cannot remove role IDs that are not currently assigned: "
+                    f"{unknown_removals}. Current role IDs: "
+                    f"{sorted(current_role_ids)}."
+                ),
             ),
         )
 
@@ -157,7 +163,7 @@ def _compute_new_role_ids(
         if role_id not in new_role_ids:
             new_role_ids.append(role_id)
 
-    return new_role_ids, None
+    return current_role_ids, new_role_ids, None
 
 
 @tool(
@@ -226,11 +232,12 @@ def manage_dashboard_roles(
             "control until it is enabled."
         )
 
-    new_role_ids, compute_error = _compute_new_role_ids(
+    current_role_ids, new_role_ids, compute_error = _compute_new_role_ids(
         dashboard, request, viewers_enabled
     )
     if compute_error is not None:
         return compute_error
+    assert current_role_ids is not None  # narrows for mypy
     assert new_role_ids is not None  # narrows for mypy
 
     try:
@@ -288,12 +295,15 @@ def manage_dashboard_roles(
             and (info := serialize_subject_object(subject)) is not None
         ],
         dashboard_url=_dashboard_url(dashboard),
-        added_role_ids=sorted(final_role_ids & set(request.add_role_ids)),
-        removed_role_ids=[
-            role_id
-            for role_id in request.remove_role_ids
-            if role_id not in final_role_ids
-        ],
+        # True deltas against the PRE-call state — not just membership in
+        # the request — so a role that was already assigned (or already
+        # absent) is never misreported as added/removed.
+        added_role_ids=sorted(
+            (final_role_ids & set(request.add_role_ids)) - set(current_role_ids)
+        ),
+        removed_role_ids=sorted(
+            (set(request.remove_role_ids) & set(current_role_ids)) - final_role_ids
+        ),
         viewers_enabled=viewers_enabled,
         warnings=warnings,
     )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -38,81 +38,19 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.commands.dashboard.exceptions import (
-    DashboardAccessDeniedError,
-    DashboardNotFoundError,
-)
-from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
     ManageDashboardRolesRequest,
     ManageDashboardRolesResponse,
 )
+from superset.mcp_service.dashboard.tool.governance_utils import (
+    dashboard_url,
+    find_and_authorize_dashboard,
+)
 from superset.mcp_service.system.schemas import serialize_subject_object
-from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.subjects.types import SubjectType
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-def _find_and_authorize_dashboard(
-    identifier: int | str,
-) -> tuple[Any, ManageDashboardRolesResponse | None]:
-    """Return (dashboard, None) on success or (None, error_response) on failure.
-
-    Mirrors the helper in ``update_dashboard``: avoids ImportError before
-    Flask app initialisation by co-locating the imports it needs with the
-    call site rather than importing them at module load time.
-    """
-    from superset import security_manager
-    from superset.daos.dashboard import DashboardDAO
-
-    try:
-        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
-    except DashboardAccessDeniedError:
-        # get_by_id_or_slug re-checks view access and raises access-denied
-        # for dashboards the caller cannot see; surface it as the
-        # structured permission_denied response instead of an unhandled
-        # error.
-        return None, ManageDashboardRolesResponse(
-            permission_denied=True,
-            error=(
-                "You do not have permission to access this dashboard. "
-                "Ask the user to grant access; do not retry."
-            ),
-        )
-    except DashboardNotFoundError:
-        return None, ManageDashboardRolesResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-    except SQLAlchemyError:
-        logger.exception("Database error looking up dashboard %r", identifier)
-        return None, ManageDashboardRolesResponse(
-            error="Failed to look up dashboard due to a database error.",
-        )
-
-    if dashboard is None:
-        return None, ManageDashboardRolesResponse(
-            error=f"Dashboard not found: {identifier!r}",
-        )
-
-    try:
-        security_manager.raise_for_editorship(dashboard)
-    except SupersetSecurityException:
-        return None, ManageDashboardRolesResponse(
-            permission_denied=True,
-            error=(
-                f"You don't have permission to edit dashboard "
-                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
-            ),
-        )
-
-    return dashboard, None
-
-
-def _dashboard_url(dashboard: Any) -> str:
-    """Build the user-facing dashboard URL, preferring slug over id."""
-    return f"{get_superset_base_url()}/dashboard/{dashboard.slug or dashboard.id}/"
 
 
 def _viewer_role_ids(dashboard: Any) -> list[int]:
@@ -186,6 +124,28 @@ def _compute_new_role_ids(
     return current_role_ids, new_role_ids, None
 
 
+def _resolve_role_subjects(new_role_ids: list[int]) -> tuple[list[Any], list[int]]:
+    """Resolve role IDs to ROLE-type Subjects, one at a time.
+
+    Mirrors the owners tool's ``get_or_create_user_subject`` loop: a role
+    that exists but has no synced Subject row yet is synced on demand
+    instead of being misreported as nonexistent. Returns
+    ``(resolved_subjects, missing_role_ids)`` where the latter contains
+    only IDs with no matching role at all.
+    """
+    from superset.subjects.utils import get_or_create_role_subject
+
+    resolved_role_subjects: list[Any] = []
+    missing_role_ids: list[int] = []
+    for role_id in new_role_ids:
+        subject = get_or_create_role_subject(role_id)
+        if subject is None:
+            missing_role_ids.append(role_id)
+        else:
+            resolved_role_subjects.append(subject)
+    return resolved_role_subjects, missing_role_ids
+
+
 @tool(
     tags=["mutate"],
     class_permission_name="Dashboard",
@@ -223,7 +183,10 @@ def manage_dashboard_roles(
     dashboard. Do not use it to answer "who can access X" for a dashboard
     the caller did not ask to modify, and do not call this tool merely to
     look up current roles — those remain off-limits per the server
-    instructions.
+    instructions. A request that has no effective change (e.g. "adding" a
+    role that is already assigned) returns an empty ``roles`` list rather
+    than the full current set, so this tool cannot be used as a disguised
+    directory lookup.
 
     Example::
 
@@ -239,7 +202,9 @@ def manage_dashboard_roles(
         f"add={request.add_role_ids} remove={request.remove_role_ids}"
     )
 
-    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    dashboard, auth_error = find_and_authorize_dashboard(
+        request.identifier, ManageDashboardRolesResponse
+    )
     if auth_error is not None:
         return auth_error
 
@@ -260,21 +225,35 @@ def manage_dashboard_roles(
     assert current_role_ids is not None  # narrows for mypy
     assert new_role_ids is not None  # narrows for mypy
 
+    # No-op short-circuit: skip the DB write and, more importantly, the
+    # full roles list in the response — mirrors manage_dashboard_owners.
+    # The roles list is only sanctioned as confirmation of an actual change
+    # (see docstring); returning it for a request that changes nothing
+    # would let a caller enumerate access roles via a disguised no-op
+    # (e.g. "add" a role that is already assigned).
+    if set(new_role_ids) == set(current_role_ids):
+        ctx.info(f"Dashboard {dashboard.id} roles unchanged; no-op request.")
+        return ManageDashboardRolesResponse(
+            dashboard_url=dashboard_url(dashboard),
+            viewers_enabled=viewers_enabled,
+            warnings=warnings
+            + ["No effective change: requested roles already match the current state."],
+        )
+
     try:
         with event_logger.log_context(action="mcp.manage_dashboard_roles.apply"):
-            from superset.subjects.utils import subjects_from_roles
-
             other_viewers = _other_viewers(dashboard)
-            resolved_role_subjects = subjects_from_roles(new_role_ids)
-            resolved_role_ids = {subject.role_id for subject in resolved_role_subjects}
-            missing_role_ids = sorted(set(new_role_ids) - resolved_role_ids)
+
+            resolved_role_subjects, missing_role_ids = _resolve_role_subjects(
+                new_role_ids
+            )
             if missing_role_ids:
                 return ManageDashboardRolesResponse(
                     viewers_enabled=viewers_enabled,
                     error=(
                         f"One or more role IDs do not exist: "
-                        f"{missing_role_ids}. Use list_roles to resolve "
-                        "valid role IDs."
+                        f"{sorted(missing_role_ids)}. Use list_roles to "
+                        "resolve valid role IDs."
                     ),
                 )
 
@@ -284,7 +263,7 @@ def manage_dashboard_roles(
             # below would otherwise leave a later `dashboard.viewers` read
             # free to raise an unhandled `SQLAlchemyError` from a broken
             # session.
-            final_role_ids = resolved_role_ids
+            final_role_ids = {subject.role_id for subject in resolved_role_subjects}
             roles_response = [
                 info
                 for subject in resolved_role_subjects
@@ -321,7 +300,7 @@ def manage_dashboard_roles(
 
     return ManageDashboardRolesResponse(
         roles=roles_response,
-        dashboard_url=_dashboard_url(dashboard),
+        dashboard_url=dashboard_url(dashboard),
         # True deltas against the PRE-call state — not just membership in
         # the request — so a role that was already assigned (or already
         # absent) is never misreported as added/removed.

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -32,7 +32,7 @@ the dashboard are preserved untouched by this tool.
 """
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
 
 from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
@@ -50,10 +50,14 @@ from superset.mcp_service.dashboard.tool.governance_utils import (
 from superset.mcp_service.system.schemas import serialize_subject_object
 from superset.subjects.types import SubjectType
 
+if TYPE_CHECKING:
+    from superset.models.dashboard import Dashboard
+    from superset.subjects.models import Subject
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _viewer_role_ids(dashboard: Any) -> list[int]:
+def _viewer_role_ids(dashboard: "Dashboard") -> list[int]:
     """Role IDs behind the dashboard's ROLE-type viewer subjects."""
     return [
         subject.role_id
@@ -62,7 +66,7 @@ def _viewer_role_ids(dashboard: Any) -> list[int]:
     ]
 
 
-def _other_viewers(dashboard: Any) -> list[Any]:
+def _other_viewers(dashboard: "Dashboard") -> list["Subject"]:
     """Non-ROLE-type viewers (USER/GROUP subjects), preserved untouched."""
     return [
         subject for subject in dashboard.viewers if subject.type != SubjectType.ROLE
@@ -70,7 +74,7 @@ def _other_viewers(dashboard: Any) -> list[Any]:
 
 
 def _compute_new_role_ids(
-    dashboard: Any, request: ManageDashboardRolesRequest, viewers_enabled: bool
+    dashboard: "Dashboard", request: ManageDashboardRolesRequest, viewers_enabled: bool
 ) -> tuple[list[int] | None, list[int] | None, ManageDashboardRolesResponse | None]:
     """Load current viewer roles and apply add/remove operations.
 
@@ -124,7 +128,9 @@ def _compute_new_role_ids(
     return current_role_ids, new_role_ids, None
 
 
-def _resolve_role_subjects(new_role_ids: list[int]) -> tuple[list[Any], list[int]]:
+def _resolve_role_subjects(
+    new_role_ids: list[int],
+) -> tuple[list["Subject"], list[int]]:
     """Resolve role IDs to ROLE-type Subjects, one at a time.
 
     Mirrors the owners tool's ``get_or_create_user_subject`` loop: a role
@@ -135,7 +141,7 @@ def _resolve_role_subjects(new_role_ids: list[int]) -> tuple[list[Any], list[int
     """
     from superset.subjects.utils import get_or_create_role_subject
 
-    resolved_role_subjects: list[Any] = []
+    resolved_role_subjects: list["Subject"] = []
     missing_role_ids: list[int] = []
     for role_id in new_role_ids:
         subject = get_or_create_role_subject(role_id)
@@ -207,6 +213,7 @@ def manage_dashboard_roles(
     )
     if auth_error is not None:
         return auth_error
+    assert dashboard is not None  # narrows for mypy
 
     viewers_enabled = is_feature_enabled("ENABLE_VIEWERS")
     warnings: list[str] = []
@@ -248,6 +255,10 @@ def manage_dashboard_roles(
                 new_role_ids
             )
             if missing_role_ids:
+                # Roll back any Subject rows _resolve_role_subjects already
+                # flushed for earlier, valid role IDs so this all-or-nothing
+                # request never leaves an uncommitted partial sync behind.
+                db.session.rollback()  # pylint: disable=consider-using-transaction
                 return ManageDashboardRolesResponse(
                     viewers_enabled=viewers_enabled,
                     error=(

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -81,9 +81,14 @@ def _find_and_authorize_dashboard(
                 "Ask the user to grant access; do not retry."
             ),
         )
-    except (DashboardNotFoundError, SQLAlchemyError):
+    except DashboardNotFoundError:
         return None, ManageDashboardRolesResponse(
             error=f"Dashboard not found: {identifier!r}",
+        )
+    except SQLAlchemyError:
+        logger.exception("Database error looking up dashboard %r", identifier)
+        return None, ManageDashboardRolesResponse(
+            error="Failed to look up dashboard due to a database error.",
         )
 
     if dashboard is None:

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -1,0 +1,238 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Manage dashboard access roles FastMCP tool
+
+Adds/removes DASHBOARD_RBAC access roles via explicit operations. Companion
+to ``manage_dashboard_owners`` — dashboard roles are dropped from the
+generic ``update_dashboard`` tool because a full-replacement access-control
+list silently widens or narrows who can see a dashboard.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.exceptions import RolesNotFoundValidationError
+from superset.exceptions import SupersetSecurityException
+from superset.extensions import db, event_logger
+from superset.mcp_service.dashboard.schemas import (
+    ManageDashboardRolesRequest,
+    ManageDashboardRolesResponse,
+    serialize_role_object,
+)
+from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+logger = logging.getLogger(__name__)
+
+
+def _find_and_authorize_dashboard(
+    identifier: int | str,
+) -> tuple[Any, ManageDashboardRolesResponse | None]:
+    """Return (dashboard, None) on success or (None, error_response) on failure.
+
+    Mirrors the helper in ``update_dashboard``: avoids ImportError before
+    Flask app initialisation by co-locating the imports it needs with the
+    call site rather than importing them at module load time.
+    """
+    from superset import security_manager
+    from superset.daos.dashboard import DashboardDAO
+
+    try:
+        dashboard = DashboardDAO.get_by_id_or_slug(identifier)
+    except (DashboardNotFoundError, SQLAlchemyError):
+        return None, ManageDashboardRolesResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    if dashboard is None:
+        return None, ManageDashboardRolesResponse(
+            error=f"Dashboard not found: {identifier!r}",
+        )
+
+    try:
+        security_manager.raise_for_ownership(dashboard)
+    except SupersetSecurityException:
+        return None, ManageDashboardRolesResponse(
+            permission_denied=True,
+            error=(
+                f"You don't have permission to edit dashboard "
+                f"'{dashboard.dashboard_title}' (ID: {dashboard.id})."
+            ),
+        )
+
+    return dashboard, None
+
+
+def _dashboard_url(dashboard: Any) -> str:
+    """Build the user-facing dashboard URL, preferring slug over id."""
+    return (
+        f"{get_superset_base_url()}/superset/dashboard/"
+        f"{dashboard.slug or dashboard.id}/"
+    )
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dashboard",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Manage dashboard access roles",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+def manage_dashboard_roles(
+    request: ManageDashboardRolesRequest, ctx: Context
+) -> ManageDashboardRolesResponse:
+    """
+    Add or remove dashboard RBAC access roles with explicit operations.
+
+    Dashboard roles (DASHBOARD_RBAC) restrict who can view a dashboard to
+    members of the listed roles, on top of normal Superset permissions. An
+    empty roles list means "no role restriction" — the dashboard is visible
+    per standard permissions instead. This only takes effect when the
+    ``DASHBOARD_RBAC`` feature flag is enabled; the response's
+    ``dashboard_rbac_enabled`` field reports whether it is, and ``warnings``
+    notes when a change was applied but has no live effect.
+
+    Unlike ``update_dashboard``'s dropped ``roles`` field, this tool never
+    accepts a full-replacement list — only
+    ``add_role_ids``/``remove_role_ids``.
+
+    Privacy: the returned ``roles`` list is sanctioned only as confirmation
+    of the add/remove operation the caller explicitly requested on this
+    dashboard. Do not use it to answer "who can access X" for a dashboard
+    the caller did not ask to modify, and do not call this tool merely to
+    look up current roles — those remain off-limits per the server
+    instructions.
+
+    Example::
+
+        manage_dashboard_roles(request={
+            "identifier": 42,
+            "add_role_ids": [5],
+        })
+    """
+    from superset import is_feature_enabled
+
+    ctx.info(
+        f"Managing dashboard roles: identifier={request.identifier} "
+        f"add={request.add_role_ids} remove={request.remove_role_ids}"
+    )
+
+    dashboard, auth_error = _find_and_authorize_dashboard(request.identifier)
+    if auth_error is not None:
+        return auth_error
+
+    dashboard_rbac_enabled = is_feature_enabled("DASHBOARD_RBAC")
+    warnings: list[str] = []
+    if not dashboard_rbac_enabled:
+        warnings.append(
+            "The DASHBOARD_RBAC feature flag is disabled on this instance; "
+            "dashboard roles will be stored but have no effect on access "
+            "control until it is enabled."
+        )
+
+    current_role_ids = [role.id for role in dashboard.roles]
+
+    unknown_removals = sorted(set(request.remove_role_ids) - set(current_role_ids))
+    if unknown_removals:
+        return ManageDashboardRolesResponse(
+            dashboard_rbac_enabled=dashboard_rbac_enabled,
+            error=(
+                f"Cannot remove role IDs that are not currently assigned: "
+                f"{unknown_removals}. Current role IDs: "
+                f"{sorted(current_role_ids)}."
+            ),
+        )
+
+    new_role_ids = [
+        role_id
+        for role_id in current_role_ids
+        if role_id not in request.remove_role_ids
+    ]
+    for role_id in request.add_role_ids:
+        if role_id not in new_role_ids:
+            new_role_ids.append(role_id)
+
+    try:
+        with event_logger.log_context(action="mcp.manage_dashboard_roles.apply"):
+            from superset.commands.utils import populate_roles
+
+            try:
+                resolved_roles = populate_roles(new_role_ids)
+            except RolesNotFoundValidationError:
+                return ManageDashboardRolesResponse(
+                    dashboard_rbac_enabled=dashboard_rbac_enabled,
+                    error=(
+                        f"One or more role IDs do not exist: "
+                        f"{request.add_role_ids}. Use list_roles to resolve "
+                        "valid role IDs."
+                    ),
+                )
+
+            dashboard.roles = resolved_roles
+            db.session.commit()  # pylint: disable=consider-using-transaction
+            try:
+                db.session.refresh(dashboard)
+            except SQLAlchemyError:
+                logger.warning(
+                    "Dashboard %s roles updated but refresh failed; "
+                    "continuing with current values",
+                    dashboard.id,
+                    exc_info=True,
+                )
+
+    except SQLAlchemyError as db_err:
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling",
+                exc_info=True,
+            )
+        logger.error("Dashboard roles update failed: %s", db_err, exc_info=True)
+        return ManageDashboardRolesResponse(
+            dashboard_rbac_enabled=dashboard_rbac_enabled,
+            error="Failed to update dashboard roles due to a database error.",
+        )
+
+    final_role_ids = {role.id for role in dashboard.roles}
+    ctx.info(f"Dashboard {dashboard.id} roles updated: {sorted(final_role_ids)}")
+
+    return ManageDashboardRolesResponse(
+        roles=[
+            info
+            for role in dashboard.roles
+            if (info := serialize_role_object(role)) is not None
+        ],
+        dashboard_url=_dashboard_url(dashboard),
+        added_role_ids=sorted(final_role_ids & set(request.add_role_ids)),
+        removed_role_ids=[
+            role_id
+            for role_id in request.remove_role_ids
+            if role_id not in final_role_ids
+        ],
+        dashboard_rbac_enabled=dashboard_rbac_enabled,
+        warnings=warnings,
+    )

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -222,7 +222,7 @@ def manage_dashboard_roles(
 
     return ManageDashboardRolesResponse(
         roles=[
-            info.model_copy(update={"permissions": None})
+            info
             for role in dashboard.roles
             if (info := serialize_role_object(role)) is not None
         ],

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_roles.py
@@ -18,10 +18,17 @@
 """
 Manage dashboard access roles FastMCP tool
 
-Adds/removes DASHBOARD_RBAC access roles via explicit operations. Companion
-to ``manage_dashboard_owners`` — dashboard roles are dropped from the
+Adds/removes role-based dashboard access via explicit operations. Companion
+to ``manage_dashboard_owners`` — dashboard access roles are dropped from the
 generic ``update_dashboard`` tool because a full-replacement access-control
 list silently widens or narrows who can see a dashboard.
+
+"Roles" are modeled as ROLE-type entries in the dashboard's Subject-based
+``viewers`` list (apache/superset#38831 replaced the legacy
+``roles``/``DASHBOARD_RBAC`` relationship with a unified Subject model
+covering User/Role/Group, gated by the ``ENABLE_VIEWERS`` feature flag
+instead of ``DASHBOARD_RBAC``). Any USER- or GROUP-type viewers already on
+the dashboard are preserved untouched by this tool.
 """
 
 import logging
@@ -32,15 +39,15 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.dashboard.exceptions import DashboardNotFoundError
-from superset.commands.exceptions import RolesNotFoundValidationError
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
 from superset.mcp_service.dashboard.schemas import (
     ManageDashboardRolesRequest,
     ManageDashboardRolesResponse,
-    serialize_role_object,
 )
+from superset.mcp_service.system.schemas import serialize_subject_object
 from superset.mcp_service.utils.url_utils import get_superset_base_url
+from superset.subjects.types import SubjectType
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +77,7 @@ def _find_and_authorize_dashboard(
         )
 
     try:
-        security_manager.raise_for_ownership(dashboard)
+        security_manager.raise_for_editorship(dashboard)
     except SupersetSecurityException:
         return None, ManageDashboardRolesResponse(
             permission_denied=True,
@@ -91,6 +98,68 @@ def _dashboard_url(dashboard: Any) -> str:
     )
 
 
+def _viewer_role_ids(dashboard: Any) -> list[int]:
+    """Role IDs behind the dashboard's ROLE-type viewer subjects."""
+    return [
+        subject.role_id
+        for subject in dashboard.viewers
+        if subject.type == SubjectType.ROLE
+    ]
+
+
+def _other_viewers(dashboard: Any) -> list[Any]:
+    """Non-ROLE-type viewers (USER/GROUP subjects), preserved untouched."""
+    return [
+        subject for subject in dashboard.viewers if subject.type != SubjectType.ROLE
+    ]
+
+
+def _compute_new_role_ids(
+    dashboard: Any, request: ManageDashboardRolesRequest, viewers_enabled: bool
+) -> tuple[list[int] | None, ManageDashboardRolesResponse | None]:
+    """Load current viewer roles and apply add/remove operations.
+
+    Returns ``(new_role_ids, None)`` on success or ``(None, error_response)``
+    when the initial lazy-load fails or a removal targets an unassigned
+    role.
+    """
+    try:
+        current_role_ids = _viewer_role_ids(dashboard)
+    except SQLAlchemyError as db_err:
+        logger.error(
+            "Failed to load roles for dashboard %s: %s",
+            request.identifier,
+            db_err,
+            exc_info=True,
+        )
+        return None, ManageDashboardRolesResponse(
+            viewers_enabled=viewers_enabled,
+            error="Failed to load dashboard roles due to a database error.",
+        )
+
+    unknown_removals = sorted(set(request.remove_role_ids) - set(current_role_ids))
+    if unknown_removals:
+        return None, ManageDashboardRolesResponse(
+            viewers_enabled=viewers_enabled,
+            error=(
+                f"Cannot remove role IDs that are not currently assigned: "
+                f"{unknown_removals}. Current role IDs: "
+                f"{sorted(current_role_ids)}."
+            ),
+        )
+
+    new_role_ids = [
+        role_id
+        for role_id in current_role_ids
+        if role_id not in request.remove_role_ids
+    ]
+    for role_id in request.add_role_ids:
+        if role_id not in new_role_ids:
+            new_role_ids.append(role_id)
+
+    return new_role_ids, None
+
+
 @tool(
     tags=["mutate"],
     class_permission_name="Dashboard",
@@ -105,15 +174,19 @@ def manage_dashboard_roles(
     request: ManageDashboardRolesRequest, ctx: Context
 ) -> ManageDashboardRolesResponse:
     """
-    Add or remove dashboard RBAC access roles with explicit operations.
+    Add or remove dashboard access roles with explicit operations.
 
-    Dashboard roles (DASHBOARD_RBAC) restrict who can view a dashboard to
-    members of the listed roles, on top of normal Superset permissions. An
-    empty roles list means "no role restriction" — the dashboard is visible
-    per standard permissions instead. This only takes effect when the
-    ``DASHBOARD_RBAC`` feature flag is enabled; the response's
-    ``dashboard_rbac_enabled`` field reports whether it is, and ``warnings``
-    notes when a change was applied but has no live effect.
+    Dashboard access roles restrict who can view a dashboard to members of
+    the listed roles, on top of normal Superset permissions. An empty roles
+    list means "no role restriction" — the dashboard is visible per standard
+    permissions instead. This only takes effect when the ``ENABLE_VIEWERS``
+    feature flag is enabled; the response's ``viewers_enabled`` field
+    reports whether it is, and ``warnings`` notes when a change was applied
+    but has no live effect.
+
+    Roles are the ROLE-type entries in the dashboard's Subject-based
+    ``viewers`` list. Any USER- or GROUP-type viewers already on the
+    dashboard are left untouched.
 
     Unlike ``update_dashboard``'s dropped ``roles`` field, this tool never
     accepts a full-replacement list — only
@@ -144,54 +217,41 @@ def manage_dashboard_roles(
     if auth_error is not None:
         return auth_error
 
-    dashboard_rbac_enabled = is_feature_enabled("DASHBOARD_RBAC")
+    viewers_enabled = is_feature_enabled("ENABLE_VIEWERS")
     warnings: list[str] = []
-    if not dashboard_rbac_enabled:
+    if not viewers_enabled:
         warnings.append(
-            "The DASHBOARD_RBAC feature flag is disabled on this instance; "
-            "dashboard roles will be stored but have no effect on access "
+            "The ENABLE_VIEWERS feature flag is disabled on this instance; "
+            "dashboard viewers will be stored but have no effect on access "
             "control until it is enabled."
         )
 
-    current_role_ids = [role.id for role in dashboard.roles]
-
-    unknown_removals = sorted(set(request.remove_role_ids) - set(current_role_ids))
-    if unknown_removals:
-        return ManageDashboardRolesResponse(
-            dashboard_rbac_enabled=dashboard_rbac_enabled,
-            error=(
-                f"Cannot remove role IDs that are not currently assigned: "
-                f"{unknown_removals}. Current role IDs: "
-                f"{sorted(current_role_ids)}."
-            ),
-        )
-
-    new_role_ids = [
-        role_id
-        for role_id in current_role_ids
-        if role_id not in request.remove_role_ids
-    ]
-    for role_id in request.add_role_ids:
-        if role_id not in new_role_ids:
-            new_role_ids.append(role_id)
+    new_role_ids, compute_error = _compute_new_role_ids(
+        dashboard, request, viewers_enabled
+    )
+    if compute_error is not None:
+        return compute_error
+    assert new_role_ids is not None  # narrows for mypy
 
     try:
         with event_logger.log_context(action="mcp.manage_dashboard_roles.apply"):
-            from superset.commands.utils import populate_roles
+            from superset.subjects.utils import subjects_from_roles
 
-            try:
-                resolved_roles = populate_roles(new_role_ids)
-            except RolesNotFoundValidationError:
+            other_viewers = _other_viewers(dashboard)
+            resolved_role_subjects = subjects_from_roles(new_role_ids)
+            resolved_role_ids = {subject.role_id for subject in resolved_role_subjects}
+            missing_role_ids = sorted(set(new_role_ids) - resolved_role_ids)
+            if missing_role_ids:
                 return ManageDashboardRolesResponse(
-                    dashboard_rbac_enabled=dashboard_rbac_enabled,
+                    viewers_enabled=viewers_enabled,
                     error=(
                         f"One or more role IDs do not exist: "
-                        f"{request.add_role_ids}. Use list_roles to resolve "
+                        f"{missing_role_ids}. Use list_roles to resolve "
                         "valid role IDs."
                     ),
                 )
 
-            dashboard.roles = resolved_roles
+            dashboard.viewers = other_viewers + resolved_role_subjects
             db.session.commit()  # pylint: disable=consider-using-transaction
             try:
                 db.session.refresh(dashboard)
@@ -213,18 +273,19 @@ def manage_dashboard_roles(
             )
         logger.error("Dashboard roles update failed: %s", db_err, exc_info=True)
         return ManageDashboardRolesResponse(
-            dashboard_rbac_enabled=dashboard_rbac_enabled,
+            viewers_enabled=viewers_enabled,
             error="Failed to update dashboard roles due to a database error.",
         )
 
-    final_role_ids = {role.id for role in dashboard.roles}
+    final_role_ids = set(_viewer_role_ids(dashboard))
     ctx.info(f"Dashboard {dashboard.id} roles updated: {sorted(final_role_ids)}")
 
     return ManageDashboardRolesResponse(
         roles=[
             info
-            for role in dashboard.roles
-            if (info := serialize_role_object(role)) is not None
+            for subject in dashboard.viewers
+            if subject.type == SubjectType.ROLE
+            and (info := serialize_subject_object(subject)) is not None
         ],
         dashboard_url=_dashboard_url(dashboard),
         added_role_ids=sorted(final_role_ids & set(request.add_role_ids)),
@@ -233,6 +294,6 @@ def manage_dashboard_roles(
             for role_id in request.remove_role_ids
             if role_id not in final_role_ids
         ],
-        dashboard_rbac_enabled=dashboard_rbac_enabled,
+        viewers_enabled=viewers_enabled,
         warnings=warnings,
     )

--- a/superset/subjects/utils.py
+++ b/superset/subjects/utils.py
@@ -141,6 +141,41 @@ def get_subject(id_: int) -> Subject | None:
     return db.session.get(Subject, id_)
 
 
+def get_role_subject(role_id: int) -> Subject | None:
+    """Get the ROLE-type Subject for a given role ID."""
+    return (
+        db.session.query(Subject)
+        .filter_by(
+            role_id=role_id,
+            type=SubjectType.ROLE,
+        )
+        .first()
+    )
+
+
+def get_or_create_role_subject(role_id: int) -> Subject | None:
+    """Get or create the ROLE-type Subject for a given role ID.
+
+    Mirrors ``get_or_create_user_subject``: a role that exists but has no
+    Subject row yet (e.g. created before the sync hooks were installed and
+    not yet backfilled) is synced on demand rather than treated as
+    nonexistent. Returns ``None`` only when no such role exists.
+    """
+    if subject := get_role_subject(role_id):
+        return subject
+
+    from superset import security_manager
+    from superset.subjects.sync import sync_role_subject
+
+    role = db.session.get(security_manager.role_model, role_id)
+    if not role:
+        return None
+
+    sync_role_subject(role)
+    db.session.flush()
+    return get_role_subject(role_id)
+
+
 def subjects_from_roles(roles: list[Role | int]) -> list[Subject]:
     """Convert a list of Role objects or role IDs to role-type Subjects.
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/conftest.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/conftest.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared fixtures for dashboard tool tests."""
+
+from collections.abc import Iterator
+from unittest.mock import Mock, patch
+
+import pytest
+
+from superset.mcp_service.app import mcp
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth() -> Iterator[Mock]:
+    """Mock authentication for all tests in this directory."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        with patch("superset.security_manager.raise_for_editorship"):
+            mock_user = Mock()
+            mock_user.id = 1
+            mock_user.username = "admin"
+            mock_get_user.return_value = mock_user
+            yield mock_get_user

--- a/tests/unit_tests/mcp_service/dashboard/tool/conftest.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/conftest.py
@@ -35,7 +35,7 @@ def mock_auth() -> Iterator[Mock]:
     """Mock authentication for all tests in this directory."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
         with patch("superset.security_manager.raise_for_editorship"):
-            mock_user = Mock()
+            mock_user: Mock = Mock()
             mock_user.id = 1
             mock_user.username = "admin"
             mock_get_user.return_value = mock_user

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -37,7 +37,7 @@ def mcp_server() -> object:
 def mock_auth():
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_ownership"):
+        with patch("superset.security_manager.raise_for_editorship"):
             mock_user = Mock()
             mock_user.id = 1
             mock_user.username = "admin"
@@ -190,7 +190,7 @@ class TestManageDashboardCertification:
         mock_get.return_value = dash
 
         with patch(
-            "superset.security_manager.raise_for_ownership",
+            "superset.security_manager.raise_for_editorship",
             side_effect=SupersetSecurityException(Mock(message="forbidden")),
         ):
             async with Client(mcp_server) as client:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -182,6 +182,29 @@ class TestManageDashboardCertification:
 
     @patch(DAO_GET)
     @pytest.mark.asyncio
+    async def test_view_only_caller_gets_permission_denied(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """get_by_id_or_slug itself re-checks view access and raises
+        DashboardAccessDeniedError for dashboards the caller cannot see;
+        that must surface as permission_denied, not an unhandled error."""
+        from superset.commands.dashboard.exceptions import (
+            DashboardAccessDeniedError,
+        )
+
+        mock_get.side_effect = DashboardAccessDeniedError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 42, "certified_by": "Team"}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -17,33 +17,14 @@
 
 """Tests for the manage_dashboard_certification MCP tool."""
 
-from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import Client
 
-from superset.mcp_service.app import mcp
 from superset.utils import json
 
-DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-
-
-@pytest.fixture
-def mcp_server() -> object:
-    return mcp
-
-
-@pytest.fixture(autouse=True)
-def mock_auth() -> Iterator[Mock]:
-    """Mock authentication for all tests in this module."""
-    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_editorship"):
-            mock_user = Mock()
-            mock_user.id = 1
-            mock_user.username = "admin"
-            mock_get_user.return_value = mock_user
-            yield mock_get_user
+DAO_GET: str = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
 
 
 def _mock_dashboard(
@@ -179,6 +160,32 @@ class TestManageDashboardCertification:
 
         payload = json.loads(result.content[0].text)
         assert "not found" in (payload.get("error") or "").lower()
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_lookup_database_error_is_not_masked_as_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """A real DB/infra failure during lookup must surface as a distinct
+        database error, not be collapsed into "not found"."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        mock_get.side_effect = SQLAlchemyError("connection to server lost")
+
+        with patch(
+            "superset.mcp_service.dashboard.tool.manage_dashboard_certification.logger"
+        ) as mock_logger:
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_certification",
+                    {"request": {"identifier": 999999, "certified_by": "Team"}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" not in (payload.get("error") or "").lower()
+        assert "database error" in (payload.get("error") or "").lower()
+        assert "connection to server lost" not in (payload.get("error") or "")
+        mock_logger.exception.assert_called_once()
 
     @patch(DAO_GET)
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -1,0 +1,215 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the manage_dashboard_certification MCP tool."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests in this module."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        with patch("superset.security_manager.raise_for_ownership"):
+            mock_user = Mock()
+            mock_user.id = 1
+            mock_user.username = "admin"
+            mock_get_user.return_value = mock_user
+            yield mock_get_user
+
+
+def _mock_dashboard(
+    id: int = 42,
+    title: str = "Test Dashboard",
+    slug: str | None = "test-slug",
+    certified_by: str | None = None,
+    certification_details: str | None = None,
+) -> Mock:
+    dashboard = Mock()
+    dashboard.id = id
+    dashboard.dashboard_title = title
+    dashboard.slug = slug
+    dashboard.certified_by = certified_by
+    dashboard.certification_details = certification_details
+    return dashboard
+
+
+class TestManageDashboardCertification:
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_set_certification(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        dash = _mock_dashboard()
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {
+                    "request": {
+                        "identifier": 42,
+                        "certified_by": "Data Platform Team",
+                        "certification_details": "Verified against source-of-truth.",
+                    }
+                },
+            )
+
+        assert dash.certified_by == "Data Platform Team"
+        assert dash.certification_details == "Verified against source-of-truth."
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        # Response text is wrapped for LLM context (mirrors the read-path
+        # sanitization on DashboardInfo.certified_by), so check substring.
+        assert "Data Platform Team" in payload["certified_by"]
+        assert set(payload["changed_fields"]) == {
+            "certified_by",
+            "certification_details",
+        }
+
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_set_certified_by_only(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        dash = _mock_dashboard(certification_details="Existing details")
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 42, "certified_by": "Analytics Guild"}},
+            )
+
+        assert dash.certified_by == "Analytics Guild"
+        assert dash.certification_details == "Existing details"
+        payload = json.loads(result.content[0].text)
+        assert payload["changed_fields"] == ["certified_by"]
+
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_clear_with_empty_string(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        dash = _mock_dashboard(
+            certified_by="Old Team", certification_details="Old details"
+        )
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {
+                    "request": {
+                        "identifier": 42,
+                        "certified_by": "",
+                        "certification_details": "",
+                    }
+                },
+            )
+
+        assert dash.certified_by is None
+        assert dash.certification_details is None
+        payload = json.loads(result.content[0].text)
+        assert payload["certified_by"] is None
+        assert payload["certification_details"] is None
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_no_fields_is_noop(self, mock_get: Mock, mcp_server: object) -> None:
+        dash = _mock_dashboard(certified_by="Existing")
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 42}},
+            )
+
+        assert dash.certified_by == "Existing"
+        payload = json.loads(result.content[0].text)
+        assert payload["changed_fields"] == []
+        assert any("No fields provided" in w for w in payload["warnings"])
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_dashboard_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        from superset.commands.dashboard.exceptions import DashboardNotFoundError
+
+        mock_get.side_effect = DashboardNotFoundError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 999999, "certified_by": "Team"}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" in (payload.get("error") or "").lower()
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_permission_denied(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        from superset.exceptions import SupersetSecurityException
+
+        dash = _mock_dashboard()
+        mock_get.return_value = dash
+
+        with patch(
+            "superset.security_manager.raise_for_ownership",
+            side_effect=SupersetSecurityException(Mock(message="forbidden")),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_certification",
+                    {"request": {"identifier": 42, "certified_by": "Team"}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
+        assert dash.certified_by is None
+
+    @pytest.mark.asyncio
+    async def test_xss_certified_by_is_sanitized(self, mcp_server: object) -> None:
+        from superset.mcp_service.dashboard.schemas import (
+            ManageDashboardCertificationRequest,
+        )
+
+        request = ManageDashboardCertificationRequest(
+            identifier=1, certified_by="<script>alert(1)</script>Team"
+        )
+        assert "<script>" not in (request.certified_by or "")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -128,6 +128,64 @@ class TestManageDashboardCertification:
         assert payload["certification_details"] is None
 
     @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_refresh_failure_after_commit_returns_captured_values(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """A failed post-commit refresh() must not fail the call: the
+        response returns the values captured before the commit and appends
+        an advisory warning."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        dash = _mock_dashboard()
+        mock_get.return_value = dash
+        mock_session.refresh.side_effect = SQLAlchemyError("stale connection")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {
+                    "request": {
+                        "identifier": 42,
+                        "certified_by": "Data Platform Team",
+                    }
+                },
+            )
+
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert payload.get("error") is None
+        assert "Data Platform Team" in payload["certified_by"]
+        assert payload["changed_fields"] == ["certified_by"]
+        assert any("refresh failed" in w.lower() for w in payload["warnings"])
+
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_rollback_failure_still_returns_structured_error(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """Even when the rollback itself fails on the already-broken
+        session, the caller must still get the structured database-error
+        response, not an unhandled exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        dash = _mock_dashboard()
+        mock_get.return_value = dash
+        mock_session.commit.side_effect = SQLAlchemyError("connection lost")
+        mock_session.rollback.side_effect = SQLAlchemyError("still broken")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 42, "certified_by": "Data Platform Team"}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "database error" in (payload.get("error") or "").lower()
+
+    @patch(DAO_GET)
     @pytest.mark.asyncio
     async def test_no_fields_is_noop(self, mock_get: Mock, mcp_server: object) -> None:
         dash = _mock_dashboard(certified_by="Existing")
@@ -186,7 +244,7 @@ class TestManageDashboardCertification:
         mock_get.side_effect = SQLAlchemyError("connection to server lost")
 
         with patch(
-            "superset.mcp_service.dashboard.tool.manage_dashboard_certification.logger"
+            "superset.mcp_service.dashboard.tool.governance_utils.logger"
         ) as mock_logger:
             async with Client(mcp_server) as client:
                 result = await client.call_tool(

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -64,7 +64,7 @@ def _mock_dashboard(
 class TestManageDashboardCertification:
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_set_certification(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -97,7 +97,7 @@ class TestManageDashboardCertification:
 
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_set_certified_by_only(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -117,7 +117,7 @@ class TestManageDashboardCertification:
 
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_clear_with_empty_string(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -145,7 +145,7 @@ class TestManageDashboardCertification:
         assert payload["certification_details"] is None
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_no_fields_is_noop(self, mock_get: Mock, mcp_server: object) -> None:
         dash = _mock_dashboard(certified_by="Existing")
         mock_get.return_value = dash
@@ -162,7 +162,7 @@ class TestManageDashboardCertification:
         assert any("No fields provided" in w for w in payload["warnings"])
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_dashboard_not_found(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -180,7 +180,7 @@ class TestManageDashboardCertification:
         assert "not found" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -203,7 +203,7 @@ class TestManageDashboardCertification:
         assert payload.get("permission_denied") is True
         assert dash.certified_by is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_xss_certified_by_is_sanitized(self, mcp_server: object) -> None:
         from superset.mcp_service.dashboard.schemas import (
             ManageDashboardCertificationRequest,
@@ -213,3 +213,17 @@ class TestManageDashboardCertification:
             identifier=1, certified_by="<script>alert(1)</script>Team"
         )
         assert "<script>" not in (request.certified_by or "")
+
+    @pytest.mark.asyncio()
+    async def test_xss_certification_details_is_sanitized(
+        self, mcp_server: object
+    ) -> None:
+        from superset.mcp_service.dashboard.schemas import (
+            ManageDashboardCertificationRequest,
+        )
+
+        request = ManageDashboardCertificationRequest(
+            identifier=1,
+            certification_details="<script>alert(1)</script>Verified details",
+        )
+        assert "<script>" not in (request.certification_details or "")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -17,6 +17,7 @@
 
 """Tests for the manage_dashboard_certification MCP tool."""
 
+from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -34,7 +35,7 @@ def mcp_server() -> object:
 
 
 @pytest.fixture(autouse=True)
-def mock_auth():
+def mock_auth() -> Iterator[Mock]:
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
         with patch("superset.security_manager.raise_for_editorship"):
@@ -227,3 +228,33 @@ class TestManageDashboardCertification:
             certification_details="<script>alert(1)</script>Verified details",
         )
         assert "<script>" not in (request.certification_details or "")
+
+    @pytest.mark.asyncio()
+    async def test_certified_by_sanitized_to_empty_rejected(
+        self, mcp_server: object
+    ) -> None:
+        """HTML-only input must not be silently treated as a clear request."""
+        from pydantic import ValidationError
+
+        from superset.mcp_service.dashboard.schemas import (
+            ManageDashboardCertificationRequest,
+        )
+
+        with pytest.raises(ValidationError, match="explicit empty string"):
+            ManageDashboardCertificationRequest(identifier=1, certified_by="<b></b>")
+
+    @pytest.mark.asyncio()
+    async def test_certification_details_sanitized_to_empty_rejected(
+        self, mcp_server: object
+    ) -> None:
+        """HTML-only input must not be silently treated as a clear request."""
+        from pydantic import ValidationError
+
+        from superset.mcp_service.dashboard.schemas import (
+            ManageDashboardCertificationRequest,
+        )
+
+        with pytest.raises(ValidationError, match="explicit empty string"):
+            ManageDashboardCertificationRequest(
+                identifier=1, certification_details="<script>alert(1)</script>"
+            )

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -84,7 +84,7 @@ class TestManageDashboardCertification:
     async def test_set_certified_by_only(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
-        dash = _mock_dashboard(certification_details="Existing details")
+        dash: Mock = _mock_dashboard(certification_details="Existing details")
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
@@ -95,7 +95,7 @@ class TestManageDashboardCertification:
 
         assert dash.certified_by == "Analytics Guild"
         assert dash.certification_details == "Existing details"
-        payload = json.loads(result.content[0].text)
+        payload: dict[str, Any] = json.loads(result.content[0].text)
         assert payload["changed_fields"] == ["certified_by"]
 
     @patch(DAO_GET)
@@ -104,7 +104,7 @@ class TestManageDashboardCertification:
     async def test_clear_with_empty_string(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
-        dash = _mock_dashboard(
+        dash: Mock = _mock_dashboard(
             certified_by="Old Team", certification_details="Old details"
         )
         mock_get.return_value = dash
@@ -326,9 +326,11 @@ class TestManageDashboardCertification:
             ManageDashboardCertificationRequest,
         )
 
-        request = ManageDashboardCertificationRequest(
-            identifier=1,
-            certification_details="<script>alert(1)</script>Verified details",
+        request: ManageDashboardCertificationRequest = (
+            ManageDashboardCertificationRequest(
+                identifier=1,
+                certification_details="<script>alert(1)</script>Verified details",
+            )
         )
         assert "<script>" not in (request.certification_details or "")
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -17,6 +17,7 @@
 
 """Tests for the manage_dashboard_certification MCP tool."""
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -34,7 +35,7 @@ def _mock_dashboard(
     certified_by: str | None = None,
     certification_details: str | None = None,
 ) -> Mock:
-    dashboard = Mock()
+    dashboard: Mock = Mock()
     dashboard.id = id
     dashboard.dashboard_title = title
     dashboard.slug = slug
@@ -50,7 +51,7 @@ class TestManageDashboardCertification:
     async def test_set_certification(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
-        dash = _mock_dashboard()
+        dash: Mock = _mock_dashboard()
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
@@ -68,7 +69,7 @@ class TestManageDashboardCertification:
         assert dash.certified_by == "Data Platform Team"
         assert dash.certification_details == "Verified against source-of-truth."
         assert mock_session.commit.call_count >= 1
-        payload = json.loads(result.content[0].text)
+        payload: dict[str, Any] = json.loads(result.content[0].text)
         # Response text is wrapped for LLM context (mirrors the read-path
         # sanitization on DashboardInfo.certified_by), so check substring.
         assert "Data Platform Team" in payload["certified_by"]
@@ -161,6 +162,18 @@ class TestManageDashboardCertification:
         payload = json.loads(result.content[0].text)
         assert "not found" in (payload.get("error") or "").lower()
 
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_identifier(self, mcp_server: object) -> None:
+        """bool subclasses int; identifier=true must not coerce to dashboard ID 1."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_certification",
+                    {"request": {"identifier": True, "certified_by": "Team"}},
+                )
+
     @patch(DAO_GET)
     @pytest.mark.asyncio
     async def test_lookup_database_error_is_not_masked_as_not_found(
@@ -240,8 +253,10 @@ class TestManageDashboardCertification:
             ManageDashboardCertificationRequest,
         )
 
-        request = ManageDashboardCertificationRequest(
-            identifier=1, certified_by="<script>alert(1)</script>Team"
+        request: ManageDashboardCertificationRequest = (
+            ManageDashboardCertificationRequest(
+                identifier=1, certified_by="<script>alert(1)</script>Team"
+            )
         )
         assert "<script>" not in (request.certified_by or "")
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -65,7 +65,7 @@ def _mock_dashboard(
 class TestManageDashboardCertification:
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_set_certification(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -98,7 +98,7 @@ class TestManageDashboardCertification:
 
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_set_certified_by_only(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -118,7 +118,7 @@ class TestManageDashboardCertification:
 
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_clear_with_empty_string(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -146,7 +146,7 @@ class TestManageDashboardCertification:
         assert payload["certification_details"] is None
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_no_fields_is_noop(self, mock_get: Mock, mcp_server: object) -> None:
         dash = _mock_dashboard(certified_by="Existing")
         mock_get.return_value = dash
@@ -163,7 +163,7 @@ class TestManageDashboardCertification:
         assert any("No fields provided" in w for w in payload["warnings"])
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_dashboard_not_found(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -181,7 +181,7 @@ class TestManageDashboardCertification:
         assert "not found" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -204,7 +204,7 @@ class TestManageDashboardCertification:
         assert payload.get("permission_denied") is True
         assert dash.certified_by is None
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_xss_certified_by_is_sanitized(self, mcp_server: object) -> None:
         from superset.mcp_service.dashboard.schemas import (
             ManageDashboardCertificationRequest,
@@ -215,7 +215,7 @@ class TestManageDashboardCertification:
         )
         assert "<script>" not in (request.certified_by or "")
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_xss_certification_details_is_sanitized(
         self, mcp_server: object
     ) -> None:
@@ -229,7 +229,7 @@ class TestManageDashboardCertification:
         )
         assert "<script>" not in (request.certification_details or "")
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_certified_by_sanitized_to_empty_rejected(
         self, mcp_server: object
     ) -> None:
@@ -243,7 +243,7 @@ class TestManageDashboardCertification:
         with pytest.raises(ValidationError, match="explicit empty string"):
             ManageDashboardCertificationRequest(identifier=1, certified_by="<b></b>")
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_certification_details_sanitized_to_empty_rejected(
         self, mcp_server: object
     ) -> None:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -453,7 +453,7 @@ class TestManageDashboardOwners:
         mock_get.side_effect = SQLAlchemyError("connection to server lost")
 
         with patch(
-            "superset.mcp_service.dashboard.tool.manage_dashboard_owners.logger"
+            "superset.mcp_service.dashboard.tool.governance_utils.logger"
         ) as mock_logger:
             async with Client(mcp_server) as client:
                 result = await client.call_tool(
@@ -467,6 +467,120 @@ class TestManageDashboardOwners:
         # The raw exception text must never reach the LLM-facing response.
         assert "connection to server lost" not in (payload.get("error") or "")
         mock_logger.exception.assert_called_once()
+
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_subjects_not_found_during_populate_returns_error(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """populate_subject_list raising SubjectsNotFoundValidationError
+        (subject rows vanished between resolution and validation) must
+        surface as the structured could-not-resolve error."""
+        from superset.subjects.exceptions import SubjectsNotFoundValidationError
+
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "bob")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
+        mock_populate.side_effect = SubjectsNotFoundValidationError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [7]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "could not be resolved" in (payload.get("error") or "").lower()
+        assert "find_users" in (payload.get("error") or "")
+
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_rollback_failure_still_returns_structured_error(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """Even when the rollback itself fails on the already-broken
+        session, the caller must still get the structured database-error
+        response, not an unhandled exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "bob")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
+        mock_populate.return_value = [existing, new_owner]
+        mock_session.commit.side_effect = SQLAlchemyError("connection lost")
+        mock_session.rollback.side_effect = SQLAlchemyError("still broken")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [7]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "database error" in (payload.get("error") or "").lower()
+
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_refresh_failure_after_commit_still_returns_owners(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """A failed post-commit refresh() must not fail the call: the
+        response is built from the subjects captured before the commit."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "bob")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
+        mock_populate.return_value = [existing, new_owner]
+        mock_session.refresh.side_effect = SQLAlchemyError("stale connection")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [7]}},
+            )
+
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert payload.get("error") is None
+        assert sorted(o["id"] for o in payload["owners"]) == [100, 101]
+        assert payload["added_owner_ids"] == [7]
 
     @patch(POPULATE_SUBJECT_LIST)
     @patch(GET_OR_CREATE_USER_SUBJECT)

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -22,6 +22,7 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``owners`` relationship).
 """
 
+from typing import Callable
 from unittest.mock import Mock, patch
 
 import pytest
@@ -33,6 +34,18 @@ from superset.utils import json
 DAO_GET: str = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
 GET_OR_CREATE_USER_SUBJECT: str = "superset.subjects.utils.get_or_create_user_subject"
 POPULATE_SUBJECT_LIST: str = "superset.commands.utils.populate_subject_list"
+
+
+def _get_or_create_side_effect(
+    mapping: dict[int, Mock],
+) -> Callable[[int], Mock | None]:
+    """Typed stand-in for ``get_or_create_user_subject``'s ``side_effect``:
+    resolves a user ID to its mocked Subject, or ``None`` if unknown."""
+
+    def _lookup(user_id: int) -> Mock | None:
+        return mapping.get(user_id)
+
+    return _lookup
 
 
 def _mock_subject(id: int, user_id: int, label: str = "user") -> Mock:
@@ -80,7 +93,9 @@ class TestManageDashboardOwners:
         new_owner = _mock_subject(101, 7, "bob")
         dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
         mock_populate.return_value = [existing, new_owner]
 
         async with Client(mcp_server) as client:
@@ -119,7 +134,7 @@ class TestManageDashboardOwners:
         remove = _mock_subject(101, 2, "carol")
         dash = _mock_dashboard(editors=[keep, remove])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: {1: keep}[uid]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({1: keep})
         mock_populate.return_value = [keep]
 
         async with Client(mcp_server) as client:
@@ -247,7 +262,7 @@ class TestManageDashboardOwners:
         existing = _mock_subject(100, 1, "admin")
         dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: existing if uid == 1 else None
+        mock_get_or_create.side_effect = _get_or_create_side_effect({1: existing})
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -281,7 +296,7 @@ class TestManageDashboardOwners:
         dave = _mock_subject(102, 3, "dave")
         dash = _mock_dashboard(editors=[admin, carol, dave])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: {3: dave}[uid]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({3: dave})
         # Requested new subject ids == [102] (dave), but populate_subject_list
         # simulates re-adding admin's subject per ensure_no_lockout.
         mock_populate.return_value = [admin, dave]
@@ -344,7 +359,9 @@ class TestManageDashboardOwners:
         new_owner = _mock_subject(101, 7, "bob")
         dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
         mock_populate.return_value = [existing, new_owner]
 
         async with Client(mcp_server) as client:
@@ -400,6 +417,30 @@ class TestManageDashboardOwners:
                     {"request": {"identifier": True, "add_owner_ids": [1]}},
                 )
 
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_add_owner_ids(self, mcp_server: object) -> None:
+        """bool subclasses int; add_owner_ids=[true] must not coerce to user ID 1."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": 42, "add_owner_ids": [True]}},
+                )
+
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_remove_owner_ids(self, mcp_server: object) -> None:
+        """bool subclasses int; remove_owner_ids=[false] must not coerce to ID 0."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": 42, "remove_owner_ids": [False]}},
+                )
+
     @patch(DAO_GET)
     @pytest.mark.asyncio
     async def test_lookup_database_error_is_not_masked_as_not_found(
@@ -452,7 +493,9 @@ class TestManageDashboardOwners:
         new_owner = _mock_subject(101, 7, "<script>alert(1)</script>")
         dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
+        mock_get_or_create.side_effect = _get_or_create_side_effect(
+            {1: existing, 7: new_owner}
+        )
         mock_populate.return_value = [existing, new_owner]
 
         async with Client(mcp_server) as client:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -1,0 +1,297 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the manage_dashboard_owners MCP tool."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
+POPULATE_OWNER_LIST = "superset.commands.utils.populate_owner_list"
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests in this module."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        with patch("superset.security_manager.raise_for_ownership"):
+            mock_user = Mock()
+            mock_user.id = 1
+            mock_user.username = "admin"
+            mock_get_user.return_value = mock_user
+            yield mock_get_user
+
+
+def _mock_user(id: int, username: str = "user") -> Mock:
+    user = Mock()
+    user.id = id
+    user.username = username
+    user.first_name = "First"
+    user.last_name = "Last"
+    user.active = True
+    user.changed_on = None
+    return user
+
+
+def _mock_dashboard(
+    id: int = 42,
+    title: str = "Test Dashboard",
+    slug: str | None = "test-slug",
+    owners: list[Mock] | None = None,
+) -> Mock:
+    dashboard = Mock()
+    dashboard.id = id
+    dashboard.dashboard_title = title
+    dashboard.slug = slug
+    dashboard.owners = owners if owners is not None else [_mock_user(1, "admin")]
+    return dashboard
+
+
+class TestManageDashboardOwners:
+    @patch(POPULATE_OWNER_LIST)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_add_owner(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        existing = _mock_user(1, "admin")
+        new_owner = _mock_user(7, "bob")
+        dash = _mock_dashboard(owners=[existing])
+        mock_get.return_value = dash
+        # populate_owner_list resolves the final list; simulate it (and the
+        # side effect of assigning dashboard.owners like the real setter).
+        mock_populate.return_value = [existing, new_owner]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [7]}},
+            )
+
+        mock_populate.assert_called_once_with([1, 7], default_to_user=False)
+        assert dash.owners == [existing, new_owner]
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert sorted(o["id"] for o in payload["owners"]) == [1, 7]
+        assert payload["added_owner_ids"] == [7]
+        assert payload["removed_owner_ids"] == []
+
+    @patch(POPULATE_OWNER_LIST)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_remove_owner(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        keep = _mock_user(1, "admin")
+        remove = _mock_user(2, "carol")
+        dash = _mock_dashboard(owners=[keep, remove])
+        mock_get.return_value = dash
+        mock_populate.return_value = [keep]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "remove_owner_ids": [2]}},
+            )
+
+        mock_populate.assert_called_once_with([1], default_to_user=False)
+        payload = json.loads(result.content[0].text)
+        assert payload["removed_owner_ids"] == [2]
+        assert [o["id"] for o in payload["owners"]] == [1]
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_remove_all_owners_rejected(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """Removing every owner must be rejected before any DB write."""
+        original_owners = [_mock_user(1, "admin")]
+        dash = _mock_dashboard(owners=original_owners)
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "remove_owner_ids": [1]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "at least one owner" in (payload.get("error") or "").lower()
+        # dashboard.owners must remain untouched
+        assert dash.owners is original_owners
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_remove_unknown_owner_id_rejected(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "remove_owner_ids": [999]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "999" in (payload.get("error") or "")
+        assert "not currently owners" in (payload.get("error") or "").lower()
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_dashboard_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        from superset.commands.dashboard.exceptions import DashboardNotFoundError
+
+        mock_get.side_effect = DashboardNotFoundError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 999999, "add_owner_ids": [1]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" in (payload.get("error") or "").lower()
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_permission_denied(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        from superset.exceptions import SupersetSecurityException
+
+        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        mock_get.return_value = dash
+
+        with patch(
+            "superset.security_manager.raise_for_ownership",
+            side_effect=SupersetSecurityException(Mock(message="forbidden")),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": 42, "add_owner_ids": [7]}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
+
+    @patch(POPULATE_OWNER_LIST)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_unknown_user_id_in_add_rejected(
+        self, mock_get: Mock, mock_populate: Mock, mcp_server: object
+    ) -> None:
+        from superset.commands.exceptions import OwnersNotFoundValidationError
+
+        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        mock_get.return_value = dash
+        mock_populate.side_effect = OwnersNotFoundValidationError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [99999]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "do not exist" in (payload.get("error") or "").lower()
+        assert "find_users" in (payload.get("error") or "")
+
+    @patch(POPULATE_OWNER_LIST)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_self_removal_auto_readded_warns(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """When populate_owner_list re-adds a caller who tried to remove
+        themselves (self-protection), the response surfaces a warning
+        instead of silently diverging from what was requested."""
+        admin = _mock_user(1, "admin")
+        carol = _mock_user(2, "carol")
+        dave = _mock_user(3, "dave")
+        dash = _mock_dashboard(owners=[admin, carol, dave])
+        mock_get.return_value = dash
+        # Requested new_owner_ids == [3] (dave), but populate_owner_list
+        # simulates re-adding admin (id=1) per its non-admin self-protection.
+        mock_populate.return_value = [admin, dave]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "remove_owner_ids": [1, 2]}},
+            )
+
+        mock_populate.assert_called_once_with([3], default_to_user=False)
+        payload = json.loads(result.content[0].text)
+        assert any("automatically re-added" in w for w in payload.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="cannot appear in both"):
+                await client.call_tool(
+                    "manage_dashboard_owners",
+                    {
+                        "request": {
+                            "identifier": 42,
+                            "add_owner_ids": [1],
+                            "remove_owner_ids": [1],
+                        }
+                    },
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_operation_rejected(self, mcp_server: object) -> None:
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="At least one of"):
+                await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": 42}},
+                )

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -213,6 +213,29 @@ class TestManageDashboardOwners:
 
     @patch(DAO_GET)
     @pytest.mark.asyncio
+    async def test_view_only_caller_gets_permission_denied(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """get_by_id_or_slug itself re-checks view access and raises
+        DashboardAccessDeniedError for dashboards the caller cannot see;
+        that must surface as permission_denied, not an unhandled error."""
+        from superset.commands.dashboard.exceptions import (
+            DashboardAccessDeniedError,
+        )
+
+        mock_get.side_effect = DashboardAccessDeniedError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [1]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -86,7 +86,7 @@ class TestManageDashboardOwners:
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_owner(
         self,
         mock_session: Mock,
@@ -125,7 +125,7 @@ class TestManageDashboardOwners:
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_remove_owner(
         self,
         mock_session: Mock,
@@ -155,7 +155,7 @@ class TestManageDashboardOwners:
         assert [o["id"] for o in payload["owners"]] == [100]
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_remove_all_owners_rejected(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -176,7 +176,7 @@ class TestManageDashboardOwners:
         assert dash.editors is original_editors
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_remove_unknown_owner_id_rejected(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -194,7 +194,7 @@ class TestManageDashboardOwners:
         assert "not currently owners" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_dashboard_not_found(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -212,7 +212,7 @@ class TestManageDashboardOwners:
         assert "not found" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -236,7 +236,7 @@ class TestManageDashboardOwners:
 
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_unknown_user_id_in_add_rejected(
         self, mock_get: Mock, mock_get_or_create: Mock, mcp_server: object
     ) -> None:
@@ -259,7 +259,7 @@ class TestManageDashboardOwners:
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_self_removal_auto_readded_warns(
         self,
         mock_session: Mock,
@@ -296,7 +296,7 @@ class TestManageDashboardOwners:
 
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_already_owner_is_noop_without_disclosure(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -324,7 +324,7 @@ class TestManageDashboardOwners:
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_partial_change_still_discloses_full_owners(
         self,
         mock_session: Mock,
@@ -356,7 +356,7 @@ class TestManageDashboardOwners:
         assert sorted(o["id"] for o in payload["owners"]) == [100, 101]
         assert payload["added_owner_ids"] == [7]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 
@@ -373,7 +373,7 @@ class TestManageDashboardOwners:
                     },
                 )
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_no_operation_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -255,9 +255,14 @@ class TestManageDashboardOwners:
 
     @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
     async def test_unknown_user_id_in_add_rejected(
-        self, mock_get: Mock, mock_get_or_create: Mock, mcp_server: object
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mcp_server: object,
     ) -> None:
         existing = _mock_subject(100, 1, "admin")
         dash = _mock_dashboard(editors=[existing])
@@ -270,6 +275,10 @@ class TestManageDashboardOwners:
                 {"request": {"identifier": 42, "add_owner_ids": [99999]}},
             )
 
+        # A rejected request must never leave uncommitted Subject rows
+        # (flushed by get_or_create_user_subject for earlier, valid user
+        # IDs in the same call) sitting in the session.
+        mock_session.rollback.assert_called_once()
         payload = json.loads(result.content[0].text)
         assert "not exist" in (payload.get("error") or "").lower()
         assert "find_users" in (payload.get("error") or "")
@@ -501,6 +510,10 @@ class TestManageDashboardOwners:
                 {"request": {"identifier": 42, "add_owner_ids": [7]}},
             )
 
+        # A rejected request must never leave uncommitted Subject rows
+        # (flushed by get_or_create_user_subject before populate_subject_list
+        # ran) sitting in the session.
+        mock_session.rollback.assert_called_once()
         payload = json.loads(result.content[0].text)
         assert "could not be resolved" in (payload.get("error") or "").lower()
         assert "find_users" in (payload.get("error") or "")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Tests for the manage_dashboard_owners MCP tool."""
+"""Tests for the manage_dashboard_owners MCP tool.
+
+"Owners" are USER-type Subjects in the dashboard's ``editors`` list (the
+Subject-based model apache/superset#38831 introduced, replacing the legacy
+``owners`` relationship).
+"""
 
 from unittest.mock import Mock, patch
 
@@ -23,10 +28,12 @@ import pytest
 from fastmcp import Client
 
 from superset.mcp_service.app import mcp
+from superset.subjects.types import SubjectType
 from superset.utils import json
 
 DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-POPULATE_OWNER_LIST = "superset.commands.utils.populate_owner_list"
+GET_OR_CREATE_USER_SUBJECT = "superset.subjects.utils.get_or_create_user_subject"
+POPULATE_SUBJECT_LIST = "superset.commands.utils.populate_subject_list"
 
 
 @pytest.fixture
@@ -38,7 +45,7 @@ def mcp_server() -> object:
 def mock_auth():
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_ownership"):
+        with patch("superset.security_manager.raise_for_editorship"):
             mock_user = Mock()
             mock_user.id = 1
             mock_user.username = "admin"
@@ -46,49 +53,52 @@ def mock_auth():
             yield mock_get_user
 
 
-def _mock_user(id: int, username: str = "user") -> Mock:
-    user = Mock()
-    user.id = id
-    user.username = username
-    user.first_name = "First"
-    user.last_name = "Last"
-    user.active = True
-    user.changed_on = None
-    return user
+def _mock_subject(id: int, user_id: int, label: str = "user") -> Mock:
+    subject = Mock()
+    subject.id = id
+    subject.type = SubjectType.USER
+    subject.user_id = user_id
+    subject.role_id = None
+    subject.label = label
+    subject.active = True
+    return subject
 
 
 def _mock_dashboard(
     id: int = 42,
     title: str = "Test Dashboard",
     slug: str | None = "test-slug",
-    owners: list[Mock] | None = None,
+    editors: list[Mock] | None = None,
 ) -> Mock:
     dashboard = Mock()
     dashboard.id = id
     dashboard.dashboard_title = title
     dashboard.slug = slug
-    dashboard.owners = owners if owners is not None else [_mock_user(1, "admin")]
+    dashboard.editors = (
+        editors if editors is not None else [_mock_subject(100, 1, "admin")]
+    )
     return dashboard
 
 
 class TestManageDashboardOwners:
-    @patch(POPULATE_OWNER_LIST)
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_owner(
         self,
         mock_session: Mock,
         mock_get: Mock,
+        mock_get_or_create: Mock,
         mock_populate: Mock,
         mcp_server: object,
     ) -> None:
-        existing = _mock_user(1, "admin")
-        new_owner = _mock_user(7, "bob")
-        dash = _mock_dashboard(owners=[existing])
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "bob")
+        dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        # populate_owner_list resolves the final list; simulate it (and the
-        # side effect of assigning dashboard.owners like the real setter).
+        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
         mock_populate.return_value = [existing, new_owner]
 
         async with Client(mcp_server) as client:
@@ -97,29 +107,37 @@ class TestManageDashboardOwners:
                 {"request": {"identifier": 42, "add_owner_ids": [7]}},
             )
 
-        mock_populate.assert_called_once_with([1, 7], default_to_user=False)
-        assert dash.owners == [existing, new_owner]
+        mock_populate.assert_called_once_with(
+            [100, 101],
+            default_to_user=False,
+            ensure_no_lockout=True,
+            field_name="editors",
+        )
+        assert dash.editors == [existing, new_owner]
         assert mock_session.commit.call_count >= 1
         payload = json.loads(result.content[0].text)
-        assert sorted(o["id"] for o in payload["owners"]) == [1, 7]
+        assert sorted(o["id"] for o in payload["owners"]) == [100, 101]
         assert payload["added_owner_ids"] == [7]
         assert payload["removed_owner_ids"] == []
 
-    @patch(POPULATE_OWNER_LIST)
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_remove_owner(
         self,
         mock_session: Mock,
         mock_get: Mock,
+        mock_get_or_create: Mock,
         mock_populate: Mock,
         mcp_server: object,
     ) -> None:
-        keep = _mock_user(1, "admin")
-        remove = _mock_user(2, "carol")
-        dash = _mock_dashboard(owners=[keep, remove])
+        keep = _mock_subject(100, 1, "admin")
+        remove = _mock_subject(101, 2, "carol")
+        dash = _mock_dashboard(editors=[keep, remove])
         mock_get.return_value = dash
+        mock_get_or_create.side_effect = lambda uid: {1: keep}[uid]
         mock_populate.return_value = [keep]
 
         async with Client(mcp_server) as client:
@@ -128,19 +146,21 @@ class TestManageDashboardOwners:
                 {"request": {"identifier": 42, "remove_owner_ids": [2]}},
             )
 
-        mock_populate.assert_called_once_with([1], default_to_user=False)
+        mock_populate.assert_called_once_with(
+            [100], default_to_user=False, ensure_no_lockout=True, field_name="editors"
+        )
         payload = json.loads(result.content[0].text)
         assert payload["removed_owner_ids"] == [2]
-        assert [o["id"] for o in payload["owners"]] == [1]
+        assert [o["id"] for o in payload["owners"]] == [100]
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_remove_all_owners_rejected(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
         """Removing every owner must be rejected before any DB write."""
-        original_owners = [_mock_user(1, "admin")]
-        dash = _mock_dashboard(owners=original_owners)
+        original_editors = [_mock_subject(100, 1, "admin")]
+        dash = _mock_dashboard(editors=original_editors)
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
@@ -151,15 +171,15 @@ class TestManageDashboardOwners:
 
         payload = json.loads(result.content[0].text)
         assert "at least one owner" in (payload.get("error") or "").lower()
-        # dashboard.owners must remain untouched
-        assert dash.owners is original_owners
+        # dashboard.editors must remain untouched
+        assert dash.editors is original_editors
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_remove_unknown_owner_id_rejected(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
-        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        dash = _mock_dashboard(editors=[_mock_subject(100, 1, "admin")])
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
@@ -173,7 +193,7 @@ class TestManageDashboardOwners:
         assert "not currently owners" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_dashboard_not_found(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
@@ -191,17 +211,17 @@ class TestManageDashboardOwners:
         assert "not found" in (payload.get("error") or "").lower()
 
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mcp_server: object
     ) -> None:
         from superset.exceptions import SupersetSecurityException
 
-        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        dash = _mock_dashboard(editors=[_mock_subject(100, 1, "admin")])
         mock_get.return_value = dash
 
         with patch(
-            "superset.security_manager.raise_for_ownership",
+            "superset.security_manager.raise_for_editorship",
             side_effect=SupersetSecurityException(Mock(message="forbidden")),
         ):
             async with Client(mcp_server) as client:
@@ -213,17 +233,16 @@ class TestManageDashboardOwners:
         payload = json.loads(result.content[0].text)
         assert payload.get("permission_denied") is True
 
-    @patch(POPULATE_OWNER_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_unknown_user_id_in_add_rejected(
-        self, mock_get: Mock, mock_populate: Mock, mcp_server: object
+        self, mock_get: Mock, mock_get_or_create: Mock, mcp_server: object
     ) -> None:
-        from superset.commands.exceptions import OwnersNotFoundValidationError
-
-        dash = _mock_dashboard(owners=[_mock_user(1, "admin")])
+        existing = _mock_subject(100, 1, "admin")
+        dash = _mock_dashboard(editors=[existing])
         mock_get.return_value = dash
-        mock_populate.side_effect = OwnersNotFoundValidationError()
+        mock_get_or_create.side_effect = lambda uid: existing if uid == 1 else None
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -232,30 +251,34 @@ class TestManageDashboardOwners:
             )
 
         payload = json.loads(result.content[0].text)
-        assert "do not exist" in (payload.get("error") or "").lower()
+        assert "not exist" in (payload.get("error") or "").lower()
         assert "find_users" in (payload.get("error") or "")
 
-    @patch(POPULATE_OWNER_LIST)
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_self_removal_auto_readded_warns(
         self,
         mock_session: Mock,
         mock_get: Mock,
+        mock_get_or_create: Mock,
         mock_populate: Mock,
         mcp_server: object,
     ) -> None:
-        """When populate_owner_list re-adds a caller who tried to remove
-        themselves (self-protection), the response surfaces a warning
-        instead of silently diverging from what was requested."""
-        admin = _mock_user(1, "admin")
-        carol = _mock_user(2, "carol")
-        dave = _mock_user(3, "dave")
-        dash = _mock_dashboard(owners=[admin, carol, dave])
+        """When populate_subject_list re-adds a caller who tried to remove
+        themselves (ensure_no_lockout self-protection), the response
+        surfaces a warning instead of silently diverging from what was
+        requested."""
+        admin = _mock_subject(100, 1, "admin")
+        carol = _mock_subject(101, 2, "carol")
+        dave = _mock_subject(102, 3, "dave")
+        dash = _mock_dashboard(editors=[admin, carol, dave])
         mock_get.return_value = dash
-        # Requested new_owner_ids == [3] (dave), but populate_owner_list
-        # simulates re-adding admin (id=1) per its non-admin self-protection.
+        mock_get_or_create.side_effect = lambda uid: {3: dave}[uid]
+        # Requested new subject ids == [102] (dave), but populate_subject_list
+        # simulates re-adding admin's subject per ensure_no_lockout.
         mock_populate.return_value = [admin, dave]
 
         async with Client(mcp_server) as client:
@@ -264,11 +287,75 @@ class TestManageDashboardOwners:
                 {"request": {"identifier": 42, "remove_owner_ids": [1, 2]}},
             )
 
-        mock_populate.assert_called_once_with([3], default_to_user=False)
+        mock_populate.assert_called_once_with(
+            [102], default_to_user=False, ensure_no_lockout=True, field_name="editors"
+        )
         payload = json.loads(result.content[0].text)
         assert any("automatically re-added" in w for w in payload.get("warnings", []))
 
-    @pytest.mark.asyncio
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio()
+    async def test_add_already_owner_is_noop_without_disclosure(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """Adding an ID that is already an owner is a no-op: skip the DB
+        write and do not return the full owner list. Otherwise a caller
+        could enumerate owners via a disguised "change" request that
+        never actually changes anything."""
+        existing = _mock_subject(100, 1, "admin")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [1]}},
+            )
+
+        mock_session.commit.assert_not_called()
+        payload = json.loads(result.content[0].text)
+        assert payload["owners"] == []
+        assert payload["added_owner_ids"] == []
+        assert any("no effective change" in w.lower() for w in payload["warnings"])
+
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio()
+    async def test_partial_change_still_discloses_full_owners(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """A request that DOES change something (even if one of several
+        requested ops is redundant) still returns the full owner list —
+        only a fully no-op request is suppressed."""
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "bob")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
+        mock_populate.return_value = [existing, new_owner]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                # add_owner_ids includes the already-current owner (1) AND
+                # a genuinely new one (7) — net effect is a real change.
+                {"request": {"identifier": 42, "add_owner_ids": [1, 7]}},
+            )
+
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert sorted(o["id"] for o in payload["owners"]) == [100, 101]
+        assert payload["added_owner_ids"] == [7]
+
+    @pytest.mark.asyncio()
     async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 
@@ -285,7 +372,7 @@ class TestManageDashboardOwners:
                     },
                 )
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_no_operation_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -22,36 +22,17 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``owners`` relationship).
 """
 
-from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import Client
 
-from superset.mcp_service.app import mcp
 from superset.subjects.types import SubjectType
 from superset.utils import json
 
-DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-GET_OR_CREATE_USER_SUBJECT = "superset.subjects.utils.get_or_create_user_subject"
-POPULATE_SUBJECT_LIST = "superset.commands.utils.populate_subject_list"
-
-
-@pytest.fixture
-def mcp_server() -> object:
-    return mcp
-
-
-@pytest.fixture(autouse=True)
-def mock_auth() -> Iterator[Mock]:
-    """Mock authentication for all tests in this module."""
-    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_editorship"):
-            mock_user = Mock()
-            mock_user.id = 1
-            mock_user.username = "admin"
-            mock_get_user.return_value = mock_user
-            yield mock_get_user
+DAO_GET: str = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
+GET_OR_CREATE_USER_SUBJECT: str = "superset.subjects.utils.get_or_create_user_subject"
+POPULATE_SUBJECT_LIST: str = "superset.commands.utils.populate_subject_list"
 
 
 def _mock_subject(id: int, user_id: int, label: str = "user") -> Mock:
@@ -406,3 +387,83 @@ class TestManageDashboardOwners:
                     "manage_dashboard_owners",
                     {"request": {"identifier": 42}},
                 )
+
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_identifier(self, mcp_server: object) -> None:
+        """bool subclasses int; identifier=true must not coerce to dashboard ID 1."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": True, "add_owner_ids": [1]}},
+                )
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_lookup_database_error_is_not_masked_as_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """A real DB/infra failure during lookup must surface as a distinct
+        database error, not be collapsed into "not found"."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        mock_get.side_effect = SQLAlchemyError("connection to server lost")
+
+        with patch(
+            "superset.mcp_service.dashboard.tool.manage_dashboard_owners.logger"
+        ) as mock_logger:
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_owners",
+                    {"request": {"identifier": 999999, "add_owner_ids": [1]}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" not in (payload.get("error") or "").lower()
+        assert "database error" in (payload.get("error") or "").lower()
+        # The raw exception text must never reach the LLM-facing response.
+        assert "connection to server lost" not in (payload.get("error") or "")
+        mock_logger.exception.assert_called_once()
+
+    @patch(POPULATE_SUBJECT_LIST)
+    @patch(GET_OR_CREATE_USER_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_owner_label_sanitized_for_llm_context(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_populate: Mock,
+        mcp_server: object,
+    ) -> None:
+        """Owner labels are user-controlled display names; they must be
+        wrapped in untrusted-content delimiters before reaching LLM context
+        so they cannot be mistaken for trusted instructions."""
+        from superset.mcp_service.utils.sanitization import (
+            LLM_CONTEXT_CLOSE_DELIMITER,
+            LLM_CONTEXT_OPEN_DELIMITER,
+        )
+
+        existing = _mock_subject(100, 1, "admin")
+        new_owner = _mock_subject(101, 7, "<script>alert(1)</script>")
+        dash = _mock_dashboard(editors=[existing])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = lambda uid: {1: existing, 7: new_owner}[uid]
+        mock_populate.return_value = [existing, new_owner]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_owners",
+                {"request": {"identifier": 42, "add_owner_ids": [7]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        new_label = next(o["label"] for o in payload["owners"] if o["id"] == 101)
+        assert new_label is not None
+        assert new_label.startswith(LLM_CONTEXT_OPEN_DELIMITER)
+        assert new_label.endswith(LLM_CONTEXT_CLOSE_DELIMITER)
+        assert "<script>alert(1)</script>" in new_label

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_owners.py
@@ -22,6 +22,7 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``owners`` relationship).
 """
 
+from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -42,7 +43,7 @@ def mcp_server() -> object:
 
 
 @pytest.fixture(autouse=True)
-def mock_auth():
+def mock_auth() -> Iterator[Mock]:
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
         with patch("superset.security_manager.raise_for_editorship"):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -370,6 +370,30 @@ class TestManageDashboardRoles:
                     {"request": {"identifier": True, "add_role_ids": [5]}},
                 )
 
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_add_role_ids(self, mcp_server: object) -> None:
+        """bool subclasses int; add_role_ids=[true] must not coerce to role ID 1."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 42, "add_role_ids": [True]}},
+                )
+
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_remove_role_ids(self, mcp_server: object) -> None:
+        """bool subclasses int; remove_role_ids=[false] must not coerce to role ID 0."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 42, "remove_role_ids": [False]}},
+                )
+
     @patch(DAO_GET)
     @pytest.mark.asyncio
     async def test_lookup_database_error_is_not_masked_as_not_found(

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -113,6 +113,40 @@ class TestManageDashboardRoles:
         assert payload["viewers_enabled"] is True
         assert payload["warnings"] == []
 
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(SUBJECTS_FROM_ROLES)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_commit_failure_rolls_back_and_returns_error(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_subjects_from_roles: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        """A DB fault during commit must be caught, trigger a rollback, and
+        surface as a structured error response rather than an unhandled
+        exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        new_subject = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[])
+        mock_get.return_value = dash
+        mock_subjects_from_roles.return_value = [new_subject]
+        mock_session.commit.side_effect = SQLAlchemyError("connection lost")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        mock_session.rollback.assert_called_once()
+        payload = json.loads(result.content[0].text)
+        assert "database error" in (payload.get("error") or "").lower()
+
     @patch(IS_FEATURE_ENABLED, return_value=False)
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
@@ -207,6 +241,30 @@ class TestManageDashboardRoles:
 
         payload = json.loads(result.content[0].text)
         assert "not found" in (payload.get("error") or "").lower()
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_view_only_caller_gets_permission_denied(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        """get_by_id_or_slug itself re-checks view access and raises
+        DashboardAccessDeniedError for dashboards the caller cannot see;
+        that must surface as permission_denied, not an unhandled error."""
+        from superset.commands.dashboard.exceptions import (
+            DashboardAccessDeniedError,
+        )
+
+        mock_get.side_effect = DashboardAccessDeniedError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [1]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -22,6 +22,7 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``roles``/``DASHBOARD_RBAC`` relationship), gated by ``ENABLE_VIEWERS``.
 """
 
+from typing import Callable
 from unittest.mock import Mock, patch
 
 import pytest
@@ -31,8 +32,20 @@ from superset.subjects.types import SubjectType
 from superset.utils import json
 
 DAO_GET: str = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-SUBJECTS_FROM_ROLES: str = "superset.subjects.utils.subjects_from_roles"
+GET_OR_CREATE_ROLE_SUBJECT: str = "superset.subjects.utils.get_or_create_role_subject"
 IS_FEATURE_ENABLED: str = "superset.is_feature_enabled"
+
+
+def _get_or_create_side_effect(
+    mapping: dict[int, Mock],
+) -> Callable[[int], Mock | None]:
+    """Typed stand-in for ``get_or_create_role_subject``'s ``side_effect``:
+    resolves a role ID to its mocked Subject, or ``None`` if unknown."""
+
+    def _lookup(role_id: int) -> Mock | None:
+        return mapping.get(role_id)
+
+    return _lookup
 
 
 def _mock_subject(id: int, role_id: int, label: str = "role") -> Mock:
@@ -62,7 +75,7 @@ def _mock_dashboard(
 
 class TestManageDashboardRoles:
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(SUBJECTS_FROM_ROLES)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
@@ -70,14 +83,14 @@ class TestManageDashboardRoles:
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
+        mock_get_or_create: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
         new_subject = _mock_subject(200, 5, "Analyst")
         dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_subjects_from_roles.return_value = [new_subject]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: new_subject})
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -85,7 +98,7 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "add_role_ids": [5]}},
             )
 
-        mock_subjects_from_roles.assert_called_once_with([5])
+        mock_get_or_create.assert_called_once_with(5)
         assert dash.viewers == [new_subject]
         assert mock_session.commit.call_count >= 1
         payload = json.loads(result.content[0].text)
@@ -95,7 +108,7 @@ class TestManageDashboardRoles:
         assert payload["warnings"] == []
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(SUBJECTS_FROM_ROLES)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
@@ -103,7 +116,7 @@ class TestManageDashboardRoles:
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
+        mock_get_or_create: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
@@ -115,7 +128,7 @@ class TestManageDashboardRoles:
         new_subject = _mock_subject(200, 5, "Analyst")
         dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_subjects_from_roles.return_value = [new_subject]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: new_subject})
         mock_session.commit.side_effect = SQLAlchemyError("connection lost")
 
         async with Client(mcp_server) as client:
@@ -128,8 +141,108 @@ class TestManageDashboardRoles:
         payload = json.loads(result.content[0].text)
         assert "database error" in (payload.get("error") or "").lower()
 
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_rollback_failure_still_returns_structured_error(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        """Even when the rollback itself fails on the already-broken
+        session, the caller must still get the structured database-error
+        response, not an unhandled exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        new_subject = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: new_subject})
+        mock_session.commit.side_effect = SQLAlchemyError("connection lost")
+        mock_session.rollback.side_effect = SQLAlchemyError("still broken")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "database error" in (payload.get("error") or "").lower()
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_refresh_failure_after_commit_returns_captured_values(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_get_or_create: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        """A failed post-commit refresh() must not fail the call: the
+        response is built from values captured before the commit."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        new_subject = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[])
+        mock_get.return_value = dash
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: new_subject})
+        mock_session.refresh.side_effect = SQLAlchemyError("stale connection")
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert payload.get("error") is None
+        assert [r["id"] for r in payload["roles"]] == [200]
+        assert payload["added_role_ids"] == [5]
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_viewers_lazy_load_failure_returns_error(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        """A DB fault while lazy-loading dashboard.viewers must surface as
+        the structured load error, not an unhandled exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        class _ViewersRaise:
+            id = 42
+            dashboard_title = "Test Dashboard"
+            slug = "test-slug"
+
+            @property
+            def viewers(self) -> list[Mock]:
+                raise SQLAlchemyError("lazy load failed")
+
+        mock_get.return_value = _ViewersRaise()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "failed to load dashboard roles" in (payload.get("error") or "").lower()
+        assert "lazy load failed" not in (payload.get("error") or "")
+
     @patch(IS_FEATURE_ENABLED, return_value=False)
-    @patch(SUBJECTS_FROM_ROLES)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
@@ -137,14 +250,14 @@ class TestManageDashboardRoles:
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
+        mock_get_or_create: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
         new_subject = _mock_subject(200, 5, "Analyst")
         dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_subjects_from_roles.return_value = [new_subject]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: new_subject})
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -157,7 +270,7 @@ class TestManageDashboardRoles:
         assert any("ENABLE_VIEWERS" in w for w in payload["warnings"])
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(SUBJECTS_FROM_ROLES)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
@@ -165,7 +278,7 @@ class TestManageDashboardRoles:
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
+        mock_get_or_create: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
@@ -173,7 +286,7 @@ class TestManageDashboardRoles:
         remove = _mock_subject(201, 6, "Sales")
         dash = _mock_dashboard(viewers=[keep, remove])
         mock_get.return_value = dash
-        mock_subjects_from_roles.return_value = [keep]
+        mock_get_or_create.side_effect = _get_or_create_side_effect({5: keep})
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -181,7 +294,7 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "remove_role_ids": [6]}},
             )
 
-        mock_subjects_from_roles.assert_called_once_with([5])
+        mock_get_or_create.assert_called_once_with(5)
         payload = json.loads(result.content[0].text)
         assert payload["removed_role_ids"] == [6]
 
@@ -272,20 +385,22 @@ class TestManageDashboardRoles:
         assert payload.get("permission_denied") is True
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(SUBJECTS_FROM_ROLES)
+    @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
     @pytest.mark.asyncio
     async def test_unknown_role_id_in_add_rejected(
         self,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
+        mock_get_or_create: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
         dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        # subjects_from_roles silently skips roles without a matching Subject.
-        mock_subjects_from_roles.return_value = []
+        # get_or_create_role_subject returns None only when no such role
+        # exists (an unsynced-but-existing role is synced on demand).
+        mock_get_or_create.return_value = None
+        mock_get_or_create.side_effect = None
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -326,24 +441,23 @@ class TestManageDashboardRoles:
                 )
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
-    async def test_add_already_assigned_role_not_reported_as_added(
+    async def test_add_already_assigned_role_is_noop_without_disclosure(
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_subjects_from_roles: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
-        """added_role_ids is a delta against the pre-call state, so a role
-        that was already assigned must not be reported as added."""
+        """ "Adding" an already-assigned role is a no-op: no DB write, no
+        added/removed deltas, and — mirroring manage_dashboard_owners — an
+        EMPTY roles list, so the tool cannot be used as a disguised
+        access-role directory lookup."""
         existing = _mock_subject(200, 5, "Analyst")
         dash = _mock_dashboard(viewers=[existing])
         mock_get.return_value = dash
-        mock_subjects_from_roles.return_value = [existing]
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -351,9 +465,12 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "add_role_ids": [5]}},
             )
 
+        mock_session.commit.assert_not_called()
         payload = json.loads(result.content[0].text)
+        assert payload["roles"] == []
         assert payload["added_role_ids"] == []
         assert payload["removed_role_ids"] == []
+        assert any("no effective change" in w.lower() for w in payload["warnings"])
         # URL matches the sibling dashboard tools' /dashboard/... pattern.
         assert payload["dashboard_url"].endswith("/dashboard/test-slug/")
         assert "/superset/dashboard/" not in payload["dashboard_url"]
@@ -406,7 +523,7 @@ class TestManageDashboardRoles:
         mock_get.side_effect = SQLAlchemyError("connection to server lost")
 
         with patch(
-            "superset.mcp_service.dashboard.tool.manage_dashboard_roles.logger"
+            "superset.mcp_service.dashboard.tool.governance_utils.logger"
         ) as mock_logger:
             async with Client(mcp_server) as client:
                 result = await client.call_tool(

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -1,0 +1,274 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the manage_dashboard_roles MCP tool."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
+POPULATE_ROLES = "superset.commands.utils.populate_roles"
+IS_FEATURE_ENABLED = "superset.is_feature_enabled"
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests in this module."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        with patch("superset.security_manager.raise_for_ownership"):
+            mock_user = Mock()
+            mock_user.id = 1
+            mock_user.username = "admin"
+            mock_get_user.return_value = mock_user
+            yield mock_get_user
+
+
+def _mock_role(id: int, name: str = "role") -> Mock:
+    role = Mock()
+    role.id = id
+    role.name = name
+    role.permissions = []
+    return role
+
+
+def _mock_dashboard(
+    id: int = 42,
+    title: str = "Test Dashboard",
+    slug: str | None = "test-slug",
+    roles: list[Mock] | None = None,
+) -> Mock:
+    dashboard = Mock()
+    dashboard.id = id
+    dashboard.dashboard_title = title
+    dashboard.slug = slug
+    dashboard.roles = roles if roles is not None else []
+    return dashboard
+
+
+class TestManageDashboardRoles:
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(POPULATE_ROLES)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_add_role(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        new_role = _mock_role(5, "Analyst")
+        dash = _mock_dashboard(roles=[])
+        mock_get.return_value = dash
+        mock_populate.return_value = [new_role]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        mock_populate.assert_called_once_with([5])
+        assert dash.roles == [new_role]
+        assert mock_session.commit.call_count >= 1
+        payload = json.loads(result.content[0].text)
+        assert [r["id"] for r in payload["roles"]] == [5]
+        assert payload["added_role_ids"] == [5]
+        assert payload["dashboard_rbac_enabled"] is True
+        assert payload["warnings"] == []
+
+    @patch(IS_FEATURE_ENABLED, return_value=False)
+    @patch(POPULATE_ROLES)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_add_role_warns_when_flag_disabled(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        new_role = _mock_role(5, "Analyst")
+        dash = _mock_dashboard(roles=[])
+        mock_get.return_value = dash
+        mock_populate.return_value = [new_role]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert payload["dashboard_rbac_enabled"] is False
+        assert any("DASHBOARD_RBAC" in w for w in payload["warnings"])
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(POPULATE_ROLES)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_remove_role(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_populate: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        keep = _mock_role(5, "Analyst")
+        remove = _mock_role(6, "Sales")
+        dash = _mock_dashboard(roles=[keep, remove])
+        mock_get.return_value = dash
+        mock_populate.return_value = [keep]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "remove_role_ids": [6]}},
+            )
+
+        mock_populate.assert_called_once_with([5])
+        payload = json.loads(result.content[0].text)
+        assert payload["removed_role_ids"] == [6]
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_remove_unknown_role_id_rejected(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        dash = _mock_dashboard(roles=[_mock_role(5, "Analyst")])
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "remove_role_ids": [999]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "999" in (payload.get("error") or "")
+        assert "not currently assigned" in (payload.get("error") or "").lower()
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_dashboard_not_found(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        from superset.commands.dashboard.exceptions import DashboardNotFoundError
+
+        mock_get.side_effect = DashboardNotFoundError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 999999, "add_role_ids": [1]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" in (payload.get("error") or "").lower()
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_permission_denied(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        from superset.exceptions import SupersetSecurityException
+
+        dash = _mock_dashboard(roles=[])
+        mock_get.return_value = dash
+
+        with patch(
+            "superset.security_manager.raise_for_ownership",
+            side_effect=SupersetSecurityException(Mock(message="forbidden")),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 42, "add_role_ids": [5]}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is True
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(POPULATE_ROLES)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_unknown_role_id_in_add_rejected(
+        self, mock_get: Mock, mock_populate: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        from superset.commands.exceptions import RolesNotFoundValidationError
+
+        dash = _mock_dashboard(roles=[])
+        mock_get.return_value = dash
+        mock_populate.side_effect = RolesNotFoundValidationError()
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [99999]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert "do not exist" in (payload.get("error") or "").lower()
+        assert "list_roles" in (payload.get("error") or "")
+
+    @pytest.mark.asyncio
+    async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="cannot appear in both"):
+                await client.call_tool(
+                    "manage_dashboard_roles",
+                    {
+                        "request": {
+                            "identifier": 42,
+                            "add_role_ids": [1],
+                            "remove_role_ids": [1],
+                        }
+                    },
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_operation_rejected(self, mcp_server: object) -> None:
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="At least one of"):
+                await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 42}},
+                )

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -84,7 +84,7 @@ class TestManageDashboardRoles:
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_role(
         self,
         mock_session: Mock,
@@ -117,7 +117,7 @@ class TestManageDashboardRoles:
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_role_warns_when_flag_disabled(
         self,
         mock_session: Mock,
@@ -145,7 +145,7 @@ class TestManageDashboardRoles:
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_remove_role(
         self,
         mock_session: Mock,
@@ -172,7 +172,7 @@ class TestManageDashboardRoles:
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_remove_unknown_role_id_rejected(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
@@ -191,7 +191,7 @@ class TestManageDashboardRoles:
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_dashboard_not_found(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
@@ -210,7 +210,7 @@ class TestManageDashboardRoles:
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
@@ -235,7 +235,7 @@ class TestManageDashboardRoles:
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_unknown_role_id_in_add_rejected(
         self,
         mock_get: Mock,
@@ -258,7 +258,7 @@ class TestManageDashboardRoles:
         assert "do not exist" in (payload.get("error") or "").lower()
         assert "list_roles" in (payload.get("error") or "")
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 
@@ -275,7 +275,7 @@ class TestManageDashboardRoles:
                     },
                 )
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_no_operation_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 
@@ -290,7 +290,7 @@ class TestManageDashboardRoles:
     @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_already_assigned_role_not_reported_as_added(
         self,
         mock_session: Mock,

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Tests for the manage_dashboard_roles MCP tool."""
+"""Tests for the manage_dashboard_roles MCP tool.
+
+"Roles" are ROLE-type Subjects in the dashboard's ``viewers`` list (the
+Subject-based model apache/superset#38831 introduced, replacing the legacy
+``roles``/``DASHBOARD_RBAC`` relationship), gated by ``ENABLE_VIEWERS``.
+"""
 
 from unittest.mock import Mock, patch
 
@@ -23,10 +28,11 @@ import pytest
 from fastmcp import Client
 
 from superset.mcp_service.app import mcp
+from superset.subjects.types import SubjectType
 from superset.utils import json
 
 DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-POPULATE_ROLES = "superset.commands.utils.populate_roles"
+SUBJECTS_FROM_ROLES = "superset.subjects.utils.subjects_from_roles"
 IS_FEATURE_ENABLED = "superset.is_feature_enabled"
 
 
@@ -39,7 +45,7 @@ def mcp_server() -> object:
 def mock_auth():
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_ownership"):
+        with patch("superset.security_manager.raise_for_editorship"):
             mock_user = Mock()
             mock_user.id = 1
             mock_user.username = "admin"
@@ -47,46 +53,49 @@ def mock_auth():
             yield mock_get_user
 
 
-def _mock_role(id: int, name: str = "role") -> Mock:
-    role = Mock()
-    role.id = id
-    role.name = name
-    role.permissions = []
-    return role
+def _mock_subject(id: int, role_id: int, label: str = "role") -> Mock:
+    subject = Mock()
+    subject.id = id
+    subject.type = SubjectType.ROLE
+    subject.user_id = None
+    subject.role_id = role_id
+    subject.label = label
+    subject.active = True
+    return subject
 
 
 def _mock_dashboard(
     id: int = 42,
     title: str = "Test Dashboard",
     slug: str | None = "test-slug",
-    roles: list[Mock] | None = None,
+    viewers: list[Mock] | None = None,
 ) -> Mock:
     dashboard = Mock()
     dashboard.id = id
     dashboard.dashboard_title = title
     dashboard.slug = slug
-    dashboard.roles = roles if roles is not None else []
+    dashboard.viewers = viewers if viewers is not None else []
     return dashboard
 
 
 class TestManageDashboardRoles:
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(POPULATE_ROLES)
+    @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_role(
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_populate: Mock,
+        mock_subjects_from_roles: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
-        new_role = _mock_role(5, "Analyst")
-        dash = _mock_dashboard(roles=[])
+        new_subject = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_populate.return_value = [new_role]
+        mock_subjects_from_roles.return_value = [new_subject]
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -94,32 +103,32 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "add_role_ids": [5]}},
             )
 
-        mock_populate.assert_called_once_with([5])
-        assert dash.roles == [new_role]
+        mock_subjects_from_roles.assert_called_once_with([5])
+        assert dash.viewers == [new_subject]
         assert mock_session.commit.call_count >= 1
         payload = json.loads(result.content[0].text)
-        assert [r["id"] for r in payload["roles"]] == [5]
+        assert [r["id"] for r in payload["roles"]] == [200]
         assert payload["added_role_ids"] == [5]
-        assert payload["dashboard_rbac_enabled"] is True
+        assert payload["viewers_enabled"] is True
         assert payload["warnings"] == []
 
     @patch(IS_FEATURE_ENABLED, return_value=False)
-    @patch(POPULATE_ROLES)
+    @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_role_warns_when_flag_disabled(
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_populate: Mock,
+        mock_subjects_from_roles: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
-        new_role = _mock_role(5, "Analyst")
-        dash = _mock_dashboard(roles=[])
+        new_subject = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_populate.return_value = [new_role]
+        mock_subjects_from_roles.return_value = [new_subject]
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -128,27 +137,27 @@ class TestManageDashboardRoles:
             )
 
         payload = json.loads(result.content[0].text)
-        assert payload["dashboard_rbac_enabled"] is False
-        assert any("DASHBOARD_RBAC" in w for w in payload["warnings"])
+        assert payload["viewers_enabled"] is False
+        assert any("ENABLE_VIEWERS" in w for w in payload["warnings"])
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(POPULATE_ROLES)
+    @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_remove_role(
         self,
         mock_session: Mock,
         mock_get: Mock,
-        mock_populate: Mock,
+        mock_subjects_from_roles: Mock,
         mock_flag: Mock,
         mcp_server: object,
     ) -> None:
-        keep = _mock_role(5, "Analyst")
-        remove = _mock_role(6, "Sales")
-        dash = _mock_dashboard(roles=[keep, remove])
+        keep = _mock_subject(200, 5, "Analyst")
+        remove = _mock_subject(201, 6, "Sales")
+        dash = _mock_dashboard(viewers=[keep, remove])
         mock_get.return_value = dash
-        mock_populate.return_value = [keep]
+        mock_subjects_from_roles.return_value = [keep]
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -156,17 +165,17 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "remove_role_ids": [6]}},
             )
 
-        mock_populate.assert_called_once_with([5])
+        mock_subjects_from_roles.assert_called_once_with([5])
         payload = json.loads(result.content[0].text)
         assert payload["removed_role_ids"] == [6]
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_remove_unknown_role_id_rejected(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
-        dash = _mock_dashboard(roles=[_mock_role(5, "Analyst")])
+        dash = _mock_dashboard(viewers=[_mock_subject(200, 5, "Analyst")])
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
@@ -181,7 +190,7 @@ class TestManageDashboardRoles:
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_dashboard_not_found(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
@@ -200,17 +209,17 @@ class TestManageDashboardRoles:
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_non_owner_gets_permission_denied(
         self, mock_get: Mock, mock_flag: Mock, mcp_server: object
     ) -> None:
         from superset.exceptions import SupersetSecurityException
 
-        dash = _mock_dashboard(roles=[])
+        dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
 
         with patch(
-            "superset.security_manager.raise_for_ownership",
+            "superset.security_manager.raise_for_editorship",
             side_effect=SupersetSecurityException(Mock(message="forbidden")),
         ):
             async with Client(mcp_server) as client:
@@ -223,17 +232,20 @@ class TestManageDashboardRoles:
         assert payload.get("permission_denied") is True
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
-    @patch(POPULATE_ROLES)
+    @patch(SUBJECTS_FROM_ROLES)
     @patch(DAO_GET)
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_unknown_role_id_in_add_rejected(
-        self, mock_get: Mock, mock_populate: Mock, mock_flag: Mock, mcp_server: object
+        self,
+        mock_get: Mock,
+        mock_subjects_from_roles: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
     ) -> None:
-        from superset.commands.exceptions import RolesNotFoundValidationError
-
-        dash = _mock_dashboard(roles=[])
+        dash = _mock_dashboard(viewers=[])
         mock_get.return_value = dash
-        mock_populate.side_effect = RolesNotFoundValidationError()
+        # subjects_from_roles silently skips roles without a matching Subject.
+        mock_subjects_from_roles.return_value = []
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -245,7 +257,7 @@ class TestManageDashboardRoles:
         assert "do not exist" in (payload.get("error") or "").lower()
         assert "list_roles" in (payload.get("error") or "")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_remove_overlap_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 
@@ -262,7 +274,7 @@ class TestManageDashboardRoles:
                     },
                 )
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_no_operation_rejected(self, mcp_server: object) -> None:
         from fastmcp.exceptions import ToolError
 

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -22,6 +22,7 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``roles``/``DASHBOARD_RBAC`` relationship), gated by ``ENABLE_VIEWERS``.
 """
 
+from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -42,7 +43,7 @@ def mcp_server() -> object:
 
 
 @pytest.fixture(autouse=True)
-def mock_auth():
+def mock_auth() -> Iterator[Mock]:
     """Mock authentication for all tests in this module."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
         with patch("superset.security_manager.raise_for_editorship"):
@@ -284,3 +285,36 @@ class TestManageDashboardRoles:
                     "manage_dashboard_roles",
                     {"request": {"identifier": 42}},
                 )
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(SUBJECTS_FROM_ROLES)
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio()
+    async def test_add_already_assigned_role_not_reported_as_added(
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mock_subjects_from_roles: Mock,
+        mock_flag: Mock,
+        mcp_server: object,
+    ) -> None:
+        """added_role_ids is a delta against the pre-call state, so a role
+        that was already assigned must not be reported as added."""
+        existing = _mock_subject(200, 5, "Analyst")
+        dash = _mock_dashboard(viewers=[existing])
+        mock_get.return_value = dash
+        mock_subjects_from_roles.return_value = [existing]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_roles",
+                {"request": {"identifier": 42, "add_role_ids": [5]}},
+            )
+
+        payload = json.loads(result.content[0].text)
+        assert payload["added_role_ids"] == []
+        assert payload["removed_role_ids"] == []
+        # URL matches the sibling dashboard tools' /dashboard/... pattern.
+        assert payload["dashboard_url"].endswith("/dashboard/test-slug/")
+        assert "/superset/dashboard/" not in payload["dashboard_url"]

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -22,36 +22,17 @@ Subject-based model apache/superset#38831 introduced, replacing the legacy
 ``roles``/``DASHBOARD_RBAC`` relationship), gated by ``ENABLE_VIEWERS``.
 """
 
-from collections.abc import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import Client
 
-from superset.mcp_service.app import mcp
 from superset.subjects.types import SubjectType
 from superset.utils import json
 
-DAO_GET = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
-SUBJECTS_FROM_ROLES = "superset.subjects.utils.subjects_from_roles"
-IS_FEATURE_ENABLED = "superset.is_feature_enabled"
-
-
-@pytest.fixture
-def mcp_server() -> object:
-    return mcp
-
-
-@pytest.fixture(autouse=True)
-def mock_auth() -> Iterator[Mock]:
-    """Mock authentication for all tests in this module."""
-    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        with patch("superset.security_manager.raise_for_editorship"):
-            mock_user = Mock()
-            mock_user.id = 1
-            mock_user.username = "admin"
-            mock_get_user.return_value = mock_user
-            yield mock_get_user
+DAO_GET: str = "superset.daos.dashboard.DashboardDAO.get_by_id_or_slug"
+SUBJECTS_FROM_ROLES: str = "superset.subjects.utils.subjects_from_roles"
+IS_FEATURE_ENABLED: str = "superset.is_feature_enabled"
 
 
 def _mock_subject(id: int, role_id: int, label: str = "role") -> Mock:
@@ -376,3 +357,41 @@ class TestManageDashboardRoles:
         # URL matches the sibling dashboard tools' /dashboard/... pattern.
         assert payload["dashboard_url"].endswith("/dashboard/test-slug/")
         assert "/superset/dashboard/" not in payload["dashboard_url"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_boolean_identifier(self, mcp_server: object) -> None:
+        """bool subclasses int; identifier=true must not coerce to dashboard ID 1."""
+        from fastmcp.exceptions import ToolError
+
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": True, "add_role_ids": [5]}},
+                )
+
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_lookup_database_error_is_not_masked_as_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """A real DB/infra failure during lookup must surface as a distinct
+        database error, not be collapsed into "not found"."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        mock_get.side_effect = SQLAlchemyError("connection to server lost")
+
+        with patch(
+            "superset.mcp_service.dashboard.tool.manage_dashboard_roles.logger"
+        ) as mock_logger:
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 999999, "add_role_ids": [5]}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert "not found" not in (payload.get("error") or "").lower()
+        assert "database error" in (payload.get("error") or "").lower()
+        assert "connection to server lost" not in (payload.get("error") or "")
+        mock_logger.exception.assert_called_once()

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_roles.py
@@ -221,9 +221,9 @@ class TestManageDashboardRoles:
         from sqlalchemy.exc import SQLAlchemyError
 
         class _ViewersRaise:
-            id = 42
-            dashboard_title = "Test Dashboard"
-            slug = "test-slug"
+            id: int = 42
+            dashboard_title: str = "Test Dashboard"
+            slug: str = "test-slug"
 
             @property
             def viewers(self) -> list[Mock]:
@@ -385,11 +385,42 @@ class TestManageDashboardRoles:
         assert payload.get("permission_denied") is True
 
     @patch(IS_FEATURE_ENABLED, return_value=True)
+    @patch(DAO_GET)
+    @pytest.mark.asyncio
+    async def test_editorship_check_db_fault_returns_database_error(
+        self, mock_get: Mock, mock_flag: Mock, mcp_server: object
+    ) -> None:
+        """``raise_for_editorship`` re-queries the editor relationship, so a
+        broken session there must surface as the structured database-error
+        response rather than an unhandled exception."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        dash = _mock_dashboard(viewers=[])
+        mock_get.return_value = dash
+
+        with patch(
+            "superset.security_manager.raise_for_editorship",
+            side_effect=SQLAlchemyError("connection lost"),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "manage_dashboard_roles",
+                    {"request": {"identifier": 42, "add_role_ids": [5]}},
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert "database error" in (payload.get("error") or "").lower()
+        # The raw exception text must never reach the LLM-facing response.
+        assert "connection lost" not in (payload.get("error") or "")
+
+    @patch(IS_FEATURE_ENABLED, return_value=True)
     @patch(GET_OR_CREATE_ROLE_SUBJECT)
     @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
     async def test_unknown_role_id_in_add_rejected(
         self,
+        mock_session: Mock,
         mock_get: Mock,
         mock_get_or_create: Mock,
         mock_flag: Mock,
@@ -408,6 +439,10 @@ class TestManageDashboardRoles:
                 {"request": {"identifier": 42, "add_role_ids": [99999]}},
             )
 
+        # A rejected request must never leave uncommitted Subject rows
+        # (flushed by get_or_create_role_subject for earlier, valid role
+        # IDs in the same call) sitting in the session.
+        mock_session.rollback.assert_called_once()
         payload = json.loads(result.content[0].text)
         assert "do not exist" in (payload.get("error") or "").lower()
         assert "list_roles" in (payload.get("error") or "")

--- a/tests/unit_tests/subjects/test_utils.py
+++ b/tests/unit_tests/subjects/test_utils.py
@@ -30,6 +30,7 @@ from superset.subjects.models import Subject
 from superset.subjects.types import SubjectType
 from superset.subjects.utils import (
     get_current_user_subject_ids,
+    get_or_create_role_subject,
     get_user_subject_ids_subquery,
 )
 
@@ -85,6 +86,59 @@ def test_get_current_user_subject_ids_guest_user(app_context):
 
     mock_subjects_from_roles.assert_called_once_with([1, 2])
     mock_get_user_id.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# get_or_create_role_subject
+# --------------------------------------------------------------------------
+
+
+@patch("superset.subjects.utils.get_role_subject")
+def test_get_or_create_role_subject_returns_existing(mock_get_role_subject):
+    """An already-synced role resolves to its Subject with no sync."""
+    existing = _make_subject(10, SubjectType.ROLE)
+    mock_get_role_subject.return_value = existing
+
+    assert get_or_create_role_subject(5) is existing
+    mock_get_role_subject.assert_called_once_with(5)
+
+
+def test_get_or_create_role_subject_syncs_unsynced_role():
+    """A role that exists but has no Subject row yet is synced on demand
+    rather than treated as nonexistent."""
+    created = _make_subject(11, SubjectType.ROLE)
+    role = MagicMock()
+    role.id = 5
+
+    with (
+        patch(
+            "superset.subjects.utils.get_role_subject",
+            side_effect=[None, created],
+        ) as mock_get_role_subject,
+        patch("superset.subjects.utils.db") as mock_db,
+        patch("superset.subjects.sync.sync_role_subject") as mock_sync,
+    ):
+        mock_db.session.get.return_value = role
+
+        assert get_or_create_role_subject(5) is created
+
+    mock_sync.assert_called_once_with(role)
+    mock_db.session.flush.assert_called_once()
+    assert mock_get_role_subject.call_count == 2
+
+
+def test_get_or_create_role_subject_missing_role_returns_none():
+    """A role ID with no matching role at all resolves to None."""
+    with (
+        patch("superset.subjects.utils.get_role_subject", return_value=None),
+        patch("superset.subjects.utils.db") as mock_db,
+        patch("superset.subjects.sync.sync_role_subject") as mock_sync,
+    ):
+        mock_db.session.get.return_value = None
+
+        assert get_or_create_role_subject(999) is None
+
+    mock_sync.assert_not_called()
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit_tests/subjects/test_utils.py
+++ b/tests/unit_tests/subjects/test_utils.py
@@ -94,7 +94,9 @@ def test_get_current_user_subject_ids_guest_user(app_context):
 
 
 @patch("superset.subjects.utils.get_role_subject")
-def test_get_or_create_role_subject_returns_existing(mock_get_role_subject):
+def test_get_or_create_role_subject_returns_existing(
+    mock_get_role_subject: MagicMock,
+) -> None:
     """An already-synced role resolves to its Subject with no sync."""
     existing = _make_subject(10, SubjectType.ROLE)
     mock_get_role_subject.return_value = existing
@@ -103,7 +105,7 @@ def test_get_or_create_role_subject_returns_existing(mock_get_role_subject):
     mock_get_role_subject.assert_called_once_with(5)
 
 
-def test_get_or_create_role_subject_syncs_unsynced_role():
+def test_get_or_create_role_subject_syncs_unsynced_role() -> None:
     """A role that exists but has no Subject row yet is synced on demand
     rather than treated as nonexistent."""
     created = _make_subject(11, SubjectType.ROLE)
@@ -127,7 +129,7 @@ def test_get_or_create_role_subject_syncs_unsynced_role():
     assert mock_get_role_subject.call_count == 2
 
 
-def test_get_or_create_role_subject_missing_role_returns_none():
+def test_get_or_create_role_subject_missing_role_returns_none() -> None:
     """A role ID with no matching role at all resolves to None."""
     with (
         patch("superset.subjects.utils.get_role_subject", return_value=None),


### PR DESCRIPTION
## Summary

Follow-up to #40957 (`update_dashboard` MCP tool). During that review, `owners`, `roles`, `certified_by`, and `certification_details` were scoped out of `update_dashboard` because they're distinct governance concerns from layout/theme/metadata, and a full-replacement list has no safety guard (`owners=[]` could silently orphan a dashboard; `roles=[]`/partial lists could silently widen or narrow access). See discussion: https://github.com/apache/superset/pull/40957#discussion_r3414810238

This PR adds three dedicated tools instead, each with explicit add/remove (or set/clear) semantics:

- **`manage_dashboard_owners`** — `add_owner_ids`/`remove_owner_ids`. Rejects removals that are not currently owners, and rejects any change that would leave the dashboard with zero owners. Surfaces a warning when a non-admin caller's self-removal is auto-reverted by `populate_subject_list`'s existing `ensure_no_lockout` self-protection.
- **`manage_dashboard_roles`** — `add_role_ids`/`remove_role_ids` for the dashboard's ROLE-type viewers (the Subject-based access model from #38831, gated by `ENABLE_VIEWERS`). Reports `viewers_enabled` and warns when the flag is off (roles are stored but inert).
- **`manage_dashboard_certification`** — independent `certified_by`/`certification_details` fields; `None` leaves a field unchanged, `""` clears it, mirroring the `slug`/`css` clear-with-empty-string convention already used by `update_dashboard`.

`theme_id`/`color_scheme` remain out of scope, per the original discussion — there's no `list_themes`/`get_theme_info` discovery tool yet, so a caller could only guess an ID.

All three tools are RBAC-gated the same way as `update_dashboard` (`class_permission_name="Dashboard"`, `method_permission_name="write"`, `security_manager.raise_for_editorship`). Since their responses disclose current owners/roles, `app.py`'s server instructions were updated with a narrow carve-out (mirroring the existing `find_users` carve-out): that data may only be used to confirm the operation the caller explicitly requested on that specific dashboard, not to answer general "who owns/can access X" questions. Both tools short-circuit effective no-ops (empty `owners`/`roles` in the response, no DB write), so neither can be used as a disguised directory lookup.

Shared lookup/authorization plumbing for the three tools lives in `dashboard/tool/governance_utils.py`; `update_dashboard` keeps its own variant (different not-found response contract) — unifying that is left to a follow-up.

## Test plan

- [x] `pytest tests/unit_tests/mcp_service/dashboard/` — 340 passed (incl. new no-op-disclosure, refresh-failure, rollback-failure, and lazy-load-failure coverage; no regressions)
- [x] `pytest tests/unit_tests/mcp_service/ tests/unit_tests/subjects/` — 2,885 passed
- [x] `pre-commit run` on changed files (mypy, ruff, ruff-format, pylint, auto-walrus) — all passed
- [x] New tools registered in `dashboard/tool/__init__.py` and imported in `app.py`
- [x] Manual review of `DEFAULT_INSTRUCTIONS` tool listing and write-tool/privacy bullets for accuracy
