### PR TITLE
fix(db): use a private engine for prequery connections to avoid listener race

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -497,17 +497,26 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             engine_context_manager = app.config["ENGINE_CONTEXT_MANAGER"]
             with engine_context_manager(self, catalog, schema):
                 with check_for_oauth2(self):
+                    prequeries = self.db_engine_spec.get_prequeries(
+                        database=self,
+                        catalog=catalog,
+                        schema=schema,
+                    )
+                    # Prequeries attach a per-call ``connect`` listener below
+                    # (and remove it on exit). SQLAlchemy's listener collection
+                    # is an unlocked deque, so mutating it on an engine shared
+                    # via ``_ENGINE_CACHE`` races with concurrent connection
+                    # checkouts iterating the same deque ("RuntimeError: deque
+                    # mutated during iteration", surfacing as 500s). Request a
+                    # private, uncached engine whenever prequeries are present
+                    # so the listener add/remove never touches a shared object.
                     engine = self._get_sqla_engine(
                         catalog=catalog,
                         schema=schema,
                         nullpool=nullpool,
                         source=source,
                         sqlalchemy_uri=sqlalchemy_uri,
-                    )
-                    prequeries = self.db_engine_spec.get_prequeries(
-                        database=self,
-                        catalog=catalog,
-                        schema=schema,
+                        cacheable=not prequeries,
                     )
                     if prequeries:
                         # SQLAlchemy connect event: runs prequeries on every new
@@ -538,6 +547,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
         nullpool: bool = True,
         source: utils.QuerySource | None = None,
         sqlalchemy_uri: str | None = None,
+        cacheable: bool = True,
     ) -> Engine:
         sqlalchemy_url = make_url_safe(
             sqlalchemy_uri if sqlalchemy_uri else self.sqlalchemy_uri_decrypted
@@ -610,9 +620,13 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
         # cache on ``not nullpool`` would leave it dormant everywhere it
         # actually matters. Unsaved instances (``self.id is None``) are
         # excluded so two distinct in-memory ``Database`` objects with the
-        # same URI can't collide on a shared cache entry.
+        # same URI can't collide on a shared cache entry. Callers that need to
+        # mutate the engine's event listeners (``get_sqla_engine`` with
+        # prequeries) pass ``cacheable=False`` for a private engine: listener
+        # registration on a shared engine races with concurrent connection
+        # checkouts iterating the same unlocked listener deque.
         cache_key: tuple[int, str, str] | None = None
-        if self.id is not None:
+        if cacheable and self.id is not None:
             cache_key = (
                 self.id,
                 str(sqlalchemy_url),

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -537,6 +537,14 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
                             yield engine
                         finally:
                             sqla.event.remove(engine, "connect", run_prequeries)
+                            # The engine is private (cacheable=False above), so
+                            # nothing else can hold a reference: dispose it to
+                            # release its pool immediately. With the default
+                            # nullpool=True this is a no-op safety net; it
+                            # matters if a caller ever passes nullpool=False,
+                            # where each private engine would otherwise keep a
+                            # short-lived QueuePool alive until GC.
+                            engine.dispose()
                     else:
                         yield engine
 

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1824,3 +1824,170 @@ def test_post_process_df_non_zero_based_index() -> None:
     assert result["col"].dtype == numpy.object_
     assert result["col"].iloc[0] == "[1, 2]"
     assert result["col"].iloc[1] == "[3, 4]"
+
+
+class _DispatchParkHarness:
+    """Coordination for parking one thread mid connect-event dispatch.
+
+    ``maybe_park`` parks the first caller after ``arm()`` — used from a DBAPI
+    connection wrapper's ``cursor()`` so the park lands inside the prequery
+    listener while SQLAlchemy iterates the engine's connect-listener deque.
+    """
+
+    def __init__(self) -> None:
+        import threading
+
+        self.parked = threading.Event()
+        self.resume = threading.Event()
+        self._lock = threading.Lock()
+        self._armed = False
+        self._consumed = False
+
+    def arm(self) -> None:
+        self._armed = True
+
+    def maybe_park(self) -> None:
+        with self._lock:
+            should_park = self._armed and not self._consumed
+            if should_park:
+                self._consumed = True
+        if should_park:
+            self.parked.set()
+            assert self.resume.wait(timeout=10), "parked thread never released"
+
+
+class _ParkingSqliteConnection:
+    """sqlite3 connection wrapper whose ``cursor()`` may park via a harness."""
+
+    def __init__(self, real: Any, harness: _DispatchParkHarness) -> None:
+        self._real = real
+        self._harness = harness
+
+    def cursor(self) -> Any:
+        self._harness.maybe_park()
+        return self._real.cursor()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+def test_prequery_listener_mutation_race_deterministic(
+    app: Any,
+    app_context: None,
+    mocker: MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """
+    Deterministic regression for the ``deque mutated during iteration`` race
+    (no timing dependence, unlike the stress test above).
+
+    The overlap that crashes pre-fix code is: thread A parked *inside* the
+    connect-event dispatch of an engine (mid-iteration over the listener
+    deque) while thread B mutates that same deque via ``event.listen``. This
+    test constructs exactly that interleaving:
+
+    - ``create_engine`` is patched to inject a ``creator`` whose DBAPI
+      connections park on the FIRST ``cursor()`` call process-wide. The
+      prequery listener's first act is ``dbapi_connection.cursor()``, so
+      thread A parks provably mid-dispatch.
+    - Thread B waits for A to park, then enters the prequery path itself,
+      which calls ``event.listen`` — on the SAME cached engine pre-fix
+      (mutating the deque A's iterator is walking), on its own private
+      engine post-fix.
+    - A is released; its dispatch loop advances the deque iterator.
+
+    Pre-fix this raises ``RuntimeError: deque mutated during iteration`` in
+    thread A on every run. With the private-engine fix, B's mutation touches
+    a different engine's deque and both threads complete.
+    """
+    import sqlite3
+    import threading
+
+    from sqlalchemy import create_engine as real_create_engine
+
+    from superset.db_engine_specs.sqlite import SqliteEngineSpec
+    from superset.models.core import _ENGINE_CACHE
+
+    _ENGINE_CACHE.clear()
+    mocker.patch(
+        "superset.models.core.security_manager.find_user",
+        return_value=None,
+    )
+    mocker.patch("superset.models.core.get_username", return_value=None)
+    mocker.patch.object(
+        SqliteEngineSpec,
+        "get_prequeries",
+        return_value=["SELECT 1"],
+    )
+
+    # Armed only after the warm-up connection below: the FIRST cursor() call
+    # on a fresh engine is SQLAlchemy's dialect isolation-level probe, which
+    # runs inside the ``first_connect`` once-mutex — parking there deadlocks
+    # the sibling thread on that mutex instead of exercising the deque race.
+    harness = _DispatchParkHarness()
+
+    db_path = tmp_path / "deterministic_race.db"
+
+    def parking_creator() -> _ParkingSqliteConnection:
+        return _ParkingSqliteConnection(sqlite3.connect(str(db_path)), harness)
+
+    def patched_create_engine(url: Any, **kwargs: Any) -> Any:
+        kwargs["creator"] = parking_creator
+        return real_create_engine(url, **kwargs)
+
+    mocker.patch(
+        "superset.models.core.create_engine",
+        side_effect=patched_create_engine,
+    )
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri=f"sqlite:///{db_path}",
+    )
+    database.id = 1
+
+    # Warm-up: consume the dialect's one-time first_connect probe on the
+    # cached engine (pre-fix code shares it with the threads below), so the
+    # park later lands inside the prequery listener's connect dispatch —
+    # where no SQLAlchemy mutex is held — not inside the probe.
+    with database.get_sqla_engine() as warm_engine:
+        with warm_engine.connect():
+            pass
+    harness.arm()
+
+    errors: list[Exception] = []
+
+    def thread_a() -> None:
+        try:
+            with app.app_context():
+                with database.get_raw_connection() as conn:
+                    conn.cursor().execute("SELECT 1")
+        except Exception as ex:  # pylint: disable=broad-except
+            errors.append(ex)
+        finally:
+            # Never leave B waiting if A failed before parking.
+            harness.parked.set()
+
+    def thread_b() -> None:
+        try:
+            assert harness.parked.wait(timeout=10), "A never parked"
+            with app.app_context():
+                # Entering the prequery path calls event.listen — on the
+                # shared cached engine pre-fix, on a private engine post-fix.
+                with database.get_raw_connection() as conn:
+                    conn.cursor().execute("SELECT 1")
+        except Exception as ex:  # pylint: disable=broad-except
+            errors.append(ex)
+        finally:
+            harness.resume.set()
+
+    t_a = threading.Thread(target=thread_a)
+    t_b = threading.Thread(target=thread_b)
+    t_a.start()
+    t_b.start()
+    t_a.join(timeout=30)
+    t_b.join(timeout=30)
+    assert not t_a.is_alive(), "thread A deadlocked"
+    assert not t_b.is_alive(), "thread B deadlocked"
+
+    assert not errors, f"deterministic interleaving raised: {errors!r}"

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -852,6 +852,151 @@ def test_get_raw_connection_executes_prequeries_exactly_once(
     mock_cursor.close.assert_called_once()
 
 
+def test_prequery_engine_bypasses_shared_cache(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression for the ``deque mutated during iteration`` race.
+
+    ``get_sqla_engine`` attaches (and later removes) a per-call ``connect``
+    listener when prequeries exist. SQLAlchemy stores listeners in an
+    unlocked deque, so mutating a *shared* engine's listeners races with
+    concurrent connection checkouts iterating the same deque. The engine
+    used for prequery calls must therefore be private: never served from,
+    nor stored in, ``_ENGINE_CACHE``.
+    """
+    from superset.db_engine_specs.sqlite import SqliteEngineSpec
+    from superset.models.core import _ENGINE_CACHE
+
+    _ENGINE_CACHE.clear()
+    mocker.patch(
+        "superset.models.core.security_manager.find_user",
+        return_value=None,
+    )
+
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+    database.id = 1  # saved instance: normally eligible for the cache
+
+    # Control: without prequeries the engine is shared via the cache.
+    with database.get_sqla_engine() as engine_a:
+        with database.get_sqla_engine() as engine_b:
+            assert engine_a is engine_b
+    assert len(_ENGINE_CACHE) == 1
+    cached_engine = next(iter(_ENGINE_CACHE.values()))
+
+    # With prequeries: a private engine per call, and the cache untouched.
+    mocker.patch.object(
+        SqliteEngineSpec,
+        "get_prequeries",
+        return_value=["SELECT 1"],
+    )
+    with database.get_sqla_engine() as engine_c:
+        with database.get_sqla_engine() as engine_d:
+            assert engine_c is not cached_engine
+            assert engine_d is not cached_engine
+            assert engine_c is not engine_d
+    assert list(_ENGINE_CACHE.values()) == [cached_engine]
+
+
+def test_prequeries_execute_on_real_connections(
+    app_context: None,
+    mocker: MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """
+    Behavioural guard: prequeries still run on every new DBAPI connection
+    even though the prequery path uses a private, uncached engine. Uses a
+    file-backed SQLite database and a table-creating prequery so the effect
+    is observable from a later query on the same connection.
+    """
+    from superset.db_engine_specs.sqlite import SqliteEngineSpec
+    from superset.models.core import _ENGINE_CACHE
+
+    _ENGINE_CACHE.clear()
+    mocker.patch(
+        "superset.models.core.security_manager.find_user",
+        return_value=None,
+    )
+    mocker.patch("superset.models.core.get_username", return_value=None)
+    mocker.patch.object(
+        SqliteEngineSpec,
+        "get_prequeries",
+        return_value=["CREATE TABLE IF NOT EXISTS prequery_marker (x INTEGER)"],
+    )
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri=f"sqlite:///{tmp_path / 'prequery.db'}",
+    )
+    database.id = 1
+
+    with database.get_raw_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE name = 'prequery_marker'")
+        assert cursor.fetchone() is not None, (
+            "prequery did not run on the new connection"
+        )
+    assert _ENGINE_CACHE == {}
+
+
+def test_concurrent_prequery_connections_do_not_race(
+    app: Any,
+    app_context: None,
+    mocker: MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """
+    Stress regression for the listener race: with a shared cached engine,
+    concurrent ``get_raw_connection`` calls with prequeries mutated the
+    engine's connect-listener deque (listen on enter, remove on exit) while
+    other threads' connection checkouts iterated it, intermittently raising
+    ``RuntimeError: deque mutated during iteration``. With a private engine
+    per prequery call there is no shared mutation left to race.
+    """
+    import threading
+
+    from superset.db_engine_specs.sqlite import SqliteEngineSpec
+    from superset.models.core import _ENGINE_CACHE
+
+    _ENGINE_CACHE.clear()
+    mocker.patch(
+        "superset.models.core.security_manager.find_user",
+        return_value=None,
+    )
+    mocker.patch("superset.models.core.get_username", return_value=None)
+    mocker.patch.object(
+        SqliteEngineSpec,
+        "get_prequeries",
+        return_value=["SELECT 1"],
+    )
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri=f"sqlite:///{tmp_path / 'race.db'}",
+    )
+    database.id = 1
+
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            with app.app_context():
+                for _ in range(50):
+                    with database.get_raw_connection() as conn:
+                        conn.cursor().execute("SELECT 1")
+        except Exception as ex:  # pylint: disable=broad-except
+            errors.append(ex)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"concurrent prequery connections raised: {errors!r}"
+
+
 def test_is_oauth2_enabled() -> None:
     """
     Test the `is_oauth2_enabled` method.
@@ -1123,6 +1268,7 @@ def test_engine_context_manager(mocker: MockerFixture, app_context: None) -> Non
         nullpool=True,
         source=None,
         sqlalchemy_uri="trino://",
+        cacheable=True,
     )
 
 


### PR DESCRIPTION
### SUMMARY

Fixes an intermittent `RuntimeError: deque mutated during iteration` (surfacing as HTTP 500s and E2E flakiness) caused by an interaction between two changes:

- #40194 made `Database.get_sqla_engine` attach a per-call SQLAlchemy `connect` listener when prequeries exist (e.g. `SET search_path` on PostgreSQL), removing it again on context exit — two mutations of the engine's connect-listener deque per call.
- #40237 introduced `_ENGINE_CACHE`, making `Engine` objects **shared across threads** per `(database_id, url, engine_kwargs)`.

SQLAlchemy stores event listeners in a plain, unlocked `collections.deque`, and dispatch iterates it unguarded (`for fn in self.listeners`). With NullPool, every `raw_connection()` creates a fresh DBAPI connection and fires that dispatch. So one thread's connection checkout can iterate the shared engine's deque while another thread's `get_sqla_engine` enter/exit mutates it — a classic race that reproduces readily under concurrent load (observed as consistent `create-dataset` 500s on one Playwright run and flaked-but-recovered failures on another).

**Fix:** compute prequeries *before* fetching the engine, and request a **private, uncached engine** (`cacheable=False`) whenever prequeries are present. The per-call listener add/remove then only ever touches an engine no other thread can see. No-prequery paths keep the shared cache and its #27897 semantics. The listener also closes over per-call, schema-specific prequeries and must not leak to other requests sharing a cached engine — which is why a register-once approach was rejected.

This restores the pre-#40237 behaviour for prequery engines only (fresh engine per call); prequery-less databases keep full engine caching. Private engines are explicitly `dispose()`d on context exit — a no-op under the default `nullpool=True`, and a pool-leak guard if a caller ever passes `nullpool=False`.

**Independent validation:** the diagnosis and fix were adversarially reviewed by a second model (verdict: *merge as-is*), which independently reproduced the exact `RuntimeError` with standalone SQLAlchemy-only code; both of its hardening suggestions (the `dispose()` above and a deterministic regression test below) are applied. Details: https://github.com/apache/superset/pull/41642#issuecomment-4870913595

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (backend concurrency fix)

### TESTING INSTRUCTIONS

Unit tests in `tests/unit_tests/models/core_test.py`:

- `test_prequery_engine_bypasses_shared_cache` — deterministic regression: with prequeries the yielded engine is never the cached instance and `_ENGINE_CACHE` is untouched; without prequeries caching behaviour is unchanged.
- `test_prequeries_execute_on_real_connections` — behavioural guard for #40194: prequeries still execute on every new DBAPI connection (file-backed SQLite, table-creating prequery, observed on the same connection).
- `test_prequery_listener_mutation_race_deterministic` — **deterministic regression** (no timing dependence): a patched engine `creator` parks one thread provably mid-connect-dispatch (inside the prequery listener's first `cursor()` call) while a second thread enters the prequery path and mutates the listener collection, then releases the first. A warm-up connection first consumes the dialect's one-time `first_connect` isolation probe, which would otherwise hold the engine's once-mutex and deadlock the sibling thread instead of exercising the race. **On pre-fix code this fails every run (6/6 observed) with the exact `deque mutated during iteration` error in under a second**; with the fix it passes standalone and in-suite.
- `test_concurrent_prequery_connections_do_not_race` — stress companion: 4 threads × 50 `get_raw_connection` calls with prequeries. Against the previous code this reproduced the production error readily (probabilistic by nature — the deterministic test above is the authoritative pin); with this fix it passes.

```bash
pytest tests/unit_tests/models/core_test.py -q
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
