### PR TITLE
test(sqllab): repair broken TablePreview and SavedQueryList jest tests

### DIFF
--- a/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
@@ -151,7 +151,7 @@ describe('table actions', () => {
         fetchMock.callHistory.calls(getTableMetadataEndpoint),
       ).toHaveLength(1),
     );
-    const refreshButton = getByRole('button', { name: 'sync' });
+    const refreshButton = getByRole('button', { name: 'Refresh table schema' });
     fireEvent.click(refreshButton);
     await waitFor(() =>
       expect(
@@ -170,7 +170,9 @@ describe('table actions', () => {
         fetchMock.callHistory.calls(getTableMetadataEndpoint),
       ).toHaveLength(1),
     );
-    const viewButton = getByRole('button', { name: 'eye' });
+    const viewButton = getByRole('button', {
+      name: 'Show CREATE VIEW statement',
+    });
     fireEvent.click(viewButton);
     await waitFor(() =>
       expect(

--- a/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
@@ -270,9 +270,9 @@ describe('SavedQueryList', () => {
 
       await screen.findByTestId('saved_query-list-view');
 
-      const queryButton = await screen.findByRole('button', {
-        name: /query/i,
-      });
+      // Scope to the create button's stable data-test: /query/i also matches the
+      // per-row "Query preview" and "Copy query URL" action buttons.
+      const queryButton = await screen.findByTestId('add-saved-query-button');
       fireEvent.click(queryButton);
 
       await waitFor(() => {

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -232,6 +232,7 @@ function SavedQueryList({
     icon: <Icons.PlusOutlined iconSize="m" />,
     name: t('Query'),
     buttonStyle: 'primary',
+    'data-test': 'add-saved-query-button',
     onClick: () => {
       // React Router's basename already includes the application root; passing
       // a relative path ensures correct navigation under subdirectory deployments.


### PR DESCRIPTION
### SUMMARY

Two `sharded-jest-tests` suites have been failing on `master` (reproduces on every open PR, e.g. #41624/#41625/#41585 — not caused by any of them). Both broke because SQL Lab action buttons gained proper accessible names, invalidating the tests' role/name queries.

- **TablePreview** (`table actions`): the refresh/view buttons are now named by their labels — `Refresh table schema` / `Show CREATE VIEW statement` — instead of falling through to the raw icon names (`sync` / `eye`, which now belong to the decorative `role="img"` icons). Queries updated to the new names.
- **SavedQueryList** (`"+ Query"` navigation test): `/query/i` now also matches the per-row `Query preview` and `Copy query URL` action buttons, so `findByRole('button', { name: /query/i })` throws "found multiple elements". Gave the create button a stable `data-test="add-saved-query-button"` and select by that.

No production behavior changes — one added `data-test` attribute plus test-query updates.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only fix (plus a `data-test` hook).

### TESTING INSTRUCTIONS

`cd superset-frontend && npm run test -- src/SqlLab/components/TablePreview/TablePreview.test.tsx src/pages/SavedQueryList/SavedQueryList.test.tsx` — both suites pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [ ] Changes UI: No — adds a `data-test` attribute only
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No