### PR TITLE
feat(i18n): backfill Turkish (tr) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -26,11 +26,11 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: tr\n"
 "Language-Team: tr <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.17.0\n"
 
 msgid ""
 "\n"
@@ -235,11 +235,15 @@ msgstr "%(object)s bu veritabanında mevcut değildir."
 msgid "%(prefix)s %(title)s"
 msgstr "%(prefix)s %(title)s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sBellek kısıtlamaları nedeniyle sonuçlar %(row_count)s satıra "
+"kısaltıldı."
 
 #, python-format
 msgid ""
@@ -271,13 +275,17 @@ msgstr ""
 "Lütfen sorgunuzu yeniden kontrol edin.\n"
 "Tartışma:   %(ex)s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s %s"
-msgstr ""
+msgstr "%s %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s ENCRYPTED EXTRA"
-msgstr ""
+msgstr "%s ŞİFRELİ EKSTRA"
 
 #, python-format
 msgid "%s Error"
@@ -287,9 +295,11 @@ msgstr "%s Hata"
 msgid "%s PASSWORD"
 msgstr "%s ŞİFRE"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Physical"
-msgstr ""
+msgstr "%s Fiziksel"
 
 #, python-format
 msgid "%s SSH TUNNEL PASSWORD"
@@ -307,9 +317,11 @@ msgstr "%s SSH TUNNEL PRIVATE KEY PASSWORD"
 msgid "%s Selected"
 msgstr "%s Seçilmiş"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Selected (%s)"
-msgstr ""
+msgstr "%s Seçildi (%s)"
 
 #, python-format
 msgid "%s Selected (Physical)"
@@ -319,49 +331,63 @@ msgstr "%s selected (Physical)"
 msgid "%s Selected (Virtual)"
 msgstr "%s selected (Virtual)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Semantik Görünüm"
 
 #, fuzzy, python-format
 msgid "%s URL"
 msgstr "%s URL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Virtual"
-msgstr ""
+msgstr "%s Sanal"
 
 #, python-format
 msgid "%s aggregates(s)"
 msgstr "%s agre (s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s column"
 msgid_plural "%s columns"
-msgstr[0] ""
+msgstr[0] "%s sütun"
 
 #, python-format
 msgid "%s column(s)"
 msgstr "%s sütun(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
+msgstr[0] "%s gün önce"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s hr ago"
 msgid_plural "%s hr ago"
-msgstr[0] ""
+msgstr[0] "%s sa önce"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s imported"
-msgstr ""
+msgstr "%s içe aktarıldı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s item"
 msgid_plural "%s items"
-msgstr[0] ""
+msgstr[0] "%s öğe"
 
 #, fuzzy, python-format
 msgid "%s item(s)"
@@ -373,15 +399,19 @@ msgid ""
 "all selected objects."
 msgstr "%s eşyaların etiketlenmedi çünkü tüm seçilmiş nesnelere izin vermediniz."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s metric"
 msgid_plural "%s metrics"
-msgstr[0] ""
+msgstr[0] "%s metrik"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s min ago"
 msgid_plural "%s min ago"
-msgstr[0] ""
+msgstr[0] "%s dk önce"
 
 #, python-format
 msgid "%s operator(s)"
@@ -396,19 +426,25 @@ msgstr[0] "%s seçeneği"
 msgid "%s option(s)"
 msgstr "%s seçeneği(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s column"
 msgid_plural "%s out of %s columns"
-msgstr[0] ""
+msgstr[0] "%s / %s sütun"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s metric"
 msgid_plural "%s out of %s metrics"
-msgstr[0] ""
+msgstr[0] "%s / %s metrik"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s selected"
-msgstr ""
+msgstr "%s / %s seçildi"
 
 #, fuzzy, python-format
 msgid "%s recipients"
@@ -419,41 +455,53 @@ msgid "%s record"
 msgid_plural "%s records..."
 msgstr[0] "%s saniye"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s record..."
 msgid_plural "%s records..."
-msgstr[0] ""
+msgstr[0] "%s kayıt..."
 
 #, fuzzy, python-format
 msgid "%s row"
 msgid_plural "%s rows"
 msgstr[0] "%s row"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s s ago"
 msgid_plural "%s s ago"
-msgstr[0] ""
+msgstr[0] "%s sn önce"
 
 #, python-format
 msgid "%s saved metric(s)"
 msgstr "%s kurtardı metric(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s second"
 msgid_plural "%s seconds"
-msgstr[0] ""
+msgstr[0] "%s saniye"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s semantik görünüm eklendi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "%s semantik görünüm eklenemedi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "%s semantik görünüm eklenemedi: %s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
@@ -524,13 +572,17 @@ msgstr ""
 "değişiklik tarayıcılarınızı açıklayacaksanız devam etmeyecektir.\n"
 "\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... ve %d daha fazla"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %s more records"
-msgstr ""
+msgstr "... ve %s kayıt daha"
 
 #, python-format
 msgid "... and %s others"
@@ -790,13 +842,19 @@ msgstr "Bir etiket yapılandırma nesnesi yaratan bir JavaScript işlevi"
 msgid "A JavaScript function that generates an icon configuration object"
 msgstr "Bir ikon yapılandırma nesnesi yaratan bir JavaScript işlevi"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"ECharts seçenek spesifikasyonuna uyan ve diğer kontrol seçeneklerini daha"
+" yüksek öncelikle geçersiz kılan bir JavaScript nesnesi. (örn. { title: {"
+" text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Ayrıntılar: "
+"https://echarts.apache.org/en/option.html. "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
@@ -932,30 +990,51 @@ msgstr ""
 "Eşitliksel olarak olumlu veya negatif değerlerin teorik etkisi.\n"
 "Bu orta değerler ya zaman temelli veya kategori bazlı olabilir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 #, fuzzy
 msgid "AND"
 msgstr "OCA"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API Key Created"
-msgstr ""
+msgstr "API Anahtarı Oluşturuldu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API Keys"
-msgstr ""
+msgstr "API Anahtarları"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key created successfully"
-msgstr ""
+msgstr "API anahtarı başarıyla oluşturuldu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key name is required"
-msgstr ""
+msgstr "API anahtarı adı zorunludur"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "API anahtarı başarıyla iptal edildi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "API anahtarları, Superset'e kapsamlı programatik erişim sağlar."
 
 msgid "APPLY"
 msgstr "UYGULA"
@@ -969,11 +1048,17 @@ msgstr "AQE"
 msgid "AUG"
 msgstr "AĞU"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Aborted"
-msgstr ""
+msgstr "İptal Edildi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Aborting"
-msgstr ""
+msgstr "İptal Ediliyor"
 
 msgid "About"
 msgstr "Hakkında"
@@ -1025,9 +1110,11 @@ msgstr "Adaptif formatlama"
 msgid "Add"
 msgstr "Ekle"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Add %s view(s)"
-msgstr ""
+msgstr "%s görünüm ekle"
 
 #, fuzzy
 msgid "Add BCC Recipients"
@@ -1068,8 +1155,11 @@ msgstr "Kural Ekle"
 msgid "Add Rule"
 msgstr "Kural Ekle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add Semantic View"
-msgstr ""
+msgstr "Semantik Görünüm Ekle"
 
 msgid "Add Tag"
 msgstr "Etiket Ekle"
@@ -1126,8 +1216,11 @@ msgstr "Bu pano için sertifikasyon ayrıntıları ekleyin"
 msgid "Add color for positive/negative change"
 msgstr "Olumlu/negative değişim için renk ekleyin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "Tüm sütunlar için hücre çubuklarına +/- renkleri ekle"
 
 msgid "Add cross-filter"
 msgstr "Çapraz filtre ekle"
@@ -1197,8 +1290,11 @@ msgstr "Yeni renk formatı ekleyin"
 msgid "Add new formatter"
 msgstr "Yeni formatter ekleyin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add numbered column"
-msgstr ""
+msgstr "Numaralı sütun ekle"
 
 #, fuzzy
 msgid "Add or edit display controls"
@@ -1453,8 +1549,11 @@ msgstr "Alarmlar & raporlar"
 msgid "Align +/-"
 msgstr "Align + /-"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Align +/- for all columns"
-msgstr ""
+msgstr "Tüm sütunlar için +/- hizala"
 
 msgid "All"
 msgstr "Tümü"
@@ -1472,8 +1571,11 @@ msgstr "Tüm grafikler"
 msgid "All charts/global scoping"
 msgstr "Tüm grafikler/global scoping"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "All dimensions"
-msgstr ""
+msgstr "Tüm boyutlar"
 
 msgid "All filters"
 msgstr "Tüm filtreler"
@@ -1619,8 +1721,11 @@ msgstr "Verisetini kaydederken bir hata oluştu"
 msgid "An error occurred while accessing the value."
 msgstr "Bir hata değere erişirken gerçekleşti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while adding semantic views"
-msgstr ""
+msgstr "Semantik görünümler eklenirken bir hata oluştu"
 
 msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
@@ -1644,8 +1749,11 @@ msgstr "Veri kaynağı oluştururken bir hata meydana geldi"
 msgid "An error occurred while creating the extension."
 msgstr "Verisetini kaydederken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while creating the semantic layer"
-msgstr ""
+msgstr "Semantik katman oluşturulurken bir hata oluştu"
 
 msgid "An error occurred while creating the value."
 msgstr "Değer oluştururken bir hata meydana geldi."
@@ -1664,29 +1772,39 @@ msgstr ""
 "Masa şemasını genişletirken bir hata meydana geldi. Lütfen yöneticinizle "
 "iletişime geçin."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s"
-msgstr ""
+msgstr "%s alınırken bir hata oluştu"
 
 #, python-format
 msgid "An error occurred while fetching %s info: %s"
 msgstr "%s bilgi getiriyorken bir hata oluştu:   %s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s owner values: %s"
-msgstr ""
+msgstr "%s sahip değerleri alınırken bir hata oluştu: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s related data"
-msgstr ""
+msgstr "%s ile ilgili veriler alınırken bir hata oluştu"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s values: %s"
-msgstr ""
+msgstr "%s değerleri alınırken bir hata oluştu: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s: %s"
-msgstr ""
+msgstr "%s alınırken bir hata oluştu: %s"
 
 #, python-format
 msgid "An error occurred while fetching %ss: %s"
@@ -1699,19 +1817,27 @@ msgstr "Mevcut CSS şablonları alırken bir hata meydana geldi"
 msgid "An error occurred while fetching available themes"
 msgstr "Verisetini kaydederken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching available views"
-msgstr ""
+msgstr "Mevcut görünümler alınırken bir hata oluştu"
 
 #, python-format
 msgid "An error occurred while fetching chart owners values: %s"
 msgstr "Grafik sahipleri değerlerini alırken bir hata oluştu:   %s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching connections"
-msgstr ""
+msgstr "Bağlantılar alınırken bir hata oluştu"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching created by values: %s"
-msgstr ""
+msgstr "Oluşturan değerleri getirilirken bir hata oluştu: %s"
 
 #, python-format
 msgid "An error occurred while fetching dashboard owner values: %s"
@@ -1751,11 +1877,17 @@ msgstr "Bir hata sahipleri değerleri alırken gerçekleşti:   %s "
 msgid "An error occurred while fetching schema values: %s"
 msgstr "Bir hata, şema değerlerini alırken gerçekleşti:   %s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching semantic layer types"
-msgstr ""
+msgstr "Semantik katman türleri getirilirken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching semantic layers"
-msgstr ""
+msgstr "Semantik katmanlar getirilirken bir hata oluştu"
 
 msgid "An error occurred while fetching tab state"
 msgstr "Bir hata, sekme devletini satın alırken gerçekleşti"
@@ -1763,9 +1895,11 @@ msgstr "Bir hata, sekme devletini satın alırken gerçekleşti"
 msgid "An error occurred while fetching table metadata"
 msgstr "Masa metadata alırken bir hata meydana geldi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching table metadata for %s"
-msgstr ""
+msgstr "%s için tablo meta verileri getirilirken bir hata oluştu"
 
 msgid ""
 "An error occurred while fetching table metadata. Please contact your "
@@ -1774,17 +1908,29 @@ msgstr ""
 "Masa metadata alırken bir hata meydana geldi. Lütfen yöneticinizle "
 "iletişime geçin."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the configuration schema"
-msgstr ""
+msgstr "Yapılandırma şeması getirilirken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the runtime schema"
-msgstr ""
+msgstr "Çalışma zamanı şeması getirilirken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the semantic layer"
-msgstr ""
+msgstr "Semantik katman getirilirken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the semantic view structure"
-msgstr ""
+msgstr "Semantik görünüm yapısı getirilirken bir hata oluştu"
 
 #, fuzzy, python-format
 msgid "An error occurred while fetching theme datasource values: %s"
@@ -1822,8 +1968,11 @@ msgstr "Bir hata anahtarı parlarken gerçekleşti."
 msgid "An error occurred while pruning logs "
 msgstr "Bir hata, girişleri yaparken gerçekleşti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while refreshing the configuration schema"
-msgstr ""
+msgstr "Yapılandırma şeması yenilenirken bir hata oluştu"
 
 msgid "An error occurred while removing query. Please contact your administrator."
 msgstr ""
@@ -1841,8 +1990,11 @@ msgstr ""
 msgid "An error occurred while rendering the visualization: %s"
 msgstr "Görselleştirme yaparken bir hata oluştu:   %s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while saving the semantic view"
-msgstr ""
+msgstr "Semantik görünüm kaydedilirken bir hata oluştu"
 
 msgid "An error occurred while starring this chart"
 msgstr "Bu grafik oynadığında bir hata meydana geldi"
@@ -1864,8 +2016,11 @@ msgstr "%s için izinler senkronize ederken bir hata oluştu:   %s "
 msgid "An error occurred while updating the extension."
 msgstr "Verisetini kaydederken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "An error occurred while updating the semantic layer"
-msgstr ""
+msgstr "Semantik katman güncellenirken bir hata oluştu"
 
 msgid "An error occurred while updating the value."
 msgstr "Değeri güncellarken bir hata meydana geldi."
@@ -2054,11 +2209,17 @@ msgstr ""
 "kaynak sorgusunun yuvarlanma penceresinde açıklanan minimum dönemleri "
 "ödediğinden emin olun."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"Yalnızca \"Hücre çubukları\" biçimlendirmesi seçildiğinde geçerlidir: "
+"\"Hücre çubuklarını göster\" seçeneği etkinleştirildiğinde histogram "
+"sütunlarının arka planı görüntülenir."
 
 msgid "Apply"
 msgstr "Uygula"
@@ -2169,10 +2330,15 @@ msgstr ""
 "Sistem varsayılan temayı kaldırmak istediğinizden emin misiniz? Uygulama "
 "yapılandırma dosyası varsayılan olarak geri alınacaktır."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
+"Bu API anahtarını iptal etmek istediğinizden emin misiniz? Bu işlem geri "
+"alınamaz."
 
 msgid "Are you sure you want to save and apply changes?"
 msgstr "Değişiklikleri kurtarmak ve uygulamak istediğinizden emin misiniz?"
@@ -2246,17 +2412,23 @@ msgstr "Auto"
 msgid "Auto Zoom"
 msgstr "Auto Zoom"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Otomatik yenileme duraklatıldı (%s saniyeye ayarlandı)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
-msgstr ""
+msgstr "Otomatik yenileme duraklatıldı - sekme etkin değil (%s saniyeye ayarlandı)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
-msgstr ""
+msgstr "Otomatik yenileme %s saniyeye ayarlandı"
 
 #, fuzzy
 msgid "Auto-detect"
@@ -2303,8 +2475,11 @@ msgstr "Ortalama"
 msgid "Average value"
 msgstr "Ortalama değer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Awaiting filter selection"
-msgstr ""
+msgstr "Filtre seçimi bekleniyor"
 
 msgid "Axis"
 msgstr "Axis"
@@ -2384,15 +2559,25 @@ msgstr "Veritabanı portu"
 msgid "Base height"
 msgstr "Grafik yüksekliği"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
-msgstr ""
+msgstr "Temel katman harita stili. MapLibre uyumlu bir stil URL'si kabul eder."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Temel katman harita stili. Mapbox stil URL'si kabul eder "
+"(mapbox://styles/...)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
-msgstr ""
+msgstr "Temel katman harita stili. MapLibre belgelerine bakın: %s"
 
 msgid "Base slope"
 msgstr "Baz eğim"
@@ -2552,8 +2737,11 @@ msgstr "Box Plot"
 msgid "Breakdowns"
 msgstr "Breakdowns"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Breakpoint Metric"
-msgstr ""
+msgstr "Kesme Noktası Metriği"
 
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
@@ -2631,6 +2819,11 @@ msgstr "son kullanılanlar"
 msgid "COPY QUERY"
 msgstr "Sorgu URL’ini kopyala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Sorguyu kopyala"
+
 msgid "CREATE TABLE AS"
 msgstr "CREATE TABLE AS"
 
@@ -2658,11 +2851,17 @@ msgstr "CSS Şablonları"
 msgid "CSS applied to the chart"
 msgstr "CSS grafiklere uygulanır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"CSS stilleri, sunucu taraflı HTML temizliği tarafından kaldırılabilir. "
+"Stiller uygulanmıyorsa, HTML temizleme yapılandırmasını ayarlaması için "
+"Superset yöneticinize başvurun."
 
 msgid "CSS template"
 msgstr "CSS şablonu"
@@ -2777,14 +2976,20 @@ msgstr "Birden fazla değer seçilebilir"
 msgid "Cancel"
 msgstr "İptal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancel Task"
-msgstr ""
+msgstr "Görevi İptal Et"
 
 msgid "Cancel query on window unload event"
 msgstr "Pencere boşaltma olayı hakkında Cancel query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "İptal işleyicisi eksik olduğundan iptal işlemi kullanılamıyor"
 
 msgid "Cannot access the query"
 msgstr "Soruya erişemez"
@@ -2971,14 +3176,23 @@ msgstr "Bu veri kaynağını değiştirmek yasaktır"
 msgid "Changing this report is forbidden"
 msgstr "Bu raporu değiştirmek yasaktır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic layer is forbidden"
-msgstr ""
+msgstr "Bu semantik katmanın değiştirilmesi yasaktır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic view is forbidden"
-msgstr ""
+msgstr "Bu semantik görünümün değiştirilmesi yasaktır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this task is forbidden"
-msgstr ""
+msgstr "Bu görevin değiştirilmesi yasaktır"
 
 msgid "Character to interpret as decimal point"
 msgstr "Decimal noktası olarak yorumlamak"
@@ -2986,9 +3200,11 @@ msgstr "Decimal noktası olarak yorumlamak"
 msgid "Chart"
 msgstr "Grafik"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "%(chart_id)s grafiği %(dashboard_id)s panosunda değil"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3151,9 +3367,11 @@ msgstr "[Label] seçimi [Grup By]"
 msgid "Choice of [Point Radius] must be present in [Group By]"
 msgstr "[Point Radius] Seçimleri [Grup By]"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Choose a %s"
-msgstr ""
+msgstr "Bir %s seçin"
 
 msgid "Choose a chart for displaying on the map"
 msgstr "Haritada görüntülemek için bir grafik seçin"
@@ -3297,9 +3515,11 @@ msgstr "Clause"
 msgid "Clear"
 msgstr "Temizle"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Clear %s filter"
-msgstr ""
+msgstr "%s filtresini temizle"
 
 #, fuzzy
 msgid "Clear Sort"
@@ -3441,8 +3661,11 @@ msgstr "Kod Kodu"
 msgid "Code Copied!"
 msgstr "Kod Copied!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Collapse"
-msgstr ""
+msgstr "Daralt"
 
 #, fuzzy
 msgid "Collapse All"
@@ -3466,11 +3689,17 @@ msgstr "Renkli Renk"
 msgid "Color +/-"
 msgstr "Renk +/-"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By X-Axis"
-msgstr ""
+msgstr "X Eksenine Göre Renklendir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By Y-Axis"
-msgstr ""
+msgstr "Y Eksenine Göre Renklendir"
 
 msgid "Color Metric"
 msgstr "Renk Metrik"
@@ -3485,11 +3714,17 @@ msgstr "Filtre tipi"
 msgid "Color Steps"
 msgstr "Renk Adımları"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Çubukları x eksenine göre renklendir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Çubukları y eksenine göre renklendir"
 
 msgid "Color bounds"
 msgstr "Renk sınırları"
@@ -3500,8 +3735,11 @@ msgstr "Renk uç noktaları"
 msgid "Color by"
 msgstr "Renk"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
-msgstr ""
+msgstr "Renk alanı onaltılık bir renk (#rrggbb) veya 'rgb(r, g, b)' olmalıdır"
 
 msgid "Color for breakpoint"
 msgstr "Red for breakpoint"
@@ -3610,15 +3848,21 @@ msgstr "Köşeler"
 msgid "Columns (%s)"
 msgstr "Saniye %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns (horizontal layout)"
-msgstr ""
+msgstr "Sütunlar (yatay düzen)"
 
 #, fuzzy
 msgid "Columns and metrics"
 msgstr "Ayarları Filtrele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns and metrics should be inside folders"
-msgstr ""
+msgstr "Sütunlar ve metrikler klasörlerin içinde olmalıdır"
 
 msgid "Columns folder can only contain column items"
 msgstr "Köşeler klasörü sadece sütun eşyaları içerebilir"
@@ -3631,8 +3875,11 @@ msgstr "Köşeler veri kümesinde eksik:   %(invalid_columns)s "
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "Metinlerde eksik sütunlar:   %(invalid_columns)s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "Sütunlar klasörlerin içinde olmalıdır"
 
 msgid "Columns subtotal position"
 msgstr "Köşeler alt toplam pozisyon"
@@ -3751,9 +3998,11 @@ msgstr "Güven aralığı 0 ile 1 arasında olmalıdır (exclusive)"
 msgid "Configuration"
 msgstr "Yapılandırma"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Configure %s"
-msgstr ""
+msgstr "%s'yi yapılandır"
 
 msgid "Configure Advanced Time Range "
 msgstr "Gelişmiş Zaman Aralığı"
@@ -3853,9 +4102,11 @@ msgstr "Bağlantı başarısız oldu, lütfen bağlantı ayarlarını kontrol ed
 msgid "Contains"
 msgstr "Devam"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Metin içerir (ILIKE %x%)"
 
 #, fuzzy
 msgid "Content format"
@@ -3892,8 +4143,11 @@ msgstr "Kontroller etiketlendi"
 msgid "Copied to clipboard!"
 msgstr "Söpücüklere!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Copied!"
-msgstr ""
+msgstr "Kopyalandı!"
 
 msgid "Copy"
 msgstr "Kopyala"
@@ -3914,8 +4168,11 @@ msgstr "Kopya ve Paste JSON kimlikleri"
 msgid "Copy code to clipboard"
 msgstr "Panoya kopyala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Copy column name"
-msgstr ""
+msgstr "Sütun adını kopyala"
 
 #, python-format
 msgid "Copy of %s"
@@ -4020,8 +4277,11 @@ msgstr "Ülke Haritası"
 msgid "Create"
 msgstr "Oluştur"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Create API Key"
-msgstr ""
+msgstr "API Anahtarı Oluştur"
 
 #, fuzzy
 msgid "Create Tag"
@@ -4074,9 +4334,11 @@ msgstr "Oluşturan"
 msgid "Created by me"
 msgstr "Benim tarafından oluşturulan"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Created by: %s"
-msgstr ""
+msgstr "Oluşturan: %s"
 
 msgid "Created on"
 msgstr "Oluşturan"
@@ -4093,8 +4355,11 @@ msgstr "Yaratıcı"
 msgid "Crimson"
 msgstr "Crimson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cross-filter column"
-msgstr ""
+msgstr "Çapraz filtre sütunu"
 
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr "Cross-filter, bu veri setini kullanan tüm grafiklere uygulanır."
@@ -4134,8 +4399,11 @@ msgstr "Para sembolü"
 msgid "Current"
 msgstr "sayı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Current Zoom"
-msgstr ""
+msgstr "Mevcut Yakınlaştırma"
 
 #, fuzzy
 msgid "Current day"
@@ -4174,11 +4442,17 @@ msgstr "Özel SQL"
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr "Özel SQL ad-hoc metrics bu veri setleri için etkinleştirilmemektedir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
-msgstr ""
+msgstr "Özel SQL alanları tek bir SQL ifadesi olarak ayrıştırılamaz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "Özel SQL alanları küme işlemleri içeremez."
 
 msgid "Custom SQL fields cannot contain sub-queries."
 msgstr "Özel SQL alanları alt bölümleri içeremez."
@@ -4211,8 +4485,11 @@ msgstr "pikselde görüntünün özel genişliği"
 msgid "Custom..."
 msgstr "Başlangıç tarihi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Customization and styling"
-msgstr ""
+msgstr "Özelleştirme ve stil"
 
 #, fuzzy
 msgid "Customization type"
@@ -4317,8 +4594,11 @@ msgstr "Günlük mevsimsellik"
 msgid "Dark"
 msgstr "Dark"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Dark (Carto)"
-msgstr ""
+msgstr "Koyu (Carto)"
 
 msgid "Dark Cyan"
 msgstr "Dark Cyan"
@@ -4329,9 +4609,11 @@ msgstr "Karanlık mod"
 msgid "Dashboard"
 msgstr "Gösterim Paneli"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Dashboard %(dashboard_id)s not found"
-msgstr ""
+msgstr "%(dashboard_id)s numaralı pano bulunamadı"
 
 #, fuzzy
 msgid "Dashboard Filter"
@@ -4367,8 +4649,10 @@ msgstr "Gösterim Paneli güncellenemedi."
 msgid "Dashboard could not be deleted."
 msgstr "Gösterim Paneli silinemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "Pano geri yüklenemedi."
 
 msgid "Dashboard could not be updated."
 msgstr "Gösterim Paneli güncellenemedi."
@@ -4424,9 +4708,11 @@ msgstr ""
 msgid "Dashboard title"
 msgstr "Gösterim Paneli başlığı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Dashboard updated %s"
-msgstr ""
+msgstr "Pano güncellendi %s"
 
 msgid "Dashboard usage"
 msgstr "Gösterim Paneli kullanımı"
@@ -4446,8 +4732,11 @@ msgstr "Dashed"
 msgid "Data"
 msgstr "Veri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Data Connections"
-msgstr ""
+msgstr "Veri Bağlantıları"
 
 #, fuzzy
 msgid "Data Export Options"
@@ -4462,11 +4751,17 @@ msgstr "Data URI izin verilmez."
 msgid "Data Zoom"
 msgstr "Data Zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Data connection"
-msgstr ""
+msgstr "Veri bağlantısı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Data connections"
-msgstr ""
+msgstr "Veri bağlantıları"
 
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
@@ -4483,8 +4778,11 @@ msgstr ""
 "Veriler sonuçlardan geri alınabilir. Orijinal sorguyu yeniden "
 "çalıştırmanız gerekir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Data error"
-msgstr ""
+msgstr "Veri hatası"
 
 #, python-format
 msgid "Data for %s"
@@ -4570,8 +4868,11 @@ msgstr "Veritabanı şifreleri"
 msgid "Database port"
 msgstr "Veritabanı portu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Database reference is not allowed on a report"
-msgstr ""
+msgstr "Raporda veritabanı referansına izin verilmez"
 
 msgid "Database schema is not allowed for csv uploads."
 msgstr "Veritabanı şemaları csv yüklemeleri için izin verilmez."
@@ -4582,8 +4883,10 @@ msgstr "Veritabanı ayarları güncellendi"
 msgid "Database type does not support file uploads."
 msgstr "Veritabanı türü dosya yüklemelerini desteklemez."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "Veritabanı yükleme dosyası izin verilen maksimum boyutu aşıyor."
 
 #, fuzzy
 msgid "Database upload file failed"
@@ -4667,8 +4970,11 @@ msgstr "Datasource & Chart Type"
 msgid "Datasource does not exist"
 msgstr "Datasource yok"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Datasource is required"
-msgstr ""
+msgstr "Veri kaynağı gereklidir"
 
 #, fuzzy
 msgid "Datasource is required for validation"
@@ -4680,8 +4986,11 @@ msgstr "Datasource türü geçersizdir"
 msgid "Datasource type is required when datasource_id is given"
 msgstr "Datasource id verildiğinde veri kaynakları türü gereklidir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Datasources"
-msgstr ""
+msgstr "Veri kaynakları"
 
 msgid "Date Time Format"
 msgstr "Date Time Format"
@@ -4940,20 +5249,27 @@ msgstr ""
 "Adımın başlangıçta, orta ya da iki veri noktası arasındaki son görünüp "
 "görünmeyeceğini tanımlar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Definition"
-msgstr ""
+msgstr "Tanım"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
+msgstr[0] "Gecikti (kaçırılan %s yenileme)"
 
 msgid "Delete"
 msgstr "Sil"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delete %s"
-msgstr ""
+msgstr "%s öğesini sil"
 
 #, python-format
 msgid "Delete %s?"
@@ -4979,11 +5295,17 @@ msgstr "Rapor Silinsin mi?"
 msgid "Delete Role?"
 msgstr "sil"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Delete Semantic Layer?"
-msgstr ""
+msgstr "Anlamsal Katman silinsin mi?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Delete Semantic View?"
-msgstr ""
+msgstr "Anlamsal Görünüm silinsin mi?"
 
 msgid "Delete Template?"
 msgstr "Şablon Silinsin mi?"
@@ -5090,10 +5412,12 @@ msgid "Deleted %(num)d saved query"
 msgid_plural "Deleted %(num)d saved queries"
 msgstr[0] "Deleted   %(num)d kurtarma"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Deleted %(num)d semantic view"
 msgid_plural "Deleted %(num)d semantic views"
-msgstr[0] ""
+msgstr[0] "%(num)d anlamsal görünüm silindi"
 
 #, fuzzy, python-format
 msgid "Deleted %(num)d theme"
@@ -5104,9 +5428,11 @@ msgstr[0] "Deleted   %(num)d tema"
 msgid "Deleted %s"
 msgstr "%s Silindi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Deleted %s item(s)"
-msgstr ""
+msgstr "%s öğe silindi"
 
 #, fuzzy, python-format
 msgid "Deleted group: %s"
@@ -5188,12 +5514,20 @@ msgstr "Detaylar"
 msgid "Details of the certification"
 msgstr "Sertifikanın ayrıntıları"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Filtrenin değerleri nasıl eşleştireceğini belirler. \"Tam eşleşme\", IN "
+"operatörünü kullanır (varsayılan). ILIKE seçenekleri, serbest metin "
+"girişi ile kısmi metin eşleşmesini etkinleştirir. Uyarı: ILIKE sorguları,"
+" büyük veri kümelerinde dizinleri etkin biçimde kullanamadığından yavaş "
+"olabilir."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Visskers ve outliersin nasıl hesaplandığını belirleyin."
@@ -5218,11 +5552,17 @@ msgstr "Dim Gray"
 msgid "Dimension"
 msgstr "Boyut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Bir öğeye tıklandığında çapraz filtre olarak yayılan boyut sütunu. "
+"Panodaki diğer grafikler bu sütunla eşleştirilir. Ayarlanmamışsa, "
+"geometri sütununa geri düşer (eski davranış, genellikle eşleştirilemez)."
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5248,9 +5588,11 @@ msgstr "Bilinmeyen değer"
 msgid "Dimensions"
 msgstr "Ölçüler"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Dimensions (%s)"
-msgstr ""
+msgstr "Boyutlar (%s)"
 
 msgid ""
 "Dimensions contain qualitative values such as names, dates, or "
@@ -5425,8 +5767,11 @@ msgstr "Domain"
 msgid "Don't refresh"
 msgstr "Veri yenilendi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Done"
-msgstr ""
+msgstr "Tamamlandı"
 
 msgid "Donut"
 msgstr "Donut"
@@ -5479,8 +5824,11 @@ msgstr ""
 "konuları - öğeler aynı sırayla araçtiplerinde görünecektir. sütunları ve "
 "metrikleri manuel olarak seçmek için düğmeye tıklayın."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Yeniden sıralamak için sürükleyin"
 
 msgid "Draw a marker on data points. Only applicable for line types."
 msgstr ""
@@ -5636,14 +5984,20 @@ msgstr "ms (1.40008: 1ms 400μs 80n)"
 msgid "Duration in ms (100.40008 => 100ms 400µs 80ns)"
 msgstr "ms (100.40008: 100ms 400μs 80n)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Duration in ms (10500 => 0:00:10.5)"
-msgstr ""
+msgstr "ms cinsinden süre (10500 => 0:00:10.5)"
 
 msgid "Duration in ms (66000 => 1m 6s)"
 msgstr "ms (66000 9)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Duration in seconds"
-msgstr ""
+msgstr "Saniye cinsinden süre"
 
 msgid "Dynamic"
 msgstr "Dinamik"
@@ -5651,14 +6005,20 @@ msgstr "Dinamik"
 msgid "Dynamic Aggregation Function"
 msgstr "Dinamik Aggregation Function"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Dynamic Section Label"
-msgstr ""
+msgstr "Dinamik Bölüm Etiketi"
 
 msgid "Dynamic group by"
 msgstr "Dinamik grup Tarafından"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Dynamic section description"
-msgstr ""
+msgstr "Dinamik bölüm açıklaması"
 
 msgid "Dynamically search all filter values"
 msgstr "Dinamik olarak tüm filtre değerlerini arama"
@@ -5669,8 +6029,11 @@ msgstr "Dinamik olarak bir şekilde bir veri kümesinden gruplama sütunları se
 msgid "ECharts"
 msgstr "ECharts"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "ECharts Seçenekleri (JS nesne değişmezleri)"
 
 msgid "EMAIL_REPORTS_CTA"
 msgstr "EMAIL REPORTS CTA"
@@ -5693,9 +6056,11 @@ msgstr "Edge genişlik"
 msgid "Edit"
 msgstr "Düzenle"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Edit %s"
-msgstr ""
+msgstr "%s öğesini düzenle"
 
 #, fuzzy, python-format
 msgid "Edit %s in modal"
@@ -5927,8 +6292,11 @@ msgstr "Etiket JavaScript modunu etkinleştir"
 msgid "Enable labels"
 msgstr "Etiketleri etkinleştir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "Matrixify'ı etkinleştir"
 
 msgid "Enable node dragging"
 msgstr "Düğüm sürüklemeyi etkinleştir"
@@ -5962,8 +6330,11 @@ msgid ""
 "out"
 msgstr "Karşılıksız NULL uzaysal girişi, lütfen bunları filtrelemeyi düşünün"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Encrypted extra fields"
-msgstr ""
+msgstr "Şifrelenmiş ek alanlar"
 
 msgid "End"
 msgstr "End"
@@ -5997,9 +6368,11 @@ msgstr "Son tarih başlama tarihinden sonra olmalıdır"
 msgid "Ends With"
 msgstr "Grafik genişliği"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Ends with (ILIKE %x)"
-msgstr ""
+msgstr "Şununla biter (ILIKE %x)"
 
 #, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
@@ -6114,13 +6487,17 @@ msgstr "Hata Fetching Tagged Objects"
 msgid "Error deleting %s"
 msgstr "Veri getirirken hata: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Tam ekran devre dışı bırakılırken hata: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
-msgstr ""
+msgstr "Tam ekran etkinleştirilirken hata: %s"
 
 #, fuzzy
 msgid "Error executing query. "
@@ -6145,9 +6522,11 @@ msgstr "RLS filtrelerde jinja ifadesi:   %(msg)s "
 msgid "Error in jinja expression in WHERE clause: %(msg)s"
 msgstr "WHERE koşulunda jinja ifadesi:   %(msg)s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr ""
+msgstr "Geçici sütundaki jinja ifadesinde hata: %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
@@ -6255,8 +6634,11 @@ msgstr "Evrim Evrimi"
 msgid "Exact"
 msgstr "Exact"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Tam eşleşme (IN)"
 
 msgid "Example"
 msgstr "Örnek"
@@ -6318,8 +6700,11 @@ msgstr "Genişleme Data Panel"
 msgid "Expand row"
 msgstr "genişletilmiş satır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Expand row to edit"
-msgstr ""
+msgstr "Düzenlemek için satırı genişlet"
 
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
@@ -6335,8 +6720,11 @@ msgstr ""
 msgid "Experimental"
 msgstr "Deneysel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Expired"
-msgstr ""
+msgstr "Süresi doldu"
 
 msgid "Explore"
 msgstr "Discover"
@@ -6433,8 +6821,11 @@ msgstr "Expose database in SQL Lab"
 msgid "Expose in SQL Lab"
 msgstr "Expose in SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Expression"
-msgstr ""
+msgstr "İfade"
 
 #, fuzzy
 msgid "Expression cannot be empty"
@@ -6448,8 +6839,11 @@ msgstr "son kullanılanlar"
 msgid "Extent"
 msgstr "son kullanılanlar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Harici bağlantı uyarısı"
 
 msgid "Extra"
 msgstr "Ekstra"
@@ -6498,6 +6892,11 @@ msgstr "ŞUB"
 msgid "FIT DATA"
 msgstr "Verisetini düzenle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Verilere sığdır"
+
 msgid "FRI"
 msgstr "CUM"
 
@@ -6519,14 +6918,23 @@ msgstr "Retrieving sonuçları başarısız oldu"
 msgid "Failed to apply theme: Invalid JSON"
 msgstr "Tartışmayı uygulamak için başarısız oldu: Invalid JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Failed to copy API key to clipboard"
-msgstr ""
+msgstr "API anahtarı panoya kopyalanamadı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Failed to copy stack trace to clipboard"
-msgstr ""
+msgstr "Yığın izi panoya kopyalanamadı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Failed to create API key"
-msgstr ""
+msgstr "API anahtarı oluşturulamadı"
 
 msgid "Failed to create report"
 msgstr "Rapor oluşturmak için başarısız oldu"
@@ -6535,15 +6943,20 @@ msgstr "Rapor oluşturmak için başarısız oldu"
 msgid "Failed to execute %(query)s"
 msgstr "%(query)s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Failed to fetch API keys"
-msgstr ""
+msgstr "API anahtarları alınamadı"
 
 msgid "Failed to generate chart edit URL"
 msgstr "Grafik düzenleme URL oluşturmak için başarısız oldu"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "İndirme oluşturulamadı: %s"
 
 msgid "Failed to load chart data"
 msgstr "Grafik verileri yüklemek için başarısız oldu"
@@ -6551,9 +6964,11 @@ msgstr "Grafik verileri yüklemek için başarısız oldu"
 msgid "Failed to load chart data."
 msgstr "Grafik verileri yüklemek için başarısız oldu."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
-msgstr ""
+msgstr "%s %s için sütunlar yüklenemedi"
 
 msgid "Failed to load top values"
 msgstr "Üst değerleri yüklemek için başarısız oldu"
@@ -6572,8 +6987,11 @@ msgstr "Sistem varsayılan temayı ortadan kaldırmak için başarısız oldu:  
 msgid "Failed to retrieve advanced type"
 msgstr "Gelişmiş türü almak için başarısız oldu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Failed to revoke API key"
-msgstr ""
+msgstr "API anahtarı iptal edilemedi"
 
 msgid "Failed to save chart customization"
 msgstr "Grafik özelleştirmesini kurtarmak için başarısız oldu"
@@ -6628,8 +7046,11 @@ msgstr "Yanlış"
 msgid "Favorite"
 msgstr "Favoriler"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Feature Not Enabled"
-msgstr ""
+msgstr "Özellik Etkin Değil"
 
 #, fuzzy
 msgid "Featured"
@@ -6651,8 +7072,11 @@ msgstr "Fetched   %s "
 msgid "Fetching"
 msgstr "Fetching"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fetching data..."
-msgstr ""
+msgstr "Veriler getiriliyor..."
 
 #, python-format
 msgid "Field cannot be decoded by JSON. %(json_error)s"
@@ -6730,8 +7154,11 @@ msgstr ""
 "Filtre yalnızca diğer filtrelerde yapılan seçimlerle ilgili değerleri "
 "gösterir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Filter options"
-msgstr ""
+msgstr "Filtre seçenekleri"
 
 msgid "Filter results"
 msgstr "Sonuçları filtrele"
@@ -6908,8 +7335,11 @@ msgstr "Kuvvet Gücü"
 msgid "Force Time Grain as Max Interval"
 msgstr "Güç zamanı Max Interval"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Zorla durdur (tüm aboneler için görevi durdurur)"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -6961,11 +7391,17 @@ msgstr ""
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr "Form verileri önbellek olarak bulamadı, dataset metadata'ya geri dönmedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Format"
-msgstr ""
+msgstr "Biçim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Format JSON configuration"
-msgstr ""
+msgstr "JSON yapılandırmasını biçimlendir"
 
 msgid "Format SQL"
 msgstr "Format SQL"
@@ -7007,11 +7443,17 @@ msgstr "Şekillenmiş değer"
 msgid "Formatting"
 msgstr "Formatting"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Formatting column"
-msgstr ""
+msgstr "Biçimlendirme sütunu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Formatting object"
-msgstr ""
+msgstr "Biçimlendirme nesnesi"
 
 msgid "Formula"
 msgstr "Formula"
@@ -7043,8 +7485,11 @@ msgstr "Tarihten itibaren tarihten daha büyük olamaz"
 msgid "Full name"
 msgstr "Full name Full name"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fullscreen is not supported in this browser."
-msgstr ""
+msgstr "Bu tarayıcıda tam ekran desteklenmiyor."
 
 msgid "Funnel Chart"
 msgstr "Funnel Chart"
@@ -7126,8 +7571,11 @@ msgstr "Google Sheet Name and URL"
 msgid "Grace period"
 msgstr "Grace dönemi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Grain"
-msgstr ""
+msgstr "Ayrıntı düzeyi"
 
 msgid "Graph Chart"
 msgstr "Graph Chart"
@@ -7160,8 +7608,11 @@ msgstr "Grid"
 msgid "Grid Size"
 msgstr "Beyaz Boyut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Grid view"
-msgstr ""
+msgstr "Izgara görünümü"
 
 msgid "Group"
 msgstr "Grup Grubu"
@@ -7450,8 +7901,11 @@ msgstr "Sorguları içe aktar"
 msgid "In"
 msgstr "In"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "In Progress"
-msgstr ""
+msgstr "Devam Ediyor"
 
 #, fuzzy
 msgid "In Range"
@@ -7467,8 +7921,11 @@ msgstr ""
 msgid "In this view you can preview the first 25 rows. "
 msgstr "Bu görüşte ilk 25 satırları önleyebilirsiniz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Inactive"
-msgstr ""
+msgstr "Etkin Değil"
 
 msgid "Include Series"
 msgstr "Add Series"
@@ -7614,8 +8071,11 @@ msgstr ""
 msgid "Invalid JSON"
 msgstr "Invalid JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Invalid JSON configuration"
-msgstr ""
+msgstr "Geçersiz JSON yapılandırması"
 
 msgid "Invalid JSON metadata"
 msgstr "Invalid JSON metadata"
@@ -7727,9 +8187,11 @@ msgstr "Invalid uzaysal noktası ile karşılaştı:   %(latlong)s "
 msgid "Invalid state."
 msgstr "Invalid state."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, sk,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
-msgstr ""
+msgstr "Geçersiz sekme kimlikleri: %(tab_ids)s"
 
 msgid "Invalid username or password"
 msgstr "Invalid kullanıcı veya şifre"
@@ -7873,14 +8335,22 @@ msgstr "Devam et"
 msgid "Key"
 msgstr "Anahtar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Key Prefix"
-msgstr ""
+msgstr "Anahtar Öneki"
 
 msgid "Keyboard shortcuts"
 msgstr "Klavye kısayolları"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
+"Anahtarlar yalnızca oluşturulurken bir kez gösterilir. Bunları güvenli "
+"bir şekilde saklayın."
 
 msgid "Keys for table"
 msgstr "Masa için Anahtarlar"
@@ -7981,8 +8451,11 @@ msgstr "%s Son Gücelleme"
 msgid "Last Updated %s by %s"
 msgstr "Son Güncelleme   %s Tarafından   %s "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Last Used"
-msgstr ""
+msgstr "Son Kullanım"
 
 #, python-format
 msgid "Last available value seen on %s"
@@ -8022,9 +8495,11 @@ msgstr "son çeyrek"
 msgid "Last run"
 msgstr "Son koşma"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Last updated %s ago"
-msgstr ""
+msgstr "%s önce güncellendi"
 
 #, fuzzy
 msgid "Last week"
@@ -8133,8 +8608,11 @@ msgstr "Daha az veya eşit (<=)"
 msgid "Less than (<)"
 msgstr "Daha az (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
 msgid "Lift percent precision"
 msgstr "Yüzde hassasiyet"
@@ -8142,8 +8620,11 @@ msgstr "Yüzde hassasiyet"
 msgid "Light"
 msgstr "Açık"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Light (Carto)"
-msgstr ""
+msgstr "Light (Carto)"
 
 msgid "Light mode"
 msgstr "Açık modu"
@@ -8273,8 +8754,11 @@ msgstr "üçgenlerle işaret etmek için değerlerin listesi"
 msgid "List updated"
 msgstr "Liste güncellendi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "List view"
-msgstr ""
+msgstr "Liste görünümü"
 
 msgid "Live render"
 msgstr "Canlı form"
@@ -8292,8 +8776,11 @@ msgstr "Cacheden yüklendi"
 msgid "Loading"
 msgstr "Yükleniyor…"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Loading filter values"
-msgstr ""
+msgstr "Filtre değerleri yükleniyor"
 
 #, fuzzy
 msgid "Loading timezones..."
@@ -8397,8 +8884,11 @@ msgstr "PZT"
 msgid "Main"
 msgstr "Benim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Main navigation"
-msgstr ""
+msgstr "Ana gezinti"
 
 msgid ""
 "Make sure that the controls are configured properly and the datasource "
@@ -8426,10 +8916,16 @@ msgstr "Pano sahipleri ve erişim izinleri yönetin"
 msgid "Manage email report"
 msgstr "e-posta raporunu yönetin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Kapsam, açıklamalar ve sınırlamalar belirlemek için filtreleri ve "
+"özelleştirmeleri yönetin. Daha iyi pano içgörüleri için yeni öğeler "
+"oluşturun."
 
 msgid "Manage your databases"
 msgstr "Veritabanınızı Yönetin"
@@ -8447,28 +8943,45 @@ msgstr "Map"
 msgid "Map Options"
 msgstr "Grafik seçenekleri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Map Renderer"
-msgstr ""
+msgstr "Harita Oluşturucu"
 
 msgid "Map Style"
 msgstr "Map Style"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (açık kaynak)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre açık kaynaklıdır ve API anahtarı gerektirmez. Mapbox için "
+"sunucuda MAPBOX_API_KEY yapılandırılması gerekir."
 
 msgid "Mapbox"
 msgstr "Mapbox"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox (API key required)"
-msgstr ""
+msgstr "Mapbox (API anahtarı gerekli)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox için sunucuda bir MAPBOX_API_KEY yapılandırılması gerekir."
 
 msgid "March"
 msgstr "Mart"
@@ -8509,8 +9022,11 @@ msgstr "Maç sistemi"
 msgid "Match time shift color with original series"
 msgstr "Maç zamanı orijinal seri ile renk değiştiriyor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Match type"
-msgstr ""
+msgstr "Eşleşme türü"
 
 msgid "Matrixify"
 msgstr "Matrixify"
@@ -8537,8 +9053,11 @@ msgstr "maksimum Font Boyut"
 msgid "Maximum Radius"
 msgstr "maksimum Radius"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum Width"
-msgstr ""
+msgstr "Maksimum Genişlik"
 
 msgid "Maximum folder nesting depth reached"
 msgstr "En fazla klasör derinliğine ulaştı"
@@ -8559,8 +9078,11 @@ msgstr "Maksimum değer"
 msgid "Maximum value on the gauge axis"
 msgstr "ölçüm ekseninde maksimum değer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Yolun maksimum genişliği, piksel veya metre cinsinden."
 
 msgid "May"
 msgstr "Mayıs"
@@ -8727,18 +9249,26 @@ msgstr ""
 msgid "Metrics"
 msgstr "Metriks"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Metrics (%s)"
-msgstr ""
+msgstr "Metrikler (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "Metrikler aynı anda hem satırlar hem de sütunlar için kullanılamaz"
 
 msgid "Metrics folder can only contain metric items"
 msgstr "Metriks klasörü sadece metrik öğeler içerebilir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "Metrikler klasörlerin içinde olmalıdır"
 
 msgid "Metrics to show in the tooltip."
 msgstr "Aracıtipte göstermek için eğlenceler."
@@ -8789,8 +9319,11 @@ msgstr "Minimum Font Boyut"
 msgid "Minimum Radius"
 msgstr "Asgari Radius"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum Width"
-msgstr ""
+msgstr "Minimum Genişlik"
 
 msgid "Minimum must be strictly less than maximum"
 msgstr "Asgari maksimumdan daha az olmalıdır"
@@ -8814,8 +9347,11 @@ msgstr "Grafikte gösterilen etiket için minimum değer."
 msgid "Minimum value on the gauge axis"
 msgstr "ölçüm ekseninde minimum değer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Yolun minimum genişliği, piksel veya metre cinsinden."
 
 msgid "Minor Split Line"
 msgstr "Minor Split Line"
@@ -8830,15 +9366,20 @@ msgstr "Dakika"
 msgid "Minutes %s"
 msgstr "Dakika   %s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Missing %s"
-msgstr ""
+msgstr "Eksik %s"
 
 msgid "Missing OAuth2 token"
 msgstr "Eksik OAuth2 token"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Missing URL parameter"
-msgstr ""
+msgstr "Eksik URL parametresi"
 
 msgid "Missing URL parameters"
 msgstr "Eksik URL parametreleri"
@@ -8892,8 +9433,11 @@ msgstr "Daha Fazla filtreler"
 msgid "MotherDuck token"
 msgstr "AnneDuck token"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Move icon"
-msgstr ""
+msgstr "Taşıma simgesi"
 
 msgid "Move only"
 msgstr "Sadece hareket ettirin"
@@ -8926,10 +9470,15 @@ msgstr ""
 msgid "Multiplier"
 msgstr "Multiplier"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
 msgstr ""
+"Bu grafiğin üzerine yazmak için grafik sahibi olmanız gerekir. Bunun "
+"yerine yeni bir grafik olarak kaydedin."
 
 msgid "Must be unique"
 msgstr "eşsiz olmalıdır"
@@ -8986,8 +9535,11 @@ msgstr "Ebeveynlerin boşunu içeren sütunun adı"
 msgid "Name of the id column"
 msgstr "Ayının adı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Name of the semantic layer"
-msgstr ""
+msgstr "Semantik katmanın adı"
 
 msgid "Name of the source nodes"
 msgstr "Kaynak düğümünün adı"
@@ -9034,8 +9586,11 @@ msgstr "Ağ hatası."
 msgid "New"
 msgstr "Şimdi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "New Semantic Layer"
-msgstr ""
+msgstr "Yeni Semantik Katman"
 
 msgid "New chart"
 msgstr "Yeni grafik"
@@ -9116,9 +9671,11 @@ msgstr "Uygun filtre yok."
 msgid "No columns found"
 msgstr "Kolonlar bulunamadı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No compatible %s found"
-msgstr ""
+msgstr "Uyumlu %s bulunamadı"
 
 msgid "No compatible catalog found"
 msgstr "Uyumlu katalog bulunamadı"
@@ -9160,14 +9717,20 @@ msgstr "Herhangi bir filtre seçilmedi."
 msgid "No filters"
 msgstr "Filtreler bulunamadı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters applied"
-msgstr ""
+msgstr "Filtre uygulanmadı"
 
 msgid "No filters are currently added to this dashboard."
 msgstr "Hiçbir filtre şu anda bu paniğe eklenmektedir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Henüz filtre veya özelleştirme oluşturulmadı"
 
 msgid "No form settings were maintained"
 msgstr "Hiçbir form ayarları muhafaza edilmedi"
@@ -9193,8 +9756,11 @@ msgstr "Tanık kayıt bulunamadı"
 msgid "No matching results found"
 msgstr "Sonuç bulunamadı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
-msgstr ""
+msgstr "Bu panoya şu anda hiçbir çok katmanlı deck.gl grafiği eklenmemiş."
 
 msgid "No records found"
 msgstr "Hiçbir kayıt bulunamadı"
@@ -9228,13 +9794,17 @@ msgstr "Henüz Kurallar Yok"
 msgid "No roles yet"
 msgstr "Henüz Kurallar Yok"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No rows were returned for this %s"
-msgstr ""
+msgstr "Bu %s için hiçbir satır döndürülmedi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No samples were returned for this %s"
-msgstr ""
+msgstr "Bu %s için hiçbir örnek döndürülmedi"
 
 msgid "No saved expressions found"
 msgstr "Bululmuş ifadeler bulunamadı"
@@ -9253,8 +9823,11 @@ msgstr ""
 msgid "No table columns"
 msgstr "Hiçbir masa sütunu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No tasks yet"
-msgstr ""
+msgstr "Henüz görev yok"
 
 msgid "No temporal columns found"
 msgstr "Sürekli sütunlar bulunamadı"
@@ -9344,8 +9917,11 @@ msgstr "Tanımlanmamış değil"
 msgid "Not equal to (≠)"
 msgstr "eşit değil (≠)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Not found"
-msgstr ""
+msgstr "Bulunamadı"
 
 msgid "Not in"
 msgstr "Değil"
@@ -9566,11 +10142,17 @@ msgstr "Sadece \"Label Type\" bir yüzde ayarlandığında geçerlidir."
 msgid "Only applies when \"Label Type\" is set to show values."
 msgstr "Sadece \"Label Type\" değerleri göstermek için ayarlandığında geçerlidir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "Dize olmayan sütunlar için yalnızca tam eşleşme kullanılabilir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Yalnızca hedefe veya kaynağına güveniyorsanız devam edin."
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -9820,8 +10402,11 @@ msgstr "Şema seç"
 msgid "Page length"
 msgstr "Sayfa uzunluğu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Page navigation"
-msgstr ""
+msgstr "Sayfa gezintisi"
 
 msgid "Paired t-test Table"
 msgstr "Paired t-test Table"
@@ -9907,23 +10492,38 @@ msgstr "Paylaşılabilir Google Sheet URL burada"
 msgid "Paste your access token here"
 msgstr "Erişiminizi buraya yapıştırın"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Path Color"
-msgstr ""
+msgstr "Yol Rengi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Path Size"
-msgstr ""
+msgstr "Yol Boyutu"
 
 msgid "Pattern"
 msgstr "Desen"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Sekme etkin değilse otomatik yenilemeyi duraklat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto-refresh"
-msgstr ""
+msgstr "Otomatik yenilemeyi duraklat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pending"
-msgstr ""
+msgstr "Beklemede"
 
 msgid "Per user caching"
 msgstr "Per user caching"
@@ -10055,8 +10655,11 @@ msgstr "sağ"
 msgid "Pin to the result panel"
 msgstr "Pin sonuç paneline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pin to top"
-msgstr ""
+msgstr "Üste sabitle"
 
 #, fuzzy
 msgid "Pivot Mode"
@@ -10195,9 +10798,11 @@ msgstr ""
 msgid "Please select at least one role or group"
 msgstr "Lütfen en az bir rol veya grup seçin"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Please select both a %s and a Chart type to proceed"
-msgstr ""
+msgstr "Devam etmek için lütfen hem %s hem de bir Grafik türü seçin"
 
 #, python-format
 msgid ""
@@ -10223,8 +10828,11 @@ msgstr ""
 msgid "Plugins"
 msgstr "Plugins"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Point Cluster Map"
-msgstr ""
+msgstr "Nokta Kümesi Haritası"
 
 msgid "Point Color"
 msgstr "Point Color"
@@ -10348,8 +10956,11 @@ msgstr "Primary y-axis Bounds"
 msgid "Primary y-axis format"
 msgstr "Primary y-axis format"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Private"
-msgstr ""
+msgstr "Özel"
 
 msgid "Private Channels (Bot in channel)"
 msgstr "Özel Kanallar (Bot in kanal)"
@@ -10385,11 +10996,17 @@ msgstr "Project Iddd"
 msgid "Proportional"
 msgstr "Proportional"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Genel ve özel olarak paylaşılan sayfalar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Yalnızca genel olarak paylaşılan sayfalar"
 
 msgid "Published"
 msgstr "Paylaşıldı"
@@ -10560,8 +11177,11 @@ msgstr "Son Kullanılanlar"
 msgid "Recipients are separated by \",\" or \";\""
 msgstr "Recipients \"\" veya \";\" ile ayrılır."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Records"
-msgstr ""
+msgstr "Kayıtlar"
 
 msgid "Rectangle"
 msgstr "Rect"
@@ -10604,8 +11224,11 @@ msgstr "Refetch sonuçları"
 msgid "Refresh dashboard"
 msgstr "Gösterim Paneliı yenile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Refresh delayed"
-msgstr ""
+msgstr "Yenileme gecikti"
 
 msgid "Refresh frequency"
 msgstr "Yenileme sıklığı"
@@ -10696,11 +11319,17 @@ msgstr "Sistem Varsayılan Teması"
 msgid "Remove cross-filter"
 msgstr "Çapraz filtrelemeyi kaldır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Remove customization"
-msgstr ""
+msgstr "Özelleştirmeyi kaldır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Remove filter"
-msgstr ""
+msgstr "Filtreyi kaldır"
 
 msgid "Remove item"
 msgstr "öğeyi kaldır"
@@ -10895,8 +11524,11 @@ msgstr "Kaynak zaten eklenmiş bir rapora sahiptir."
 msgid "Resource was not found."
 msgstr "Kaynak bulunamadı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "Kaynak, sahiplik doğrulanmadan önce kaldırıldı"
 
 msgid "Restore filter"
 msgstr "Geri yükleme filtresi"
@@ -10914,8 +11546,11 @@ msgstr "Sonuçlar geri dönüşümlü değildir."
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr "Asynchronous sorgular için gerekli sonuçlar yapılandırılmıyor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resume auto-refresh"
-msgstr ""
+msgstr "Otomatik yenilemeyi sürdür"
 
 #, fuzzy
 msgid "Retry"
@@ -10925,8 +11560,11 @@ msgstr "her"
 msgid "Retry fetching results"
 msgstr "Grafikleri getirirken hata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Return to Superset"
-msgstr ""
+msgstr "Superset'e dön"
 
 msgid "Return to specific datetime."
 msgstr "Belirli tarih zamana dön."
@@ -10937,17 +11575,29 @@ msgstr "Ters Lat & Long"
 msgid "Reverse lat/long "
 msgstr "Ters lat /long"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke"
-msgstr ""
+msgstr "İptal et"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke API Key"
-msgstr ""
+msgstr "API Anahtarını İptal Et"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Bu API anahtarını iptal et"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoked"
-msgstr ""
+msgstr "İptal edildi"
 
 msgid "Rich Tooltip"
 msgstr "Rich Tooltip"
@@ -11078,8 +11728,11 @@ msgstr "Row limit"
 msgid "Rows"
 msgstr "Satırlar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Rows (vertical layout)"
-msgstr ""
+msgstr "Satırlar (dikey düzen)"
 
 msgid "Rows per page, 0 means no pagination"
 msgstr "Sayfa başına Rows, 0, paginasyon anlamına gelir"
@@ -11145,11 +11798,17 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab, tam olarak ayrıştırılamayan bir ifadeye yetki veremez. Tabloları"
+" açıkça nitelendirin ve saklı yordam veya satıcıya özgü çağrıların içinde"
+" dinamik SQL kullanmaktan kaçının."
 
 #, fuzzy
 msgid "SQL Lab queries"
@@ -11280,9 +11939,11 @@ msgstr "Kaydet (Üstüne yaz)"
 msgid "Save as"
 msgstr "Farklı kaydet"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Save as %s"
-msgstr ""
+msgstr "%s olarak kaydet"
 
 msgid "Save as Dataset"
 msgstr "Veriseti Olarak Kaydet"
@@ -11328,8 +11989,11 @@ msgstr "Verisetini Kaydet veya Üstüne Yaz"
 msgid "Save query"
 msgstr "Sorguyu kaydet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Bu API anahtarını güvenli şekilde kaydedin"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr "Bu sorguyu sanal bir veri kümesi olarak keşfetmeye devam edin"
@@ -11365,8 +12029,11 @@ msgstr "Yükleniyor…"
 msgid "Scale and Move"
 msgstr "Scale ve Move"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "Metrik tabanlı çizgi genişliklerine uygulanan ölçek faktörü"
 
 msgid "Scale only"
 msgstr "Sadece Scale sadece"
@@ -11460,23 +12127,35 @@ msgstr "Kolonları ara"
 msgid "Search box"
 msgstr "Arama kutusu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Search by"
-msgstr ""
+msgstr "Şuna göre ara"
 
 msgid "Search by query text"
 msgstr "Sorgu metni ile arama"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Search calculated columns by name"
-msgstr ""
+msgstr "Hesaplanan sütunları ada göre ara"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Search charts by name, owner, or dashboard"
-msgstr ""
+msgstr "Grafikleri ada, sahibine veya panoya göre ara"
 
 msgid "Search columns"
 msgstr "Kolonları ara"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Search columns by name"
-msgstr ""
+msgstr "Sütunları ada göre ara"
 
 #, fuzzy
 msgid "Search columns..."
@@ -11485,8 +12164,11 @@ msgstr "Kolonları ara"
 msgid "Search in filters"
 msgstr "Filtrelerde ara"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Search metrics by key or label"
-msgstr ""
+msgstr "Metrikleri anahtara veya etikete göre ara"
 
 #, fuzzy
 msgid "Search owners"
@@ -11534,8 +12216,11 @@ msgstr "Güvenli ekstra"
 msgid "Security"
 msgstr "Güvenlik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "See "
-msgstr ""
+msgstr "Bakınız "
 
 #, python-format
 msgid "See all %(tableName)s"
@@ -11553,9 +12238,11 @@ msgstr "Sorgu ayrıntılarına bakınız"
 msgid "Select"
 msgstr "Seç"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Select %s or type to search %s"
-msgstr ""
+msgstr "%s seçin veya %s aramak için yazın"
 
 msgid "Select ..."
 msgstr "Seç…"
@@ -11582,9 +12269,11 @@ msgstr "Tags"
 msgid "Select Value"
 msgstr "Dosya seç"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Select a %s"
-msgstr ""
+msgstr "%s seçin"
 
 #, fuzzy
 msgid "Select a CSS template"
@@ -11645,11 +12334,17 @@ msgstr "Şema seç"
 msgid "Select a schema if the database supports this"
 msgstr "Veritabanı bunu desteklerse bir şema seçin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select a semantic layer"
-msgstr ""
+msgstr "Bir anlamsal katman seçin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select a semantic layer type"
-msgstr ""
+msgstr "Bir anlamsal katman türü seçin"
 
 msgid "Select a sheet name from the uploaded file"
 msgstr "Yükleme dosyasından bir isim seçin"
@@ -11712,8 +12407,11 @@ msgstr "Renk şeması seçin"
 msgid "Select column"
 msgstr "Kolon seç"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select column name"
-msgstr ""
+msgstr "Sütun adı seçin"
 
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
@@ -11816,8 +12514,11 @@ msgstr ""
 msgid "Select layers to hide"
 msgstr "Grafikleri seç"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select object name"
-msgstr ""
+msgstr "Nesne adı seçin"
 
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
@@ -11858,8 +12559,11 @@ msgstr "Sahipleri seçin"
 msgid "Select page size"
 msgstr "Şema seç"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select permissions"
-msgstr ""
+msgstr "İzinleri seçin"
 
 #, fuzzy
 msgid "Select roles"
@@ -11871,14 +12575,20 @@ msgstr "Kurtarılan metrikleri seçin"
 msgid "Select saved queries"
 msgstr "Kurtarılan sorguları seçin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select schema"
-msgstr ""
+msgstr "Şema seçin"
 
 msgid "Select scheme"
 msgstr "Şema seç"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Select semantic views"
-msgstr ""
+msgstr "Anlamsal görünümler seçin"
 
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
@@ -11954,15 +12664,26 @@ msgstr "Filtre seç"
 msgid "Select the geojson column"
 msgstr "Geojson sütununu seçin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Harita döşeme sağlayıcısını seçin. MapLibre açık kaynaklıdır ve API "
+"anahtarı gerektirmez. Mapbox için Superset'te MAPBOX_API_KEY "
+"yapılandırılması gerekir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Her yolun hangi renk kesim noktası aralığına girdiğini belirlemek için "
+"kullanılan metriği seçin."
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -11984,14 +12705,23 @@ msgstr ""
 "Kontrol panelinde vurgulanan alanda (s) değerleri seçin. Ardından,   %s "
 "düğmesine tıklayarak sorguyu çalıştırın."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Filtre denetiminde hangi zaman birimlerinin kullanılabilir olduğunu "
+"seçin. Bu yalnızca bir kullanıcı arayüzü izin listesidir ve temel "
+"sorgulara ek koşullar eklemez."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Selected"
-msgstr ""
+msgstr "Seçildi"
 
 #, fuzzy
 msgid "Selecting a database is required"
@@ -12001,65 +12731,125 @@ msgstr "Sorgu yazmak için veritabanı seç"
 msgid "Selection method"
 msgstr "Şema seç"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic"
-msgstr ""
+msgstr "Semantik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Layer"
-msgstr ""
+msgstr "Semantik Katman"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Semantik Görünüm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Semantik Görünümler"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer"
-msgstr ""
+msgstr "Semantik katman"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be created."
-msgstr ""
+msgstr "Semantik katman oluşturulamadı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be deleted."
-msgstr ""
+msgstr "Semantik katman silinemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be updated."
-msgstr ""
+msgstr "Semantik katman güncellenemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer created"
-msgstr ""
+msgstr "Semantik katman oluşturuldu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer does not exist"
-msgstr ""
+msgstr "Semantik katman mevcut değil"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer parameters are invalid."
-msgstr ""
+msgstr "Semantik katman parametreleri geçersiz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer type"
-msgstr ""
+msgstr "Semantik katman türü"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer updated"
-msgstr ""
+msgstr "Semantik katman güncellendi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be created."
-msgstr ""
+msgstr "Semantik görünüm oluşturulamadı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be deleted."
-msgstr ""
+msgstr "Semantik görünüm silinemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be updated."
-msgstr ""
+msgstr "Semantik görünüm güncellenemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view does not exist"
-msgstr ""
+msgstr "Semantik görünüm mevcut değil"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view parameters are invalid."
-msgstr ""
+msgstr "Semantik görünüm parametreleri geçersiz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Semantik görünüm güncellendi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Semantik görünümler"
 
 msgid "Send as CSV"
 msgstr "Gönder"
@@ -12213,8 +13003,11 @@ msgstr "Grafiği email ile paylaş"
 msgid "Share permalink by email"
 msgstr "Linki email ile paylaş"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Shared"
-msgstr ""
+msgstr "Paylaşıldı"
 
 msgid "Shared query"
 msgstr "Pylaşılmış sorgu"
@@ -12292,8 +13085,11 @@ msgstr "Show Metric Names"
 msgid "Show Range Filter"
 msgstr "Show Range Filter"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Show SQL"
-msgstr ""
+msgstr "SQL'i Göster"
 
 msgid "Show Timestamp"
 msgstr "Show Timestampamp"
@@ -12335,8 +13131,11 @@ msgstr "Göster Rota ticks"
 msgid "Show cell bars"
 msgstr "Göster hücre barları"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Show cell bars for all columns"
-msgstr ""
+msgstr "Tüm sütunlar için hücre çubuklarını göster"
 
 msgid "Show chart description"
 msgstr "Show grafik açıklaması"
@@ -12584,14 +13383,25 @@ msgstr ""
 msgid "Solid"
 msgstr "Katı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Bazı gruplar çözümlenemedi ve ID olarak gösteriliyor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Bazı izinler çözümlenemedi ve ID olarak gösteriliyor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
+"Diğer sekmelerdeki bazı zorunlu filtrelerin değerleri var ve "
+"temizlenmeyecek"
 
 msgid "Some roles do not exist"
 msgstr "Bazı roller var"
@@ -12693,11 +13503,17 @@ msgstr "Sırala"
 msgid "Sort by metric"
 msgstr "Sort by metric"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Sort by original table order"
-msgstr ""
+msgstr "Orijinal tablo sırasına göre sırala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Sort by series"
-msgstr ""
+msgstr "Seriye göre sırala"
 
 msgid "Sort columns alphabetically"
 msgstr "Sort alfabetik sütunlar"
@@ -12724,11 +13540,18 @@ msgstr "Sort metric"
 msgid "Sort query by"
 msgstr "Sorguyu Dışa Aktar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Sonuçları seri adına göre artan sırayla sırala. \"Metriğe göre sırala\" "
+"ile birleştirildiğinde, bu eşit metrik değerleri için bir kılavuz görevi "
+"görür. Bu sıralamayı eklemek bazı veritabanlarında sorgu performansını "
+"düşürebilir."
 
 msgid "Sort rows by"
 msgstr "Sort Tarafından Sort"
@@ -12751,8 +13574,11 @@ msgstr "Kaynak SQL"
 msgid "Source category"
 msgstr "Source kategori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Source location"
-msgstr ""
+msgstr "Kaynak konumu"
 
 msgid "Sparkline"
 msgstr "Spark"
@@ -12861,8 +13687,11 @@ msgstr "Başlamaya başladı"
 msgid "Starts With"
 msgstr "Grafik genişliği"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Starts with (ILIKE x%)"
-msgstr ""
+msgstr "Şununla başlar (ILIKE x%)"
 
 msgid "State"
 msgstr "Durum"
@@ -12920,8 +13749,11 @@ msgstr "Akış"
 msgid "Streets"
 msgstr "Sokaklar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Streets (Carto)"
-msgstr ""
+msgstr "Sokaklar (Carto)"
 
 msgid "Strength to pull the graph toward center"
 msgstr "Grafikleri merkeze doğru çekmek için güç"
@@ -12938,8 +13770,13 @@ msgstr "Strod"
 msgid "Structural"
 msgstr "Yapısal yapılar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
 msgstr ""
+"Yapı, yukarı akış semantik katmanı tarafından yönetilmekte ve salt "
+"okunurdur."
 
 msgid "Style"
 msgstr "Style"
@@ -12961,8 +13798,11 @@ msgstr "Subdomain"
 msgid "Submit"
 msgstr "Gönder"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Subscribers"
-msgstr ""
+msgstr "Aboneler"
 
 #, fuzzy
 msgid "Subtitle"
@@ -12974,9 +13814,11 @@ msgstr "Subtotal"
 msgid "Success"
 msgstr "Başarı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Successfully changed %s!"
-msgstr ""
+msgstr "%s başarıyla değiştirildi!"
 
 msgid "Suffix"
 msgstr "Suffix"
@@ -13033,9 +13875,11 @@ msgstr "Superset beklenmedik bir hatayla karşılaştı."
 msgid "Supported databases"
 msgstr "Desteklenen veritabanı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Swap %s"
-msgstr ""
+msgstr "%s değiştir"
 
 msgid "Swap rows and columns"
 msgstr "Swap satırları ve sütunları"
@@ -13239,35 +14083,63 @@ msgstr "Hedef kategori"
 msgid "Target value"
 msgstr "Hedef değeri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task"
-msgstr ""
+msgstr "Görev"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Task cancelled: %s"
-msgstr ""
+msgstr "Görev iptal edildi: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task could not be aborted."
-msgstr ""
+msgstr "Görev durdurulamadı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task could not be created."
-msgstr ""
+msgstr "Görev oluşturulamadı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task could not be updated."
-msgstr ""
+msgstr "Görev güncellenemedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"Görev durdurulamaz. Görev devam ediyor ancak bir durdurma işleyicisi "
+"kaydetmedi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task parameters are invalid."
-msgstr ""
+msgstr "Görev parametreleri geçersiz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks"
-msgstr ""
+msgstr "Görevler"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
-msgstr ""
+msgstr "Arka plan işlemleri yürütüldükçe görevler burada görünecektir."
 
 #, fuzzy
 msgid "Template"
@@ -13327,13 +14199,17 @@ msgstr "Metin hizası"
 msgid "Text embedded in email"
 msgstr "Metin e-postada gömülü"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "The %s"
-msgstr ""
+msgstr "%s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "The %s linked to this chart may have been deleted."
-msgstr ""
+msgstr "Bu grafikle bağlantılı %s silinmiş olabilir."
 
 #, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
@@ -13362,17 +14238,29 @@ msgstr ""
 "GeoJsonLayer GeoJSON formatlı verileri alır ve etkileşimli poligonlar, "
 "çizgiler ve puanlar olarak verir (circles, ikonlar ve / veya metinler)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Global Task Framework etkin değil. GLOBAL_TASK_FRAMEWORK özellik "
+"bayrağını etkinleştirmek için lütfen yöneticinizle iletişime geçin."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Global Task Framework etkin değil. @task kullanmak için özellik "
+"bayraklarınızda GLOBAL_TASK_FRAMEWORK=True olarak ayarlayın. Yapılandırma"
+" ayrıntıları için bkz. https://superset.apache.org/docs/configuration"
+"/async-queries-celery."
 
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
@@ -13422,8 +14310,11 @@ msgstr ""
 "Renkler atamak için kullanılan kaynak düğümleri kategorisi. Eğer bir node"
 " bir kategoriden daha ilişkiliyse, sadece ilki kullanılacaktır."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
-msgstr ""
+msgstr "Grafik hâlâ yükleniyor. Lütfen bir an bekleyip tekrar deneyin."
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
@@ -13648,10 +14539,15 @@ msgid ""
 "%(columns)s. "
 msgstr "“ Dizi columns’teki aşağıdaki girişler “columns’te eksik:   %(columns)s ."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"Aşağıdaki alanlar, dışa aktarma sırasında maskelenmiş hassas bilgiler "
+"içermektedir. Bu veritabanını içe aktarmak için lütfen değerleri girin."
 
 #, python-format
 msgid ""
@@ -13912,8 +14808,11 @@ msgstr ""
 "mevcut olmadığını ve gerekli olup olmadığının ardından manuel olarak "
 "eklenmelidir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
-msgstr ""
+msgstr "Aşağıdaki veritabanlarını içe aktarmak için şifreler gereklidir."
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr "Zamanlayıcı biçimi. For strings use"
@@ -14213,8 +15112,11 @@ msgstr "Belirtilen nokta ikizi için ölçü ünitesi"
 msgid "The upper limit of the threshold range of the Isoband"
 msgstr "Isoband'ın eş aralığının üst sınırı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The user has been created successfully."
-msgstr ""
+msgstr "Kullanıcı başarıyla oluşturuldu."
 
 #, fuzzy
 msgid "The user has been updated successfully."
@@ -14265,10 +15167,15 @@ msgstr "elementlerin sınırının genişliği"
 msgid "The width of the lines"
 msgstr "hatların genişliği"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
 msgstr ""
+"Çizgilerin genişliği sabit bir değer veya bir metriğe dayalı değişken "
+"genişlik olarak belirlenebilir."
 
 #, fuzzy
 msgid "Theme"
@@ -14331,11 +15238,15 @@ msgstr ""
 "Bu bileşen için yeterli yer yoktur. Genişliğini azaltmaya veya hedef "
 "genişliğini arttırmaya çalışın."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"Kontrol paneliniz yenilenirken bir sorun oluştu. Planlandığı üzere %s "
+"içinde tekrar deneyeceğiz."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -14367,11 +15278,17 @@ msgstr "En sevdiğiniz durumu getiren bir hata vardı:   %s "
 msgid "There was an error fetching the filtered charts and dashboards:"
 msgstr "Grafiği yüklerken hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "There was an error loading groups."
-msgstr ""
+msgstr "Gruplar yüklenirken bir hata oluştu."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "There was an error loading permissions."
-msgstr ""
+msgstr "İzinler yüklenirken bir hata oluştu."
 
 #, fuzzy
 msgid "There was an error loading the catalogs"
@@ -14410,11 +15327,17 @@ msgstr "Şemaları yüklerken hata oluştu"
 msgid "There was an error updating the user. Please, try again."
 msgstr "Şemaları yüklerken hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "There was an error while fetching groups"
-msgstr ""
+msgstr "Gruplar alınırken bir hata oluştu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "There was an error while fetching permissions"
-msgstr ""
+msgstr "İzinler alınırken bir hata oluştu"
 
 #, fuzzy
 msgid "There was an error while fetching users"
@@ -14423,9 +15346,11 @@ msgstr "Grafikleri getirirken hata"
 msgid "There was an error with your request"
 msgstr "İstekinizle bir hata vardı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue cancelling the task: %s"
-msgstr ""
+msgstr "Görev iptal edilirken bir sorun oluştu: %s"
 
 #, python-format
 msgid "There was an issue deleting %s"
@@ -14443,9 +15368,11 @@ msgstr "Kullanıcı için bir sorun silindi:   %s "
 msgid "There was an issue deleting rules: %s"
 msgstr "Tartışma kuralları vardı:   %s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected %s"
-msgstr ""
+msgstr "Seçilen %s silinirken bir sorun oluştu"
 
 #, python-format
 msgid "There was an issue deleting the selected %s: %s"
@@ -14478,21 +15405,29 @@ msgstr "%s Şemaları yüklerken hata oluştu"
 msgid "There was an issue deleting: %s"
 msgstr "Bir sorun kaldı:   %s "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue duplicating the %s."
-msgstr ""
+msgstr "%s kopyalanırken bir sorun oluştu."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue duplicating the selected %s: %s"
-msgstr ""
+msgstr "Seçilen %s kopyalanırken bir sorun oluştu: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue exporting the %s"
-msgstr ""
+msgstr "%s dışa aktarılırken bir sorun oluştu"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue exporting the selected %s"
-msgstr ""
+msgstr "Seçilen %s dışa aktarılırken bir sorun oluştu"
 
 #, fuzzy
 msgid "There was an issue exporting the selected charts"
@@ -14600,8 +15535,11 @@ msgstr ""
 msgid "This chart has been moved to a different filter scope."
 msgstr "Bu grafik farklı bir filtre alanına taşındı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr ""
+msgstr "Bu grafik harici olarak yönetilmektedir ve Superset'te üzerine yazılamaz."
 
 msgid "This chart is managed externally, and can't be edited in Superset"
 msgstr "Bu grafik dışsal olarak yönetilir ve Superset'te düzenlenebilir."
@@ -14616,9 +15554,11 @@ msgstr ""
 "Bu grafik türü, bir grafik kaynağı olarak yanlış olmayan bir sorgu "
 "kullanırken desteklenmez."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
-msgstr ""
+msgstr "Bu sütun mevcut %s ile uyumsuz olabilir"
 
 msgid "This column might be incompatible with current dataset"
 msgstr "Bu sütun mevcut veri setleriyle uyumlu olabilir"
@@ -14711,12 +15651,19 @@ msgstr ""
 "Bu veritabanı masası herhangi bir veri içermiyor. Lütfen farklı bir masa "
 "seçin."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Bu veritabanı kimlik doğrulama için OAuth2 kullanmaktadır. Verilere "
+"erişim için Apache Superset'e izin vermek üzere lütfen yukarıdaki "
+"bağlantıya tıklayın. Kişisel erişim tokenınız şifreli olarak saklanacak "
+"ve yalnızca sizin çalıştırdığınız sorgular için kullanılacaktır."
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr "Bu veri kümesi dışsal olarak yönetilir ve Superset'te düzenlenebilir."
@@ -14751,18 +15698,26 @@ msgstr ""
 msgid "This filter already exist on the report"
 msgstr "Filtre değeri listesi boş olamaz"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This filter might be incompatible with current %s"
-msgstr ""
+msgstr "Bu filtre mevcut %s ile uyumsuz olabilir"
 
 msgid "This folder is currently empty"
 msgstr "Bu klasör şu anda boş"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Bu klasör yalnızca sütunları destekler"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Bu klasör yalnızca metrikleri destekler"
 
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr "Bu işlevsellik, güvenlik nedenleri için çevrenizde devre dışı bırakılır."
@@ -14808,8 +15763,11 @@ msgstr "Bu varsayılan klasördür"
 msgid "This is the default light theme"
 msgstr "Bu varsayılan ışık temasıdır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "Bu anahtarı yalnızca bir kez göreceksiniz. Güvenli bir yerde saklayın."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -14820,13 +15778,20 @@ msgstr ""
 "ve pozisyonları sürükleyerek dinamik olarak oluşturulur ve pano "
 "görünümünde düşer ve düşer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Bu bağlantı, adresi güvenli olmadığı için takip edilemiyor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Bu bağlantı sizi harici bir web sitesine yönlendirecektir. Harici "
+"hedeflerin güvenliğini garanti edemeyiz."
 
 msgid "This markdown component has an error."
 msgstr "Bu işaret bileşeninin bir hatası vardır."
@@ -14846,9 +15811,11 @@ msgstr ""
 msgid "This may be triggered by:"
 msgstr "Bu, tetiklenebilir:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This metric might be incompatible with current %s"
-msgstr ""
+msgstr "Bu metrik mevcut %s ile uyumsuz olabilir"
 
 msgid "This name is already taken. Please choose another one."
 msgstr "Bu isim zaten alınır. Lütfen başka birini seçin."
@@ -14925,9 +15892,11 @@ msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
 msgstr[0] "Bu tetiklendi:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "Bu işlem, %s abone için görevi iptal edecek (durduracak)."
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
@@ -14938,8 +15907,11 @@ msgstr ""
 " sütunlara eklenecektir. Temel koşullu formatlama aşağıda koşullu "
 "formatlama ile yazılabilir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "Bu işlem görevi iptal edecek."
 
 msgid "This will remove your current embed configuration."
 msgstr "Bu, mevcut gömülü yapılandırmanızı kaldıracaktır."
@@ -15081,8 +16053,11 @@ msgstr "Zaman tahıl filtresi eklenti"
 msgid "Time grain missing"
 msgstr "Zaman tahıl eksik"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Time grain options"
-msgstr ""
+msgstr "Zaman dilimi seçenekleri"
 
 msgid "Time granularity"
 msgstr "Zaman granularity"
@@ -15128,18 +16103,26 @@ msgstr "Zaman Dizisi"
 msgid "Time-series Table"
 msgstr "Zaman serisi Masa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Timed Out"
-msgstr ""
+msgstr "Zaman Aşımına Uğradı"
 
 #, fuzzy
 msgid "Timeline"
 msgstr "Zaman aralığı"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Zaman aşımı yapılandırıldı (%s saniye), ancak herhangi bir iptal "
+"işleyicisi tanımlanmadı. Görev, zaman aşımı süresini geçtikten sonra da "
+"çalışmaya devam edecek."
 
 msgid "Timeout error"
 msgstr "Zamanout hatası"
@@ -15333,8 +16316,11 @@ msgstr "Truncate uzun hücreler yukarıda bulunan \"min genişlik\" için"
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr "Truncates, tarih ünitesi tarafından belirtilen doğruluk tarihine kadar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Bu URL'ye güven ve bir daha sorma"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
@@ -15369,8 +16355,11 @@ msgstr "Bir değer girin"
 msgid "Type is required"
 msgstr "Tip gereklidir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "İzin verilen Google E-Tabloları türü"
 
 msgid "Type of chart to display in sparkline"
 msgstr "Ekranda görüntülemek için grafik türü"
@@ -15378,14 +16367,23 @@ msgstr "Ekranda görüntülemek için grafik türü"
 msgid "Type of comparison, value difference or percentage"
 msgstr "Karşılaştırma türü, değer farkı veya yüzde yüzdesi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (contains)..."
-msgstr ""
+msgstr "Aramak için yazın (içerir)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Aramak için yazın (şununla biter)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Aramak için yazın (şununla başlar)..."
 
 msgid "UI Configuration"
 msgstr "UI Yapı Kataloğu"
@@ -15396,8 +16394,11 @@ msgstr "UI tema yönetimi etkinleştirilmemektedir."
 msgid "URL"
 msgstr "URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "URL Filters"
-msgstr ""
+msgstr "URL Filtreleri"
 
 msgid "URL Parameters"
 msgstr "URL parametreleri"
@@ -15431,11 +16432,17 @@ msgstr ""
 "\"bigquery.readsessions.reads.reads.readsessions.reads.reads.reads.readsessions.getData\""
 " olarak adlandırılır."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"Bağlanılamıyor. Hizmet hesabında aşağıdaki rollerin ayarlandığını "
+"doğrulayın: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud"
+" Datastore Creator\""
 
 msgid "Unable to create chart without a query id."
 msgstr "Bir sorgu id olmadan grafik oluşturmak için kullanılamaz."
@@ -15454,15 +16461,21 @@ msgstr "Decode değer"
 msgid "Unable to encode value"
 msgstr "kodlama değeri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
-msgstr ""
+msgstr "Semantik görünümler alınamıyor. Katman yapılandırmasını kontrol edin."
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
 msgstr "Böyle bir tatil bulmak mümkün değil: [  %(holiday)s ]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to generate download payload"
-msgstr ""
+msgstr "İndirme verisi oluşturulamıyor"
 
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
@@ -15529,8 +16542,11 @@ msgstr "Undo the action"
 msgid "Undo?"
 msgstr "Geri almak ister misiniz?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr ""
+msgstr "Beklenmeyen HTTP 401 yanıtı. Kimlik bilgilerinizi kontrol edin."
 
 msgid "Unexpected error"
 msgstr "Beklenmeyen hata"
@@ -15590,8 +16606,11 @@ msgstr "Bilinmeyen hata"
 msgid "Unknown input format"
 msgstr "Bilinmeyen giriş formatı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "Bilinmeyen tokenlar uyarı olarak vurgulanacaktır."
 
 msgid "Unknown type"
 msgstr "Bilinmeyen tip"
@@ -15603,14 +16622,22 @@ msgstr "Bilinmeyen değer"
 msgid "Unpin"
 msgstr "çalışıyor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Sonuç panelinden sabitlemeyi kaldır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Üstten sabitlemeyi kaldır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Güvenli olmayan bağlantı engellendi"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
@@ -15659,8 +16686,11 @@ msgstr "Onaylı"
 msgid "Update"
 msgstr "Güncelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Update auto-refresh"
-msgstr ""
+msgstr "Otomatik yenilemeyi güncelle"
 
 msgid "Update chart"
 msgstr "Grafiği güncelle"
@@ -15892,8 +16922,11 @@ msgstr ""
 "görselleştirmedeki bireysel yollar üzerinden Hover. Çok aşamalı, multi-"
 "gruplar ve boru hatları için kullanışlı."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Boyutun daha fazla değeri varsa ilk 25 değeri kullanır."
 
 msgid "Valid SQL expression"
 msgstr "Geçerli SQL ifadesi"
@@ -16170,8 +17203,11 @@ msgstr "WFS"
 msgid "WMS"
 msgstr "WMS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "İlk yenileme bekleniyor"
 
 #, python-format
 msgid "Waiting on %s"
@@ -16200,10 +17236,15 @@ msgstr ""
 "Uyarı! Veri setini değiştirmek, metadata'nın mevcut değilse grafiği "
 "kırabilir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Uyarı: ILIKE sorguları, dizinleri etkin biçimde kullanamadıkları için "
+"büyük veri kümelerinde yavaş olabilir."
 
 msgid "Was unable to check your query"
 msgstr "Sorunuzu kontrol edemiyordu"
@@ -16399,10 +17440,15 @@ msgstr "“Grup By” kullanırken tek bir metrik kullanmakla sınırlıdır"
 msgid "When using other than adaptive formatting, labels may overlap"
 msgstr "Adaptif formatlamadan diğerini kullanırken, etiketler örtüşebilir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
 msgstr ""
+"Bu seçenek kullanıldığında varsayılan değer ayarlanamaz. Bu seçeneğin "
+"kullanılması, kontrol panelinizin yüklenme sürelerini etkileyebilir."
 
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
 msgstr "İlerleme barı birden fazla veri grubu olduğunda örtüşüyor"
@@ -16474,8 +17520,11 @@ msgstr "X-axis'in min ve max değerlerini gösterebilmek"
 msgid "Whether to display the min and max values of the Y-axis"
 msgstr "Y-kütürün min ve max değerlerini gösterelim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Whether to display the numbered column"
-msgstr ""
+msgstr "Numaralı sütunun görüntülenip görüntülenmeyeceği"
 
 msgid "Whether to display the numerical values within the cells"
 msgstr "Hücre içindeki sayısal değerleri gösterip gösterebilme"
@@ -16590,8 +17639,11 @@ msgstr "Güven aralığının genişliği. 0 ile 1 arasında olmalıdır"
 msgid "Width of the sparkline"
 msgstr "Şalinen genişliği"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Width scale multiplier"
-msgstr ""
+msgstr "Genişlik ölçeği çarpanı"
 
 msgid "Window must be > 0"
 msgstr "Pencere > 0"
@@ -16887,8 +17939,11 @@ msgstr "Bu grafiği değiştirmeye yetkiniz yok"
 msgid "You do not have permission to edit this dashboard"
 msgstr "Bu gösterim paneliı değiştirmeye yetkiniz yok"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You do not have permission to perform this operation"
-msgstr ""
+msgstr "Bu işlemi gerçekleştirme izniniz yok"
 
 msgid "You do not have permission to read tags"
 msgstr "Etiketler okumak için izniniz yok"
@@ -16911,17 +17966,29 @@ msgstr "Bu verisetine erişemezsiniz."
 msgid "You don't have access to this embedded dashboard config."
 msgstr "Bu gömülü Gösterim Paneli’un configine erişemezsiniz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have access to this semantic view."
-msgstr ""
+msgstr "Bu semantik görünüme erişiminiz yok."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to copy to clipboard"
-msgstr ""
+msgstr "Panoya kopyalama izniniz yok"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export data"
-msgstr ""
+msgstr "Veri dışa aktarma izniniz yok"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export images"
-msgstr ""
+msgstr "Görsel dışa aktarma izniniz yok"
 
 msgid "You don't have permission to modify the value."
 msgstr "Değeri değiştirmek için yetkiniz yok."
@@ -16945,12 +18012,17 @@ msgstr "Bu başlığı değiştirmeye yetkiniz yok."
 msgid "You don't have the rights to create a dashboard"
 msgstr "You don’t have the rights to create a gösterim paneli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have the rights to export data"
-msgstr ""
+msgstr "Veri dışa aktarma hakkınız yok"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "You have been removed from task: %s"
-msgstr ""
+msgstr "Görevden kaldırıldınız: %s"
 
 msgid "You have removed this filter."
 msgstr "Filtreyi kaldırdınız."
@@ -16972,11 +18044,15 @@ msgstr ""
 "eylemleri tamamen geri alamayacaksınız. Tarihi sıfırlamak için mevcut "
 "durumunuzu kurtarabilirsin."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You must be a %s owner in order to edit. Please reach out to a %s owner "
 "to request modifications or edit access."
 msgstr ""
+"Düzenleyebilmek için %s sahibi olmanız gerekir. Değişiklik veya düzenleme"
+" erişimi talep etmek için lütfen bir %s sahibiyle iletişime geçin."
 
 msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
@@ -16991,8 +18067,11 @@ msgstr "Yeni pano için bir isim seçmelisiniz"
 msgid "You must run the query successfully first"
 msgstr "Önce sorguyu başarıyla çalıştırmalısınız"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Yapmanız gerekiyor"
 
 msgid ""
 "You updated the values in the control panel, but the chart was not "
@@ -17003,11 +18082,15 @@ msgstr ""
 " güncellenmedi. \"Güncel grafikler\" düğmesine tıklayarak sorguyu "
 "çalıştırın veya"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Bu görevden kaldırılacaksınız. %s diğer abone(ler) için çalışmaya devam "
+"edecek."
 
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
@@ -17066,8 +18149,11 @@ msgstr "Raporunuz silinemez"
 msgid "Your user information"
 msgstr "Ek bilgi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Z-A"
-msgstr ""
+msgstr "Z-A"
 
 msgid "ZIP file contains multiple file types"
 msgstr "ZIP dosyası birden çok dosya türü içeriyor"
@@ -17141,9 +18227,10 @@ msgstr ""
 msgid "`operation` property of post processing object undefined"
 msgstr "“İşin posta işleme mülkiyetini tanımlanmamış değil"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` 1 ile %(max)s arasında olmalıdır"
 
 msgid "`prophet` package not installed"
 msgstr "\"prophet' paketi yüklemedi"
@@ -17164,8 +18251,11 @@ msgstr "\"row offset\" 0'dan fazla veya eşit olmalıdır"
 msgid "`width` must be greater or equal to 0"
 msgstr "“altın” 0'a daha büyük veya eşit olmalıdır"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "a few seconds"
-msgstr ""
+msgstr "birkaç saniye"
 
 msgid "aggregate"
 msgstr "Toplam"
@@ -17207,8 +18297,11 @@ msgstr "Otomatik"
 msgid "background"
 msgstr "Arka plan"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "background color"
-msgstr ""
+msgstr "arka plan rengi"
 
 msgid "basis"
 msgstr "Temel"
@@ -17233,8 +18326,11 @@ msgstr "bfill"
 msgid "bolt"
 msgstr "Kurun"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "boolean"
-msgstr ""
+msgstr "mantıksal"
 
 msgid "boolean type icon"
 msgstr "boolean type icon"
@@ -17254,8 +18350,11 @@ msgstr "boş bırakılamaz"
 msgid "cardinal"
 msgstr "kartinal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "cell bar"
-msgstr ""
+msgstr "hücre çubuğu"
 
 msgid "change"
 msgstr "Değişim değişikliği"
@@ -17340,11 +18439,17 @@ msgstr "gösterim paneli"
 msgid "dashboards"
 msgstr "Gösterim Panelleri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "data connection"
-msgstr ""
+msgstr "veri bağlantısı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "data connections"
-msgstr ""
+msgstr "veri bağlantıları"
 
 msgid "database"
 msgstr "veritabanı"
@@ -17361,11 +18466,17 @@ msgstr "veriseti ismi"
 msgid "datasets"
 msgstr "verisetleri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "datasource"
-msgstr ""
+msgstr "veri kaynağı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "datasources"
-msgstr ""
+msgstr "veri kaynakları"
 
 msgid "date"
 msgstr "tarih"
@@ -17476,8 +18587,11 @@ msgstr "e.g. world population"
 msgid "e.g. xy12345.us-east-2.aws"
 msgstr "e.g. xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "örn. CI/CD Pipeline, Analytics Script"
 
 msgid "edit mode"
 msgstr "düzenleme modu"
@@ -17489,8 +18603,11 @@ msgstr "e-posta konusu"
 msgid "ends with"
 msgstr "Grafik genişliği"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "entire row"
-msgstr ""
+msgstr "tüm satır"
 
 msgid "entries"
 msgstr "giriş girişleri"
@@ -17525,14 +18642,20 @@ msgstr "her ay"
 msgid "expand"
 msgstr "Geniş genişleme"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard bir nesne olmalıdır"
 
 msgid "failed"
 msgstr "Başarısız oldu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "veda"
 
 msgid "fetching"
 msgstr "Getirmek"
@@ -17543,8 +18666,11 @@ msgstr "ffill"
 msgid "flat"
 msgstr "flat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "for a list of available helpers."
-msgstr ""
+msgstr "mevcut yardımcıların listesi için."
 
 msgid "for more information on how to structure your URI."
 msgstr "URI'nızı nasıl inşa edeceğiniz hakkında daha fazla bilgi için."
@@ -17559,8 +18685,11 @@ msgstr "function type icon"
 msgid "geohash (square)"
 msgstr "geohash (square)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "greeting"
-msgstr ""
+msgstr "selamlama"
 
 msgid "heatmap"
 msgstr "Heatmap"
@@ -17568,8 +18697,11 @@ msgstr "Heatmap"
 msgid "heatmap: values are normalized across the entire heatmap"
 msgstr "Heatmap: Değerler tüm ısımap ile normalleştirilmiştir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "merhaba"
 
 msgid "here"
 msgstr "İşte burada"
@@ -17580,8 +18712,11 @@ msgstr "saat"
 msgid "in"
 msgstr "in"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "bu işlemi gerçekleştirmek için."
 
 msgid "invalid email"
 msgstr "geçersiz e-posta"
@@ -17660,8 +18795,11 @@ msgstr " {min}     {name}  "
 msgid "linear"
 msgstr "lineer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "locale_key"
-msgstr ""
+msgstr "locale_key"
 
 msgid "log"
 msgstr "log"
@@ -17714,30 +18852,43 @@ msgstr "Bir değere sahip olmalıdır"
 msgid "name"
 msgstr "isim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters bir liste olmalıdır"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] gerekli anahtarlar eksik: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] bir nesne olmalıdır"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues bir liste olmalıdır"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' panoda mevcut değil"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId boş olmayan bir dize olmalıdır"
 
 msgid "no SQL validator is configured"
 msgstr "Hiçbir SQL doğrulama cihazı yapılandırılamaz"
@@ -17749,8 +18900,11 @@ msgstr "Hiçbir SQL doğrulama cihazı   %(engine_spec)s için yapılandırılı
 msgid "not containing"
 msgstr "Dahil değil,"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "numeric"
-msgstr ""
+msgstr "sayısal"
 
 msgid "numeric type icon"
 msgstr "numeric tip icon"
@@ -17833,8 +18987,11 @@ msgstr "Önceki takvim haftası"
 msgid "previous calendar year"
 msgstr "Önceki takvim yılı"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "yetkilendirme sağlayın"
 
 msgid "quarter"
 msgstr "çeyrek"
@@ -17922,8 +19079,11 @@ msgstr "durduruldu"
 msgid "stream"
 msgstr "akış"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "string"
-msgstr ""
+msgstr "dize"
 
 msgid "string type icon"
 msgstr "dize türü ikon"
@@ -17943,27 +19103,39 @@ msgstr "Kelimeler."
 msgid "tag"
 msgstr "etiket"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "task"
-msgstr ""
+msgstr "görev"
 
 msgid "temporal type icon"
 msgstr "Zaman türü ikonum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "text color"
-msgstr ""
+msgstr "metin rengi"
 
 msgid "textarea"
 msgstr "metin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "Handlebars grafik belgeleri"
 
 #, fuzzy
 msgid "theme"
 msgstr "Zaman"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "timestamp"
-msgstr ""
+msgstr "zaman damgası"
 
 msgid "to"
 msgstr "toklanmak için"
@@ -18054,5 +19226,8 @@ msgstr "zoom alanı"
 msgid "© Layer attribution"
 msgstr "© Originion"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -1813,9 +1813,11 @@ msgstr "%s alırken bir hata oluştu:   %s "
 msgid "An error occurred while fetching available CSS templates"
 msgstr "Mevcut CSS şablonları alırken bir hata meydana geldi"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "An error occurred while fetching available themes"
-msgstr "Verisetini kaydederken bir hata oluştu"
+msgstr "Mevcut temalar getirilirken bir hata oluştu"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -4141,7 +4143,7 @@ msgid "Controls labeled "
 msgstr "Kontroller etiketlendi"
 
 msgid "Copied to clipboard!"
-msgstr "Söpücüklere!"
+msgstr "Panoya kopyalandı!"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -4481,9 +4483,11 @@ msgstr "Özel zaman filtre eklentisi"
 msgid "Custom width of the screenshot in pixels"
 msgstr "pikselde görüntünün özel genişliği"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Custom..."
-msgstr "Başlangıç tarihi"
+msgstr "Özel..."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Turkish (`tr`) catalog using `scripts/translations/backfill_po.py`, which drafts translations with Claude using every other language's existing translation of the same string as cross-language disambiguation context (per `docs/developer_docs/contributing/howtos.md`). Do-not-translate tokens (icon names, enum values, SQL keywords, API field names, placeholders) are skipped.

All generated strings are marked `#, fuzzy` with a `Machine-translated via backfill_po.py` attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend builds include fuzzy entries, so these translations render in the UI once built; reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only, no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l tr` succeeds.
- Turkish native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API