### PR TITLE
test(ci): stabilize master checks

### DIFF
--- a/superset-frontend/playwright/tests/dataset/create-dataset.spec.ts
+++ b/superset-frontend/playwright/tests/dataset/create-dataset.spec.ts
@@ -29,6 +29,7 @@ import { waitForPost } from '../../helpers/api/intercepts';
 import { expectStatusOneOf } from '../../helpers/api/assertions';
 import { getDatabaseByName } from '../../helpers/api/database';
 import { apiExecuteSql } from '../../helpers/api/sqllab';
+import { TIMEOUT } from '../../utils/constants';
 
 interface ExamplesSetupResult {
   tableName: string;
@@ -116,7 +117,7 @@ async function dropTempTable(
 // Uses test.describe only because Playwright's serial mode API requires it -
 // (Deviation from "avoid describe" guideline is necessary for functional reasons)
 test.describe('create dataset wizard', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({ mode: 'serial', timeout: TIMEOUT.SLOW_TEST });
 
   test('should create a dataset via wizard', async ({ page, testAssets }) => {
     const { tableName, dbId, createDatasetPage } = await setupExamplesDataset(

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_datasets.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_datasets.py
@@ -17,6 +17,7 @@
 
 """Unit tests for the MCP get_dashboard_datasets tool."""
 
+from importlib import import_module
 from unittest.mock import Mock, patch
 
 import pytest
@@ -28,6 +29,10 @@ from superset.mcp_service.utils.sanitization import (
     LLM_CONTEXT_OPEN_DELIMITER,
 )
 from superset.utils import json
+
+get_dashboard_datasets_module = import_module(
+    "superset.mcp_service.dashboard.tool.get_dashboard_datasets"
+)
 
 
 def _wrapped(value: str) -> str:
@@ -142,8 +147,8 @@ def mock_dataset_access():
 @pytest.fixture(autouse=True)
 def allow_data_model_metadata():
     """Keep tests in the metadata-allowed path unless a test overrides it."""
-    with patch(
-        "superset.mcp_service.dashboard.tool.get_dashboard_datasets."
+    with patch.object(
+        get_dashboard_datasets_module,
         "user_can_view_data_model_metadata",
         return_value=True,
     ) as mock_allow:

--- a/tests/unit_tests/pandas_postprocessing/test_prophet.py
+++ b/tests/unit_tests/pandas_postprocessing/test_prophet.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
+from importlib import import_module
 from importlib.util import find_spec
 from unittest.mock import patch
 
@@ -25,6 +26,8 @@ from superset.exceptions import InvalidPostProcessingError
 from superset.utils.core import DTTM_ALIAS
 from superset.utils.pandas_postprocessing import prophet
 from tests.unit_tests.fixtures.dataframes import prophet_df
+
+prophet_module = import_module("superset.utils.pandas_postprocessing.prophet")
 
 
 def test_prophet_valid():
@@ -207,9 +210,7 @@ def test_prophet_fit_error():
     if find_spec("prophet") is None:
         pytest.skip("prophet not installed")
 
-    with patch(
-        "superset.utils.pandas_postprocessing.prophet._prophet_fit_and_predict"
-    ) as mock_fit:
+    with patch.object(prophet_module, "_prophet_fit_and_predict") as mock_fit:
         mock_fit.side_effect = InvalidPostProcessingError(
             "Unable to generate forecast: Dataframe has fewer than 2 non-NaN rows."
         )

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -2983,8 +2983,9 @@ def test_coerce_integer_rejects_non_integer_float() -> None:
 
 
 def test_coerce_integer_rejects_other_types() -> None:
+    raw: Any = [1]
     with pytest.raises(ValueError, match="Invalid integer value"):
-        _coerce_scalar_filter_value([1], _dim(pa.int64()))
+        _coerce_scalar_filter_value(raw, _dim(pa.int64()))
 
 
 @pytest.mark.parametrize(
@@ -3008,8 +3009,9 @@ def test_coerce_floating_invalid_string_raises() -> None:
 
 
 def test_coerce_floating_rejects_other_types() -> None:
+    raw: Any = [1.0]
     with pytest.raises(ValueError, match="Invalid numeric value"):
-        _coerce_scalar_filter_value([1.0], _dim(pa.float64()))
+        _coerce_scalar_filter_value(raw, _dim(pa.float64()))
 
 
 def test_coerce_date_from_datetime() -> None:


### PR DESCRIPTION
### SUMMARY
Fixes the current master CI regressions observed across recent master runs:

- Update stale unit-test patches to target the real module objects instead of package exports that shadow submodules with function objects.
- Give the dataset creation Playwright spec the existing slow-test timeout budget, matching the work it performs in CI.
- Type intentional invalid semantic-layer test inputs as `Any` so mypy accepts the negative cases without changing test behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable; this is a test-only CI stabilization change.

### TESTING INSTRUCTIONS
- `PATH=/Users/joeli/.nvm/versions/node/v24.16.0/bin:$PATH pre-commit run --files superset-frontend/playwright/tests/dataset/create-dataset.spec.ts tests/unit_tests/semantic_layers/mapper_test.py tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_datasets.py tests/unit_tests/pandas_postprocessing/test_prophet.py`
- `PATH=/Users/joeli/.nvm/versions/node/v24.16.0/bin:$PATH pre-commit run`
- `pytest tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_datasets.py tests/unit_tests/pandas_postprocessing/test_prophet.py::test_prophet_fit_error tests/unit_tests/semantic_layers/mapper_test.py -q` was attempted locally, but this worktree fails during test collection before these tests run because local `sqlglot`/Dremio imports raise `TypeError: Cannot create a consistent method resolution order (MRO) for bases Expression, Func`.
- `pre-commit run --all-files` was attempted locally; it is blocked in this environment by docs/helm/frontend build prerequisites and an unrelated all-files `ruff` C901 finding in `superset/mcp_service/sql_lab/tool/execute_sql.py`. The latest master `pre-commit checks` Action is green, so CI remains the source of truth for the full matrix.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
