### PR TITLE
feat(i18n): backfill French (fr) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -203,17 +203,23 @@ msgstr "\"%s\" est maintenant le thème sombre du système"
 msgid "\"%s\" is now the system default theme"
 msgstr "\"%s\" est maintenant le thème par défaut du système"
 
-#, python-format
-msgid "%% calculation"
-msgstr "%% calcul"
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
+msgid "% calculation"
+msgstr "% calcul"
 
-#, python-format
-msgid "%% of parent"
-msgstr "%% du parent"
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
+msgid "% of parent"
+msgstr "% du parent"
 
-#, python-format
-msgid "%% of total"
-msgstr "%% du total"
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
+msgid "% of total"
+msgstr "% du total"
 
 #, python-format
 msgid "%(dialect)s cannot be used as a data source for security reasons."
@@ -241,11 +247,15 @@ msgstr "%(object)s n'existe pas dans cette base de données."
 msgid "%(prefix)s %(title)s"
 msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sLes résultats ont été tronqués à %(row_count)s lignes en raison"
+" de contraintes mémoire."
 
 #, python-format
 msgid ""
@@ -329,9 +339,11 @@ msgstr "%s Sélectionnée (Physique)"
 msgid "%s Selected (Virtual)"
 msgstr "%s Sélectionnée (Virtuelle)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Vue sémantique"
 
 #, python-format
 msgid "%s URL"
@@ -469,17 +481,23 @@ msgid_plural "%s seconds"
 msgstr[0] "5 secondes"
 msgstr[1] ""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s vue(s) sémantique(s) ajoutée(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "Échec de l'ajout de %s vue(s) sémantique(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "Échec de l'ajout de %s vue(s) sémantique(s) : %s"
 
 #, python-format
 msgid "%s tab selected"
@@ -814,19 +832,31 @@ msgstr ">= (plus grand ou égal)"
 msgid "A Big Number"
 msgstr "Gros nombre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "Une fonction JavaScript qui génère un objet de configuration d'étiquette"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "Une fonction JavaScript qui génère un objet de configuration d'icône"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"Un objet JavaScript conforme à la spécification des options ECharts, "
+"remplaçant les autres options de contrôle avec une priorité plus élevée. "
+"(ex. { title: { text: \"Mon graphique\" }, tooltip: { trigger: \"item\" }"
+" }). Détails : https://echarts.apache.org/en/option.html. "
 
 msgid "A comma separated list of columns that should be parsed as dates"
 msgstr "Liste de Colonnes séparée par des virgules à traiter comme des dates"
@@ -994,11 +1024,17 @@ msgstr "Le rapport a été créé"
 msgid "API key name is required"
 msgstr "Le nom du tableau est obligatoire"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "Clé API révoquée avec succès"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "Les clés API permettent un accès programmatique limité à Superset."
 
 msgid "APPLY"
 msgstr "APPLIQUER"
@@ -1283,11 +1319,13 @@ msgstr "Ajouter aux onglets"
 msgid "Added"
 msgstr "Ajouté"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 nouvelle colonne ajoutée au jeu de données virtuel"
+msgstr[1] "%s nouvelles colonnes ajoutées au jeu de données virtuel"
 
 #, python-format
 msgid "Added to 1 dashboard"
@@ -2127,11 +2165,17 @@ msgstr ""
 "assurer que la requête source respecte les périodes minimales définies "
 "dans la fenêtre glissante."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"S'applique uniquement lorsque le formatage « Barres de cellule » est "
+"sélectionné : l'arrière-plan des colonnes de l'histogramme est affiché si"
+" l'option « Afficher les barres de cellule » est activée."
 
 msgid "Apply"
 msgstr "Appliquer"
@@ -2318,13 +2362,19 @@ msgstr "Auto"
 msgid "Auto Zoom"
 msgstr "Zoom automatique"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Actualisation automatique suspendue (définie à %s secondes)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
 msgstr ""
+"Actualisation automatique suspendue - onglet inactif (définie à %s "
+"secondes)"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
@@ -2460,8 +2510,13 @@ msgstr "Hauteur de base"
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr "Style de la couche de base de la carte. Voir la documentation Mapbox : %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Style de carte de la couche de base. Accepte une URL de style Mapbox "
+"(mapbox://styles/...)."
 
 #, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
@@ -2700,6 +2755,11 @@ msgstr "destinataires en copie"
 msgid "COPY QUERY"
 msgstr "Copier la requête"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Copier la requête"
+
 msgid "CREATE TABLE AS"
 msgstr "CREATE TABLE AS"
 
@@ -2727,11 +2787,17 @@ msgstr "Modèles CSS"
 msgid "CSS applied to the chart"
 msgstr "CSS appliqué au graphique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"Les styles CSS peuvent être supprimés par l'assainissement HTML côté "
+"serveur. Si les styles ne s'appliquent pas, demandez à votre "
+"administrateur Superset d'ajuster la configuration d'assainissement HTML."
 
 msgid "CSS template"
 msgstr "Modèles CSS"
@@ -2789,10 +2855,16 @@ msgstr "La requête CVAS (create view as select) n'est pas une instruction SELEC
 msgid "Cache Timeout (seconds)"
 msgstr "Délai d'inactivité et reprise du cache (secondes)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
+"Mettre en cache les données séparément pour chaque utilisateur en "
+"fonction de ses rôles et permissions d'accès aux données. Lorsque "
+"désactivé, un cache unique sera utilisé pour tous les utilisateurs."
 
 msgid "Cache timeout"
 msgstr "Délai d'inactivité et reprise du cache"
@@ -2850,8 +2922,11 @@ msgstr "Annuler"
 msgid "Cancel query on window unload event"
 msgstr "Annuler la requête lors de l'événement de déchargement de la fenêtre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "Annulation impossible en raison d'un gestionnaire d'annulation manquant"
 
 msgid "Cannot access the query"
 msgstr "Impossible d'accéder à la requête"
@@ -2887,8 +2962,11 @@ msgstr "Impossible de charger le filtre"
 msgid "Cannot modify system themes."
 msgstr "Impossible de modifier les thèmes système."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "Impossible d'imbriquer des dossiers dans les dossiers par défaut"
 
 #, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
@@ -2949,8 +3027,11 @@ msgstr "Taille des cellules"
 msgid "Cell content"
 msgstr "Contenu de cellule"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "Mise en page et style des cellules"
 
 msgid "Cell limit"
 msgstr "Limite de la cellule"
@@ -3060,9 +3141,13 @@ msgstr "Caractère à interpréter comme un point décimal"
 msgid "Chart"
 msgstr "Graphique"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
 msgstr ""
+"Le graphique %(chart_id)s ne se trouve pas sur le tableau de bord "
+"%(dashboard_id)s"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3120,8 +3205,13 @@ msgstr "Le graphique n'a pas pu être créé."
 msgid "Chart could not be updated."
 msgstr "Le graphique n'a pas pu être mis à jour."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
 msgstr ""
+"Personnalisation du graphique pour contrôler la visibilité des couches "
+"deck.gl"
 
 msgid "Chart customization value is required"
 msgstr "La valeur de personnalisation du graphe est obligatoire"
@@ -3268,10 +3358,15 @@ msgstr "choisir les Colonnes à traiter comme des dates"
 msgid "Choose columns to read"
 msgstr "choisir les Colonnes à lire"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
 msgstr ""
+"Choisissez parmi les filtres de tableau de bord existants et sélectionnez"
+" une valeur pour affiner les résultats de votre rapport."
 
 msgid "Choose how many X-Axis labels to show"
 msgstr "Choisir combien d'étiquettes de l'axe X afficher"
@@ -3279,10 +3374,15 @@ msgstr "Choisir combien d'étiquettes de l'axe X afficher"
 msgid "Choose index column"
 msgstr "Choisir la colonne d'index"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
+"Choisissez les couches à masquer dans tous les graphiques à couches "
+"multiples deck.gl de ce tableau de bord."
 
 msgid "Choose notification method and recipients."
 msgstr "Ajouter une méthode et des destinataires de notification"
@@ -3554,11 +3654,17 @@ msgstr "Type de schéma de couleurs"
 msgid "Color Steps"
 msgstr "Étapes de couleur"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Colorer les barres par axe x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Colorer les barres par axe y"
 
 msgid "Color bounds"
 msgstr "Limites de couleur"
@@ -3569,8 +3675,13 @@ msgstr "Points de rupture de couleur"
 msgid "Color by"
 msgstr "Colorer par"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
 msgstr ""
+"Le champ couleur doit être une couleur hexadécimale (#rrggbb) ou 'rgb(r, "
+"g, b)'"
 
 #, fuzzy
 msgid "Color for breakpoint"
@@ -3691,8 +3802,11 @@ msgstr " Colonnes et métriques"
 msgid "Columns and metrics should be inside folders"
 msgstr " Colonnes et métriques"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "Le dossier de colonnes ne peut contenir que des éléments de colonne"
 
 #, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3702,8 +3816,11 @@ msgstr "Colonnes absentes du jeu de données : %(invalid_columns)s"
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "Colonnes absentes de la source de données : %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "Les colonnes doivent être à l'intérieur des dossiers"
 
 msgid "Columns subtotal position"
 msgstr "Position du sous-total des colonnes"
@@ -3778,11 +3895,17 @@ msgstr ""
 "Chaque groupe est associé à une ligne et l'évolution dans le temps est "
 "visualisée par la longueur des barres et la couleur."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
 msgstr ""
+"Compare les métriques entre différentes périodes. Affiche les données de "
+"séries temporelles sur plusieurs périodes (comme des semaines ou des "
+"mois) pour montrer les tendances et les modèles d'une période à l'autre."
 
 msgid "Comparison"
 msgstr "Comparaison"
@@ -3922,9 +4045,11 @@ msgstr "La connexion a échoué, veuillez vérifier vos paramètres de connexion
 msgid "Contains"
 msgstr "Contient"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Contient du texte (ILIKE %x%)"
 
 #, fuzzy
 msgid "Content format"
@@ -4249,8 +4374,13 @@ msgstr ""
 "Les mesures SQL ponctuelles personnalisées ne sont pas activées pour cet "
 "ensemble de données"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
+"Les champs SQL personnalisés ne peuvent pas être analysés comme une seule"
+" instruction SQL."
 
 #, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
@@ -4271,8 +4401,13 @@ msgstr "Formatage conditionnel personnalisé"
 msgid "Custom date"
 msgstr "Date Personnalisé"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
 msgstr ""
+"Les champs personnalisés ne sont pas disponibles dans les cellules de "
+"carte thermique agrégées"
 
 msgid "Custom time filter plugin"
 msgstr "Plugiciel de filtre horaire personnalisé"
@@ -4317,20 +4452,35 @@ msgstr "Personnaliser les colonnes"
 msgid "Customize data source, filters, and layout."
 msgstr "Personnaliser la source de données, les filtres et la mise en page."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personnalisez l'étiquette affichée pour les valeurs décroissantes dans "
+"les info-bulles et la légende du graphique."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personnalisez l'étiquette affichée pour les valeurs croissantes dans les "
+"info-bulles et la légende du graphique."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
+"Personnalisez l'étiquette affichée pour les valeurs totales dans les "
+"info-bulles, la légende et l'axe du graphique."
 
 msgid "Customize tooltips template"
 msgstr "Personnaliser les templates d'infobulles"
@@ -4434,8 +4584,10 @@ msgstr "Le tableau de bord n'a pas pu être mis à jour."
 msgid "Dashboard could not be deleted."
 msgstr "Le tableau de bord n'a pas pu être supprimé."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "Le tableau de bord n'a pas pu être restauré."
 
 msgid "Dashboard could not be updated."
 msgstr "Le tableau de bord n'a pas pu être mis à jour."
@@ -4658,8 +4810,12 @@ msgstr "Mise à jour des paramètres de la base de données"
 msgid "Database type does not support file uploads."
 msgstr "La base de données ne prend pas en charge le chargement de fichiers"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
+"Le fichier à téléverser dans la base de données dépasse la taille "
+"maximale autorisée."
 
 msgid "Database upload file failed"
 msgstr "Le chargement de fichier dans la base a échoué"
@@ -5040,11 +5196,13 @@ msgstr ""
 msgid "Definition"
 msgstr "déviation"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Retardé (%s actualisation manquée)"
+msgstr[1] "Retardé (%s actualisations manquées)"
 
 msgid "Delete"
 msgstr "Supprimer"
@@ -5290,12 +5448,21 @@ msgstr "Totaux"
 msgid "Details of the certification"
 msgstr "Détails de la certification"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Détermine comment le filtre fait correspondre les valeurs. « "
+"Correspondance exacte » utilise l'opérateur IN (par défaut). Les options "
+"ILIKE permettent une correspondance partielle de texte avec une saisie "
+"libre. Avertissement : les requêtes ILIKE peuvent être lentes sur de "
+"grands ensembles de données car elles ne peuvent pas utiliser les index "
+"efficacement."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Détermine le mode de calcul des moustaches et des valeurs aberrantes."
@@ -5323,11 +5490,18 @@ msgstr "Granularité de temps"
 msgid "Dimension"
 msgstr "Dimension"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Colonne de dimension émise comme filtre croisé lorsqu'un élément est "
+"cliqué. Les autres graphiques du tableau de bord sont mis en "
+"correspondance avec cette colonne. Si non défini, revient à la colonne de"
+" géométrie (comportement hérité, souvent sans correspondance)."
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5488,8 +5662,13 @@ msgstr "Afficher le total au niveau de la ligne"
 msgid "Display row level total"
 msgstr "Afficher le total au niveau de la ligne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
 msgstr ""
+"Afficher l'horodatage de la dernière requête sur les graphiques dans la "
+"vue du tableau de bord"
 
 msgid "Display type icon"
 msgstr "Afficher l'icône de type"
@@ -5580,11 +5759,18 @@ msgstr "Glisser-déposer des composants et des graphiques dans le tableau de bor
 msgid "Drag and drop components to this tab"
 msgstr "Glissez-déposer des composants dans cet onglet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
+"Faites glisser des colonnes et des métriques ici pour personnaliser le "
+"contenu des info-bulles. L'ordre est important - les éléments "
+"apparaîtront dans le même ordre dans les info-bulles. Cliquez sur le "
+"bouton pour sélectionner manuellement des colonnes et des métriques."
 
 #, fuzzy
 msgid "Drag to reorder"
@@ -5763,8 +5949,11 @@ msgstr "Durée en ms (66000 => 1m 6s)"
 msgid "Duration in seconds"
 msgstr "Saisir la durée en secondes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "Dynamique"
 
 msgid "Dynamic Aggregation Function"
 msgstr "Fonction d'agrégation dynamique"
@@ -5783,14 +5972,22 @@ msgstr "Fonction d'agrégation dynamique"
 msgid "Dynamically search all filter values"
 msgstr "Charge dynamiquement les valeurs du filtre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
 msgstr ""
+"Sélectionner dynamiquement des colonnes de regroupement à partir d'un jeu"
+" de données"
 
 msgid "ECharts"
 msgstr "ECharts"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "Options ECharts (littéraux d'objets JS)"
 
 #, fuzzy
 msgid "EMAIL_REPORTS_CTA"
@@ -6030,15 +6227,21 @@ msgstr "Activer les prévisions"
 msgid "Enable graph roaming"
 msgstr "Activer le déplacement graphique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "Activer le mode JavaScript pour les icônes"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "Colonnex du tableau"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "Activer le mode JavaScript pour les étiquettes"
 
 #, fuzzy
 msgid "Enable labels"
@@ -6060,17 +6263,29 @@ msgstr "Activer l'expansion des lignes dans les schémas"
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr "Activer la pagination des résultats côté serveur (fonction expérimentale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "Active la configuration personnalisée des icônes via JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "Active la configuration personnalisée des étiquettes via JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "Active le rendu des icônes pour les points GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "Active le rendu des étiquettes pour les points GeoJSON"
 
 msgid ""
 "Encountered invalid NULL spatial entry,"
@@ -6161,8 +6376,11 @@ msgstr "Saisir la durée en secondes"
 msgid "Enter fullscreen"
 msgstr "Passer en plein écran"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "Saisissez les valeurs minimale et maximale pour le filtre de plage"
 
 msgid "Enter report name"
 msgstr "Saisir le nom du rapport"
@@ -6234,9 +6452,11 @@ msgstr ""
 msgid "Error deleting %s"
 msgstr "Une erreur s'est produite durant la récupération des données : %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Erreur lors de la désactivation du plein écran : %s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6384,8 +6604,11 @@ msgstr "Évolution"
 msgid "Exact"
 msgstr "Exact"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Correspondance exacte (IN)"
 
 msgid "Example"
 msgstr "Exemple"
@@ -6510,8 +6733,11 @@ msgstr "Échec de l'export, veuillez réessayer."
 msgid "Export failed: %s"
 msgstr "Rapport échoué"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "Exporter la capture d'écran (jpeg)"
 
 #, fuzzy, python-format
 msgid "Export successful: %s"
@@ -6573,8 +6799,11 @@ msgstr "Dimensions"
 msgid "Extent"
 msgstr "Étendue"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Avertissement de lien externe"
 
 msgid "Extra"
 msgstr "Extra"
@@ -6625,6 +6854,11 @@ msgstr "FEB"
 #, fuzzy
 msgid "FIT DATA"
 msgstr "Modifier l’ensemble de données"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Ajuster aux données"
 
 msgid "FRI"
 msgstr "FRI"
@@ -6759,8 +6993,11 @@ msgstr "Échec de la validation de l'expression. Veuillez réessayer."
 msgid "Failed to verify select options: %s"
 msgstr "Échec de la vérification des options de sélection : %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
-msgstr ""
+msgstr "Retour au format CSV ; bibliothèque d'exportation Excel non disponible."
 
 msgid "False"
 msgstr "est faux"
@@ -6815,10 +7052,15 @@ msgstr "Le champ est requis"
 msgid "File extension is not allowed."
 msgstr "L’URI des données n’est pas autorisé."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
 msgstr ""
+"La gestion des fichiers n'est pas prise en charge par ce navigateur. "
+"Veuillez utiliser un navigateur moderne tel que Chrome ou Edge."
 
 #, fuzzy
 msgid "File settings"
@@ -7064,11 +7306,17 @@ msgstr "Interdit"
 msgid "Force"
 msgstr "Forcer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "Forcer la granularité temporelle comme intervalle maximum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Forcer l'abandon (arrête la tâche pour tous les abonnés)"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -7100,8 +7348,13 @@ msgstr "Forcer l'actualisation de la liste des schémas"
 msgid "Force refresh table list"
 msgstr "Forcer l'actualisation de la liste des tableaux"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
 msgstr ""
+"Force la granularité temporelle sélectionnée comme intervalle maximum "
+"pour les étiquettes de l'axe X"
 
 msgid "Forecast periods"
 msgstr "Périodes de prévision"
@@ -7149,12 +7402,20 @@ msgstr ""
 "ECharts :\n"
 "{a} (série), {b} (nom), {c} (valeur), {d} (pourcentage)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"Formatez les métriques ou les colonnes avec des symboles monétaires en "
+"préfixe ou suffixe. Choisissez un symbole manuellement ou utilisez « "
+"Détection automatique » pour appliquer le symbole correct en fonction de "
+"la colonne de code de devise du jeu de données. Lorsque plusieurs devises"
+" sont présentes, le formatage revient aux nombres neutres."
 
 msgid "Formatted CSV attached in email"
 msgstr "CSV formatté attaché dans le courriel"
@@ -7366,8 +7627,11 @@ msgstr ""
 msgid "Guest user cannot modify chart payload"
 msgstr "Un utilisateur invité ne peut pas modifier le contenu du graphique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "Chemin HTTP"
 
 #, fuzzy
 msgid "Handlebars"
@@ -7545,10 +7809,16 @@ msgstr ""
 "Si activé, ce contrôle trie les résultats/valeurs par ordre décroissant, "
 "sinon il les trie par ordre croissant."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
+"S'il reste vide, il ne sera pas sauvegardé et sera supprimé de la liste. "
+"Pour supprimer des dossiers, déplacez les métriques et les colonnes vers "
+"d'autres dossiers."
 
 #, fuzzy
 msgid "If table already exists"
@@ -7699,8 +7969,11 @@ msgstr "Info"
 msgid "Inherit range from time filter"
 msgstr "Hériter de la plage du filtre temporel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "Profondeur initiale de l'arborescence"
 
 msgid "Inner Radius"
 msgstr "Rayon intérieur"
@@ -7749,8 +8022,11 @@ msgstr "Haut à gauche"
 msgid "Inside right"
 msgstr "Haut à droite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "En haut à l'intérieur"
 
 #, fuzzy
 msgid "Inside top left"
@@ -7991,10 +8267,15 @@ msgstr ""
 msgid "Issue 1001 - The database is under an unusual load."
 msgstr "Problème 1001 - La base de données est soumise à une charge inhabituelle."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
 msgstr ""
+"Il ne sera pas supprimé même s'il est vide. Il ne sera pas affiché dans "
+"la vue d'édition du graphique s'il est vide."
 
 msgid "It’s not recommended to truncate Y axis in Bar chart."
 msgstr "Il n’est pas recommandé de tronquer l’axe dans le graphique à barres."
@@ -8079,8 +8360,13 @@ msgstr "Préfixe"
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
+"Les clés ne sont affichées qu'une seule fois lors de la création. "
+"Conservez-les en lieu sûr."
 
 msgid "Keys for table"
 msgstr "Clefs pour le tableau"
@@ -8334,8 +8620,11 @@ msgstr "Plus petit ou égal (<=)"
 msgid "Less than (<)"
 msgstr "Plus petit que (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
 msgid "Lift percent precision"
 msgstr "Précision du pourcentage de levée"
@@ -8638,10 +8927,16 @@ msgstr "Gérer les propriétaires du tableau de bord et les permissions d'accès
 msgid "Manage email report"
 msgstr "Supprimer le rapport par courriel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Gérez les filtres et les personnalisations pour définir la portée, les "
+"descriptions et les limitations. Créez de nouveaux éléments pour de "
+"meilleures informations sur le tableau de bord."
 
 msgid "Manage your databases"
 msgstr "Gérer vos bases de données"
@@ -8665,13 +8960,21 @@ msgstr "Rendu en direct"
 msgid "Map Style"
 msgstr "Style de carte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (open source)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre est open source et ne nécessite pas de clé API. Mapbox nécessite"
+" que MAPBOX_API_KEY soit configuré sur le serveur."
 
 msgid "Mapbox"
 msgstr "Mapbox"
@@ -8680,8 +8983,11 @@ msgstr "Mapbox"
 msgid "Mapbox (API key required)"
 msgstr "le courriel est obligatoire"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox nécessite qu'un MAPBOX_API_KEY soit configuré sur le serveur."
 
 msgid "March"
 msgstr "Mars"
@@ -8757,8 +9063,11 @@ msgstr "Rayon maximal"
 msgid "Maximum Width"
 msgstr "Largeur minimale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "Profondeur maximale d'imbrication des dossiers atteinte"
 
 msgid "Maximum number of features to fetch from service"
 msgstr "Nombre maximum de caractéristiques à récupérer depuis le service"
@@ -8957,14 +9266,25 @@ msgstr "Mesures"
 msgid "Metrics (%s)"
 msgstr "Mesures"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
 msgstr ""
+"Les métriques ne peuvent pas être utilisées à la fois pour les lignes et "
+"les colonnes en même temps"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "Le dossier de métriques ne peut contenir que des éléments de métriques"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "Les métriques doivent être dans des dossiers"
 
 #, fuzzy
 msgid "Metrics to show in the tooltip."
@@ -9162,10 +9482,15 @@ msgstr ""
 msgid "Multiplier"
 msgstr "Multiplicateur"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
 msgstr ""
+"Vous devez être le propriétaire du graphique pour écraser ce graphique. "
+"Enregistrez-le plutôt comme un nouveau graphique."
 
 msgid "Must be unique"
 msgstr "Doit être unique"
@@ -9241,8 +9566,13 @@ msgstr "Donner un nom à la base de données"
 msgid "Name your database"
 msgstr "Nom de votre base de données"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
 msgstr ""
+"Nommez votre dossier et, pour le modifier ultérieurement, cliquez sur le "
+"nom du dossier"
 
 #, fuzzy
 msgid "Native filter column is required"
@@ -9426,8 +9756,11 @@ msgstr "Aucun filtre"
 msgid "No filters are currently added to this dashboard."
 msgstr "Aucun filtre n'est actuellement ajouté à ce tableau de bord."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Aucun filtre ou personnalisation créé pour l'instant"
 
 msgid "No form settings were maintained"
 msgstr "Aucun paramètre de formulaire n'a été conservé"
@@ -9861,11 +10194,19 @@ msgstr ""
 "Ne s'applique que lorsque le « Type d'étiquette » est réglé sur "
 "l'affichage des valeurs."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
 msgstr ""
+"Seule la correspondance exacte est disponible pour les colonnes non "
+"textuelles."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Ne continuez que si vous faites confiance à la destination ou à sa source."
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -10231,8 +10572,11 @@ msgstr "Taille du point"
 msgid "Pattern"
 msgstr "Modèle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Suspendre l'actualisation automatique si l'onglet est inactif"
 
 #, fuzzy
 msgid "Pause auto-refresh"
@@ -10305,8 +10649,11 @@ msgstr "Personne ou groupe qui a certifié ce tableau de bord."
 msgid "Person or group that has certified this metric"
 msgstr "Personne ou groupe qui a certifié cette mesure"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "Informations personnelles"
 
 msgid "Physical"
 msgstr "Physique"
@@ -10375,8 +10722,11 @@ msgstr "Epingler à gauche"
 msgid "Pin Right"
 msgstr "Epingler à droite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "Épingler au panneau de résultats"
 
 #, fuzzy
 msgid "Pin to top"
@@ -10709,9 +11059,11 @@ msgstr "Mot de passe de la Clé privée"
 msgid "Proceed"
 msgstr "Continuer"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "Traitement de l'exportation pour %s"
 
 msgid "Processing export..."
 msgstr "Génération de l'export..."
@@ -10729,11 +11081,17 @@ msgstr "Déclassé"
 msgid "Proportional"
 msgstr "Proportionnel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Feuilles partagées publiquement et en privé"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Feuilles partagées publiquement uniquement"
 
 msgid "Published"
 msgstr "Publié"
@@ -11242,8 +11600,11 @@ msgstr "Réinitialiser"
 msgid "Reset Columns"
 msgstr "Sélectionner une colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "Réinitialiser tous les dossiers aux valeurs par défaut"
 
 #, fuzzy
 msgid "Reset columns"
@@ -11272,8 +11633,11 @@ msgstr "La ressource a déjà un rapport joint."
 msgid "Resource was not found."
 msgstr "Base de données non trouvée."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "La ressource a été supprimée avant que la propriété n'ait pu être vérifiée"
 
 msgid "Restore filter"
 msgstr "Restaurer le filtre"
@@ -11324,8 +11688,11 @@ msgstr "Supprimer"
 msgid "Revoke API Key"
 msgstr "Clé de regroupement"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Révoquer cette clé API"
 
 #, fuzzy
 msgid "Revoked"
@@ -11541,11 +11908,18 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab ne peut pas autoriser une instruction qui n'a pas pu être "
+"entièrement analysée. Qualifiez explicitement les tables et évitez le SQL"
+" dynamique dans les procédures stockées ou les appels spécifiques au "
+"fournisseur."
 
 #, fuzzy
 msgid "SQL Lab queries"
@@ -11724,8 +12098,11 @@ msgstr "Enregistrer ou remplacer l’ensemble de données"
 msgid "Save query"
 msgstr "Enregistrer la requête"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Enregistrez cette clé API en lieu sûr"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr ""
@@ -11762,8 +12139,13 @@ msgstr "Enregistrement..."
 msgid "Scale and Move"
 msgstr "Échelle et mouvement"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
 msgstr ""
+"Facteur d'échelle appliqué aux largeurs de ligne déterminées par les "
+"métriques"
 
 msgid "Scale only"
 msgstr "Échelle seulement"
@@ -12055,8 +12437,11 @@ msgstr ""
 "d'agrégation sur une colonne ou écrire du SQL personnalisé pour créer une"
 " métrique."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr ""
+msgstr "Sélectionner un modèle CSS prédéfini à appliquer à votre tableau de bord"
 
 msgid "Select a schema"
 msgstr "Sélectionner un schéma"
@@ -12224,6 +12609,9 @@ msgstr "Format de courriel"
 msgid "Select groups"
 msgstr "Sélectionner les propriétaires"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -12231,6 +12619,13 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"Sélectionnez les couches dans l'ordre dans lequel vous souhaitez les "
+"empiler. La première sélectionnée apparaît en bas. Les couches vous "
+"permettent de combiner plusieurs visualisations sur une seule carte. "
+"Chaque couche est un graphique deck.gl enregistré (comme des nuages de "
+"points, des polygones ou des arcs) qui affiche différentes données ou "
+"informations. Empilez-les pour révéler des tendances et des relations "
+"dans vos données."
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -12360,21 +12755,44 @@ msgstr ""
 "les graphiques qui utilisent le même ensemble de données ou contiennent "
 "le même nom de colonne dans le tableau de bord."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
 msgstr ""
+"Sélectionner la couleur utilisée pour les valeurs indiquant une hausse "
+"dans le graphique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
 msgstr ""
+"Sélectionner la couleur utilisée pour les valeurs représentant les barres"
+" totales dans le graphique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
+"Sélectionner la couleur utilisée pour les valeurs indiquant une baisse "
+"dans le graphique."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"Sélectionner la colonne contenant les codes de devise tels que USD, EUR, "
+"GBP, etc. Utilisée lors de la création de graphiques lorsque le formatage"
+" de devise « Détection automatique » est activé. Si cette colonne n'est "
+"pas définie ou si une métrique de graphique contient plusieurs devises, "
+"les graphiques utiliseront un formatage numérique neutre."
 
 #, fuzzy
 msgid "Select the fixed color"
@@ -12384,15 +12802,26 @@ msgstr "Sélectionner la colonne geojson"
 msgid "Select the geojson column"
 msgstr "Sélectionner la colonne geojson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Sélectionner le fournisseur de tuiles cartographiques. MapLibre est open "
+"source et ne nécessite pas de clé API. Mapbox requiert que MAPBOX_API_KEY"
+" soit configuré dans Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Sélectionner la métrique utilisée pour déterminer dans quelle plage de "
+"point de rupture de couleur tombe chaque chemin."
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -12415,11 +12844,18 @@ msgstr ""
 "panneau de commande. Exécutez ensuite la requête en cliquant sur le "
 "bouton %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Sélectionner les granularités temporelles disponibles dans le contrôle de"
+" filtre. Il s'agit uniquement d'une liste d'autorisation de l'interface "
+"utilisateur et n'ajoute pas de conditions supplémentaires aux requêtes "
+"sous-jacentes."
 
 #, fuzzy
 msgid "Selected"
@@ -12441,11 +12877,17 @@ msgstr "courriel"
 msgid "Semantic Layer"
 msgstr "Couche d'annotations"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Vue sémantique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Vues sémantiques"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12503,11 +12945,17 @@ msgstr "L’ensemble de données n'existe pas"
 msgid "Semantic view parameters are invalid."
 msgstr "Les paramètres de l'ensemble de données ne sont pas valides."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Vue sémantique mise à jour"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Vues sémantiques"
 
 msgid "Send as CSV"
 msgstr "Envoyer comme CSV"
@@ -12542,11 +12990,17 @@ msgstr "Style de série"
 msgid "Series chart type (line, bar etc)"
 msgstr "Type de graphique de la série (ligne, barre, etc.)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "Paramètre de diminution de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "Paramètre d'augmentation de série"
 
 msgid "Series limit"
 msgstr "Limite de série"
@@ -12631,11 +13085,18 @@ msgstr "Supprimer le rapport par courriel"
 msgid "Set up basic details, such as name and description."
 msgstr "Configurer les informations de base, telles que le nom et la description."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"Définit la colonne temporelle par défaut pour ce jeu de données. "
+"Sélectionnée automatiquement comme colonne de temps lors de la création "
+"de graphiques nécessitant une dimension temporelle et utilisée dans les "
+"filtres de temps au niveau du tableau de bord."
 
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
@@ -13046,14 +13507,29 @@ msgstr ""
 msgid "Solid"
 msgstr "Solide"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
 msgstr ""
+"Certains groupes n'ont pas pu être résolus et sont affichés sous forme "
+"d'identifiants."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
 msgstr ""
+"Certaines autorisations n'ont pas pu être résolues et sont affichées sous"
+" forme d'identifiants."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
+"Certains filtres obligatoires sur d'autres onglets ont des valeurs et ne "
+"seront pas effacés"
 
 msgid "Some roles do not exist"
 msgstr "Des profils n'existent pas"
@@ -13199,11 +13675,18 @@ msgstr "Trier les mesures"
 msgid "Sort query by"
 msgstr "Exporter la requête"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Trier les résultats par nom de série en ordre croissant. Combiné avec « "
+"Trier par métrique », cela sert de critère de départage pour les valeurs "
+"de métrique égales. L'ajout de ce tri peut réduire les performances des "
+"requêtes sur certaines bases de données."
 
 msgid "Sort rows by"
 msgstr "Trier les rangées par"
@@ -13419,8 +13902,13 @@ msgstr "Tracé"
 msgid "Structural"
 msgstr "Structurel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
 msgstr ""
+"La structure est gérée par la couche sémantique en amont et est en "
+"lecture seule."
 
 msgid "Style"
 msgstr "Style"
@@ -13750,10 +14238,15 @@ msgstr "La balise n'a pas pu être créée."
 msgid "Task could not be updated."
 msgstr "Le jeu de données n'a pas pu être mis à jour."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"La tâche ne peut pas être interrompue. La tâche est en cours mais n'a pas"
+" enregistré de gestionnaire d'interruption."
 
 #, fuzzy
 msgid "Task parameters are invalid."
@@ -13763,8 +14256,13 @@ msgstr "Les paramètres de balise sont invalides."
 msgid "Tasks"
 msgstr "tags"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
 msgstr ""
+"Les tâches apparaîtront ici au fur et à mesure que les opérations en "
+"arrière-plan seront exécutées."
 
 #, fuzzy
 msgid "Template"
@@ -13862,17 +14360,30 @@ msgstr ""
 "restitue sous forme de polygones, de lignes et de points interactifs "
 "(cercles, icônes et/ou textes)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Le Global Task Framework n'est pas activé. Veuillez contacter votre "
+"administrateur pour activer l'indicateur de fonctionnalité "
+"GLOBAL_TASK_FRAMEWORK."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Le Global Task Framework n'est pas activé. Définissez "
+"GLOBAL_TASK_FRAMEWORK=True dans vos indicateurs de fonctionnalité pour "
+"utiliser @task. Consultez https://superset.apache.org/docs/configuration"
+"/async-queries-celery pour les détails de configuration."
 
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
@@ -13924,8 +14435,13 @@ msgstr ""
 "La catégorie de nœuds sources utilisée pour attribuer des couleurs. Si un"
 " nœud est associé à plus d’une catégorie, seul le premier sera utilisé."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
 msgstr ""
+"Le graphique est encore en cours de chargement. Veuillez patienter un "
+"instant et réessayer."
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
@@ -14161,8 +14677,11 @@ msgstr ""
 "automatiquement l'étendue pour inclure tous les points de données dans la"
 " vue. CUSTOM permet aux utilisateurs de définir manuellement l'étendue."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "La propriété d'entité à utiliser pour les étiquettes de points"
 
 #, python-format
 msgid ""
@@ -14172,10 +14691,16 @@ msgstr ""
 "Les entrées suivantes dans « series_columns » sont manquantes dans « "
 "columns » : %(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"Les champs suivants contiennent des informations sensibles qui ont été "
+"masquées lors de l'exportation. Veuillez fournir les valeurs pour "
+"importer cette base de données."
 
 #, python-format
 msgid ""
@@ -14254,16 +14779,27 @@ msgstr "Le nom d'hôte fourni ne peut pas être résolu."
 msgid "The id of the active chart"
 msgstr "L'identifiant du graphique actif"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"L'URL de l'image de l'icône à afficher pour les points GeoJSON. Notez que"
+" l'URL de l'image doit être conforme à la politique de sécurité du "
+"contenu (CSP) pour se charger correctement."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
 msgstr ""
+"Le niveau initial (profondeur) de l'arbre. S'il est défini à -1, tous les"
+" nœuds sont développés."
 
 #, fuzzy
 msgid "The layer attribution"
@@ -14457,8 +14993,13 @@ msgstr ""
 "fichiers d'export et doivent être ajoutés manuellement après l'import si "
 "nécessaire."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
 msgstr ""
+"Les mots de passe des bases de données ci-dessous sont nécessaires pour "
+"les importer."
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr ""
@@ -14773,11 +15314,17 @@ msgstr "Ajouter le nom du graphique"
 msgid "The type of visualization to display"
 msgstr "Le type de visualisation à afficher"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for icon size"
-msgstr ""
+msgstr "L'unité de taille des icônes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "L'unité de taille des étiquettes"
 
 msgid "The unit of measure for the specified point radius"
 msgstr "L'unité de mesure pour le rayon de point spécifié"
@@ -14845,10 +15392,15 @@ msgstr "La largeur des lignes"
 msgid "The width of the lines"
 msgstr "La largeur des lignes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
 msgstr ""
+"La largeur des lignes sous forme de valeur fixe ou de largeur variable "
+"basée sur une métrique."
 
 msgid "Theme"
 msgstr "Thème"
@@ -14911,11 +15463,15 @@ msgstr ""
 "Espace insuffisant pour ce composant. Diminuez sa largeur ou augmentez la"
 " largeur de destination."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"Un problème est survenu lors de l'actualisation de votre tableau de bord."
+" Nous réessaierons dans %s, comme prévu."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -15352,12 +15908,20 @@ msgstr ""
 "Cette table de base de données ne contient aucune donnée. Veuillez "
 "sélectionner un autre tableau."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Cette base de données utilise OAuth2 pour l'authentification. Veuillez "
+"cliquer sur le lien ci-dessus pour accorder à Apache Superset "
+"l'autorisation d'accéder aux données. Votre jeton d'accès personnel sera "
+"stocké de manière chiffrée et utilisé uniquement pour les requêtes que "
+"vous exécutez."
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
@@ -15399,35 +15963,62 @@ msgstr "La liste de valeurs du filtre ne peut pas être vide"
 msgid "This filter might be incompatible with current %s"
 msgstr "Ce filtre pourrait être incompatible avec l’ensemble de données actuel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "Ce dossier est actuellement vide"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Ce dossier ne prend en charge que les colonnes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Ce dossier ne prend en charge que les métriques"
 
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr ""
 "Cette fonctionnalité est désactivée dans votre environnement pour des "
 "raisons de sécurité."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
+"Il s'agit d'un dossier de colonnes par défaut. Son nom ne peut pas être "
+"modifié ni supprimé. Il peut rester vide mais n'acceptera que des "
+"éléments de colonne."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
+"Il s'agit d'un dossier de métriques par défaut. Son nom ne peut pas être "
+"modifié ni supprimé. Il peut rester vide mais n'acceptera que des "
+"éléments de métrique."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "Ceci est un message d'erreur personnalisé pour a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "Ceci est un message d'erreur personnalisé pour b"
 
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
@@ -15453,8 +16044,11 @@ msgstr "Ceci est le thème par défaut du système"
 msgid "This is the default light theme"
 msgstr "Ceci est le thème clair par défaut du système"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "C'est la seule fois que vous verrez cette clé. Conservez-la en lieu sûr."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -15466,13 +16060,20 @@ msgstr ""
 " la position des widgets par glisser-déposer dans la vue du tableau de "
 "bord"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Ce lien ne peut pas être suivi car son adresse n'est pas sécurisée."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Ce lien vous dirigera vers un site web externe. Nous ne pouvons pas "
+"garantir la sécurité des destinations externes."
 
 msgid "This markdown component has an error."
 msgstr "Ce composant markdown comporte une erreur."
@@ -15575,9 +16176,11 @@ msgid_plural "This may be triggered by:"
 msgstr[0] "Cela a été déclenché par :"
 msgstr[1] "Ceci peut être déclenché par :"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "Cela interrompra (arrêtera) la tâche pour tous les %s abonné(s)."
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
@@ -15589,16 +16192,24 @@ msgstr ""
 "diminutions. La mise en forme conditionnelle de base peut être remplacée "
 "par la mise en forme conditionnelle ci-dessous."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "Cela annulera la tâche."
 
 msgid "This will remove your current embed configuration."
 msgstr "Cela supprimera votre configuration d’intégration actuelle."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
+"Cela réorganisera toutes les métriques et colonnes dans les dossiers par "
+"défaut. Tous les dossiers personnalisés seront supprimés."
 
 msgid "Threshold"
 msgstr "Seuil"
@@ -15801,11 +16412,16 @@ msgstr "Format de temps"
 msgid "Timeline"
 msgstr "Fuseau horaire"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Délai d'expiration configuré (%s secondes) mais aucun gestionnaire "
+"d'interruption défini. La tâche continuera à s'exécuter après "
+"l'expiration du délai."
 
 msgid "Timeout error"
 msgstr "Erreur de dépassement de délai"
@@ -15834,12 +16450,20 @@ msgstr "Le titre est obligatoire"
 msgid "Title or Slug"
 msgstr "Titre ou logotype"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Pour commencer à utiliser vos Google Sheets, vous devez d'abord créer une"
+" base de données. Les bases de données sont utilisées comme moyen "
+"d'identifier vos données afin qu'elles puissent être interrogées et "
+"visualisées. Cette base de données contiendra toutes vos Google Sheets "
+"individuelles que vous choisissez de connecter ici."
 
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
@@ -15854,8 +16478,11 @@ msgstr "Pour filtrer sur une mesure, utiliser l'onglet Custom SQL."
 msgid "To get a readable URL for your dashboard"
 msgstr "Pour obtenir une URL lisible pour votre tableau de bord"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "URI de demande de jeton"
 
 #, fuzzy
 msgid "Tool Panel"
@@ -15997,8 +16624,11 @@ msgstr "Tronquer les cellules longues à la « largeur minimale » définie ci
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr "Tronquer la date spécifiée à la précision spécifiée par l'unité de date."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Faire confiance à cette URL et ne plus demander"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
@@ -16036,8 +16666,11 @@ msgstr "Saisissez une valeur"
 msgid "Type is required"
 msgstr "Le type est requis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "Type de Google Sheets autorisé"
 
 #, fuzzy
 msgid "Type of chart to display in sparkline"
@@ -16050,11 +16683,17 @@ msgstr "Type de comparaison, différence de valeur ou pourcentage"
 msgid "Type to search (contains)..."
 msgstr "Recherche de colonnes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Tapez pour rechercher (se termine par)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Tapez pour rechercher (commence par)..."
 
 msgid "UI Configuration"
 msgstr "Configuration UI"
@@ -16117,10 +16756,16 @@ msgstr ""
 msgid "Unable to create chart without a query id."
 msgstr "Impossible de créer un graphique sans ID de requête."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"Impossible de créer le rapport : l'adresse e-mail de l'utilisateur est "
+"requise mais introuvable. Veuillez vous assurer que votre profil "
+"utilisateur dispose d'une adresse e-mail valide."
 
 msgid "Unable to decode value"
 msgstr "Impossible de décoder la valeur"
@@ -16128,8 +16773,13 @@ msgstr "Impossible de décoder la valeur"
 msgid "Unable to encode value"
 msgstr "Impossible de coder la valeur"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
+"Impossible de récupérer les vues sémantiques. Vérifiez la configuration "
+"de la couche."
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
@@ -16278,8 +16928,11 @@ msgstr "Erreur inconnue"
 msgid "Unknown input format"
 msgstr "Format d'entrée inconnu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "Les jetons inconnus seront mis en évidence comme avertissements."
 
 #, fuzzy
 msgid "Unknown type"
@@ -16293,14 +16946,22 @@ msgstr "Valeur inconnue"
 msgid "Unpin"
 msgstr "en cours d’exécution"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Détacher du panneau de résultats"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Détacher du haut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Lien non sécurisé bloqué"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
@@ -16314,8 +16975,13 @@ msgstr "Valeur de modèle non sûre pour la clé %(key)s: %(value_type)s"
 msgid "Unsupported clause type: %(clause)s"
 msgstr "Type de clause non pris en charge : %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
 msgstr ""
+"Type de fichier non pris en charge. Veuillez utiliser des fichiers CSV, "
+"Excel ou en colonnes."
 
 #, python-format
 msgid "Unsupported post processing operation: %(operation)s"
@@ -16420,10 +17086,16 @@ msgstr "Utilisez %s pour ouvrir un nouvel onglet."
 msgid "Use Area Proportions"
 msgstr "Utiliser les proportions d'aires"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
+"Utilisez la syntaxe Handlebars pour créer des info-bulles personnalisées."
+" Les variables disponibles sont basées sur votre sélection de contenu d"
+"'info-bulle ci-dessus."
 
 msgid "Use a log scale"
 msgstr "Utiliser une échelle de journalisation"
@@ -16590,8 +17262,11 @@ msgstr ""
 "valeur a suivies. Utile pour la visualisation d’entonnoirs et de "
 "pipelines à plusieurs étapes et groupes."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Utilise les 25 premières valeurs si la dimension en contient davantage."
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -16884,8 +17559,11 @@ msgstr "WMS"
 msgid "WMS"
 msgstr "WMS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "En attente du premier rafraîchissement"
 
 #, python-format
 msgid "Waiting on %s"
@@ -16897,8 +17575,11 @@ msgstr "En attente de la base de donnée..."
 msgid "Want to add a new database?"
 msgstr "Ajouter un nouvelle base de données?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "Entrepôt"
 
 msgid "Warning"
 msgstr "Avertissement"
@@ -16913,10 +17594,16 @@ msgstr ""
 "Attention! Changer l’ensemble de données peut mettre en erreur le "
 "graphique si la métadonnées n'existe pas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Avertissement : les requêtes ILIKE peuvent être lentes sur les grands "
+"ensembles de données car elles ne peuvent pas utiliser les index "
+"efficacement."
 
 msgid "Was unable to check your query"
 msgstr "Impossible de vérifier votre requête"
@@ -17797,8 +18484,11 @@ msgstr "Vous devez entrer un nom pour le nouveau tableau de Bord"
 msgid "You must run the query successfully first"
 msgstr "Vous devez d'abord exécuter la requête avec succès"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Vous devez"
 
 msgid ""
 "You updated the values in the control panel, but the chart was not "
@@ -17809,11 +18499,15 @@ msgstr ""
 "graphique n’a pas été mis à jour automatiquement. Exécutez la requête en "
 "cliquant sur le bouton « Mettre à jour le graphique » ou"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Vous serez retiré de cette tâche. Elle continuera à s'exécuter pour %s "
+"autre(s) abonné(s)."
 
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
@@ -17823,11 +18517,17 @@ msgstr ""
 "des données (colonnes, mesures) qui correspondent à ce nouveau ensemble "
 "de données ont été conservés."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "Votre compte est activé. Vous pouvez vous connecter avec vos identifiants."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "Vos modifications seront perdues si vous quittez sans enregistrer."
 
 msgid "Your chart is not up to date"
 msgstr "Votre graphique n’est pas à jour"
@@ -17930,8 +18630,11 @@ msgstr ""
 " en tant que rapport par rapport à la mesure primaire. Si elle est omise,"
 " la couleur est catégorique et basée sur des étiquettes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[personnalisation sans titre]"
 
 msgid "`compare_columns` must have the same length as `source_columns`."
 msgstr "« compare_columns » doit être de même longueur que « source_columns »."
@@ -17955,9 +18658,10 @@ msgstr ""
 msgid "`operation` property of post processing object undefined"
 msgstr "La propriété « operation » de l'objet de post-traitement est indéfinie"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` doit être compris entre 1 et %(max)s"
 
 msgid "`prophet` package not installed"
 msgstr "Paquet « prophet » non installée"
@@ -18308,8 +19012,11 @@ msgstr "p. ex. world_population"
 msgid "e.g. xy12345.us-east-2.aws"
 msgstr "p. ex., xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "ex. : pipeline CI/CD, script d'analyse"
 
 msgid "edit mode"
 msgstr "mode edition"
@@ -18360,14 +19067,20 @@ msgstr "chaque mois"
 msgid "expand"
 msgstr "agrandir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard doit être un objet"
 
 msgid "failed"
 msgstr "échoué"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "au revoir"
 
 msgid "fetching"
 msgstr "récupération"
@@ -18407,8 +19120,11 @@ msgstr ""
 "carte thermique : les valeurs sont normalisées sur toute la carte "
 "thermique"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "bonjour"
 
 msgid "here"
 msgstr "ici"
@@ -18419,8 +19135,11 @@ msgstr "heure"
 msgid "in"
 msgstr "dans"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "afin d'exécuter cette opération."
 
 msgid "invalid email"
 msgstr "email invalide"
@@ -18452,16 +19171,16 @@ msgid ""
 msgstr ""
 "est liée à %s graphiques qui apparaissent sur %s tableaux de bord et les "
 "utilisateurs ont %s onglets SQL Lab ouverts qui utilisent cette base de "
-"données. Êtes-vous sûr de vouloir continuer ? La suppression de la base de"
-" données brisera ces objets."
+"données. Êtes-vous sûr de vouloir continuer ? La suppression de la base "
+"de données brisera ces objets."
 
 #, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
 msgstr ""
-"est lié à %s graphiques qui apparaissent sur %s tableaux de bord. Êtes-vous"
-" sûr de vouloir continuer ? La suppression de l'ensemble de données "
+"est lié à %s graphiques qui apparaissent sur %s tableaux de bord. Êtes-"
+"vous sûr de vouloir continuer ? La suppression de l'ensemble de données "
 "brisera ces objets."
 
 msgid "is not"
@@ -18562,30 +19281,45 @@ msgstr "doit avoir une valeur"
 msgid "name"
 msgstr "Nom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters doit être une liste"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] clés requises manquantes : %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] doit être un objet"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues doit être une liste"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
 msgstr ""
+"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' n'existe pas sur le"
+" tableau de bord"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId doit être une chaîne non vide"
 
 #, fuzzy
 msgid "no SQL validator is configured"
@@ -18817,8 +19551,11 @@ msgstr "Couleur cible"
 msgid "textarea"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "la documentation du graphique Handlebars"
 
 msgid "theme"
 msgstr "thème"
@@ -18925,5 +19662,8 @@ msgstr "zone de zoom"
 msgid "© Layer attribution"
 msgstr "© Attribution de la couche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the French (`fr`) catalog using `scripts/translations/backfill_po.py` (Claude, cross-language context), **skipping do-not-translate tokens** (icon names, enum values, SQL keywords, API field names, placeholders — see #41651).

All generated strings are marked `#, fuzzy` with an attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend (`pybabel compile --use-fuzzy`, see #41648) builds include fuzzy entries, so these translations render in the UI once built — reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only — no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l fr` succeeds.
- French native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API