### PR TITLE
fix(a11y): add aria-label to cross-filter search icon

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.test.tsx
@@ -70,3 +70,12 @@ test('Search icon should highlight emitter', async () => {
     expect(mockedProps.onHighlightFilterSource).toHaveBeenCalled();
   });
 });
+
+test('Search icon should have an accessible name', async () => {
+  setup(mockedProps);
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: 'Locate the chart' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
@@ -80,6 +80,7 @@ const CrossFilterChartTitle = (props: {
           data-test="cross-filters-highlight-emitter"
           role="button"
           tabIndex={0}
+          aria-label={t('Locate the chart')}
           onClick={onHighlightFilterSource}
         />
       </Tooltip>


### PR DESCRIPTION
## Summary
- The cross-filter chart title's search icon (`CrossFilterTitle.tsx`) is a `role="button"` icon-only control (clicking it highlights/locates the source chart), but had no accessible name — screen readers would only announce the raw SVG icon content.
- **WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A.**
- Added `aria-label={t('Locate the chart')}`, reusing the same translated string already shown in the element's visual `Tooltip`, so the visible and accessible names stay in sync.
- Added a unit test asserting the icon is reachable via `getByRole('button', { name: 'Locate the chart' })`.
- Behavior is unchanged — purely additive `aria-label` + `tabIndex`/`role`/`onClick` untouched.

## Test plan
- [x] `npx jest src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.test.tsx` — 4/4 passing, including the new accessible-name assertion.
- [ ] Manual: open a dashboard with a cross-filter applied, tab to the search icon next to the filtered chart's title, and confirm a screen reader announces "Locate the chart, button" (not just "search, button" or nothing).

## Notes
Also spotted a pre-existing, separate gap while reviewing: the icon has `onClick` but no `onKeyDown`, so Enter/Space won't activate it for keyboard users (the sibling `VerticalCollapse.tsx` in the same directory already handles this correctly and can serve as a reference). Leaving that out of scope for this PR since it's unrelated to the missing-label fix; happy to follow up separately.