### PR TITLE
fix(i18n): correct mistranslated entries flagged in review (pl/pt_BR/sl/sk/fi)

### DIFF
--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -15242,11 +15242,11 @@ msgstr ""
 msgid "Mapbox"
 msgstr "Mapbox"
 
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, es,
-# fr, ja, lv, mi, ru, sk, uk]
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Mapbox (API key required)"
-msgstr "Sähköposti on pakollinen"
+msgstr "Mapbox (API-avain vaaditaan)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -31603,11 +31603,11 @@ msgstr "ffill"
 msgid "flat"
 msgstr "tasainen"
 
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
-# de, es, fa, ja, lv, mi, nl, pt_BR, ru, sk, sl, tr, uk]
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "for a list of available helpers."
-msgstr "Ei käytettävissä olevia suodattimia."
+msgstr "katso lista käytettävissä olevista apufunktioista."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -3100,9 +3100,11 @@ msgstr "Nie można uzyskać dostępu do zapytania"
 msgid "Cannot delete a database that has datasets attached"
 msgstr "Nie można usunąć bazy danych, do której są przypisane zestawy danych"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Cannot delete system themes"
-msgstr "Nie można uzyskać dostępu do zapytania"
+msgstr "Nie można usunąć motywów systemowych"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -7645,9 +7647,11 @@ msgstr "Filtry porównawcze muszą mieć wartość"
 msgid "Filters for values equal to this exact value."
 msgstr "Filtruje wartości równe tej dokładnej wartości."
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Filters for values greater than or equal."
-msgstr "`row_limit` musi być większe lub równe 0"
+msgstr "Filtry dla wartości większych lub równych."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -15053,13 +15057,17 @@ msgstr ""
 "Zadanie nie może zostać przerwane. Zadanie jest w toku, ale nie "
 "zarejestrowano procedury obsługi przerwania."
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Task parameters are invalid."
-msgstr "Parametry etykiety są nieprawidłowe."
+msgstr "Parametry zadania są nieprawidłowe."
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Tasks"
-msgstr "tagi"
+msgstr "Zadania"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -5052,9 +5052,11 @@ msgstr "Esquemas permitidos para upload de arquivos"
 msgid "Database settings updated"
 msgstr "Configurações do banco de dados atualizadas"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Database type does not support file uploads."
-msgstr "O banco de dados não é compatível com subconsultas"
+msgstr "O tipo de banco de dados não suporta upload de arquivos."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
 #, fuzzy
@@ -15206,9 +15208,11 @@ msgstr ""
 msgid "The exponent to compute all sizes from. \"EXP\" only"
 msgstr "O expoente a partir do qual calcular todos os tamanhos. Somente \"EXP\""
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
-msgstr "URI de dados não são permitidos."
+msgstr "A extensão %(id)s não pôde ser carregada."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -17461,9 +17465,11 @@ msgstr "ícone de tipo desconhecido"
 msgid "Unknown value"
 msgstr "Valor desconhecido"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Unpin"
-msgstr "em execução"
+msgstr "Desafixar"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -8701,9 +8701,11 @@ msgstr ""
 msgid "Mapbox"
 msgstr "Mapbox"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Mapbox (API key required)"
-msgstr "E-mail je povinný"
+msgstr "Mapbox (vyžaduje sa kľúč API)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -11255,9 +11257,11 @@ msgstr "Obrátit zemepisnou šírku/délku "
 msgid "Revoke"
 msgstr "Odstrániť"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Revoke API Key"
-msgstr "Kľúč skupiny"
+msgstr "Odvolať API kľúč"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -17276,9 +17276,11 @@ msgstr "SQL-izraz"
 msgid "Validate query"
 msgstr "Ogled poizvedbe"
 
+# Machine-corrected via backfill_po.py (claude-sonnet-4-6) [replaced a
+# mistranslation]
 #, fuzzy
 msgid "Validate your expression"
-msgstr "Neveljaven cron izraz"
+msgstr "Preverite vaš izraz"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]


### PR DESCRIPTION
### SUMMARY

The review bots (Bito/CodeAnt) flagged a set of clearly-wrong translations across several catalogs during the AI backfill sweep. Most are **pre-existing** cross-contamination / copy-paste errors (unrelated msgstr assigned to a msgid), surfaced because they sit near the backfill diffs. This corrects **12 entries across five merged catalogs**, re-translated via Claude and marked `#, fuzzy` for native-speaker review.

| Lang | msgid | was | now |
|---|---|---|---|
| pl | `Tasks` | "tagi" (tags) | "Zadania" |
| pl | `Cannot delete system themes` | "Cannot access query" | correct |
| pl | `Filters for values greater than or equal.` | "row_limit must be ≥ 0" | correct |
| pl | `Task parameters are invalid.` | "Label parameters..." | correct |
| pt_BR | `Unpin` | "em execução" (running) | "Desafixar" |
| pt_BR | `The extension %(id)s could not be loaded.` | dropped `%(id)s`, wrong text | correct, placeholder kept |
| pt_BR | `Database type does not support file uploads.` | "...subqueries" | correct |
| sl | `Validate your expression` | "Invalid cron expression" | "Preverite vaš izraz" |
| sk | `Mapbox (API key required)` | "Email is required" | correct |
| sk | `Revoke API Key` | "Group key" | "Odvolať API kľúč" |
| fi | `Mapbox (API key required)` | "Email is required" | correct |
| fi | `for a list of available helpers.` | "No available filters" | correct |

Note: `es` entries the bots flagged (`API key name is required`, `HTML sanitization`) are already correct in master, so they're not included. `ca`'s "per a" flag is a faithful translation. `fr`'s pre-existing errors are covered by @jeanpommier's in-flight French work.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalogs only. The corrected strings render in the UI once rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l pl -l pt_BR -l sl -l sk -l fi` succeeds.
- Native speakers: review the corrected `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API