### PR TITLE
fix(ci): allow showtime to check out fork PR code under checkout v7

### DIFF
--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -2,7 +2,8 @@ name: 🎪 Superset Showtime
 
 # Ultra-simple: just sync on any PR state change
 on:
-  # zizmor: ignore[dangerous-triggers] - required to react to PR label changes; this workflow does not check out or execute PR-provided code
+  # zizmor: ignore[dangerous-triggers] - required to react to PR label changes; PR code is
+  # only checked out and built after the maintainer-authorization gate (write/admin actors)
   pull_request_target:
     types: [labeled, unlabeled, synchronize, closed]
 
@@ -156,6 +157,10 @@ jobs:
         with:
           ref: ${{ steps.check.outputs.target_sha }}
           persist-credentials: false
+          # Building fork PR code is Showtime's purpose: deploys are gated on the
+          # maintainer-authorization step above (write/admin actors only), so this
+          # checkout is an explicit, authorized opt-in rather than an automatic one.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Docker Environment (only if build needed)
         if: steps.auth.outputs.authorized == 'true' && steps.check.outputs.build_needed == 'true'


### PR DESCRIPTION
### SUMMARY

Showtime ephemeral-environment launches fail on every fork PR since #41358 bumped `actions/checkout` from 6.0.3 to 7.0.0. checkout v7 introduced a safety guard that refuses to fetch fork-PR code inside a `pull_request_target` workflow unless the step explicitly opts in, so the "🎪 Sync PR to desired state" job now dies at the checkout step with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow.

Checking out and building fork PR code is Showtime's entire purpose, and the checkout step is already gated behind the maintainer-authorization step (only actors with `write`/`admin` permission pass) and uses `persist-credentials: false`. This PR sets `allow-unsafe-pr-checkout: true` on that step — the opt-in the guard itself prescribes — and fixes the stale zizmor comment at the top of the workflow, which claimed the workflow never checks out PR-provided code.

The other `pull_request_target` workflows (`labeler.yml`, `welcome-new-users.yml`) have no checkout step, and the `workflow_run` docs workflows either restrict to same-repo heads or run on push, so this is the only workflow affected by the v7 guard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI workflow change)

### TESTING INSTRUCTIONS

1. After merge, add the `showtime-trigger-start` label to a fork PR (e.g. re-trigger on #41637, where the failure was observed: [run 28544444889](https://github.com/apache/superset/actions/runs/28544444889/job/84637161338)).
2. The "🎪 Sync PR to desired state" job should proceed past the "Checkout PR code" step and build/deploy the environment.

Pre-commit (`check yaml`, `zizmor` GHA security audit) passes on the changed file.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: regression introduced by #41358
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)