### PR TITLE
chore(ci): correct codeql-action version pin comment to v4.36.2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -75,6 +75,6 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### SUMMARY

The `github/codeql-action/init` and `analyze` steps in `codeql-analysis.yml` are pinned to SHA `8aad20d150bbac5944a9f9d289da16a4b0d87c1e`, but the trailing comment claimed the generic `# v4` major tag. That SHA actually resolves to release **v4.36.2** (the `v4` moving tag has since advanced to a different commit).

zizmor's `ref-version-mismatch` audit flags this: the pin comment must truthfully name the version the SHA points to. This PR updates both comments to `# v4.36.2`, which also matches the full-patch-version convention every other pinned action in this repo already uses (e.g. `actions/checkout@... # v7.0.0`, `actions/github-script@... # v9.0.0`).

No functional change — the immutable SHA is unchanged, only the human-readable comment is corrected.

Resolves code-scanning alert #2561.

### BEFORE/AFTER

Before:
```yaml
uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
```
After:
```yaml
uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
```

### TESTING INSTRUCTIONS

`pre-commit run --files .github/workflows/codeql-analysis.yml` passes, including the `zizmor` GHA security audit hook.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
