### PR TITLE
fix(i18n): compile fuzzy translations into the backend .mo files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY superset/translations/ /app/translations_mo/
 RUN if [ "${BUILD_TRANSLATIONS}" = "true" ]; then \
-        pybabel compile --use-fuzzy -d /app/translations_mo | true; \
+        pybabel compile --use-fuzzy -d /app/translations_mo || true; \
     fi; \
     rm -f /app/translations_mo/*/*/*.[po,json]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY superset/translations/ /app/translations_mo/
 RUN if [ "${BUILD_TRANSLATIONS}" = "true" ]; then \
-        pybabel compile -d /app/translations_mo | true; \
+        pybabel compile --use-fuzzy -d /app/translations_mo | true; \
     fi; \
     rm -f /app/translations_mo/*/*/*.[po,json]
 

--- a/docs/developer_docs/contributing/howtos.md
+++ b/docs/developer_docs/contributing/howtos.md
@@ -332,15 +332,28 @@ cd superset-frontend
 npm run build-translation
 
 # Backend
-pybabel compile -d superset/translations
+pybabel compile --use-fuzzy -d superset/translations
 ```
+
+`--use-fuzzy` includes `#, fuzzy` entries in the compiled `.mo` files. Superset
+serves fuzzy translations on purpose: the frontend build (`po2json --fuzzy`)
+already includes them, `flask fab babel-compile` (used by the release images)
+compiles with `-f`, and the production `Dockerfile` compiles with `--use-fuzzy`
+as well. This keeps machine-generated (and other draft) translations visible in
+the UI rather than falling back to English while they await review.
 
 ### Backfilling missing translations with AI
 
 For languages with many untranslated strings, the repo includes a script that
 uses Claude AI to generate draft translations for any missing entries. All
 AI-generated strings are marked `#, fuzzy` and tagged with an attribution
-comment so that human reviewers know they need to be checked before merging.
+comment so that human reviewers know they need to be checked.
+
+Note that `#, fuzzy` marks a translation as *needing review*, not as *withheld*:
+both the frontend and backend builds serve fuzzy entries (see [Applying
+translations](#applying-translations) above), so an AI-generated string is shown
+in the UI as soon as it is built and deployed. Reviewers should verify each
+entry and remove the `#, fuzzy` flag to promote it to a confirmed translation.
 
 #### Prerequisites
 


### PR DESCRIPTION
### SUMMARY

The main `Dockerfile` compiled backend translations with a bare `pybabel compile`, which **omits `#, fuzzy` entries** — so fuzzy (machine-generated and other draft) translations fell back to English on the backend. This is inconsistent with every other translation build path in the repo:

- the **frontend** build (`superset-frontend/scripts/po2json.sh`) runs `po2json --fuzzy`, which *includes* fuzzy entries;
- **`flask fab babel-compile`** — used by the RELEASING images (`RELEASING/Dockerfile.from_*_tarball`) and `scripts/translations/generate_mo_files.sh` — runs `pybabel compile -f` internally (see `flask_appbuilder/cli.py`).

So the production image was the *only* path dropping fuzzy translations. This PR adds `--use-fuzzy` to the Dockerfile's `pybabel compile`, making the backend serve fuzzy translations consistently with the frontend and the other backend build paths.

**Motivation:** we're running an AI-assisted backfill across the language catalogs (fuzzy-marked, pending native-speaker review — see the de/lv/fi/es/sk/th/uk/cs PRs). With this change, those draft translations (and any other `#, fuzzy` entries) are shown in the UI on both frontend and backend rather than falling back to English while awaiting review. `#, fuzzy` remains the "needs review" marker; reviewers de-fuzz to confirm.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Backend-compiled catalogs (`BUILD_TRANSLATIONS=true`):
- **Before:** `#, fuzzy` entries excluded → English fallback in server-rendered strings.
- **After:** `#, fuzzy` entries included → translated string served (matching the frontend).

### TESTING INSTRUCTIONS

```bash
# fuzzy entry is included with --use-fuzzy, excluded without it
pybabel compile --use-fuzzy --statistics -d superset/translations
```
Build the image with `--build-arg BUILD_TRANSLATIONS=true` and confirm a `#, fuzzy` backend string renders translated rather than in English.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API