### PR TITLE
fix(dashboard): use theme border for chart tiles

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/theme/types.ts
@@ -253,7 +253,7 @@ export interface SupersetSpecificTokens {
     { type?: string; variant?: string; color?: string }
   >;
 
-  // Dashboard tile tokens (opt-in, fallbacks: colorBgContainer bg, no border, borderRadius, hairline box-shadow)
+  // Dashboard tile tokens (opt-in, fallbacks: colorBgContainer bg, colorBorder border, borderRadius, hairline box-shadow)
   dashboardTileBg?: string;
   dashboardTileBorder?: string;
   dashboardTileBorderRadius?: number;

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -355,6 +355,26 @@ describe('DashboardBuilder', () => {
     expect(filterbar).toHaveStyleRule('width', `${expectedValue}px`);
   });
 
+  test('should render dashboard chart holder borders with theme token', () => {
+    const { container } = setup();
+    const dashboardContent = container.querySelector('.dashboard-content');
+
+    expect(dashboardContent).toHaveStyleRule(
+      'border',
+      `1px solid ${supersetTheme.colorBorder}`,
+      {
+        target: '.dashboard-component-chart-holder',
+      },
+    );
+    expect(dashboardContent).toHaveStyleRule(
+      'border-radius',
+      `${supersetTheme.borderRadius}px`,
+      {
+        target: '.dashboard-component-chart-holder',
+      },
+    );
+  });
+
   test('should set header max width based on open filter bar width', () => {
     const expectedValue = 320;
     const setter = jest.fn();

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -317,6 +317,8 @@ const StyledDashboardContent = styled.div<{
       width: 100%;
       height: 100%;
       background-color: ${theme.dashboardTileBg ?? theme.colorBgContainer};
+      border: ${theme.dashboardTileBorder ?? `1px solid ${theme.colorBorder}`};
+      border-radius: ${theme.dashboardTileBorderRadius ?? theme.borderRadius}px;
       position: relative;
       padding: ${theme.sizeUnit * 4}px;
       box-sizing: border-box;
@@ -329,16 +331,12 @@ const StyledDashboardContent = styled.div<{
         box-shadow ${theme.motionDurationMid} ease-in-out;
 
       &.fade-in {
-        border-radius: ${theme.borderRadius}px;
         box-shadow:
           inset 0 0 0 2px ${theme.colorPrimary},
           0 0 0 3px ${addAlpha(theme.colorPrimary, 0.1)};
       }
 
       &.fade-out {
-        border: ${theme.dashboardTileBorder ?? 'none'};
-        border-radius: ${theme.dashboardTileBorderRadius ??
-        theme.borderRadius}px;
         box-shadow: ${theme.dashboardTileBoxShadow ??
         `0 0 0 1px ${addAlpha(theme.colorBorder, 0.5)}`};
       }


### PR DESCRIPTION
### SUMMARY
- add a resting chart tile border using the active theme colorBorder token
- keep the existing border radius token on chart holders
- add DashboardBuilder coverage for the chart holder border styles

Closes #41618

### SCREENSHOTS

Captured from a local Superset Sales Dashboard with example data loaded.

Before:

![Before chart tile border change](https://gist.githubusercontent.com/YinkaMetrics/70ad92c2f93201dc02747abfa6a0890d/raw/dashboard-6-before.png)

After:

![After chart tile border change](https://gist.githubusercontent.com/YinkaMetrics/70ad92c2f93201dc02747abfa6a0890d/raw/dashboard-6-after.png)

### TESTING INSTRUCTIONS
- env NODE_ENV=test NODE_OPTIONS=--max-old-space-size=8192 node_modules/.bin/jest --config jest.config.js --silent --runInBand src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
- superset-frontend/node_modules/.bin/prettier --check superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
- git diff --check
