### PR TITLE
fix(embedded): register AG Grid modules for view-as-table modal

### DIFF
--- a/superset-frontend/src/embedded/index.test.tsx
+++ b/superset-frontend/src/embedded/index.test.tsx
@@ -1,0 +1,29 @@
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
+
+jest.mock('@superset-ui/core/components/ThemedAgGridReact', () => ({
+  setupAGGridModules: jest.fn(),
+}));
+jest.mock('src/preamble', () => jest.fn().mockResolvedValue(true));
+jest.mock('src/setup/setupPlugins', () => jest.fn(), { virtual: true });
+jest.mock('src/setup/setupCodeOverrides', () => jest.fn(), { virtual: true });
+jest.mock('src/utils/getBootstrapData', () => ({
+  __esModule: true,
+  default: () => ({ embedded: { dashboard_id: '123' } }),
+  applicationRoot: () => '/',
+}));
+
+describe('embedded/index.tsx', () => {
+  beforeAll(() => {
+    document.body.innerHTML = '<div id="app"></div>';
+  });
+
+  it('initializes AG Grid modules on bootstrap', async () => {
+    require('./index');
+
+    // index.tsx uses initPreamble().then(...) to initialize plugins and AG grid
+    // Wait for the promise chain to resolve
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(setupAGGridModules).toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/src/embedded/index.test.tsx
+++ b/superset-frontend/src/embedded/index.test.tsx
@@ -1,15 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
+
+jest.mock('src/public-path', () => ({}));
+
+jest.mock('query-string', () => ({}));
 
 jest.mock('@superset-ui/core/components/ThemedAgGridReact', () => ({
   setupAGGridModules: jest.fn(),
 }));
+
 jest.mock('src/preamble', () => jest.fn().mockResolvedValue(true));
+
 jest.mock('src/setup/setupPlugins', () => jest.fn(), { virtual: true });
+
 jest.mock('src/setup/setupCodeOverrides', () => jest.fn(), { virtual: true });
+
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
-  default: () => ({ embedded: { dashboard_id: '123' } }),
+  default: () => ({
+    embedded: { dashboard_id: '123' },
+    common: {
+      application_root: '/',
+      static_assets_prefix: '/',
+      conf: {
+        SQLLAB_DEFAULT_DBID: 1,
+        DEFAULT_SQLLAB_LIMIT: 1000,
+      },
+    },
+  }),
   applicationRoot: () => '/',
+  staticAssetsPrefix: () => '/',
 }));
 
 describe('embedded/index.tsx', () => {
@@ -17,7 +54,7 @@ describe('embedded/index.tsx', () => {
     document.body.innerHTML = '<div id="app"></div>';
   });
 
-  it('initializes AG Grid modules on bootstrap', async () => {
+  test('initializes AG Grid modules on bootstrap', async () => {
     require('./index');
 
     // index.tsx uses initPreamble().then(...) to initialize plugins and AG grid

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -33,6 +33,7 @@ import {
 import Switchboard from '@superset-ui/switchboard';
 import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import initPreamble from 'src/preamble';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import setupClient from 'src/setup/setupClient';
 import { useUiConfig } from 'src/components/UiConfigContext';
 import { store, USER_LOADED } from 'src/views/store';
@@ -69,6 +70,7 @@ const pluginsReady = initPreamble()
       ]);
     setupPlugins();
     setupCodeOverrides({ embedded: true });
+    setupAGGridModules();
   });
 
 const debugMode = process.env.WEBPACK_MODE === 'development';


### PR DESCRIPTION
SUMMARY

Fixes an issue where the “View as table” action fails in Embedded Dashboard mode with the following error:

AG Grid: error #272 No AG Grid modules are registered!

The embedded dashboard application uses a separate bootstrap entrypoint from the main Superset application. While the main application initializes AG Grid modules during startup, the embedded bootstrap flow did not initialize them before AG Grid components were mounted.

This change ensures AG Grid modules are initialized during embedded application startup, aligning the embedded initialization flow with the main application and allowing the “View as table” modal to render correctly inside embedded dashboards.

Fixes #41630.

⸻

BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before

* Clicking View as table inside an embedded dashboard opens an empty modal.
* The browser console displays:
    * AG Grid: error #272 No AG Grid modules are registered!

After

* Clicking View as table correctly renders the table inside the modal.
* No AG Grid registration errors appear in the browser console.

⸻

TESTING INSTRUCTIONS

1. Enable embedded dashboards by setting:
    EMBEDDED_SUPERSET = True
2. Embed a dashboard using the Embedded SDK.
3. Open the chart actions menu (...) on any chart.
4. Click View as table.
5. Verify the table renders successfully.
6. Verify no AG Grid registration errors appear in the browser console.
7. Verify the main Superset dashboard experience remains unchanged.

Additionally:

* Added regression coverage to verify AG Grid modules are initialized during embedded application bootstrap.