### PR TITLE
chore(ci): suppress zizmor adhoc-packages on GHA validator install

### DIFF
--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -37,8 +37,9 @@ jobs:
           node-version: "20"
 
       - name: Install Dependencies
-        # Versions are pinned to avoid ad-hoc, unpinned package installs
-        # (zizmor adhoc-packages). Bump deliberately when upgrading.
+        # Versions are pinned to avoid ad-hoc, unpinned package installs.
+        # Bump deliberately when upgrading.
+        # zizmor: ignore[adhoc-packages] - @action-validator is a global CLI tool installed to validate the repo's workflows; a global CLI install has no application manifest/lockfile context, and the versions are pinned above
         run: npm install -g @action-validator/core@0.6.0 @action-validator/cli@0.6.0
 
       - name: Run Script


### PR DESCRIPTION
### SUMMARY

Resolves code-scanning alert #2558 (`zizmor` / `adhoc-packages`) on `.github/workflows/github-action-validator.yml:42`.

That step installs `@action-validator/core` and `@action-validator/cli` globally as CLI tools whose sole purpose is to validate this repo's own GitHub Actions workflows. A global CLI install has no application manifest/lockfile to hash-pin against, so zizmor's `adhoc-packages` heuristic fires here even though the versions are explicitly pinned (`@0.6.0`). This is a false positive for this class of install.

The fix adds a scoped inline `# zizmor: ignore[adhoc-packages]` suppression with a justification, matching the existing precedent already in the repo at `.github/actions/setup-supersetbot/action.yml` (which suppresses the same rule for the same reason — a global CLI tool install). The pre-existing pinning-rationale comment is retained.

No behavior change; this is a CI/security-annotation-only change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

`pre-commit run --files .github/workflows/github-action-validator.yml` passes, including the `zizmor (GHA security audit)` hook. The open code-scanning alert #2558 should close once this lands on master and the scan re-runs.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)