### PR TITLE
fix(sqllab): filter results table when typing in the search box

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -1132,4 +1132,49 @@ describe('ResultSet', () => {
     });
     expect(mockOpenInNewTab).not.toHaveBeenCalled();
   });
+
+  test('filters the results table when typing in the search box', async () => {
+    const filterableQuery = {
+      ...queries[0],
+      id: 'filterableQueryId',
+      cached: false,
+      results: {
+        columns: [{ is_dttm: false, column_name: 'fruit', type: 'STRING' }],
+        selected_columns: [
+          { is_dttm: false, column_name: 'fruit', type: 'STRING' },
+        ],
+        data: [{ fruit: 'apple' }, { fruit: 'banana' }],
+      },
+    };
+    const { getByTestId, getByPlaceholderText, queryByText } = setup(
+      { ...mockedProps, cache: false, queryId: filterableQuery.id },
+      mockStore({
+        ...initialState,
+        user,
+        sqlLab: {
+          ...initialState.sqlLab,
+          queries: {
+            [filterableQuery.id]: filterableQuery,
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('table-container')).toBeInTheDocument();
+    });
+    // Both rows are visible before filtering
+    expect(queryByText('apple')).toBeInTheDocument();
+    expect(queryByText('banana')).toBeInTheDocument();
+
+    // Typing in the search box filters the rows (case-insensitive substring)
+    fireEvent.change(getByPlaceholderText('Filter results'), {
+      target: { value: 'APP' },
+    });
+
+    await waitFor(() => {
+      expect(queryByText('banana')).not.toBeInTheDocument();
+    });
+    expect(queryByText('apple')).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, useCallback, useRef, memo } from 'react';
+import { useMemo, useCallback, memo } from 'react';
 import { GridSize } from 'src/components/GridTable/constants';
 import { GridTable } from 'src/components/GridTable';
 import { type ColDef } from 'src/components/GridTable/types';
@@ -109,15 +109,15 @@ export const FilterableTable = ({
     [orderedColumnKeys, allowHTML, getCellContent],
   );
 
-  const keyword = useRef<string | undefined>(filterText);
-  keyword.current = filterText;
-
-  const keywordFilter = useCallback((node: { data: Datum }) => {
-    if (keyword.current && node.data) {
-      return hasMatch(keyword.current, node.data);
-    }
-    return true;
-  }, []);
+  const keywordFilter = useCallback(
+    (node: { data: Datum }) => {
+      if (filterText && node.data) {
+        return hasMatch(filterText, node.data);
+      }
+      return true;
+    },
+    [filterText],
+  );
 
   return (
     <div className="filterable-table-container" data-test="table-container">


### PR DESCRIPTION
### SUMMARY

The **Filter results** search box in the SQL Lab results panel stopped filtering the table — typing did nothing.

Root cause is in `FilterableTable`: it built the ag-Grid external-filter callback with empty `useCallback` deps reading `filterText` from a ref, so the callback *reference* never changed as the user typed. `GridTable` derives `isExternalFilterPresent` from that reference, so ag-Grid never re-applied the filter.

Fix: depend on `filterText` directly so a new value yields a new callback reference and ag-Grid re-runs the (case-insensitive substring) filter. This restores the fix from #38813 that the React 18 upgrade (#38563) reverted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_To add._ Before: typing in "Filter results" leaves all rows shown. After: rows filter live to the typed text.

### TESTING INSTRUCTIONS

1. SQL Lab → run any query with multiple rows.
2. Type into the **Filter results** box above the results table.
3. The table filters live to rows matching the text (case-insensitive).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [x] Changes UI — SQL Lab results table filtering
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No