### PR TITLE
feat(i18n): backfill Chinese (Simplified) (zh) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: zhouyao94@qq.com\n"
 "POT-Creation-Date: 2026-06-08 12:27-0700\n"
 "PO-Revision-Date: 2019-01-04 22:19+0800\n"
-"Last-Translator: cdmikechen \n"
+"Last-Translator: cdmikechen\n"
 "Language: zh\n"
 "Language-Team: zh <benedictjin2016@gmail.com>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
@@ -29,6 +29,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The cumulative option allows you to see how your data "
@@ -42,7 +45,13 @@ msgid ""
 "                original data, it just changes the way the histogram is "
 "displayed."
 msgstr ""
+"\n"
+"                "
+"累积选项允许您查看数据如何在不同值之间积累。启用后，直方图的柱条表示到每个区间为止的频率累计总和。这有助于您了解遇到某个特定点以下的值的可能性。请记住，启用累积不会更改您的原始数据，只是改变直方图的显示方式。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The normalize option transforms the histogram values into"
@@ -56,6 +65,9 @@ msgid ""
 "                clearer understanding of the proportion of data points "
 "within each bin."
 msgstr ""
+"\n"
+"                "
+"归一化选项通过将每个区间的计数除以数据点总数，将直方图的值转换为比例或概率。此归一化过程确保结果值之和为1，从而可以对数据分布进行相对比较，并更清楚地了解每个区间内数据点的比例。"
 
 msgid ""
 "\n"
@@ -66,7 +78,9 @@ msgstr ""
 "\n"
 "此过滤条件是从看板上下文继承的。保存图表时不会保存。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "\n"
 "            <p>Your report/alert was unable to be generated because of "
@@ -75,6 +89,11 @@ msgid ""
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
+"\n"
+"            <p>您的报告/警报因以下错误无法生成：%(text)s</p>\n"
+"            <p>请检查您的仪表盘/图表是否存在错误。</p>\n"
+"            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
+"            "
 
 msgid " (excluded)"
 msgstr "(不包含)"
@@ -92,9 +111,11 @@ msgstr "一个已存在的看板或者"
 msgid " a new one"
 msgstr "另存为新的"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " at line %(line)d"
-msgstr ""
+msgstr " 在第 %(line)d 行"
 
 msgid " expression which needs to adhere to the "
 msgstr " 表达式必须基于 "
@@ -103,12 +124,17 @@ msgstr " 表达式必须基于 "
 msgid " for details."
 msgstr "详细信息"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " near '%(highlight)s'"
-msgstr ""
+msgstr " 在 '%(highlight)s' 附近"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " source code of Superset's sandboxed parser"
-msgstr ""
+msgstr " Superset 沙箱解析器的源代码"
 
 msgid ""
 " standard to ensure that the lexicographical ordering\n"
@@ -138,15 +164,22 @@ msgstr "添加计算列"
 msgid " to add metrics"
 msgstr "添加指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to check for details."
-msgstr ""
+msgstr " 以查看详细信息。"
 
 #, fuzzy
 msgid " to edit or add columns and metrics."
 msgstr "编辑或增加列与指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh_TW]
+#, fuzzy
 msgid " to mark a column as a time column"
-msgstr ""
+msgstr " 标记列为时间列"
 
 msgid " to open SQL Lab. From there you can save the query as a dataset."
 msgstr "然后打开SQL工具箱。在那里你可以将查询保存为一个数据集。"
@@ -155,19 +188,26 @@ msgstr "然后打开SQL工具箱。在那里你可以将查询保存为一个数
 msgid " to see details."
 msgstr "查看查询详情"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to visualize your data."
-msgstr ""
+msgstr " 以可视化您的数据。"
 
 msgid "!= (Is not equal)"
 msgstr "不等于（!=）"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system dark theme"
-msgstr ""
+msgstr "\"%s\" 现在是系统深色主题"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system default theme"
-msgstr ""
+msgstr "\"%s\" 现在是系统默认主题"
 
 #, fuzzy, python-format
 msgid "% calculation"
@@ -185,38 +225,52 @@ msgstr "显示总计"
 msgid "%(dialect)s cannot be used as a data source for security reasons."
 msgstr "出于安全原因，%(dialect)s SQLite数据库不能用作数据源。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(label)s file"
-msgstr ""
+msgstr "%(label)s 文件"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(name)s.csv"
-msgstr ""
+msgstr "%(name)s.csv"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(name)s.pdf"
-msgstr ""
+msgstr "%(name)s.pdf"
 
 #, python-format
 msgid "%(object)s does not exist in this database."
 msgstr "数据库中不存在 %(object)s 。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(prefix)s %(title)s"
-msgstr ""
+msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
-msgstr ""
+msgstr "%(prefix)s由于内存限制，结果已截断至 %(row_count)s 行。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%(report_type)s schedule frequency exceeding limit. Please configure a "
 "schedule with a minimum interval of %(minimum_interval)d minutes per "
 "execution."
-msgstr ""
+msgstr "%(report_type)s 计划频率超出限制。请配置每次执行最小间隔为 %(minimum_interval)d 分钟的计划。"
 
 #, python-format
 msgid "%(rows)d rows returned"
@@ -287,9 +341,11 @@ msgstr "%s 个被选中（实体）"
 msgid "%s Selected (Virtual)"
 msgstr "%s 个被选中（虚拟）"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s 语义视图"
 
 #, fuzzy, python-format
 msgid "%s URL"
@@ -335,11 +391,13 @@ msgstr[0] "%s 个选项"
 msgid "%s item(s)"
 msgstr "%s 个选项"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%s items could not be tagged because you don’t have edit permissions to "
 "all selected objects."
-msgstr ""
+msgstr "%s 个项目无法标记，因为您没有所有所选对象的编辑权限。"
 
 #, fuzzy, python-format
 msgid "%s metric"
@@ -411,17 +469,23 @@ msgid "%s second"
 msgid_plural "%s seconds"
 msgstr[0] "5秒"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "已添加 %s 个语义视图"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "添加 %s 个语义视图失败"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "添加 %s 个语义视图失败：%s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
@@ -447,7 +511,9 @@ msgstr "无描述，单击可查看堆栈跟踪"
 msgid "), and they become available in your SQL (example:"
 msgstr "), 他们在你的SQL中会变成有效数据 (比如:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -456,8 +522,16 @@ msgid ""
 "    Error: %(text)s\n"
 "    "
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"    %(description)s\n"
+"\n"
+"    错误：%(text)s\n"
+"    "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -467,13 +541,26 @@ msgid ""
 "\n"
 "%(table)s\n"
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"%(description)s\n"
+"\n"
+"<%(url)s|在 Superset 中探索>\n"
+"\n"
+"%(table)s\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "+ %s more"
-msgstr ""
+msgstr "+ 还有 %s 个"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ", then paste the JSON below. See our"
-msgstr ""
+msgstr "，然后粘贴下面的 JSON。请参阅我们的"
 
 msgid ""
 "-- Note: Unless you save your query, these tabs will NOT persist if you "
@@ -481,17 +568,21 @@ msgid ""
 "\n"
 msgstr "--  注意：除非您保存查询，否则如果清除cookie或更改浏览器时，这些选项卡将不会保留。\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... 以及 %d 个更多"
 
 #, fuzzy, python-format
 msgid "... and %s more records"
 msgstr "原始记录"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "... and %s others"
-msgstr ""
+msgstr "... 以及其他 %s 个"
 
 msgid "0 Selected"
 msgstr "0个被选中"
@@ -594,20 +685,39 @@ msgstr "156周"
 msgid "156 weeks ago"
 msgstr "156周之前"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1AS"
-msgstr ""
+msgstr "1AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1D"
-msgstr ""
+msgstr "1D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1H"
-msgstr ""
+msgstr "1H"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1M"
-msgstr ""
+msgstr "1M"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1T"
-msgstr ""
+msgstr "1T"
 
 #, fuzzy
 msgid "2 years"
@@ -619,8 +729,12 @@ msgstr "2年之前"
 msgid "2/98 percentiles"
 msgstr "2/98百分位"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "22"
-msgstr ""
+msgstr "22"
 
 #, fuzzy
 msgid "24 hours"
@@ -665,11 +779,19 @@ msgstr "30秒钟"
 msgid "30 seconds"
 msgstr "30秒钟"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "4 weeks (freq=4W-MON)"
-msgstr ""
+msgstr "4 周 (freq=4W-MON)"
 
 msgid "5 minute"
 msgstr "5分钟"
@@ -716,8 +838,12 @@ msgstr "7个日历日的频率"
 msgid "7 days"
 msgstr "7天"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "7D"
-msgstr ""
+msgstr "7D"
 
 msgid "9/91 percentiles"
 msgstr "9/91百分位"
@@ -765,19 +891,30 @@ msgstr "大于等于（>=）"
 msgid "A Big Number"
 msgstr "大数字"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "生成标签配置对象的 JavaScript 函数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "生成图标配置对象的 JavaScript 函数"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"符合 ECharts 选项规范的 JavaScript 对象，以更高优先级覆盖其他控件选项。（例如 { title: { text: \"My "
+"Chart\" }, tooltip: { trigger: \"item\" } "
+"}）。详情：https://echarts.apache.org/en/option.html。 "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
@@ -787,37 +924,55 @@ msgstr "应作为日期解析的列的逗号分隔列表。"
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr "允许以逗号分割的CSV文件上传"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A database port is required when connecting via SSH Tunnel."
-msgstr ""
+msgstr "通过 SSH 隧道连接时需要提供数据库端口。"
 
 msgid "A database with the same name already exists."
 msgstr "已存在同名的数据库。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A date is required when using custom date shift"
-msgstr ""
+msgstr "使用自定义日期偏移时需要提供日期"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "A dictionary with column names and their data types if you need to change"
 " the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas "
 "library for supported data types."
 msgstr ""
+"如果需要更改默认值，请提供包含列名及其数据类型的字典。示例：{\"user_id\":\"int\"}。请查阅 Python 的 Pandas "
+"库以了解支持的数据类型。"
 
 msgid ""
 "A full URL pointing to the location of the built plugin (could be hosted "
 "on a CDN for example)"
 msgstr "指向内置插件位置的完整URL（例如，可以托管在CDN上）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A handlebars template that is applied to the data"
-msgstr ""
+msgstr "应用于数据的 Handlebars 模板"
 
 msgid "A human-friendly name"
 msgstr "人性化的名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A list of domain names that can embed this dashboard. Leaving this field "
 "empty will allow embedding from any domain."
-msgstr ""
+msgstr "可以嵌入此仪表盘的域名列表。将此字段留空将允许来自任何域的嵌入。"
 
 #, fuzzy
 msgid "A list of tags that have been applied to this chart."
@@ -833,10 +988,14 @@ msgstr "有权处理该图表的用户列表。可按名称或用户名搜索。
 msgid "A map of the world, that can indicate values in different countries."
 msgstr "一张世界地图，可以显示不同国家的价值观。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A map that takes rendering circles with a variable radius at "
 "latitude/longitude coordinates"
-msgstr ""
+msgstr "在经纬度坐标上以可变半径渲染圆圈的地图"
 
 msgid "A metric to use for color"
 msgstr "用于颜色的指标"
@@ -869,8 +1028,12 @@ msgstr "对 [时间] 配置的引用，会将粒度考虑在内"
 msgid "A report named \"%(name)s\" already exists"
 msgstr "报告 %(name)s 已存在"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A reusable dataset will be saved with your chart."
-msgstr ""
+msgstr "可重用的数据集将与您的图表一起保存。"
 
 msgid ""
 "A set of parameters that become available in the query using Jinja "
@@ -892,6 +1055,10 @@ msgstr "截图超时"
 msgid "A valid color scheme is required"
 msgstr "需要有效的配色方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A waterfall chart is a form of data visualization that helps in "
 "understanding\n"
@@ -899,7 +1066,7 @@ msgid ""
 "negative values.\n"
 "          These intermediate values can either be time based or category "
 "based."
-msgstr ""
+msgstr "瀑布图是一种数据可视化形式，有助于理解依次引入的正值或负值的累积效果。这些中间值可以基于时间或类别。"
 
 #, fuzzy
 msgid "A-Z"
@@ -925,11 +1092,17 @@ msgstr "报告已创建"
 msgid "API key name is required"
 msgstr "需要名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "API 密钥已成功撤销"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "API 密钥允许对 Superset 进行有范围的编程访问。"
 
 msgid "APPLY"
 msgstr "应用"
@@ -1036,10 +1209,13 @@ msgstr "隐藏Layer"
 msgid "Add Log"
 msgstr "新增日志"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Add Query A and Query B identifiers to tooltips to help differentiate "
 "series"
-msgstr ""
+msgstr "在提示框中添加查询A和查询B的标识符，以帮助区分系列"
 
 #, fuzzy
 msgid "Add Role"
@@ -1100,18 +1276,28 @@ msgstr "新增通知方法"
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr "在“编辑数据源”对话框中向数据集添加计算列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "在\"编辑数据源\"对话框中向数据集添加计算时间列"
 
 #, fuzzy
 msgid "Add certification details for this dashboard"
 msgstr "认证细节"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Add color for positive/negative change"
-msgstr ""
+msgstr "为正/负变化添加颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "为所有列的单元格条形图添加正/负颜色"
 
 #, fuzzy
 msgid "Add cross-filter"
@@ -1169,8 +1355,11 @@ msgstr "增加条件"
 msgid "Add metric"
 msgstr "新增指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "在\"编辑数据源\"对话框中向数据集添加指标"
 
 msgid "Add new color formatter"
 msgstr "增加新的的颜色格式化器"
@@ -1228,10 +1417,12 @@ msgstr "添加到看板"
 msgid "Added"
 msgstr "已添加"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
+msgstr[0] "已向虚拟数据集添加了 1 个新列"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"
@@ -1263,10 +1454,13 @@ msgstr "附加文本到数据前(后)，例如：单位"
 msgid "Additive"
 msgstr "附加"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Adds color to the chart symbols based on the positive or negative change "
 "from the comparison value."
-msgstr ""
+msgstr "根据与比较值的正负变化，为图表符号添加颜色。"
 
 msgid "Adjust how this database will interact with SQL Lab."
 msgstr "调整此数据库与 SQL 工具箱的交互方式。"
@@ -1321,10 +1515,13 @@ msgstr "选择看板"
 msgid "After"
 msgstr "之后"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "After making the changes, copy the query and paste in the virtual dataset"
 " SQL snippet settings."
-msgstr ""
+msgstr "完成修改后，复制查询并粘贴到虚拟数据集 SQL 片段设置中。"
 
 msgid "Aggregate"
 msgstr "聚合"
@@ -1345,10 +1542,14 @@ msgid ""
 "and columns"
 msgstr "在旋转和计算总的行和列时，应用聚合函数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Aggregates data within the boundary of grid cells and maps the aggregated"
 " values to a dynamic color scale"
-msgstr ""
+msgstr "在网格单元格边界内聚合数据，并将聚合值映射到动态颜色比例尺"
 
 #, fuzzy
 msgid "Aggregation"
@@ -1475,11 +1676,17 @@ msgstr "允许 CREATE TABLE AS"
 msgid "Allow CREATE VIEW AS"
 msgstr "允许 CREATE VIEW AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow DDL and DML"
-msgstr ""
+msgstr "允许 DDL 和 DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow changing catalogs"
-msgstr ""
+msgstr "允许更改目录"
 
 msgid ""
 "Allow column names to be changed to case insensitive format, if supported"
@@ -1514,11 +1721,16 @@ msgstr "允许上传文件到数据库"
 msgid "Allow node selections"
 msgstr "允许节点选择"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Allow the execution of DDL (Data Definition Language: CREATE, DROP, "
 "TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, "
 "DELETE, etc)"
 msgstr ""
+"允许执行 DDL（数据定义语言：CREATE、DROP、TRUNCATE 等）和 DML（数据修改语言：INSERT、UPDATE、DELETE "
+"等）"
 
 msgid "Allow this database to be explored"
 msgstr "允许浏览此数据库"
@@ -1974,8 +2186,11 @@ msgstr "注释与注释层"
 msgid "Annotations could not be deleted."
 msgstr "无法删除注释。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ant Design Theme Editor"
-msgstr ""
+msgstr "Ant Design 主题编辑器"
 
 msgid "Any"
 msgstr "所有"
@@ -1988,13 +2203,19 @@ msgid ""
 "dashboard's individual charts"
 msgstr "此处选择的任何调色板都将覆盖应用于此看板的各个图表的颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Any dashboards using these themes will be automatically dissociated from "
 "them."
-msgstr ""
+msgstr "使用这些主题的所有仪表板将自动与它们解除关联。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Any dashboards using this theme will be automatically dissociated from it."
-msgstr ""
+msgstr "使用此主题的所有仪表板将自动与其解除关联。"
 
 msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
 msgstr "可以添加任何允许通过SQL AlChemy URI进行连接的数据库。"
@@ -2025,11 +2246,14 @@ msgid ""
 "source query satisfies the minimum periods defined in the rolling window."
 msgstr "应用的滚动窗口（rolling window）未返回任何数据。请确保源查询满足滚动窗口中定义的最小周期。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
-msgstr ""
+msgstr "仅在选择\"单元格条形\"格式时适用：如果启用了\"显示单元格条形\"选项，则显示直方图列的背景。"
 
 msgid "Apply"
 msgstr "应用"
@@ -2052,10 +2276,13 @@ msgstr "将条件颜色格式应用于指标"
 msgid "Apply conditional color formatting to numeric columns"
 msgstr "将条件颜色格式应用于数字列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Apply custom CSS to the dashboard. Use class names or element selectors "
 "to target specific components."
-msgstr ""
+msgstr "将自定义 CSS 应用到仪表板。使用类名或元素选择器来定位特定组件。"
 
 #, fuzzy
 msgid "Apply filters"
@@ -2132,15 +2359,21 @@ msgstr "您确实要删除选定的查询吗？"
 msgid "Are you sure you want to overwrite this dataset?"
 msgstr "确实要删除选定的数据集吗？"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system dark theme? The application "
 "will fall back to the configuration file dark theme."
-msgstr ""
+msgstr "确定要删除系统深色主题吗？应用程序将回退到配置文件中的深色主题。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system default theme? The application"
 " will fall back to the configuration file default."
-msgstr ""
+msgstr "您确定要删除系统默认主题吗？应用将回退到配置文件中的默认设置。"
 
 #, fuzzy
 msgid ""
@@ -2151,17 +2384,21 @@ msgstr "确实要删除选定的注释吗？"
 msgid "Are you sure you want to save and apply changes?"
 msgstr "确实要保存并应用更改吗？"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system dark theme? This will "
 "apply to all users who haven't set a personal preference."
-msgstr ""
+msgstr "您确定要将\"%s\"设置为系统深色主题吗？这将应用于所有未设置个人偏好的用户。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system default theme? This "
 "will apply to all users who haven't set a personal preference."
-msgstr ""
+msgstr "您确定要将\"%s\"设置为系统默认主题吗？这将应用于所有未设置个人偏好的用户。"
 
 #, fuzzy
 msgid "Area"
@@ -2204,11 +2441,17 @@ msgstr "分布"
 msgid "August"
 msgstr "八月"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization Request URI"
-msgstr ""
+msgstr "授权请求URI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization needed"
-msgstr ""
+msgstr "需要授权"
 
 #, fuzzy
 msgid "Auto"
@@ -2218,13 +2461,17 @@ msgstr "自动"
 msgid "Auto Zoom"
 msgstr "数据缩放"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "自动刷新已暂停（已设置为 %s 秒）"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
-msgstr ""
+msgstr "自动刷新已暂停 - 标签页不活跃（已设置为 %s 秒）"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
@@ -2243,11 +2490,17 @@ msgstr "自适配过滤条件"
 msgid "Autocomplete query predicate"
 msgstr "自动补全查询谓词"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on available space"
-msgstr ""
+msgstr "根据可用空间自动调整列宽"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on content"
-msgstr ""
+msgstr "根据内容自动调整列宽"
 
 #, fuzzy
 msgid "Automatically sync columns"
@@ -2372,18 +2625,29 @@ msgstr "数据库端口"
 msgid "Base height"
 msgstr "图表高度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
-msgstr ""
+msgstr "底图样式。接受与 MapLibre 兼容的样式 URL。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
-msgstr ""
+msgstr "底图样式。接受 Mapbox 样式 URL（mapbox://styles/...）。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
-msgstr ""
+msgstr "底图样式。请参阅 MapLibre 文档：%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Base slope"
-msgstr ""
+msgstr "基础坡度"
 
 #, fuzzy
 msgid "Base width"
@@ -2395,8 +2659,12 @@ msgstr "基于指标"
 msgid "Based on granularity, number of time periods to compare against"
 msgstr "根据粒度、要比较的时间阶段"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Based on what should series be ordered on the chart and legend"
-msgstr ""
+msgstr "图表和图例中系列的排序依据"
 
 msgid "Basic"
 msgstr "基础"
@@ -2422,8 +2690,12 @@ msgstr "之前"
 msgid "Big Number"
 msgstr "数字"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Big Number with Time Period Comparison"
-msgstr ""
+msgstr "带时间段对比的大数字"
 
 msgid "Big Number with Trendline"
 msgstr "带趋势线的数字"
@@ -2436,9 +2708,11 @@ msgstr "处于"
 msgid "Blanks"
 msgstr "布尔值"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "第 %(block_num)s 块，共 %(block_count)s 块"
 
 #, fuzzy
 msgid "Border color"
@@ -2480,11 +2754,14 @@ msgid ""
 "range. It won't narrow the data's extent."
 msgstr "Y轴的边界。当空时，边界是根据数据的最小/最大值动态定义的。请注意，此功能只会扩展轴范围。它不会缩小数据范围。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the X-axis. Selected time merges with min/max date of the "
 "data. When left empty, bounds dynamically defined based on the min/max of"
 " the data."
-msgstr ""
+msgstr "X 轴的边界。所选时间与数据的最小/最大日期合并。留空时，边界将根据数据的最小/最大值动态确定。"
 
 msgid ""
 "Bounds for the Y-axis. When left empty, the bounds are dynamically "
@@ -2527,11 +2804,16 @@ msgstr "分解"
 msgid "Breakpoint Metric"
 msgstr "基于指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
 "      This can help viewers understand how each category affects the "
 "overall value."
 msgstr ""
+"按此控件中指定的类别细分系列。\n"
+"      这有助于查看者了解每个类别如何影响整体值。"
 
 msgid "Bubble Chart"
 msgstr "气泡图"
@@ -2563,8 +2845,12 @@ msgstr "桶分割点"
 msgid "Bulk select"
 msgstr "批量选择"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bulk tag"
-msgstr ""
+msgstr "批量标签"
 
 msgid "Bullet Chart"
 msgstr "子弹图"
@@ -2599,6 +2885,11 @@ msgstr "最近"
 msgid "COPY QUERY"
 msgstr "复制查询URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "复制查询"
+
 msgid "CREATE TABLE AS"
 msgstr "允许 CREATE TABLE AS"
 
@@ -2625,14 +2916,21 @@ msgstr "CSS 样式"
 msgid "CSS Templates"
 msgstr "CSS 模板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS applied to the chart"
-msgstr ""
+msgstr "应用于图表的 CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
-msgstr ""
+msgstr "CSS 样式可能会被服务器端 HTML 清理删除。如果样式未生效，请联系 Superset 管理员调整 HTML 清理配置。"
 
 msgid "CSS template"
 msgstr "CSS 模板"
@@ -2691,10 +2989,13 @@ msgstr "CVAS (create view as select)查询不是SELECT语句。"
 msgid "Cache Timeout (seconds)"
 msgstr "缓存超时（秒）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
-msgstr ""
+msgstr "根据数据访问角色和权限，为每位用户单独缓存数据。禁用后，所有用户将共享同一缓存。"
 
 msgid "Cache timeout"
 msgstr "缓存时间"
@@ -2718,11 +3019,19 @@ msgstr "缓存的值未找到"
 msgid "Calculate contribution per series or row"
 msgstr "计算每个系列或总计的贡献"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from first step"
-msgstr ""
+msgstr "从第一步计算"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from previous step"
-msgstr ""
+msgstr "从上一步计算"
 
 #, python-format
 msgid "Calculated column [%s] requires an expression"
@@ -2754,8 +3063,11 @@ msgstr "取消"
 msgid "Cancel query on window unload event"
 msgstr "当窗口关闭时取消查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "由于缺少中止处理程序，无法取消"
 
 msgid "Cannot access the query"
 msgstr "无法访问查询"
@@ -2767,27 +3079,45 @@ msgstr "无法删除附加了数据集的数据库"
 msgid "Cannot delete system themes"
 msgstr "无法访问查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
-msgstr ""
+msgstr "无法删除已设置为系统默认或深色主题的主题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
-msgstr ""
+msgstr "无法删除已设置为系统默认或深色主题的主题。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Cannot find the table (%s) metadata."
-msgstr ""
+msgstr "找不到表 (%s) 的元数据。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cannot have multiple credentials for the SSH Tunnel"
-msgstr ""
+msgstr "SSH 隧道不能有多个凭据"
 
 msgid "Cannot load filter"
 msgstr "无法加载筛选器"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot modify system themes."
-msgstr ""
+msgstr "无法修改系统主题。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "无法在默认文件夹中嵌套文件夹"
 
 #, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
@@ -2841,8 +3171,12 @@ msgstr "分类名称"
 msgid "Category of target nodes"
 msgstr "目标节点类别"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category, Value and Percentage"
-msgstr ""
+msgstr "类别、值和百分比"
 
 msgid "Cell Padding"
 msgstr "单元填充"
@@ -2856,8 +3190,11 @@ msgstr "单元尺寸"
 msgid "Cell content"
 msgstr "单元格内容"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "单元格布局和样式"
 
 #, fuzzy
 msgid "Cell limit"
@@ -2911,8 +3248,11 @@ msgstr "范围"
 msgid "Changes saved."
 msgstr "修改已保存"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changes the sort value of the items in the legend only"
-msgstr ""
+msgstr "仅更改图例中项目的排序值"
 
 #, fuzzy
 msgid "Changing one or more of these dashboards is forbidden"
@@ -2969,9 +3309,11 @@ msgstr "将字符解释为小数点的字符。"
 msgid "Chart"
 msgstr "图表"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "图表 %(chart_id)s 不在仪表板 %(dashboard_id)s 上"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3031,8 +3373,11 @@ msgstr "您的图表无法创建。"
 msgid "Chart could not be updated."
 msgstr "您的图表无法更新。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
-msgstr ""
+msgstr "用于控制 deck.gl 图层可见性的图表自定义设置"
 
 #, fuzzy
 msgid "Chart customization value is required"
@@ -3093,8 +3438,12 @@ msgstr "图表标题"
 msgid "Chart type"
 msgstr "图表标题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart type requires a dataset"
-msgstr ""
+msgstr "图表类型需要数据集"
 
 #, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
@@ -3188,22 +3537,31 @@ msgstr "应作为日期解析的列的逗号分隔列表。"
 msgid "Choose columns to read"
 msgstr "要读取的列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
-msgstr ""
+msgstr "从现有仪表板过滤器中选择，并选择一个值以精细化报告结果。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose how many X-Axis labels to show"
-msgstr ""
+msgstr "选择要显示多少个 X 轴标签"
 
 #, fuzzy
 msgid "Choose index column"
 msgstr "索引字段"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
-msgstr ""
+msgstr "选择要在此仪表板中所有 deck.gl 多图层图表中隐藏的图层。"
 
 #, fuzzy
 msgid "Choose notification method and recipients."
@@ -3246,10 +3604,14 @@ msgstr ""
 "应视为null的值的Json列表。例如：[\"\"], [\"None\", \"N/A\"], [\"nan\", "
 "\"null\"]。警告：Hive数据库仅支持单个值。用 [\"\"] 代表空字符串。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Choose whether a country should be shaded by the metric, or assigned a "
 "color based on a categorical color palette"
-msgstr ""
+msgstr "选择是按指标对国家进行着色，还是根据分类调色板分配颜色"
 
 #, fuzzy
 msgid "Choose..."
@@ -3310,8 +3672,11 @@ msgstr "清除所有过滤器"
 msgid "Clear default dark theme"
 msgstr "默认时间"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "清除默认浅色主题"
 
 #, fuzzy
 msgid "Clear form"
@@ -3321,8 +3686,11 @@ msgstr "清除表单"
 msgid "Clear local theme"
 msgstr "线性颜色方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear the selection to revert to the system default theme"
-msgstr ""
+msgstr "清除选择以恢复为系统默认主题"
 
 #, fuzzy
 msgid ""
@@ -3410,8 +3778,11 @@ msgstr "关闭"
 msgid "Close all other tabs"
 msgstr "关闭其他选项卡"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Close color breakpoint editor"
-msgstr ""
+msgstr "关闭颜色断点编辑器"
 
 msgid "Close tab"
 msgstr "关闭选项卡"
@@ -3479,11 +3850,17 @@ msgstr "配色方案"
 msgid "Color Steps"
 msgstr "色阶"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "按 X 轴为条形着色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "按 Y 轴为条形着色"
 
 #, fuzzy
 msgid "Color bounds"
@@ -3497,8 +3874,11 @@ msgstr "桶分割点"
 msgid "Color by"
 msgstr "颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
-msgstr ""
+msgstr "颜色字段必须是十六进制颜色（#rrggbb）或 'rgb(r, g, b)'"
 
 #, fuzzy
 msgid "Color for breakpoint"
@@ -3518,10 +3898,13 @@ msgstr "目标位置的颜色"
 msgid "Color scheme"
 msgstr "配色方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Color will be shaded based the normalized (0% to 100%) value of a given "
 "cell against the other cells in the selected range: "
-msgstr ""
+msgstr "颜色将根据给定单元格相对于所选范围内其他单元格的归一化值（0% 至 100%）进行着色："
 
 #, fuzzy
 msgid "Color: "
@@ -3622,8 +4005,11 @@ msgstr "添加指标"
 msgid "Columns and metrics should be inside folders"
 msgstr "添加指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "列文件夹只能包含列项目"
 
 #, fuzzy, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3633,8 +4019,11 @@ msgstr "数据源中缺少列：%(invalid_columns)s"
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "数据源中缺少列：%(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "列应放置在文件夹内"
 
 msgid "Columns subtotal position"
 msgstr "列的小计位置"
@@ -3689,8 +4078,11 @@ msgid ""
 "quickly."
 msgstr "快速比较多个时间序列图表和相关指标。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Compare results with other time periods."
-msgstr ""
+msgstr "与其他时间段的结果进行比较。"
 
 msgid "Compare the same summarized metric across multiple groups."
 msgstr "跨多个组比较相同的汇总指标"
@@ -3701,11 +4093,14 @@ msgid ""
 "and color."
 msgstr "比较指标在不同组之间随时间的变化情况。每一组被映射到一行，并且随着时间的变化被可视化地显示条的长度和颜色。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
-msgstr ""
+msgstr "比较不同时间段之间的指标。显示跨多个时间段（如周或月）的时序数据，以展示各时期的趋势和规律。"
 
 msgid "Comparison"
 msgstr "比较"
@@ -3720,8 +4115,12 @@ msgstr "比较前缀"
 msgid "Comparison suffix"
 msgstr "比较前缀"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Compose multiple layers together to form complex visuals."
-msgstr ""
+msgstr "将多个图层组合在一起以形成复杂的可视化效果。"
 
 msgid "Compute the contribution to the total"
 msgstr "计算对总数的贡献值"
@@ -3762,17 +4161,26 @@ msgstr "配置时间范围：最近..."
 msgid "Configure Time Range: Previous..."
 msgstr "配置时间范围：上一期..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure automatic dashboard refresh"
-msgstr ""
+msgstr "配置仪表板自动刷新"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure caching and performance settings"
-msgstr ""
+msgstr "配置缓存和性能设置"
 
 msgid "Configure custom time range"
 msgstr "配置自定义时间范围"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure dashboard appearance, colors, and custom CSS"
-msgstr ""
+msgstr "配置仪表板外观、颜色和自定义 CSS"
 
 msgid "Configure filter scopes"
 msgstr "配置过滤范围"
@@ -3780,8 +4188,11 @@ msgstr "配置过滤范围"
 msgid "Configure the basics of your Annotation Layer."
 msgstr "注释层基本配置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure the chart size for each zoom level"
-msgstr ""
+msgstr "为每个缩放级别配置图表大小"
 
 msgid "Configure this dashboard to embed it into an external web application."
 msgstr "配置此仪表板，以便将其嵌入到外部网络应用程序中。"
@@ -3808,14 +4219,21 @@ msgstr "显示密码"
 msgid "Confirm save"
 msgstr "确认保存"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm the user's password"
-msgstr ""
+msgstr "确认用户密码"
 
 msgid "Connect"
 msgstr "连接"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Connect Google Sheet"
-msgstr ""
+msgstr "连接 Google 表格"
 
 msgid "Connect Google Sheets as tables to this database"
 msgstr "将Google Sheet作为表格连接到此数据库"
@@ -3850,9 +4268,11 @@ msgstr "连接失败，请检查您的连接配置"
 msgid "Contains"
 msgstr "连续式"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "包含文本（ILIKE %x%）"
 
 #, fuzzy
 msgid "Content format"
@@ -3899,14 +4319,20 @@ msgstr "SQL复制成功！"
 msgid "Copy"
 msgstr "复制"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy SELECT statement"
-msgstr ""
+msgstr "复制 SELECT 语句"
 
 msgid "Copy SELECT statement to the clipboard"
 msgstr "将 SELECT 语句复制到剪贴板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy URL"
-msgstr ""
+msgstr "复制 URL"
 
 msgid "Copy and Paste JSON credentials"
 msgstr "复制和粘贴JSON凭据"
@@ -3933,15 +4359,22 @@ msgstr "将查询链接复制到剪贴板"
 msgid "Copy query link to your clipboard"
 msgstr "将查询链接复制到剪贴板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the current data"
-msgstr ""
+msgstr "复制当前数据"
 
 #, fuzzy
 msgid "Copy the identifier of the account you are trying to connect to."
 msgstr "将尝试连接的账号复制到这里"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Copy the name of the HTTP Path of your cluster."
-msgstr ""
+msgstr "复制集群的 HTTP 路径名称。"
 
 #, fuzzy
 msgid "Copy the name of the database you are trying to connect to."
@@ -3987,12 +4420,18 @@ msgstr "无法加载数据库驱动程序"
 msgid "Could not load database driver for: %(engine)s"
 msgstr "无法加载数据库驱动程序：{}"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Could not resolve hostname: \"%(host)s\"."
-msgstr ""
+msgstr "无法解析主机名：\"%(host)s\"。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Could not validate the user in the current session."
-msgstr ""
+msgstr "无法验证当前会话中的用户。"
 
 #, fuzzy
 msgid "Count"
@@ -4110,8 +4549,12 @@ msgstr "血红色"
 msgid "Cross-filter column"
 msgstr "交叉筛选作用域"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
-msgstr ""
+msgstr "交叉过滤器将应用于所有使用此数据集的图表。"
 
 #, fuzzy
 msgid "Cross-filtering is not enabled for this dashboard."
@@ -4196,21 +4639,34 @@ msgstr "自定义SQL"
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr "此数据集无法启用自定义SQL即席查询、"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
-msgstr ""
+msgstr "自定义 SQL 字段无法解析为单个 SQL 语句。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "自定义 SQL 字段不能包含集合操作。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Custom SQL fields cannot contain sub-queries."
-msgstr ""
+msgstr "自定义 SQL 字段不能包含子查询。"
 
 #, fuzzy
 msgid "Custom color palettes"
 msgstr "自动补全"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom column name (leave blank for default)"
-msgstr ""
+msgstr "自定义列名（留空则使用默认值）"
 
 #, fuzzy
 msgid "Custom conditional formatting"
@@ -4220,14 +4676,20 @@ msgstr "条件格式设置"
 msgid "Custom date"
 msgstr "自定义"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
-msgstr ""
+msgstr "自定义字段在聚合热图单元格中不可用"
 
 msgid "Custom time filter plugin"
 msgstr "自定义时间过滤器插件"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom width of the screenshot in pixels"
-msgstr ""
+msgstr "截图的自定义宽度（像素）"
 
 #, fuzzy
 msgid "Custom..."
@@ -4255,38 +4717,57 @@ msgstr "定制化配置"
 msgid "Customize Metrics"
 msgstr "自定义指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize cell titles using Handlebars template syntax. Available "
 "variables: {{rowLabel}}, {{colLabel}}"
-msgstr ""
+msgstr "使用 Handlebars 模板语法自定义单元格标题。可用变量：{{rowLabel}}、{{colLabel}}"
 
 msgid "Customize columns"
 msgstr "自定义列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Customize data source, filters, and layout."
-msgstr ""
+msgstr "自定义数据源、过滤器和布局。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
-msgstr ""
+msgstr "自定义图表工具提示和图例中下降值显示的标签。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
-msgstr ""
+msgstr "自定义图表工具提示和图例中上升值显示的标签。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
-msgstr ""
+msgstr "自定义图表工具提示、图例和坐标轴中总计值显示的标签。"
 
 #, fuzzy
 msgid "Customize tooltips template"
 msgstr "CSS 模板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cyclic dependency detected"
-msgstr ""
+msgstr "检测到循环依赖"
 
 msgid "D3 format"
 msgstr "D3 格式"
@@ -4310,12 +4791,18 @@ msgstr "D3时间插件格式语法: https://github.com/d3/d3-time-format"
 msgid "DATETIME"
 msgstr "日期/时间"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "DB column %(col_name)s has unknown type: %(value_type)s"
-msgstr ""
+msgstr "数据库列 %(col_name)s 的类型未知：%(value_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "DD/MM format dates, international and European format"
-msgstr ""
+msgstr "DD/MM 格式日期，国际和欧洲格式"
 
 msgid "DEC"
 msgstr "十二月"
@@ -4337,8 +4824,12 @@ msgstr "暗色"
 msgid "Dark (Carto)"
 msgstr "雷达图"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dark Cyan"
-msgstr ""
+msgstr "深青色"
 
 msgid "Dark mode"
 msgstr "黑暗模式"
@@ -4362,8 +4853,11 @@ msgstr "看板"
 msgid "Dashboard [%s] just got created and chart [%s] was added to it"
 msgstr "看板 [%s] 刚刚被创建，并且图表 [%s] 已被添加到其中"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard cannot be copied due to invalid parameters."
-msgstr ""
+msgstr "由于参数无效，无法复制仪表板。"
 
 #, fuzzy
 msgid "Dashboard cannot be favorited."
@@ -4384,8 +4878,10 @@ msgstr "看板无法更新。"
 msgid "Dashboard could not be deleted."
 msgstr "看板无法被删除。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "仪表板无法恢复。"
 
 msgid "Dashboard could not be updated."
 msgstr "看板无法更新。"
@@ -4405,8 +4901,11 @@ msgstr "该看板已成功保存。"
 msgid "Dashboard imported"
 msgstr "看板已导入"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard name and URL configuration"
-msgstr ""
+msgstr "仪表板名称和URL配置"
 
 #, fuzzy
 msgid "Dashboard name is required"
@@ -4429,12 +4928,19 @@ msgstr "看板属性"
 msgid "Dashboard scheme"
 msgstr "看板模式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Dashboard time range filters apply to temporal columns defined in\n"
 "          the filter section of each chart. Add temporal columns to the "
 "chart\n"
 "          filters to have this dashboard filter impact those charts."
 msgstr ""
+"仪表板时间范围过滤器适用于每个图表过滤器部分中定义的\n"
+"          时间列。将时间列添加到图表\n"
+"          过滤器中，使此仪表板过滤器对这些图表生效。"
 
 #, fuzzy
 msgid "Dashboard title"
@@ -4476,8 +4982,12 @@ msgstr "图表选项"
 msgid "Data Table"
 msgstr "数据表"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data URI is not allowed."
-msgstr ""
+msgstr "不允许使用数据URI。"
 
 msgid "Data Zoom"
 msgstr "数据缩放"
@@ -4561,10 +5071,13 @@ msgstr "数据库不存在"
 msgid "Database does not support subqueries"
 msgstr "数据库不支持子查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Database driver for importing maybe not installed. Visit the Superset "
 "documentation page for installation instructions: "
-msgstr ""
+msgstr "用于导入的数据库驱动程序可能未安装。请访问Superset文档页面获取安装说明："
 
 msgid "Database error"
 msgstr "数据库错误"
@@ -4607,15 +5120,20 @@ msgstr "数据库设置已更新"
 msgid "Database type does not support file uploads."
 msgstr "数据库不支持子查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "数据库上传文件超出允许的最大大小。"
 
 #, fuzzy
 msgid "Database upload file failed"
 msgstr "选择将要上传文件的数据库"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database upload file failed, while saving metadata"
-msgstr ""
+msgstr "保存元数据时，数据库文件上传失败"
 
 msgid "Databases"
 msgstr "数据库"
@@ -4665,9 +5183,12 @@ msgstr "数据集名称"
 msgid "Dataset parameters are invalid."
 msgstr "数据集参数无效。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "数据集架构无效，原因：%(error)s"
 
 msgid "Datasets"
 msgstr "数据集"
@@ -4702,8 +5223,12 @@ msgstr "需要数据集"
 msgid "Datasource is required for validation"
 msgstr "警报需要数据库"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Datasource type is invalid"
-msgstr ""
+msgstr "数据源类型无效"
 
 msgid "Datasource type is required when datasource_id is given"
 msgstr "给定数据源id时，需要提供数据源类型"
@@ -4736,8 +5261,12 @@ msgstr "时间格式"
 msgid "Day"
 msgstr "天"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Day (freq=D)"
-msgstr ""
+msgstr "天（频率=D）"
 
 #, python-format
 msgid "Days %s"
@@ -4835,10 +5364,13 @@ msgstr "选择方案"
 msgid "Default URL"
 msgstr "默认URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# pt_BR, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
-msgstr ""
+msgstr "从数据集列表页面访问时重定向的默认URL。接受相对URL，例如"
 
 msgid "Default Value"
 msgstr "缺省值"
@@ -4898,8 +5430,11 @@ msgid ""
 "array."
 msgstr "定义一个 JavaScript 函数，该函数接收用于可视化的数据数组，并期望返回该数组的修改版本。这可以用来改变数据的属性、进行过滤或丰富数组。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define color breakpoints for the data"
-msgstr ""
+msgstr "为数据定义颜色断点"
 
 msgid ""
 "Define contour layers. Isolines represent a collection of line segments "
@@ -4908,11 +5443,17 @@ msgid ""
 " a given threshold range."
 msgstr "定义等高线图层。等值线代表一组线段的集合，这些线段将高于和低于给定阈值的区域分隔开来。等值带代表一组多边形的集合，用以填充包含在给定阈值范围内的区域。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define delivery schedule, timezone, and frequency settings."
-msgstr ""
+msgstr "定义发送计划、时区和频率设置。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define the database, SQL query, and triggering conditions for alert."
-msgstr ""
+msgstr "定义告警的数据库、SQL查询和触发条件。"
 
 #, fuzzy
 msgid "Defined through system configuration."
@@ -4923,8 +5464,12 @@ msgid ""
 "[Periods] text box"
 msgstr "定义要应用的滚动窗口函数，与 [期限] 文本框一起使用"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Defines the grid size in pixels"
-msgstr ""
+msgstr "定义网格大小（以像素为单位）"
 
 #, fuzzy
 msgid ""
@@ -4942,10 +5487,14 @@ msgid ""
 "granularity selected"
 msgstr "定义滚动窗口函数的大小，相对于所选的时间粒度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Defines the value that determines the boundary between different regions "
 "or levels in the data "
-msgstr ""
+msgstr "定义决定数据中不同区域或层级之间边界的值 "
 
 msgid ""
 "Defines whether the step should appear at the beginning, middle or end "
@@ -4956,10 +5505,12 @@ msgstr "定义步骤应出现在两个数据点之间的开始、中间还是结
 msgid "Definition"
 msgstr "偏离"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
+msgstr[0] "延迟（错过了 %s 次刷新）"
 
 msgid "Delete"
 msgstr "删除"
@@ -5204,12 +5755,15 @@ msgstr "详细信息"
 msgid "Details of the certification"
 msgstr "认证详情"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
-msgstr ""
+msgstr "决定过滤器如何匹配值。\"精确匹配\"使用IN运算符（默认）。ILIKE选项通过自由文本输入启用部分文本匹配。警告：ILIKE查询在大型数据集上可能较慢，因为它们无法有效使用索引。"
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "确定如何计算箱须和离群值。"
@@ -5236,11 +5790,14 @@ msgstr "深灰色"
 msgid "Dimension"
 msgstr "维度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
-msgstr ""
+msgstr "点击要素时作为交叉过滤器发出的维度列。仪表板上的其他图表与此列进行匹配。如未设置，则回退到几何列（旧版行为，通常无法匹配）。"
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5372,22 +5929,31 @@ msgstr "显示配置"
 msgid "Display cumulative total at end"
 msgstr "显示列级别合计"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
+msgstr "在矩阵顶部显示每列的标题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display labels for each row on the left side of the matrix"
-msgstr ""
+msgstr "在矩阵左侧显示每行的标签"
 
 msgid ""
 "Display metrics side by side within each column, as opposed to each "
 "column being displayed side by side for each metric."
 msgstr "在每个列中并排显示指标，而不是每个指标并排显示每个列。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Display percents in the label and tooltip as the percent of the total "
 "value, from the first step of the funnel, or from the previous step in "
 "the funnel."
-msgstr ""
+msgstr "在标签和提示框中显示百分比，可作为总值的百分比、漏斗第一步的百分比或漏斗中上一步的百分比。"
 
 #, fuzzy
 msgid "Display row level subtotal"
@@ -5396,8 +5962,11 @@ msgstr "显示行级小计"
 msgid "Display row level total"
 msgstr "显示行级合计"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
-msgstr ""
+msgstr "在仪表板视图的图表上显示最近查询的时间戳"
 
 #, fuzzy
 msgid "Display type icon"
@@ -5419,10 +5988,13 @@ msgstr "分布"
 msgid "Divider"
 msgstr "分隔"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
-msgstr ""
+msgstr "根据维度中的值将每个类别划分为子类别。可用于排除交叉项。"
 
 msgid "Do you want a donut or a pie?"
 msgstr "是否用圆环圈替代饼图？"
@@ -5459,8 +6031,11 @@ msgstr "下载为图片"
 msgid "Download as image"
 msgstr "下载为图片"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download is on the way"
-msgstr ""
+msgstr "下载正在进行中"
 
 msgid "Download to CSV"
 msgstr "下载为CSV"
@@ -5469,11 +6044,13 @@ msgstr "下载为CSV"
 msgid "Download to client"
 msgstr "下载为CSV"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Downloading %(rows)s rows based on the LIMIT configuration. If you want "
 "the entire result set, you need to adjust the LIMIT."
-msgstr ""
+msgstr "正在根据 LIMIT 配置下载 %(rows)s 行。如需获取完整结果集，请调整 LIMIT。"
 
 msgid "Draft"
 msgstr "草稿"
@@ -5484,11 +6061,14 @@ msgstr "拖放组件或图表到此看板"
 msgid "Drag and drop components to this tab"
 msgstr "拖放组件或图表到此选项卡"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
-msgstr ""
+msgstr "将列和指标拖拽至此处以自定义提示框内容。顺序很重要——各项将以相同顺序显示在提示框中。点击按钮可手动选择列和指标。"
 
 #, fuzzy
 msgid "Drag to reorder"
@@ -5537,10 +6117,13 @@ msgid ""
 "dimension value."
 msgstr "由于此图表未按维度值对数据进行分组，因此钻取详情的功能已被禁用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled for this database. Change the database "
 "settings to enable it."
-msgstr ""
+msgstr "此数据库已禁用钻取详情功能。请更改数据库设置以启用它。"
 
 #, python-format
 msgid "Drill to detail: %s"
@@ -5649,8 +6232,11 @@ msgstr "时长(毫秒)(66000 => 1m 6s)"
 msgid "Duration in seconds"
 msgstr "输入间隔时间(秒)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "动态"
 
 #, fuzzy
 msgid "Dynamic Aggregation Function"
@@ -5671,14 +6257,20 @@ msgstr "动态聚合函数"
 msgid "Dynamically search all filter values"
 msgstr "动态搜索所有的过滤器值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "从数据集中动态选择分组列"
 
 msgid "ECharts"
 msgstr "ECharts图表"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "ECharts 选项（JS 对象字面量）"
 
 #, fuzzy
 msgid "EMAIL_REPORTS_CTA"
@@ -5863,8 +6455,11 @@ msgstr "详细信息"
 msgid "Email reports active"
 msgstr "激活邮件报告"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Email subject name (optional)"
-msgstr ""
+msgstr "电子邮件主题名称（可选）"
 
 #, fuzzy
 msgid "Embed"
@@ -5910,8 +6505,11 @@ msgstr "空的行"
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr "在数据库设置中启用“允许上传文件到数据库”"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable Matrixify"
-msgstr ""
+msgstr "启用 Matrixify"
 
 #, fuzzy
 msgid "Enable cross-filtering"
@@ -5933,22 +6531,31 @@ msgstr "启用预测中"
 msgid "Enable graph roaming"
 msgstr "启用图形漫游"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "启用图标 JavaScript 模式"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "表的列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "启用标签 JavaScript 模式"
 
 #, fuzzy
 msgid "Enable labels"
 msgstr "范围标签"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "启用 matrixify"
 
 msgid "Enable node dragging"
 msgstr "启用节点拖动"
@@ -5962,17 +6569,29 @@ msgstr "在模式中启用行展开功能"
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr "支持服务器端结果分页(实验功能)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "通过 JavaScript 启用自定义图标配置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "通过 JavaScript 启用自定义标签配置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "启用 GeoJSON 点的图标渲染"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "启用 GeoJSON 点的标签渲染"
 
 msgid ""
 "Encountered invalid NULL spatial entry,"
@@ -6063,8 +6682,11 @@ msgstr "输入间隔时间(秒)"
 msgid "Enter fullscreen"
 msgstr "全屏"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "输入范围过滤器的最小值和最大值"
 
 #, fuzzy
 msgid "Enter report name"
@@ -6086,11 +6708,17 @@ msgstr "告警名称"
 msgid "Enter the required %(dbModelName)s credentials"
 msgstr "请输入必要的 %(dbModelName)s 的凭据"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the unique project id for your database."
-msgstr ""
+msgstr "输入您数据库的唯一项目 ID。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's email"
-msgstr ""
+msgstr "输入用户的电子邮件"
 
 #, fuzzy
 msgid "Enter the user's first name"
@@ -6104,15 +6732,21 @@ msgstr "告警名称"
 msgid "Enter the user's password"
 msgstr "告警名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's username"
-msgstr ""
+msgstr "输入用户的用户名"
 
 #, fuzzy
 msgid "Enter theme name"
 msgstr "告警名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter your login and password below:"
-msgstr ""
+msgstr "请在下方输入您的登录名和密码："
 
 msgid "Entity"
 msgstr "实体"
@@ -6138,9 +6772,11 @@ msgstr "获取标签对象错误"
 msgid "Error deleting %s"
 msgstr "获取数据时出错：%s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "禁用全屏时出错：%s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6283,8 +6919,11 @@ msgstr "演化"
 msgid "Exact"
 msgstr "精确"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "精确匹配 (IN)"
 
 msgid "Example"
 msgstr "例子"
@@ -6300,8 +6939,11 @@ msgstr "周报"
 msgid "Excel XML Export"
 msgstr "周报"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excel file format cannot be determined"
-msgstr ""
+msgstr "无法确定 Excel 文件格式"
 
 #, fuzzy
 msgid "Excel upload"
@@ -6355,12 +6997,19 @@ msgstr "标题行"
 msgid "Expand row to edit"
 msgstr "标题行"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
 "        in milliseconds since epoch. mathjs is used to evaluate the "
 "formulas.\n"
 "        Example: '2x+5'"
 msgstr ""
+"需要一个含有时间依赖参数 'x' 的公式\n"
+"        单位为自纪元起的毫秒数。使用 mathjs 计算公式。\n"
+"        示例：'2x+5'"
 
 msgid "Experimental"
 msgstr "实验"
@@ -6417,8 +7066,11 @@ msgstr "图片发送失败，请刷新或重试"
 msgid "Export failed: %s"
 msgstr "报告失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "导出截图（jpeg）"
 
 #, fuzzy, python-format
 msgid "Export successful: %s"
@@ -6488,8 +7140,11 @@ msgstr "维度"
 msgid "Extent"
 msgstr "最近"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "外部链接警告"
 
 msgid "Extra"
 msgstr "扩展"
@@ -6536,6 +7191,11 @@ msgstr "二月"
 msgid "FIT DATA"
 msgstr "编辑数据集"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "适配数据"
+
 msgid "FRI"
 msgstr "星期五"
 
@@ -6545,8 +7205,11 @@ msgstr "因子"
 msgid "Factor to multiply the metric by"
 msgstr "用于乘以度量值的因子"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fail login count"
-msgstr ""
+msgstr "登录失败次数"
 
 msgid "Failed"
 msgstr "失败"
@@ -6554,8 +7217,11 @@ msgstr "失败"
 msgid "Failed at retrieving results"
 msgstr "检索结果失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to apply theme: Invalid JSON"
-msgstr ""
+msgstr "应用主题失败：JSON 无效"
 
 #, fuzzy
 msgid "Failed to copy API key to clipboard"
@@ -6572,26 +7238,42 @@ msgstr "创建报告发生错误"
 msgid "Failed to create report"
 msgstr "创建报告发生错误"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Failed to execute %(query)s"
-msgstr ""
+msgstr "执行 %(query)s 失败"
 
 #, fuzzy
 msgid "Failed to fetch API keys"
 msgstr "给对象打标签失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to generate chart edit URL"
-msgstr ""
+msgstr "生成图表编辑 URL 失败"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "生成下载失败：%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data"
-msgstr ""
+msgstr "加载图表数据失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data."
-msgstr ""
+msgstr "加载图表数据失败。"
 
 #, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
@@ -6601,12 +7283,17 @@ msgstr "上传列式文件到数据库"
 msgid "Failed to load top values"
 msgstr "停止查询失败。 %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "打开文件失败。请重试。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr ""
+msgstr "移除系统深色主题失败：%s"
 
 #, fuzzy, python-format
 msgid "Failed to remove system default theme: %s"
@@ -6632,12 +7319,17 @@ msgstr "保存交叉筛选作用域失败"
 msgid "Failed to save cross-filters setting"
 msgstr "保存交叉筛选作用域失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to set local theme: Invalid JSON configuration"
-msgstr ""
+msgstr "设置本地主题失败：JSON 配置无效"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system dark theme: %s"
-msgstr ""
+msgstr "设置系统深色主题失败：%s"
 
 #, fuzzy, python-format
 msgid "Failed to set system default theme: %s"
@@ -6650,8 +7342,11 @@ msgstr "无法启动远程查询"
 msgid "Failed to stop query."
 msgstr "停止查询失败。 %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to store query results. Please try again."
-msgstr ""
+msgstr "存储查询结果失败。请重试。"
 
 #, fuzzy
 msgid "Failed to tag items"
@@ -6660,15 +7355,21 @@ msgstr "给对象打标签失败"
 msgid "Failed to update report"
 msgstr "更新报告失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to validate expression. Please try again."
-msgstr ""
+msgstr "验证表达式失败。请重试。"
 
 #, python-format
 msgid "Failed to verify select options: %s"
 msgstr "验证选择选项失败：%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
-msgstr ""
+msgstr "回退到 CSV；Excel 导出库不可用。"
 
 #, fuzzy
 msgid "False"
@@ -6684,8 +7385,11 @@ msgstr "SSH隧道未激活"
 msgid "Featured"
 msgstr "特色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Featured color palettes"
-msgstr ""
+msgstr "特色调色板"
 
 msgid "February"
 msgstr "二月"
@@ -6720,13 +7424,19 @@ msgstr "不能为空"
 msgid "Field is required"
 msgstr "字段是必需的"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "File extension is not allowed."
-msgstr ""
+msgstr "不允许使用该文件扩展名。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
-msgstr ""
+msgstr "此浏览器不支持文件处理。请使用 Chrome 或 Edge 等现代浏览器。"
 
 #, fuzzy
 msgid "File settings"
@@ -6746,8 +7456,11 @@ msgstr "填写所有必填字段以启用默认值"
 msgid "Fill method"
 msgstr "填充方式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill out the registration form"
-msgstr ""
+msgstr "填写注册表"
 
 #, fuzzy
 msgid "Filled"
@@ -6781,8 +7494,12 @@ msgstr "过滤器菜单"
 msgid "Filter name"
 msgstr "过滤器名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Filter only displays values relevant to selections made in other filters."
-msgstr ""
+msgstr "筛选器仅显示与其他筛选器中所做选择相关的值。"
 
 #, fuzzy
 msgid "Filter options"
@@ -6823,15 +7540,21 @@ msgstr "按指标过滤"
 msgid "Filters for comparison must have a value"
 msgstr "用于比较的过滤器必须有值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values equal to this exact value."
-msgstr ""
+msgstr "筛选与此精确值相等的数据。"
 
 #, fuzzy
 msgid "Filters for values greater than or equal."
 msgstr "`行限制` 必须大于或等于0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values less than or equal."
-msgstr ""
+msgstr "筛选小于或等于指定值的数据。"
 
 #, python-format
 msgid "Filters out of scope (%d)"
@@ -6946,17 +7669,26 @@ msgid ""
 "e.g. Admin if admin should see all data."
 msgstr "对于常规过滤，这些是此过滤将应用于的角色。对于基本过滤，这些是过滤不适用的角色，例如Admin代表admin应该查看所有数据。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forbidden"
-msgstr ""
+msgstr "禁止"
 
 msgid "Force"
 msgstr "力导向"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "将时间粒度强制设为最大间隔"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "强制中止（停止所有订阅者的任务）"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -6988,8 +7720,11 @@ msgstr "强制刷新模式列表"
 msgid "Force refresh table list"
 msgstr "强制刷新表列表"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
-msgstr ""
+msgstr "将所选时间粒度强制设为 X 轴标签的最大间隔"
 
 msgid "Forecast periods"
 msgstr "预测期"
@@ -7001,11 +7736,19 @@ msgstr "外键"
 msgid "Forest Green"
 msgstr "森林绿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to chart metadata."
-msgstr ""
+msgstr "在缓存中未找到表单数据，正在回退到图表元数据。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to dataset metadata."
-msgstr ""
+msgstr "在缓存中未找到表单数据，正在回退到数据集元数据。"
 
 #, fuzzy
 msgid "Format"
@@ -7023,19 +7766,28 @@ msgstr "格式化SQL"
 msgid "Format SQL query"
 msgstr "格式化SQL"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "Format data labels. Use variables: {name}, {value}, {percent}. \\n "
 "represents a new line. ECharts compatibility:\n"
 "{a} (series), {b} (name), {c} (value), {d} (percentage)"
 msgstr ""
+"格式化数据标签。使用变量：{name}、{value}、{percent}。\\n 表示换行。ECharts 兼容性：\n"
+"{a}（系列），{b}（名称），{c}（值），{d}（百分比）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"将指标或列格式化为带有货币符号的前缀或后缀。手动选择符号，或使用\"Auto-"
+"detect\"根据数据集的货币代码列自动应用正确的符号。当存在多种货币时，格式化将回退为中性数字。"
 
 msgid "Formatted CSV attached in email"
 msgstr "邮件中附上格式化好的CSV"
@@ -7114,10 +7866,13 @@ msgstr "分组"
 msgid "Gantt Chart"
 msgstr "圆点图"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Gantt chart visualizes important events over a time span. Every data "
 "point displayed as a separate event along a horizontal line."
-msgstr ""
+msgstr "甘特图将时间跨度内的重要事件可视化。每个数据点沿水平线显示为独立的事件。"
 
 msgid "Gauge Chart"
 msgstr "仪表图"
@@ -7164,14 +7919,25 @@ msgstr "按日期单位获取最后的日期。"
 msgid "Get the specify date for the holiday"
 msgstr "获取指定节假日的日期"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Give access to multiple catalogs in a single database connection."
-msgstr ""
+msgstr "在单个数据库连接中授予对多个目录的访问权限。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Go to the edit mode to configure the dashboard and add charts"
-msgstr ""
+msgstr "进入编辑模式以配置仪表板并添加图表"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Gold"
-msgstr ""
+msgstr "金色"
 
 msgid "Google Sheet Name and URL"
 msgstr "Google Sheet名称和URL"
@@ -7208,8 +7974,11 @@ msgstr "大于等于(>=)"
 msgid "Greater than (>)"
 msgstr "大于（>）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Green for increase, red for decrease"
-msgstr ""
+msgstr "绿色表示增加，红色表示减少"
 
 #, fuzzy
 msgid "Grid"
@@ -7240,8 +8009,11 @@ msgstr "分组"
 msgid "Group by"
 msgstr "分组"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group remaining as \"Others\""
-msgstr ""
+msgstr "将剩余项目分组为\"其他\""
 
 #, fuzzy
 msgid "Grouping"
@@ -7251,16 +8023,25 @@ msgstr "范围"
 msgid "Groups"
 msgstr "分组"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Groups remaining series into an \"Others\" category when series limit is "
 "reached. This prevents incomplete time series data from being displayed."
-msgstr ""
+msgstr "当系列限制达到时，将剩余系列归入\"其他\"类别。这可防止显示不完整的时间序列数据。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Guest user cannot modify chart payload"
-msgstr ""
+msgstr "访客用户无法修改图表数据"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "HTTP 路径"
 
 msgid "Handlebars"
 msgstr "Handlebars"
@@ -7269,8 +8050,11 @@ msgstr "Handlebars"
 msgid "Handlebars Template"
 msgstr "Handlebars模板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hard value bounds applied for color coding."
-msgstr ""
+msgstr "已为颜色编码应用硬性值范围。"
 
 #, fuzzy
 msgid "Has created by"
@@ -7373,14 +8157,21 @@ msgstr "小时偏移"
 msgid "How do you want to enter service account credentials?"
 msgstr "您希望如何输入服务帐户凭据？"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "How many buckets should the data be grouped in."
-msgstr ""
+msgstr "数据应分为多少个桶。"
 
 msgid "How many periods into the future do we want to predict"
 msgstr "想要预测未来的多少个时期"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "How many top values to select"
-msgstr ""
+msgstr "选择多少个顶部值"
 
 msgid ""
 "How to display time shifts: as individual lines; as the difference "
@@ -7433,22 +8224,31 @@ msgstr ""
 msgid "If a metric is specified, sorting will be done based on the metric value"
 msgstr "如果指定了度量，则将根据该度量值进行排序"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If enabled, this control sorts the results/values descending, otherwise "
 "it sorts the results ascending."
-msgstr ""
+msgstr "如果启用，此控件将结果/值按降序排序，否则按升序排序。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
-msgstr ""
+msgstr "如果保持为空，则不会保存，并将从列表中删除。要删除文件夹，请将指标和列移至其他文件夹。"
 
 #, fuzzy
 msgid "If table already exists"
 msgstr "标签已存在"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "If you don't save, changes will be lost."
-msgstr ""
+msgstr "如果不保存，更改将丢失。"
 
 #, fuzzy
 msgid "Ignore cache when generating report"
@@ -7511,9 +8311,11 @@ msgstr "由于未知原因，导入保存的查询失败。"
 msgid "Import themes"
 msgstr "导入查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "In"
-msgstr ""
+msgstr "属于"
 
 #, fuzzy
 msgid "In Progress"
@@ -7523,13 +8325,19 @@ msgstr "进度"
 msgid "In Range"
 msgstr "时间范围"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
 "service account or configure an OAuth2 client."
-msgstr ""
+msgstr "要连接到非公开的表格，您需要提供服务账号或配置 OAuth2 客户端。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "In this view you can preview the first 25 rows. "
-msgstr ""
+msgstr "在此视图中，您可以预览前 25 行。"
 
 #, fuzzy
 msgid "Inactive"
@@ -7586,11 +8394,17 @@ msgstr "查看键和索引（%s）"
 msgid "Info"
 msgstr "信息"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inherit range from time filter"
-msgstr ""
+msgstr "从时间过滤器继承范围"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "初始树深度"
 
 msgid "Inner Radius"
 msgstr "内半径"
@@ -7608,8 +8422,11 @@ msgstr "输入字段支持自定义。例如，30代表30°"
 msgid "Insert Layer URL"
 msgstr "隐藏Layer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer title"
-msgstr ""
+msgstr "插入图层标题"
 
 #, fuzzy
 msgid "Inside"
@@ -7635,8 +8452,11 @@ msgstr "上左"
 msgid "Inside right"
 msgstr "上右"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "内侧顶部"
 
 #, fuzzy
 msgid "Inside top left"
@@ -7656,8 +8476,11 @@ msgstr "强度半径"
 msgid "Intensity Radius is the radius at which the weight is distributed"
 msgstr "强度半径是指权重分布的半径"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity is the value multiplied by the weight to obtain the final weight"
-msgstr ""
+msgstr "强度是值与权重的乘积，用于获取最终权重"
 
 #, fuzzy
 msgid "Interval"
@@ -7734,14 +8557,20 @@ msgstr "无效cron表达式"
 msgid "Invalid cumulative operator: %(operator)s"
 msgstr "累积运算符无效：%(operator)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid currency code in saved metrics"
-msgstr ""
+msgstr "已保存指标中的货币代码无效"
 
 msgid "Invalid date/timestamp format"
 msgstr "无效的日期/时间戳格式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid executor type"
-msgstr ""
+msgstr "无效的执行器类型"
 
 #, fuzzy
 msgid "Invalid expression"
@@ -7761,8 +8590,12 @@ msgstr "无效的 geodetic 字符串"
 msgid "Invalid geohash string"
 msgstr "无效的geohash字符串"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid input"
-msgstr ""
+msgstr "无效输入"
 
 msgid "Invalid lat/long configuration."
 msgstr "错误的经纬度配置。"
@@ -7782,12 +8615,18 @@ msgstr "无效的numpy函数：%(operator)s"
 msgid "Invalid options for %(rolling_type)s: %(options)s"
 msgstr "%(rolling_type)s 的选项无效：%(options)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid permalink key"
-msgstr ""
+msgstr "无效的永久链接键"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid reference to column: \"%(column)s\""
-msgstr ""
+msgstr "对列的引用无效：\"%(column)s\""
 
 #, python-format
 msgid "Invalid result type: %(result_type)s"
@@ -7879,10 +8718,13 @@ msgstr "Issue 1000 - 数据集太大，无法进行查询。"
 msgid "Issue 1001 - The database is under an unusual load."
 msgstr "Issue 1001 - 数据库负载异常。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
-msgstr ""
+msgstr "即使为空也不会被删除。如果为空，则不会在图表编辑视图中显示。"
 
 #, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
@@ -7904,8 +8746,11 @@ msgstr "JSON 元数据"
 msgid "JSON metadata"
 msgstr "JSON 元数据"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON metadata and advanced configuration"
-msgstr ""
+msgstr "JSON 元数据和高级配置"
 
 #, fuzzy
 msgid "JSON metadata is invalid!"
@@ -7930,8 +8775,12 @@ msgstr "一月"
 msgid "JavaScript data interceptor"
 msgstr "JS数据拦截器"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "JavaScript onClick href"
-msgstr ""
+msgstr "JavaScript onClick href"
 
 msgid "JavaScript tooltip generator"
 msgstr "JS提示生成器"
@@ -7949,8 +8798,12 @@ msgstr "六月"
 msgid "KPI"
 msgstr "指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Keep control settings?"
-msgstr ""
+msgstr "保留控件设置？"
 
 msgid "Keep editing"
 msgstr "继续编辑"
@@ -7966,8 +8819,11 @@ msgstr "前缀"
 msgid "Keyboard shortcuts"
 msgstr "键盘快捷键"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
-msgstr ""
+msgstr "密钥仅在创建时显示一次。请安全存储。"
 
 msgid "Keys for table"
 msgstr "表的键"
@@ -8013,8 +8869,11 @@ msgstr "填充颜色"
 msgid "Label descending"
 msgstr "降序"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label for the index column. Don't use an existing column name."
-msgstr ""
+msgstr "索引列的标签。请勿使用已有的列名。"
 
 msgid "Label for your query"
 msgstr "为您的查询设置标签"
@@ -8146,8 +9005,11 @@ msgstr "年"
 msgid "Layer Name"
 msgstr "告警名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Layer URL"
-msgstr ""
+msgstr "图层 URL"
 
 msgid "Layer configuration"
 msgstr "配置层"
@@ -8234,8 +9096,11 @@ msgstr "小于等于 (<=)"
 msgid "Less than (<)"
 msgstr "小于（<）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
 msgid "Lift percent precision"
 msgstr "提升百分比精度"
@@ -8251,8 +9116,12 @@ msgstr "折线图"
 msgid "Light mode"
 msgstr "明亮模式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like"
-msgstr ""
+msgstr "Like"
 
 #, fuzzy
 msgid "Like (case insensitive)"
@@ -8303,8 +9172,11 @@ msgid ""
 "chart common in many fields."
 msgstr "时间序列折线图用于可视化在规则时间间隔内进行的重复测量。折线图是一种图表，它将信息显示为一系列由直线段连接的数据点。它是许多领域中常见的一种基本类型的图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line charts on a map"
-msgstr ""
+msgstr "地图上的折线图"
 
 msgid "Line interpolation as defined by d3.js"
 msgstr "由 d3.js 定义的线插值"
@@ -8345,8 +9217,11 @@ msgstr "最后一个"
 msgid "List Groups"
 msgstr "数字"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List Roles"
-msgstr ""
+msgstr "角色列表"
 
 #, fuzzy
 msgid "List Unique Values"
@@ -8359,8 +9234,12 @@ msgstr "数字"
 msgid "List of extra columns made available in JavaScript functions"
 msgstr "在JavaScript函数中可用的额外列列表"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List of n+1 values for bucketing metric into n buckets."
-msgstr ""
+msgstr "将指标分组到 n 个区间的 n+1 个值的列表。"
 
 #, fuzzy
 msgid "List of the column names that should be read"
@@ -8412,12 +9291,17 @@ msgstr "加载中..."
 msgid "Local"
 msgstr "对数尺度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Local theme set for preview"
-msgstr ""
+msgstr "已为预览设置本地主题"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Local theme set to \"%s\""
-msgstr ""
+msgstr "本地主题已设置为\"%s\""
 
 #, fuzzy
 msgid "Locate the chart"
@@ -8521,8 +9405,11 @@ msgid ""
 "contains data for the selected time range"
 msgstr "此查询没有返回任何结果。如果希望返回结果，请确保所有过滤选择的配置正确，并且数据源包含所选时间范围的数据。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Make the x-axis categorical"
-msgstr ""
+msgstr "将X轴设为分类轴"
 
 msgid ""
 "Malformed request. slice_id or table_name and db_name arguments are "
@@ -8532,17 +9419,23 @@ msgstr "格式错误的请求。需要使用 slice_id 或 table_name 和 db_name
 msgid "Manage"
 msgstr "管理"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage dashboard owners and access permissions"
-msgstr ""
+msgstr "管理仪表盘所有者和访问权限"
 
 #, fuzzy
 msgid "Manage email report"
 msgstr "管理邮件报告"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
-msgstr ""
+msgstr "管理过滤器和自定义设置以设定范围、描述和限制。创建新元素以获得更好的仪表盘洞察。"
 
 msgid "Manage your databases"
 msgstr "管理你的数据库"
@@ -8568,13 +9461,19 @@ msgstr "实时渲染"
 msgid "Map Style"
 msgstr "地图样式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre（开源）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "MapLibre是开源的，不需要API密钥。Mapbox需要在服务器上配置MAPBOX_API_KEY。"
 
 msgid "Mapbox"
 msgstr "MapBox地图"
@@ -8583,8 +9482,11 @@ msgstr "MapBox地图"
 msgid "Mapbox (API key required)"
 msgstr "需要值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox需要在服务器上配置MAPBOX_API_KEY。"
 
 msgid "March"
 msgstr "三月"
@@ -8592,8 +9494,12 @@ msgstr "三月"
 msgid "Margin"
 msgstr "边距"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Mark a column as temporal in \"Edit datasource\" modal"
-msgstr ""
+msgstr "在\"编辑数据源\"对话框中将列标记为时间列"
 
 msgid "Marker"
 msgstr "标记"
@@ -8619,18 +9525,27 @@ msgstr "标记"
 msgid "Markup type"
 msgstr "Markup 类型"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match system"
-msgstr ""
+msgstr "匹配系统"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match time shift color with original series"
-msgstr ""
+msgstr "将时间偏移颜色与原始系列匹配"
 
 #, fuzzy
 msgid "Match type"
 msgstr "数据类型"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Matrixify"
-msgstr ""
+msgstr "矩阵化"
 
 msgid "Max"
 msgstr "最大值"
@@ -8642,8 +9557,11 @@ msgstr "最大气泡的尺寸"
 msgid "Max value"
 msgstr "最大值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Max. features"
-msgstr ""
+msgstr "最大要素数"
 
 msgid "Maximum"
 msgstr "最大"
@@ -8658,11 +9576,17 @@ msgstr "最大半径"
 msgid "Maximum Width"
 msgstr "最小宽度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "已达到最大文件夹嵌套深度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum number of features to fetch from service"
-msgstr ""
+msgstr "从服务获取的最大要素数量"
 
 msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
@@ -8710,20 +9634,36 @@ msgstr "中位数值"
 msgid "Medium"
 msgstr "中"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - binary (1024B => 1KiB)"
-msgstr ""
+msgstr "内存（字节）- 二进制 (1024B => 1KiB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - decimal (1024B => 1.024kB)"
-msgstr ""
+msgstr "内存（字节）- 十进制 (1024B => 1.024kB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - binary (1024B => 1KiB/s)"
-msgstr ""
+msgstr "内存传输速率（字节）- 二进制 (1024B => 1KiB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
+msgstr "内存传输速率（字节）- 十进制 (1024B => 1.024kB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Menu actions trigger"
-msgstr ""
+msgstr "菜单操作触发器"
 
 msgid "Message content"
 msgstr "消息内容"
@@ -8744,12 +9684,15 @@ msgstr "米"
 msgid "Method"
 msgstr "方法"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Method to compute the displayed value. \"Overall value\" calculates a "
 "single metric across the entire filtered time period, ideal for non-"
 "additive metrics like ratios, averages, or distinct counts. Other methods"
 " operate over the time series data points."
-msgstr ""
+msgstr "计算显示值的方法。\"总体值\"在整个筛选时间段内计算单一指标，适用于比率、平均值或去重计数等非加性指标。其他方法对时间序列数据点进行运算。"
 
 msgid "Metric"
 msgstr "指标"
@@ -8762,9 +9705,11 @@ msgstr "指标 '%(metric)s' 不存在"
 msgid "Metric Key"
 msgstr "指标"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Metric ``%(metric_name)s`` not found in %(dataset_name)s."
-msgstr ""
+msgstr "在 %(dataset_name)s 中未找到指标 ``%(metric_name)s``。"
 
 msgid "Metric ascending"
 msgstr "指标升序"
@@ -8815,14 +9760,22 @@ msgstr "显示底部标题的指标"
 msgid "Metric to use for ordering Top N values"
 msgstr "节点值的指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used as a weight for the grid's coloring"
-msgstr ""
+msgstr "用于网格着色权重的指标"
 
 msgid "Metric used to calculate bubble size"
 msgstr "用来计算气泡大小的指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used to control height"
-msgstr ""
+msgstr "用于控制高度的指标"
 
 #, fuzzy
 msgid ""
@@ -8844,14 +9797,23 @@ msgstr "指标"
 msgid "Metrics (%s)"
 msgstr "指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "指标不能同时用于行和列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "指标文件夹只能包含指标项目"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "指标应放置在文件夹中"
 
 #, fuzzy
 msgid "Metrics to show in the tooltip."
@@ -8912,13 +9874,20 @@ msgstr "最小半径"
 msgid "Minimum Width"
 msgstr "最小宽度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Minimum must be strictly less than maximum"
-msgstr ""
+msgstr "最小值必须严格小于最大值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this minimum radius."
-msgstr ""
+msgstr "圆的最小半径大小（以像素为单位）。随着缩放级别的变化，这可确保圆始终遵守此最小半径。"
 
 msgid "Minimum threshold in percentage points for showing labels."
 msgstr "标签显示百分比最小阈值"
@@ -8955,8 +9924,11 @@ msgstr "%s分钟"
 msgid "Missing %s"
 msgstr "丢失数据集"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Missing OAuth2 token"
-msgstr ""
+msgstr "缺少 OAuth2 令牌"
 
 #, fuzzy
 msgid "Missing URL parameter"
@@ -8977,10 +9949,12 @@ msgstr "已修改"
 msgid "Modified %s"
 msgstr "最后修改 %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
+msgstr[0] "已修改虚拟数据集中的 %s 列"
 
 msgid "Modified by"
 msgstr "修改人"
@@ -9015,8 +9989,11 @@ msgstr "热图选项"
 msgid "More filters"
 msgstr "更多过滤器"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "MotherDuck token"
-msgstr ""
+msgstr "MotherDuck 令牌"
 
 #, fuzzy
 msgid "Move icon"
@@ -9052,10 +10029,13 @@ msgstr "接受多种格式，查看geopy.points库以获取更多细节"
 msgid "Multiplier"
 msgstr "倍数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
-msgstr ""
+msgstr "必须是图表所有者才能覆盖此图表。请改为另存为新图表。"
 
 msgid "Must be unique"
 msgstr "需要唯一"
@@ -9067,14 +10047,22 @@ msgstr "选择图表或看板，不能都全部选择"
 msgid "Must have a [Group By] column to have 'count' as the [Label]"
 msgstr "[Group By] 列必须要有 ‘count’字段作为 [标签]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Must provide credentials for the SSH Tunnel"
-msgstr ""
+msgstr "必须提供 SSH 隧道的凭据"
 
 msgid "Must specify a value for filters with comparison operators"
 msgstr "必须为带有比较操作符的过滤器指定一个值吗"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "My beautiful colors"
-msgstr ""
+msgstr "我的美丽颜色"
 
 msgid "My column"
 msgstr "我的列"
@@ -9132,8 +10120,11 @@ msgstr "标签的名称"
 msgid "Name your database"
 msgstr "数据库名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
-msgstr ""
+msgstr "命名您的文件夹，若要稍后编辑，请点击文件夹名称"
 
 #, fuzzy
 msgid "Native filter column is required"
@@ -9295,8 +10286,11 @@ msgstr "没有与您的搜索匹配的数据库"
 msgid "No description available."
 msgstr "没有可用的描述"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No entities have this tag currently assigned"
-msgstr ""
+msgstr "当前没有实体被分配此标签"
 
 msgid "No filter"
 msgstr "无筛选"
@@ -9316,11 +10310,18 @@ msgstr "无筛选"
 msgid "No filters are currently added to this dashboard."
 msgstr "此看板中没有过滤条件。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "尚未创建任何过滤器或自定义设置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No form settings were maintained"
-msgstr ""
+msgstr "未保留任何表单设置"
 
 msgid "No global filters are currently added"
 msgstr "当前没有已添加的全局过滤器"
@@ -9359,8 +10360,12 @@ msgstr "无结果"
 msgid "No results found"
 msgstr "未找到结果"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No results match your filter criteria"
-msgstr ""
+msgstr "没有结果符合您的筛选条件"
 
 msgid "No results were returned for this query"
 msgstr "此查询没有数据返回"
@@ -9424,8 +10429,12 @@ msgstr "还没有规则"
 msgid "No users yet"
 msgstr "还没有规则"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No validator found (configured for the engine)"
-msgstr ""
+msgstr "未找到验证器（为引擎配置的）"
 
 #, fuzzy, python-format
 msgid ""
@@ -9487,8 +10496,11 @@ msgstr "没有应用过滤器"
 msgid "Not added to any dashboard"
 msgstr "没有添加到任何看板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not all required fields are complete. Please provide the following:"
-msgstr ""
+msgstr "并非所有必填字段均已填写完整。请提供以下内容："
 
 #, fuzzy
 msgid "Not available"
@@ -9557,12 +10569,19 @@ msgstr "空或空白"
 msgid "Number Format"
 msgstr "数字格式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Number bounds used for color encoding from red to blue.\n"
 "               Reverse the numbers for blue to red. To get pure red or "
 "blue,\n"
 "               you can enter either only min or max."
 msgstr ""
+"用于从红色到蓝色颜色编码的数值范围。\n"
+"               反转数值可获得从蓝色到红色的效果。若要获得纯红色或纯蓝色，\n"
+"               可以只输入最小值或最大值。"
 
 msgid "Number format"
 msgstr "数字格式化"
@@ -9578,11 +10597,17 @@ msgstr "数字格式化"
 msgid "Number of buckets to group data"
 msgstr "数据分组的桶数量"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts per row when not fitting dynamically"
-msgstr ""
+msgstr "非动态适配时每行显示的图表数量"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts to display per row"
-msgstr ""
+msgstr "每行显示的图表数量"
 
 msgid "Number of decimal digits to round numbers to"
 msgstr "要四舍五入的十进制位数"
@@ -9593,10 +10618,13 @@ msgstr "用于显示升力值的小数位数"
 msgid "Number of decimal places with which to display p-values"
 msgstr "用于显示p值的小数位数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Number of periods to compare against. You can use negative numbers to "
 "compare from the beginning of the time range."
-msgstr ""
+msgstr "比较的周期数。可使用负数从时间范围的起始处进行比较。"
 
 #, fuzzy
 msgid "Number of periods to ratio against"
@@ -9718,17 +10746,29 @@ msgstr "仅总计"
 msgid "Only `SELECT` statements are allowed"
 msgstr "将 SELECT 语句复制到剪贴板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is not set to a percentage."
-msgstr ""
+msgstr "仅当\"标签类型\"未设置为百分比时适用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is set to show values."
-msgstr ""
+msgstr "仅当\"标签类型\"设置为显示值时适用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "非字符串列只支持精确匹配。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "仅在信任目标或其来源时继续。"
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -9738,8 +10778,11 @@ msgstr "仅在堆叠图上显示合计值，而不在所选类别上显示"
 msgid "Only single queries supported"
 msgstr "仅支持单个查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only the default catalog is supported for this connection"
-msgstr ""
+msgstr "此连接仅支持默认目录"
 
 #, fuzzy
 msgid "Oops! An error occurred!"
@@ -9757,11 +10800,18 @@ msgstr "所有聚合群、点和标签的不透明度。在0到1之间。"
 msgid "Opacity of area chart."
 msgstr "面积图的不透明度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Opacity of bubbles, 0 means completely transparent, 1 means opaque"
-msgstr ""
+msgstr "气泡的不透明度，0表示完全透明，1表示不透明"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Opacity, expects values between 0 and 100"
-msgstr ""
+msgstr "不透明度，期望值在 0 到 100 之间"
 
 msgid "Open Datasource tab"
 msgstr "打开数据源tab"
@@ -9826,12 +10876,15 @@ msgstr "按选定列对结果进行排序"
 msgid "Ordering"
 msgstr "排序"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Orders the query result that generates the source data for this chart. If"
 " a series or row limit is reached, this determines what data are "
 "truncated. If undefined, defaults to the first metric (where "
 "appropriate)."
-msgstr ""
+msgstr "对生成该图表源数据的查询结果进行排序。如果达到系列或行数限制，此设置决定哪些数据被截断。如果未定义，则默认使用第一个指标（在适用的情况下）。"
 
 #, fuzzy
 msgid "Orientation"
@@ -9901,10 +10954,14 @@ msgid ""
 "\"Custom\" to set a custom comparison range."
 msgstr "从相对时间段覆盖一个或多个时间序列。期望自然语言中的相对时间增量（例如：24小时、7天、56周、365天）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Overlays a hexagonal grid on a map, and aggregates data within the "
 "boundary of each cell."
-msgstr ""
+msgstr "在地图上叠加六边形网格，并聚合每个单元格边界内的数据。"
 
 #, fuzzy
 msgid "Override time grain"
@@ -9991,8 +11048,12 @@ msgstr "参数"
 msgid "Parameters "
 msgstr "参数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Parameters related to the view and perspective on the map"
-msgstr ""
+msgstr "与地图视图和视角相关的参数"
 
 msgid "Parent"
 msgstr "父类"
@@ -10040,8 +11101,12 @@ msgstr "看板不存在"
 msgid "Paste"
 msgstr "更新"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Paste Private Key here"
-msgstr ""
+msgstr "在此粘贴私钥"
 
 #, fuzzy
 msgid "Paste content of service credentials JSON file here"
@@ -10065,8 +11130,11 @@ msgstr "字体大小"
 msgid "Pattern"
 msgstr "样式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "如果标签页处于非活动状态，则暂停自动刷新"
 
 #, fuzzy
 msgid "Pause auto-refresh"
@@ -10099,8 +11167,11 @@ msgstr "百分比"
 msgid "Percentage change"
 msgstr "百分比变化"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage difference between the time periods"
-msgstr ""
+msgstr "时间段之间的百分比差异"
 
 #, fuzzy
 msgid "Percentage metric calculation"
@@ -10132,9 +11203,11 @@ msgstr "周期必须是整数值"
 msgid "Permissions"
 msgstr "版本"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Permissions successfully synced for %s"
-msgstr ""
+msgstr "%s 的权限已成功同步"
 
 msgid "Person or group that has certified this chart."
 msgstr "认证此图表的个人或组。"
@@ -10145,8 +11218,11 @@ msgstr "认证此看板的个人或组。"
 msgid "Person or group that has certified this metric"
 msgstr "认证此指标的个人或组"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "个人信息"
 
 msgid "Physical"
 msgstr "实体"
@@ -10154,8 +11230,12 @@ msgstr "实体"
 msgid "Physical (table or view)"
 msgstr "实体（表或视图）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Pick a dimension from which categorical colors are defined"
-msgstr ""
+msgstr "选择一个用于定义分类颜色的维度"
 
 msgid "Pick a metric for x, y and size"
 msgstr "为 x 轴，y 轴和大小选择一个指标"
@@ -10187,14 +11267,20 @@ msgstr "选择您最爱的 Markup 语言"
 msgid "Pie Chart"
 msgstr "饼图"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pie charts on a map"
-msgstr ""
+msgstr "地图上的饼图"
 
 msgid "Pie shape"
 msgstr "饼图形状"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Piecewise"
-msgstr ""
+msgstr "分段"
 
 msgid "Pin"
 msgstr "标记"
@@ -10211,8 +11297,11 @@ msgstr "上左"
 msgid "Pin Right"
 msgstr "上右"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "固定到结果面板"
 
 #, fuzzy
 msgid "Pin to top"
@@ -10272,8 +11361,11 @@ msgid ""
 "your query again."
 msgstr "请检查您的模板参数是否有语法错误，并确保它们在您的 SQL 查询和设置参数中保持一致。然后，再次尝试运行您的查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please choose a valid value"
-msgstr ""
+msgstr "请选择有效值"
 
 #, fuzzy
 msgid "Please choose at least one groupby"
@@ -10282,8 +11374,12 @@ msgstr "请至少选择一个分组字段 "
 msgid "Please confirm"
 msgstr "请确认"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please confirm the overwrite values."
-msgstr ""
+msgstr "请确认覆盖值。"
 
 #, fuzzy
 msgid "Please confirm your password"
@@ -10296,11 +11392,17 @@ msgstr "请输入要测试的SQLAlchemy URI"
 msgid "Please enter a valid email"
 msgstr "请输入要测试的SQLAlchemy URI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "请输入有效的电子邮件地址"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter valid text. Spaces alone are not permitted."
-msgstr ""
+msgstr "请输入有效文本。不允许仅输入空格。"
 
 #, fuzzy
 msgid "Please enter your email"
@@ -10322,17 +11424,27 @@ msgstr "请确认"
 msgid "Please enter your username"
 msgstr "为您的查询设置标签"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please fix the following errors"
-msgstr ""
+msgstr "请修复以下错误"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please provide a valid min or max value"
-msgstr ""
+msgstr "请提供有效的最小值或最大值"
 
 msgid "Please re-enter the password."
 msgstr "请重新输入密码。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please re-export your file and try importing again"
-msgstr ""
+msgstr "请重新导出您的文件并重试导入"
 
 #, fuzzy
 msgid "Please reach out to the Chart Owner for assistance."
@@ -10353,17 +11465,23 @@ msgstr "请至少选择一个分组字段 "
 msgid "Please select both a %s and a Chart type to proceed"
 msgstr "请同时选择数据集和图表类型以继续"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja "
 "macro."
-msgstr ""
+msgstr "请在 Jinja 宏中为 ``%(name)s`` 指标指定数据集 ID。"
 
 msgid "Please use 3 different metric labels"
 msgstr "请在左右轴上选择不同的指标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Plot the distance (like flight paths) between origin and destination."
-msgstr ""
+msgstr "绘制起点和终点之间的距离（如飞行路径）。"
 
 msgid ""
 "Plots the individual metrics for each row in the data vertically and "
@@ -10516,8 +11634,11 @@ msgstr "主Y轴格式"
 msgid "Private"
 msgstr "私钥"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Private Channels (Bot in channel)"
-msgstr ""
+msgstr "私人频道（频道内的机器人）"
 
 msgid "Private Key"
 msgstr "私钥"
@@ -10533,12 +11654,17 @@ msgstr "私钥密码"
 msgid "Proceed"
 msgstr "继续"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "正在处理 %s 的导出"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Processing export..."
-msgstr ""
+msgstr "正在处理导出..."
 
 msgid "Progress"
 msgstr "进度"
@@ -10553,11 +11679,17 @@ msgstr "过时"
 msgid "Proportional"
 msgstr "比例"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "公开和私有共享表格"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "仅公开共享的表格"
 
 msgid "Published"
 msgstr "已发布"
@@ -10680,8 +11812,12 @@ msgstr "径向"
 msgid "Radius"
 msgstr "单元格半径"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Radius in kilometers"
-msgstr ""
+msgstr "半径（千米）"
 
 #, fuzzy
 msgid "Radius in meters"
@@ -10745,14 +11881,24 @@ msgstr "原始记录"
 msgid "Rectangle"
 msgstr "长方形"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Recurring (every)"
-msgstr ""
+msgstr "重复（每）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Red for increase, green for decrease"
-msgstr ""
+msgstr "红色表示增加，绿色表示减少"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Redo the action"
-msgstr ""
+msgstr "重做操作"
 
 msgid "Reduce X ticks"
 msgstr "减少 X 轴的刻度"
@@ -10787,9 +11933,11 @@ msgstr "刷新看板"
 msgid "Refresh frequency"
 msgstr "刷新频率"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Refresh frequency must be at least %s seconds"
-msgstr ""
+msgstr "刷新频率必须至少为 %s 秒"
 
 msgid "Refresh interval"
 msgstr "刷新间隔"
@@ -10829,8 +11977,11 @@ msgstr "预过滤"
 msgid "Registration date"
 msgstr "开始时间"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "注册成功"
 
 #, fuzzy
 msgid "Regular"
@@ -10866,8 +12017,11 @@ msgstr "重新加载"
 msgid "Remove"
 msgstr "删除"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Dark Theme"
-msgstr ""
+msgstr "移除系统深色主题"
 
 #, fuzzy
 msgid "Remove System Default Theme"
@@ -10894,24 +12048,35 @@ msgstr "从日志中删除查询"
 msgid "Remove table preview"
 msgstr "删除表格预览"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] ""
+msgstr[0] "已从虚拟数据集中删除 %s 列"
 
 msgid "Rename tab"
 msgstr "重命名选项卡"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render HTML"
-msgstr ""
+msgstr "渲染 HTML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render columns in HTML format"
-msgstr ""
+msgstr "以 HTML 格式渲染列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Renders table cells as HTML when applicable. For example, HTML <a> tags "
 "will be rendered as hyperlinks."
-msgstr ""
+msgstr "在适用时将表格单元格渲染为 HTML。例如，HTML <a> 标签将被渲染为超链接。"
 
 msgid "Replace"
 msgstr "替换"
@@ -11013,8 +12178,11 @@ msgstr "排斥力"
 msgid "Repulsion strength between nodes"
 msgstr "节点间的排斥力强度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request Access"
-msgstr ""
+msgstr "请求访问"
 
 #, python-format
 msgid "Request is incorrect: %(error)s"
@@ -11055,8 +12223,11 @@ msgstr "重置"
 msgid "Reset Columns"
 msgstr "选择列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "将所有文件夹重置为默认值"
 
 #, fuzzy
 msgid "Reset columns"
@@ -11081,15 +12252,22 @@ msgstr "刷新默认值"
 msgid "Resize"
 msgstr "重置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Resource already has an attached report."
-msgstr ""
+msgstr "资源已有附加的报告。"
 
 #, fuzzy
 msgid "Resource was not found."
 msgstr "资源没有找到"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "在验证所有权之前，资源已被删除"
 
 msgid "Restore filter"
 msgstr "还原过滤条件"
@@ -11141,8 +12319,11 @@ msgstr "删除"
 msgid "Revoke API Key"
 msgstr "分组"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "撤销此 API 密钥"
 
 #, fuzzy
 msgid "Revoked"
@@ -11176,8 +12357,12 @@ msgstr "从右到左"
 msgid "Right value"
 msgstr "右侧的值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Right-click on a dimension value to drill to detail by that value."
-msgstr ""
+msgstr "右键单击维度值以按该值深入查看详情。"
 
 msgid "Role"
 msgstr "角色"
@@ -11248,11 +12433,14 @@ msgstr "行"
 msgid "Row Level Security"
 msgstr "行级安全"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
-msgstr ""
+msgstr "行数限制：百分比根据检索到的数据子集计算，遵循行数限制。所有记录：百分比根据完整数据集计算，忽略行数限制。"
 
 #, fuzzy
 msgid ""
@@ -11327,9 +12515,11 @@ msgstr "运行选定的查询"
 msgid "Running"
 msgstr "正在执行"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "正在运行第 %(block_num)s 个块，共 %(block_count)s 个"
 
 msgid "SAT"
 msgstr "星期六"
@@ -11343,11 +12533,14 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL 工具箱"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
-msgstr ""
+msgstr "SQL Lab 无法授权无法完全解析的语句。请明确限定表名，并避免在存储过程或特定供应商调用中使用动态 SQL。"
 
 #, fuzzy
 msgid "SQL Lab queries"
@@ -11464,8 +12657,12 @@ msgstr "图表保存"
 msgid "Satellite"
 msgstr "卫星"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Satellite Streets"
-msgstr ""
+msgstr "卫星街道"
 
 msgid "Saturday"
 msgstr "星期六"
@@ -11518,8 +12715,11 @@ msgstr "保存并转到看板"
 msgid "Save chart"
 msgstr "图表保存"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Save color breakpoint values"
-msgstr ""
+msgstr "保存颜色断点值"
 
 msgid "Save dashboard"
 msgstr "保存看板"
@@ -11537,8 +12737,11 @@ msgstr "保存或覆盖数据集"
 msgid "Save query"
 msgstr "保存查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "安全保存此 API 密钥"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr "将这个查询保存为虚拟数据集以继续探索"
@@ -11574,8 +12777,11 @@ msgstr "加载中..."
 msgid "Scale and Move"
 msgstr "缩放和移动"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "应用于指标驱动线宽的缩放系数"
 
 msgid "Scale only"
 msgstr "仅缩放"
@@ -11647,8 +12853,11 @@ msgstr "截图宽度必须位于 %(min)spx - %(max)spx 之间"
 msgid "Scroll"
 msgstr "滚动"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scroll down to the bottom to enable overwriting changes. "
-msgstr ""
+msgstr "向下滚动到底部以启用覆盖更改。 "
 
 msgid "Search"
 msgstr "搜索"
@@ -11864,8 +13073,11 @@ msgid ""
 "column or write custom SQL to create a metric."
 msgstr "选择一个要展示的指标。您可以使用聚合函数对列进行操作，或编写自定义SQL来创建一个指标。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr ""
+msgstr "选择预定义的CSS模板以应用到您的仪表板"
 
 #, fuzzy
 msgid "Select a schema"
@@ -11895,10 +13107,13 @@ msgstr "删除数据库"
 msgid "Select a theme"
 msgstr "选择方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select a time grain for the visualization. The grain is the time interval"
 " represented by a single point on the chart."
-msgstr ""
+msgstr "为可视化选择时间粒度。粒度是图表上单个点所代表的时间间隔。"
 
 msgid "Select a visualization type"
 msgstr "选择一个可视化类型"
@@ -11950,10 +13165,13 @@ msgstr "选择列"
 msgid "Select column name"
 msgstr "选择列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
 "columns."
-msgstr ""
+msgstr "选择将在表格中显示的列。您可以多选列。"
 
 #, fuzzy
 msgid "Select content type"
@@ -12034,13 +13252,16 @@ msgstr "数值格式"
 msgid "Select groups"
 msgstr "选择所有者"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
 "Each layer is a saved deck.gl chart (like scatter plots, polygons, or "
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
-msgstr ""
+msgstr "按照您希望叠加的顺序选择图层。第一个选择的显示在底部。图层让您可以在一张地图上组合多个可视化。每个图层是一个已保存的deck.gl图表（如散点图、多边形或弧线），显示不同的数据或洞察。叠加它们以揭示数据中的模式和关系。"
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -12110,11 +13331,16 @@ msgstr "选择方案"
 msgid "Select semantic views"
 msgstr "选择方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
 "same size. \"LINEAR\" increases sizes linearly based on specified slope. "
 "\"EXP\" increases sizes exponentially based on specified exponent"
 msgstr ""
+"选择用于计算值的形状。\"FIXED\" 将所有缩放级别设置为相同大小。\"LINEAR\" 根据指定的斜率线性增加大小。\"EXP\" "
+"根据指定的指数以指数方式增加大小"
 
 msgid "Select subject"
 msgstr "选择主题"
@@ -12146,21 +13372,35 @@ msgid ""
 "column name in the dashboard."
 msgstr "选择您希望在与此图表交互时应用交叉筛选的图表。您可以选择“所有图表”，以对使用相同数据集或在仪表板中包含相同列名的所有图表应用筛选器。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
-msgstr ""
+msgstr "选择在图表中用于表示增加值的颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
-msgstr ""
+msgstr "选择用于表示图表中汇总条形的值的颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
-msgstr ""
+msgstr "选择图表中用于表示数值下降的颜色。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"选择包含货币代码（如 USD、EUR、GBP "
+"等）的列。当启用\"自动检测\"货币格式时，用于构建图表。如果未设置此列，或者图表指标包含多种货币，图表将回退到中性数字格式。"
 
 #, fuzzy
 msgid "Select the fixed color"
@@ -12170,15 +13410,21 @@ msgstr "选择GeoJSON列"
 msgid "Select the geojson column"
 msgstr "选择GeoJSON列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
-msgstr ""
+msgstr "选择地图瓦片提供商。MapLibre 是开源的，不需要 API 密钥。Mapbox 需要在 Superset 中配置 MAPBOX_API_KEY。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
-msgstr ""
+msgstr "选择用于确定每条路径属于哪个颜色断点范围的指标。"
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -12198,11 +13444,14 @@ msgid ""
 "query by clicking on the %s button."
 msgstr "在控制面板中的突出显示字段中选择值。然后点击 %s 按钮来运行查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
-msgstr ""
+msgstr "选择过滤器控件中可用的时间粒度。这仅是界面允许列表，不会向底层查询添加额外条件。"
 
 #, fuzzy
 msgid "Selected"
@@ -12224,11 +13473,17 @@ msgstr "详细信息"
 msgid "Semantic Layer"
 msgstr "注释层"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "语义视图"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "语义视图"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12286,11 +13541,17 @@ msgstr "数据集不存在"
 msgid "Semantic view parameters are invalid."
 msgstr "数据集参数无效。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "语义视图已更新"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "语义视图"
 
 msgid "Send as CSV"
 msgstr "发送为CSV"
@@ -12327,11 +13588,17 @@ msgstr "系列样式"
 msgid "Series chart type (line, bar etc)"
 msgstr "系列图表类型(折线，柱状图等)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "系列递减设置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "系列递增设置"
 
 msgid "Series limit"
 msgstr "系列限制"
@@ -12353,9 +13620,11 @@ msgstr "页面长度"
 msgid "Server pagination"
 msgstr "服务端分页"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Server pagination needs to be enabled for values over %s"
-msgstr ""
+msgstr "对于超过 %s 的值，需要启用服务器分页"
 
 msgid "Service Account"
 msgstr "服务帐户"
@@ -12364,8 +13633,11 @@ msgstr "服务帐户"
 msgid "Service version"
 msgstr "服务帐户"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Dark Theme"
-msgstr ""
+msgstr "设置系统深色主题"
 
 #, fuzzy
 msgid "Set System Default Theme"
@@ -12390,38 +13662,62 @@ msgstr "设置过滤映射"
 msgid "Set local theme for testing"
 msgstr "启用预测中"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing (preview only)"
-msgstr ""
+msgstr "设置本地主题用于测试（仅预览）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set refresh frequency for current session only."
-msgstr ""
+msgstr "仅为当前会话设置刷新频率。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set the automatic refresh frequency for this dashboard."
-msgstr ""
+msgstr "设置此仪表盘的自动刷新频率。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Set the automatic refresh frequency for this dashboard. The dashboard "
 "will reload its data at the specified interval."
-msgstr ""
+msgstr "设置此仪表板的自动刷新频率。仪表板将按指定间隔重新加载数据。"
 
 #, fuzzy
 msgid "Set up an email report"
 msgstr "设置邮件报告"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set up basic details, such as name and description."
-msgstr ""
+msgstr "设置基本信息，如名称和描述。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
-msgstr ""
+msgstr "设置此数据集的默认时间列。在构建需要时间维度的图表时自动选为时间列，并用于仪表板级别的时间筛选器。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
 "        represented by one ring with the innermost circle as the top of "
 "the hierarchy."
 msgstr ""
+"设置图表的层级级别。每个级别由\n"
+"        一个环表示，最内层的圆圈代表层级的顶端。"
 
 msgid "Settings"
 msgstr "设置"
@@ -12458,8 +13754,12 @@ msgstr "共享查询字段"
 msgid "Sheet name"
 msgstr "Sheet名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Shift + Click to sort by multiple columns"
-msgstr ""
+msgstr "Shift + 单击可按多列排序"
 
 #, fuzzy
 msgid "Shift start date"
@@ -12780,9 +14080,11 @@ msgstr "需要值"
 msgid "Skip spaces after delimiter"
 msgstr "在分隔符之后跳过空格。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Skipped %d system themes that cannot be deleted"
-msgstr ""
+msgstr "已跳过 %d 个无法删除的系统主题"
 
 #, fuzzy
 msgid "Slice Id"
@@ -12792,8 +14094,11 @@ msgstr "线宽"
 msgid "Slider"
 msgstr "线性"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slider and range input"
-msgstr ""
+msgstr "滑块和范围输入"
 
 msgid "Slug"
 msgstr "Slug"
@@ -12813,17 +14118,30 @@ msgid ""
 "edges, Smooth-line sometimes looks smarter and more professional."
 msgstr "时间序列平滑线是折线图的变体。没有角度和硬边，平滑线看起来更聪明、更专业。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Solid"
-msgstr ""
+msgstr "实线"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "部分群组无法解析，以 ID 形式显示。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "部分权限无法解析，以 ID 形式显示。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
-msgstr ""
+msgstr "其他标签页上的某些必填筛选器已有值，不会被清除"
 
 msgid "Some roles do not exist"
 msgstr "看板"
@@ -12832,10 +14150,13 @@ msgstr "看板"
 msgid "Something went wrong while saving the user info"
 msgstr "抱歉，出了点问题。请稍后再试。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Something went wrong with embedded authentication. Check the dev console "
 "for details."
-msgstr ""
+msgstr "嵌入式身份验证出错。请查看开发者控制台以获取详细信息。"
 
 #, fuzzy
 msgid "Something went wrong."
@@ -12967,17 +14288,24 @@ msgstr "排序指标"
 msgid "Sort query by"
 msgstr "导出查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
-msgstr ""
+msgstr "按系列名称升序排列结果。与\"按指标排序\"结合使用时，当指标值相同时用作决胜依据。添加此排序可能会降低某些数据库的查询性能。"
 
 msgid "Sort rows by"
 msgstr "排序 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sort series in ascending order"
-msgstr ""
+msgstr "按升序排列系列"
 
 msgid "Sort type"
 msgstr "排序类型"
@@ -13009,11 +14337,19 @@ msgstr "空间"
 msgid "Specific Date/Time"
 msgstr "具体日期/时间"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE TABLE AS schema in: public"
-msgstr ""
+msgstr "指定在以下架构中 CREATE TABLE AS 的名称：public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE VIEW AS schema in: public"
-msgstr ""
+msgstr "指定在以下架构中 CREATE VIEW AS 的名称：public"
 
 #, fuzzy
 msgid ""
@@ -13024,8 +14360,11 @@ msgstr "指定数据库版本。这在Presto中用于查询成本估算，在Dre
 msgid "Split number"
 msgstr "数字"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Split stack by"
-msgstr ""
+msgstr "堆叠拆分依据"
 
 #, fuzzy
 msgid "Square kilometers"
@@ -13043,8 +14382,11 @@ msgstr "平方英里"
 msgid "Stack"
 msgstr "堆叠"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack in groups, where each group corresponds to a dimension"
-msgstr ""
+msgstr "按组堆叠，每组对应一个维度"
 
 msgid "Stack series"
 msgstr "堆叠系列"
@@ -13195,8 +14537,11 @@ msgstr "描边"
 msgid "Structural"
 msgstr "结构"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
-msgstr ""
+msgstr "结构由上游语义层管理，为只读状态。"
 
 msgid "Style"
 msgstr "风格"
@@ -13226,8 +14571,12 @@ msgstr "分类"
 msgid "Subtitle"
 msgstr "选项卡标题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Subtotal"
-msgstr ""
+msgstr "小计"
 
 msgid "Success"
 msgstr "成功"
@@ -13307,11 +14656,17 @@ msgid ""
 "well."
 msgstr "用于可视化时间序列数据。在步进图、折线图、散点图和条形图之间进行选择,也有许多自定义选项"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the next tab"
-msgstr ""
+msgstr "切换到下一个标签页"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the previous tab"
-msgstr ""
+msgstr "切换到上一个标签页"
 
 msgid "Symbol"
 msgstr "符号"
@@ -13322,39 +14677,57 @@ msgstr "边线两端的符号"
 msgid "Symbol size"
 msgstr "符号的大小"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sync Permissions"
-msgstr ""
+msgstr "同步权限"
 
 msgid "Sync columns from source"
 msgstr "从源同步列"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s"
-msgstr ""
+msgstr "正在同步 %s 的权限"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s in the background"
-msgstr ""
+msgstr "正在后台同步 %s 的权限"
 
 msgid "Syntax"
 msgstr "语法"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
-msgstr ""
+msgstr "语法错误：%(qualifier)s 输入 \"%(input)s\" 期望 \"%(expected)s\""
 
 #, fuzzy
 msgid "System"
 msgstr "流式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System Theme - Read Only"
-msgstr ""
+msgstr "系统主题 - 只读"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System dark theme removed"
-msgstr ""
+msgstr "系统深色主题已移除"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System default theme removed"
-msgstr ""
+msgstr "系统默认主题已删除"
 
 msgid "TABLES"
 msgstr "表"
@@ -13372,9 +14745,11 @@ msgstr "星期二"
 msgid "Tab name"
 msgstr "选项卡名字"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Tab schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "标签页架构无效，原因：%(error)s"
 
 msgid "Tab title"
 msgstr "选项卡标题"
@@ -13399,10 +14774,13 @@ msgid ""
 "connection, schema, and table name"
 msgstr "找不到 [%(table_name)s] 表，请仔细检查您的数据库连接、Schema 和 表名"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Table already exists. You can change your 'if table already exists' "
 "strategy to append or replace or provide a different Table Name to use."
-msgstr ""
+msgstr "表已存在。您可以将\"如果表已存在\"的策略更改为追加或替换，或者提供不同的表名以供使用。"
 
 msgid "Table cache timeout"
 msgstr "数据库表缓存超时"
@@ -13522,10 +14900,13 @@ msgstr "无法创建标签。"
 msgid "Task could not be updated."
 msgstr "无法更新标签。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
-msgstr ""
+msgstr "任务无法中止。任务正在进行中，但未注册中止处理程序。"
 
 #, fuzzy
 msgid "Task parameters are invalid."
@@ -13535,18 +14916,26 @@ msgstr "标签参数无效。"
 msgid "Tasks"
 msgstr "标签"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
-msgstr ""
+msgstr "后台操作执行时，任务将显示在此处。"
 
 #, fuzzy
 msgid "Template"
 msgstr "css模板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Template for cell titles. Use Handlebars templating syntax (a popular "
 "templating library that uses double curly brackets for variable "
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
+"单元格标题的模板。使用 Handlebars 模板语法（一种使用双花括号进行变量替换的流行模板库）：{{row}}, {{column}}, "
+"{{rowLabel}}, {{columnLabel}}"
 
 msgid "Template parameters"
 msgstr "模板参数"
@@ -13555,9 +14944,11 @@ msgstr "模板参数"
 msgid "Template processing error: %(error)s"
 msgstr "错误：%(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "模板处理失败：%(ex)s"
 
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
@@ -13580,8 +14971,11 @@ msgstr "测试连接"
 msgid "Text"
 msgstr "文本"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Text / Markdown"
-msgstr ""
+msgstr "文本 / Markdown"
 
 msgid "Text align"
 msgstr "文本对齐"
@@ -13597,9 +14991,12 @@ msgstr "刷新于 %s"
 msgid "The %s linked to this chart may have been deleted."
 msgstr "这个图表所链接的数据集可能被删除了。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
-msgstr ""
+msgstr "来自 %s 的 API 响应与 IDatabaseTable 接口不匹配。"
 
 msgid ""
 "The CSS for individual dashboards can be altered here, or in the "
@@ -13614,23 +15011,39 @@ msgstr ""
 "CTA（create table as "
 "select）只能与最后一条语句为SELECT的查询一起运行。请确保查询的最后一个语句是SELECT。然后再次尝试运行查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The GeoJsonLayer takes in GeoJSON formatted data and renders it as "
 "interactive polygons, lines and points (circles, icons and/or texts)."
-msgstr ""
+msgstr "GeoJsonLayer接收GeoJSON格式的数据，并将其渲染为交互式多边形、线条和点（圆形、图标和/或文本）。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
-msgstr ""
+msgstr "Global Task Framework未启用。请联系您的管理员以启用GLOBAL_TASK_FRAMEWORK功能标志。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Global Task "
+"Framework未启用。请在功能标志中设置GLOBAL_TASK_FRAMEWORK=True以使用@task。有关配置详情，请参阅https://superset.apache.org/docs/configuration"
+"/async-queries-celery。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
 "values across\n"
@@ -13640,18 +15053,33 @@ msgid ""
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
+"桑基图直观地追踪值在各系统阶段的流动和转换。\n"
+"          节点代表各阶段，通过描绘值流向的连接相互连通。节点\n"
+"          高度对应可视化的指标，清晰展示\n"
+"          值的分布和转换情况。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The URL is missing the dataset_id or slice_id parameters."
-msgstr ""
+msgstr "URL中缺少dataset_id或slice_id参数。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The X-axis is not on the filters list"
-msgstr ""
+msgstr "X轴不在过滤器列表中"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The X-axis is not on the filters list which will prevent it from being "
 "used in time range filters in dashboards. Would you like to add it to the"
 " filters list?"
-msgstr ""
+msgstr "X轴不在过滤器列表中，这将导致其无法在仪表板的时间范围过滤器中使用。是否要将其添加到过滤器列表中？"
 
 msgid "The annotation has been saved"
 msgstr "注释已保存。"
@@ -13668,8 +15096,11 @@ msgid ""
 "associated with more than one category, only the first will be used."
 msgstr "用于分配颜色的源节点类别。如果一个节点与多个类别关联，则只使用第一个类别"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
-msgstr ""
+msgstr "图表仍在加载中。请稍候后重试。"
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
@@ -13709,8 +15140,11 @@ msgid ""
 "        Edit the color scheme in the dashboard properties."
 msgstr "配色方案由相关的看板决定。在看板属性中编辑配色方案"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color used when a value doesn't match any defined breakpoints."
-msgstr ""
+msgstr "当值与任何已定义的断点不匹配时使用的颜色。"
 
 #, fuzzy
 msgid ""
@@ -13725,20 +15159,32 @@ msgstr ""
 msgid "The column header label"
 msgstr "列的标题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the source of the edge."
-msgstr ""
+msgstr "用作边的起点的列。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the target of the edge."
-msgstr ""
+msgstr "用作边的终点的列。"
 
 msgid "The column was deleted or renamed in the database."
 msgstr "该列已在数据库中删除或重命名。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The configuration for the map layers"
-msgstr ""
+msgstr "地图图层的配置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The corner radius of the chart background"
-msgstr ""
+msgstr "图表背景的圆角半径"
 
 msgid ""
 "The country code standard that Superset should expect to find in the "

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -15232,12 +15232,23 @@ msgstr "数据库没有找到"
 msgid "The dataset associated with this chart no longer exists"
 msgstr "这个图表所链接的数据集可能被删除了。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
-msgstr ""
+msgstr "返回图表x轴值的数据集列/指标。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's y-axis."
-msgstr ""
+msgstr "返回图表y轴值的数据集列/指标。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
 "              based on the changes in your SQL query. If your changes "
@@ -15245,6 +15256,8 @@ msgid ""
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
+"数据集列将根据SQL查询中的更改自动同步。\n"
+"              如果您的更改不影响列定义，您可以跳过此步骤。"
 
 msgid ""
 "The dataset configuration exposed here\n"
@@ -15263,11 +15276,17 @@ msgstr "这个数据源无法被加载"
 msgid "The datasource is too large to query."
 msgstr "数据源太大，无法进行查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default catalog that should be used for the connection."
-msgstr ""
+msgstr "连接应使用的默认目录。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default schema that should be used for the connection."
-msgstr ""
+msgstr "连接应使用的默认模式。"
 
 msgid ""
 "The description can be displayed as widget headers in the dashboard view."
@@ -15298,21 +15317,30 @@ msgstr ""
 "1. engine_params 对象在调用 sqlalchemy.create_engine 时被引用, metadata_params 在调用"
 " sqlalchemy.MetaData 时被引用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The exponent to compute all sizes from. \"EXP\" only"
-msgstr ""
+msgstr "用于计算所有大小的指数。仅适用于\"EXP\""
 
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
 msgstr "这个查询无法被加载"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
 "the extent so that all data points are included in the viewport. CUSTOM "
 "allows users to define the extent manually."
-msgstr ""
+msgstr "应用程序启动时地图的范围。FIT DATA 会自动设置范围，使所有数据点都包含在视口中。CUSTOM 允许用户手动定义范围。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "用于点标签的要素属性"
 
 #, python-format
 msgid ""
@@ -15320,25 +15348,34 @@ msgid ""
 "%(columns)s. "
 msgstr " `series_columns`中的下列条目在 `columns` 中缺失: %(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
-msgstr ""
+msgstr "以下字段包含在导出时被遮蔽的敏感信息。请提供相应值以导入此数据库。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The following filters have the 'Select first filter value by default'\n"
 "                    option checked and could not be loaded, which is "
 "preventing the dashboard\n"
 "                    from rendering: %s"
-msgstr ""
+msgstr "以下筛选器勾选了\"默认选择第一个筛选器值\"选项，但无法加载，导致仪表盘无法渲染：%s"
 
 #, fuzzy
 msgid "The font size of the point labels"
 msgstr "是否显示指示器"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The function to use when aggregating points into groups"
-msgstr ""
+msgstr "将点聚合到组时使用的函数"
 
 #, fuzzy
 msgid "The group has been created successfully."
@@ -15348,9 +15385,15 @@ msgstr "报告已创建"
 msgid "The group has been updated successfully."
 msgstr "注释已更新。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
-msgstr ""
+msgstr "当前缩放级别的高度，用于计算所有其他高度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
 "          representing the frequency or count of values within different "
@@ -15359,6 +15402,9 @@ msgid ""
 " and provides\n"
 "          insights into its shape, central tendency, and spread."
 msgstr ""
+"直方图通过表示不同范围或区间（bins）内值的频率或计数来显示数据集的分布。\n"
+"          它有助于可视化数据中的模式、聚类和异常值，并提供\n"
+"          对其形状、集中趋势和分布情况的洞察。"
 
 #, python-format
 msgid "The host \"%(hostname)s\" might be down and can't be reached."
@@ -15383,23 +15429,33 @@ msgstr "提供的主机名无法解析。"
 msgid "The id of the active chart"
 msgstr "活动图表的ID"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
-msgstr ""
+msgstr "用于显示 GeoJSON 点的图标图像 URL。请注意，图像 URL 必须符合内容安全策略（CSP）才能正确加载。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
-msgstr ""
+msgstr "树的初始层级（深度）。如果设置为 -1，则所有节点都将展开。"
 
 #, fuzzy
 msgid "The layer attribution"
 msgstr "时间相关的表单属性"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The lower limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "等值带（Isoband）阈值范围的下限"
 
 msgid ""
 "The maximum number of subdivisions of each group; lower values are pruned"
@@ -15446,8 +15502,11 @@ msgstr "度量的最大值。这是一个可选配置"
 msgid "The name of the geometry column"
 msgstr "ID列名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the layer as described in GetCapabilities"
-msgstr ""
+msgstr "GetCapabilities 中描述的图层名称"
 
 #, fuzzy
 msgid "The name of the rule must be unique"
@@ -15549,8 +15608,11 @@ msgstr ""
 "需要以下数据库的密码才能将其与图表一起导入。请注意，数据库配置的 \"Secure Extra\" 和 \"Certificate\" "
 "部分不在导出文件中，如果需要，应在导入后手动添加。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
-msgstr ""
+msgstr "导入以下数据库需要提供相应的密码。"
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr "时间戳格式的模式。供字符串使用 "
@@ -15635,14 +15697,20 @@ msgstr "报告已创建"
 msgid "The report will be sent to your email at"
 msgstr "计划的报告将作为PNG发送到您的电子邮件"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The result of this query must be a value capable of numeric "
 "interpretation e.g. 1, 1.0, or \"1\" (compatible with Python's float() "
 "function)."
-msgstr ""
+msgstr "此查询的结果必须是可进行数值解析的值，例如 1、1.0 或 \"1\"（与 Python 的 float() 函数兼容）。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The result size exceeds the allowed limit."
-msgstr ""
+msgstr "结果大小超出了允许的限制。"
 
 msgid "The results backend no longer has the data from the query."
 msgstr "结果后端不再拥有来自查询的数据。"
@@ -15667,10 +15735,13 @@ msgstr "报告已创建"
 msgid "The role has been updated successfully."
 msgstr "注释已更新。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The row limit set for the chart was reached. The chart may show partial "
 "data."
-msgstr ""
+msgstr "已达到为图表设置的行数限制。图表可能只显示部分数据。"
 
 #, python-format
 msgid ""
@@ -15684,21 +15755,31 @@ msgid ""
 "used to run this query."
 msgstr "表 \"%(schema_name)s\" 不存在。必须使用有效的表来运行此查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The schema of the submitted payload is invalid."
-msgstr ""
+msgstr "提交的有效负载（payload）的架构无效。"
 
 msgid "The schema was deleted or renamed in the database."
 msgstr "该模式已在数据库中删除或重命名。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot could not be downloaded. Please, try again later."
-msgstr ""
+msgstr "截图下载失败。请稍后重试。"
 
 #, fuzzy
 msgid "The screenshot has been downloaded."
 msgstr "报告已创建"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot is being generated. Please, do not leave the page."
-msgstr ""
+msgstr "正在生成截图。请不要离开此页面。"
 
 #, fuzzy
 msgid "The service url of the layer"
@@ -15715,8 +15796,11 @@ msgstr "等值线的宽度（以像素为单位）"
 msgid "The size of the square cell, in pixels"
 msgstr "平方单元的大小，以像素为单位"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The slope to compute all sizes from. \"LINEAR\" only"
-msgstr ""
+msgstr "用于计算所有大小的斜率。仅适用于 \"LINEAR\""
 
 #, fuzzy
 msgid "The submitted payload failed validation."
@@ -15802,14 +15886,21 @@ msgstr "要显示的可视化类型"
 msgid "The unit for icon size"
 msgstr "气泡尺寸"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "标签大小的单位"
 
 msgid "The unit of measure for the specified point radius"
 msgstr "指定点半径的度量单位"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The upper limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "等值带阈值范围的上限"
 
 #, fuzzy
 msgid "The user has been created successfully."
@@ -15826,8 +15917,12 @@ msgstr "用户已经被删除"
 msgid "The user was updated successfully"
 msgstr "该看板已成功保存。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The user/password combination is not valid (Incorrect password for user)."
-msgstr ""
+msgstr "用户名/密码组合无效（用户密码不正确）。"
 
 #, python-format
 msgid "The username \"%(username)s\" does not exist."
@@ -15836,8 +15931,11 @@ msgstr "指标 '%(username)s' 不存在"
 msgid "The username provided when connecting to a database is not valid."
 msgstr "连接到数据库时提供的用户名无效。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The values overlap other breakpoint values"
-msgstr ""
+msgstr "这些值与其他断点值重叠"
 
 #, fuzzy
 msgid "The version of the service"
@@ -15854,8 +15952,11 @@ msgstr "X轴刻度的布局方式"
 msgid "The width of the Isoline in pixels"
 msgstr "等值线的宽度（以像素为单位）"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the current zoom level to compute all widths from"
-msgstr ""
+msgstr "当前缩放级别的宽度，用于计算所有宽度"
 
 #, fuzzy
 msgid "The width of the elements border"
@@ -15865,10 +15966,13 @@ msgstr "线条的宽度"
 msgid "The width of the lines"
 msgstr "线条的宽度"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
-msgstr ""
+msgstr "线条的宽度，可以是固定值，也可以是基于指标的可变宽度。"
 
 #, fuzzy
 msgid "Theme"
@@ -15901,8 +16005,12 @@ msgstr "存在关联的警报或报告：%(report_names)s"
 msgid "There are no charts added to this dashboard"
 msgstr "此看板中没有添加图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "There are no components added to this tab"
-msgstr ""
+msgstr "此标签页没有添加任何组件"
 
 msgid "There are no filters in this dashboard."
 msgstr "此看板中没有过滤条件。"
@@ -15929,11 +16037,13 @@ msgid ""
 "or increasing the destination width."
 msgstr "此组件没有足够的空间。请尝试减小其宽度，或增加目标宽度。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
-msgstr ""
+msgstr "刷新仪表盘时出现问题。我们将按计划在 %s 后重试。"
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -16201,19 +16311,29 @@ msgstr "此图表将交叉筛选应用于那些数据集包含具有相同名称
 msgid "This chart has been moved to a different filter scope."
 msgstr "此图表已移至其他过滤器范围内。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr ""
+msgstr "此图表由外部管理，无法在 Superset 中覆盖。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This chart is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "此图表由外部管理，无法在 Superset 中编辑"
 
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr "此图表可能与过滤器不兼容(数据集不匹配)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This chart type is not supported when using an unsaved query as a chart "
 "source. "
-msgstr ""
+msgstr "当使用未保存的查询作为图表来源时，不支持此图表类型。"
 
 #, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
@@ -16226,6 +16346,9 @@ msgstr "此图表可能与过滤器不兼容(数据集不匹配)"
 msgid "This column must contain date/time information."
 msgstr "此列必须包含日期时间信息。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This control filters the whole chart based on the selected time range. "
 "All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. "
@@ -16235,21 +16358,35 @@ msgid ""
 "engine's local timezone. Note one can explicitly set the timezone per the"
 " ISO 8601 format if specifying either the start and/or end time."
 msgstr ""
+"此控件根据所选时间范围过滤整个图表。所有相对时间，例如\"上个月\"、\"最近7天\"、\"现在\"等，均在服务器上使用服务器本地时间（不含时区）进行评估。所有工具提示和占位符时间均以UTC（不含时区）表示。时间戳随后由数据库使用引擎的本地时区进行评估。请注意，如果指定开始时间和/或结束时间，可以按照ISO"
+" 8601格式显式设置时区。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the \"time_range\" field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
-msgstr ""
+msgstr "这控制是否应将当前视图中的\"time_range\"字段传递给包含注释数据的图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the time grain field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
-msgstr ""
+msgstr "这控制是否应将当前视图中的时间粒度字段传递给包含注释数据的图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dashboard is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "此仪表盘由外部管理，无法在 Superset 中编辑"
 
 msgid ""
 "This dashboard is not published which means it will not show up in the "
@@ -16285,44 +16422,75 @@ msgid ""
 "Please contact your administrator for more assistance."
 msgstr "找不到此查询中引用的数据库。请与管理员联系以获得进一步帮助，或重试。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This database is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "此数据库由外部管理，无法在 Superset 中编辑"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This database table does not contain any data. Please select a different "
 "table."
-msgstr ""
+msgstr "此数据库表不包含任何数据。请选择其他表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"此数据库使用 OAuth2 进行身份验证。请点击上方链接，授权 Apache Superset "
+"访问数据。您的个人访问令牌将被加密存储，仅用于您运行的查询。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dataset is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "此数据集由外部管理，无法在 Superset 中编辑"
 
 msgid "This defines the element to be plotted on the chart"
 msgstr "这定义了要在图表上绘制的元素"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This email is already associated with an account. Please choose another "
 "one."
-msgstr ""
+msgstr "此电子邮件已与账户关联。请选择其他邮箱。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This feature is experimental and may change or have limitations"
-msgstr ""
+msgstr "此功能处于实验阶段，可能会发生变化或存在限制"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the calculated "
 "dimension to charts. It is also used as the alias in the SQL query."
-msgstr ""
+msgstr "此字段用作唯一标识符，以将计算维度附加到图表。它也用作 SQL 查询中的别名。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the metric to charts."
 " It is also used as the alias in the SQL query."
-msgstr ""
+msgstr "此字段用作唯一标识符，以将指标附加到图表。它也用作 SQL 查询中的别名。"
 
 #, fuzzy
 msgid "This filter already exist on the report"
@@ -16332,33 +16500,54 @@ msgstr "过滤器值列表不能为空"
 msgid "This filter might be incompatible with current %s"
 msgstr "此图表可能与过滤器不兼容(数据集不匹配)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "此文件夹当前为空"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "此文件夹仅支持列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "此文件夹仅支持指标"
 
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr "出于安全考虑，此功能在您的环境中被禁用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
-msgstr ""
+msgstr "这是默认的列文件夹。其名称无法更改或删除。它可以保持为空，但只接受列项目。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
-msgstr ""
+msgstr "这是默认的指标文件夹。其名称无法更改或删除。它可以保持为空，但只接受指标项目。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "这是 a 的自定义错误消息"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "这是 b 的自定义错误消息"
 
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
@@ -16378,11 +16567,17 @@ msgstr "默认时间"
 msgid "This is the default folder"
 msgstr "刷新默认值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "这是默认的浅色主题"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "这是您唯一一次看到此密钥。请安全存储。"
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -16390,13 +16585,18 @@ msgid ""
 "and positions by using drag & drop in the dashboard view"
 msgstr "这个JSON对象描述了部件在看板中的位置。它是动态生成的，可以通过拖放，在看板中调整整部件的大小和位置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "此链接无法访问，因为其地址不安全。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
-msgstr ""
+msgstr "此链接将引导您访问外部网站。我们无法保证外部目标的安全性。"
 
 msgid "This markdown component has an error."
 msgstr "此 markdown 组件有错误。"
@@ -16404,10 +16604,13 @@ msgstr "此 markdown 组件有错误。"
 msgid "This markdown component has an error. Please revert your recent changes."
 msgstr "此 markdown 组件有错误。请还原最近的更改。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This may be due to the extension not being activated or the content not "
 "being available."
-msgstr ""
+msgstr "这可能是由于扩展未激活或内容不可用。"
 
 msgid "This may be triggered by:"
 msgstr "这可能由以下因素触发："
@@ -16416,16 +16619,25 @@ msgstr "这可能由以下因素触发："
 msgid "This metric might be incompatible with current %s"
 msgstr "此图表可能与过滤器不兼容(数据集不匹配)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This name is already taken. Please choose another one."
-msgstr ""
+msgstr "此名称已被占用。请选择其他名称。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This option has been disabled by the administrator."
-msgstr ""
+msgstr "此选项已被管理员禁用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This page is intended to be embedded in an iframe, but it looks like that"
 " is not the case."
-msgstr ""
+msgstr "此页面旨在嵌入 iframe 中，但目前似乎并非如此。"
 
 #, fuzzy
 msgid ""
@@ -16441,11 +16653,15 @@ msgstr "本节包含允许对查询结果进行高级分析处理后的选项。
 msgid "This section contains validation errors"
 msgstr "这部分有错误"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This session has encountered an interruption, and some controls may not "
 "work as intended. If you are the developer of this app, please check that"
 " the guest token is being generated correctly."
-msgstr ""
+msgstr "本次会话遇到中断，部分控件可能无法按预期工作。如果您是此应用程序的开发者，请检查访客令牌是否正确生成。"
 
 msgid "This table already has a dataset"
 msgstr "该表已经有了数据集"
@@ -16455,14 +16671,23 @@ msgid ""
 "associate one dataset with a table.\n"
 msgstr "此表已经关联了一个数据集。一个表只能关联一个数据集。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally"
-msgstr ""
+msgstr "此主题在本地设置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally for your session"
-msgstr ""
+msgstr "此主题已为您的会话在本地设置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This username is already taken. Please choose another one."
-msgstr ""
+msgstr "此用户名已被占用。请选择其他用户名。"
 
 msgid "This value should be greater than the left target value"
 msgstr "这个值应该大于左边的目标值"
@@ -16482,26 +16707,37 @@ msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
 msgstr[0] "这是由以下因素引发的："
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "这将中止（停止）所有 %s 个订阅者的任务。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
 "to main columns for increase and decrease. Basic conditional formatting "
 "can be overwritten by conditional formatting below."
-msgstr ""
+msgstr "这将应用于整个表格。主要列将添加箭头（↑ 和 ↓）以表示增加和减少。基本条件格式可以被下方的条件格式覆盖。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "这将取消该任务。"
 
 msgid "This will remove your current embed configuration."
 msgstr "这会移除当前的嵌入配置。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
-msgstr ""
+msgstr "这将把所有指标和列重新整理到默认文件夹中。所有自定义文件夹将被删除。"
 
 #, fuzzy
 msgid "Threshold"
@@ -16607,10 +16843,16 @@ msgstr "应用时间范围的时间列"
 msgid "Time comparison"
 msgstr "时间比较"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Time delta in natural language\n"
 "                  (example:  24 hours, 7 days, 56 weeks, 365 days)"
 msgstr ""
+"自然语言表示的时间差\n"
+"                  （示例：24 小时、7 天、56 周、365 天）"
 
 #, python-format
 msgid ""
@@ -16694,11 +16936,13 @@ msgstr "时间格式"
 msgid "Timeline"
 msgstr "时区"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
-msgstr ""
+msgstr "已配置超时（%s 秒），但未定义中止处理程序。任务将在超时后继续运行。"
 
 msgid "Timeout error"
 msgstr "超时错误"
@@ -16727,17 +16971,25 @@ msgstr "标题是必填项"
 msgid "Title or Slug"
 msgstr "标题或者Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"要开始使用 Google 表格，您需要先创建一个数据库。数据库用于识别您的数据，以便对其进行查询和可视化。此数据库将保存您在此选择连接的所有 "
+"Google 表格。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
 "clicking the column header."
-msgstr ""
+msgstr "要启用多列排序，请在单击列标题时按住 ⇧ Shift 键。"
 
 msgid "To filter on a metric, use Custom SQL tab."
 msgstr "若要在计量值上筛选，请使用自定义SQL选项卡。"
@@ -16745,8 +16997,11 @@ msgstr "若要在计量值上筛选，请使用自定义SQL选项卡。"
 msgid "To get a readable URL for your dashboard"
 msgstr "为看板生成一个可读的 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "令牌请求 URI"
 
 #, fuzzy
 msgid "Tool Panel"
@@ -16799,13 +17054,19 @@ msgstr "自上而下"
 msgid "Total"
 msgstr "总计"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggfunc)s)"
-msgstr ""
+msgstr "总计 (%(aggfunc)s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggregatorName)s)"
-msgstr ""
+msgstr "总计 (%(aggregatorName)s)"
 
 #, fuzzy
 msgid "Total color"
@@ -16835,8 +17096,12 @@ msgstr "透明"
 msgid "Transpose pivot"
 msgstr "转置透视图"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Treat values as categorical."
-msgstr ""
+msgstr "将值视为分类数据。"
 
 msgid "Tree Chart"
 msgstr "树状图"
@@ -16887,27 +17152,39 @@ msgstr "截断Y轴"
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
 msgstr "截断Y轴。可以通过指定最小或最大界限来重写。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate long cells to the \"min width\" set above"
-msgstr ""
+msgstr "将长单元格截断为上面设置的\"最小宽度\""
 
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr "将指定的日期截取为指定的日期单位精度。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "信任此URL并不再询问"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr "尝试应用不同的筛选器或确保您的数据源包含数据。“"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Try different criteria to display results."
-msgstr ""
+msgstr "尝试不同的条件以显示结果。"
 
 msgid "Tuesday"
 msgstr "星期二"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Tukey"
-msgstr ""
+msgstr "Tukey"
 
 msgid "Type"
 msgstr "类型"
@@ -16929,11 +17206,17 @@ msgstr "请输入值"
 msgid "Type is required"
 msgstr "类型是必需的"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "允许的 Google 表格类型"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Type of chart to display in sparkline"
-msgstr ""
+msgstr "在迷你图中显示的图表类型"
 
 msgid "Type of comparison, value difference or percentage"
 msgstr "比较类型，值差异或百分比"
@@ -16942,17 +17225,26 @@ msgstr "比较类型，值差异或百分比"
 msgid "Type to search (contains)..."
 msgstr "使用列"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "输入以搜索（结尾为）..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "输入以搜索（开头为）..."
 
 msgid "UI Configuration"
 msgstr "UI 配置"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "UI theme administration is not enabled."
-msgstr ""
+msgstr "UI主题管理未启用。"
 
 msgid "URL"
 msgstr "URL 地址"
@@ -16971,8 +17263,11 @@ msgstr "使用 Slug"
 msgid "URL parameters"
 msgstr "URL 参数"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to calculate such a date delta"
-msgstr ""
+msgstr "无法计算此类日期差值"
 
 #, python-format
 msgid "Unable to connect to catalog named \"%(catalog_name)s\"."
@@ -16982,35 +17277,65 @@ msgstr "无法连接到名为\\%(catalog_name)s\\的目录。"
 msgid "Unable to connect to database \"%(database)s\"."
 msgstr "不能连接到数据库\"%(database)s\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", "
 "\"BigQuery Job User\" and the following permissions are set "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
+"无法连接。请验证服务账户上已设置以下角色：\"BigQuery Data Viewer\"、\"BigQuery Metadata "
+"Viewer\"、\"BigQuery Job "
+"User\"，以及已设置以下权限：\"bigquery.readsessions.create\"、\"bigquery.readsessions.getData\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"无法连接。请验证服务账户上已设置以下角色：\"Cloud Datastore Viewer\"、\"Cloud Datastore "
+"User\"、\"Cloud Datastore Creator\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to create chart without a query id."
-msgstr ""
+msgstr "没有查询ID，无法创建图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
-msgstr ""
+msgstr "无法创建报告：需要用户电子邮件地址但未找到。请确保您的用户配置文件包含有效的电子邮件地址。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to decode value"
-msgstr ""
+msgstr "无法解码值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to encode value"
-msgstr ""
+msgstr "无法编码值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
-msgstr ""
+msgstr "无法获取语义视图。请检查图层配置。"
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
@@ -17020,15 +17345,22 @@ msgstr "找不到这样的假期：[%(holiday)s]"
 msgid "Unable to generate download payload"
 msgstr "添加到看板"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
 "ensure your dataset has a properly configured time column."
-msgstr ""
+msgstr "无法识别用于日期范围时间比较的时间列。请确保您的数据集已正确配置时间列。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
-msgstr ""
+msgstr "无法加载所选表的列。请选择其他表。"
 
 #, fuzzy
 msgid "Unable to load dashboard"
@@ -17049,18 +17381,28 @@ msgid ""
 "later. Please contact your administrator if this problem persists."
 msgstr "无法将表结构状态迁移到后端。系统将稍后重试。如果此问题仍然存在，请与管理员联系。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to parse SQL"
-msgstr ""
+msgstr "无法解析 SQL"
 
 #, fuzzy
 msgid "Unable to read the file, please refresh and try again."
 msgstr "图片发送失败，请刷新或重试"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to retrieve dashboard colors"
-msgstr ""
+msgstr "无法获取仪表板颜色"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to sync permissions for this database connection."
-msgstr ""
+msgstr "无法同步此数据库连接的权限。"
 
 msgid "Undefined"
 msgstr "未命名"
@@ -17139,8 +17481,11 @@ msgstr "未知错误"
 msgid "Unknown input format"
 msgstr "未知输入格式"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "未知令牌将被标记为警告。"
 
 #, fuzzy
 msgid "Unknown type"
@@ -17153,14 +17498,22 @@ msgstr "未知值"
 msgid "Unpin"
 msgstr "正在执行"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "从结果面板取消固定"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "从顶部取消固定"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "不安全链接已被拦截"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
@@ -17174,8 +17527,11 @@ msgstr "键的模板值不安全 %(key)s: %(value_type)s"
 msgid "Unsupported clause type: %(clause)s"
 msgstr "不支持的条款类型: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
-msgstr ""
+msgstr "不支持的文件类型。请使用 CSV、Excel 或列式文件。"
 
 #, python-format
 msgid "Unsupported post processing operation: %(operation)s"
@@ -17253,9 +17609,11 @@ msgstr "上传Excel"
 msgid "Upload JSON file"
 msgstr "上传JSON文件"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Upload a file with a valid extension. Valid: [%s]"
-msgstr ""
+msgstr "请上传具有有效扩展名的文件。有效扩展名：[%s]"
 
 #, fuzzy
 msgid "Upload credentials"
@@ -17291,10 +17649,13 @@ msgstr "使用 %s 打开新的选项卡。"
 msgid "Use Area Proportions"
 msgstr "使用面积比例"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
-msgstr ""
+msgstr "使用 Handlebars 语法创建自定义工具提示。可用变量基于上方工具提示内容的选择。"
 
 msgid "Use a log scale"
 msgstr "使用对数刻度"
@@ -17326,8 +17687,12 @@ msgstr "自动配色"
 msgid "Use current extent"
 msgstr "运行查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use date formatting even when metric value is not a timestamp"
-msgstr ""
+msgstr "即使指标值不是时间戳，也使用日期格式"
 
 #, fuzzy
 msgid "Use gradient"
@@ -17342,11 +17707,19 @@ msgstr "只使用一个值"
 msgid "Use the Advanced Analytics options below"
 msgstr "使用下面的高级分析选项"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want a query that aggregates"
-msgstr ""
+msgstr "如果需要聚合查询，请使用此部分"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want to query atomic rows"
-msgstr ""
+msgstr "如果需要查询原子行，请使用此部分"
 
 msgid "Use this to define a static color for all circles"
 msgstr "使用此定义所有圆圈的静态颜色"
@@ -17436,8 +17809,11 @@ msgid ""
 "funnels and pipelines."
 msgstr "使用圆圈来可视化数据在系统不同阶段的流动。将鼠标悬停在可视化图表的各个路径上，以理解值经历的各个阶段。这对于多阶段、多组的漏斗和管道可视化非常有用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "如果维度的值超过 25 个，则使用前 25 个值。"
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -17451,9 +17827,11 @@ msgstr "查看查询语句"
 msgid "Validate your expression"
 msgstr "无效cron表达式"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Validating connectivity for %s"
-msgstr ""
+msgstr "正在验证 %s 的连接"
 
 #, fuzzy
 msgid "Validating..."
@@ -17487,8 +17865,11 @@ msgstr "值边界"
 msgid "Value cannot exceed %s"
 msgstr "值不能超过 %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value difference between the time periods"
-msgstr ""
+msgstr "时间段之间的数值差异"
 
 msgid "Value format"
 msgstr "数值格式"
@@ -17500,8 +17881,11 @@ msgstr "`行偏移量` 必须大于或等于0"
 msgid "Value is required"
 msgstr "需要值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value less than"
-msgstr ""
+msgstr "值小于"
 
 #, fuzzy
 msgid "Value must be 0 or greater"
@@ -17521,13 +17905,20 @@ msgstr "这些值依赖于其他过滤器"
 msgid "Values dependent on"
 msgstr "值依赖于"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Values less than this percentage will be grouped into the Other category."
-msgstr ""
+msgstr "小于此百分比的值将被归入\"其他\"类别。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Values selected in other filters will affect the filter options to only "
 "show relevant values"
-msgstr ""
+msgstr "在其他筛选器中选择的值将影响筛选器选项，仅显示相关值"
 
 msgid "Version"
 msgstr "版本"
@@ -17623,10 +18014,14 @@ msgid ""
 "to emphasize the strength of the link between each pair of groups."
 msgstr "可视化各组之间的相关指标。热图擅长显示两组之间的相关性或强度。颜色用于强调各组之间的联系强度。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize geospatial data like 3D buildings, landscapes, or objects in "
 "grid view."
-msgstr ""
+msgstr "在网格视图中可视化地理空间数据，如3D建筑、地形或对象。"
 
 msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
@@ -17646,13 +18041,21 @@ msgid ""
 "showcased using bubble color."
 msgstr "在单个图表中跨三维数据（X轴、Y轴和气泡大小）可视化度量。同一组中的气泡可以“使用气泡颜色显示"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Visualizes connected points, which form a path, on a map."
-msgstr ""
+msgstr "在地图上可视化已连接的点，这些点构成一条路径。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes geographic areas from your data as polygons on a Mapbox "
 "rendered map. Polygons can be colored using a metric."
-msgstr ""
+msgstr "将数据中的地理区域以多边形的形式在 Mapbox 渲染的地图上可视化展示。多边形可以使用指标进行着色。"
 
 msgid ""
 "Visualizes how a metric has changed over a time using a color scale and a"
@@ -17694,8 +18097,11 @@ msgstr ""
 msgid "WMS"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "等待首次刷新"
 
 #, fuzzy, python-format
 msgid "Waiting on %s"
@@ -17708,8 +18114,11 @@ msgstr "管理你的数据库"
 msgid "Want to add a new database?"
 msgstr "添加一个新数据库?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "数据仓库"
 
 msgid "Warning"
 msgstr "警告！"
@@ -17722,10 +18131,13 @@ msgid ""
 "not exist."
 msgstr "警告！如果元数据不存在，更改数据集可能会破坏图表。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
-msgstr ""
+msgstr "警告：ILIKE 查询在大型数据集上可能较慢，因为它们无法有效使用索引。"
 
 #, fuzzy
 msgid "Was unable to check your query"
@@ -17757,18 +18169,25 @@ msgid ""
 "%(location)s."
 msgstr "我们似乎无法解析行 %(location)s 所处的列 \"%(column_name)s\" 。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "We have the following keys: %s"
-msgstr ""
+msgstr "我们有以下键：%s"
 
 #, fuzzy
 msgid "We were unable to activate or deactivate this report."
 msgstr "“我们无法激活或禁用该报告。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "We were unable to carry over any controls when switching to this new "
 "dataset."
-msgstr ""
+msgstr "切换到此新数据集时，我们无法延续任何控件设置。"
 
 #, python-format
 msgid ""
@@ -17802,9 +18221,12 @@ msgstr "周日为一周开始"
 msgid "Weekly Report"
 msgstr "周报"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Weekly Report for %s"
-msgstr ""
+msgstr "%s 的每周报告"
 
 msgid "Weekly seasonality"
 msgstr "周度季节性"
@@ -17886,10 +18308,13 @@ msgid ""
 "to the main datetime column."
 msgstr "当对次要时间列进行筛选时，将相同的筛选条件应用到主日期时间列。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When unchecked, colors from the selected color scheme will be used for "
 "time shifted series"
-msgstr ""
+msgstr "当未选中时，所选配色方案中的颜色将用于时间偏移序列"
 
 msgid ""
 "When using \"Autocomplete filters\", this can be used to improve "
@@ -17904,13 +18329,20 @@ msgstr ""
 msgid "When using 'Group By' you are limited to use a single metric"
 msgstr "当使用“Group by”时，只限于使用单个度量。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "When using other than adaptive formatting, labels may overlap"
-msgstr ""
+msgstr "使用非自适应格式时，标签可能会重叠"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
-msgstr ""
+msgstr "使用此选项时，无法设置默认值。使用此选项可能会影响仪表板的加载时间。"
 
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
 msgstr "当有多组数据时进度条是否重叠"
@@ -18143,8 +18575,12 @@ msgstr "世界地图"
 msgid "Write a description for your query"
 msgstr "为您的查询写一段描述"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Write a handlebars template to render the data"
-msgstr ""
+msgstr "编写 Handlebars 模板以渲染数据"
 
 msgid "X Axis"
 msgstr "X 轴"
@@ -18265,8 +18701,12 @@ msgstr "Y 轴比例尺间隔"
 msgid "Year"
 msgstr "年"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Year (freq=AS)"
-msgstr ""
+msgstr "年（freq=AS）"
 
 msgid "Yearly seasonality"
 msgstr "年度季节性"
@@ -18293,9 +18733,11 @@ msgstr "是的，覆盖"
 msgid "You are adding tags to %s %ss"
 msgstr "你给 %s %ss 添加了标签"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "您正在编辑虚拟数据集中的查询 "
 
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
@@ -18334,31 +18776,52 @@ msgid ""
 "overwrite?"
 msgstr "您正在导入一个或多个已存在的数据集。覆盖可能会导致您丢失一些工作。确定要覆盖吗？"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in a dashboard context with labels shared "
 "across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
+"您正在仪表板上下文中查看此图表，其中标签在多个图表之间共享。\n"
+"        配色方案选择已禁用。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in the context of a dashboard that is directly"
 " affecting its colors.\n"
 "        To edit the color scheme, open this chart outside of the "
 "dashboard."
 msgstr ""
+"您正在仪表板上下文中查看此图表，该仪表板正在直接影响其颜色。\n"
+"        要编辑配色方案，请在仪表板外部打开此图表。"
 
 #, fuzzy
 msgid "You can"
 msgstr "你可以"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can add the components in the"
-msgstr ""
+msgstr "您可以在"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can add the components in the edit mode."
-msgstr ""
+msgstr "您可以在编辑模式下添加组件。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can also just click on the chart to apply cross-filter."
-msgstr ""
+msgstr "您也可以直接点击图表以应用交叉过滤器。"
 
 msgid ""
 "You can choose to display all charts that you have access to or only the "
@@ -18378,10 +18841,14 @@ msgstr "您可以在图表设置的下拉菜单中预览看板列表。"
 msgid "You can't apply cross-filter on this data point."
 msgstr "您无法在这个数据点上应用交叉筛选。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You cannot delete the last temporal filter as it's used for time range "
 "filters in dashboards."
-msgstr ""
+msgstr "您无法删除最后一个时间过滤器，因为它用于仪表板中的时间范围过滤器。"
 
 msgid "You cannot use 45° tick layout along with the time range filter"
 msgstr "不能将45°刻度线布局与时间范围过滤器一起使用"
@@ -18486,23 +18953,32 @@ msgstr "您有一些未保存的修改。"
 msgid "You have unsaved changes."
 msgstr "您有一些未保存的修改。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid ""
 "You have used all %(historyLength)s undo slots and will not be able to "
 "fully undo subsequent actions. You may save your current state to reset "
 "the history."
-msgstr ""
+msgstr "您已使用全部 %(historyLength)s 个撤销槽，将无法完全撤销后续操作。您可以保存当前状态以重置历史记录。"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You must be a %s owner in order to edit. Please reach out to a %s owner "
 "to request modifications or edit access."
-msgstr ""
+msgstr "您必须是 %s 的所有者才能进行编辑。请联系 %s 的所有者以请求修改或编辑权限。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
 "dataset owner to request modifications or edit access."
-msgstr ""
+msgstr "您必须是数据集所有者才能进行编辑。请联系数据集所有者以请求修改或编辑权限。"
 
 msgid "You must pick a name for the new dashboard"
 msgstr "您必须为新的看板选择一个名称"
@@ -18510,8 +18986,11 @@ msgstr "您必须为新的看板选择一个名称"
 msgid "You must run the query successfully first"
 msgstr "必须先成功运行查询"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "您需要"
 
 msgid ""
 "You updated the values in the control panel, but the chart was not "
@@ -18519,22 +18998,34 @@ msgid ""
 "button or"
 msgstr "您已更新了控制面板中的值，但图表未自动更新。请点击“更新图表”按钮运行查询或"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
-msgstr ""
+msgstr "您将从此任务中移除。它将继续为其他 %s 位订阅者运行。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
-msgstr ""
+msgstr "您已更改数据集。与新数据集匹配的包含数据（列、指标）的所有控件均已保留。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "您的账户已激活。您可以使用凭据登录。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "如果您不保存就离开，更改将丢失。"
 
 #, fuzzy
 msgid "Your chart is not up to date"
@@ -18543,8 +19034,11 @@ msgstr "不是最新的"
 msgid "Your chart is ready to go!"
 msgstr "图表已就绪！"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your dashboard is near the size limit."
-msgstr ""
+msgstr "您的仪表板接近大小限制。"
 
 msgid "Your dashboard is too large. Please reduce its size before saving it."
 msgstr "您的看板太大了。保存前请缩小尺寸。"
@@ -18584,8 +19078,11 @@ msgstr "附加信息"
 msgid "Z-A"
 msgstr "z-a键"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ZIP file contains multiple file types"
-msgstr ""
+msgstr "ZIP 文件包含多种文件类型"
 
 #, fuzzy
 msgid "Zero imputation"
@@ -18633,8 +19130,11 @@ msgid ""
 "based on labels"
 msgstr "次计量指标用来定义颜色与主度量的比率。如果两个度量匹配，则将颜色映射到级别组"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[未命名的自定义]"
 
 msgid "`compare_columns` must have the same length as `source_columns`."
 msgstr "比较的列长度必须原始列保持一致"
@@ -18654,9 +19154,10 @@ msgstr "如果分组被使用 `count` 表示 COUNT(*)。数值列将与聚合器
 msgid "`operation` property of post processing object undefined"
 msgstr "后处理必须指定操作类型（`operation`）"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` 必须在 1 到 %(max)s 之间"
 
 msgid "`prophet` package not installed"
 msgstr "未安装程序包 `prophet`"
@@ -18709,8 +19210,12 @@ msgstr "注释"
 msgid "annotation_layer"
 msgstr "注释层"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "asfreq"
-msgstr ""
+msgstr "asfreq"
 
 msgid "at"
 msgstr "在"
@@ -18741,12 +19246,19 @@ msgstr "格式，比如："
 msgid "beta"
 msgstr "扩展"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "between {down} and {up} {name}"
-msgstr ""
+msgstr "在 {down} 和 {up} 之间的 {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "bfill"
-msgstr ""
+msgstr "bfill"
 
 msgid "bolt"
 msgstr "螺栓"
@@ -18755,8 +19267,12 @@ msgstr "螺栓"
 msgid "boolean"
 msgstr "布尔值"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "boolean type icon"
-msgstr ""
+msgstr "布尔类型图标"
 
 msgid "bottom"
 msgstr "底部"
@@ -18799,14 +19315,26 @@ msgstr "点击这里"
 msgid "close"
 msgstr "关闭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-2 (cca2)"
-msgstr ""
+msgstr "ISO 3166-1 alpha-2 代码 (cca2)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-3 (cca3)"
-msgstr ""
+msgstr "ISO 3166-1 alpha-3 代码 (cca3)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code International Olympic Committee (cioc)"
-msgstr ""
+msgstr "国际奥委会代码 (cioc)"
 
 #, fuzzy
 msgid "color scheme for comparison"
@@ -18819,9 +19347,11 @@ msgstr "颜色"
 msgid "column"
 msgstr "列"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "connecting to %(dbModelName)s"
-msgstr ""
+msgstr "正在连接到 %(dbModelName)s"
 
 #, fuzzy
 msgid "containing"
@@ -18977,8 +19507,12 @@ msgstr "描述"
 msgid "deviation"
 msgstr "偏离"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "dialect+driver://username:password@host:port/database"
-msgstr ""
+msgstr "dialect+driver://用户名:密码@主机:端口/数据库"
 
 #, fuzzy
 msgid "documentation"
@@ -19009,8 +19543,11 @@ msgstr "例如：compute_wh"
 msgid "e.g. default"
 msgstr "默认"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "e.g. hive_metastore"
-msgstr ""
+msgstr "例如 hive_metastore"
 
 msgid "e.g. param1=value1&param2=value2"
 msgstr "例如：param1=value1&param2=value2"
@@ -19024,8 +19561,11 @@ msgstr "例如：postgres"
 msgid "e.g. xy12345.us-east-2.aws"
 msgstr "例如：xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "例如，CI/CD 流水线、分析脚本"
 
 #, fuzzy
 msgid "edit mode"
@@ -19081,21 +19621,30 @@ msgstr "每个月"
 msgid "expand"
 msgstr "展开"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard 必须是一个对象"
 
 #, fuzzy
 msgid "failed"
 msgstr "失败"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "再见"
 
 msgid "fetching"
 msgstr "抓取中"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ffill"
-msgstr ""
+msgstr "ffill"
 
 #, fuzzy
 msgid "flat"
@@ -19112,11 +19661,19 @@ msgstr "来查询有关如何构造URI的更多信息。"
 msgid "formatted"
 msgstr "格式日期"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "function type icon"
-msgstr ""
+msgstr "函数类型图标"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "geohash (square)"
-msgstr ""
+msgstr "geohash（正方形）"
 
 #, fuzzy
 msgid "greeting"
@@ -19129,8 +19686,11 @@ msgstr "热力图"
 msgid "heatmap: values are normalized across the entire heatmap"
 msgstr "热力图：其中所有数值都经过了归一化"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "你好"
 
 #, fuzzy
 msgid "here"
@@ -19142,8 +19702,11 @@ msgstr "小时"
 msgid "in"
 msgstr "处于"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "以便运行此操作。"
 
 #, fuzzy
 msgid "invalid email"
@@ -19153,10 +19716,13 @@ msgstr "无效状态。"
 msgid "is"
 msgstr "处于"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
-msgstr ""
+msgstr "应为 Mapbox/OSM URL（例如 mapbox://styles/...）或瓦片服务器 URL（例如 tile://http...）"
 
 msgid "is expected to be a number"
 msgstr "应该为数字"
@@ -19183,8 +19749,11 @@ msgid ""
 "want to continue? Deleting the dataset will break those objects."
 msgstr "数据集 %s 已经链接到 %s 图表和 %s 看板内。确定要继续吗？删除数据集将破坏这些对象。"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not"
-msgstr ""
+msgstr "不是"
 
 #, fuzzy
 msgid "is not null"
@@ -19213,9 +19782,12 @@ msgstr "最新分区："
 msgid "left"
 msgstr "左"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "less than {min} {name}"
-msgstr ""
+msgstr "小于 {min} {name}"
 
 #, fuzzy
 msgid "linear"
@@ -19273,9 +19845,12 @@ msgstr "单调性"
 msgid "month"
 msgstr "月"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "more than {max} {name}"
-msgstr ""
+msgstr "大于 {max} {name}"
 
 msgid "must have a value"
 msgstr "必填"
@@ -19284,30 +19859,43 @@ msgstr "必填"
 msgid "name"
 msgstr "名称"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters 必须是一个列表"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] 缺少必需的键：%(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] 必须是一个对象"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues 必须是一个列表"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' 在仪表盘中不存在"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId 必须是非空字符串"
 
 #, fuzzy
 msgid "no SQL validator is configured"
@@ -19325,14 +19913,21 @@ msgstr "Not In"
 msgid "numeric"
 msgstr "数字"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "numeric type icon"
-msgstr ""
+msgstr "数值类型图标"
 
 msgid "nvd3"
 msgstr "nvd3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "of"
-msgstr ""
+msgstr "共"
 
 #, fuzzy
 msgid "offline"
@@ -19411,8 +20006,11 @@ msgstr "前一周"
 msgid "previous calendar year"
 msgstr "前一年"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "提供授权"
 
 #, fuzzy
 msgid "quarter"
@@ -19442,8 +20040,12 @@ msgstr "报告"
 msgid "reports"
 msgstr "报告"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "restore zoom"
-msgstr ""
+msgstr "恢复缩放"
 
 msgid "right"
 msgstr "右"
@@ -19548,8 +20150,11 @@ msgstr "目标颜色"
 msgid "textarea"
 msgstr "文本区域"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "Handlebars 图表文档"
 
 #, fuzzy
 msgid "theme"
@@ -19636,17 +20241,33 @@ msgstr "周日为一周开始"
 msgid "working timeout"
 msgstr "执行超时"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x"
-msgstr ""
+msgstr "x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x: values are normalized within each column"
-msgstr ""
+msgstr "x：每列内的值已归一化"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y"
-msgstr ""
+msgstr "y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y: values are normalized within each row"
-msgstr ""
+msgstr "y：每行内的值已归一化"
 
 msgid "year"
 msgstr "年"
@@ -19657,8 +20278,14 @@ msgstr ""
 msgid "zoom area"
 msgstr "缩放面积"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "© Layer attribution"
-msgstr ""
+msgstr "© 图层归属"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -1422,7 +1422,7 @@ msgstr "已添加"
 #, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] "已向虚拟数据集添加了 1 个新列"
+msgstr[0] "已将 %s 个新列添加到虚拟数据集"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Chinese (Simplified) (`zh`) catalog using `scripts/translations/backfill_po.py`, which drafts translations with Claude using every other language's existing translation of the same string as cross-language disambiguation context (per `docs/developer_docs/contributing/howtos.md`). Do-not-translate tokens (icon names, enum values, SQL keywords, API field names, placeholders) are skipped.

All generated strings are marked `#, fuzzy` with a `Machine-translated via backfill_po.py` attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend builds include fuzzy entries, so these translations render in the UI once built; reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only, no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l zh` succeeds.
- Chinese (Simplified) native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API