### PR TITLE
fix(a11y): add aria-label to VizTypeGallery search clear icon

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -778,7 +778,11 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
           suffix={
             <InputIconAlignment>
               {searchInputValue && (
-                <Icons.CloseOutlined iconSize="m" onClick={stopSearching} />
+                <Icons.CloseOutlined
+                  iconSize="m"
+                  onClick={stopSearching}
+                  aria-label={t('Clear search')}
+                />
               )}
             </InputIconAlignment>
           }


### PR DESCRIPTION
## Summary

The "clear search" icon in the visualization type gallery (`VizTypeGallery.tsx`) is an icon-only interactive control (`Icons.CloseOutlined` with an `onClick` handler) with no explicit accessible name. It falls back to `BaseIcon`'s auto-generated label derived from the icon's component name (`"close"`), which is generic and doesn't describe what the control actually does in this context (it clears the search input and returns to the previously active category).

**WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A.**

## Change

Added an explicit, translated `aria-label={t('Clear search')}` directly on the icon, overriding the generic auto-generated fallback. Confirmed via `BaseIcon.tsx`'s prop-spread order that an explicit `aria-label` passed by the caller wins over the auto-generated one.

No behavior change — purely an accessibility/semantics improvement.

## Test plan

- [ ] Open the "Create a new chart" viz type gallery, type into the search box
- [ ] Tab to the clear ("x") icon that appears in the search input's suffix
- [ ] Verify a screen reader announces "Clear search, button" instead of the generic "close, button"
- [ ] Click/activate it and confirm the search still clears as before (no behavior change)