### PR TITLE
feat(i18n): backfill Slovenian (sl) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -88,7 +88,9 @@ msgstr ""
 "                Pri shranjevanju grafikona se ne bo shranil.\n"
 "              "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "\n"
 "            <p>Your report/alert was unable to be generated because of "
@@ -97,6 +99,13 @@ msgid ""
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
+"\n"
+"            <p>Vašega poročila/opozorila ni bilo mogoče ustvariti zaradi "
+"naslednje napake: %(text)s</p>\n"
+"            <p>Prosimo, preverite nadzorno ploščo/grafikon za napake.</p>"
+"\n"
+"            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
+"            "
 
 msgid " (excluded)"
 msgstr " (ni vključeno)"
@@ -166,8 +175,11 @@ msgstr " za dodajanje izračunanih stolpcev"
 msgid " to add metrics"
 msgstr " za dodajanje mer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to check for details."
-msgstr ""
+msgstr " za preverjanje podrobnosti."
 
 msgid " to edit or add columns and metrics."
 msgstr " za urejanje ali dodajanje stolpcev in mer."
@@ -190,13 +202,17 @@ msgstr " za vizualizacijo podatkov."
 msgid "!= (Is not equal)"
 msgstr "!= (ni enako)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system dark theme"
-msgstr ""
+msgstr "\"%s\" je zdaj sistemska temna tema"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system default theme"
-msgstr ""
+msgstr "\"%s\" je zdaj privzeta sistemska tema"
 
 #, python-format
 msgid "% calculation"
@@ -236,11 +252,15 @@ msgstr "%(object)s ne obstaja v tej podatkovni bazi."
 msgid "%(prefix)s %(title)s"
 msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sRezultati so bili skrajšani na %(row_count)s vrstic zaradi "
+"omejitev pomnilnika."
 
 #, python-format
 msgid ""
@@ -329,9 +349,11 @@ msgstr "Izbranih: %s (fizični)"
 msgid "%s Selected (Virtual)"
 msgstr "Izbranih: %s (virtualni)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Semantični pogled"
 
 #, fuzzy, python-format
 msgid "%s URL"
@@ -497,17 +519,23 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s semantičnih pogledov dodano"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "Dodajanje %s semantičnih pogledov ni uspelo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "Dodajanje %s semantičnih pogledov ni uspelo: %s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
@@ -571,8 +599,11 @@ msgstr ""
 msgid "+ %s more"
 msgstr "+ %s več"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ", then paste the JSON below. See our"
-msgstr ""
+msgstr ", nato prilepite JSON spodaj. Oglejte si naše"
 
 msgid ""
 "-- Note: Unless you save your query, these tabs will NOT persist if you "
@@ -844,19 +875,31 @@ msgstr ">= (večje ali enako)"
 msgid "A Big Number"
 msgstr "Velika številka"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "Funkcija JavaScript, ki ustvari konfiguracijski objekt oznake"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "Funkcija JavaScript, ki ustvari konfiguracijski objekt ikone"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"Objekt JavaScript, ki ustreza specifikaciji možnosti ECharts in prepiše "
+"druge možnosti kontrolnika z višjo prednostjo. (npr. { title: { text: "
+"\"My Chart\" }, tooltip: { trigger: \"item\" } }). Podrobnosti: "
+"https://echarts.apache.org/en/option.html. "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
@@ -871,8 +914,11 @@ msgstr "Pri povezavi preko SSH-tunela so potrebna vrata podatkovne baze."
 msgid "A database with the same name already exists."
 msgstr "Podatkovna baza z enakim imenom že obstaja."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A date is required when using custom date shift"
-msgstr ""
+msgstr "Datum je obvezen pri uporabi prilagojenega premika datuma"
 
 #, python-brace-format
 msgid ""
@@ -1018,11 +1064,17 @@ msgstr "Poročilo je bilo ustvarjeno"
 msgid "API key name is required"
 msgstr "Zahtevano je ime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "Ključ API je bil uspešno preklican"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "Ključi API omogočajo omejeni programski dostop do Superset."
 
 msgid "APPLY"
 msgstr "UPORABI"
@@ -1122,10 +1174,15 @@ msgstr "Skrij sloj"
 msgid "Add Log"
 msgstr "Dodaj dnevnik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Add Query A and Query B identifiers to tooltips to help differentiate "
 "series"
 msgstr ""
+"Dodaj identifikatorje Poizvedbe A in Poizvedbe B v opise orodij za lažje "
+"razlikovanje serij"
 
 #, fuzzy
 msgid "Add Role"
@@ -1314,13 +1371,15 @@ msgstr "Dodaj na nadzorno ploščo"
 msgid "Added"
 msgstr "Dodano"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "V virtualni nabor podatkov je bil dodan 1 nov stolpec"
+msgstr[1] "V virtualni nabor podatkov sta bila dodana %s nova stolpca"
+msgstr[2] "V virtualni nabor podatkov so bili dodani %s novi stolpci"
+msgstr[3] "V virtualni nabor podatkov je bilo dodanih %s novih stolpcev"
 
 #, python-format
 msgid "Added to 1 dashboard"
@@ -1407,10 +1466,15 @@ msgstr "Zadevane nadzorne plošče"
 msgid "After"
 msgstr "Potem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "After making the changes, copy the query and paste in the virtual dataset"
 " SQL snippet settings."
 msgstr ""
+"Po izvedbi sprememb kopirajte poizvedbo in jo prilepite v nastavitve "
+"delčka SQL virtualnega nabora podatkov."
 
 msgid "Aggregate"
 msgstr "Agregacija"
@@ -2081,8 +2145,11 @@ msgstr "Oznake in sloji"
 msgid "Annotations could not be deleted."
 msgstr "Oznak ni mogoče izbrisati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ant Design Theme Editor"
-msgstr ""
+msgstr "Urejevalnik tem Ant Design"
 
 msgid "Any"
 msgstr "Katerikoli"
@@ -2097,13 +2164,21 @@ msgstr ""
 "Na tem mestu izbrana barvna shema bo nadomestila barve posameznih "
 "grafikonov v tej nadzorni plošči"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Any dashboards using these themes will be automatically dissociated from "
 "them."
 msgstr ""
+"Vse nadzorne plošče, ki uporabljajo te teme, bodo samodejno ločene od "
+"njih."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Any dashboards using this theme will be automatically dissociated from it."
-msgstr ""
+msgstr "Vse nadzorne plošče, ki uporabljajo to temo, bodo samodejno ločene od nje."
 
 msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
 msgstr ""
@@ -2140,11 +2215,16 @@ msgstr ""
 "Izbrano drseče okno ni vrnilo podatkov. Poskrbite, da izvorna poizvedba "
 "ustreza minimalni periodi drsečega okna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"Velja samo, ko je izbrano oblikovanje »Celični trakovi«: ozadje stolpcev "
+"histograma se prikaže, če je omogočena možnost »Prikaži celične trakove«."
 
 msgid "Apply"
 msgstr "Uporabi"
@@ -2166,10 +2246,15 @@ msgstr "Za mere uporabi pogojno oblikovanje z barvami"
 msgid "Apply conditional color formatting to numeric columns"
 msgstr "Za numerične stolpce uporabi pogojno oblikovanje z barvami"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Apply custom CSS to the dashboard. Use class names or element selectors "
 "to target specific components."
 msgstr ""
+"Nanesite lastni CSS na nadzorno ploščo. Uporabite imena razredov ali "
+"selektorje elementov za ciljanje določenih komponent."
 
 msgid "Apply filters"
 msgstr "Uporabi filtre"
@@ -2240,15 +2325,25 @@ msgstr "Ali ste prepričani, da želite izbrisati izbrane poizvedbe?"
 msgid "Are you sure you want to overwrite this dataset?"
 msgstr "Ali ste prepričani, da želite prepisati podatkovni set?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system dark theme? The application "
 "will fall back to the configuration file dark theme."
 msgstr ""
+"Ste prepričani, da želite odstraniti sistemsko temno temo? Aplikacija se "
+"bo vrnila na temno temo iz konfiguracijske datoteke."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system default theme? The application"
 " will fall back to the configuration file default."
 msgstr ""
+"Ste prepričani, da želite odstraniti privzeto sistemsko temo? Aplikacija "
+"se bo vrnila na privzeto nastavitev iz konfiguracijske datoteke."
 
 #, fuzzy
 msgid ""
@@ -2259,17 +2354,25 @@ msgstr "Ali ste prepričani, da želite izbrisati izbrane oznake?"
 msgid "Are you sure you want to save and apply changes?"
 msgstr "Ali resnično želite shraniti in uporabiti spremembe?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system dark theme? This will "
 "apply to all users who haven't set a personal preference."
 msgstr ""
+"Ste prepričani, da želite nastaviti \"%s\" kot sistemsko temno temo? To "
+"bo veljalo za vse uporabnike, ki niso nastavili osebnih nastavitev."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system default theme? This "
 "will apply to all users who haven't set a personal preference."
 msgstr ""
+"Ste prepričani, da želite nastaviti \"%s\" kot privzeto sistemsko temo? "
+"To bo veljalo za vse uporabnike, ki niso nastavili osebnih nastavitev."
 
 msgid "Area"
 msgstr "Ploščina"
@@ -2324,13 +2427,19 @@ msgstr "Samodejno"
 msgid "Auto Zoom"
 msgstr "Samodejna povečava"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Samodejno osveževanje je zaustavljeno (nastavljeno na %s sekund)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
 msgstr ""
+"Samodejno osveževanje je zaustavljeno – zavihek neaktiven (nastavljeno na"
+" %s sekund)"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
@@ -2349,11 +2458,17 @@ msgstr "Samodokončaj filtre"
 msgid "Autocomplete query predicate"
 msgstr "Predikat za samodokončanje poizvedb"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on available space"
-msgstr ""
+msgstr "Samodejno prilagajanje širine stolpca glede na razpoložljiv prostor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on content"
-msgstr ""
+msgstr "Samodejno prilagajanje širine stolpca glede na vsebino"
 
 #, fuzzy
 msgid "Automatically sync columns"
@@ -2470,15 +2585,23 @@ msgstr "Višina grafikona"
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr "Slog osnovnega zemljevida. Glej dokumentacijo Mapbox: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Slog karte osnovnega sloja. Sprejema URL sloga Mapbox "
+"(mapbox://styles/...)."
 
 #, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
 msgstr "Slog osnovnega zemljevida. Glej dokumentacijo Mapbox: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Base slope"
-msgstr ""
+msgstr "Osnovni naklon"
 
 #, fuzzy
 msgid "Base width"
@@ -2529,9 +2652,11 @@ msgstr "Razdelki"
 msgid "Blanks"
 msgstr "BOOLEAN"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "Blok %(block_num)s od %(block_count)s"
 
 #, fuzzy
 msgid "Border color"
@@ -2573,11 +2698,17 @@ msgstr ""
 "prazno, se meje nastavijo dinamično na podlagi min./max. vrednosti "
 "podatkov. Funkcija omeji le prikaz, obseg podatkov pa ostane enak."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the X-axis. Selected time merges with min/max date of the "
 "data. When left empty, bounds dynamically defined based on the min/max of"
 " the data."
 msgstr ""
+"Meje za os X. Izbrani čas se združi z minimalnim/maksimalnim datumom "
+"podatkov. Kadar je prazno, so meje dinamično določene na podlagi "
+"minimuma/maksimuma podatkov."
 
 msgid ""
 "Bounds for the Y-axis. When left empty, the bounds are dynamically "
@@ -2705,6 +2836,11 @@ msgstr "V vednost (CC)"
 msgid "COPY QUERY"
 msgstr "Kopiraj URL poizvedbe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Kopiraj poizvedbo"
+
 msgid "CREATE TABLE AS"
 msgstr "CREATE TABLE AS"
 
@@ -2732,11 +2868,17 @@ msgstr "CSS predloge"
 msgid "CSS applied to the chart"
 msgstr "CSS slogi uporabljeni za grafikon"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"Slogi CSS so morda odstranjeni s strežniško sanitizacijo HTML. Če se "
+"slogi ne uveljavljajo, prosite skrbnika Superset, da prilagodi "
+"konfiguracijo sanitizacije HTML."
 
 msgid "CSS template"
 msgstr "CSS predloga"
@@ -2796,10 +2938,16 @@ msgstr "CVAS (create view as select) poizvedba ni SELECT stavek."
 msgid "Cache Timeout (seconds)"
 msgstr "Trajanje predpomnilnika (sekunde)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
+"Predpomnite podatke ločeno za vsakega uporabnika glede na njegove vloge "
+"in dovoljenja za dostop do podatkov. Ko je onemogočeno, bo za vse "
+"uporabnike uporabljen en sam predpomnilnik."
 
 msgid "Cache timeout"
 msgstr "Časovna omejitev predpomnilnika"
@@ -2856,8 +3004,11 @@ msgstr "Prekliči"
 msgid "Cancel query on window unload event"
 msgstr "Prekini poizvedbo pri dogodku zaprtja okna (window unload event)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "Preklic ni na voljo zaradi manjkajočega upravljalnika prekinitve"
 
 msgid "Cannot access the query"
 msgstr "Dostop do poizvedbe ni mogoč"
@@ -2869,15 +3020,27 @@ msgstr "Podatkovne baze s povezanimi podatkovnimi viri ni mogoče izbrisati"
 msgid "Cannot delete system themes"
 msgstr "Dostop do poizvedbe ni mogoč"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
 msgstr ""
+"Ni mogoče izbrisati teme, ki je nastavljena kot privzeta sistemska ali "
+"temna tema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
 msgstr ""
+"Ni mogoče izbrisati teme, ki je nastavljena kot privzeta sistemska ali "
+"temna tema."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Cannot find the table (%s) metadata."
-msgstr ""
+msgstr "Ni mogoče najti metapodatkov tabele (%s)."
 
 msgid "Cannot have multiple credentials for the SSH Tunnel"
 msgstr "Za SSH-tunel ne morete imeti več prijavnih podatkov"
@@ -2885,11 +3048,17 @@ msgstr "Za SSH-tunel ne morete imeti več prijavnih podatkov"
 msgid "Cannot load filter"
 msgstr "Filtra ni mogoče naložiti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot modify system themes."
-msgstr ""
+msgstr "Sistemskih tem ni mogoče spreminjati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "Ni mogoče gnezditi map v privzetih mapah"
 
 #, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
@@ -2952,8 +3121,11 @@ msgstr "Velikost celice"
 msgid "Cell content"
 msgstr "Vsebina celice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "Postavitev in slog celice"
 
 msgid "Cell limit"
 msgstr "Omejitev števila celic"
@@ -3004,8 +3176,11 @@ msgstr "sprememba"
 msgid "Changes saved."
 msgstr "Spremembe shranjene."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changes the sort value of the items in the legend only"
-msgstr ""
+msgstr "Spremeni vrednost razvrščanja samo za elemente v legendi"
 
 msgid "Changing one or more of these dashboards is forbidden"
 msgstr "Spreminjanje teh nadzornih plošč ni dovoljeno"
@@ -3063,9 +3238,11 @@ msgstr "Znak, ki bo prepoznan kot decimalno ločilo"
 msgid "Chart"
 msgstr "Grafikon"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "Grafikon %(chart_id)s ni na nadzorni plošči %(dashboard_id)s"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3126,8 +3303,11 @@ msgstr "Grafikona ni mogoče ustvariti."
 msgid "Chart could not be updated."
 msgstr "Grafikona ni mogoče posodobiti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
-msgstr ""
+msgstr "Prilagajanje grafikona za nadzor vidnosti sloja deck.gl"
 
 #, fuzzy
 msgid "Chart customization value is required"
@@ -3274,21 +3454,34 @@ msgstr "Izberite stolpce, ki bodo prepoznani kot datumi"
 msgid "Choose columns to read"
 msgstr "Izberite stolpce za branje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
 msgstr ""
+"Izberite med obstoječimi filtri nadzorne plošče in izberite vrednost za "
+"natančnejšo opredelitev rezultatov poročila."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose how many X-Axis labels to show"
-msgstr ""
+msgstr "Izberite, koliko oznak osi X prikazati"
 
 msgid "Choose index column"
 msgstr "Izberite Indeksni stolpec"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
+"Izberite sloje, ki jih želite skriti iz vseh večslojnih grafikonov "
+"deck.gl na tej nadzorni plošči."
 
 msgid "Choose notification method and recipients."
 msgstr "Dodajte način obveščanja in prejemnike."
@@ -3390,8 +3583,11 @@ msgstr "počisti vse filtre"
 msgid "Clear default dark theme"
 msgstr "Privzet datumčas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "Počisti privzeto svetlo temo"
 
 msgid "Clear form"
 msgstr "Počisti polja"
@@ -3400,8 +3596,11 @@ msgstr "Počisti polja"
 msgid "Clear local theme"
 msgstr "Linearna barvna shema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear the selection to revert to the system default theme"
-msgstr ""
+msgstr "Počisti izbiro, da se vrneš na privzeto sistemsko temo"
 
 #, fuzzy
 msgid ""
@@ -3494,8 +3693,11 @@ msgstr "Zapri"
 msgid "Close all other tabs"
 msgstr "Zapri vse ostale zavihke"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Close color breakpoint editor"
-msgstr ""
+msgstr "Zapri urejevalnik barvnih prelomnih točk"
 
 msgid "Close tab"
 msgstr "Zapri zavihek"
@@ -3560,11 +3762,17 @@ msgstr "Barvna shema"
 msgid "Color Steps"
 msgstr "Barvni koraki"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Pobarvaj stolpce po osi x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Pobarvaj stolpce po osi y"
 
 msgid "Color bounds"
 msgstr "Barvne meje"
@@ -3576,8 +3784,11 @@ msgstr "Točke za razčlenitev razdelkov"
 msgid "Color by"
 msgstr "Barva glede na"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
-msgstr ""
+msgstr "Polje barve mora biti šestnajstiška barva (#rrggbb) ali 'rgb(r, g, b)'"
 
 #, fuzzy
 msgid "Color for breakpoint"
@@ -3699,8 +3910,11 @@ msgstr " za dodajanje mer"
 msgid "Columns and metrics should be inside folders"
 msgstr " za dodajanje mer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "Mapa stolpcev lahko vsebuje samo elemente stolpcev"
 
 #, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3710,8 +3924,11 @@ msgstr "V podatkovnem viru manjkajo stolpci: %(invalid_columns)s"
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "V podatkovnem viru manjkajo stolpci: %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "Stolpci naj bodo znotraj map"
 
 msgid "Columns subtotal position"
 msgstr "Položaj delnih vsot stolpcev"
@@ -3787,11 +4004,17 @@ msgstr ""
 "skupina predstavlja eno vrstico, časovne spremembe pa so prikazane z "
 "dolžino stolpcev in barvami."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
 msgstr ""
+"Primerja meritve med različnimi časovnimi obdobji. Prikazuje podatke "
+"časovnih vrst čez več obdobij (kot so tedni ali meseci), da prikaže "
+"trende in vzorce med obdobji."
 
 msgid "Comparison"
 msgstr "Primerjava"
@@ -3845,17 +4068,26 @@ msgstr "Nastavi časovno obdobje: Zadnji ..."
 msgid "Configure Time Range: Previous..."
 msgstr "Nastavi časovno obdobje: Prejšnji ..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure automatic dashboard refresh"
-msgstr ""
+msgstr "Konfiguriraj samodejno osveževanje nadzorne plošče"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure caching and performance settings"
-msgstr ""
+msgstr "Konfiguriraj nastavitve predpomnenja in zmogljivosti"
 
 msgid "Configure custom time range"
 msgstr "Nastavi prilagojeno časovno obdobje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure dashboard appearance, colors, and custom CSS"
-msgstr ""
+msgstr "Konfiguriraj videz nadzorne plošče, barve in CSS po meri"
 
 msgid "Configure filter scopes"
 msgstr "Nastavi doseg filtrov"
@@ -3863,8 +4095,11 @@ msgstr "Nastavi doseg filtrov"
 msgid "Configure the basics of your Annotation Layer."
 msgstr "Osnovne nastavitve sloja z oznakami."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure the chart size for each zoom level"
-msgstr ""
+msgstr "Konfiguriraj velikost grafikona za vsako raven povečave"
 
 msgid "Configure this dashboard to embed it into an external web application."
 msgstr "Nastavite nadzorno ploščo za vgradnjo v zunanjo spletno aplikacijo."
@@ -3890,8 +4125,11 @@ msgstr "Prikaži geslo."
 msgid "Confirm save"
 msgstr "Potrdite shranjevanje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm the user's password"
-msgstr ""
+msgstr "Potrdi geslo uporabnika"
 
 msgid "Connect"
 msgstr "Poveži"
@@ -3931,9 +4169,11 @@ msgstr "Povezava neuspešna. Preverite nastavitve povezave."
 msgid "Contains"
 msgstr "Zvezno"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Vsebuje besedilo (ILIKE %x%)"
 
 msgid "Content format"
 msgstr "Oblika vsebine"
@@ -3975,14 +4215,20 @@ msgstr "SQL kopiran!"
 msgid "Copy"
 msgstr "Kopiraj"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy SELECT statement"
-msgstr ""
+msgstr "Kopiraj stavek SELECT"
 
 msgid "Copy SELECT statement to the clipboard"
 msgstr "Kopiraj stavek SELECT na odložišče"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy URL"
-msgstr ""
+msgstr "Kopiraj URL"
 
 msgid "Copy and Paste JSON credentials"
 msgstr "Kopiraj in prilepi JSON prijavne podatke"
@@ -4008,8 +4254,11 @@ msgstr "Kopiraj povezavo v odložišče"
 msgid "Copy query link to your clipboard"
 msgstr "Kopiraj povezavo do poizvedbe v odložišče"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the current data"
-msgstr ""
+msgstr "Kopiraj trenutne podatke"
 
 msgid "Copy the identifier of the account you are trying to connect to."
 msgstr "Kopirajte ID računa, s katerim se skušate povezati."
@@ -4064,8 +4313,11 @@ msgstr "Ni mogoče naložiti gonilnika podatkovne baze: {}"
 msgid "Could not resolve hostname: \"%(host)s\"."
 msgstr "Gostitelj ni dosegljiv: \"%(host)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Could not validate the user in the current session."
-msgstr ""
+msgstr "Uporabnika v trenutni seji ni bilo mogoče preveriti."
 
 msgid "Count"
 msgstr "Število"
@@ -4254,8 +4506,11 @@ msgstr "Prilagojen SQL"
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr "Prilagodljive ad-hoc SQL-mere za ta podatkovni set niso omogočene"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
-msgstr ""
+msgstr "Polja SQL po meri ni mogoče razčleniti kot en sam stavek SQL."
 
 #, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
@@ -4267,8 +4522,11 @@ msgstr "Prilagojena SQL-polja ne smejo vsebovati podpoizvedb."
 msgid "Custom color palettes"
 msgstr "Prilagojene barvne palete"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom column name (leave blank for default)"
-msgstr ""
+msgstr "Ime stolpca po meri (pusti prazno za privzeto)"
 
 msgid "Custom conditional formatting"
 msgstr "Prilagojeno pogojno oblikovanje"
@@ -4276,8 +4534,11 @@ msgstr "Prilagojeno pogojno oblikovanje"
 msgid "Custom date"
 msgstr "Prilagojen datum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
-msgstr ""
+msgstr "Polja po meri niso na voljo v združenih celicah toplotne karte"
 
 msgid "Custom time filter plugin"
 msgstr "Prilagojeni vtičnik za časovni filter"
@@ -4311,10 +4572,15 @@ msgstr "Prilagodi"
 msgid "Customize Metrics"
 msgstr "Prilagodi mere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize cell titles using Handlebars template syntax. Available "
 "variables: {{rowLabel}}, {{colLabel}}"
 msgstr ""
+"Prilagodi naslove celic z uporabo sintakse predloge Handlebars. "
+"Razpoložljive spremenljivke: {{rowLabel}}, {{colLabel}}"
 
 msgid "Customize columns"
 msgstr "Prilagodi stolpce"
@@ -4322,20 +4588,35 @@ msgstr "Prilagodi stolpce"
 msgid "Customize data source, filters, and layout."
 msgstr "Prilagodite podatkovni vir, filtre in izgled."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Prilagodi oznako, prikazano za padajoče vrednosti v namigih in legendi "
+"grafikona."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Prilagodi oznako, prikazano za naraščajoče vrednosti v namigih in legendi"
+" grafikona."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
+"Prilagodi oznako, prikazano za skupne vrednosti v namigih grafikona, "
+"legendi in osi grafikona."
 
 #, fuzzy
 msgid "Customize tooltips template"
@@ -4437,8 +4718,10 @@ msgstr "Nadzorne plošče ni mogoče posodobiti."
 msgid "Dashboard could not be deleted."
 msgstr "Nadzorne plošče ni mogoče izbrisati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "Nadzorne plošče ni bilo mogoče obnoviti."
 
 msgid "Dashboard could not be updated."
 msgstr "Nadzorne plošče ni mogoče posodobiti."
@@ -4457,8 +4740,11 @@ msgstr "Nadzorna plošča je bila uspešno shranjena."
 msgid "Dashboard imported"
 msgstr "Nadzorna plošča uvožena"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard name and URL configuration"
-msgstr ""
+msgstr "Konfiguracija imena in URL-ja nadzorne plošče"
 
 #, fuzzy
 msgid "Dashboard name is required"
@@ -4657,8 +4943,10 @@ msgstr "Nastavitve podatkovne baze posodobljene"
 msgid "Database type does not support file uploads."
 msgstr "Tip podatkovne baze ne podpira nalaganje datotek."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "Datoteka za nalaganje v bazo podatkov presega največjo dovoljeno velikost."
 
 msgid "Database upload file failed"
 msgstr "Nalaganje datoteke v podatkovno bazo ni uspelo"
@@ -4879,10 +5167,15 @@ msgstr "Privzeta shema"
 msgid "Default URL"
 msgstr "Privzeti URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# pt_BR, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
 msgstr ""
+"Privzeti URL za preusmeritev pri dostopu s strani seznama naborov "
+"podatkov. Sprejema relativne URL-je, kot so"
 
 msgid "Default Value"
 msgstr "Privzeta vrednost"
@@ -4951,8 +5244,11 @@ msgstr ""
 "in vrne spremenjeno verzijo tega niza. Lahko se uporabi za spreminjanje "
 "lastnosti podatkov, filtra ali obogatitve niza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define color breakpoints for the data"
-msgstr ""
+msgstr "Določi barvne prelomne točke za podatke"
 
 msgid ""
 "Define contour layers. Isolines represent a collection of line segments "
@@ -5019,13 +5315,15 @@ msgstr ""
 msgid "Definition"
 msgstr "deviacija"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Zakasnelo (preskočeno %s osveževanje)"
+msgstr[1] "Zakasnelo (preskočeni %s osveževanji)"
+msgstr[2] "Zakasnelo (preskočena %s osveževanja)"
+msgstr[3] "Zakasnelo (preskočenih %s osveževanj)"
 
 msgid "Delete"
 msgstr "Izbriši"
@@ -5301,12 +5599,19 @@ msgstr "Podrobnosti"
 msgid "Details of the certification"
 msgstr "Podrobnosti certifikacije"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Določa, kako filter ujema vrednosti. \"Natančno ujemanje\" uporablja "
+"operator IN (privzeto). Možnosti ILIKE omogočajo delno ujemanje besedila "
+"s prostim vnosom. Opozorilo: poizvedbe ILIKE so lahko počasne na velikih "
+"naborih podatkov, ker ne morejo učinkovito uporabiti indeksov."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Določa kako so izračunani kvantili in izstopajoče vrednosti."
@@ -5331,11 +5636,18 @@ msgstr "Temno-siva"
 msgid "Dimension"
 msgstr "Dimenzija"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Stolpec dimenzije, oddan kot navzkrižni filter ob kliku na element. Drugi"
+" grafikoni na nadzorni plošči se ujemajo s tem stolpcem. Če ni "
+"nastavljeno, se vrne na stolpec geometrije (zastarelo vedenje, ki se "
+"pogosto ne ujema)."
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5468,11 +5780,17 @@ msgstr "Prikaži nastavitve"
 msgid "Display cumulative total at end"
 msgstr "Prikaži vsoto na nivoju stolpca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
+msgstr "Prikaži glave za vsak stolpec na vrhu matrike"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display labels for each row on the left side of the matrix"
-msgstr ""
+msgstr "Prikaži oznake za vsako vrstico na levi strani matrike"
 
 msgid ""
 "Display metrics side by side within each column, as opposed to each "
@@ -5495,8 +5813,13 @@ msgstr "Prikaži delno vsoto na nivoju vrstice"
 msgid "Display row level total"
 msgstr "Prikaži vsoto na nivoju vrstice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
 msgstr ""
+"Prikaži časovni žig zadnje poizvedbe na grafikonih v pogledu nadzorne "
+"plošče"
 
 #, fuzzy
 msgid "Display type icon"
@@ -5522,10 +5845,15 @@ msgstr "Porazdelitev"
 msgid "Divider"
 msgstr "Ločilnik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
 msgstr ""
+"Razdeli vsako kategorijo na podkategorije glede na vrednosti v dimenziji."
+" Lahko se uporabi za izključitev presečišč."
 
 msgid "Do you want a donut or a pie?"
 msgstr "Želite kolobar ali torto?"
@@ -5559,8 +5887,11 @@ msgstr "Izvozi kot sliko"
 msgid "Download as image"
 msgstr "Izvozi kot sliko"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download is on the way"
-msgstr ""
+msgstr "Prenos poteka"
 
 msgid "Download to CSV"
 msgstr "Izvozi kot CSV"
@@ -5569,11 +5900,15 @@ msgstr "Izvozi kot CSV"
 msgid "Download to client"
 msgstr "Izvozi kot CSV"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Downloading %(rows)s rows based on the LIMIT configuration. If you want "
 "the entire result set, you need to adjust the LIMIT."
 msgstr ""
+"Prenaša se %(rows)s vrstic na podlagi konfiguracije LIMIT. Če želite "
+"celoten nabor rezultatov, morate prilagoditi LIMIT."
 
 msgid "Draft"
 msgstr "Osnutek"
@@ -5584,11 +5919,17 @@ msgstr "Povlecite in spustite elemente in grafikone na nadzorno ploščo"
 msgid "Drag and drop components to this tab"
 msgstr "Povlecite in spustite elemente na zavihek"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
+"Povlecite stolpce in meritve sem, da prilagodite vsebino namiga. Vrstni "
+"red je pomemben – elementi se bodo prikazali v enakem vrstnem redu v "
+"namigih. Kliknite gumb za ročno izbiro stolpcev in meritev."
 
 #, fuzzy
 msgid "Drag to reorder"
@@ -5762,8 +6103,11 @@ msgstr "Trajanje v ms (66000 => 1m 6s)"
 msgid "Duration in seconds"
 msgstr "Vnesite trajanje v sekundah"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "Dinamično"
 
 msgid "Dynamic Aggregation Function"
 msgstr "Dinamična agregacijska funkcija"
@@ -5783,14 +6127,20 @@ msgstr "Dinamična agregacijska funkcija"
 msgid "Dynamically search all filter values"
 msgstr "Dinamično poišče vse možnosti filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "Dinamično izberi stolpce za grupiranje iz nabora podatkov"
 
 msgid "ECharts"
 msgstr "ECharts"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "Možnosti ECharts (literali objektov JS)"
 
 msgid "EMAIL_REPORTS_CTA"
 msgstr "EMAIL_REPORTS_CTA"
@@ -6012,8 +6362,11 @@ msgstr "Prazna vrstica"
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr "Omogoči 'Dovoli nalaganje podatkov' v nastavitvah vseh podatkovnih baz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable Matrixify"
-msgstr ""
+msgstr "Omogoči Matrixify"
 
 msgid "Enable cross-filtering"
 msgstr "Omogoči medsebojne filtre"
@@ -6033,22 +6386,31 @@ msgstr "Omogoči napovedovanje"
 msgid "Enable graph roaming"
 msgstr "Omogoči preoblikovanje grafikona"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "Omogoči JavaScript način za ikone"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "Stolpci tabele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "Omogoči JavaScript način za oznake"
 
 #, fuzzy
 msgid "Enable labels"
 msgstr "Oznake razponov"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "Omogoči matrixify"
 
 msgid "Enable node dragging"
 msgstr "Omogoči premikanje vozlišč"
@@ -6064,17 +6426,29 @@ msgstr ""
 "Omogoči številčenje strani rezultatov na strani strežnika (funkcija v "
 "razvoju)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "Omogoča prilagojeno konfiguracijo ikon prek JavaScripta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "Omogoča prilagojeno konfiguracijo oznak prek JavaScripta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "Omogoča upodabljanje ikon za točke GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "Omogoča upodabljanje oznak za točke GeoJSON"
 
 msgid ""
 "Encountered invalid NULL spatial entry,"
@@ -6164,8 +6538,11 @@ msgstr "Vnesite trajanje v sekundah"
 msgid "Enter fullscreen"
 msgstr "Vklopi celozaslonski način"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "Vnesite minimalne in maksimalne vrednosti za filter obsega"
 
 msgid "Enter report name"
 msgstr "Vnesite naslov poročila"
@@ -6186,11 +6563,17 @@ msgstr "Vnesite naslov opozorila"
 msgid "Enter the required %(dbModelName)s credentials"
 msgstr "Vnesite potrebne %(dbModelName)s vpisne podatke"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the unique project id for your database."
-msgstr ""
+msgstr "Vnesite edinstveni ID projekta za vašo bazo podatkov."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's email"
-msgstr ""
+msgstr "Vnesite e-poštni naslov uporabnika"
 
 #, fuzzy
 msgid "Enter the user's first name"
@@ -6204,15 +6587,21 @@ msgstr "Vnesite naslov opozorila"
 msgid "Enter the user's password"
 msgstr "Vnesite naslov opozorila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's username"
-msgstr ""
+msgstr "Vnesite uporabniško ime uporabnika"
 
 #, fuzzy
 msgid "Enter theme name"
 msgstr "Vnesite naslov opozorila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter your login and password below:"
-msgstr ""
+msgstr "Vnesite svoje prijavne podatke in geslo spodaj:"
 
 msgid "Entity"
 msgstr "Entiteta"
@@ -6237,9 +6626,11 @@ msgstr "Pri pridobivanju označenih elementov je prišlo do napake"
 msgid "Error deleting %s"
 msgstr "Napaka pri pridobivanju podatkov: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Napaka pri onemogočanju celozaslonskega načina: %s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6375,8 +6766,11 @@ msgstr "Evolucija"
 msgid "Exact"
 msgstr "Natančno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Natančno ujemanje (IN)"
 
 msgid "Example"
 msgstr "Primer"
@@ -6509,8 +6903,11 @@ msgstr "Prenos slike ni uspel. Osvežite in poskusite ponovno."
 msgid "Export failed: %s"
 msgstr "Poročilo ni uspelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "Izvozi posnetek zaslona (jpeg)"
 
 #, fuzzy, python-format
 msgid "Export successful: %s"
@@ -6573,8 +6970,11 @@ msgstr "Dimenzije"
 msgid "Extent"
 msgstr "nedavno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Opozorilo o zunanjem linku"
 
 msgid "Extra"
 msgstr "Dodatno"
@@ -6623,6 +7023,11 @@ msgstr "FEB"
 msgid "FIT DATA"
 msgstr "Uredi podatkovni set"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Prilagodi podatkom"
+
 msgid "FRI"
 msgstr "PET"
 
@@ -6632,8 +7037,11 @@ msgstr "Faktor"
 msgid "Factor to multiply the metric by"
 msgstr "Faktor, s katerim množite mero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fail login count"
-msgstr ""
+msgstr "Število neuspešnih prijav"
 
 msgid "Failed"
 msgstr "Ni uspelo"
@@ -6641,8 +7049,11 @@ msgstr "Ni uspelo"
 msgid "Failed at retrieving results"
 msgstr "Napaka pri pridobivanju rezultatov"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to apply theme: Invalid JSON"
-msgstr ""
+msgstr "Teme ni bilo mogoče uporabiti: neveljavna vrednost JSON"
 
 #, fuzzy
 msgid "Failed to copy API key to clipboard"
@@ -6688,12 +7099,17 @@ msgstr "Neuspešno nalaganje podatkov grafikona"
 msgid "Failed to load top values"
 msgstr "Neuspešno ustavljanje poizvedbe. %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "Datoteke ni bilo mogoče odpreti. Poskusite znova."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr ""
+msgstr "Sistemske temne teme ni bilo mogoče odstraniti: %s"
 
 #, fuzzy, python-format
 msgid "Failed to remove system default theme: %s"
@@ -6717,12 +7133,17 @@ msgstr "Shranjevanje dosega medsebojnega filtra ni uspelo"
 msgid "Failed to save cross-filters setting"
 msgstr "Shranjevanje dosega medsebojnega filtra ni uspelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to set local theme: Invalid JSON configuration"
-msgstr ""
+msgstr "Lokalne teme ni bilo mogoče nastaviti: neveljavna konfiguracija JSON"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system dark theme: %s"
-msgstr ""
+msgstr "Sistemske temne teme ni bilo mogoče nastaviti: %s"
 
 #, fuzzy, python-format
 msgid "Failed to set system default theme: %s"
@@ -6735,8 +7156,11 @@ msgstr "Na delavcu ni bilo mogoče zagnati oddaljene poizvedbe."
 msgid "Failed to stop query."
 msgstr "Neuspešno ustavljanje poizvedbe. %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to store query results. Please try again."
-msgstr ""
+msgstr "Rezultatov poizvedbe ni bilo mogoče shraniti. Poskusite znova."
 
 msgid "Failed to tag items"
 msgstr "Napaka pri označevanju elementov"
@@ -6744,15 +7168,21 @@ msgstr "Napaka pri označevanju elementov"
 msgid "Failed to update report"
 msgstr "Posodabljanje poročila neuspešno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to validate expression. Please try again."
-msgstr ""
+msgstr "Izraza ni bilo mogoče preveriti. Poskusite znova."
 
 #, python-format
 msgid "Failed to verify select options: %s"
 msgstr "Preverjanje možnosti izbire ni uspelo: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
-msgstr ""
+msgstr "Preklapljam na CSV; knjižnica za izvoz v Excel ni na voljo."
 
 #, fuzzy
 msgid "False"
@@ -6806,10 +7236,15 @@ msgstr "Polje je obvezno"
 msgid "File extension is not allowed."
 msgstr "Končnica datoteke ni dovoljena."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
 msgstr ""
+"Ravnanje z datotekami ni podprto v tem brskalniku. Prosimo, uporabite "
+"sodoben brskalnik, kot je Chrome ali Edge."
 
 #, fuzzy
 msgid "File settings"
@@ -6827,8 +7262,11 @@ msgstr "Izpolnite vsa polja, da omogočite \"Privzeto vrednost\""
 msgid "Fill method"
 msgstr "Način polnjenja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill out the registration form"
-msgstr ""
+msgstr "Izpolnite registracijski obrazec"
 
 msgid "Filled"
 msgstr "Zapolnjeno"
@@ -6898,15 +7336,21 @@ msgstr "Filtrira po merah"
 msgid "Filters for comparison must have a value"
 msgstr "Filtri za primerjavo morajo imeti vrednost"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values equal to this exact value."
-msgstr ""
+msgstr "Filtrira vrednosti, ki so enake tej točni vrednosti."
 
 #, fuzzy
 msgid "Filters for values greater than or equal."
 msgstr "`row_limit` mora biti večja ali enaka 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values less than or equal."
-msgstr ""
+msgstr "Filtrira vrednosti, ki so manjše ali enake."
 
 #, python-format
 msgid "Filters out of scope (%d)"
@@ -7032,17 +7476,26 @@ msgstr ""
 "filtre, so te vloge tiste, ki NE bodo filtrirane, npr. Admin, če naj "
 "administrator vidi vse podatke."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forbidden"
-msgstr ""
+msgstr "Prepovedano"
 
 msgid "Force"
 msgstr "Sila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "Prisili časovno zrnatost kot največji interval"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Prisili prekinitev (ustavi opravilo za vse naročnike)"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -7073,8 +7526,11 @@ msgstr "Osveži seznam shem"
 msgid "Force refresh table list"
 msgstr "Osveži seznam tabel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
-msgstr ""
+msgstr "Prisili izbrano časovno zrnatost kot največji interval za oznake osi X"
 
 msgid "Forecast periods"
 msgstr "Periode napovedi"
@@ -7120,12 +7576,20 @@ msgstr ""
 "{percent}. \\n predstavlja novo vrstico. Kompatibilnost z ECharts:\n"
 "{a} (serija), {b} (naziv), {c} (vrednost), {d} (odstotek)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"Oblikujte metrike ali stolpce z valutnimi simboli kot predponami ali "
+"priponami. Izberite simbol ročno ali uporabite 'Samodejno zaznavanje', da"
+" se na podlagi stolpca z valutno kodo v naboru podatkov uporabi pravilen "
+"simbol. Kadar je prisotnih več valut, se oblikovanje vrne na nevtralne "
+"številke."
 
 msgid "Formatted CSV attached in email"
 msgstr "Oblikovan CSV pripet e-pošti"
@@ -7197,10 +7661,15 @@ msgstr "GROUP BY"
 msgid "Gantt Chart"
 msgstr "Graf"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Gantt chart visualizes important events over a time span. Every data "
 "point displayed as a separate event along a horizontal line."
 msgstr ""
+"Ganttov grafikon prikazuje pomembne dogodke v časovnem obdobju. Vsaka "
+"podatkovna točka je prikazana kot ločen dogodek vzdolž vodoravne črte."
 
 msgid "Gauge Chart"
 msgstr "Števčni grafikon"
@@ -7316,8 +7785,11 @@ msgstr "Ključ za združevanje"
 msgid "Group by"
 msgstr "Združevanje po (Group by)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group remaining as \"Others\""
-msgstr ""
+msgstr "Preostale razvrsti v skupino \"Ostalo\""
 
 #, fuzzy
 msgid "Grouping"
@@ -7327,16 +7799,25 @@ msgstr "Doseg"
 msgid "Groups"
 msgstr "Združevanje po (Group by)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Groups remaining series into an \"Others\" category when series limit is "
 "reached. This prevents incomplete time series data from being displayed."
 msgstr ""
+"Preostale serije razvrsti v kategorijo \"Ostalo\", ko je dosežena "
+"omejitev serij. S tem se prepreči prikaz nepopolnih podatkov časovnih "
+"vrst."
 
 msgid "Guest user cannot modify chart payload"
 msgstr "Gost ne more spreminjati atributov grafikona"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "Pot HTTP"
 
 msgid "Handlebars"
 msgstr "Handlebars"
@@ -7445,8 +7926,11 @@ msgstr "V koliko razdelkov bodo razvrščeni podatki."
 msgid "How many periods into the future do we want to predict"
 msgstr "Za koliko period v prihodnosti želite napoved"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "How many top values to select"
-msgstr ""
+msgstr "Koliko najvišjih vrednosti izbrati"
 
 msgid ""
 "How to display time shifts: as individual lines; as the difference "
@@ -7509,17 +7993,25 @@ msgid ""
 "it sorts the results ascending."
 msgstr "Če je omogočeno, so vrednosti razvrščene padajoče, drugače pa naraščajoče."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
+"Če ostane prazno, ne bo shranjeno in bo odstranjeno s seznama. Če želite "
+"odstraniti mape, premaknite metrike in stolpce v druge mape."
 
 #, fuzzy
 msgid "If table already exists"
 msgstr "Oznaka že obstaja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "If you don't save, changes will be lost."
-msgstr ""
+msgstr "Če ne shranite, bodo spremembe izgubljene."
 
 msgid "Ignore cache when generating report"
 msgstr "Ne upoštevaj predpomnjenja pri ustvarjanju poročila"
@@ -7594,13 +8086,21 @@ msgstr "Napredek"
 msgid "In Range"
 msgstr "Časovno obdobje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
 "service account or configure an OAuth2 client."
 msgstr ""
+"Za povezavo z nejavnimi preglednicami morate posredovati storitveni račun"
+" ali konfigurirati odjemalca OAuth2."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "In this view you can preview the first 25 rows. "
-msgstr ""
+msgstr "V tem pogledu si lahko ogledate prvih 25 vrstic. "
 
 #, fuzzy
 msgid "Inactive"
@@ -7657,8 +8157,11 @@ msgstr "Informacije"
 msgid "Inherit range from time filter"
 msgstr "Prevzemi obdobje iz časovnega filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "Začetna globina drevesa"
 
 msgid "Inner Radius"
 msgstr "Notranji polmer"
@@ -7676,8 +8179,11 @@ msgstr "Vnosno polje omogoča poljubno rotacijo (vnesite 30 za 30°)"
 msgid "Insert Layer URL"
 msgstr "Skrij sloj"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer title"
-msgstr ""
+msgstr "Vnesite naslov sloja"
 
 #, fuzzy
 msgid "Inside"
@@ -7703,8 +8209,11 @@ msgstr "Zgoraj levo"
 msgid "Inside right"
 msgstr "Zgoraj desno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "Znotraj zgoraj"
 
 #, fuzzy
 msgid "Inside top left"
@@ -7807,8 +8316,11 @@ msgstr "Neveljavna koda valute v shranjeni meri"
 msgid "Invalid date/timestamp format"
 msgstr "Neveljaven zapis datuma/časa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid executor type"
-msgstr ""
+msgstr "Neveljaven tip izvršitelja"
 
 #, fuzzy
 msgid "Invalid expression"
@@ -7938,10 +8450,15 @@ msgstr "Težava 1000 - podatkovni vir je prevelik za poizvedbo."
 msgid "Issue 1001 - The database is under an unusual load."
 msgstr "Težava 1001 - podatkovni vir je neobičajno obremenjen."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
 msgstr ""
+"Ne bo odstranjeno, tudi če je prazno. V pogledu za urejanje grafikona ne "
+"bo prikazano, če je prazno."
 
 #, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
@@ -7963,8 +8480,11 @@ msgstr "JSON-metapodatki"
 msgid "JSON metadata"
 msgstr "JSON-metapodatki"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON metadata and advanced configuration"
-msgstr ""
+msgstr "Metapodatki JSON in napredna konfiguracija"
 
 msgid "JSON metadata is invalid!"
 msgstr "JSON-metapodatki niso veljavni!"
@@ -8026,8 +8546,11 @@ msgstr "Predpona"
 msgid "Keyboard shortcuts"
 msgstr "Bližnjice na tipkovnici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
-msgstr ""
+msgstr "Ključi so prikazani samo enkrat ob ustvarjanju. Hranite jih varno."
 
 msgid "Keys for table"
 msgstr "Ključi za tabelo"
@@ -8197,8 +8720,11 @@ msgstr "leto"
 msgid "Layer Name"
 msgstr "Naslov opozorila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Layer URL"
-msgstr ""
+msgstr "URL sloja"
 
 msgid "Layer configuration"
 msgstr "Nastavitve sloja"
@@ -8280,8 +8806,11 @@ msgstr "Manjše ali enako (<=)"
 msgid "Less than (<)"
 msgstr "Manjše kot (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
 msgid "Lift percent precision"
 msgstr "Točnost procentualnega dviga"
@@ -8352,8 +8881,11 @@ msgstr ""
 "Črtni grafikon se uporablja za vizualizacijo meritev zajetih skozi čas. "
 "Posamezne točke so med seboj povezane z ravnimi črtami."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line charts on a map"
-msgstr ""
+msgstr "Črtni grafikoni na zemljevidu"
 
 msgid "Line interpolation as defined by d3.js"
 msgstr "Interpolacija krivulje na osnovi d3.js"
@@ -8391,8 +8923,11 @@ msgstr "Zadnji"
 msgid "List Groups"
 msgstr "Število razdelitev"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List Roles"
-msgstr ""
+msgstr "Seznam vlog"
 
 msgid "List Unique Values"
 msgstr "Seznam unikatnih vrednosti"
@@ -8455,12 +8990,17 @@ msgstr "Nalagam ..."
 msgid "Local"
 msgstr "Logaritemska skala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Local theme set for preview"
-msgstr ""
+msgstr "Lokalna tema nastavljena za predogled"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Local theme set to \"%s\""
-msgstr ""
+msgstr "Lokalna tema nastavljena na \"%s\""
 
 msgid "Locate the chart"
 msgstr "Lociraj grafikon"
@@ -8570,16 +9110,24 @@ msgstr ""
 msgid "Manage"
 msgstr "Upravljanje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage dashboard owners and access permissions"
-msgstr ""
+msgstr "Upravljajte lastnike nadzorne plošče in dovoljenja za dostop"
 
 msgid "Manage email report"
 msgstr "Upravljaj e-poštno poročilo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Upravljajte filtre in prilagoditve za nastavitev obsega, opisov in "
+"omejitev. Ustvarite nove elemente za boljši vpogled v nadzorno ploščo."
 
 msgid "Manage your databases"
 msgstr "Upravljajte podatkovne baze"
@@ -8604,13 +9152,21 @@ msgstr "Sprotni izris"
 msgid "Map Style"
 msgstr "Slog zemljevida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (odprtokodna)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre je odprtokoden in ne zahteva ključa API. Mapbox zahteva, da je "
+"MAPBOX_API_KEY konfiguriran na strežniku."
 
 msgid "Mapbox"
 msgstr "Mapbox"
@@ -8619,8 +9175,11 @@ msgstr "Mapbox"
 msgid "Mapbox (API key required)"
 msgstr "Zahtevana je vrednost"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox zahteva, da je MAPBOX_API_KEY konfiguriran na strežniku."
 
 msgid "March"
 msgstr "Marec"
@@ -8655,8 +9214,11 @@ msgstr "Markerji"
 msgid "Markup type"
 msgstr "Tip označevanja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match system"
-msgstr ""
+msgstr "Ujemi sistem"
 
 msgid "Match time shift color with original series"
 msgstr "Uskladi barvo časovnega premika z izvorno serijo"
@@ -8665,8 +9227,11 @@ msgstr "Uskladi barvo časovnega premika z izvorno serijo"
 msgid "Match type"
 msgstr "Tip podatka"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Matrixify"
-msgstr ""
+msgstr "Matrixify"
 
 msgid "Max"
 msgstr "Max"
@@ -8678,8 +9243,11 @@ msgstr "Max. velikost mehurčka"
 msgid "Max value"
 msgstr "Maksimalna vrednost"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Max. features"
-msgstr ""
+msgstr "Maks. objektov"
 
 msgid "Maximum"
 msgstr "Maksimum"
@@ -8694,11 +9262,17 @@ msgstr "Max. polmer"
 msgid "Maximum Width"
 msgstr "Min. širina"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "Dosežena največja globina gnezdenja map"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum number of features to fetch from service"
-msgstr ""
+msgstr "Največje število objektov za pridobitev iz storitve"
 
 msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
@@ -8749,17 +9323,29 @@ msgstr "Mediane"
 msgid "Medium"
 msgstr "Srednje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - binary (1024B => 1KiB)"
-msgstr ""
+msgstr "Pomnilnik v bajtih - dvojiški (1024B => 1KiB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - decimal (1024B => 1.024kB)"
-msgstr ""
+msgstr "Pomnilnik v bajtih - desetiški (1024B => 1.024kB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - binary (1024B => 1KiB/s)"
-msgstr ""
+msgstr "Hitrost prenosa pomnilnika v bajtih - dvojiški (1024B => 1KiB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
+msgstr "Hitrost prenosa pomnilnika v bajtih - desetiški (1024B => 1.024kB/s)"
 
 msgid "Menu actions trigger"
 msgstr "Preklapljanje funkcionalnosti menijev"
@@ -8783,12 +9369,19 @@ msgstr "metri"
 msgid "Method"
 msgstr "Metoda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Method to compute the displayed value. \"Overall value\" calculates a "
 "single metric across the entire filtered time period, ideal for non-"
 "additive metrics like ratios, averages, or distinct counts. Other methods"
 " operate over the time series data points."
 msgstr ""
+"Metoda za izračun prikazane vrednosti. \"Skupna vrednost\" izračuna eno "
+"metriko za celotno filtrirano časovno obdobje, kar je idealno za "
+"neaditivne metrike, kot so razmerja, povprečja ali število različnih "
+"vrednosti. Druge metode delujejo na podatkovnih točkah časovne vrste."
 
 msgid "Metric"
 msgstr "Mera"
@@ -8886,14 +9479,23 @@ msgstr "Mere"
 msgid "Metrics (%s)"
 msgstr "Mere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "Metrik ni mogoče hkrati uporabiti za vrstice in stolpce"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "Mapa z metrikami lahko vsebuje samo elemente metrik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "Metrike bi morale biti znotraj map"
 
 #, fuzzy
 msgid "Metrics to show in the tooltip."
@@ -8951,8 +9553,11 @@ msgstr "Min. polmer"
 msgid "Minimum Width"
 msgstr "Min. širina"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Minimum must be strictly less than maximum"
-msgstr ""
+msgstr "Minimum mora biti strogo manjši od maksimuma"
 
 msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
@@ -8994,8 +9599,11 @@ msgstr "Minute %s"
 msgid "Missing %s"
 msgstr "Manjka podatkovni set"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Missing OAuth2 token"
-msgstr ""
+msgstr "Manjkajoči žeton OAuth2"
 
 #, fuzzy
 msgid "Missing URL parameter"
@@ -9014,13 +9622,15 @@ msgstr "Spremenjeno"
 msgid "Modified %s"
 msgstr "Zadnja sprememba %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Spremenjen 1 stolpec v virtualnem naboru podatkov"
+msgstr[1] "Spremenjena %s stolpca v virtualnem naboru podatkov"
+msgstr[2] "Spremenjeni %s stolpci v virtualnem naboru podatkov"
+msgstr[3] "Spremenjenih %s stolpcev v virtualnem naboru podatkov"
 
 msgid "Modified by"
 msgstr "Spremenil"
@@ -9091,10 +9701,15 @@ msgstr ""
 msgid "Multiplier"
 msgstr "Množitelj"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
 msgstr ""
+"Morate biti lastnik grafikona, da bi ga prepisali. Namesto tega shranite "
+"kot nov grafikon."
 
 msgid "Must be unique"
 msgstr "Mora biti unikaten"
@@ -9166,8 +9781,11 @@ msgstr "Ime vaše oznake"
 msgid "Name your database"
 msgstr "Poimenujte podatkovno bazo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
-msgstr ""
+msgstr "Poimenujte svojo mapo in za kasnejše urejanje kliknite na ime mape"
 
 #, fuzzy
 msgid "Native filter column is required"
@@ -9337,8 +9955,11 @@ msgstr "Brez filtrov"
 msgid "No filters are currently added to this dashboard."
 msgstr "Trenutno na nadzorno ploščo še ni dodanih filtrov."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Še niso ustvarjeni filtri ali prilagoditve"
 
 msgid "No form settings were maintained"
 msgstr "Nastavitve forme se niso ohranile"
@@ -9590,11 +10211,17 @@ msgstr "Oblika zapisa števila"
 msgid "Number of buckets to group data"
 msgstr "Število razdelkov za združevanje podatkov"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts per row when not fitting dynamically"
-msgstr ""
+msgstr "Število grafikonov v vrstici, ko se ne prilagajajo dinamično"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts to display per row"
-msgstr ""
+msgstr "Število grafikonov za prikaz v vrstici"
 
 msgid "Number of decimal digits to round numbers to"
 msgstr "Število decimalnih mest za zaokroževanje števil"
@@ -9739,11 +10366,17 @@ msgstr "Veljavno samo, ko \"Tip oznake\" ni procent."
 msgid "Only applies when \"Label Type\" is set to show values."
 msgstr "Veljavno samo, ko je izbran \"Tip oznake\" za prikaz vrednosti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "Za stolpce, ki niso tekstovni, je na voljo samo natančno ujemanje."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Nadaljujte samo, če zaupate cilju ali njegovemu viru."
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -10095,8 +10728,11 @@ msgstr "Velikost točke"
 msgid "Pattern"
 msgstr "Vzorec"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Začasno ustavi samodejno osvežavanje, če je zavihek neaktiven"
 
 #, fuzzy
 msgid "Pause auto-refresh"
@@ -10157,9 +10793,11 @@ msgstr "Periode morajo biti celo število"
 msgid "Permissions"
 msgstr "Verzija"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Permissions successfully synced for %s"
-msgstr ""
+msgstr "Dovoljenja uspešno sinhronizirana za %s"
 
 msgid "Person or group that has certified this chart."
 msgstr "Oseba ali skupina, ki je certificirala ta grafikon."
@@ -10170,8 +10808,11 @@ msgstr "Oseba ali skupina, ki je certificirala to nadzorno ploščo."
 msgid "Person or group that has certified this metric"
 msgstr "Oseba ali skupina, ki je certificirala to mero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "Osebni podatki"
 
 msgid "Physical"
 msgstr "Fizičen"
@@ -10213,8 +10854,11 @@ msgstr "Izberite svoj priljubljen označevalni jezik"
 msgid "Pie Chart"
 msgstr "Tortni grafikon"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pie charts on a map"
-msgstr ""
+msgstr "Tortni grafikoni na zemljevidu"
 
 msgid "Pie shape"
 msgstr "Oblika torte"
@@ -10237,8 +10881,11 @@ msgstr "Zgoraj levo"
 msgid "Pin Right"
 msgstr "Zgoraj desno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "Pripni na panel rezultatov"
 
 #, fuzzy
 msgid "Pin to top"
@@ -10305,8 +10952,11 @@ msgstr ""
 "Preverite, če imajo Jinja parametri sintaktične napake in poskrbite, da "
 "se ujemajo znotraj SQL-poizvedbe. Potem ponovno poženite poizvedbo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please choose a valid value"
-msgstr ""
+msgstr "Izberite veljavno vrednost"
 
 msgid "Please choose at least one groupby"
 msgstr "Izberite vsaj en 'Group by'"
@@ -10328,8 +10978,11 @@ msgstr "Vnesite SQLAlchemy URI za test"
 msgid "Please enter a valid email"
 msgstr "Vnesite SQLAlchemy URI za test"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Vnesite veljavni e-poštni naslov"
 
 msgid "Please enter valid text. Spaces alone are not permitted."
 msgstr "Vnesite veljaven zapis. Samo presledki niso dovoljeni."
@@ -10358,8 +11011,11 @@ msgstr "Ime vaše poizvedbe"
 msgid "Please fix the following errors"
 msgstr "Imamo naslednje ključe: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please provide a valid min or max value"
-msgstr ""
+msgstr "Vnesite veljavno minimalno ali maksimalno vrednost"
 
 msgid "Please re-enter the password."
 msgstr "Ponovno vpišite geslo."
@@ -10560,12 +11216,17 @@ msgstr "Geslo privatnega ključa"
 msgid "Proceed"
 msgstr "Nadaljuj"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "Obdelava izvoza za %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Processing export..."
-msgstr ""
+msgstr "Obdelava izvoza..."
 
 msgid "Progress"
 msgstr "Napredek"
@@ -10580,11 +11241,17 @@ msgstr "Zastarelo"
 msgid "Proportional"
 msgstr "Proporcionalno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Javno in zasebno deljeni listi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Samo javno deljeni listi"
 
 msgid "Published"
 msgstr "Objavljeno"
@@ -10807,9 +11474,11 @@ msgstr "Osveži nadzorno ploščo"
 msgid "Refresh frequency"
 msgstr "Frekvenca osveževanja"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Refresh frequency must be at least %s seconds"
-msgstr ""
+msgstr "Pogostost osveževanja mora biti vsaj %s sekund"
 
 msgid "Refresh interval"
 msgstr "Interval osveževanja"
@@ -10845,8 +11514,11 @@ msgstr "Predfilter"
 msgid "Registration date"
 msgstr "Začetni datum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "Registracija uspešna"
 
 msgid "Regular"
 msgstr "Navaden"
@@ -10884,8 +11556,11 @@ msgstr "Ponovno naloži"
 msgid "Remove"
 msgstr "Odstrani"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Dark Theme"
-msgstr ""
+msgstr "Odstrani sistemsko temno temo"
 
 #, fuzzy
 msgid "Remove System Default Theme"
@@ -10911,13 +11586,15 @@ msgstr "Odstrani poizvedbo iz dnevnika"
 msgid "Remove table preview"
 msgstr "Odstrani predogled tabele"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Odstranjen 1 stolpec iz virtualnega nabora podatkov"
+msgstr[1] "Odstranjena %s stolpca iz virtualnega nabora podatkov"
+msgstr[2] "Odstranjeni %s stolpci iz virtualnega nabora podatkov"
+msgstr[3] "Odstranjenih %s stolpcev iz virtualnega nabora podatkov"
 
 msgid "Rename tab"
 msgstr "Preimenuj zavihek"
@@ -10928,10 +11605,15 @@ msgstr "Izvedi HTML"
 msgid "Render columns in HTML format"
 msgstr "Izvede HTML v stolpcih"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Renders table cells as HTML when applicable. For example, HTML <a> tags "
 "will be rendered as hyperlinks."
 msgstr ""
+"Prikazuje celice tabele kot HTML, kadar je to primerno. Na primer, oznake"
+" HTML <a> bodo prikazane kot hiperpovezave."
 
 msgid "Replace"
 msgstr "Zamenjaj"
@@ -11030,8 +11712,11 @@ msgstr "Odbijanje"
 msgid "Repulsion strength between nodes"
 msgstr "Odbojna sila med vozlišči"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request Access"
-msgstr ""
+msgstr "Zahtevaj dostop"
 
 #, python-format
 msgid "Request is incorrect: %(error)s"
@@ -11068,8 +11753,11 @@ msgstr "Ponastavi"
 msgid "Reset Columns"
 msgstr "Izberite stolpec"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "Ponastavi vse mape na privzeto"
 
 #, fuzzy
 msgid "Reset columns"
@@ -11100,8 +11788,11 @@ msgstr "Vir že ima povezano poročilo."
 msgid "Resource was not found."
 msgstr "Vir ni bil najden."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "Vir je bil odstranjen, preden je bilo mogoče preveriti lastništvo"
 
 msgid "Restore filter"
 msgstr "Povrni filter"
@@ -11153,8 +11844,11 @@ msgstr "Odstrani"
 msgid "Revoke API Key"
 msgstr "Ključ za združevanje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Prekliči ta API ključ"
 
 #, fuzzy
 msgid "Revoked"
@@ -11264,11 +11958,18 @@ msgstr "Vrstica"
 msgid "Row Level Security"
 msgstr "Varnost na nivoju vrstic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
 msgstr ""
+"Omejitev vrstic: odstotki so izračunani na podlagi podmnožice "
+"pridobljenih podatkov, ob upoštevanju omejitve vrstic. Vsi zapisi: "
+"odstotki so izračunani na podlagi celotnega nabora podatkov, brez "
+"upoštevanja omejitve vrstic."
 
 msgid ""
 "Row containing the headers to use as column names (0 is first line of "
@@ -11355,11 +12056,18 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL laboratorij"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab ne more odobriti stavka, ki ga ni bilo mogoče v celoti "
+"razčleniti. Eksplicitno kvalificirajte tabele in se izogibajte "
+"dinamičnemu SQL-u znotraj shranjenih procedur ali klicev, specifičnih za "
+"dobavitelja."
 
 #, fuzzy
 msgid "SQL Lab queries"
@@ -11519,8 +12227,11 @@ msgstr "Shrani in pojdi na nadzorno ploščo"
 msgid "Save chart"
 msgstr "Shrani grafikon"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Save color breakpoint values"
-msgstr ""
+msgstr "Shrani vrednosti prelomnih točk barv"
 
 msgid "Save dashboard"
 msgstr "Shrani nadzorno ploščo"
@@ -11537,8 +12248,11 @@ msgstr "Shrani ali prepiši podatkovni set"
 msgid "Save query"
 msgstr "Shrani poizvedbo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Varno shrani ta API ključ"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr "Shranite poizvedbo kot virtualni podatkovni set"
@@ -11574,8 +12288,11 @@ msgstr "Nalagam ..."
 msgid "Scale and Move"
 msgstr "Povečava in premikanje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "Faktor skaliranja, ki se uporablja za širine linij, določenih z metrikami"
 
 msgid "Scale only"
 msgstr "Samo povečava"
@@ -11850,8 +12567,13 @@ msgstr ""
 "Izberite mero za prikaz. Uporabite lahko agregacijsko funkcijo na stolpcu"
 " ali napišete poljuben SQL-izraz za mero."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
 msgstr ""
+"Izberite vnaprej določeno predlogo CSS za uporabo na svojem nadzornem "
+"panelu"
 
 msgid "Select a schema"
 msgstr "Izberite shemo"
@@ -12008,6 +12730,9 @@ msgstr "Izberite obliko"
 msgid "Select groups"
 msgstr "Izberite lastnike"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -12015,6 +12740,12 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"Izberite plasti v vrstnem redu, v katerem jih želite zložiti. Prva "
+"izbrana se prikaže na dnu. Plasti vam omogočajo kombiniranje več "
+"vizualizacij na eni karti. Vsaka plast je shranjen grafikon deck.gl (kot "
+"so razpršeni grafikoni, poligoni ali loki), ki prikazuje različne podatke"
+" ali vpoglede. Zložite jih, da razkrijete vzorce in odnose v svojih "
+"podatkih."
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -12086,11 +12817,18 @@ msgstr "Izberite shemo"
 msgid "Select semantic views"
 msgstr "Izberite shemo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
 "same size. \"LINEAR\" increases sizes linearly based on specified slope. "
 "\"EXP\" increases sizes exponentially based on specified exponent"
 msgstr ""
+"Izberite obliko za izračun vrednosti. \"FIXED\" nastavi vse ravni "
+"povečave na isto velikost. \"LINEAR\" linearno povečuje velikosti glede "
+"na določen naklon. \"EXP\" eksponentno povečuje velikosti glede na "
+"določen eksponent"
 
 msgid "Select subject"
 msgstr "Izberite zadevo"
@@ -12128,21 +12866,44 @@ msgstr ""
 "medsebojne filtre za vse grafikone, ki uporabljajo isti podatkovni niz "
 "ali vsebujejo stolpec z enakim nazivom."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
 msgstr ""
+"Izberite barvo, ki se uporablja za vrednosti, ki kažejo povečanje na "
+"grafikonu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
 msgstr ""
+"Izberite barvo, ki se uporablja za vrednosti, ki predstavljajo skupne "
+"stolpce na grafikonu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
+"Izberite barvo, ki se uporablja za vrednosti, ki kažejo zmanjšanje na "
+"grafikonu."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"Izberite stolpec, ki vsebuje kode valut, kot so USD, EUR, GBP itd. "
+"Uporablja se pri gradnji grafikonov, ko je omogočeno samodejno zaznavanje"
+" oblikovanja valut. Če ta stolpec ni nastavljen ali če meritev grafikona "
+"vsebuje več valut, bodo grafikoni prešli na nevtralno številčno "
+"oblikovanje."
 
 #, fuzzy
 msgid "Select the fixed color"
@@ -12151,15 +12912,26 @@ msgstr "Izberite geojson stolpec"
 msgid "Select the geojson column"
 msgstr "Izberite geojson stolpec"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Izberite ponudnika kartografskih ploščic. MapLibre je odprtokodna rešitev"
+" in ne zahteva API ključa. Mapbox zahteva, da je MAPBOX_API_KEY "
+"konfiguriran v Superset-u."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Izberite metriko, ki se uporablja za določanje, v kateri razpon prelomnih"
+" točk barve spada vsaka pot."
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -12181,11 +12953,17 @@ msgstr ""
 "Izberite vrednosti v osvetljenih poljih na levi strani kontrolnika in "
 "zaženite poizvedbo z gumbom %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Izberite, katera časovna zrna so na voljo v kontrolniku filtra. To je "
+"samo seznam dovoljenih možnosti za vmesnik in ne dodaja dodatnih pogojev "
+"osnovnim poizvedbam."
 
 #, fuzzy
 msgid "Selected"
@@ -12206,11 +12984,17 @@ msgstr "Podrobnosti"
 msgid "Semantic Layer"
 msgstr "Sloj z oznakami"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Semantični pogled"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Semantični pogledi"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12268,11 +13052,17 @@ msgstr "Podatkovni set ne obstaja"
 msgid "Semantic view parameters are invalid."
 msgstr "Parametri podatkovnega seta so neveljavni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Semantični pogled posodobljen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Semantični pogledi"
 
 msgid "Send as CSV"
 msgstr "Pošlji kot CSV"
@@ -12307,11 +13097,17 @@ msgstr "Slog serije"
 msgid "Series chart type (line, bar etc)"
 msgstr "Tip grafikona za posamezno podatkovno serijo (črtni, stolpčni, ...)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "Nastavitev zmanjšanja serije"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "Nastavitev povečanja serije"
 
 msgid "Series limit"
 msgstr "Omejitev števila serij"
@@ -12333,9 +13129,11 @@ msgstr "Dolžina strani strežnika"
 msgid "Server pagination"
 msgstr "Paginacija na strani strežnika"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Server pagination needs to be enabled for values over %s"
-msgstr ""
+msgstr "Strežniška paginacija mora biti omogočena za vrednosti nad %s"
 
 msgid "Service Account"
 msgstr "Servisni račun"
@@ -12344,8 +13142,11 @@ msgstr "Servisni račun"
 msgid "Service version"
 msgstr "Servisni račun"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Dark Theme"
-msgstr ""
+msgstr "Nastavi sistemsko temno temo"
 
 #, fuzzy
 msgid "Set System Default Theme"
@@ -12370,19 +13171,33 @@ msgstr "Nastavi shemo filtrov"
 msgid "Set local theme for testing"
 msgstr "Omogoči napovedovanje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing (preview only)"
-msgstr ""
+msgstr "Nastavi lokalno temo za testiranje (samo predogled)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set refresh frequency for current session only."
-msgstr ""
+msgstr "Nastavi frekvenco osveževanja samo za trenutno sejo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set the automatic refresh frequency for this dashboard."
-msgstr ""
+msgstr "Nastavi samodejno frekvenco osveževanja za ta nadzorni panel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Set the automatic refresh frequency for this dashboard. The dashboard "
 "will reload its data at the specified interval."
 msgstr ""
+"Nastavi samodejno frekvenco osveževanja za ta nadzorni panel. Nadzorni "
+"panel bo znova naložil svoje podatke v določenem intervalu."
 
 msgid "Set up an email report"
 msgstr "Nastavite e-poštno poročilo"
@@ -12390,11 +13205,17 @@ msgstr "Nastavite e-poštno poročilo"
 msgid "Set up basic details, such as name and description."
 msgstr "Nastavite bistvene atribute, kot sta ime in opis."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"Nastavi privzeti časovni stolpec za ta nabor podatkov. Samodejno se "
+"izbere kot časovni stolpec pri gradnji grafikonov, ki zahtevajo časovno "
+"dimenzijo, in se uporablja v časovnih filtrih na ravni nadzornega panela."
 
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
@@ -12765,9 +13586,11 @@ msgstr "Zahtevana je vrednost"
 msgid "Skip spaces after delimiter"
 msgstr "Izpusti presledke za ločilnikom"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Skipped %d system themes that cannot be deleted"
-msgstr ""
+msgstr "Preskočeno %d sistemskih tem, ki jih ni mogoče izbrisati"
 
 #, fuzzy
 msgid "Slice Id"
@@ -12777,8 +13600,11 @@ msgstr "Debelina črte"
 msgid "Slider"
 msgstr "Zapolnjen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slider and range input"
-msgstr ""
+msgstr "Drsnik in vnos obsega"
 
 msgid "Slug"
 msgstr "Slug"
@@ -12802,14 +13628,25 @@ msgstr ""
 msgid "Solid"
 msgstr "Zapolnjen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Nekaterih skupin ni bilo mogoče razrešiti in so prikazane kot ID-ji."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Nekaterih dovoljenj ni bilo mogoče razrešiti in so prikazana kot ID-ji."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
+"Nekateri zahtevani filtri na drugih zavihkih imajo vrednosti in ne bodo "
+"počiščeni"
 
 msgid "Some roles do not exist"
 msgstr "Nekatere vloge ne obstajajo"
@@ -12946,11 +13783,18 @@ msgstr "Mera za razvrščanje"
 msgid "Sort query by"
 msgstr "Razvrščanje poizvedbe po"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Razvrsti rezultate po imenu serije v naraščajočem vrstnem redu. V "
+"kombinaciji z »Razvrsti po metriki« to deluje kot odločilec pri enakih "
+"vrednostih metrike. Dodajanje tega razvrščanja lahko zmanjša zmogljivost "
+"poizvedb na nekaterih zbirkah podatkov."
 
 msgid "Sort rows by"
 msgstr "Razvrsti vrstice"
@@ -13003,8 +13847,11 @@ msgstr ""
 msgid "Split number"
 msgstr "Število razdelitev"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Split stack by"
-msgstr ""
+msgstr "Razdeli sklad po"
 
 msgid "Square kilometers"
 msgstr "Kvadratni kilometri"
@@ -13018,8 +13865,11 @@ msgstr "Kvadratne milje"
 msgid "Stack"
 msgstr "Naloži"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack in groups, where each group corresponds to a dimension"
-msgstr ""
+msgstr "Zloži v skupine, kjer vsaka skupina ustreza dimenziji"
 
 msgid "Stack series"
 msgstr "Nalagaj serije"
@@ -13163,8 +14013,13 @@ msgstr "Obrobljeno"
 msgid "Structural"
 msgstr "Strukturni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
 msgstr ""
+"Struktura je upravljana s strani nadrejenega semantičnega sloja in je "
+"samo za branje."
 
 msgid "Style"
 msgstr "Slog"
@@ -13290,19 +14145,26 @@ msgstr "Simbol za konca povezave"
 msgid "Symbol size"
 msgstr "Velikost simbola"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sync Permissions"
-msgstr ""
+msgstr "Sinhroniziraj dovoljenja"
 
 msgid "Sync columns from source"
 msgstr "Sinhroniziraj stolpce z virom"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s"
-msgstr ""
+msgstr "Sinhronizacija dovoljenj za %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s in the background"
-msgstr ""
+msgstr "Sinhronizacija dovoljenj za %s v ozadju"
 
 msgid "Syntax"
 msgstr "Sintaksa"
@@ -13317,14 +14179,23 @@ msgstr ""
 msgid "System"
 msgstr "tok"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System Theme - Read Only"
-msgstr ""
+msgstr "Sistemska tema - samo za branje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System dark theme removed"
-msgstr ""
+msgstr "Sistemska temna tema je bila odstranjena"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System default theme removed"
-msgstr ""
+msgstr "Sistemska privzeta tema je bila odstranjena"
 
 msgid "TABLES"
 msgstr "TABELE"
@@ -13486,10 +14357,15 @@ msgstr "Oznake ni mogoče ustvariti."
 msgid "Task could not be updated."
 msgstr "Oznake ni mogoče posodobiti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"Naloge ni mogoče prekiniti. Naloga je v teku, vendar ni registrirala "
+"obravnavalnika za prekinitev."
 
 #, fuzzy
 msgid "Task parameters are invalid."
@@ -13499,17 +14375,27 @@ msgstr "Parametri oznak so neveljavni."
 msgid "Tasks"
 msgstr "oznake"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
-msgstr ""
+msgstr "Naloge se bodo prikazale tukaj, ko se bodo izvajale operacije v ozadju."
 
 msgid "Template"
 msgstr "Predloga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Template for cell titles. Use Handlebars templating syntax (a popular "
 "templating library that uses double curly brackets for variable "
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
+"Predloga za naslove celic. Uporabite sintakso predlog Handlebars "
+"(priljubljena knjižnica predlog, ki za nadomeščanje spremenljivk "
+"uporablja dvojne zavite oklepaje): {{row}}, {{column}}, {{rowLabel}}, "
+"{{columnLabel}}"
 
 msgid "Template parameters"
 msgstr "Parametri predlog"
@@ -13518,9 +14404,11 @@ msgstr "Parametri predlog"
 msgid "Template processing error: %(error)s"
 msgstr "Napaka obdelave: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "Obdelava predloge ni uspela: %(ex)s"
 
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
@@ -13590,17 +14478,29 @@ msgstr ""
 "GeoJsonLayer uporablja podatke v formatu GeoJSON in jih izriše kot "
 "interaktivne poligone, črte in točke (krogi, ikone in/ali besedila)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Global Task Framework ni omogočen. Prosimo, stopite v stik z vašim "
+"skrbnikom, da omogoči zastavico funkcije GLOBAL_TASK_FRAMEWORK."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Global Task Framework ni omogočen. Nastavite GLOBAL_TASK_FRAMEWORK=True v"
+" svojih zastavicah funkcij za uporabo @task. Za podrobnosti o "
+"konfiguraciji glejte https://superset.apache.org/docs/configuration"
+"/async-queries-celery."
 
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
@@ -13652,8 +14552,13 @@ msgstr ""
 "Kategorija izvornih vozlišč, na podlagi katere je določena barva. Če je "
 "vozlišče povezano z več kot eno kategorijo, bo uporabljena samo prva."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
 msgstr ""
+"Grafikon se še vedno nalaga. Prosimo, počakajte trenutek in poskusite "
+"znova."
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
@@ -13694,8 +14599,13 @@ msgstr ""
 "Barvna shema je določena s povezano nadzorno ploščo.\n"
 "        Barvno shemo uredite v nastavitvah nadzorne plošče."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color used when a value doesn't match any defined breakpoints."
 msgstr ""
+"Barva, ki se uporabi, ko vrednost ne ustreza nobeni definirani mejni "
+"točki."
 
 #, fuzzy
 msgid ""
@@ -13718,11 +14628,17 @@ msgstr "Stolpec, ki bo uporabljen kot cilj povezave."
 msgid "The column was deleted or renamed in the database."
 msgstr "Stolpec je bil izbrisan ali preimenovan v podatkovni bazi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The configuration for the map layers"
-msgstr ""
+msgstr "Konfiguracija za plasti zemljevida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The corner radius of the chart background"
-msgstr ""
+msgstr "Polmer kotov ozadja grafikona"
 
 msgid ""
 "The country code standard that Superset should expect to find in the "
@@ -13777,6 +14693,9 @@ msgstr "Stolpec/mera podatkovnega seta, ki vrne vrednosti za x-os grafikona."
 msgid "The dataset column/metric that returns the values on your chart's y-axis."
 msgstr "Stolpec/mera podatkovnega seta, ki vrne vrednosti za y-os grafikona."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
 "              based on the changes in your SQL query. If your changes "
@@ -13784,6 +14703,11 @@ msgid ""
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
+"Stolpci nabora podatkov bodo samodejno sinhronizirani\n"
+"              na osnovi sprememb v vaši SQL poizvedbi. Če vaše spremembe "
+"ne\n"
+"              vplivajo na definicije stolpcev, boste morda želeli "
+"preskočiti ta korak."
 
 msgid ""
 "The dataset configuration exposed here\n"
@@ -13842,21 +14766,33 @@ msgid ""
 "call."
 msgstr "Objekt engine_params se razširi v klic sqlalchemy.create_engine."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The exponent to compute all sizes from. \"EXP\" only"
-msgstr ""
+msgstr "Eksponent za izračun vseh velikosti. Samo za \"EXP\""
 
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
 msgstr "Končnica datoteke ni dovoljena."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
 "the extent so that all data points are included in the viewport. CUSTOM "
 "allows users to define the extent manually."
 msgstr ""
+"Obseg zemljevida ob zagonu aplikacije. FIT DATA samodejno nastavi obseg "
+"tako, da so vse podatkovne točke vključene v pogled. CUSTOM omogoča "
+"uporabnikom, da obseg določijo ročno."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "Lastnost elementa, ki se uporablja za oznake točk"
 
 #, python-format
 msgid ""
@@ -13864,10 +14800,15 @@ msgid ""
 "%(columns)s. "
 msgstr "V 'columns' manjkajo naslednji vnosi iz 'series_columns': %(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"Naslednja polja vsebujejo občutljive informacije, ki so bile maskirane "
+"med izvozom. Prosimo, vnesite vrednosti za uvoz te baze podatkov."
 
 #, python-format
 msgid ""
@@ -13896,8 +14837,11 @@ msgstr "Poročilo je bilo ustvarjeno"
 msgid "The group has been updated successfully."
 msgstr "Označba je bila posodobljena"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
-msgstr ""
+msgstr "Višina trenutne ravni povečave za izračun vseh višin"
 
 msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
@@ -13937,16 +14881,27 @@ msgstr "Imena gostitelja ni mogoče razrešiti."
 msgid "The id of the active chart"
 msgstr "Identifikator aktivnega grafikona"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"URL slike ikone za prikaz pri točkah GeoJSON. Upoštevajte, da mora URL "
+"slike biti skladen s pravilnikom o varnosti vsebine (CSP) za pravilno "
+"nalaganje."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
 msgstr ""
+"Začetna raven (globina) drevesa. Če je nastavljeno na -1, so vsa vozlišča"
+" razširjena."
 
 #, fuzzy
 msgid "The layer attribution"
@@ -14009,8 +14964,11 @@ msgstr ""
 msgid "The name of the geometry column"
 msgstr "Ime id-stolpca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the layer as described in GetCapabilities"
-msgstr ""
+msgstr "Ime plasti, kot je opisano v GetCapabilities"
 
 msgid "The name of the rule must be unique"
 msgstr "Ime pravila mora biti unikatno"
@@ -14127,8 +15085,11 @@ msgstr ""
 "nastavitvah podatkovne baze nista prisotni v izvoženih datotekah in jih "
 "je potrebno dodati ročno po uvozu, če je to potrebno."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
-msgstr ""
+msgstr "Za uvoz spodnjih baz podatkov so potrebna gesla."
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr "Format zapisa časovne značke. Za znakovne nize uporabite "
@@ -14319,8 +15280,11 @@ msgstr "Debelina plastnic v pikslih"
 msgid "The size of the square cell, in pixels"
 msgstr "Velikost kvadratne celice v pikslih"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The slope to compute all sizes from. \"LINEAR\" only"
-msgstr ""
+msgstr "Naklon za izračun vseh velikosti. Samo za \"LINEAR\""
 
 msgid "The submitted payload failed validation."
 msgstr "Neuspešna validacija podanih podatkov."
@@ -14425,8 +15389,11 @@ msgstr "Tip vizualizacije za prikaz"
 msgid "The unit for icon size"
 msgstr "Velikost mehurčka"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "Enota za velikost oznake"
 
 msgid "The unit of measure for the specified point radius"
 msgstr "Enota merila za definiran radij točk"
@@ -14459,8 +15426,11 @@ msgstr "Uporabniško ime \"%(username)s\" ne obstaja."
 msgid "The username provided when connecting to a database is not valid."
 msgstr "Uporabniško ime za povezavo s podatkovno bazo je neveljavno."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The values overlap other breakpoint values"
-msgstr ""
+msgstr "Vrednosti se prekrivajo z vrednostmi drugih mejnih točk"
 
 #, fuzzy
 msgid "The version of the service"
@@ -14476,8 +15446,11 @@ msgstr "Način razporeditve oznak na X-osi"
 msgid "The width of the Isoline in pixels"
 msgstr "Debelina plastnic v pikslih"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the current zoom level to compute all widths from"
-msgstr ""
+msgstr "Širina trenutne ravni povečave za izračun vseh širin"
 
 #, fuzzy
 msgid "The width of the elements border"
@@ -14486,10 +15459,13 @@ msgstr "Debelina črt"
 msgid "The width of the lines"
 msgstr "Debelina črt"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
-msgstr ""
+msgstr "Širina črt kot fiksna vrednost ali spremenljiva širina na osnovi metrike."
 
 # SUPERSET UI
 #, fuzzy
@@ -14555,11 +15531,15 @@ msgstr ""
 "Za to komponento ni dovolj prostora. Poskusite zmanjšati širino ali pa "
 "povečati širino cilja."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"Pri osveževanju vaše nadzorne plošče je prišlo do težave. Poskusili bomo "
+"znova čez %s, kot je načrtovano."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -14947,12 +15927,19 @@ msgid ""
 "table."
 msgstr "Tabela podatkovne baze ne vsebuje podatkov. Izberite drugo tabelo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Ta baza podatkov za avtentikacijo uporablja OAuth2. Prosimo, kliknite "
+"zgornjo povezavo, da Apache Supersetu podelite dovoljenje za dostop do "
+"podatkov. Vaš osebni žeton za dostop bo shranjen šifrirano in bo "
+"uporabljen samo za poizvedbe, ki jih zaženete sami."
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
@@ -14962,13 +15949,19 @@ msgstr ""
 msgid "This defines the element to be plotted on the chart"
 msgstr "Določa element, ki bo izrisan na grafikonu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This email is already associated with an account. Please choose another "
 "one."
-msgstr ""
+msgstr "Ta e-poštni naslov je že povezan z računom. Prosimo, izberite drugega."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This feature is experimental and may change or have limitations"
-msgstr ""
+msgstr "Ta funkcija je eksperimentalna in se lahko spremeni ali ima omejitve"
 
 msgid ""
 "This field is used as a unique identifier to attach the calculated "
@@ -14992,33 +15985,58 @@ msgstr "Seznam vrednosti filtra ne sme biti prazen"
 msgid "This filter might be incompatible with current %s"
 msgstr "Ta filter je lahko nekompatibilen s trenutnim podatkovnim setom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "Ta mapa je trenutno prazna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Ta mapa podpira samo stolpce"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Ta mapa podpira samo metrike"
 
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr "Ta funkcionalnost je v vašem okolju onemogočena zaradi varnosti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
+"To je privzeta mapa za stolpce. Njenega imena ni mogoče spremeniti ali "
+"odstraniti. Lahko ostane prazna, a bo sprejemala samo elemente stolpcev."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
+"To je privzeta mapa za metrike. Njenega imena ni mogoče spremeniti ali "
+"odstraniti. Lahko ostane prazna, a bo sprejemala samo elemente metrik."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "To je sporočilo o napaki po meri za a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "To je sporočilo o napaki po meri za b"
 
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
@@ -15040,11 +16058,17 @@ msgstr "Privzet datumčas"
 msgid "This is the default folder"
 msgstr "Osveži privzete vrednosti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "To je privzeta svetla tema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "To je edinkrat, ko boste videli ta ključ. Shranite ga varno."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -15055,13 +16079,20 @@ msgstr ""
 " se dinamično, ko prilagajamo velikost in postavitev pripomočkov z "
 "uporabo povleci&spusti v pogledu nadzorne plošče"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Tej povezavi ni mogoče slediti, ker je njen naslov nevaren."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Ta povezava vas bo odpeljala na zunanje spletno mesto. Ne moremo "
+"zagotoviti varnosti zunanjih destinacij."
 
 msgid "This markdown component has an error."
 msgstr "Markdown komponenta ima napako."
@@ -15069,10 +16100,15 @@ msgstr "Markdown komponenta ima napako."
 msgid "This markdown component has an error. Please revert your recent changes."
 msgstr "Markdown komponenta ima napako. Povrnite nedavne spremembe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This may be due to the extension not being activated or the content not "
 "being available."
 msgstr ""
+"To je morda posledica tega, da razširitev ni aktivirana ali vsebina ni na"
+" voljo."
 
 msgid "This may be triggered by:"
 msgstr "To je lahko sproženo z/s:"
@@ -15081,8 +16117,11 @@ msgstr "To je lahko sproženo z/s:"
 msgid "This metric might be incompatible with current %s"
 msgstr "Ta mera je lahko nekompatibilna s trenutnim podatkovnim setom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This name is already taken. Please choose another one."
-msgstr ""
+msgstr "To ime je že zasedeno. Prosimo, izberite drugo."
 
 msgid "This option has been disabled by the administrator."
 msgstr "To opcijo je onemogočil administrator."
@@ -15128,14 +16167,23 @@ msgstr ""
 "Ta tabela že ima povezan podatkovni set. S tabelo je lahko povezan le en "
 "podatkovni set.\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally"
-msgstr ""
+msgstr "Ta tema je nastavljena lokalno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally for your session"
-msgstr ""
+msgstr "Ta tema je nastavljena lokalno za vašo sejo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This username is already taken. Please choose another one."
-msgstr ""
+msgstr "To uporabniško ime je že zasedeno. Prosimo, izberite drugo."
 
 msgid "This value should be greater than the left target value"
 msgstr "Ta vrednost mora biti večja od leve ciljne vrednosti"
@@ -15156,9 +16204,11 @@ msgstr[1] "To je bilo sproženo z:"
 msgstr[2] "To je bilo sproženo z:"
 msgstr[3] "To je bilo sproženo z:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "To bo prekinilo (ustavilo) nalogo za vseh %s naročnikov."
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
@@ -15169,16 +16219,24 @@ msgstr ""
 "glavnim stolpcem za povečevanje in zmanjševanje. Osnovno pogojno "
 "oblikovanje, lahko spremenite s pogojnim oblikovanjem spodaj."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "To bo preklicalo nalogo."
 
 msgid "This will remove your current embed configuration."
 msgstr "To bo odstranilo trenutno konfiguracijo za vgrajevanje."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
+"To bo preorganiziralo vse metrike in stolpce v privzete mape. Vse mape po"
+" meri bodo odstranjene."
 
 msgid "Threshold"
 msgstr "Prag"
@@ -15370,11 +16428,16 @@ msgstr "Oblika zapisa časa"
 msgid "Timeline"
 msgstr "Časovni pas"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Konfigurirana je časovna omejitev (%s sekund), a ni definiran "
+"upravljalnik za prekinitev. Naloga bo nadaljevala z izvajanjem po preteku"
+" časovne omejitve."
 
 msgid "Timeout error"
 msgstr "Napaka pretečenega časa"
@@ -15403,17 +16466,30 @@ msgstr "Naslov je obvezen"
 msgid "Title or Slug"
 msgstr "Naslov ali `Slug`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Za začetek uporabe Google Preglednic morate najprej ustvariti bazo "
+"podatkov. Baze podatkov se uporabljajo kot način identifikacije vaših "
+"podatkov, da jih je mogoče poizvedovati in vizualizirati. Ta baza "
+"podatkov bo vsebovala vse vaše posamezne Google Preglednice, ki jih "
+"izberete za povezavo tukaj."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
 "clicking the column header."
 msgstr ""
+"Za omogočanje razvrščanja po več stolpcih pridržite tipko ⇧ Shift med "
+"klikom na glavo stolpca."
 
 msgid "To filter on a metric, use Custom SQL tab."
 msgstr "Za filtriranje po meri uporabite zavihek za SQL-izraz."
@@ -15421,8 +16497,11 @@ msgstr "Za filtriranje po meri uporabite zavihek za SQL-izraz."
 msgid "To get a readable URL for your dashboard"
 msgstr "Za pridobitev berljivega URL-ja za nadzorno ploščo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "URI zahteve za žeton"
 
 #, fuzzy
 msgid "Tool Panel"
@@ -15564,8 +16643,11 @@ msgstr "Prireži dolge celice na \"min. širino\" nastavljeno zgoraj"
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr "Zaokroži datum-čas, glede na definirano časovno enoto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Zaupaj temu URL-ju in ne sprašuj ponovno"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
@@ -15601,11 +16683,17 @@ msgstr "Vnesite vrednost"
 msgid "Type is required"
 msgstr "Tip je obvezen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "Dovoljena vrsta Google Preglednic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Type of chart to display in sparkline"
-msgstr ""
+msgstr "Vrsta grafikona za prikaz v sparkline"
 
 msgid "Type of comparison, value difference or percentage"
 msgstr "Vrsta primerjave, razlike vrednosti ali procenta"
@@ -15614,17 +16702,26 @@ msgstr "Vrsta primerjave, razlike vrednosti ali procenta"
 msgid "Type to search (contains)..."
 msgstr "Iskanje stolpcev"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Vtipkajte za iskanje (se konča z)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Vtipkajte za iskanje (se začne z)..."
 
 msgid "UI Configuration"
 msgstr "UI-nastavitve"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "UI theme administration is not enabled."
-msgstr ""
+msgstr "Upravljanje tem uporabniškega vmesnika ni omogočeno."
 
 msgid "URL"
 msgstr "URL"
@@ -15679,10 +16776,16 @@ msgstr ""
 msgid "Unable to create chart without a query id."
 msgstr "Grafikona ni mogoče ustvariti brez id-ja poizvedbe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"Poročila ni mogoče ustvariti: zahtevani e-poštni naslov uporabnika ni bil"
+" najden. Prepričajte se, da ima vaš uporabniški profil veljaven e-poštni "
+"naslov."
 
 msgid "Unable to decode value"
 msgstr "Vrednosti ni mogoče dešifrirati"
@@ -15690,8 +16793,11 @@ msgstr "Vrednosti ni mogoče dešifrirati"
 msgid "Unable to encode value"
 msgstr "Vrednosti ni mogoče šifrirati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
-msgstr ""
+msgstr "Semantičnih pogledov ni mogoče pridobiti. Preverite konfiguracijo sloja."
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
@@ -15701,10 +16807,16 @@ msgstr "Ni mogoče najti takšnega praznika: [%(holiday)s]"
 msgid "Unable to generate download payload"
 msgstr "Nadzorne plošče ni mogoče naložiti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
 "ensure your dataset has a properly configured time column."
 msgstr ""
+"Časovnega stolpca za primerjavo časovnih razponov ni mogoče "
+"identificirati. Prepričajte se, da ima vaš nabor podatkov pravilno "
+"konfiguriran časovni stolpec."
 
 msgid ""
 "Unable to load columns for the selected table. Please select a different "
@@ -15736,8 +16848,11 @@ msgstr ""
 "Stanja sheme tabele ni mogoče prenesti v sistem. Superset bo ponovil "
 "poskus kasneje. Če se težava ponavlja, kontaktirajte administratorja."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to parse SQL"
-msgstr ""
+msgstr "SQL-a ni mogoče razčleniti"
 
 #, fuzzy
 msgid "Unable to read the file, please refresh and try again."
@@ -15746,8 +16861,11 @@ msgstr "Prenos slike ni uspel. Osvežite in poskusite ponovno."
 msgid "Unable to retrieve dashboard colors"
 msgstr "Neuspešno pridobivanje barv nadzorne plošče"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to sync permissions for this database connection."
-msgstr ""
+msgstr "Dovoljenj za to podatkovno povezavo ni mogoče sinhronizirati."
 
 msgid "Undefined"
 msgstr "Ni definirano"
@@ -15824,8 +16942,11 @@ msgstr "Neznana napaka"
 msgid "Unknown input format"
 msgstr "Neznana oblika vnosa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "Neznani žetoni bodo označeni kot opozorila."
 
 msgid "Unknown type"
 msgstr "Neznan tip"
@@ -15837,14 +16958,22 @@ msgstr "Neznana vrednost"
 msgid "Unpin"
 msgstr "v teku"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Odpni iz plošče z rezultati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Odpni z vrha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Nevarna povezava je blokirana"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
@@ -15858,8 +16987,13 @@ msgstr "Nevaren vzorec za ključ %(key)s: %(value_type)s"
 msgid "Unsupported clause type: %(clause)s"
 msgstr "Nepodprt tip izraza: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
 msgstr ""
+"Nepodprta vrsta datoteke. Prosimo, uporabite datoteke CSV, Excel ali "
+"stolpčne datoteke."
 
 #, python-format
 msgid "Unsupported post processing operation: %(operation)s"
@@ -15963,10 +17097,15 @@ msgstr "Uporabite %s za odpiranje v novem zavihku."
 msgid "Use Area Proportions"
 msgstr "Uporabi razmerje površin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
+"Uporabite sintakso Handlebars za ustvarjanje prilagojenih namigov. "
+"Razpoložljive spremenljivke temeljijo na zgornji izbiri vsebine namiga."
 
 msgid "Use a log scale"
 msgstr "Uporabi logaritemsko skalo"
@@ -16123,8 +17262,11 @@ msgstr ""
 "premikom kurzorja prikaže vrednosti na posameznem nivoju. Uporabno za "
 "večnivojsko, večskupinsko vizualizacijo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Uporabi prvih 25 vrednosti, če ima dimenzija več."
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -16138,9 +17280,11 @@ msgstr "Ogled poizvedbe"
 msgid "Validate your expression"
 msgstr "Neveljaven cron izraz"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Validating connectivity for %s"
-msgstr ""
+msgstr "Preverjanje povezljivosti za %s"
 
 #, fuzzy
 msgid "Validating..."
@@ -16186,8 +17330,11 @@ msgstr "Vrednost mora biti večja od 0"
 msgid "Value is required"
 msgstr "Zahtevana je vrednost"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value less than"
-msgstr ""
+msgstr "Vrednost manjša od"
 
 msgid "Value must be 0 or greater"
 msgstr "Vrednost mora biti 0 ali večja"
@@ -16205,8 +17352,13 @@ msgstr "Vrednosti so odvisne od drugih filtrov"
 msgid "Values dependent on"
 msgstr "Vrednosti so odvisne od"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Values less than this percentage will be grouped into the Other category."
 msgstr ""
+"Vrednosti, ki so manjše od tega odstotka, bodo razvrščene v kategorijo "
+"»Ostalo«."
 
 msgid ""
 "Values selected in other filters will affect the filter options to only "
@@ -16391,8 +17543,11 @@ msgstr ""
 msgid "WMS"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "Čakanje na prvo osvežitev"
 
 #, python-format
 msgid "Waiting on %s"
@@ -16404,8 +17559,11 @@ msgstr "Čakanje na podatkovno bazo..."
 msgid "Want to add a new database?"
 msgstr "Želite dodati novo podatkovno bazo?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "Skladišče"
 
 msgid "Warning"
 msgstr "Opozorilo"
@@ -16420,10 +17578,15 @@ msgstr ""
 "Opozorilo! Sprememba podatkovnega seta lahko pokvari grafikon, če "
 "metapodatki ne obstajajo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Opozorilo: poizvedbe ILIKE so lahko počasne na velikih naborih podatkov, "
+"ker ne morejo učinkovito uporabljati indeksov."
 
 msgid "Was unable to check your query"
 msgstr "Poizvedbe ni bilo mogoče preveriti"
@@ -16641,10 +17804,15 @@ msgstr "Ko uporabljate 'Group By', ste omejeni na uporabo ene mere"
 msgid "When using other than adaptive formatting, labels may overlap"
 msgstr "Če ne uporabljate prilagodljive oblike, se oznake lahko prekrivajo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
 msgstr ""
+"Ko je ta možnost aktivna, privzete vrednosti ni mogoče nastaviti. Uporaba"
+" te možnosti lahko vpliva na čas nalaganja vaše nadzorne plošče."
 
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
 msgstr "Če želite prekrivanje območij, ko imate več skupin podatkov"
@@ -17019,9 +18187,11 @@ msgstr "Da, prepiši spremembe"
 msgid "You are adding tags to %s %ss"
 msgstr "Oznake dodajate %s %ss"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "Urejate poizvedbo iz virtualnega nabora podatkov "
 
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
@@ -17072,18 +18242,31 @@ msgstr ""
 "Uvažate enega ali več podatkovnih setov, ki že obstajajo. S prepisom "
 "lahko izgubite podatke. Ali ste prepričani, da želite prepisati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in a dashboard context with labels shared "
 "across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
+"Ta grafikon si ogledujete v kontekstu nadzorne plošče z oznakami, ki so "
+"skupne več grafikonom.\n"
+"        Izbira barvne sheme je onemogočena."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in the context of a dashboard that is directly"
 " affecting its colors.\n"
 "        To edit the color scheme, open this chart outside of the "
 "dashboard."
 msgstr ""
+"Ta grafikon si ogledujete v kontekstu nadzorne plošče, ki neposredno "
+"vpliva na njegove barve.\n"
+"        Če želite urediti barvno shemo, odprite ta grafikon zunaj "
+"nadzorne plošče."
 
 msgid "You can"
 msgstr "Lahko"
@@ -17255,8 +18438,11 @@ msgstr "Izbrati morate ime nove nadzorne plošče"
 msgid "You must run the query successfully first"
 msgstr "Najprej morate uspešno izvesti poizvedbo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Morate"
 
 msgid ""
 "You updated the values in the control panel, but the chart was not "
@@ -17267,11 +18453,15 @@ msgstr ""
 "samodejno posodobil. Zaženite poizvedbo z gumbom \"Posodobi grafikon\" "
 "ali"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Odstranjeni boste iz te naloge. Nadaljevala se bo izvajati za %s "
+"drugega(-ih) naročnika(-ov)."
 
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
@@ -17280,11 +18470,17 @@ msgstr ""
 "Spremenili ste podatkovne sete. Vsi kontrolniki nad podatki (stolpci, "
 "mere), ki se ujemajo z novim podatkovnim setom, se bodo ohranili."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "Vaš račun je aktiviran. Prijavite se lahko s svojimi poverilnicami."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "Vaše spremembe bodo izgubljene, če zapustite brez shranjevanja."
 
 msgid "Your chart is not up to date"
 msgstr "Grafikon ni aktualen"
@@ -17292,8 +18488,11 @@ msgstr "Grafikon ni aktualen"
 msgid "Your chart is ready to go!"
 msgstr "Grafikon je pripravljen!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your dashboard is near the size limit."
-msgstr ""
+msgstr "Vaša nadzorna plošča se približuje omejitvi velikosti."
 
 msgid "Your dashboard is too large. Please reduce its size before saving it."
 msgstr "Vaša nadzorna plošča je prevelika. Pred shranjevanjem jo zmanjšajte."
@@ -17384,8 +18583,11 @@ msgstr ""
 "[opcijsko] sekundarna mera določa barvo kot razmerje do primarne mere. Če"
 " je izpuščena, je barva določena kategorično na podlagi oznak"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[nepoimenovana prilagoditev]"
 
 msgid "`compare_columns` must have the same length as `source_columns`."
 msgstr "`compare_columns` morajo imeti enako dolžino kot `source_columns`."
@@ -17409,9 +18611,10 @@ msgstr ""
 msgid "`operation` property of post processing object undefined"
 msgstr "Lastnost  `operation` poprocesirnega objekta ni definirana"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` mora biti med 1 in %(max)s"
 
 msgid "`prophet` package not installed"
 msgstr "Knjižnica `prophet` ni nameščena"
@@ -17752,8 +18955,11 @@ msgstr "npr. world_population"
 msgid "e.g. xy12345.us-east-2.aws"
 msgstr "npr. xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "npr. CI/CD Pipeline, Analytics Script"
 
 msgid "edit mode"
 msgstr "načinu urejanja"
@@ -17803,14 +19009,20 @@ msgstr "vsak mesec"
 msgid "expand"
 msgstr "razširi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard mora biti objekt"
 
 msgid "failed"
 msgstr "ni uspelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "zbogom"
 
 msgid "fetching"
 msgstr "pridobivanje"
@@ -17848,8 +19060,11 @@ msgstr "toplotni prikaz"
 msgid "heatmap: values are normalized across the entire heatmap"
 msgstr "heatmap: vrednosti so normirane po celotni temperaturni lestvici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "zdravo"
 
 msgid "here"
 msgstr "tukaj"
@@ -17860,8 +19075,11 @@ msgstr "ura"
 msgid "in"
 msgstr "v"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "da bi izvedli to operacijo."
 
 msgid "invalid email"
 msgstr "neveljaven email"
@@ -17870,10 +19088,15 @@ msgstr "neveljaven email"
 msgid "is"
 msgstr "Razdelki"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
 msgstr ""
+"mora biti Mapbox/OSM URL (npr. mapbox://styles/...) ali URL strežnika za "
+"ploščice (npr. tile://http...)"
 
 msgid "is expected to be a number"
 msgstr "pričakovano je število"
@@ -17904,8 +19127,11 @@ msgstr ""
 "je povezan z grafikoni %s, ki so prisotni na %s nadzornih ploščah. Ali "
 "želite nadaljevati? Izbris podatkovnega seta bo pokvaril te objekte."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not"
-msgstr ""
+msgstr "ni"
 
 #, fuzzy
 msgid "is not null"
@@ -17999,30 +19225,45 @@ msgstr "mora imeti vrednost"
 msgid "name"
 msgstr "ime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters mora biti seznam"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] manjkajo zahtevani ključi: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] mora biti objekt"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues mora biti seznam"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
 msgstr ""
+"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' ne obstaja na "
+"nadzorni plošči"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId mora biti neprazen niz znakov"
 
 msgid "no SQL validator is configured"
 msgstr "potrjevalnik SQL ni nastavljen"
@@ -18045,8 +19286,11 @@ msgstr "ikona numeričnega tipa"
 msgid "nvd3"
 msgstr "nvd3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "of"
-msgstr ""
+msgstr "od"
 
 msgid "offline"
 msgstr "offline"
@@ -18246,8 +19490,11 @@ msgstr "Ciljna barva"
 msgid "textarea"
 msgstr "področje besedila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "dokumentacijo grafikona Handlebars"
 
 # SUPERSET UI
 #, fuzzy
@@ -18347,8 +19594,14 @@ msgstr ""
 msgid "zoom area"
 msgstr "približaj območje"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "© Layer attribution"
-msgstr ""
+msgstr "© Atribucija sloja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Slovenian (`sl`) catalog using `scripts/translations/backfill_po.py` (Claude, cross-language context), **skipping do-not-translate tokens** (icon names, enum values, SQL keywords, API field names, placeholders — see #41651).

All generated strings are marked `#, fuzzy` with an attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend (`pybabel compile --use-fuzzy`, see #41648) builds include fuzzy entries, so these translations render in the UI once built — reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only — no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l sl` succeeds.
- Slovenian native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API