### PR TITLE
fix(drill-detail): drill to detail by a null value dimension should use NULL_STRING

### DIFF
--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
@@ -38,6 +38,7 @@ import { css, styled } from '@apache-superset/core/theme';
 import { useSelector } from 'react-redux';
 import { type ItemType } from '@superset-ui/core/components/Menu';
 import { RootState } from 'src/dashboard/types';
+import { NULL_STRING } from 'src/utils/common';
 import { getSubmenuYOffset } from '../utils';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 import { TruncatedMenuLabel } from '../MenuItemWithTruncation';
@@ -219,33 +220,41 @@ export const useDrillDetailMenuItems = ({
           popupOffset: [0, submenuYOffset],
           popupClassName: 'chart-context-submenu',
           children: [
-            ...filters.map((filter, i) => ({
-              key: `drill-detail-filter-${i}`,
-              onClick: openModal.bind(null, [filter]),
-              label: (
-                <div
-                  css={css`
-                    max-width: 200px;
-                  `}
-                >
-                  <TruncatedMenuLabel
-                    tooltipText={`${DRILL_TO_DETAIL_BY} ${filter.formattedVal}`}
-                    aria-label={`${DRILL_TO_DETAIL_BY} ${filter.formattedVal}`}
+            ...filters.map((filter, i) => {
+              const isNullVal =
+                isEmpty(filter.formattedVal) ||
+                filter.formattedVal === NULL_STRING;
+              const formattedVal = isNullVal
+                ? NULL_STRING
+                : filter.formattedVal;
+              return {
+                key: `drill-detail-filter-${i}`,
+                onClick: openModal.bind(null, [filter]),
+                label: (
+                  <div
+                    css={css`
+                      max-width: 200px;
+                    `}
                   >
-                    <span
-                      css={css`
-                        display: inline;
-                      `}
+                    <TruncatedMenuLabel
+                      tooltipText={`${DRILL_TO_DETAIL_BY} ${formattedVal}`}
+                      aria-label={`${DRILL_TO_DETAIL_BY} ${formattedVal}`}
                     >
-                      {DRILL_TO_DETAIL_BY}{' '}
-                      <StyledFilter stripHTML>
-                        {filter.formattedVal}
-                      </StyledFilter>
-                    </span>
-                  </TruncatedMenuLabel>
-                </div>
-              ),
-            })),
+                      <span
+                        css={css`
+                          display: inline;
+                        `}
+                      >
+                        {DRILL_TO_DETAIL_BY}{' '}
+                        <StyledFilter stripHTML={!isNullVal}>
+                          {formattedVal}
+                        </StyledFilter>
+                      </span>
+                    </TruncatedMenuLabel>
+                  </div>
+                ),
+              };
+            }),
             ...(filters.length > 1
               ? [
                   {

--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
@@ -222,8 +222,7 @@ export const useDrillDetailMenuItems = ({
           children: [
             ...filters.map((filter, i) => {
               const isNullVal =
-                isEmpty(filter.formattedVal) ||
-                filter.formattedVal === NULL_STRING;
+                filter.val === null || filter.formattedVal === NULL_STRING;
               const formattedVal = isNullVal
                 ? NULL_STRING
                 : filter.formattedVal;

--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/useDrillDetailMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/useDrillDetailMenuItems.test.tsx
@@ -74,6 +74,13 @@ const filterB: BinaryQueryObjectFilterClause = {
   formattedVal: 'Two days ago',
 };
 
+const filterNull: BinaryQueryObjectFilterClause = {
+  col: 'sample_column_3',
+  op: '==',
+  val: null as unknown as string,
+  formattedVal: '<NULL>',
+};
+
 const MockRenderChart = ({
   chartId,
   formData,
@@ -425,4 +432,15 @@ test.skip('context menu for supported chart, dimensions, all filters', async () 
   const filters = [filterA, filterB];
   await setupMenu(filters);
   await expectDrillToDetailByAll(filters);
+});
+
+test('context menu renders <NULL> for null dimension values', async () => {
+  renderMenu({
+    formData: defaultFormData,
+    isContextMenu: true,
+    filters: [filterNull],
+  });
+
+  await expectDrillToDetailByEnabled();
+  await expectDrillToDetailByDimension(filterNull);
 });


### PR DESCRIPTION
### SUMMARY

Fixes #41677

When drilling to detail by a dimension whose value is `null`, the context menu previously showed "Drill to detail by " with a blank value. This was because `formatSeriesName` returns the `<NULL>` placeholder, but the `StyledFilter` component ran `removeHTMLTags` on it, which stripped `<NULL>` as if it were an HTML tag, leaving an empty label.

This fix detects null/empty values (including the existing `<NULL>` placeholder) and renders them with HTML stripping disabled, so the menu now correctly shows "Drill to detail by `<NULL>`" using NULL_STRING.

Added a unit test in `useDrillDetailMenuItems.test.tsx` covering the null-value case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="373" height="216" alt="image" src="https://github.com/user-attachments/assets/15eb19f0-d188-486b-9a9d-a8b2835934e3" />

After:

<img width="246" height="147" alt="image" src="https://github.com/user-attachments/assets/faf38f4f-8511-463d-947c-7e0c6ce75b19" />

### TESTING INSTRUCTIONS

1. Create a chart with a dimension that has null values
2. Add it to a dashboard
3. Right a chart value and observe "Drill to detail by <NULL>" now, rather than "Drill to detail by ".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
