### PR TITLE
docs(readme): add security documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A modern, enterprise-ready business intelligence web application.
 - **[User Guide](https://superset.apache.org/user-docs/)** — For analysts and business users. Explore data, build charts, create dashboards, and connect databases.
 - **[Administrator Guide](https://superset.apache.org/admin-docs/)** — Install, configure, and operate Superset. Covers security, scaling, and database drivers.
 - **[Developer Guide](https://superset.apache.org/developer-docs/)** — Contribute to Superset or build on its REST API and extension framework.
+- **[Security](https://superset.apache.org/security/)** — Learn about Superset's security model and best practices.
 
 [**Why Superset?**](#why-superset) |
 [**Supported Databases**](#supported-databases) |


### PR DESCRIPTION
### SUMMARY
Add a link to the security documentation in the README's documentation section to improve discoverability of security resources for users and contributors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - documentation change only

### TESTING INSTRUCTIONS
1. View the README.md file
2. Navigate to the Documentation section
3. Verify the new Security link is present and points to https://superset.apache.org/security/

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Generated with [Devin](https://devin.ai)