### PR TITLE
feat(auth): Skip OAUTH provider selection

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING, Uni
 from flask import current_app, Flask, g, Request
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
+from flask_appbuilder.security.manager import AUTH_OAUTH
 from flask_appbuilder.security.sqla.apis import GroupApi, RoleApi, UserApi
 from flask_appbuilder.security.sqla.apis.permission_view_menu.api import (
     PermissionViewMenuApi,
@@ -4330,10 +4331,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     # temporal change to remove the roles view from the security menu,
     # after migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
     def register_views(self) -> None:
-        from superset.views.auth import SupersetAuthView, SupersetRegisterUserView
+        from superset.views.auth import (
+            SupersetAuthView,
+            SupersetOAuthView,
+            SupersetRegisterUserView,
+        )
 
         if self.register_superset_auth_view:
-            self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
+            auth_type = current_app.config["AUTH_TYPE"]
+            if auth_type == AUTH_OAUTH:
+                self.auth_view = self.appbuilder.add_view_no_menu(SupersetOAuthView)
+            else:
+                self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
         if self.register_superset_registeruser_view:
             self.registeruser_view = self.appbuilder.add_view_no_menu(
                 SupersetRegisterUserView

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -40,7 +40,7 @@ from flask import current_app, Flask, g, has_app_context, Request, Response
 from flask_appbuilder import Model
 from flask_appbuilder.api import expose, permission_name, protect, safe
 from flask_appbuilder.models.filters import BaseFilter
-from flask_appbuilder.security.manager import AUTH_REMOTE_USER
+from flask_appbuilder.security.manager import AUTH_OAUTH, AUTH_REMOTE_USER
 from flask_appbuilder.security.sqla.apis import GroupApi, RoleApi, UserApi
 from flask_appbuilder.security.sqla.apis.permission_view_menu.api import (
     PermissionViewMenuApi,
@@ -5890,7 +5890,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     # temporal change to remove the roles view from the security menu,
     # after migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
     def register_views(self) -> None:
-        from superset.views.auth import SupersetAuthView, SupersetRegisterUserView
+        from superset.views.auth import (
+            SupersetAuthView,
+            SupersetOAuthView,
+            SupersetRegisterUserView,
+        )
 
         # AUTH_REMOTE_USER has no interactive login form to render: the whole
         # point is that an upstream proxy already authenticated the request and
@@ -5905,7 +5909,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # ever being checked. Skip registering it for this auth type so
         # FlaskAppBuilder's AuthRemoteUserView actually claims the route.
         if self.register_superset_auth_view and self.auth_type != AUTH_REMOTE_USER:
-            self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
+            auth_type = current_app.config["AUTH_TYPE"]
+            if auth_type == AUTH_OAUTH:
+                self.auth_view = self.appbuilder.add_view_no_menu(SupersetOAuthView)
+            else:
+                self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
         if self.register_superset_registeruser_view:
             self.registeruser_view = self.appbuilder.add_view_no_menu(
                 SupersetRegisterUserView

--- a/superset/views/auth.py
+++ b/superset/views/auth.py
@@ -22,7 +22,7 @@ from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.const import LOGMSG_ERR_SEC_NO_REGISTER_HASH
 from flask_appbuilder.security.decorators import no_cache
-from flask_appbuilder.security.views import AuthView, WerkzeugResponse
+from flask_appbuilder.security.views import AuthOAuthView, AuthView, WerkzeugResponse
 from flask_babel import lazy_gettext
 
 from superset.views.base import BaseSupersetView
@@ -40,6 +40,20 @@ class SupersetAuthView(BaseSupersetView, AuthView):
             return redirect(self.appbuilder.get_url_for_index)
 
         return super().render_app_template()
+
+
+class SupersetOAuthView(BaseSupersetView, AuthOAuthView):
+    route_base = "/login"
+
+    @expose("/")
+    @expose("/<provider>")
+    @no_cache
+    def login(self, provider: Optional[str] = None) -> WerkzeugResponse:
+        if provider is None:
+            providers = list(self.appbuilder.sm.oauth_remotes.keys())
+            if len(providers) == 1:
+                provider = providers[0]
+        return super().login(provider)
 
 
 class SupersetRegisterUserView(BaseSupersetView):

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -20,8 +20,11 @@
 import json  # noqa: TID251
 from types import SimpleNamespace
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import pytest
+from flask import Flask
+from flask_appbuilder.security.manager import AuthOAuthView
 from flask_appbuilder.security.sqla.models import Role, User
 from pytest_mock import MockerFixture
 
@@ -39,6 +42,7 @@ from superset.security.manager import (
 from superset.sql.parse import Table
 from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils.core import DatasourceName, override_user
+from superset.views.auth import SupersetOAuthView
 
 
 def test_security_manager(app_context: None) -> None:
@@ -49,20 +53,96 @@ def test_security_manager(app_context: None) -> None:
     assert sm
 
 
-@pytest.fixture
-def stored_metrics() -> list[AdhocMetric]:
+def test_superset_oauth_view_oauth_oauth_single_provider(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
     """
-    Return a list of metrics.
+    Test that SupersetOAuthView auto-selects the provider and delegates
+    to the parent login method when only a single OAuth provider is configured.
     """
-    return [
+    from superset.views.auth import SupersetOAuthView
+
+    mock_provider = MagicMock()
+    mock_remotes = {"google": mock_provider}
+
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+
+    mock_super_login = mocker.patch(
+        "superset.views.auth.AuthOAuthView.login", return_value="mocked_response"
+    )
+
+    oauth_view = SupersetOAuthView()
+
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with("google")
+
+
+def test_superset_oauth_view_oauth_multiple_providers(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
+    """
+    Test that SupersetOAuthView does NOT auto-select when multiple OAuth
+    providers are configured, and instead calls parent login without provider.
+    """
+    from superset.views.auth import SupersetOAuthView
+
+    mock_provider1 = MagicMock()
+    mock_provider2 = MagicMock()
+    mock_remotes = {"google": mock_provider1, "github": mock_provider2}
+
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+
+    mock_super_login = mocker.patch(
+        "superset.views.auth.AuthOAuthView.login", return_value="mocked_response"
+    )
+
+    oauth_view = SupersetOAuthView()
+
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with(None)
+
+
+def test_security_manager_with_oauth_auth_type(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
+    """
+    Test that SupersetSecurityManager login works correctly when
+    AUTH_TYPE is set to AUTH_OAUTH with a single provider.
+    """
+    from flask_appbuilder.security.manager import AUTH_OAUTH
+
+    app.config["AUTH_TYPE"] = AUTH_OAUTH
+    app.config["OAUTH_PROVIDERS"] = [
         {
-            "column": None,
-            "expressionType": "SQL",
-            "hasCustomLabel": False,
-            "label": "COUNT(*) + 1",
-            "sqlExpression": "COUNT(*) + 1",
-        },
+            "name": "google",
+            "icon": "fa-google",
+            "token_key": "access_token",
+            "remote_app": {
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "api_base_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                "client_kwargs": {"scope": "email profile"},
+            },
+        }
     ]
+
+    mock_provider = mocker.Mock()
+    mock_remotes = {"google": mock_provider}
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+    mock_super_login = mocker.patch.object(AuthOAuthView, "login")
+
+    oauth_view = SupersetOAuthView()
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with("google")
 
 
 @pytest.fixture

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -60,8 +60,6 @@ def test_superset_oauth_view_oauth_oauth_single_provider(
     Test that SupersetOAuthView auto-selects the provider and delegates
     to the parent login method when only a single OAuth provider is configured.
     """
-    from superset.views.auth import SupersetOAuthView
-
     mock_provider = MagicMock()
     mock_remotes = {"google": mock_provider}
 
@@ -87,8 +85,6 @@ def test_superset_oauth_view_oauth_multiple_providers(
     Test that SupersetOAuthView does NOT auto-select when multiple OAuth
     providers are configured, and instead calls parent login without provider.
     """
-    from superset.views.auth import SupersetOAuthView
-
     mock_provider1 = MagicMock()
     mock_provider2 = MagicMock()
     mock_remotes = {"google": mock_provider1, "github": mock_provider2}
@@ -143,6 +139,22 @@ def test_security_manager_with_oauth_auth_type(
     oauth_view.login()
 
     mock_super_login.assert_called_once_with("google")
+
+
+@pytest.fixture
+def stored_metrics() -> list[AdhocMetric]:
+    """
+    Return a list of metrics.
+    """
+    return [
+        {
+            "column": None,
+            "expressionType": "SQL",
+            "hasCustomLabel": False,
+            "label": "COUNT(*) + 1",
+            "sqlExpression": "COUNT(*) + 1",
+        },
+    ]
 
 
 @pytest.fixture

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -144,8 +144,6 @@ def test_superset_oauth_view_oauth_oauth_single_provider(
     Test that SupersetOAuthView auto-selects the provider and delegates
     to the parent login method when only a single OAuth provider is configured.
     """
-    from superset.views.auth import SupersetOAuthView
-
     mock_provider = MagicMock()
     mock_remotes = {"google": mock_provider}
 
@@ -171,8 +169,6 @@ def test_superset_oauth_view_oauth_multiple_providers(
     Test that SupersetOAuthView does NOT auto-select when multiple OAuth
     providers are configured, and instead calls parent login without provider.
     """
-    from superset.views.auth import SupersetOAuthView
-
     mock_provider1 = MagicMock()
     mock_provider2 = MagicMock()
     mock_remotes = {"google": mock_provider1, "github": mock_provider2}
@@ -227,6 +223,22 @@ def test_security_manager_with_oauth_auth_type(
     oauth_view.login()
 
     mock_super_login.assert_called_once_with("google")
+
+
+@pytest.fixture
+def stored_metrics() -> list[AdhocMetric]:
+    """
+    Return a list of metrics.
+    """
+    return [
+        {
+            "column": None,
+            "expressionType": "SQL",
+            "hasCustomLabel": False,
+            "label": "COUNT(*) + 1",
+            "sqlExpression": "COUNT(*) + 1",
+        },
+    ]
 
 
 @pytest.fixture

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -24,8 +24,9 @@ from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
-from flask import current_app
+from flask import current_app, Flask
 from flask_appbuilder.const import AUTH_DB, AUTH_REMOTE_USER
+from flask_appbuilder.security.manager import AuthOAuthView
 from flask_appbuilder.security.sqla.models import Role, User
 from pytest_mock import MockerFixture
 
@@ -43,6 +44,7 @@ from superset.security.manager import (
 from superset.sql.parse import Table
 from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils.core import DatasourceName, override_user
+from superset.views.auth import SupersetOAuthView
 
 
 def test_security_manager(app_context: None) -> None:
@@ -135,20 +137,96 @@ def test_register_views_still_registers_superset_auth_view_for_db_auth(
     assert SupersetAuthView in registered
 
 
-@pytest.fixture
-def stored_metrics() -> list[AdhocMetric]:
+def test_superset_oauth_view_oauth_oauth_single_provider(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
     """
-    Return a list of metrics.
+    Test that SupersetOAuthView auto-selects the provider and delegates
+    to the parent login method when only a single OAuth provider is configured.
     """
-    return [
+    from superset.views.auth import SupersetOAuthView
+
+    mock_provider = MagicMock()
+    mock_remotes = {"google": mock_provider}
+
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+
+    mock_super_login = mocker.patch(
+        "superset.views.auth.AuthOAuthView.login", return_value="mocked_response"
+    )
+
+    oauth_view = SupersetOAuthView()
+
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with("google")
+
+
+def test_superset_oauth_view_oauth_multiple_providers(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
+    """
+    Test that SupersetOAuthView does NOT auto-select when multiple OAuth
+    providers are configured, and instead calls parent login without provider.
+    """
+    from superset.views.auth import SupersetOAuthView
+
+    mock_provider1 = MagicMock()
+    mock_provider2 = MagicMock()
+    mock_remotes = {"google": mock_provider1, "github": mock_provider2}
+
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+
+    mock_super_login = mocker.patch(
+        "superset.views.auth.AuthOAuthView.login", return_value="mocked_response"
+    )
+
+    oauth_view = SupersetOAuthView()
+
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with(None)
+
+
+def test_security_manager_with_oauth_auth_type(
+    mocker: MockerFixture, app: Flask, app_context: None
+) -> None:
+    """
+    Test that SupersetSecurityManager login works correctly when
+    AUTH_TYPE is set to AUTH_OAUTH with a single provider.
+    """
+    from flask_appbuilder.security.manager import AUTH_OAUTH
+
+    app.config["AUTH_TYPE"] = AUTH_OAUTH
+    app.config["OAUTH_PROVIDERS"] = [
         {
-            "column": None,
-            "expressionType": "SQL",
-            "hasCustomLabel": False,
-            "label": "COUNT(*) + 1",
-            "sqlExpression": "COUNT(*) + 1",
-        },
+            "name": "google",
+            "icon": "fa-google",
+            "token_key": "access_token",
+            "remote_app": {
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "api_base_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                "client_kwargs": {"scope": "email profile"},
+            },
+        }
     ]
+
+    mock_provider = mocker.Mock()
+    mock_remotes = {"google": mock_provider}
+    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
+    mock_super_login = mocker.patch.object(AuthOAuthView, "login")
+
+    oauth_view = SupersetOAuthView()
+    oauth_view.appbuilder = app.appbuilder
+
+    oauth_view.login()
+
+    mock_super_login.assert_called_once_with("google")
 
 
 @pytest.fixture

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -26,7 +26,6 @@ from unittest.mock import MagicMock
 import pytest
 from flask import current_app, Flask
 from flask_appbuilder.const import AUTH_DB, AUTH_REMOTE_USER
-from flask_appbuilder.security.manager import AuthOAuthView
 from flask_appbuilder.security.sqla.models import Role, User
 from pytest_mock import MockerFixture
 
@@ -137,7 +136,7 @@ def test_register_views_still_registers_superset_auth_view_for_db_auth(
     assert SupersetAuthView in registered
 
 
-def test_superset_oauth_view_oauth_oauth_single_provider(
+def test_superset_oauth_view_oauth_single_provider(
     mocker: MockerFixture, app: Flask, app_context: None
 ) -> None:
     """
@@ -186,43 +185,6 @@ def test_superset_oauth_view_oauth_multiple_providers(
     oauth_view.login()
 
     mock_super_login.assert_called_once_with(None)
-
-
-def test_security_manager_with_oauth_auth_type(
-    mocker: MockerFixture, app: Flask, app_context: None
-) -> None:
-    """
-    Test that SupersetSecurityManager login works correctly when
-    AUTH_TYPE is set to AUTH_OAUTH with a single provider.
-    """
-    from flask_appbuilder.security.manager import AUTH_OAUTH
-
-    app.config["AUTH_TYPE"] = AUTH_OAUTH
-    app.config["OAUTH_PROVIDERS"] = [
-        {
-            "name": "google",
-            "icon": "fa-google",
-            "token_key": "access_token",
-            "remote_app": {
-                "client_id": "test_client_id",
-                "client_secret": "test_client_secret",
-                "api_base_url": "https://accounts.google.com/o/oauth2/v2/auth",
-                "client_kwargs": {"scope": "email profile"},
-            },
-        }
-    ]
-
-    mock_provider = mocker.Mock()
-    mock_remotes = {"google": mock_provider}
-    mocker.patch.object(app.appbuilder.sm, "oauth_remotes", mock_remotes)
-    mock_super_login = mocker.patch.object(AuthOAuthView, "login")
-
-    oauth_view = SupersetOAuthView()
-    oauth_view.appbuilder = app.appbuilder
-
-    oauth_view.login()
-
-    mock_super_login.assert_called_once_with("google")
 
 
 @pytest.fixture


### PR DESCRIPTION


### SUMMARY
This PR introduces  functionality to skip provider selection screen if there is only one OAUTH provider and forwards request directly to the only OAUTH provider.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Provider selection should not be visible when only one provider used.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
