### PR TITLE
feat(mcp): add replaces parameter to @tool decorator for override

### DIFF
--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -58,6 +58,7 @@ def tool(
     class_permission_name: str | None = None,
     method_permission_name: str | None = None,
     annotations: ToolAnnotations | None = None,
+    replaces: str | None = None,
 ) -> Any:  # Use Any to avoid mypy issues with dependency injection
     """
     Decorator to register an MCP tool with optional authentication.
@@ -87,6 +88,11 @@ def tool(
             Defaults to "write" if tags includes "mutate", else "read".
         annotations: MCP tool annotations (title, readOnlyHint, destructiveHint, etc.)
             These hints help MCP clients understand tool behavior and safety.
+        replaces: Name of an existing tool to replace. When set, the decorated
+            function is registered under this exact name (bypassing extension
+            namespace prefixing) and the original tool is removed from the
+            registry. Use this to swap out a host tool with a custom
+            implementation while keeping the same tool name visible to the LLM.
 
     Returns:
         Decorator function that registers and wraps the tool, or the wrapped function
@@ -120,6 +126,11 @@ def tool(
         def create_chart(name: str) -> dict:
             '''Create a new chart'''
             return {"name": name}
+
+        @tool(replaces="get_instance_info")  # Replace an existing host tool
+        def my_custom_instance_info() -> dict:
+            '''Lightweight replacement for the built-in instance info tool'''
+            return {"current_user": ...}
     """
     raise NotImplementedError(
         "MCP tool decorator not initialized. "

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -38,6 +38,32 @@ F = TypeVar("F", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 
+def _resolve_tool_name(base_name: str, replaces: Optional[str]) -> tuple[str, str]:
+    """Return (tool_name, context_type) for registration.
+
+    When *replaces* is set the tool is replacing a host tool, so the name is
+    used as-is and context_type is always "host".
+    """
+    if replaces is not None:
+        return replaces, "host"
+    return _get_prefixed_id_with_context(base_name)
+
+
+def _remove_tool_for_replacement(mcp: Any, name: str) -> None:
+    """Remove *name* from the MCP registry before registering a replacement.
+
+    Logs a warning (rather than raising) when the tool is not found, which
+    can happen if registration order changes or in partial-init environments.
+    """
+    try:
+        mcp.remove_tool(name)
+    except KeyError:
+        logger.warning(
+            "Tool %r not found for replacement — it may not have been registered yet",
+            name,
+        )
+
+
 def _get_prefixed_id_with_context(base_id: str) -> tuple[str, str]:
     """
     Get ID with extension prefixing based on ambient context.
@@ -68,6 +94,7 @@ def create_tool_decorator(
     class_permission_name: Optional[str] = None,
     method_permission_name: Optional[str] = None,
     annotations: ToolAnnotations | None = None,
+    replaces: Optional[str] = None,
 ) -> Callable[[F], F] | F:
     """
     Create the concrete MCP tool decorator implementation.
@@ -89,6 +116,8 @@ def create_tool_decorator(
         method_permission_name: FAB action name (e.g., "read", "write").
             Defaults to "write" if tags has "mutate", else "read".
         annotations: MCP tool annotations (title, readOnlyHint, destructiveHint, etc.)
+        replaces: Name of an existing host tool to replace. The decorated function
+            is registered under this exact name and the original tool is removed first.
 
     Returns:
         Decorator that registers and wraps the tool with optional authentication,
@@ -105,8 +134,9 @@ def create_tool_decorator(
             tool_description = description or func.__doc__ or f"Tool: {base_tool_name}"
             tool_tags = tags or []
 
-            # Get prefixed ID based on ambient context
-            tool_name, context_type = _get_prefixed_id_with_context(base_tool_name)
+            tool_name, context_type = _resolve_tool_name(base_tool_name, replaces)
+            if replaces is not None:
+                _remove_tool_for_replacement(mcp, replaces)
 
             # Store RBAC permission metadata on the function so
             # mcp_auth_hook can read them at call time.
@@ -132,19 +162,20 @@ def create_tool_decorator(
 
             from fastmcp.tools import Tool
 
-            tool = Tool.from_function(
+            new_tool = Tool.from_function(
                 wrapped_func,
                 name=tool_name,
                 description=tool_description,
                 tags=tool_tags,
                 annotations=annotations,
             )
-            mcp.add_tool(tool)
+            mcp.add_tool(new_tool)
 
             protected_status = "protected" if protect else "public"
             logger.info(
-                "Registered MCP tool: %s (%s, %s)",
+                "Registered MCP tool: %s (replaces=%s, %s, %s)",
                 tool_name,
+                replaces,
                 protected_status,
                 context_type,
             )

--- a/tests/unit_tests/mcp_service/test_tool_replaces.py
+++ b/tests/unit_tests/mcp_service/test_tool_replaces.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the ``replaces`` parameter on the MCP ``@tool`` decorator.
+
+``replaces`` lets an extension swap out a host tool while keeping the same
+name visible to the LLM: the original tool is removed from the registry and
+the decorated function is registered under the replaced name, bypassing the
+usual extension-namespace prefixing.
+"""
+
+import logging
+from typing import Any, Callable
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.core.mcp.core_mcp_injection import (
+    _remove_tool_for_replacement,
+    _resolve_tool_name,
+    create_tool_decorator,
+)
+from superset.mcp_service.app import mcp as real_mcp
+
+_CONTEXT_PATCH_TARGET = (
+    "superset.core.mcp.core_mcp_injection.get_current_extension_context"
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_tool_name
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_tool_name_without_replaces_uses_prefixed_id() -> None:
+    """With no ``replaces``, the existing prefixing behavior is unchanged."""
+    with patch(_CONTEXT_PATCH_TARGET, return_value=None):
+        tool_name, context_type = _resolve_tool_name("my_tool", None)
+
+    assert tool_name == "my_tool"
+    assert context_type == "host"
+
+
+def test_resolve_tool_name_with_replaces_bypasses_extension_prefix() -> None:
+    """``replaces`` is used verbatim even inside an active extension context,
+    so the decorated function overrides the host tool name rather than being
+    registered under an extension-namespaced name."""
+    mock_context = MagicMock()
+    mock_context.manifest.publisher = "acme"
+    mock_context.manifest.name = "analytics"
+
+    with patch(_CONTEXT_PATCH_TARGET, return_value=mock_context):
+        tool_name, context_type = _resolve_tool_name("my_tool", "get_instance_info")
+
+    assert tool_name == "get_instance_info"
+    assert context_type == "host"
+
+
+# ---------------------------------------------------------------------------
+# _remove_tool_for_replacement
+# ---------------------------------------------------------------------------
+
+
+def test_remove_tool_for_replacement_removes_existing_tool() -> None:
+    """The named tool is removed from the registry via ``mcp.remove_tool``."""
+    mock_mcp = MagicMock()
+
+    _remove_tool_for_replacement(mock_mcp, "get_instance_info")
+
+    mock_mcp.remove_tool.assert_called_once_with("get_instance_info")
+
+
+# ---------------------------------------------------------------------------
+# create_tool_decorator(replaces=...)
+# ---------------------------------------------------------------------------
+
+
+def _custom_instance_info() -> dict[str, Any]:
+    """Custom replacement tool."""
+    return {}
+
+
+def _brand_new_tool() -> dict[str, Any]:
+    """A normal, non-replacing tool."""
+    return {}
+
+
+def test_create_tool_decorator_with_replaces_removes_old_tool_first() -> None:
+    """Decorating with ``replaces`` removes the original tool before the
+    replacement is registered."""
+    decorator: Callable[..., Any] = create_tool_decorator(replaces="get_instance_info")
+
+    with (
+        patch.object(real_mcp, "remove_tool") as mock_remove,
+        patch.object(real_mcp, "add_tool") as mock_add,
+    ):
+        decorator(_custom_instance_info)
+
+    mock_remove.assert_called_once_with("get_instance_info")
+    mock_add.assert_called_once()
+
+
+def test_create_tool_decorator_with_replaces_registers_under_replaced_name() -> None:
+    """The new tool is registered under the ``replaces`` name, not the
+    decorated function's own name."""
+    decorator: Callable[..., Any] = create_tool_decorator(replaces="get_instance_info")
+
+    with (
+        patch.object(real_mcp, "remove_tool"),
+        patch.object(real_mcp, "add_tool") as mock_add,
+    ):
+        decorator(_custom_instance_info)
+
+    registered_tool = mock_add.call_args.args[0]
+    assert registered_tool.name == "get_instance_info"
+
+
+def test_create_tool_decorator_without_replaces_does_not_remove_anything() -> None:
+    """Without ``replaces``, no removal call is made — only additive
+    registration, matching pre-existing behavior."""
+    decorator: Callable[..., Any] = create_tool_decorator()
+
+    with (
+        patch.object(real_mcp, "remove_tool") as mock_remove,
+        patch.object(real_mcp, "add_tool"),
+    ):
+        decorator(_brand_new_tool)
+
+    mock_remove.assert_not_called()
+
+
+def test_create_tool_decorator_replaces_survives_missing_original_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If the tool being replaced was never registered, ``create_tool_decorator``
+    still registers the replacement instead of failing the whole decoration."""
+    decorator: Callable[..., Any] = create_tool_decorator(replaces="missing")
+
+    with (
+        patch.object(
+            real_mcp, "remove_tool", side_effect=KeyError("missing")
+        ) as mock_remove,
+        patch.object(real_mcp, "add_tool") as mock_add,
+        caplog.at_level(logging.WARNING, logger="superset.core.mcp.core_mcp_injection"),
+    ):
+        decorator(_custom_instance_info)
+
+    mock_remove.assert_called_once_with("missing")
+    mock_add.assert_called_once()
+    assert "missing" in caplog.text


### PR DESCRIPTION
### SUMMARY

Added a replaces parameter to the @tool decorator in superset-core that allows extensions to cleanly replace existing host tools under their original name, without extension namespace prefixing

#### Problem

The original get_instance_info tool was taking ~280 seconds per call. The bottleneck was security filter subqueries (DashboardAccessFilter, ChartFilter, etc.) applied to every COUNT(*). Extensions had no clean way to swap out a host tool — the only option was monkey-patching module globals, which broke silently when re-exports obscured the target module.

#### Changes

- superset-core/src/superset_core/mcp/decorators.py: added replaces: str | None = None to the tool() stub signature and docstring
- superset/core/mcp/core_mcp_injection.py:
  - Added _resolve_tool_name(base_name, replaces) — returns (replaces, "host") directly when replacing, bypassing _get_prefixed_id_with_context entirely since host tool replacement is always a host-context operation
  - Added _remove_tool_for_replacement(mcp, name) — removes the original tool from the FastMCP registry before registering the replacement, with a warning (not raise) if the tool isn't found
  - Added replaces parameter to create_tool_decorator()

### TESTING INSTRUCTIONS

added specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
