### PR TITLE
chore(ci): correct codeql-action version comment to match pinned SHA

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -75,6 +75,6 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### SUMMARY

The `github/codeql-action/init` and `analyze` steps in `.github/workflows/codeql-analysis.yml` are pinned to commit SHA `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` but annotated with a `# v4` comment. That SHA is actually the **v4.36.2** release, and the moving `v4` major tag currently resolves to a different commit (`fb84f6228fd846d3c392887f22b18ce2d9139495`).

zizmor's `ref-version-mismatch` rule flags this because the version comment no longer matches the ref the SHA points to, which is misleading when someone reads or audits the pin. This updates both comments to `# v4.36.2` so the annotation truthfully reflects the pinned release — matching how other actions in this same workflow annotate their exact versions (e.g. `actions/checkout@... # v7.0.0`).

The pin itself (the SHA) is unchanged, so there is no functional change to which action code runs; this is purely a truthful-comment correction.

Resolves code-scanning alert #2560

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

`pre-commit run zizmor --files .github/workflows/codeql-analysis.yml` passes; the `ref-version-mismatch` warning on line 67 is cleared. No behavioral change to CI since the pinned SHA is identical.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)