### PR TITLE
feat(i18n): backfill new safe-link strings in de/lv/fi (AI-generated, needs review)

### DIFF
--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -14944,8 +14944,10 @@ msgstr ""
 "Dashboard. Es wird dynamisch generiert, wenn die Größe und Positionen der"
 " Widgets per Drag & Drop in der Dashboard-Ansicht angepasst werden"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Diesem Link kann nicht gefolgt werden, da seine Adresse unsicher ist."
 
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
@@ -15755,8 +15757,10 @@ msgstr "Vom Ergebnisbereich lösen"
 msgid "Unpin from top"
 msgstr "Von oben lösen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Unsicherer Link blockiert"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"

--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -26672,8 +26672,10 @@ msgstr ""
 "dynaamisesti, kun widgetien kokoa ja sijaintia muokataan vetämällä ja "
 "pudottamalla koontinäyttönäkymässä"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Tätä linkkiä ei voi avata, koska sen osoite on vaarallinen."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -28096,8 +28098,10 @@ msgstr "Kiinnitä tulosruutuun"
 msgid "Unpin from top"
 msgstr "Irrota yläreunasta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Vaarallinen linkki estetty"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]

--- a/superset/translations/lv/LC_MESSAGES/messages.po
+++ b/superset/translations/lv/LC_MESSAGES/messages.po
@@ -14952,8 +14952,10 @@ msgstr ""
 "dinamiski ģenerēts, pielāgojot logrīku izmērus un pozīcijas, izmantojot "
 "vilkšanu un nomešanu paneļa skatā"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Šo saiti nevar sekot, jo tās adrese ir nedrošā."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -15775,8 +15777,10 @@ msgstr "Piespraust rezultātu panelī"
 msgid "Unpin from top"
 msgstr "Atspraust no augšas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Nedrošā saite bloķēta"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"


### PR DESCRIPTION
### SUMMARY

#39925 added two new user-facing strings — `"Unsafe link blocked"` and `"This link cannot be followed because its address is unsafe."` — to every message catalog. The German (#41608), Latvian (#41612), and Finnish (#41613) backfill PRs had already merged by then, so these two strings landed **untranslated** in those three catalogs.

This small follow-up fills them (6 entries total) via `scripts/translations/backfill_po.py`, marked `#, fuzzy` with the usual attribution comment for human review — consistent with the rest of the i18n backfill sweep.

The other in-flight backfill PRs (#41609 es, #41640 sk, #41641 th, #41645 uk) already include these strings, since they were rebased after #39925 landed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalogs only — no layout or behavior change. Note: the frontend `po2json --fuzzy` build includes these fuzzy strings, so they render in the UI once the frontend is rebuilt; the backend excludes them (English fallback).

### TESTING INSTRUCTIONS

- `pybabel compile -d superset/translations -l de -l lv -l fi` succeeds.
- de/lv/fi speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
