### PR TITLE
fix(dashboard): use theme border for chart tiles

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -317,6 +317,8 @@ const StyledDashboardContent = styled.div<{
       width: 100%;
       height: 100%;
       background-color: ${theme.colorBgContainer};
+      border: 1px solid ${theme.colorBorder};
+      border-radius: ${theme.borderRadius}px;
       position: relative;
       padding: ${theme.sizeUnit * 4}px;
       box-sizing: border-box;
@@ -329,14 +331,12 @@ const StyledDashboardContent = styled.div<{
         box-shadow ${theme.motionDurationMid} ease-in-out;
 
       &.fade-in {
-        border-radius: ${theme.borderRadius}px;
         box-shadow:
           inset 0 0 0 2px ${theme.colorPrimary},
           0 0 0 3px ${addAlpha(theme.colorPrimary, 0.1)};
       }
 
       &.fade-out {
-        border-radius: ${theme.borderRadius}px;
         box-shadow: 0 0 0 1px ${addAlpha(theme.colorBorder, 0.5)};
       }
 


### PR DESCRIPTION
### SUMMARY
Fixes #41618.

Adds a resting `colorBorder` border to dashboard chart tiles and keeps the tile radius on the base chart-holder style so light, dark, and custom themes can show tile boundaries consistently.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not included. This is a token-backed style change for dashboard chart tile borders.

### TESTING INSTRUCTIONS
1. Apply a custom theme with `colorBorder` set to a visible color.
2. Open a dashboard with multiple chart tiles.
3. Confirm chart tiles render a visible border using the active theme border color.
4. Toggle theme mode and confirm the border follows the active theme.

Validated locally:
- `git diff --check`
- `npx --yes prettier@3.8.4 --check src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx`
- `pre-commit run trailing-whitespace --files superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx`
- `pre-commit run end-of-file-fixer --files superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx`
- `pre-commit run prettier-frontend --files superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #41618
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
