### PR TITLE
fix(dao): SQL-faithful NULL and non-string handling in LIKE-family operators

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -37,7 +37,7 @@ from flask import current_app
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from pydantic import BaseModel, Field
-from sqlalchemy import asc, cast, desc, or_, Text
+from sqlalchemy import asc, cast, desc, false, or_, Text
 from sqlalchemy.exc import SQLAlchemyError, StatementError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
@@ -82,24 +82,46 @@ class ColumnOperatorEnum(str, Enum):
         return op_func(column, value)
 
 
-def _escape_like(value: str) -> str:
-    """Escape LIKE/ILIKE wildcards to prevent wildcard injection."""
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+def _escape_like(value: Any) -> str:
+    """Escape LIKE/ILIKE wildcards to prevent wildcard injection.
+
+    The filter payload is typed ``Any``, so non-string scalars (e.g. numeric
+    JSON values) can reach LIKE-family operators; coerce them to ``str`` so
+    they degrade to a literal match instead of raising ``AttributeError``.
+    ``None`` never reaches this function — ``_like_op`` short-circuits it
+    first, because coercing ``None`` to ``""`` would build a wildcard-only
+    pattern (``%%``) that matches every row.
+    """
+    return str(value).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _like_op(template: str, case_insensitive: bool = False) -> Any:
+    """Build a LIKE-family operator with SQL-faithful NULL semantics.
+
+    ``template`` places the escaped value inside the pattern (e.g. ``"%{}%"``
+    for contains). A ``None`` value matches no rows — mirroring SQL's
+    three-valued logic, where ``x LIKE NULL`` evaluates to NULL — rather
+    than raising or degenerating into a match-everything pattern.
+    """
+
+    def op(col: Any, val: Any) -> Any:
+        if val is None:
+            return false()
+        pattern = template.format(_escape_like(val))
+        if case_insensitive:
+            return col.ilike(pattern, escape="\\")
+        return col.like(pattern, escape="\\")
+
+    return op
 
 
 # Define operator_map as a module-level dict after the enum is defined
 operator_map: Dict[ColumnOperatorEnum, Any] = {
     ColumnOperatorEnum.eq: lambda col, val: col == val,
     ColumnOperatorEnum.ne: lambda col, val: col != val,
-    ColumnOperatorEnum.sw: lambda col, val: col.like(
-        f"{_escape_like(val)}%", escape="\\"
-    ),
-    ColumnOperatorEnum.ew: lambda col, val: col.like(
-        f"%{_escape_like(val)}", escape="\\"
-    ),
-    ColumnOperatorEnum.ct: lambda col, val: col.ilike(
-        f"%{_escape_like(val)}%", escape="\\"
-    ),
+    ColumnOperatorEnum.sw: _like_op("{}%"),
+    ColumnOperatorEnum.ew: _like_op("%{}"),
+    ColumnOperatorEnum.ct: _like_op("%{}%", case_insensitive=True),
     ColumnOperatorEnum.in_: lambda col, val: col.in_(
         val if isinstance(val, (list, tuple)) else [val]
     ),
@@ -110,12 +132,8 @@ operator_map: Dict[ColumnOperatorEnum, Any] = {
     ColumnOperatorEnum.gte: lambda col, val: col >= val,
     ColumnOperatorEnum.lt: lambda col, val: col < val,
     ColumnOperatorEnum.lte: lambda col, val: col <= val,
-    ColumnOperatorEnum.like: lambda col, val: col.like(
-        f"%{_escape_like(val)}%", escape="\\"
-    ),
-    ColumnOperatorEnum.ilike: lambda col, val: col.ilike(
-        f"%{_escape_like(val)}%", escape="\\"
-    ),
+    ColumnOperatorEnum.like: _like_op("%{}%"),
+    ColumnOperatorEnum.ilike: _like_op("%{}%", case_insensitive=True),
     ColumnOperatorEnum.is_null: lambda col, _: col.is_(None),
     ColumnOperatorEnum.is_not_null: lambda col, _: col.isnot(None),
 }

--- a/tests/unit_tests/dao/base_dao_test.py
+++ b/tests/unit_tests/dao/base_dao_test.py
@@ -309,3 +309,67 @@ def test_list_page_size_below_one_is_floored():
     mock_query = _list_with_page_size(0)
 
     mock_query.limit.assert_called_once_with(1)
+
+
+def test_like_operators_none_value_matches_no_rows() -> None:
+    """A ``None`` value on a LIKE-family operator must match no rows.
+
+    Mirrors SQL three-valued logic (``x LIKE NULL`` is NULL). The failure
+    modes this pins against: raising ``AttributeError`` (``None`` has no
+    ``.replace``) and, worse, coercing ``None`` to ``""`` — which builds a
+    wildcard-only pattern (``%%``/``%``) that silently matches every row.
+    """
+    Base_test = declarative_base()  # noqa: N806
+
+    class NoneValueModel(Base_test):  # type: ignore
+        __tablename__ = "none_value_model"
+        id = Column(Integer, primary_key=True)
+        name = Column(String(50))
+
+    like_family = [
+        ColumnOperatorEnum.sw,
+        ColumnOperatorEnum.ew,
+        ColumnOperatorEnum.ct,
+        ColumnOperatorEnum.like,
+        ColumnOperatorEnum.ilike,
+    ]
+    for operator in like_family:
+        clause = operator.apply(NoneValueModel.name, None)
+        sql = str(clause.compile(compile_kwargs={"literal_binds": True}))
+        assert sql.strip().lower() == "false", (
+            f"{operator.name} with None should compile to a no-match clause, "
+            f"got: {sql!r}"
+        )
+        assert "%" not in sql, (
+            f"{operator.name} with None must not build a wildcard pattern "
+            f"(would match every row): {sql!r}"
+        )
+
+
+def test_like_operators_non_string_value_matches_literally() -> None:
+    """Non-string scalars (e.g. numeric JSON payloads) degrade to a literal
+    match instead of raising ``AttributeError``."""
+    Base_test = declarative_base()  # noqa: N806
+
+    class NumericValueModel(Base_test):  # type: ignore
+        __tablename__ = "numeric_value_model"
+        id = Column(Integer, primary_key=True)
+        name = Column(String(50))
+
+    clause = ColumnOperatorEnum.ct.apply(NumericValueModel.name, 123)
+    sql = str(clause.compile(compile_kwargs={"literal_binds": True}))
+    assert "'%123%'" in sql
+
+
+def test_like_operators_escape_wildcards_in_value() -> None:
+    """User-supplied ``%``/``_`` are escaped, not treated as wildcards."""
+    Base_test = declarative_base()  # noqa: N806
+
+    class WildcardValueModel(Base_test):  # type: ignore
+        __tablename__ = "wildcard_value_model"
+        id = Column(Integer, primary_key=True)
+        name = Column(String(50))
+
+    clause = ColumnOperatorEnum.ct.apply(WildcardValueModel.name, "100%_done")
+    sql = str(clause.compile(compile_kwargs={"literal_binds": True}))
+    assert "100\\%\\_done" in sql


### PR DESCRIPTION
### SUMMARY

The DAO column-operator filter payload (`ColumnOperator.value`) is typed `Any`, so non-string JSON values can reach the LIKE-family operators (`sw`/`ew`/`ct`/`like`/`ilike`) in `superset/daos/base.py`. Two failure modes exist on master:

- A **non-string scalar** (e.g. a numeric JSON value) raises `AttributeError` inside `_escape_like` (`int` has no `.replace`) and surfaces as a 500.
- The tempting fix — coercing `None` to `""` — is worse: the surrounding wildcards build a pattern like `%%` that **silently matches every row**, turning a null-valued "contains" filter into a match-all. (Not a security issue — these operators run after `base_filter` RBAC scoping — but a correctness trap: misleading results instead of an error.)

This PR replaces the five duplicated LIKE lambdas with a small `_like_op` factory:

- **`None` matches no rows** (`false()`), mirroring SQL three-valued logic where `x LIKE NULL` evaluates to `NULL`.
- **Other scalars coerce to `str`** for a literal, wildcard-escaped match (`123` → `'%123%'`).
- Wildcard escaping (`%`, `_`, `\`) is unchanged.

Extracted from #40130 per review feedback (the hardening is unrelated to soft delete); the equivalent change there is being reverted in favour of this standalone fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/dao/base_dao_test.py -q
```

New tests pin all three behaviours across the LIKE family: `None` → compiles to a no-match clause with **no wildcard pattern**; numeric value → literal match; `%`/`_` in user input → escaped. The `None` test reproduces the `AttributeError` against master's code (verified by running it with the fix reverted).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)