### PR TITLE
fix(sqllab): preserve saved query description when editing

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -749,7 +749,7 @@ describe('async actions', () => {
         database_name: 'examples',
         id: 2,
       },
-      description: '',
+      description: 'A saved query description',
       id: 1,
       label: 'Query 1',
       schema: 'public',
@@ -799,6 +799,7 @@ describe('async actions', () => {
 
       const expectedParams = {
         name: 'Query 1',
+        description: 'A saved query description',
         dbId: 2,
         catalog: null,
         schema: 'public',

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -1539,6 +1539,7 @@ export function popSavedQuery(
         } as Record<string, unknown>;
         const tmpAdaptedProps = {
           name: queryEditorProps.name as string,
+          description: queryEditorProps.description as string,
           dbId: (queryEditorProps.database as { id: number }).id,
           catalog: queryEditorProps.catalog as string,
           schema: queryEditorProps.schema as string,

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -172,6 +172,45 @@ describe('SavedQuery', () => {
     expect(updateBtn).toBeInTheDocument();
   });
 
+  test('pre-fills the description from an existing saved query and updates with it unchanged', async () => {
+    const storedDescription = 'This is the stored description';
+    const mockOnUpdate = jest.fn();
+
+    render(<SaveQuery {...mockedProps} onUpdate={mockOnUpdate} />, {
+      useRedux: true,
+      store: mockStore({
+        ...mockState,
+        sqlLab: {
+          ...mockState.sqlLab,
+          queryEditors: [
+            {
+              id: mockedProps.queryEditorId,
+              dbId: 1,
+              catalog: null,
+              schema: 'main',
+              sql: 'SELECT * FROM t',
+              name: 'My saved query',
+              description: storedDescription,
+              remoteId: 42,
+            },
+          ],
+        },
+      }),
+    });
+
+    userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const descriptionTextbox = screen.getAllByRole('textbox')[1];
+    expect(descriptionTextbox).toHaveValue(storedDescription);
+
+    userEvent.click(screen.getByRole('button', { name: /update/i }));
+
+    await waitFor(() => expect(mockOnUpdate).toHaveBeenCalled());
+    expect(mockOnUpdate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ description: storedDescription }),
+    );
+  });
+
   test('renders a split save button when allows_virtual_table_explore is enabled', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, {
       useRedux: true,

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -200,7 +200,9 @@ describe('SavedQuery', () => {
 
     userEvent.click(screen.getByRole('button', { name: /save/i }));
 
-    const descriptionTextbox = screen.getAllByRole('textbox')[1];
+    const descriptionTextbox = screen.getByRole('textbox', {
+      name: 'Description',
+    });
     expect(descriptionTextbox).toHaveValue(storedDescription);
 
     userEvent.click(screen.getByRole('button', { name: /update/i }));

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -162,16 +162,22 @@ const SaveQuery = ({
     <Form layout="vertical">
       <Row>
         <Col xs={24}>
-          <FormItem label={t('Name')}>
-            <Input type="text" value={label} onChange={onLabelChange} />
+          <FormItem label={t('Name')} htmlFor="save-query-name">
+            <Input
+              id="save-query-name"
+              type="text"
+              value={label}
+              onChange={onLabelChange}
+            />
           </FormItem>
         </Col>
       </Row>
       <br />
       <Row>
         <Col xs={24}>
-          <FormItem label={t('Description')}>
+          <FormItem label={t('Description')} htmlFor="save-query-description">
             <Input.TextArea
+              id="save-query-description"
               rows={4}
               value={description}
               onChange={onDescriptionChange}


### PR DESCRIPTION
### SUMMARY

Editing a saved query (Saved Queries → Edit) opens it in SQL Lab and shows the **Save query** modal with a **blank Description**, even when the query has a stored description — the Name field populates correctly. Clicking **Update** without re-typing then sends an empty description and **wipes the stored value**.

Root cause: the Edit flow dispatches `popSavedQuery` (`SqlLab/actions/sqlLab.ts`), which fetches the saved query and rebuilds a hand-picked `tmpAdaptedProps` object for `addQueryEditor` — that object copied `name` but omitted `description`. So the query editor's Redux state had no description, the modal initialized the field to `''`, and Update persisted `''`.

Fix: carry `description` through `tmpAdaptedProps` (it's already in the saved_query API `show_columns` and typed on `QueryEditor`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: Description field blank on edit → Update wipes the stored description. After: Description pre-fills with the stored value and Update preserves it.

### TESTING INSTRUCTIONS

1. SQL Lab → save a query with a name **and** a non-empty description.
2. SQL Lab → Saved Queries → Edit (pencil) that query.
3. Save → Save query → the Description field is pre-filled; Update keeps the description intact.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [x] Changes UI — SQL Lab Save query modal now pre-fills Description on edit
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No