### PR TITLE
fix(deps): override fast-uri to 3.1.3 to fix CVE-2026-13676

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -20315,9 +20315,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -413,6 +413,7 @@
     "@luma.gl/shadertools": "~9.2.5",
     "@luma.gl/webgl": "~9.2.5",
     "fast-xml-parser": "^5.8.0",
+    "fast-uri": "^3.1.3",
     "jest-mock": "^30.4.0",
     "jest-runtime": "^30.4.0",
     "@jest/globals": "^30.4.0",


### PR DESCRIPTION
### SUMMARY

`fast-uri` versions prior to `3.1.3` fail to canonicalize Unicode (IDN) hostnames for HTTP-family URLs, which can lead to host confusion (CVE-2026-13676). It is currently pulled in transitively (via `@fastify/ajv-compiler` → `ajv`) and resolves to `3.1.2` in the lockfile.

This adds an `overrides` entry forcing `fast-uri` to `^3.1.3`, staying on the `3.x` line (note `4.0.0` is also listed as affected by the advisory). Only the `fast-uri` resolution changes in `package-lock.json`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — dependency-only change.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npm ci` resolves cleanly.
- `npm ls fast-uri` shows `3.1.3`.
- Frontend build and unit tests pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
