### PR TITLE
fix(dockerfile): allow GH auth-less fetch of `uv` when building Superset image locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ RUN useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash 
 # Some bash scripts needed throughout the layers
 COPY --chmod=755 docker/*.sh /app/docker/
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN pip install --no-cache-dir --upgrade uv
 
 # Using uv as it's faster/simpler than pip
 RUN uv venv /app/.venv


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(dockerfile): allow GH auth-less fetch of `uv` when building Superset image locally

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolve following issue when I was trying to building Superset image via `docker compose up --build` locally

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1108" height="218" alt="image" src="https://github.com/user-attachments/assets/10563e11-0c4f-4f24-8731-6dedfa0698b8" />

After (notice the 3rd line has `uv` installed successfully)
<img width="1108" height="259" alt="image" src="https://github.com/user-attachments/assets/7ea8a791-a10a-4806-a311-166976bf801b" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Checkout `master` branch
2. Run `docker compose up --build` command
3. Experience the pain

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
