### PR TITLE
fix(redshift): suppress unavoidable pkg_resources deprecation warning

### DIFF
--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -34,13 +34,18 @@ from superset.models.sql_lab import Query
 from superset.sql.parse import Table
 from superset.utils import json
 
-# sqlalchemy-redshift's own __init__ still imports pkg_resources; the pinned
-# range (see pyproject.toml) can't move to the pkg_resources-free 1.0.0
-# release without SQLAlchemy 2.0 (apache/superset#39750 was closed for this
-# reason). This module is eagerly imported by load_engine_specs() at every
-# Superset startup, well before SQLAlchemy lazily imports sqlalchemy_redshift
-# via the "redshift://" dialect entry point on first connection, so the
-# filter is guaranteed to be registered in time.
+# sqlalchemy-redshift's own __init__ still imports pkg_resources (#36082);
+# the pinned range (see pyproject.toml) can't move to the pkg_resources-free
+# 1.0.0 release without SQLAlchemy 2.0 (apache/superset#39750 was closed for
+# this reason). Database._get_sqla_engine() (superset/models/core.py) always
+# reads self.db_engine_spec -- which imports every db_engine_specs module,
+# including this one, via load_engine_specs() -- before it calls
+# create_engine(), which is what triggers SQLAlchemy's lazy "redshift://"
+# dialect entry-point loading that actually imports sqlalchemy_redshift. So
+# by the time that import happens, this filter is already registered.
+# Setuptools 80.x (pinned in requirements/base.txt) raises this as a plain
+# UserWarning, not DeprecationWarning -- don't add category=DeprecationWarning
+# here, it would silently stop matching.
 warnings.filterwarnings(
     "ignore",
     message=r"pkg_resources is deprecated as an API",

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from re import Pattern
 from typing import Any
 
@@ -32,6 +33,18 @@ from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.sql.parse import Table
 from superset.utils import json
+
+# sqlalchemy-redshift's own __init__ still imports pkg_resources; the pinned
+# range (see pyproject.toml) can't move to the pkg_resources-free 1.0.0
+# release without SQLAlchemy 2.0 (apache/superset#39750 was closed for this
+# reason). This module is eagerly imported by load_engine_specs() at every
+# Superset startup, well before SQLAlchemy lazily imports sqlalchemy_redshift
+# via the "redshift://" dialect entry point on first connection, so the
+# filter is guaranteed to be registered in time.
+warnings.filterwarnings(
+    "ignore",
+    message=r"pkg_resources is deprecated as an API",
+)
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
### What
Production logs show `sqlalchemy_redshift/__init__.py:1: UserWarning: pkg_resources is deprecated as an API` firing on every Redshift connection (web and celery worker processes). Closes #36082.

### Why this can't be fixed at the source
`sqlalchemy-redshift`'s own `__init__.py` does `from pkg_resources import ...`. The only upstream release that removes this (`1.0.0`, which switched to `importlib.metadata`) requires `SQLAlchemy>=2.0.0,<3`, which conflicts with this repo's `sqlalchemy>=1.4,<2` pin. A prior attempt to bump the pin (#39750) was closed by @rusackas: "Closing... let's wait for SQLAlchemy 2." So until the SQLAlchemy 2.0 migration lands, the warning can't be resolved by a dependency bump.

### What changed
Suppress the warning at its known-safe source in `superset/db_engine_specs/redshift.py`, following the same pattern already used for an analogous unavoidable third-party warning (`authlib.jose`, added in #40977 in `superset/mcp_service/__init__.py`).

Placement is deliberate, not incidental: `Database._get_sqla_engine()` (`superset/models/core.py`) always resolves `self.db_engine_spec` — which imports every module under `db_engine_specs/`, including this one, via `load_engine_specs()` — before calling `create_engine()`, which is what triggers SQLAlchemy's lazy `redshift://` dialect-entry-point loading that actually imports `sqlalchemy_redshift`. So the filter is guaranteed to be registered before the warning can fire, for both web and worker processes.

The filter intentionally omits `category=` — setuptools 80.x (pinned in `requirements/base.txt`) raises this as a plain `UserWarning`, not `DeprecationWarning`; adding that category would silently stop the suppression from matching.

### No behavior change
Purely additive: one `import warnings` + one `warnings.filterwarnings()` call. No connection-handling logic touched.

### Test plan
- [x] Pre-commit hooks (ruff, mypy, pylint, engine-spec metadata validation) pass
- [x] Verified via source inspection that `_get_sqla_engine` resolves `db_engine_spec` before `create_engine` (superset/models/core.py:545 vs ~623)
- [x] Verified setuptools 80.9.0 (pinned) emits `UserWarning`, not `DeprecationWarning`, for this message
- [x] Confirmed no open/in-flight PR addresses this (`gh pr list --search "pkg_resources"` / `"redshift deprecat"`)