### PR TITLE
fix(dashboard): show a not-found state for a deleted dashboard

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.test.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.test.tsx
@@ -22,6 +22,7 @@ import {
   createStore,
   render,
   screen,
+  userEvent,
   waitFor,
 } from 'spec/helpers/testing-library';
 import reducerIndex from 'spec/helpers/reducerIndex';
@@ -30,7 +31,7 @@ import {
   useDashboardCharts,
   useDashboardDatasets,
 } from 'src/hooks/apiResources';
-import { SupersetClient } from '@superset-ui/core';
+import { SupersetApiError, SupersetClient } from '@superset-ui/core';
 import CrudThemeProvider from 'src/components/CrudThemeProvider';
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
 import {
@@ -557,6 +558,48 @@ test('does not overwrite filterState when modern native_filters URL format is us
   expect(
     callArg.dataMask['NATIVE_FILTER-OvPTDNKc9'].currentState,
   ).toBeUndefined();
+});
+
+test('renders a not-found state instead of throwing when the dashboard 404s', async () => {
+  mockUseDashboard.mockReturnValue({
+    result: null,
+    error: new SupersetApiError({ status: 404, message: 'Not found' }),
+  });
+  mockUseDashboardCharts.mockReturnValue({
+    result: null,
+    error: new SupersetApiError({ status: 404, message: 'Not found' }),
+  });
+  mockUseDashboardDatasets.mockReturnValue({
+    result: null,
+    error: new SupersetApiError({ status: 404, message: 'Not found' }),
+    status: 'error',
+  });
+
+  render(
+    <Suspense fallback="loading">
+      <DashboardPage idOrSlug="404" />
+    </Suspense>,
+    {
+      useRedux: true,
+      useRouter: true,
+      initialState: {
+        dashboardInfo: {},
+        dashboardState: { sliceIds: [] },
+        nativeFilters: { filters: {} },
+        dataMask: {},
+      },
+    },
+  );
+
+  expect(
+    await screen.findByText('This dashboard does not exist'),
+  ).toBeInTheDocument();
+  expect(screen.queryByTestId('dashboard-builder')).not.toBeInTheDocument();
+
+  await userEvent.click(
+    screen.getByRole('button', { name: 'See all dashboards' }),
+  );
+  expect(window.location.pathname).toBe('/dashboard/list/');
 });
 
 test('clears undo history after hydrating the dashboard', async () => {

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -24,7 +24,7 @@ import { useTheme } from '@apache-superset/core/theme';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
-import { Loading } from '@superset-ui/core/components';
+import { EmptyState, Loading } from '@superset-ui/core/components';
 import {
   useDashboard,
   useDashboardCharts,
@@ -67,7 +67,8 @@ import SyncDashboardState, {
   getDashboardContextLocalStorage,
 } from '../components/SyncDashboardState';
 import { AutoRefreshProvider } from '../contexts/AutoRefreshContext';
-import { Filter, PartialFilters } from '@superset-ui/core';
+import { Filter, PartialFilters, SupersetApiError } from '@superset-ui/core';
+import { RoutePaths } from 'src/views/routePaths';
 import {
   parseRisonFilters,
   risonFiltersToExtraFormDataFilters,
@@ -151,6 +152,9 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   const isDashboardHydrated = useRef(false);
 
   const error = dashboardApiError || chartsApiError;
+  // Only 404 gets a graceful not-found state; a 403 (access denied) still
+  // surfaces through the error boundary.
+  const isNotFoundError = (error as SupersetApiError | null)?.status === 404;
   const readyToRender = Boolean(dashboard && charts);
   const { dashboard_title, id = 0 } = dashboard || {};
 
@@ -365,18 +369,21 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
 
   useEffect(() => {
     if (datasetsApiError) {
-      addDangerToast(
-        t('Error loading chart datasources. Filters may not work correctly.'),
-      );
+      // A missing dashboard also 404s its datasets; the not-found state covers it.
+      if (!isNotFoundError) {
+        addDangerToast(
+          t('Error loading chart datasources. Filters may not work correctly.'),
+        );
+      }
     } else {
       dispatch(setDatasources(datasets));
     }
-  }, [addDangerToast, datasets, datasetsApiError, dispatch]);
+  }, [addDangerToast, datasets, datasetsApiError, dispatch, isNotFoundError]);
 
   const relevantDataMask = useSelector(selectRelevantDatamask);
   const activeFilters = useSelector(selectActiveFilters);
 
-  if (error) throw error; // caught in error boundary
+  if (error && !isNotFoundError) throw error; // caught in error boundary
 
   const globalStyles = useMemo(
     () => [
@@ -389,9 +396,25 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
     [theme],
   );
 
-  if (error) throw error; // caught in error boundary
+  if (error && !isNotFoundError) throw error; // caught in error boundary
 
   const DashboardBuilderComponent = useMemo(() => <DashboardBuilder />, []);
+
+  if (isNotFoundError) {
+    return (
+      <EmptyState
+        size="large"
+        image="empty-dashboard.svg"
+        title={t('This dashboard does not exist')}
+        description={t(
+          'The dashboard you are looking for may have been deleted or moved.',
+        )}
+        buttonText={t('See all dashboards')}
+        buttonAction={() => history.push(RoutePaths.DASHBOARD_LIST)}
+      />
+    );
+  }
+
   return (
     <>
       <Global styles={globalStyles} />


### PR DESCRIPTION
### SUMMARY

Opening a dashboard that no longer exists — e.g. deleted in another tab, then clicked in a stale list — showed a raw full-page **"Unexpected error"** overlay with `SupersetApiError: Not found`.

`DashboardPage` re-threw the dashboard GET's 404 (`if (error) throw error`) to the app-wide error boundary. Fix: detect the 404 and render the shared `EmptyState` ("This dashboard does not exist" + a **See all dashboards** link to the dashboard list) instead of throwing. The chart-datasources toast is also suppressed when the dashboard itself is missing (its datasets endpoint 404s too).

Scope: **only 404** is handled gracefully. A **403** (access-denied) is a distinct case and intentionally still surfaces through the error boundary (verified against `dashboards/api.py`: deleted → `response_404`, no-access → `response_403`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: red "Unexpected error / SupersetApiError: Not found" overlay. 
<img width="1682" height="1041" alt="image" src="https://github.com/user-attachments/assets/b584911d-d675-454b-b475-007fbbb0890b" />


After: an EmptyState reading "This dashboard does not exist" with a "See all dashboards" button.

<img width="1682" height="1041" alt="image" src="https://github.com/user-attachments/assets/70b3b0d3-271e-4dd2-9833-7618f2347188" />


### TESTING INSTRUCTIONS

1. Open the Dashboards list in two tabs (same user).
2. In tab 1, delete a dashboard still shown in tab 2.
3. In tab 2, click that dashboard → a not-found state (not a raw error) with a link back to the dashboard list.
4. (Also: navigating directly to a non-existent `/superset/dashboard/<id>/` shows the same graceful state.)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [x] Changes UI — graceful not-found state on the dashboard route
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No