### PR TITLE
feat(i18n): backfill Portuguese (pt) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -28,6 +28,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The cumulative option allows you to see how your data "
@@ -41,7 +44,21 @@ msgid ""
 "                original data, it just changes the way the histogram is "
 "displayed."
 msgstr ""
+"\n"
+"                A opção cumulativa permite-lhe ver como os seus dados se "
+"acumulam ao longo de diferentes\n"
+"                valores. Quando ativada, as barras do histograma "
+"representam o total acumulado de frequências\n"
+"                até cada intervalo. Isto ajuda-o a compreender a "
+"probabilidade de encontrar valores\n"
+"                abaixo de um determinado ponto. Tenha em atenção que "
+"ativar a opção cumulativa não altera os seus\n"
+"                dados originais, apenas muda a forma como o histograma é "
+"apresentado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The normalize option transforms the histogram values into"
@@ -55,15 +72,36 @@ msgid ""
 "                clearer understanding of the proportion of data points "
 "within each bin."
 msgstr ""
+"\n"
+"                A opção de normalização transforma os valores do "
+"histograma em proporções ou\n"
+"                probabilidades dividindo a contagem de cada intervalo "
+"pelo total de pontos de dados.\n"
+"                Este processo de normalização garante que os valores "
+"resultantes somam 1,\n"
+"                permitindo uma comparação relativa da distribuição dos "
+"dados e proporcionando uma\n"
+"                compreensão mais clara da proporção de pontos de dados em"
+" cada intervalo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "\n"
 "                This filter was inherited from the dashboard's context.\n"
 "                It won't be saved when saving the chart.\n"
 "              "
 msgstr ""
+"\n"
+"                Este filtro foi herdado do contexto do painel.\n"
+"                Não será guardado ao guardar o gráfico.\n"
+"              "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "\n"
 "            <p>Your report/alert was unable to be generated because of "
@@ -72,14 +110,31 @@ msgid ""
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
+"\n"
+"            <p>O seu relatório/alerta não pôde ser gerado devido ao "
+"seguinte erro: %(text)s</p>\n"
+"            <p>Por favor, verifique o seu painel/gráfico em busca de "
+"erros.</p>\n"
+"            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
+"            "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " (excluded)"
-msgstr ""
+msgstr " (excluído)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " Set the opacity to 0 if you do not want to override the color specified "
 "in the GeoJSON"
 msgstr ""
+" Defina a opacidade para 0 se não pretender substituir a cor especificada"
+" no GeoJSON"
 
 #, fuzzy
 msgid " a dashboard OR "
@@ -89,23 +144,41 @@ msgstr "Dashboard"
 msgid " a new one"
 msgstr "Alterado em"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " at line %(line)d"
-msgstr ""
+msgstr " na linha %(line)d"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " expression which needs to adhere to the "
-msgstr ""
+msgstr " expressão que deve cumprir com o "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " for details."
-msgstr ""
+msgstr " para detalhes."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " near '%(highlight)s'"
-msgstr ""
+msgstr " perto de '%(highlight)s'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " source code of Superset's sandboxed parser"
-msgstr ""
+msgstr " código-fonte do analisador isolado do Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " standard to ensure that the lexicographical ordering\n"
 "                      coincides with the chronological ordering. If the\n"
@@ -122,6 +195,21 @@ msgid ""
 "defaults on a per\n"
 "                      database/column name level via the extra parameter."
 msgstr ""
+" padrão para garantir que a ordenação lexicográfica\n"
+"                      coincida com a ordenação cronológica. Se o\n"
+"                      formato do carimbo de data/hora não cumprir o "
+"padrão ISO 8601,\n"
+"                      terá de definir uma expressão e um tipo para\n"
+"                      transformar a cadeia numa data ou carimbo de "
+"data/hora. Note\n"
+"                      que atualmente os fusos horários não são "
+"suportados. Se o tempo for armazenado\n"
+"                      no formato epoch, coloque `epoch_s` ou `epoch_ms`. "
+"Se nenhum padrão\n"
+"                      for especificado, utilizamos os valores "
+"predefinidos opcionais por\n"
+"                      base de dados/nome de coluna através do parâmetro "
+"extra."
 
 #, fuzzy
 msgid " to add calculated columns"
@@ -131,102 +219,174 @@ msgstr "Lista de Colunas"
 msgid " to add metrics"
 msgstr "Adicionar Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to check for details."
-msgstr ""
+msgstr " para verificar os detalhes."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to edit or add columns and metrics."
-msgstr ""
+msgstr " para editar ou adicionar colunas e métricas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh_TW]
+#, fuzzy
 msgid " to mark a column as a time column"
-msgstr ""
+msgstr " para marcar uma coluna como coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " to open SQL Lab. From there you can save the query as a dataset."
 msgstr ""
+" para abrir o SQL Lab. A partir daí pode guardar a consulta como um "
+"conjunto de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to see details."
-msgstr ""
+msgstr " para ver detalhes."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to visualize your data."
-msgstr ""
+msgstr " para visualizar os seus dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "!= (Is not equal)"
-msgstr ""
+msgstr "!= (Não é igual)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system dark theme"
-msgstr ""
+msgstr "\"%s\" é agora o tema escuro do sistema"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system default theme"
-msgstr ""
+msgstr "\"%s\" é agora o tema predefinido do sistema"
 
 #, fuzzy, python-format
 msgid "% calculation"
 msgstr "Escolha um tipo de visualização"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "% of parent"
-msgstr ""
+msgstr "% do pai"
 
 #, fuzzy, python-format
 msgid "% of total"
 msgstr "Mostrar Tabela"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(dialect)s cannot be used as a data source for security reasons."
 msgstr ""
+"%(dialect)s não pode ser utilizado como fonte de dados por razões de "
+"segurança."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(label)s file"
-msgstr ""
+msgstr "ficheiro %(label)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(name)s.csv"
-msgstr ""
+msgstr "%(name)s.csv"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(name)s.pdf"
-msgstr ""
+msgstr "%(name)s.pdf"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(object)s does not exist in this database."
-msgstr ""
+msgstr "%(object)s não existe nesta base de dados."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(prefix)s %(title)s"
-msgstr ""
+msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sResultados truncados a %(row_count)s linhas devido a limitações"
+" de memória."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%(report_type)s schedule frequency exceeding limit. Please configure a "
 "schedule with a minimum interval of %(minimum_interval)d minutes per "
 "execution."
 msgstr ""
+"A frequência de agendamento de %(report_type)s excede o limite. Por "
+"favor, configure um agendamento com um intervalo mínimo de "
+"%(minimum_interval)d minutos por execução."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(rows)d rows returned"
-msgstr ""
+msgstr "%(rows)d linhas devolvidas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, lv,
+# mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid "%(suggestion)s instead of \"%(undefinedParameter)s?\""
 msgid_plural ""
 "%(firstSuggestions)s or %(lastSuggestion)s instead of "
 "\"%(undefinedParameter)s\"?"
-msgstr[0] ""
+msgstr[0] "%(suggestion)s em vez de \"%(undefinedParameter)s\"?"
 msgstr[1] ""
+"%(firstSuggestions)s ou %(lastSuggestion)s em vez de "
+"\"%(undefinedParameter)s\"?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "%(validator)s was unable to check your query.\n"
 "Please recheck your query.\n"
 "Exception: %(ex)s"
 msgstr ""
+"%(validator)s não conseguiu verificar a sua consulta.\n"
+"Por favor, verifique novamente a sua consulta.\n"
+"Exceção: %(ex)s"
 
 #, fuzzy, python-format
 msgid "%s %s"
@@ -244,21 +404,32 @@ msgstr "Erro"
 msgid "%s PASSWORD"
 msgstr "Broker Port"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Physical"
-msgstr ""
+msgstr "%s Físico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PASSWORD"
-msgstr ""
+msgstr "%s SENHA DO TÚNEL SSH"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY"
-msgstr ""
+msgstr "%s CHAVE PRIVADA DO TÚNEL SSH"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY PASSWORD"
-msgstr ""
+msgstr "%s SENHA DA CHAVE PRIVADA DO TÚNEL SSH"
 
 #, python-format
 msgid "%s Selected"
@@ -268,17 +439,25 @@ msgstr "Executar a query selecionada"
 msgid "%s Selected (%s)"
 msgstr "Executar a query selecionada"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Physical)"
-msgstr ""
+msgstr "%s Selecionado (Físico)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Virtual)"
-msgstr ""
+msgstr "%s Selecionado (Virtual)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Vista Semântica"
 
 #, fuzzy, python-format
 msgid "%s URL"
@@ -288,9 +467,12 @@ msgstr "URL"
 msgid "%s Virtual"
 msgstr "URL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s aggregates(s)"
-msgstr ""
+msgstr "%s agregado(s)"
 
 #, fuzzy, python-format
 msgid "%s column"
@@ -302,11 +484,13 @@ msgstr[1] ""
 msgid "%s column(s)"
 msgstr "Lista de Colunas"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "há %s dia"
+msgstr[1] "há %s dias"
 
 #, fuzzy, python-format
 msgid "%s hr ago"
@@ -328,11 +512,15 @@ msgstr[1] ""
 msgid "%s item(s)"
 msgstr "Opções"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%s items could not be tagged because you don’t have edit permissions to "
 "all selected objects."
 msgstr ""
+"%s itens não puderam ser etiquetados porque não tem permissões de edição "
+"para todos os objetos selecionados."
 
 #, fuzzy, python-format
 msgid "%s metric"
@@ -376,9 +564,11 @@ msgstr[1] ""
 msgid "%s out of %s selected"
 msgstr "Executar a query selecionada"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "%s recipients"
-msgstr ""
+msgstr "%s destinatários"
 
 #, fuzzy, python-format
 msgid "%s record"
@@ -398,15 +588,20 @@ msgid_plural "%s rows"
 msgstr[0] "Erro"
 msgstr[1] ""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s s ago"
 msgid_plural "%s s ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "há %ss"
+msgstr[1] "há %ss"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s saved metric(s)"
-msgstr ""
+msgstr "%s métrica(s) guardada(s)"
 
 #, fuzzy, python-format
 msgid "%s second"
@@ -414,17 +609,23 @@ msgid_plural "%s seconds"
 msgstr[0] "30 segundos"
 msgstr[1] ""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s vista(s) semântica(s) adicionada(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "Falha ao adicionar %s vista(s) semântica(s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "Falha ao adicionar %s vista(s) semântica(s): %s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
@@ -434,23 +635,44 @@ msgstr "Executar a query selecionada"
 msgid "%s updated"
 msgstr "%s - sem título"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s%s"
-msgstr ""
+msgstr "%s%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(Removed)"
-msgstr ""
+msgstr "(Removido)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(deleted or invalid type)"
-msgstr ""
+msgstr "(tipo eliminado ou inválido)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(no description, click to see stack trace)"
-msgstr ""
+msgstr "(sem descrição, clique para ver o rastreamento de pilha)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "), and they become available in your SQL (example:"
-msgstr ""
+msgstr "), e ficam disponíveis no seu SQL (exemplo:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -459,8 +681,16 @@ msgid ""
 "    Error: %(text)s\n"
 "    "
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"    %(description)s\n"
+"\n"
+"    Erro: %(text)s\n"
+"    "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -470,92 +700,161 @@ msgid ""
 "\n"
 "%(table)s\n"
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"%(description)s\n"
+"\n"
+"<%(url)s|Explorar no Superset>\n"
+"\n"
+"%(table)s\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "+ %s more"
-msgstr ""
+msgstr "+ %s mais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ", then paste the JSON below. See our"
-msgstr ""
+msgstr ", depois cole o JSON abaixo. Consulte o nosso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "-- Note: Unless you save your query, these tabs will NOT persist if you "
 "clear your cookies or change browsers.\n"
 "\n"
 msgstr ""
+"-- Nota: A menos que guarde a sua consulta, estes separadores NÃO serão "
+"mantidos se limpar os cookies ou mudar de navegador.\n"
+"\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... e mais %d"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %s more records"
-msgstr ""
+msgstr "... e mais %s registos"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "... and %s others"
-msgstr ""
+msgstr "... e %s outros"
 
 msgid "0 Selected"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 calendar day frequency"
-msgstr ""
+msgstr "Frequência de 1 dia de calendário"
 
 #, fuzzy
 msgid "1 day"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 day ago"
-msgstr ""
+msgstr "há 1 dia"
 
 msgid "1 hour"
 msgstr "hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 hourly frequency"
-msgstr ""
+msgstr "Frequência de 1 hora"
 
 msgid "1 minute"
 msgstr "1 minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 minutely frequency"
-msgstr ""
+msgstr "Frequência de 1 minuto"
 
 #, fuzzy
 msgid "1 month ago"
 msgstr "mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month end frequency"
-msgstr ""
+msgstr "Frequência de fim de mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month start frequency"
-msgstr ""
+msgstr "Frequência de início de mês"
 
 #, fuzzy
 msgid "1 week"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 week ago"
-msgstr ""
+msgstr "há 1 semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Monday (freq=W-MON)"
-msgstr ""
+msgstr "1 semana com início à Segunda-feira (freq=W-MON)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Sunday (freq=W-SUN)"
-msgstr ""
+msgstr "1 semana com início ao Domingo (freq=W-SUN)"
 
 #, fuzzy
 msgid "1 year"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 year ago"
-msgstr ""
+msgstr "há 1 ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year end frequency"
-msgstr ""
+msgstr "Frequência de fim de 1 ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year start frequency"
-msgstr ""
+msgstr "Frequência de início de 1 ano"
 
 #, fuzzy
 msgid "10 minute"
@@ -565,8 +864,11 @@ msgstr "1 minuto"
 msgid "10 seconds"
 msgstr "30 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "10/90 percentiles"
-msgstr ""
+msgstr "10/90 percentis"
 
 msgid "10000"
 msgstr ""
@@ -575,8 +877,12 @@ msgstr ""
 msgid "104 weeks"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "104 weeks ago"
-msgstr ""
+msgstr "há 104 semanas"
 
 #, fuzzy
 msgid "12 hours"
@@ -590,36 +896,71 @@ msgstr "1 minuto"
 msgid "156 weeks"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "156 weeks ago"
-msgstr ""
+msgstr "há 156 semanas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1AS"
-msgstr ""
+msgstr "1AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1D"
-msgstr ""
+msgstr "1D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1H"
-msgstr ""
+msgstr "1H"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1M"
-msgstr ""
+msgstr "1M"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1T"
-msgstr ""
+msgstr "1T"
 
 #, fuzzy
 msgid "2 years"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2 years ago"
-msgstr ""
+msgstr "há 2 anos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2/98 percentiles"
-msgstr ""
+msgstr "2/98 percentis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "22"
-msgstr ""
+msgstr "22"
 
 #, fuzzy
 msgid "24 hours"
@@ -629,11 +970,19 @@ msgstr "hora"
 msgid "28 days"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "28 days ago"
-msgstr ""
+msgstr "há 28 dias"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #, fuzzy
 msgid "3 letter code of the country"
@@ -643,14 +992,25 @@ msgstr "Código de 3 letras do país"
 msgid "3 years"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "3 years ago"
-msgstr ""
+msgstr "há 3 anos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "30 days"
-msgstr ""
+msgstr "30 dias"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "30 days ago"
-msgstr ""
+msgstr "há 30 dias"
 
 #, fuzzy
 msgid "30 minute"
@@ -666,11 +1026,19 @@ msgstr "30 segundos"
 msgid "30 seconds"
 msgstr "30 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "4 weeks (freq=4W-MON)"
-msgstr ""
+msgstr "4 semanas (freq=4W-MON)"
 
 #, fuzzy
 msgid "5 minute"
@@ -687,18 +1055,28 @@ msgstr "30 segundos"
 msgid "5 seconds"
 msgstr "30 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "5/95 percentiles"
-msgstr ""
+msgstr "5/95 percentis"
 
 #, fuzzy
 msgid "52 weeks"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "52 weeks ago"
-msgstr ""
+msgstr "há 52 semanas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "52 weeks starting Monday (freq=52W-MON)"
-msgstr ""
+msgstr "52 semanas com início à Segunda-feira (freq=52W-MON)"
 
 #, fuzzy
 msgid "6 hour"
@@ -708,36 +1086,72 @@ msgstr "hora"
 msgid "6 hours"
 msgstr "hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "60 days"
-msgstr ""
+msgstr "60 dias"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "7 calendar day frequency"
-msgstr ""
+msgstr "Frequência de 7 dias de calendário"
 
 #, fuzzy
 msgid "7 days"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "7D"
-msgstr ""
+msgstr "7D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "9/91 percentiles"
-msgstr ""
+msgstr "9/91 percentis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "90 days"
-msgstr ""
+msgstr "90 dias"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ":"
-msgstr ""
+msgstr ":"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "< (Smaller than)"
-msgstr ""
+msgstr "< (Menor que)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<= (Smaller or equal)"
-msgstr ""
+msgstr "<= (Menor ou igual)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<enter SQL expression here>"
-msgstr ""
+msgstr "<insira a expressão SQL aqui>"
 
 #, fuzzy
 msgid "<new column>"
@@ -747,38 +1161,68 @@ msgstr "Coluna de tempo"
 msgid "<new metric>"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "<new spatial>"
-msgstr ""
+msgstr "<novo espacial>"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "<no type>"
-msgstr ""
+msgstr "<nenhum tipo>"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "== (Is equal)"
-msgstr ""
+msgstr "== (É igual)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "> (Larger than)"
-msgstr ""
+msgstr "> (Maior que)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ">= (Larger or equal)"
-msgstr ""
+msgstr ">= (Maior ou igual)"
 
 #, fuzzy
 msgid "A Big Number"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "Uma função JavaScript que gera um objeto de configuração de rótulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "Uma função JavaScript que gera um objeto de configuração de ícone"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"Um objeto JavaScript que adere à especificação de opções do ECharts, "
+"substituindo outras opções de controlo com maior precedência. (ex.: { "
+"title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). "
+"Detalhes: https://echarts.apache.org/en/option.html. "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
@@ -786,44 +1230,86 @@ msgstr ""
 "Selecione os nomes das colunas a serem tratadas como datas na lista "
 "pendente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr ""
+"Uma lista separada por vírgulas de esquemas para os quais os ficheiros "
+"têm permissão para fazer upload."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A database port is required when connecting via SSH Tunnel."
 msgstr ""
+"É necessária uma porta de base de dados quando se liga através de um "
+"túnel SSH."
 
 #, fuzzy
 msgid "A database with the same name already exists."
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A date is required when using custom date shift"
-msgstr ""
+msgstr "É necessária uma data quando se utiliza um desvio de data personalizado"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "A dictionary with column names and their data types if you need to change"
 " the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas "
 "library for supported data types."
 msgstr ""
+"Um dicionário com nomes de colunas e os seus tipos de dados caso seja "
+"necessário alterar os valores predefinidos. Exemplo: "
+"{\"user_id\":\"int\"}. Consulte a biblioteca Pandas do Python para os "
+"tipos de dados suportados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A full URL pointing to the location of the built plugin (could be hosted "
 "on a CDN for example)"
 msgstr ""
+"Um URL completo que aponta para a localização do plugin construído (pode "
+"estar alojado num CDN, por exemplo)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A handlebars template that is applied to the data"
-msgstr ""
+msgstr "Um modelo Handlebars que é aplicado aos dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A human-friendly name"
-msgstr ""
+msgstr "Um nome amigável para o utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A list of domain names that can embed this dashboard. Leaving this field "
 "empty will allow embedding from any domain."
 msgstr ""
+"Uma lista de nomes de domínio que podem incorporar este dashboard. Deixar"
+" este campo vazio permitirá a incorporação a partir de qualquer domínio."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A list of tags that have been applied to this chart."
-msgstr ""
+msgstr "Uma lista de etiquetas que foram aplicadas a este gráfico."
 
 #, fuzzy
 msgid "A list of tags that have been applied to this dashboard."
@@ -832,13 +1318,23 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "A list of users who can alter the chart. Searchable by name or username."
 msgstr "Proprietários é uma lista de utilizadores que podem alterar o dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A map of the world, that can indicate values in different countries."
-msgstr ""
+msgstr "Um mapa do mundo que pode indicar valores em diferentes países."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A map that takes rendering circles with a variable radius at "
 "latitude/longitude coordinates"
 msgstr ""
+"Um mapa que apresenta círculos com raio variável nas coordenadas de "
+"latitude/longitude"
 
 msgid "A metric to use for color"
 msgstr "Uma métrica a utilizar para cor"
@@ -855,11 +1351,18 @@ msgstr "Não foi possível gravar a sua query"
 msgid "A new dashboard will be created."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A polar coordinate chart where the circle is broken into wedges of equal "
 "angle, and the value represented by any wedge is illustrated by its area,"
 " rather than its radius or sweep angle."
 msgstr ""
+"Um gráfico de coordenadas polares onde o círculo é dividido em cunhas de "
+"igual ângulo, e o valor representado por qualquer cunha é ilustrado pela "
+"sua área, em vez do seu raio ou ângulo de varrimento."
 
 msgid "A readable URL for your dashboard"
 msgstr "Obter um URL legível para o seu dashboard"
@@ -873,13 +1376,23 @@ msgstr ""
 msgid "A report named \"%(name)s\" already exists"
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A reusable dataset will be saved with your chart."
-msgstr ""
+msgstr "Um conjunto de dados reutilizável será guardado com o seu gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
+"Um conjunto de parâmetros que ficam disponíveis na consulta utilizando a "
+"sintaxe de modelos Jinja"
 
 #, fuzzy
 msgid "A timeout occurred while executing the query."
@@ -897,9 +1410,17 @@ msgstr "Ocorreu um erro ao criar a origem dos dados"
 msgid "A timeout occurred while taking a screenshot."
 msgstr "Ocorreu um erro ao carregar os metadados da tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A valid color scheme is required"
-msgstr ""
+msgstr "É necessário um esquema de cores válido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A waterfall chart is a form of data visualization that helps in "
 "understanding\n"
@@ -908,9 +1429,18 @@ msgid ""
 "          These intermediate values can either be time based or category "
 "based."
 msgstr ""
+"Um gráfico de cascata é uma forma de visualização de dados que ajuda a "
+"compreender\n"
+"          o efeito cumulativo de valores positivos ou negativos "
+"introduzidos sequencialmente.\n"
+"          Estes valores intermédios podem ser baseados no tempo ou em "
+"categorias."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 #, fuzzy
 msgid "AND"
@@ -920,8 +1450,11 @@ msgstr "dia"
 msgid "API Key Created"
 msgstr "foi criado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API Keys"
-msgstr ""
+msgstr "Chaves API"
 
 #, fuzzy
 msgid "API key created successfully"
@@ -931,23 +1464,47 @@ msgstr "Esta origem de dados parece ter sido excluída"
 msgid "API key name is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "Chave API revogada com sucesso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
 msgstr ""
+"As chaves API permitem o acesso programático com âmbito restrito ao "
+"Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APPLY"
-msgstr ""
+msgstr "APLICAR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APR"
-msgstr ""
+msgstr "ABR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "AQE"
-msgstr ""
+msgstr "AQE"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "AUG"
-msgstr ""
+msgstr "AGO"
 
 #, fuzzy
 msgid "Aborted"
@@ -957,14 +1514,25 @@ msgstr "Estado"
 msgid "Aborting"
 msgstr "Mensagem de Aviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "About"
-msgstr ""
+msgstr "Sobre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Access & ownership"
-msgstr ""
+msgstr "Acesso e propriedade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Access token"
-msgstr ""
+msgstr "Token de acesso"
 
 #, fuzzy
 msgid "Account"
@@ -994,8 +1562,12 @@ msgstr "Valor de filtro"
 msgid "Actual range for comparison"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Actual time range"
-msgstr ""
+msgstr "Intervalo de tempo real"
 
 #, fuzzy
 msgid "Actual value"
@@ -1005,21 +1577,35 @@ msgstr "Valor de filtro"
 msgid "Actual values"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Adaptive formatting"
-msgstr ""
+msgstr "Formatação adaptativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add"
-msgstr ""
+msgstr "Adicionar"
 
 #, fuzzy, python-format
 msgid "Add %s view(s)"
 msgstr "Opções"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add BCC Recipients"
-msgstr ""
+msgstr "Adicionar Destinatários BCC"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add CC Recipients"
-msgstr ""
+msgstr "Adicionar Destinatários CC"
 
 #, fuzzy
 msgid "Add CSS template"
@@ -1036,26 +1622,45 @@ msgstr "Janela de exibição"
 msgid "Add Layer"
 msgstr "ocultar barra de ferramentas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Add Log"
-msgstr ""
+msgstr "Adicionar Registo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Add Query A and Query B identifiers to tooltips to help differentiate "
 "series"
 msgstr ""
+"Adicionar identificadores de Consulta A e Consulta B às dicas de "
+"ferramentas para ajudar a diferenciar as séries"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add Role"
-msgstr ""
+msgstr "Adicionar Papel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add Rule"
-msgstr ""
+msgstr "Adicionar Regra"
 
 #, fuzzy
 msgid "Add Semantic View"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add Tag"
-msgstr ""
+msgstr "Adicionar Etiqueta"
 
 #, fuzzy
 msgid "Add User"
@@ -1072,8 +1677,12 @@ msgstr "Adicionar Base de Dados"
 msgid "Add a new tab"
 msgstr "Query numa nova aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add a new tab to create SQL Query"
-msgstr ""
+msgstr "Adicionar um novo separador para criar uma Consulta SQL"
 
 #, fuzzy
 msgid "Add additional custom parameters"
@@ -1103,33 +1712,67 @@ msgstr "Camadas de anotação"
 msgid "Add another notification method"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr ""
+"Adicionar colunas calculadas ao conjunto de dados no modal \"Editar fonte"
+" de dados\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
 msgstr ""
+"Adicionar colunas temporais calculadas ao conjunto de dados no modal "
+"\"Editar fonte de dados\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fr,
+# ja, lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add certification details for this dashboard"
-msgstr ""
+msgstr "Adicionar detalhes de certificação para este painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Add color for positive/negative change"
-msgstr ""
+msgstr "Adicionar cor para alteração positiva/negativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "Adicionar cores às barras de células para +/- em todas as colunas"
 
 #, fuzzy
 msgid "Add cross-filter"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add custom scoping"
-msgstr ""
+msgstr "Adicionar âmbito personalizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add dataset columns here to group the pivot table columns."
 msgstr ""
+"Adicione aqui colunas do conjunto de dados para agrupar as colunas da "
+"tabela dinâmica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add delivery method"
-msgstr ""
+msgstr "Adicionar método de entrega"
 
 #, fuzzy
 msgid "Add description of your tag"
@@ -1139,8 +1782,11 @@ msgstr "Escreva uma descrição para sua consulta"
 msgid "Add display control"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add divider"
-msgstr ""
+msgstr "Adicionar separador"
 
 #, fuzzy
 msgid "Add extra connection information."
@@ -1150,6 +1796,10 @@ msgstr "Metadados adicionais"
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Add filter clauses to control the filter's source query,\n"
 "                    though only in the context of the autocomplete i.e., "
@@ -1161,6 +1811,16 @@ msgid ""
 "                    of the underlying data or limit the available values "
 "displayed in the filter."
 msgstr ""
+"Adicionar cláusulas de filtro para controlar a consulta de origem do "
+"filtro,\n"
+"                    mas apenas no contexto da conclusão automática, ou "
+"seja, estas condições\n"
+"                    não afetam a forma como o filtro é aplicado ao "
+"painel. Isto é útil\n"
+"                    quando pretende melhorar o desempenho da consulta "
+"analisando apenas um subconjunto\n"
+"                    dos dados subjacentes ou limitar os valores "
+"disponíveis apresentados no filtro."
 
 #, fuzzy
 msgid "Add folder"
@@ -1173,14 +1833,25 @@ msgstr "Adicionar filtro"
 msgid "Add metric"
 msgstr "Adicionar Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "Adicionar métricas ao conjunto de dados no modal \"Editar fonte de dados\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new color formatter"
-msgstr ""
+msgstr "Adicionar novo formatador de cores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new formatter"
-msgstr ""
+msgstr "Adicionar novo formatador"
 
 #, fuzzy
 msgid "Add numbered column"
@@ -1198,18 +1869,30 @@ msgstr "Adicionar filtro"
 msgid "Add report"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to preview chart"
-msgstr ""
+msgstr "Adicionar valores de controlo necessários para pré-visualizar o gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to save chart"
-msgstr ""
+msgstr "Adicionar valores de controlo necessários para guardar o gráfico"
 
 #, fuzzy
 msgid "Add sheet"
 msgstr "Adicionar Base de Dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add tag to entities"
-msgstr ""
+msgstr "Adicionar etiqueta às entidades"
 
 #, fuzzy
 msgid "Add the name of the chart"
@@ -1230,14 +1913,20 @@ msgstr "Adicionar ao novo dashboard"
 msgid "Add to tabs"
 msgstr "Adicionar ao novo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Added"
-msgstr ""
+msgstr "Adicionado"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Foi adicionada 1 nova coluna ao conjunto de dados virtual"
+msgstr[1] "Foram adicionadas %s novas colunas ao conjunto de dados virtual"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"
@@ -1249,15 +1938,23 @@ msgstr[1] ""
 msgid "Additional Parameters"
 msgstr "Editar propriedades da visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional fields may be required"
-msgstr ""
+msgstr "Podem ser necessários campos adicionais"
 
 #, fuzzy
 msgid "Additional information"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Additional padding for legend."
-msgstr ""
+msgstr "Preenchimento adicional para a legenda."
 
 #, fuzzy
 msgid "Additional parameters"
@@ -1267,22 +1964,43 @@ msgstr "Editar propriedades da visualização"
 msgid "Additional settings."
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional text to add before or after the value, e.g. unit"
-msgstr ""
+msgstr "Texto adicional a adicionar antes ou depois do valor, por exemplo, unidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Additive"
-msgstr ""
+msgstr "Aditivo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Adds color to the chart symbols based on the positive or negative change "
 "from the comparison value."
 msgstr ""
+"Adiciona cor aos símbolos do gráfico com base na alteração positiva ou "
+"negativa em relação ao valor de comparação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust how this database will interact with SQL Lab."
-msgstr ""
+msgstr "Ajustar como esta base de dados irá interagir com o SQL Lab."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust performance settings of this database."
-msgstr ""
+msgstr "Ajustar as definições de desempenho desta base de dados."
 
 msgid "Advanced"
 msgstr "Análise Avançada"
@@ -1334,10 +2052,15 @@ msgstr "Por favor insira um nome para o dashboard"
 msgid "After"
 msgstr "Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "After making the changes, copy the query and paste in the virtual dataset"
 " SQL snippet settings."
 msgstr ""
+"Após efetuar as alterações, copie a consulta e cole nas definições do "
+"fragmento SQL do conjunto de dados virtual."
 
 #, fuzzy
 msgid "Aggregate"
@@ -1351,20 +2074,38 @@ msgstr "Soma Agregada"
 msgid "Aggregate Sum"
 msgstr "Soma Agregada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function applied to the list of points in each cluster to "
 "produce the cluster label."
 msgstr ""
+"Função de agregação aplicada à lista de pontos em cada cluster para "
+"produzir a etiqueta do cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function to apply when pivoting and computing the total rows "
 "and columns"
 msgstr ""
+"Função de agregação a aplicar ao dinamizar e calcular o total de linhas e"
+" colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Aggregates data within the boundary of grid cells and maps the aggregated"
 " values to a dynamic color scale"
 msgstr ""
+"Agrega dados dentro dos limites das células da grelha e mapeia os valores"
+" agregados numa escala de cores dinâmica"
 
 #, fuzzy
 msgid "Aggregation"
@@ -1382,8 +2123,12 @@ msgstr "Função de agregação"
 msgid "Alert"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert Triggered, In Grace Period"
-msgstr ""
+msgstr "Alerta Acionado, Em Período de Carência"
 
 #, fuzzy
 msgid "Alert condition"
@@ -1393,87 +2138,162 @@ msgstr "Conexão de teste"
 msgid "Alert contents"
 msgstr "Conteúdo Criado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert ended grace period."
-msgstr ""
+msgstr "O alerta terminou o período de carência."
 
 #, fuzzy
 msgid "Alert failed"
 msgstr "Nome da Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert fired during grace period."
-msgstr ""
+msgstr "O alerta foi acionado durante o período de carência."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert found an error while executing a query."
-msgstr ""
+msgstr "O alerta encontrou um erro ao executar uma consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Alert is active"
-msgstr ""
+msgstr "O alerta está ativo"
 
 #, fuzzy
 msgid "Alert name"
 msgstr "Tipo de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert on grace period"
-msgstr ""
+msgstr "Alerta no período de carência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned a non-number value."
-msgstr ""
+msgstr "A consulta do alerta devolveu um valor não numérico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one column."
-msgstr ""
+msgstr "A consulta do alerta devolveu mais do que uma coluna."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one column. %(num_cols)s columns returned"
 msgstr ""
+"A consulta do alerta devolveu mais do que uma coluna. %(num_cols)s "
+"colunas devolvidas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one row."
-msgstr ""
+msgstr "A consulta do alerta devolveu mais do que uma linha."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one row. %(num_rows)s rows returned"
 msgstr ""
+"A consulta do alerta devolveu mais do que uma linha. %(num_rows)s linhas "
+"devolvidas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert running"
-msgstr ""
+msgstr "Alerta em execução"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert triggered, notification sent"
-msgstr ""
+msgstr "Alerta acionado, notificação enviada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert validator config error."
-msgstr ""
+msgstr "Erro de configuração do validador de alertas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alerts"
-msgstr ""
+msgstr "Alertas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alerts & Reports"
-msgstr ""
+msgstr "Alertas e Relatórios"
 
 #, fuzzy
 msgid "Alerts & reports"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Align +/-"
-msgstr ""
+msgstr "Alinhar +/-"
 
 #, fuzzy
 msgid "Align +/- for all columns"
 msgstr "Mostrar Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All"
-msgstr ""
+msgstr "Tudo"
 
 #, fuzzy, python-format
 msgid "All %s hidden columns"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All Text"
-msgstr ""
+msgstr "Todo o Texto"
 
 msgid "All charts"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All charts/global scoping"
-msgstr ""
+msgstr "Todos os gráficos/âmbito global"
 
 #, fuzzy
 msgid "All dimensions"
@@ -1482,8 +2302,12 @@ msgstr "descrição"
 msgid "All filters"
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "All panels"
-msgstr ""
+msgstr "Todos os painéis"
 
 #, fuzzy
 msgid "All records"
@@ -1495,74 +2319,154 @@ msgstr "Permitir CREATE TABLE AS"
 msgid "Allow CREATE VIEW AS"
 msgstr "Permitir CREATE TABLE AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow DDL and DML"
-msgstr ""
+msgstr "Permitir DDL e DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow changing catalogs"
-msgstr ""
+msgstr "Permitir alteração de catálogos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow column names to be changed to case insensitive format, if supported"
 " (e.g. Oracle, Snowflake)."
 msgstr ""
+"Permitir que os nomes das colunas sejam alterados para um formato "
+"insensível a maiúsculas/minúsculas, se suportado (ex.: Oracle, "
+"Snowflake)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow columns to be rearranged"
-msgstr ""
+msgstr "Permitir que as colunas sejam reorganizadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new tables based on queries"
-msgstr ""
+msgstr "Permitir criação de novas tabelas baseadas em consultas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow creation of new values"
-msgstr ""
+msgstr "Permitir criação de novos valores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new views based on queries"
-msgstr ""
+msgstr "Permitir criação de novas vistas baseadas em consultas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow data manipulation language"
-msgstr ""
+msgstr "Permitir linguagem de manipulação de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow end user to drag-and-drop column headers to rearrange them. Note "
 "their changes won't persist for the next time they open the chart."
 msgstr ""
+"Permitir que o utilizador final arraste e largue os cabeçalhos das "
+"colunas para os reorganizar. Note que as alterações não serão mantidas na"
+" próxima vez que o gráfico for aberto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow file uploads to database"
-msgstr ""
+msgstr "Permitir carregamento de ficheiros para a base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Allow node selections"
-msgstr ""
+msgstr "Permitir seleções de nós"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Allow the execution of DDL (Data Definition Language: CREATE, DROP, "
 "TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, "
 "DELETE, etc)"
 msgstr ""
+"Permitir a execução de DDL (Data Definition Language: CREATE, DROP, "
+"TRUNCATE, etc.) e DML (Data Modification Language: INSERT, UPDATE, "
+"DELETE, etc)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be explored"
-msgstr ""
+msgstr "Permitir que esta base de dados seja explorada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be queried in SQL Lab"
-msgstr ""
+msgstr "Permitir que esta base de dados seja consultada no SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Allow users to select multiple values"
-msgstr ""
+msgstr "Permitir que os utilizadores selecionem múltiplos valores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allowed Domains (comma separated)"
-msgstr ""
+msgstr "Domínios permitidos (separados por vírgula)"
 
 #, fuzzy
 msgid "Alphabetical"
 msgstr "Ordenar colunas por ordem alfabética"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Also known as a box and whisker plot, this visualization compares the "
 "distributions of a related metric across multiple groups. The box in the "
 "middle emphasizes the mean, median, and inner 2 quartiles. The whiskers "
 "around each box visualize the min, max, range, and outer 2 quartiles."
 msgstr ""
+"Também conhecido como gráfico de caixa e bigode, esta visualização "
+"compara as distribuições de uma métrica relacionada em vários grupos. A "
+"caixa no meio enfatiza a média, a mediana e os dois quartis internos. Os "
+"bigodes em torno de cada caixa visualizam o mínimo, o máximo, o intervalo"
+" e os dois quartis externos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Altered"
-msgstr ""
+msgstr "Alterado"
 
 #, fuzzy
 msgid "Always filter main datetime column"
@@ -1576,21 +2480,41 @@ msgstr "Ocorreu um erro ao criar a origem dos dados"
 msgid "An alert named \"%(name)s\" already exists"
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An enclosed time range (both start and end) must be specified when using "
 "a Time Comparison."
 msgstr ""
+"Deve ser especificado um intervalo de tempo fechado (início e fim) quando"
+" se utiliza uma Comparação de Tempo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An engine must be specified when passing individual parameters to a "
 "database."
 msgstr ""
+"Deve ser especificado um motor ao passar parâmetros individuais para uma "
+"base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error has occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
 msgid "An error occurred saving dataset"
 msgstr "Ocorreu um erro ao criar a origem dos dados"
@@ -1847,11 +2771,18 @@ msgstr "Ocorreu um erro ao criar a origem dos dados"
 msgid "An error occurred while starring this chart"
 msgstr "Ocorreu um erro ao criar a origem dos dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while storing your query in the backend. To avoid "
 "losing your changes, please save your query using the \"Save Query\" "
 "button."
 msgstr ""
+"Ocorreu um erro ao armazenar a sua consulta no backend. Para evitar a "
+"perda das suas alterações, guarde a consulta utilizando o botão \"Guardar"
+" Consulta\"."
 
 #, fuzzy, python-format
 msgid "An error occurred while syncing permissions for %s: %s"
@@ -1877,17 +2808,33 @@ msgstr "Ocorreu um erro ao renderizar a visualização: %s"
 msgid "An error occurred while upserting the value."
 msgstr "Ocorreu um erro ao renderizar a visualização: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "An unexpected error occurred"
-msgstr ""
+msgstr "Ocorreu um erro inesperado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Anchor to"
-msgstr ""
+msgstr "Ancorar a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to end progress axis"
-msgstr ""
+msgstr "Ângulo a que termina o eixo de progresso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to start progress axis"
-msgstr ""
+msgstr "Ângulo a que inicia o eixo de progresso"
 
 #, fuzzy
 msgid "Animation"
@@ -1907,11 +2854,19 @@ msgstr "Camadas de anotação"
 msgid "Annotation Slice Configuration"
 msgstr "Edite a configuração da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be created."
-msgstr ""
+msgstr "Não foi possível criar a anotação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be updated."
-msgstr ""
+msgstr "Não foi possível atualizar a anotação."
 
 #, fuzzy
 msgid "Annotation layer"
@@ -1982,8 +2937,12 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Annotation not found."
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros de anotação são inválidos."
 
 #, fuzzy
 msgid "Annotation source"
@@ -2008,39 +2967,80 @@ msgstr "Camadas de anotação"
 msgid "Annotations and layers"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotations could not be deleted."
-msgstr ""
+msgstr "Não foi possível eliminar as anotações."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ant Design Theme Editor"
-msgstr ""
+msgstr "Editor de Temas Ant Design"
 
 #, fuzzy
 msgid "Any"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Any additional detail to show in the certification tooltip."
 msgstr ""
+"Qualquer detalhe adicional a mostrar na dica de ferramenta de "
+"certificação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Any color palette selected here will override the colors applied to this "
 "dashboard's individual charts"
 msgstr ""
+"Qualquer paleta de cores selecionada aqui substituirá as cores aplicadas "
+"aos gráficos individuais deste painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Any dashboards using these themes will be automatically dissociated from "
 "them."
 msgstr ""
+"Quaisquer painéis que utilizem estes temas serão automaticamente "
+"dissociados deles."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Any dashboards using this theme will be automatically dissociated from it."
 msgstr ""
+"Quaisquer painéis que utilizem este tema serão automaticamente "
+"dissociados dele."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
 msgstr ""
+"Todas as bases de dados que permitem ligações através de URIs SQL Alchemy"
+" podem ser adicionadas. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Any databases that allow connections via SQL Alchemy URIs can be added. "
 "Learn about how to connect a database driver "
 msgstr ""
+"Todas as bases de dados que permitem ligações através de URIs SQL Alchemy"
+" podem ser adicionadas. Saiba como ligar um controlador de base de dados "
 
 #, fuzzy, python-format
 msgid "Applied cross-filters (%d)"
@@ -2058,19 +3058,36 @@ msgstr "Adicionar filtro"
 msgid "Applied filters: %s"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Applied rolling window did not return any data. Please make sure the "
 "source query satisfies the minimum periods defined in the rolling window."
 msgstr ""
+"A janela deslizante aplicada não devolveu quaisquer dados. Certifique-se "
+"de que a consulta de origem satisfaz os períodos mínimos definidos na "
+"janela deslizante."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"Aplica-se apenas quando a formatação \"Barras de célula\" está "
+"selecionada: o fundo das colunas do histograma é apresentado se o "
+"sinalizador \"Mostrar barras de célula\" estiver ativado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply"
-msgstr ""
+msgstr "Aplicar"
 
 #, fuzzy
 msgid "Apply Filter"
@@ -2084,113 +3101,224 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Apply conditional color formatting to metric"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to metrics"
-msgstr ""
+msgstr "Aplicar formatação de cor condicional a métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to numeric columns"
-msgstr ""
+msgstr "Aplicar formatação de cor condicional a colunas numéricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Apply custom CSS to the dashboard. Use class names or element selectors "
 "to target specific components."
 msgstr ""
+"Aplicar CSS personalizado ao painel. Utilize nomes de classes ou "
+"seletores de elementos para selecionar componentes específicos."
 
 #, fuzzy
 msgid "Apply filters"
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Apply metrics on"
-msgstr ""
+msgstr "Aplicar métricas em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "April"
-msgstr ""
+msgstr "Abril"
 
 #, fuzzy
 msgid "Arc"
 msgstr "Pesquisa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you intend to overwrite the following values?"
-msgstr ""
+msgstr "Tem a certeza de que pretende substituir os seguintes valores?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to cancel?"
-msgstr ""
+msgstr "Tem a certeza de que deseja cancelar?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete %s?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar %s?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete the selected %s?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar o %s selecionado?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected annotations?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar as anotações selecionadas?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected charts?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os gráficos selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected dashboards?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os dashboards selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected groups?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os grupos selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected layers?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar as camadas selecionadas?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected roles?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar as funções selecionadas?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected rules?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar as regras selecionadas?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected tags?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar as tags selecionadas?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected templates?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os modelos selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected themes?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os temas selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected users?"
-msgstr ""
+msgstr "Tem a certeza de que deseja eliminar os utilizadores selecionados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to overwrite this dataset?"
-msgstr ""
+msgstr "Tem a certeza de que deseja substituir este conjunto de dados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system dark theme? The application "
 "will fall back to the configuration file dark theme."
 msgstr ""
+"Tem a certeza de que deseja remover o tema escuro do sistema? A aplicação"
+" irá reverter para o tema escuro do ficheiro de configuração."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system default theme? The application"
 " will fall back to the configuration file default."
 msgstr ""
+"Tem a certeza de que deseja remover o tema predefinido do sistema? A "
+"aplicação irá reverter para a predefinição do ficheiro de configuração."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
+"Tem a certeza de que deseja revogar esta chave de API? Esta ação não pode"
+" ser anulada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to save and apply changes?"
-msgstr ""
+msgstr "Tem a certeza de que deseja guardar e aplicar as alterações?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system dark theme? This will "
 "apply to all users who haven't set a personal preference."
 msgstr ""
+"Tem a certeza de que deseja definir \"%s\" como o tema escuro do sistema?"
+" Isto será aplicado a todos os utilizadores que não definiram uma "
+"preferência pessoal."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system default theme? This "
 "will apply to all users who haven't set a personal preference."
 msgstr ""
+"Tem a certeza de que deseja definir \"%s\" como o tema predefinido do "
+"sistema? Isto será aplicado a todos os utilizadores que não definiram uma"
+" preferência pessoal."
 
 #, fuzzy
 msgid "Area"
@@ -2208,73 +3336,136 @@ msgstr "Explorar gráfico"
 msgid "Area chart opacity"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Area charts are similar to line charts in that they represent variables "
 "with the same scale, but area charts stack the metrics on top of each "
 "other."
 msgstr ""
+"Os gráficos de área são semelhantes aos gráficos de linhas na medida em "
+"que representam variáveis com a mesma escala, mas os gráficos de área "
+"empilham as métricas umas sobre as outras."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Arrow"
-msgstr ""
+msgstr "Seta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Assign a set of parameters as"
-msgstr ""
+msgstr "Atribuir um conjunto de parâmetros como"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Assist"
-msgstr ""
+msgstr "Assistência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Asynchronous query execution"
-msgstr ""
+msgstr "Execução de consulta assíncrona"
 
 #, fuzzy
 msgid "Attribution"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "August"
-msgstr ""
+msgstr "Agosto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization Request URI"
-msgstr ""
+msgstr "URI do pedido de autorização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization needed"
-msgstr ""
+msgstr "Autorização necessária"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Auto"
-msgstr ""
+msgstr "Automático"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Auto Zoom"
-msgstr ""
+msgstr "Zoom Automático"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Atualização automática pausada (definida para %s segundos)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
 msgstr ""
+"Atualização automática pausada - separador inativo (definido para %s "
+"segundos)"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Auto-detect"
-msgstr ""
+msgstr "Deteção automática"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete"
-msgstr ""
+msgstr "Preenchimento automático"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete filters"
-msgstr ""
+msgstr "Filtros de preenchimento automático"
 
 #, fuzzy
 msgid "Autocomplete query predicate"
 msgstr "Carregar Valores de Predicado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on available space"
-msgstr ""
+msgstr "Ajustar automaticamente a largura da coluna com base no espaço disponível"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on content"
-msgstr ""
+msgstr "Ajustar automaticamente a largura da coluna com base no conteúdo"
 
 #, fuzzy
 msgid "Automatically sync columns"
@@ -2296,15 +3487,23 @@ msgstr "Cláusula WHERE personalizada"
 msgid "Autosize all columns"
 msgstr "Cláusula WHERE personalizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Available sorting modes:"
-msgstr ""
+msgstr "Modos de ordenação disponíveis:"
 
 #, fuzzy
 msgid "Average"
 msgstr "Gerir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Average value"
-msgstr ""
+msgstr "Valor médio"
 
 #, fuzzy
 msgid "Awaiting filter selection"
@@ -2314,8 +3513,12 @@ msgstr "Lista de Métricas"
 msgid "Axis"
 msgstr "Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Axis Bounds"
-msgstr ""
+msgstr "Limites do Eixo"
 
 #, fuzzy
 msgid "Axis Format"
@@ -2333,48 +3536,99 @@ msgstr "Ordenar decrescente"
 msgid "Axis descending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Axis title margin"
-msgstr ""
+msgstr "MARGEM DO TÍTULO DO EIXO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Axis title position"
-msgstr ""
+msgstr "POSIÇÃO DO TÍTULO DO EIXO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "BCC recipients"
-msgstr ""
+msgstr "Destinatários BCC"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "BOOLEAN"
-msgstr ""
+msgstr "BOOLEANO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back"
-msgstr ""
+msgstr "Voltar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back to all"
-msgstr ""
+msgstr "Voltar para todos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Backend"
-msgstr ""
+msgstr "Backend"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Background Color"
-msgstr ""
+msgstr "Cor de Fundo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Backward values"
-msgstr ""
+msgstr "Valores anteriores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bad formula."
-msgstr ""
+msgstr "Fórmula incorreta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bad spatial key"
-msgstr ""
+msgstr "Chave espacial inválida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bar"
-msgstr ""
+msgstr "Barra"
 
 #, fuzzy
 msgid "Bar Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bar Charts are used to show metrics as a series of bars."
 msgstr ""
+"Os gráficos de barras são utilizados para mostrar métricas como uma série"
+" de barras."
 
 #, fuzzy
 msgid "Bar Values"
@@ -2392,21 +3646,39 @@ msgstr "Base de dados"
 msgid "Base exponent"
 msgstr "Base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Base height"
-msgstr ""
+msgstr "Altura base"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr ""
+"Estilo do mapa da camada base. Aceita um URL de estilo compatível com "
+"MapLibre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Estilo do mapa da camada base. Aceita um URL de estilo Mapbox "
+"(mapbox://styles/...)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
-msgstr ""
+msgstr "Estilo do mapa da camada base. Consulte a documentação MapLibre: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Base slope"
-msgstr ""
+msgstr "Inclinação base"
 
 #, fuzzy
 msgid "Base width"
@@ -2416,14 +3688,26 @@ msgstr "Largura"
 msgid "Based on a metric"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Based on granularity, number of time periods to compare against"
-msgstr ""
+msgstr "Com base na granularidade, número de períodos de tempo para comparação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Based on what should series be ordered on the chart and legend"
-msgstr ""
+msgstr "Com base no que as séries devem ser ordenadas no gráfico e na legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Basic"
-msgstr ""
+msgstr "Básico"
 
 #, fuzzy
 msgid "Basic conditional formatting"
@@ -2433,12 +3717,19 @@ msgstr "Metadados adicionais"
 msgid "Basic information about the chart"
 msgstr "Metadados adicionais"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Batch editing %d filters:"
-msgstr ""
+msgstr "Edição em lote de %d filtros:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Be careful."
-msgstr ""
+msgstr "Cuidado."
 
 #, fuzzy
 msgid "Before"
@@ -2447,8 +3738,12 @@ msgstr "Intervalo de atualização"
 msgid "Big Number"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Big Number with Time Period Comparison"
-msgstr ""
+msgstr "Número Grande com Comparação de Período de Tempo"
 
 msgid "Big Number with Trendline"
 msgstr "Número grande com linha de tendência"
@@ -2461,9 +3756,11 @@ msgstr "Mín"
 msgid "Blanks"
 msgstr "Mín"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "Bloco %(block_num)s de %(block_count)s"
 
 #, fuzzy
 msgid "Border color"
@@ -2477,57 +3774,119 @@ msgstr "Largura"
 msgid "Bottom"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom Margin"
-msgstr ""
+msgstr "Margem Inferior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bottom left"
-msgstr ""
+msgstr "Inferior esquerda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom margin, in pixels, allowing for more room for axis labels"
 msgstr ""
+"Margem inferior, em píxeis, permitindo mais espaço para as etiquetas dos "
+"eixos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bottom right"
-msgstr ""
+msgstr "Inferior direita"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom to Top"
-msgstr ""
+msgstr "De baixo para cima"
 
 #, fuzzy
 msgid "Bounds"
 msgstr "30 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for numerical X axis. Not applicable for temporal or categorical "
 "axes. When left empty, the bounds are dynamically defined based on the "
 "min/max of the data. Note that this feature will only expand the axis "
 "range. It won't narrow the data's extent."
 msgstr ""
+"Limites para o eixo X numérico. Não aplicável para eixos temporais ou "
+"categóricos. Quando deixado vazio, os limites são definidos dinamicamente"
+" com base no mínimo/máximo dos dados. Tenha em atenção que esta "
+"funcionalidade só irá expandir o intervalo do eixo. Não irá reduzir a "
+"extensão dos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the X-axis. Selected time merges with min/max date of the "
 "data. When left empty, bounds dynamically defined based on the min/max of"
 " the data."
 msgstr ""
+"Limites para o eixo X. O tempo selecionado funde-se com a data mín./máx. "
+"dos dados. Quando deixado vazio, os limites são definidos dinamicamente "
+"com base no mínimo/máximo dos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Bounds for the Y-axis. When left empty, the bounds are dynamically "
 "defined based on the min/max of the data. Note that this feature will "
 "only expand the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limites para o eixo Y. Quando deixados em branco, os limites são "
+"definidos dinamicamente com base no mínimo/máximo dos dados. Tenha em "
+"atenção que esta funcionalidade só irá expandir o intervalo do eixo. Não "
+"irá reduzir a extensão dos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Bounds for the axis. When left empty, the bounds are dynamically defined "
 "based on the min/max of the data. Note that this feature will only expand"
 " the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limites para o eixo. Quando deixados em branco, os limites são definidos "
+"dinamicamente com base no mínimo/máximo dos dados. Tenha em atenção que "
+"esta funcionalidade só irá expandir o intervalo do eixo. Não irá reduzir "
+"a extensão dos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the primary Y-axis. When left empty, the bounds are "
 "dynamically defined based on the min/max of the data. Note that this "
 "feature will only expand the axis range. It won't narrow the data's "
 "extent."
 msgstr ""
+"Limites para o eixo Y primário. Quando deixados em branco, os limites são"
+" definidos dinamicamente com base no mínimo/máximo dos dados. Tenha em "
+"atenção que esta funcionalidade só irá expandir o intervalo do eixo. Não "
+"irá reduzir a extensão dos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the secondary Y-axis. Only works when Independent Y-axis\n"
 "                bounds are enabled. When left empty, the bounds are "
@@ -2536,22 +3895,39 @@ msgid ""
 "will only expand\n"
 "                the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limites para o eixo Y secundário. Só funciona quando os limites "
+"independentes do eixo Y\n"
+"                estão ativados. Quando deixado vazio, os limites são "
+"definidos dinamicamente\n"
+"                com base no mínimo/máximo dos dados. Tenha em atenção que"
+" esta funcionalidade só irá expandir\n"
+"                o intervalo do eixo. Não irá reduzir a extensão dos dados."
 
 msgid "Box Plot"
 msgstr "Box Plot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Breakdowns"
-msgstr ""
+msgstr "Decomposições"
 
 #, fuzzy
 msgid "Breakpoint Metric"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
 "      This can help viewers understand how each category affects the "
 "overall value."
 msgstr ""
+"Desagrega a série pela categoria especificada neste controlo.\n"
+"      Isto pode ajudar os utilizadores a compreender como cada categoria "
+"afeta o valor global."
 
 msgid "Bubble Chart"
 msgstr "Gráfico de bolhas"
@@ -2579,47 +3955,92 @@ msgstr "Tamanho da bolha"
 msgid "Bubble size number format"
 msgstr "Escolha uma métrica para o eixo direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bucket break points"
-msgstr ""
+msgstr "Pontos de quebra do intervalo"
 
 #, fuzzy
 msgid "Bulk select"
 msgstr "Selecione %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bulk tag"
-msgstr ""
+msgstr "Etiquetagem em massa"
 
 msgid "Bullet Chart"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Business"
-msgstr ""
+msgstr "Negócios"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "By default, each filter loads at most 1000 choices at the initial page "
 "load. Check this box if you have more than 1000 filter values and want to"
 " enable dynamically searching that loads filter values as users type (may"
 " add stress to your database)."
 msgstr ""
+"Por predefinição, cada filtro carrega, no máximo, 1000 opções no "
+"carregamento inicial da página. Assinale esta caixa se tiver mais de 1000"
+" valores de filtro e pretender ativar a pesquisa dinâmica que carrega os "
+"valores de filtro à medida que os utilizadores escrevem (pode aumentar o "
+"stress da sua base de dados)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use column names as sorting key"
-msgstr ""
+msgstr "Por chave: utilizar os nomes das colunas como chave de ordenação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use row names as sorting key"
-msgstr ""
+msgstr "Por chave: utilizar os nomes das linhas como chave de ordenação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By value: use metric values as sorting key"
-msgstr ""
+msgstr "Por valor: utilizar os valores métricos como chave de ordenação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CANCEL"
-msgstr ""
+msgstr "CANCELAR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CC recipients"
-msgstr ""
+msgstr "Destinatários CC"
 
 #, fuzzy
 msgid "COPY QUERY"
 msgstr "Query vazia?"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Copiar consulta"
 
 msgid "CREATE TABLE AS"
 msgstr "Permitir CREATE TABLE AS"
@@ -2627,11 +4048,19 @@ msgstr "Permitir CREATE TABLE AS"
 msgid "CREATE VIEW AS"
 msgstr "Permitir CREATE TABLE AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CREATE VIEW statement"
-msgstr ""
+msgstr "Instrução CREATE VIEW"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CRON Schedule"
-msgstr ""
+msgstr "Agendamento CRON"
 
 #, fuzzy
 msgid "CRON expression"
@@ -2647,14 +4076,24 @@ msgstr "Modelos CSS"
 msgid "CSS Templates"
 msgstr "Modelos CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS applied to the chart"
-msgstr ""
+msgstr "CSS aplicado ao gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"Os estilos CSS podem ser removidos pela sanitização HTML do lado do "
+"servidor. Se os estilos não estiverem a ser aplicados, solicite ao "
+"administrador do Superset que ajuste a configuração de sanitização HTML."
 
 #, fuzzy
 msgid "CSS template"
@@ -2679,40 +4118,80 @@ msgstr "Exportar"
 msgid "CSV file downloaded successfully"
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CSV upload"
-msgstr ""
+msgstr "Carregamento de CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CTAS & CVAS SCHEMA"
-msgstr ""
+msgstr "ESQUEMA CTAS E CVAS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CTAS (create table as select) can only be run with a query where the last"
 " statement is a SELECT. Please make sure your query has a SELECT as its "
 "last statement. Then, try running your query again."
 msgstr ""
+"O CTAS (criar tabela como select) só pode ser executado com uma consulta "
+"em que a última instrução seja um SELECT. Certifique-se de que a sua "
+"consulta tem um SELECT como última instrução. De seguida, tente executar "
+"a consulta novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "CUSTOM"
-msgstr ""
+msgstr "PERSONALIZADO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CVAS (create view as select) can only be run with a query with a single "
 "SELECT statement. Please make sure your query has only a SELECT "
 "statement. Then, try running your query again."
 msgstr ""
+"O CVAS (criar vista como select) só pode ser executado com uma consulta "
+"com uma única instrução SELECT. Certifique-se de que a sua consulta tem "
+"apenas uma instrução SELECT. De seguida, tente executar a consulta "
+"novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query has more than one statement."
-msgstr ""
+msgstr "A consulta CVAS (criar vista como select) tem mais do que uma instrução."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query is not a SELECT statement."
-msgstr ""
+msgstr "A consulta CVAS (criar vista como select) não é uma instrução SELECT."
 
 msgid "Cache Timeout (seconds)"
 msgstr "Cache atingiu tempo limite (segundos)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
+"Guardar dados em cache separadamente para cada utilizador com base nas "
+"suas funções e permissões de acesso a dados. Quando desativado, será "
+"utilizado um único cache para todos os utilizadores."
 
 #, fuzzy
 msgid "Cache timeout"
@@ -2722,28 +4201,54 @@ msgstr "Tempo limite para cache"
 msgid "Cache timeout must be a number"
 msgstr "Cache atingiu tempo limite (segundos)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cached"
-msgstr ""
+msgstr "Em cache"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cached %s"
-msgstr ""
+msgstr "Em cache %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Cached value not found"
-msgstr ""
+msgstr "Valor em cache não encontrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate contribution per series or row"
-msgstr ""
+msgstr "Calcular a contribuição por série ou linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from first step"
-msgstr ""
+msgstr "Calcular desde o primeiro passo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from previous step"
-msgstr ""
+msgstr "Calcular desde o passo anterior"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Calculated column [%s] requires an expression"
-msgstr ""
+msgstr "A coluna calculada [%s] requer uma expressão"
 
 #, fuzzy
 msgid "Calculated columns"
@@ -2755,11 +4260,21 @@ msgstr "Escolha um tipo de visualização"
 msgid "Calendar Heatmap"
 msgstr "Calendário com Mapa de Calor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Can not move top level tab into nested tabs"
 msgstr ""
+"Não é possível mover o separador de nível superior para separadores "
+"aninhados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Can select multiple values"
-msgstr ""
+msgstr "Pode selecionar vários valores"
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -2768,46 +4283,95 @@ msgstr "Cancelar"
 msgid "Cancel Task"
 msgstr "Cancelar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cancel query on window unload event"
-msgstr ""
+msgstr "Cancelar consulta no evento de descarga da janela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "Cancelamento não disponível devido à falta do manipulador de interrupção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot access the query"
-msgstr ""
+msgstr "Não é possível aceder à consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot delete a database that has datasets attached"
 msgstr ""
+"Não é possível eliminar uma base de dados que tenha conjuntos de dados "
+"anexados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete system themes"
-msgstr ""
+msgstr "Não é possível eliminar temas do sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
 msgstr ""
+"Não é possível eliminar um tema que está definido como tema do sistema "
+"predefinido ou tema escuro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
 msgstr ""
+"Não é possível eliminar um tema que está definido como tema do sistema "
+"predefinido ou tema escuro."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Cannot find the table (%s) metadata."
-msgstr ""
+msgstr "Não é possível encontrar os metadados da tabela (%s)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cannot have multiple credentials for the SSH Tunnel"
-msgstr ""
+msgstr "Não é possível ter múltiplas credenciais para o Túnel SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot load filter"
-msgstr ""
+msgstr "Não é possível carregar o filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot modify system themes."
-msgstr ""
+msgstr "Não é possível modificar temas do sistema."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "Não é possível aninhar pastas em pastas predefinidas"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
-msgstr ""
+msgstr "Não é possível analisar a cadeia de tempo [%(human_readable)s]"
 
 #, fuzzy
 msgid "Captcha"
@@ -2817,50 +4381,93 @@ msgstr "Crie uma nova visualização"
 msgid "Cartodiagram"
 msgstr "Diagrama de Partição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Catalog"
-msgstr ""
+msgstr "Catálogo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categorical"
-msgstr ""
+msgstr "Categórico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Categorical Color"
-msgstr ""
+msgstr "Cor Categórica"
 
 #, fuzzy
 msgid "Categorical palette"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categories to group by on the x-axis."
-msgstr ""
+msgstr "Categorias para agrupar no eixo x."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category"
-msgstr ""
+msgstr "Categoria"
 
 #, fuzzy
 msgid "Category Name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Percentage"
-msgstr ""
+msgstr "Categoria e Percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Value"
-msgstr ""
+msgstr "Categoria e Valor"
 
 #, fuzzy
 msgid "Category name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category of target nodes"
-msgstr ""
+msgstr "Categoria dos nós de destino"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category, Value and Percentage"
-msgstr ""
+msgstr "Categoria, Valor e Percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Padding"
-msgstr ""
+msgstr "Preenchimento de Célula"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Radius"
-msgstr ""
+msgstr "Raio da Célula"
 
 #, fuzzy
 msgid "Cell Size"
@@ -2870,8 +4477,11 @@ msgstr "Tamanho da bolha"
 msgid "Cell content"
 msgstr "Conteúdo Criado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "Disposição e estilo da célula"
 
 #, fuzzy
 msgid "Cell limit"
@@ -2881,38 +4491,68 @@ msgstr "Limite de série"
 msgid "Cell title template"
 msgstr "Carregue um modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Centroid (Longitude and Latitude): "
-msgstr ""
+msgstr "Centroide (Longitude e Latitude): "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certification"
-msgstr ""
+msgstr "Certificação"
 
 #, fuzzy
 msgid "Certification and additional settings"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certification details"
-msgstr ""
+msgstr "Detalhes de certificação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certified"
-msgstr ""
+msgstr "Certificado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certified By"
-msgstr ""
+msgstr "Certificado Por"
 
 #, fuzzy
 msgid "Certified by"
 msgstr "Modificado"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Certified by %s"
-msgstr ""
+msgstr "Certificado por %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of columns."
-msgstr ""
+msgstr "Alterar a ordem das colunas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of rows."
-msgstr ""
+msgstr "Alterar a ordem das linhas."
 
 #, fuzzy
 msgid "Changed by"
@@ -2922,37 +4562,65 @@ msgstr "Alterado por"
 msgid "Changed on"
 msgstr "Gerir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changes saved."
-msgstr ""
+msgstr "Alterações guardadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changes the sort value of the items in the legend only"
-msgstr ""
+msgstr "Altera apenas o valor de ordenação dos itens na legenda"
 
 #, fuzzy
 msgid "Changing one or more of these dashboards is forbidden"
 msgstr "Editar propriedades do dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing the dataset may break the chart if the chart relies on columns "
 "or metadata that does not exist in the target dataset"
 msgstr ""
+"Alterar o conjunto de dados pode danificar o gráfico se o gráfico "
+"depender de colunas ou metadados que não existem no conjunto de dados de "
+"destino"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing these settings will affect all charts using this dataset, "
 "including charts owned by other people."
 msgstr ""
+"Alterar estas definições afetará todos os gráficos que utilizam este "
+"conjunto de dados, incluindo gráficos pertencentes a outras pessoas."
 
 msgid "Changing this Dashboard is forbidden"
 msgstr "Editar propriedades do dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this chart is forbidden"
-msgstr ""
+msgstr "É proibido alterar este gráfico"
 
 msgid "Changing this control takes effect instantly"
 msgstr "Esta edição tem efeito instantâneo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this dataset is forbidden"
-msgstr ""
+msgstr "É proibido alterar este conjunto de dados"
 
 #, fuzzy
 msgid "Changing this dataset is forbidden."
@@ -2962,8 +4630,12 @@ msgstr "Editar propriedades do dashboard"
 msgid "Changing this datasource is forbidden"
 msgstr "Editar propriedades do dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this report is forbidden"
-msgstr ""
+msgstr "É proibido alterar este relatório"
 
 #, fuzzy
 msgid "Changing this semantic layer is forbidden"
@@ -2977,15 +4649,21 @@ msgstr "Editar propriedades do dashboard"
 msgid "Changing this task is forbidden"
 msgstr "Editar propriedades do dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Character to interpret as decimal point"
-msgstr ""
+msgstr "Carácter a interpretar como ponto decimal"
 
 msgid "Chart"
 msgstr "Carregar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "O gráfico %(chart_id)s não está no dashboard %(dashboard_id)s"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3002,8 +4680,12 @@ msgstr "Tipo de gráfico"
 msgid "Chart Options"
 msgstr "Editar propriedades da visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart Orientation"
-msgstr ""
+msgstr "Orientação do Gráfico"
 
 #, fuzzy, python-format
 msgid "Chart Owner: %s"
@@ -3023,17 +4705,23 @@ msgstr "Mover gráfico"
 msgid "Chart Type"
 msgstr "Mover gráfico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] has been overwritten"
-msgstr ""
+msgstr "O gráfico [%s] foi sobreescrito"
 
 #, fuzzy, python-format
 msgid "Chart [%s] has been saved"
 msgstr "Esta origem de dados parece ter sido excluída"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] was added to dashboard [%s]"
-msgstr ""
+msgstr "O gráfico [%s] foi adicionado ao painel [%s]"
 
 #, fuzzy
 msgid "Chart cache timeout"
@@ -3048,21 +4736,40 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Chart could not be updated."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
 msgstr ""
+"Personalização do gráfico para controlar a visibilidade das camadas "
+"deck.gl"
 
 #, fuzzy
 msgid "Chart customization value is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart does not exist"
-msgstr ""
+msgstr "O gráfico não existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart has no query context saved. Please save the chart again."
 msgstr ""
+"O gráfico não tem contexto de consulta guardado. Por favor, guarde o "
+"gráfico novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart height"
-msgstr ""
+msgstr "Altura do gráfico"
 
 #, fuzzy
 msgid "Chart imported"
@@ -3087,8 +4794,12 @@ msgstr "Editar propriedades da visualização"
 msgid "Chart owners"
 msgstr "Opções do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros do gráfico são inválidos."
 
 #, fuzzy
 msgid "Chart properties"
@@ -3110,8 +4821,12 @@ msgstr "Mover gráfico"
 msgid "Chart type"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart type requires a dataset"
-msgstr ""
+msgstr "O tipo de gráfico requer um conjunto de dados"
 
 #, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
@@ -3134,10 +4849,16 @@ msgstr "Subtítulo"
 msgid "Check for sorting ascending"
 msgstr "Ordenar de forma descendente ou ascendente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Check if the Rose Chart should use segment area instead of segment radius"
 " for proportioning"
 msgstr ""
+"Verificar se o Gráfico de Rosa deve utilizar a área do segmento em vez do"
+" raio do segmento para o cálculo das proporções"
 
 msgid "Check out this chart in dashboard:"
 msgstr "Verificar dashboard: %s"
@@ -3149,11 +4870,19 @@ msgstr "Verificar dashboard: %s"
 msgid "Check out this dashboard: "
 msgstr "Verificar dashboard: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Check to force date partitions to have the same height"
-msgstr ""
+msgstr "Marcar para forçar as partições de data a terem a mesma altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Child label position"
-msgstr ""
+msgstr "Posição da etiqueta filha"
 
 msgid "Choice of [Label] must be present in [Group By]"
 msgstr "A escolha do [Rótulo] deve estar presente em [Agrupar por]"
@@ -3203,43 +4932,68 @@ msgstr "Origem de dados %(name)s já existe"
 msgid "Choose chart type"
 msgstr "Escolha uma origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose columns to be parsed as dates"
-msgstr ""
+msgstr "Escolher colunas a analisar como datas"
 
 #, fuzzy
 msgid "Choose columns to read"
 msgstr "Cargos a permitir ao utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
 msgstr ""
+"Escolha entre os filtros de painel existentes e selecione um valor para "
+"refinar os resultados do seu relatório."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose how many X-Axis labels to show"
-msgstr ""
+msgstr "Escolha quantas etiquetas do Eixo X mostrar"
 
 #, fuzzy
 msgid "Choose index column"
 msgstr "Adicionar Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
+"Escolha as camadas a ocultar de todos os gráficos de Múltiplas Camadas "
+"deck.gl neste painel."
 
 #, fuzzy
 msgid "Choose notification method and recipients."
 msgstr "Metadados adicionais"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Choose numbers between %(min)s and %(max)s"
-msgstr ""
+msgstr "Escolha números entre %(min)s e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose one of the available databases from the panel on the left."
-msgstr ""
+msgstr "Escolha uma das bases de dados disponíveis no painel à esquerda."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose one of the available databases on the left panel."
-msgstr ""
+msgstr "Escolha uma das bases de dados disponíveis no painel da esquerda."
 
 #, fuzzy
 msgid "Choose sheet name"
@@ -3249,61 +5003,122 @@ msgstr "Nome Detalhado"
 msgid "Choose the annotation layer type"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose the format for legend values"
-msgstr ""
+msgstr "Escolha o formato dos valores da legenda"
 
 #, fuzzy
 msgid "Choose the position of the legend"
 msgstr "Calcular contribuição para o total"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose the source of your annotations"
-msgstr ""
+msgstr "Escolha a origem das suas anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose values that should be treated as null. Warning: Hive database "
 "supports only a single value"
 msgstr ""
+"Escolha valores que devem ser tratados como nulos. Aviso: A base de dados"
+" Hive suporta apenas um único valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Choose whether a country should be shaded by the metric, or assigned a "
 "color based on a categorical color palette"
 msgstr ""
+"Escolha se um país deve ser sombreado pela métrica ou se lhe deve ser "
+"atribuída uma cor com base numa paleta de cores categórica"
 
 #, fuzzy
 msgid "Choose..."
 msgstr "Escolha uma origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chord Diagram"
-msgstr ""
+msgstr "Diagrama de acordes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chosen non-numeric column"
-msgstr ""
+msgstr "Coluna não numérica escolhida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Circle"
-msgstr ""
+msgstr "Círculo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Arrow"
-msgstr ""
+msgstr "Círculo -> Seta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Circle"
-msgstr ""
+msgstr "Círculo -> Círculo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle radar shape"
-msgstr ""
+msgstr "Forma de radar circular"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circular"
-msgstr ""
+msgstr "Circular"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
+"Vista clássica de um conjunto de dados em folha de cálculo, linha por "
+"coluna. Utilize tabelas para apresentar uma vista dos dados subjacentes "
+"ou para mostrar métricas agregadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clause"
-msgstr ""
+msgstr "Cláusula"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear"
-msgstr ""
+msgstr "Limpar"
 
 #, fuzzy, python-format
 msgid "Clear %s filter"
@@ -3313,11 +5128,18 @@ msgstr "Filtros"
 msgid "Clear Sort"
 msgstr "Fonte de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear all"
-msgstr ""
+msgstr "Limpar tudo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear all data"
-msgstr ""
+msgstr "Limpar todos os dados"
 
 #, fuzzy
 msgid "Clear all filters"
@@ -3327,47 +5149,92 @@ msgstr "Filtros"
 msgid "Clear default dark theme"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "Limpar tema claro predefinido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear form"
-msgstr ""
+msgstr "Limpar formulário"
 
 #, fuzzy
 msgid "Clear local theme"
 msgstr "Esquema de cores lineares"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear the selection to revert to the system default theme"
-msgstr ""
+msgstr "Limpar a seleção para reverter ao tema predefinido do sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid ""
 "Click on \"Add or edit filters and controls\" option in Settings to "
 "create new dashboard filters"
 msgstr ""
+"Clique na opção \"Adicionar ou editar filtros e controlos\" nas "
+"Definições para criar novos filtros de painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Click on \"Create chart\" button in the control panel on the left to "
 "preview a visualization or"
 msgstr ""
+"Clique no botão \"Criar gráfico\" no painel de controlo à esquerda para "
+"pré-visualizar uma visualização ou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to make changes."
-msgstr ""
+msgstr "Clique no cadeado para fazer alterações."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to prevent further changes."
-msgstr ""
+msgstr "Clique no cadeado para impedir alterações futuras."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that allows you to input "
 "the SQLAlchemy URL for this database manually."
 msgstr ""
+"Clique nesta ligação para mudar para um formulário alternativo que lhe "
+"permite introduzir manualmente o URL do SQLAlchemy para esta base de "
+"dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that exposes only the "
 "required fields needed to connect this database."
 msgstr ""
+"Clique nesta ligação para mudar para um formulário alternativo que expõe "
+"apenas os campos obrigatórios necessários para ligar esta base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to add a contour"
-msgstr ""
+msgstr "Clique para adicionar um contorno"
 
 #, fuzzy
 msgid "Click to add new breakpoint"
@@ -3377,8 +5244,12 @@ msgstr "clique para editar o título"
 msgid "Click to add new layer"
 msgstr "clique para editar o título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to cancel sorting"
-msgstr ""
+msgstr "Clique para cancelar a ordenação"
 
 msgid "Click to edit"
 msgstr "clique para editar o título"
@@ -3420,23 +5291,42 @@ msgstr "Largura"
 msgid "Client Secret"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close all other tabs"
-msgstr ""
+msgstr "Fechar todos os outros separadores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Close color breakpoint editor"
-msgstr ""
+msgstr "Fechar o editor de pontos de quebra de cor"
 
 msgid "Close tab"
 msgstr "fechar aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cluster label aggregator"
-msgstr ""
+msgstr "Agregador de etiquetas de cluster"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clustering Radius"
-msgstr ""
+msgstr "Raio de agrupamento"
 
 msgid "Code"
 msgstr "Código"
@@ -3453,23 +5343,40 @@ msgstr "Remover pré-visualização de tabela"
 msgid "Collapse All"
 msgstr "Remover pré-visualização de tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Collapse all"
-msgstr ""
+msgstr "Recolher tudo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse data panel"
-msgstr ""
+msgstr "Recolher painel de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse row"
-msgstr ""
+msgstr "Recolher linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse tab content"
-msgstr ""
+msgstr "Recolher conteúdo do separador"
 
 msgid "Color"
 msgstr "Cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Color +/-"
-msgstr ""
+msgstr "Cor +/-"
 
 #, fuzzy
 msgid "Color By X-Axis"
@@ -3494,27 +5401,46 @@ msgstr "Esquema de cores"
 msgid "Color Steps"
 msgstr "Esquema de cores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Colorir barras pelo eixo x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Colorir barras pelo eixo y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Color bounds"
-msgstr ""
+msgstr "Limites de cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color breakpoints"
-msgstr ""
+msgstr "Pontos de interrupção de cor"
 
 #, fuzzy
 msgid "Color by"
 msgstr "Ordenar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
-msgstr ""
+msgstr "O campo de cor deve ser uma cor hexadecimal (#rrggbb) ou 'rgb(r, g, b)'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color for breakpoint"
-msgstr ""
+msgstr "Cor para o ponto de interrupção"
 
 msgid "Color metric"
 msgstr "Métrica de cor"
@@ -3523,16 +5449,25 @@ msgstr "Métrica de cor"
 msgid "Color of the source location"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color of the target location"
-msgstr ""
+msgstr "Cor da localização de destino"
 
 msgid "Color scheme"
 msgstr "Esquema de cores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Color will be shaded based the normalized (0% to 100%) value of a given "
 "cell against the other cells in the selected range: "
 msgstr ""
+"A cor será sombreada com base no valor normalizado (0% a 100%) de uma "
+"determinada célula em relação às outras células no intervalo selecionado:"
+" "
 
 #, fuzzy
 msgid "Color: "
@@ -3541,40 +5476,66 @@ msgstr "Cor"
 msgid "Column"
 msgstr "Coluna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Column \"%(column)s\" is not numeric or does not exists in the query "
 "results."
 msgstr ""
+"A coluna \"%(column)s\" não é numérica ou não existe nos resultados da "
+"consulta."
 
 #, fuzzy
 msgid "Column Configuration"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Column Formatting"
-msgstr ""
+msgstr "Formatação de Colunas"
 
 #, fuzzy
 msgid "Column Settings"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Column containing ISO 3166-2 codes of region/province/department in your "
 "table."
 msgstr ""
+"Coluna que contém os códigos ISO 3166-2 de região/província/departamento "
+"na sua tabela."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing latitude data"
-msgstr ""
+msgstr "Coluna que contém dados de latitude"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing longitude data"
-msgstr ""
+msgstr "Coluna que contém dados de longitude"
 
 #, fuzzy
 msgid "Column data types"
 msgstr "Dados carregados em cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Column header tooltip"
-msgstr ""
+msgstr "Dica de ferramenta do cabeçalho de coluna"
 
 #, fuzzy
 msgid "Column is required"
@@ -3584,13 +5545,19 @@ msgstr "Origem de dados"
 msgid "Column name"
 msgstr "Colunas"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column name [%s] is duplicated"
-msgstr ""
+msgstr "O nome da coluna [%s] está duplicado"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column referenced by aggregate is undefined: %(column)s"
-msgstr ""
+msgstr "A coluna referenciada pelo agregado não está definida: %(column)s"
 
 #, fuzzy
 msgid "Column select"
@@ -3600,10 +5567,15 @@ msgstr "Coluna"
 msgid "Column to group by"
 msgstr "Um ou vários controles para agrupar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Column to use as the index of the dataframe. If None is given, Index "
 "label is used."
 msgstr ""
+"Coluna a utilizar como índice do dataframe. Se não for indicada nenhuma, "
+"é utilizado o rótulo Índice."
 
 #, fuzzy
 msgid "Column type"
@@ -3632,28 +5604,50 @@ msgstr "Adicionar Métrica"
 msgid "Columns and metrics should be inside folders"
 msgstr "Adicionar Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "A pasta de colunas só pode conter itens de coluna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
-msgstr ""
+msgstr "Colunas em falta no conjunto de dados: %(invalid_columns)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Columns missing in datasource: %(invalid_columns)s"
-msgstr ""
+msgstr "Colunas em falta na fonte de dados: %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "As colunas devem estar dentro de pastas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns subtotal position"
-msgstr ""
+msgstr "Posição do subtotal das colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to be parsed as dates"
-msgstr ""
+msgstr "Colunas a analisar como datas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Columns to calculate distribution across."
-msgstr ""
+msgstr "Colunas para calcular a distribuição."
 
 #, fuzzy
 msgid "Columns to display"
@@ -3663,76 +5657,144 @@ msgstr "Selecione uma métrica para visualizar"
 msgid "Columns to group by"
 msgstr "Um ou vários controles para agrupar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the columns"
-msgstr ""
+msgstr "Colunas para agrupar nas colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the rows"
-msgstr ""
+msgstr "Colunas para agrupar nas linhas"
 
 #, fuzzy
 msgid "Columns to read"
 msgstr "Cargos a permitir ao utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to show in the tooltip."
-msgstr ""
+msgstr "Colunas a mostrar na dica de ferramenta."
 
 #, fuzzy
 msgid "Combine metrics"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated color picks for the intervals, e.g. 1,2,4. Integers "
 "denote colors from the chosen color scheme and are 1-indexed. Length must"
 " be matching that of interval bounds."
 msgstr ""
+"Seleções de cores separadas por vírgulas para os intervalos, por exemplo,"
+" 1,2,4. Os números inteiros indicam cores do esquema de cores escolhido e"
+" são indexados a partir de 1. O comprimento deve corresponder ao dos "
+"limites do intervalo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and "
 "4-5. Last number should match the value provided for MAX."
 msgstr ""
+"Limites de intervalos separados por vírgulas, por exemplo, 2,4,5 para "
+"intervalos 0-2, 2-4 e 4-5. O último número deve corresponder ao valor "
+"fornecido para MAX."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparator option"
-msgstr ""
+msgstr "Opção de comparador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compare multiple time series charts (as sparklines) and related metrics "
 "quickly."
 msgstr ""
+"Compare rapidamente vários gráficos de séries temporais (como sparklines)"
+" e métricas relacionadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Compare results with other time periods."
-msgstr ""
+msgstr "Compare os resultados com outros períodos de tempo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Compare the same summarized metric across multiple groups."
-msgstr ""
+msgstr "Compare a mesma métrica resumida em vários grupos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compares how a metric changes over time between different groups. Each "
 "group is mapped to a row and change over time is visualized bar lengths "
 "and color."
 msgstr ""
+"Compara a forma como uma métrica muda ao longo do tempo entre diferentes "
+"grupos. Cada grupo é mapeado para uma linha e a alteração ao longo do "
+"tempo é visualizada nos comprimentos das barras e na cor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
 msgstr ""
+"Compara métricas entre diferentes períodos de tempo. Apresenta dados de "
+"séries temporais em vários períodos (como semanas ou meses) para mostrar "
+"tendências e padrões período a período."
 
 #, fuzzy
 msgid "Comparison"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparison Period Lag"
-msgstr ""
+msgstr "Atraso do Período de Comparação"
 
 #, fuzzy
 msgid "Comparison font size"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Comparison suffix"
-msgstr ""
+msgstr "Sufixo de comparação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Compose multiple layers together to form complex visuals."
-msgstr ""
+msgstr "Componha várias camadas para formar visuais complexos."
 
 msgid "Compute the contribution to the total"
 msgstr "Calcular contribuição para o total"
@@ -3749,11 +5811,19 @@ msgstr "Metadados adicionais"
 msgid "Conditional formatting"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Confidence interval"
-msgstr ""
+msgstr "Intervalo de confiança"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confidence interval must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "O intervalo de confiança deve estar entre 0 e 1 (exclusivo)"
 
 msgid "Configuration"
 msgstr "Contribuição"
@@ -3762,44 +5832,91 @@ msgstr "Contribuição"
 msgid "Configure %s"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Configure Advanced Time Range "
-msgstr ""
+msgstr "Configurar Intervalo de Tempo Avançado "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure Time Range: Current..."
-msgstr ""
+msgstr "Configurar Intervalo de Tempo: Atual..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Last..."
-msgstr ""
+msgstr "Configurar Intervalo de Tempo: Último..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Previous..."
-msgstr ""
+msgstr "Configurar Intervalo de Tempo: Anterior..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure automatic dashboard refresh"
-msgstr ""
+msgstr "Configurar a atualização automática do painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure caching and performance settings"
-msgstr ""
+msgstr "Configurar as definições de cache e desempenho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure custom time range"
-msgstr ""
+msgstr "Configurar intervalo de tempo personalizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure dashboard appearance, colors, and custom CSS"
-msgstr ""
+msgstr "Configurar a aparência, cores e CSS personalizado do painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure filter scopes"
-msgstr ""
+msgstr "Configurar os âmbitos de filtragem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure the basics of your Annotation Layer."
-msgstr ""
+msgstr "Configure os fundamentos da sua Camada de Anotação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure the chart size for each zoom level"
-msgstr ""
+msgstr "Configure o tamanho do gráfico para cada nível de zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure this dashboard to embed it into an external web application."
-msgstr ""
+msgstr "Configure este painel para o incorporar numa aplicação web externa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure your how you overlay is displayed here."
-msgstr ""
+msgstr "Configure a forma como a sua sobreposição é apresentada aqui."
 
 #, fuzzy
 msgid "Confirm"
@@ -3817,21 +5934,36 @@ msgstr "Substitua a visualização %s"
 msgid "Confirm password"
 msgstr "Mostrar Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confirm save"
-msgstr ""
+msgstr "Confirmar guardar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm the user's password"
-msgstr ""
+msgstr "Confirmar a palavra-passe do utilizador"
 
 #, fuzzy
 msgid "Connect"
 msgstr "Conexão de teste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Connect Google Sheet"
-msgstr ""
+msgstr "Ligar o Google Sheet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect Google Sheets as tables to this database"
-msgstr ""
+msgstr "Ligar as Google Sheets como tabelas a esta base de dados"
 
 #, fuzzy
 msgid "Connect a database"
@@ -3841,11 +5973,19 @@ msgstr "Selecione uma base de dados"
 msgid "Connect database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database using the dynamic form instead"
-msgstr ""
+msgstr "Ligar esta base de dados utilizando o formulário dinâmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database with a SQLAlchemy URI string instead"
-msgstr ""
+msgstr "Ligar esta base de dados com uma cadeia URI SQLAlchemy"
 
 #, fuzzy
 msgid "Connect to engine"
@@ -3854,19 +5994,28 @@ msgstr "Conexão de teste"
 msgid "Connection"
 msgstr "Conexão de teste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Connection failed, please check your connection settings"
-msgstr ""
+msgstr "Falha na ligação, verifique as configurações de ligação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Connection failed, please check your connection settings."
-msgstr ""
+msgstr "Falha na ligação, verifique as configurações de ligação."
 
 #, fuzzy
 msgid "Contains"
 msgstr "Coluna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Contém texto (ILIKE %x%)"
 
 #, fuzzy
 msgid "Content format"
@@ -3876,11 +6025,18 @@ msgstr "Formato de data e hora"
 msgid "Content type"
 msgstr "Tipo de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Continuous"
-msgstr ""
+msgstr "Contínuo"
 
 #, fuzzy
 msgid "Contours"
@@ -3893,14 +6049,25 @@ msgstr "Contribuição"
 msgid "Contribution Mode"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Control"
-msgstr ""
+msgstr "Controlo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Control labeled "
-msgstr ""
+msgstr "Controlo com etiqueta "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Controls labeled "
-msgstr ""
+msgstr "Controlos com etiqueta "
 
 #, fuzzy
 msgid "Copied to clipboard!"
@@ -3910,20 +6077,34 @@ msgstr "Copiar para área de transferência"
 msgid "Copied!"
 msgstr "Copiado!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy SELECT statement"
-msgstr ""
+msgstr "Copiar instrução SELECT"
 
 msgid "Copy SELECT statement to the clipboard"
 msgstr "Copiar a instrução SELECT para a área de transferência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy URL"
-msgstr ""
+msgstr "Copiar URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy and Paste JSON credentials"
-msgstr ""
+msgstr "Copiar e colar credenciais JSON"
 
 #, fuzzy
 msgid "Copy code to clipboard"
@@ -3947,17 +6128,30 @@ msgstr "Copiar query de partição para a área de transferência"
 msgid "Copy query link to your clipboard"
 msgstr "Copiar query de partição para a área de transferência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the current data"
-msgstr ""
+msgstr "Copiar os dados atuais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the identifier of the account you are trying to connect to."
-msgstr ""
+msgstr "Copie o identificador da conta à qual está a tentar ligar-se."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Copy the name of the HTTP Path of your cluster."
-msgstr ""
+msgstr "Copie o nome do Caminho HTTP do seu cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the name of the database you are trying to connect to."
-msgstr ""
+msgstr "Copie o nome da base de dados à qual está a tentar ligar-se."
 
 #, fuzzy
 msgid "Copy to Clipboard"
@@ -3966,11 +6160,17 @@ msgstr "Copiar para área de transferência"
 msgid "Copy to clipboard"
 msgstr "Copiar para área de transferência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy with Headers"
-msgstr ""
+msgstr "Copiar com Cabeçalhos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Corner Radius"
-msgstr ""
+msgstr "Raio do Canto"
 
 #, fuzzy
 msgid "Correlation"
@@ -3980,18 +6180,28 @@ msgstr "Descrição"
 msgid "Cost estimate"
 msgstr "Modelos CSS"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Could not connect to database: \"%(database)s\""
-msgstr ""
+msgstr "Não foi possível ligar à base de dados: \"%(database)s\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not determine datasource type"
-msgstr ""
+msgstr "Não foi possível determinar o tipo de fonte de dados"
 
 msgid "Could not fetch all saved charts"
 msgstr "Não foi possível ligar ao servidor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not find viz object"
-msgstr ""
+msgstr "Não foi possível encontrar o objeto viz"
 
 msgid "Could not load database driver"
 msgstr "Não foi possível ligar ao servidor"
@@ -4000,28 +6210,49 @@ msgstr "Não foi possível ligar ao servidor"
 msgid "Could not load database driver for: %(engine)s"
 msgstr "Não foi possível ligar ao servidor"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Could not resolve hostname: \"%(host)s\"."
-msgstr ""
+msgstr "Não foi possível resolver o nome do anfitrião: \"%(host)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Could not validate the user in the current session."
-msgstr ""
+msgstr "Não foi possível validar o utilizador na sessão atual."
 
 #, fuzzy
 msgid "Count"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Count Unique Values"
-msgstr ""
+msgstr "Contar Valores Únicos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Columns"
-msgstr ""
+msgstr "Contar como Fração de Colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Rows"
-msgstr ""
+msgstr "Contar como Fração de Linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Total"
-msgstr ""
+msgstr "Contar como Fração do Total"
 
 #, fuzzy
 msgid "Country"
@@ -4035,8 +6266,12 @@ msgstr "Esquema de cores lineares"
 msgid "Country Column"
 msgstr "Controlo de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Country Field Type"
-msgstr ""
+msgstr "Tipo de Campo País"
 
 msgid "Country Map"
 msgstr "Mapa de País"
@@ -4057,10 +6292,17 @@ msgstr "Criado em"
 msgid "Create a dataset"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
+"Crie um conjunto de dados para começar a visualizar os seus dados como um"
+" gráfico ou vá para\n"
+"          SQL Lab para consultar os seus dados."
 
 #, fuzzy
 msgid "Create a new Tag"
@@ -4088,8 +6330,12 @@ msgstr "Criado em"
 msgid "Create new chart"
 msgstr "Crie uma nova visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Create or select schema..."
-msgstr ""
+msgstr "Criar ou selecionar esquema..."
 
 msgid "Created"
 msgstr "Criado em"
@@ -4110,8 +6356,11 @@ msgstr "Criado em"
 msgid "Created on"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Creating SSH Tunnel failed for an unknown reason"
-msgstr ""
+msgstr "A criação do Túnel SSH falhou por um motivo desconhecido"
 
 msgid "Creating a data source and creating a new tab"
 msgstr "A criar uma nova origem de dados, a exibir numa nova aba"
@@ -4127,8 +6376,14 @@ msgstr "Acção"
 msgid "Cross-filter column"
 msgstr "Perfil"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
+"O filtro cruzado será aplicado a todos os gráficos que utilizam este "
+"conjunto de dados."
 
 #, fuzzy
 msgid "Cross-filtering is not enabled for this dashboard."
@@ -4150,8 +6405,12 @@ msgstr "Perfil"
 msgid "Cumulative"
 msgstr "Acção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency"
-msgstr ""
+msgstr "Moeda"
 
 #, fuzzy
 msgid "Currency code column"
@@ -4161,11 +6420,19 @@ msgstr "Formato de valor"
 msgid "Currency format"
 msgstr "Formato de valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency prefix or suffix"
-msgstr ""
+msgstr "Prefixo ou sufixo da moeda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency symbol"
-msgstr ""
+msgstr "Símbolo da moeda"
 
 #, fuzzy
 msgid "Current"
@@ -4195,39 +6462,78 @@ msgstr "Executar query"
 msgid "Current year"
 msgstr "Executar query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Currently rendered: %s"
-msgstr ""
+msgstr "Atualmente renderizado: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom"
-msgstr ""
+msgstr "Personalizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom Plugin"
-msgstr ""
+msgstr "Plugin personalizado"
 
 msgid "Custom Plugins"
 msgstr "Cláusula WHERE personalizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL"
-msgstr ""
+msgstr "SQL personalizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr ""
+"As métricas ad-hoc de SQL personalizado não estão ativadas para este "
+"conjunto de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
+"Os campos SQL personalizados não podem ser analisados como uma única "
+"instrução SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "Os campos SQL personalizados não podem conter operações de conjunto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Custom SQL fields cannot contain sub-queries."
-msgstr ""
+msgstr "Os campos SQL personalizados não podem conter subconsultas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Custom color palettes"
-msgstr ""
+msgstr "Paletas de cores personalizadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom column name (leave blank for default)"
-msgstr ""
+msgstr "Nome de coluna personalizado (deixe em branco para o valor predefinido)"
 
 #, fuzzy
 msgid "Custom conditional formatting"
@@ -4237,14 +6543,26 @@ msgstr "Metadados adicionais"
 msgid "Custom date"
 msgstr "Início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
 msgstr ""
+"Campos personalizados não disponíveis em células de mapa de calor "
+"agregadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom time filter plugin"
-msgstr ""
+msgstr "Plugin de filtro de tempo personalizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom width of the screenshot in pixels"
-msgstr ""
+msgstr "Largura personalizada da captura de ecrã em píxeis"
 
 #, fuzzy
 msgid "Custom..."
@@ -4262,103 +6580,190 @@ msgstr "Tipo de Visualização"
 msgid "Customization value is required"
 msgstr "Origem de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Customizations out of scope (%d)"
-msgstr ""
+msgstr "Personalizações fora do âmbito (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Customize"
-msgstr ""
+msgstr "Personalizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Customize Metrics"
-msgstr ""
+msgstr "Personalizar métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize cell titles using Handlebars template syntax. Available "
 "variables: {{rowLabel}}, {{colLabel}}"
 msgstr ""
+"Personalize os títulos das células utilizando a sintaxe de modelos "
+"Handlebars. Variáveis disponíveis: {{rowLabel}}, {{colLabel}}"
 
 #, fuzzy
 msgid "Customize columns"
 msgstr "Cláusula WHERE personalizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Customize data source, filters, and layout."
-msgstr ""
+msgstr "Personalize a fonte de dados, os filtros e o layout."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personalize a etiqueta apresentada para valores decrescentes nas dicas e "
+"na legenda do gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personalize a etiqueta apresentada para valores crescentes nas dicas e na"
+" legenda do gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
+"Personalize a etiqueta apresentada para os valores totais nas dicas, "
+"legenda e eixo do gráfico."
 
 #, fuzzy
 msgid "Customize tooltips template"
 msgstr "Modelos CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cyclic dependency detected"
-msgstr ""
+msgstr "Dependência cíclica detetada"
 
 #, fuzzy
 msgid "D3 format"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 format syntax: https://github.com/d3/d3-format"
-msgstr ""
+msgstr "Sintaxe do formato D3: https://github.com/d3/d3-format"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "D3 number format for numbers between -1.0 and 1.0, useful when you want "
 "to have different significant digits for small and large numbers"
 msgstr ""
+"Formato de número D3 para números entre -1,0 e 1,0, útil quando se "
+"pretende ter dígitos significativos diferentes para números pequenos e "
+"grandes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format for datetime columns"
-msgstr ""
+msgstr "Formato de hora D3 para colunas datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
-msgstr ""
+msgstr "Sintaxe do formato de hora D3: https://github.com/d3/d3-time-format"
 
 #, fuzzy
 msgid "DATETIME"
 msgstr "Formato da datahora"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "DB column %(col_name)s has unknown type: %(value_type)s"
 msgstr ""
+"A coluna da base de dados %(col_name)s tem tipo desconhecido: "
+"%(value_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "DD/MM format dates, international and European format"
-msgstr ""
+msgstr "Datas no formato DD/MM, formato internacional e europeu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DEC"
-msgstr ""
+msgstr "DEZ"
 
 msgid "DELETE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DML"
-msgstr ""
+msgstr "DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Daily seasonality"
-msgstr ""
+msgstr "Sazonalidade diária"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dark"
-msgstr ""
+msgstr "Escuro"
 
 #, fuzzy
 msgid "Dark (Carto)"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dark Cyan"
-msgstr ""
+msgstr "Ciano Escuro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dark mode"
-msgstr ""
+msgstr "Modo escuro"
 
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -4375,12 +6780,19 @@ msgstr "Dashboard"
 msgid "Dashboard Id"
 msgstr "Dashboard"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Dashboard [%s] just got created and chart [%s] was added to it"
 msgstr ""
+"O painel [%s] acabou de ser criado e o gráfico [%s] foi adicionado ao "
+"mesmo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard cannot be copied due to invalid parameters."
-msgstr ""
+msgstr "O painel não pode ser copiado devido a parâmetros inválidos."
 
 #, fuzzy
 msgid "Dashboard cannot be favorited."
@@ -4401,14 +6813,20 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Dashboard could not be deleted."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "O painel não pôde ser restaurado."
 
 msgid "Dashboard could not be updated."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dashboard does not exist"
-msgstr ""
+msgstr "O painel não existe"
 
 #, fuzzy
 msgid "Dashboard exported as example successfully"
@@ -4422,8 +6840,11 @@ msgstr "Dashboard gravado com sucesso."
 msgid "Dashboard imported"
 msgstr "[Nome do dashboard]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard name and URL configuration"
-msgstr ""
+msgstr "Configuração do nome e URL do painel"
 
 #, fuzzy
 msgid "Dashboard name is required"
@@ -4433,8 +6854,12 @@ msgstr "Origem de dados"
 msgid "Dashboard native filters could not be patched."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dashboard parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros do painel são inválidos."
 
 #, fuzzy
 msgid "Dashboard properties"
@@ -4448,12 +6873,21 @@ msgstr "Editar propriedades do dashboard"
 msgid "Dashboard scheme"
 msgstr "[Nome do dashboard]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Dashboard time range filters apply to temporal columns defined in\n"
 "          the filter section of each chart. Add temporal columns to the "
 "chart\n"
 "          filters to have this dashboard filter impact those charts."
 msgstr ""
+"Os filtros de intervalo de tempo do painel aplicam-se a colunas temporais"
+" definidas na\n"
+"          secção de filtros de cada gráfico. Adicione colunas temporais "
+"aos filtros\n"
+"          do gráfico para que este filtro do painel afete esses gráficos."
 
 #, fuzzy
 msgid "Dashboard title"
@@ -4496,11 +6930,19 @@ msgstr "Editar propriedades da visualização"
 msgid "Data Table"
 msgstr "Editar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data URI is not allowed."
-msgstr ""
+msgstr "O URI de dados não é permitido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Data Zoom"
-msgstr ""
+msgstr "Zoom de dados"
 
 #, fuzzy
 msgid "Data connection"
@@ -4510,24 +6952,39 @@ msgstr "Selecione qualquer coluna para inspeção de metadados"
 msgid "Data connections"
 msgstr "Selecione qualquer coluna para inspeção de metadados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
 "format might have changed, rendering the old data stake. You need to re-"
 "run the original query."
 msgstr ""
+"Os dados não puderam ser desserializados do backend de resultados. O "
+"formato de armazenamento pode ter mudado, tornando os dados antigos "
+"inválidos. É necessário executar novamente a consulta original."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be retrieved from the results backend. You need to re-run "
 "the original query."
 msgstr ""
+"Os dados não puderam ser obtidos do backend de resultados. É necessário "
+"executar novamente a consulta original."
 
 #, fuzzy
 msgid "Data error"
 msgstr "Expressão de base de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Data for %s"
-msgstr ""
+msgstr "Dados para %s"
 
 #, fuzzy
 msgid "Data imported"
@@ -4547,8 +7004,12 @@ msgstr "Tabela de dados"
 msgid "DataFrame include at least one series"
 msgstr "Selecione pelo menos uma métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DataFrame must include temporal column"
-msgstr ""
+msgstr "O DataFrame deve incluir uma coluna temporal"
 
 msgid "Database"
 msgstr "Base de dados"
@@ -4568,46 +7029,80 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Database could not be created."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database could not be deleted."
-msgstr ""
+msgstr "Não foi possível eliminar a base de dados."
 
 msgid "Database could not be updated."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not allow data manipulation."
-msgstr ""
+msgstr "A base de dados não permite a manipulação de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not exist"
-msgstr ""
+msgstr "A base de dados não existe"
 
 #, fuzzy
 msgid "Database does not support subqueries"
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Database driver for importing maybe not installed. Visit the Superset "
 "documentation page for installation instructions: "
 msgstr ""
+"O controlador de base de dados para importação pode não estar instalado. "
+"Visite a página de documentação do Superset para obter instruções de "
+"instalação: "
 
 #, fuzzy
 msgid "Database error"
 msgstr "Expressão de base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database is offline."
-msgstr ""
+msgstr "A base de dados está offline."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database is required for alerts"
-msgstr ""
+msgstr "A base de dados é necessária para os alertas"
 
 #, fuzzy
 msgid "Database name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database not found."
-msgstr ""
+msgstr "Base de dados não encontrada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros da base de dados são inválidos."
 
 #, fuzzy
 msgid "Database passwords"
@@ -4617,11 +7112,17 @@ msgstr "Expressão de base de dados"
 msgid "Database port"
 msgstr "Base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Database reference is not allowed on a report"
-msgstr ""
+msgstr "A referência à base de dados não é permitida num relatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database schema is not allowed for csv uploads."
-msgstr ""
+msgstr "O esquema da base de dados não é permitido para carregamentos de CSV."
 
 #, fuzzy
 msgid "Database settings updated"
@@ -4631,15 +7132,22 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Database type does not support file uploads."
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
 msgstr ""
+"O ficheiro de carregamento da base de dados excede o tamanho máximo "
+"permitido."
 
 #, fuzzy
 msgid "Database upload file failed"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database upload file failed, while saving metadata"
-msgstr ""
+msgstr "Falha no carregamento do ficheiro da base de dados ao guardar os metadados"
 
 msgid "Databases"
 msgstr "Bases de dados"
@@ -4692,27 +7200,45 @@ msgstr "Anotações"
 msgid "Dataset name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros do conjunto de dados são inválidos."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "O esquema do conjunto de dados é inválido, causado por: %(error)s"
 
 msgid "Datasets"
 msgstr "Bases de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Datasets can be created from database tables or SQL queries. Select a "
 "database table to the left or "
 msgstr ""
+"Os conjuntos de dados podem ser criados a partir de tabelas de base de "
+"dados ou consultas SQL. Selecione uma tabela de base de dados à esquerda "
+"ou "
 
 #, fuzzy
 msgid "Datasets could not be deleted."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasets do not contain a temporal column"
-msgstr ""
+msgstr "Os conjuntos de dados não contêm uma coluna temporal"
 
 msgid "Datasource"
 msgstr "Fonte de dados"
@@ -4737,8 +7263,12 @@ msgstr "Origem de dados"
 msgid "Datasource type is invalid"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasource type is required when datasource_id is given"
-msgstr ""
+msgstr "O tipo de fonte de dados é obrigatório quando datasource_id é fornecido"
 
 #, fuzzy
 msgid "Datasources"
@@ -4752,8 +7282,11 @@ msgstr "Formato de data e hora"
 msgid "Date format"
 msgstr "Formato de data e hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Date format string"
-msgstr ""
+msgstr "Cadeia de formato de data"
 
 msgid "Date/Time"
 msgstr "Formato da datahora"
@@ -4773,67 +7306,121 @@ msgstr "Formato de data e hora"
 msgid "Day"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Day (freq=D)"
-msgstr ""
+msgstr "Dia (freq=D)"
 
 #, fuzzy, python-format
 msgid "Days %s"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Db engine did not return all queried columns"
-msgstr ""
+msgstr "O motor da base de dados não devolveu todas as colunas consultadas"
 
 #, fuzzy
 msgid "Deactivate"
 msgstr "Acção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "December"
-msgstr ""
+msgstr "Dezembro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Decides which column or measure to sort the base axis by."
-msgstr ""
+msgstr "Decide por qual coluna ou medida ordenar o eixo base."
 
 #, fuzzy
 msgid "Decimal character"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D Grid"
-msgstr ""
+msgstr "Deck.gl - Grelha 3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D HEX"
-msgstr ""
+msgstr "Deck.gl - 3D HEX"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Arc"
-msgstr ""
+msgstr "Deck.gl - Arco"
 
 #, fuzzy
 msgid "Deck.gl - Contour"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - GeoJSON"
-msgstr ""
+msgstr "Deck.gl - GeoJSON"
 
 #, fuzzy
 msgid "Deck.gl - Heatmap"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Multiple Layers"
-msgstr ""
+msgstr "Deck.gl - Múltiplas Camadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Paths"
-msgstr ""
+msgstr "Deck.gl - Caminhos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Polygon"
-msgstr ""
+msgstr "Deck.gl - Polígono"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Scatter plot"
-msgstr ""
+msgstr "Deck.gl - Gráfico de Dispersão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Screen Grid"
-msgstr ""
+msgstr "Deck.gl - Grelha de Ecrã"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Deck.gl Layer Visibility"
-msgstr ""
+msgstr "Visibilidade de Camada Deck.gl"
 
 #, fuzzy
 msgid "Deckgl"
@@ -4870,10 +7457,15 @@ msgstr "Selecione um esquema (%s)"
 msgid "Default URL"
 msgstr "URL da Base de Dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# pt_BR, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
 msgstr ""
+"URL predefinido para redirecionar ao aceder a partir da página de lista "
+"de conjuntos de dados. Aceita URLs relativos como"
 
 msgid "Default Value"
 msgstr "Latitude padrão"
@@ -4902,64 +7494,138 @@ msgstr "Latitude padrão"
 msgid "Default message"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Default minimal column width in pixels, actual width may still be larger "
 "than this if other columns don't need much space"
 msgstr ""
+"Largura mínima predefinida da coluna em píxeis; a largura real pode ser "
+"superior a esta se as outras colunas não necessitarem de muito espaço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Default value must be set when \"Filter has default value\" is checked"
 msgstr ""
+"O valor predefinido deve ser definido quando \"O filtro tem valor "
+"predefinido\" está marcado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Default value must be set when \"Filter value is required\" is checked"
 msgstr ""
+"O valor predefinido deve ser definido quando \"O valor do filtro é "
+"obrigatório\" está marcado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default value set automatically when \"Select first filter value by "
 "default\" is checked"
 msgstr ""
+"O valor predefinido é definido automaticamente quando \"Selecionar o "
+"primeiro valor do filtro por predefinição\" está marcado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a function that receives the input and outputs the content for a "
 "tooltip"
 msgstr ""
+"Defina uma função que receba a entrada e produza o conteúdo para uma dica"
+" de ferramenta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Define a function that returns a URL to navigate to when user clicks"
 msgstr ""
+"Defina uma função que devolva um URL para onde navegar quando o "
+"utilizador clicar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a javascript function that receives the data array used in the "
 "visualization and is expected to return a modified version of that array."
 " This can be used to alter properties of the data, filter, or enrich the "
 "array."
 msgstr ""
+"Defina uma função javascript que receba a matriz de dados utilizada na "
+"visualização e que devolva uma versão modificada dessa matriz. Pode ser "
+"utilizada para alterar as propriedades dos dados, filtrar ou enriquecer a"
+" matriz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define color breakpoints for the data"
-msgstr ""
+msgstr "Defina pontos de quebra de cor para os dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define contour layers. Isolines represent a collection of line segments "
 "that serparate the area above and below a given threshold. Isobands "
 "represent a collection of polygons that fill the are containing values in"
 " a given threshold range."
 msgstr ""
+"Defina camadas de contorno. As isolinhas representam uma coleção de "
+"segmentos de linha que separam a área acima e abaixo de um determinado "
+"limiar. As isobandas representam uma coleção de polígonos que preenchem a"
+" área contendo valores num determinado intervalo de limiar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define delivery schedule, timezone, and frequency settings."
 msgstr ""
+"Defina o calendário de entrega, o fuso horário e as configurações de "
+"frequência."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define the database, SQL query, and triggering conditions for alert."
 msgstr ""
+"Defina a base de dados, a consulta SQL e as condições de ativação para o "
+"alerta."
 
 #, fuzzy
 msgid "Defined through system configuration."
 msgstr "Controlo de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines a rolling window function to apply, works along with the "
 "[Periods] text box"
 msgstr ""
+"Define uma função de janela deslizante a aplicar, funciona em conjunto "
+"com a caixa de texto [Períodos]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Defines the grid size in pixels"
-msgstr ""
+msgstr "Define o tamanho da grelha em píxeis"
 
 #, fuzzy
 msgid ""
@@ -4976,30 +7642,54 @@ msgstr ""
 "Define o agrupamento de entidades. Cada série corresponde a uma cor "
 "específica no gráfico e tem uma alternância de legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines the size of the rolling window function, relative to the time "
 "granularity selected"
 msgstr ""
+"Define o tamanho da função de janela deslizante, relativamente à "
+"granularidade temporal selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Defines the value that determines the boundary between different regions "
 "or levels in the data "
 msgstr ""
+"Define o valor que determina o limite entre diferentes regiões ou níveis "
+"nos dados "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines whether the step should appear at the beginning, middle or end "
 "between two data points"
 msgstr ""
+"Define se o passo deve aparecer no início, no meio ou no fim entre dois "
+"pontos de dados"
 
 #, fuzzy
 msgid "Definition"
 msgstr "descrição"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
 msgstr[0] ""
+"Atrasado (perdeu %s atualização)\n"
+"Atrasado (perdeu %s atualizações)"
 msgstr[1] ""
+"Atrasado (perdeu %s atualização)\n"
+"Atrasado (perdeu %s atualizações)"
 
 msgid "Delete"
 msgstr "Eliminar"
@@ -5062,8 +7752,12 @@ msgstr "Anotações"
 msgid "Delete dashboard tab?"
 msgstr "Por favor insira um nome para o dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete email report"
-msgstr ""
+msgstr "Eliminar relatório de e-mail"
 
 #, fuzzy
 msgid "Delete group"
@@ -5084,8 +7778,12 @@ msgstr "Carregue um modelo"
 msgid "Delete theme"
 msgstr "Carregue um modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete this container and save to remove this message."
-msgstr ""
+msgstr "Elimine este contentor e guarde para remover esta mensagem."
 
 #, fuzzy
 msgid "Delete user"
@@ -5115,17 +7813,27 @@ msgid_plural "Deleted %(num)d annotation layers"
 msgstr[0] "Selecione uma camada de anotação"
 msgstr[1] "Selecione uma camada de anotação"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d chart"
 msgid_plural "Deleted %(num)d charts"
 msgstr[0] ""
+"Eliminado %(num)d gráfico\n"
+"Eliminados %(num)d gráficos"
 msgstr[1] ""
+"Eliminado %(num)d gráfico\n"
+"Eliminados %(num)d gráficos"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d css template"
 msgid_plural "Deleted %(num)d css templates"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Eliminado %(num)d modelo CSS"
+msgstr[1] "Eliminados %(num)d modelos CSS"
 
 #, python-format
 msgid "Deleted %(num)d dashboard"
@@ -5139,29 +7847,39 @@ msgid_plural "Deleted %(num)d datasets"
 msgstr[0] "Selecione uma base de dados"
 msgstr[1] "Selecione uma base de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d report schedule"
 msgid_plural "Deleted %(num)d report schedules"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Eliminado %(num)d agendamento de relatório"
+msgstr[1] "Eliminados %(num)d agendamentos de relatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, nl, ro, ru, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid "Deleted %(num)d rules"
 msgid_plural "Deleted %(num)d rules"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Eliminada %(num)d regra"
+msgstr[1] "Eliminadas %(num)d regras"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d saved query"
 msgid_plural "Deleted %(num)d saved queries"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Eliminada %(num)d consulta guardada"
+msgstr[1] "Eliminadas %(num)d consultas guardadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
 #, fuzzy, python-format
 msgid "Deleted %(num)d semantic view"
 msgid_plural "Deleted %(num)d semantic views"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Eliminada %(num)d vista semântica"
+msgstr[1] "Eliminadas %(num)d vistas semânticas"
 
 #, fuzzy, python-format
 msgid "Deleted %(num)d theme"
@@ -5209,16 +7927,30 @@ msgstr "Eliminar"
 msgid "Deleted: %s"
 msgstr "Eliminar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Deleting a tab will remove all content within it and will deactivate any "
 "related alerts or reports. You may still reverse this action with the"
 msgstr ""
+"Eliminar um separador irá remover todo o conteúdo que contém e desativar "
+"quaisquer alertas ou relatórios relacionados. Ainda pode reverter esta "
+"ação com o"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delimited long & lat single column"
-msgstr ""
+msgstr "Coluna única de longitude e latitude delimitada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delimiter"
-msgstr ""
+msgstr "Delimitador"
 
 #, fuzzy
 msgid "Delivery method"
@@ -5228,21 +7960,33 @@ msgstr "mês"
 msgid "Density"
 msgstr "Entidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dependent on"
-msgstr ""
+msgstr "Dependente de"
 
 msgid "Description"
 msgstr "Descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description (this can be seen in the list)"
-msgstr ""
+msgstr "Descrição (pode ser vista na lista)"
 
 #, fuzzy
 msgid "Description Columns"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description text that shows up below your Big Number"
-msgstr ""
+msgstr "Texto de descrição que aparece abaixo do seu Número Grande"
 
 #, fuzzy
 msgid "Deselect all"
@@ -5252,32 +7996,63 @@ msgstr "Repor Estado"
 msgid "Design with"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Details"
-msgstr ""
+msgstr "Detalhes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Details of the certification"
-msgstr ""
+msgstr "Detalhes da certificação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Determina como o filtro corresponde aos valores. \"Correspondência "
+"exata\" utiliza o operador IN (predefinição). As opções ILIKE permitem "
+"correspondência parcial de texto com uma entrada de texto livre. Aviso: "
+"as consultas ILIKE podem ser lentas em conjuntos de dados grandes, pois "
+"não conseguem utilizar índices de forma eficaz."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Determines how whiskers and outliers are calculated."
-msgstr ""
+msgstr "Determina como os bigodes e os valores atípicos são calculados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Determines whether or not this dashboard is visible in the list of all "
 "dashboards"
-msgstr ""
+msgstr "Determina se este painel é visível ou não na lista de todos os painéis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Diamond"
-msgstr ""
+msgstr "Diamante"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Did you mean:"
-msgstr ""
+msgstr "Quis dizer:"
 
 #, fuzzy
 msgid "Difference"
@@ -5291,11 +8066,18 @@ msgstr "Granularidade Temporal"
 msgid "Dimension"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Coluna de dimensão emitida como filtro cruzado quando um elemento é "
+"clicado. Outros gráficos no painel correspondem a esta coluna. Se não "
+"definida, utiliza a coluna de geometria (comportamento legado, "
+"frequentemente sem correspondência)."
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5309,28 +8091,46 @@ msgstr "descrição"
 msgid "Dimension selection"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on x-axis."
-msgstr ""
+msgstr "Dimensão a usar no eixo x."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on y-axis."
-msgstr ""
+msgstr "Dimensão a usar no eixo y."
 
 #, fuzzy
 msgid "Dimension values"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dimensions"
-msgstr ""
+msgstr "Dimensões"
 
 #, fuzzy, python-format
 msgid "Dimensions (%s)"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Dimensions contain qualitative values such as names, dates, or "
 "geographical data. Use dimensions to categorize, segment, and reveal the "
 "details in your data. Dimensions affect the level of detail in the view."
 msgstr ""
+"As dimensões contêm valores qualitativos como nomes, datas ou dados "
+"geográficos. Use as dimensões para categorizar, segmentar e revelar os "
+"detalhes nos seus dados. As dimensões afetam o nível de detalhe na vista."
 
 msgid "Directed Force Layout"
 msgstr "Layout de Forças"
@@ -5339,27 +8139,50 @@ msgstr "Layout de Forças"
 msgid "Directional"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable SQL Lab data preview queries"
-msgstr ""
+msgstr "Desativar consultas de pré-visualização de dados do SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Disable data preview when fetching table metadata in SQL Lab.  Useful to "
 "avoid browser performance issues when using  databases with very wide "
 "tables."
 msgstr ""
+"Desativar a pré-visualização de dados ao obter metadados de tabelas no "
+"SQL Lab. Útil para evitar problemas de desempenho do navegador quando se "
+"utilizam bases de dados com tabelas muito largas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disable drill to detail"
-msgstr ""
+msgstr "Desativar exploração em detalhe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable embedding?"
-msgstr ""
+msgstr "Desativar incorporação?"
 
 #, fuzzy
 msgid "Disabled"
 msgstr "Editar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disables the drill to detail feature for this database."
 msgstr ""
+"Desativa a funcionalidade de exploração em detalhe para esta base de "
+"dados."
 
 #, fuzzy
 msgid "Discard"
@@ -5373,28 +8196,45 @@ msgstr "Nome do modelo"
 msgid "Display all"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column in the chart"
-msgstr ""
+msgstr "Mostrar coluna no gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column level subtotal"
-msgstr ""
+msgstr "Mostrar subtotal ao nível da coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display column level total"
-msgstr ""
+msgstr "Mostrar total ao nível da coluna"
 
 #, fuzzy
 msgid "Display column name"
 msgstr "Colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display configuration"
-msgstr ""
+msgstr "Configuração de visualização"
 
 #, fuzzy
 msgid "Display control configuration"
 msgstr "Controlo de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control has default value"
-msgstr ""
+msgstr "O controlo de visualização tem valor predefinido"
 
 #, fuzzy
 msgid "Display control name"
@@ -5420,69 +8260,133 @@ msgstr "Colunas"
 msgid "Display controls (%s)"
 msgstr "Colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display cumulative total at end"
-msgstr ""
+msgstr "Mostrar total cumulativo no final"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
+msgstr "Mostrar cabeçalhos para cada coluna no topo da matriz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display labels for each row on the left side of the matrix"
-msgstr ""
+msgstr "Mostrar etiquetas para cada linha no lado esquerdo da matriz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Display metrics side by side within each column, as opposed to each "
 "column being displayed side by side for each metric."
 msgstr ""
+"Mostrar as métricas lado a lado dentro de cada coluna, em vez de cada "
+"coluna ser apresentada lado a lado para cada métrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Display percents in the label and tooltip as the percent of the total "
 "value, from the first step of the funnel, or from the previous step in "
 "the funnel."
 msgstr ""
+"Mostrar as percentagens na etiqueta e na dica de ferramenta como "
+"percentagem do valor total, a partir do primeiro passo do funil, ou a "
+"partir do passo anterior no funil."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display row level subtotal"
-msgstr ""
+msgstr "Mostrar subtotal ao nível da linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display row level total"
-msgstr ""
+msgstr "Mostrar total ao nível da linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
-msgstr ""
+msgstr "Mostrar o timestamp da última consulta nos gráficos na vista do painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display type icon"
-msgstr ""
+msgstr "Mostrar ícone de tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Displays connections between entities in a graph structure. Useful for "
 "mapping relationships and showing which nodes are important in a network."
 " Graph charts can be configured to be force-directed or circulate. If "
 "your data has a geospatial component, try the deck.gl Arc chart."
 msgstr ""
+"Apresenta ligações entre entidades numa estrutura de grafo. Útil para "
+"mapear relações e mostrar quais os nós que são importantes numa rede. Os "
+"gráficos de grafo podem ser configurados para serem dirigidos por força "
+"ou circulares. Se os seus dados tiverem um componente geoespacial, "
+"experimente o gráfico Arc do deck.gl."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Distribute across"
-msgstr ""
+msgstr "Distribuir por"
 
 #, fuzzy
 msgid "Distribution"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Divider"
-msgstr ""
+msgstr "Divisor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
 msgstr ""
+"Divide cada categoria em subcategorias com base nos valores da dimensão. "
+"Pode ser usado para excluir interseções."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Do you want a donut or a pie?"
-msgstr ""
+msgstr "Quer um donut ou uma tarte?"
 
 #, fuzzy
 msgid "Documentation"
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Domain"
-msgstr ""
+msgstr "Domínio"
 
 #, fuzzy
 msgid "Don't refresh"
@@ -5500,133 +8404,263 @@ msgstr "mês"
 msgid "Dotted"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Download"
-msgstr ""
+msgstr "Descarregar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download as Image"
-msgstr ""
+msgstr "Descarregar como Imagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download as image"
-msgstr ""
+msgstr "Descarregar como imagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download is on the way"
-msgstr ""
+msgstr "O descarregamento está em curso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download to CSV"
-msgstr ""
+msgstr "Descarregar para CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Download to client"
-msgstr ""
+msgstr "Descarregar para o cliente"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Downloading %(rows)s rows based on the LIMIT configuration. If you want "
 "the entire result set, you need to adjust the LIMIT."
 msgstr ""
+"A descarregar %(rows)s linhas com base na configuração LIMIT. Se "
+"pretender o conjunto completo de resultados, deverá ajustar o LIMIT."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draft"
-msgstr ""
+msgstr "Rascunho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components and charts to the dashboard"
-msgstr ""
+msgstr "Arraste e largue componentes e gráficos para o painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components to this tab"
-msgstr ""
+msgstr "Arraste e largue componentes para este separador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
+"Arraste colunas e métricas para aqui para personalizar o conteúdo do "
+"tooltip. A ordem importa - os itens aparecem na mesma ordem nos tooltips."
+" Clique no botão para selecionar manualmente colunas e métricas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Arraste para reordenar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw a marker on data points. Only applicable for line types."
 msgstr ""
+"Desenhar um marcador nos pontos de dados. Aplicável apenas para tipos de "
+"linha."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw area under curves. Only applicable for line types."
-msgstr ""
+msgstr "Desenhar área sob curvas. Aplicável apenas para tipos de linha."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw line from Pie to label when labels outside?"
 msgstr ""
+"Desenhar linha do Gráfico Circular para a etiqueta quando as etiquetas "
+"estão fora?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Draw split lines for minor axis ticks"
-msgstr ""
+msgstr "Desenhar linhas de divisão para as marcas do eixo secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw split lines for minor y-axis ticks"
-msgstr ""
+msgstr "Desenhar linhas de divisão para as marcas secundárias do eixo y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by"
-msgstr ""
+msgstr "Drill by"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not available for this data point"
-msgstr ""
+msgstr "Drill by não está disponível para este ponto de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not yet supported for this chart type"
-msgstr ""
+msgstr "Drill by ainda não é suportado para este tipo de gráfico"
 
 #, fuzzy, python-format
 msgid "Drill by: %s"
 msgstr "Ordenar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail"
-msgstr ""
+msgstr "Drill to detail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by"
-msgstr ""
+msgstr "Drill to detail por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by value is not yet supported for this chart type."
-msgstr ""
+msgstr "Drill to detail por valor ainda não é suportado para este tipo de gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled because this chart does not group data by "
 "dimension value."
 msgstr ""
+"Drill to detail está desativado porque este gráfico não agrupa dados por "
+"valor de dimensão."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled for this database. Change the database "
 "settings to enable it."
 msgstr ""
+"Drill to detail está desativado para esta base de dados. Altere as "
+"definições da base de dados para o ativar."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Drill to detail: %s"
-msgstr ""
+msgstr "Drill to detail: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column here or click"
 msgid_plural "Drop columns here or click"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Largar uma coluna aqui ou clicar"
+msgstr[1] "Largar colunas aqui ou clicar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column/metric here or click"
 msgid_plural "Drop columns/metrics here or click"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Largar uma coluna/métrica aqui ou clicar"
+msgstr[1] "Largar colunas/métricas aqui ou clicar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Drop a temporal column here or click"
-msgstr ""
+msgstr "Largar uma coluna temporal aqui ou clicar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drop columns/metrics here or click"
-msgstr ""
+msgstr "Largar colunas/métricas aqui ou clicar"
 
 #, fuzzy
 msgid "Dttm"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplicar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Duplicate column name(s): %(columns)s"
-msgstr ""
+msgstr "Nome(s) de coluna duplicado(s): %(columns)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Duplicate column/metric labels: %(labels)s. Please make sure all columns "
 "and metrics have a unique label."
 msgstr ""
+"Etiquetas de coluna/métrica duplicadas: %(labels)s. Certifique-se de que "
+"todas as colunas e métricas têm uma etiqueta única."
 
 #, fuzzy
 msgid "Duplicate dataset"
@@ -5640,21 +8674,34 @@ msgstr "Editar Base de Dados"
 msgid "Duplicate role"
 msgstr "Editar Base de Dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Duplicate role %(name)s"
-msgstr ""
+msgstr "Duplicar função %(name)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duplicate tab"
-msgstr ""
+msgstr "Duplicar separador"
 
 msgid "Duration"
 msgstr "Descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the caching timeout for charts of this database."
 " A timeout of 0 indicates that the cache never expires, and -1 bypasses "
 "the cache. Note this defaults to the global timeout if undefined."
 msgstr ""
+"Duração (em segundos) do tempo limite de cache para os gráficos desta "
+"base de dados. Um tempo limite de 0 indica que a cache nunca expira, e -1"
+" contorna a cache. Tenha em conta que o padrão é o tempo limite global se"
+" não estiver definido."
 
 #, fuzzy
 msgid ""
@@ -5679,27 +8726,47 @@ msgstr "Duração (em segundos) do tempo limite da cache para esta visualizaçã
 msgid "Duration Ms"
 msgstr "Descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (1.40008 => 1ms 400µs 80ns)"
-msgstr ""
+msgstr "Duração em ms (1,40008 => 1ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duration in ms (100.40008 => 100ms 400µs 80ns)"
-msgstr ""
+msgstr "Duração em ms (100,40008 => 100ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Duration in ms (10500 => 0:00:10.5)"
-msgstr ""
+msgstr "Duração em ms (10500 => 0:00:10.5)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (66000 => 1m 6s)"
-msgstr ""
+msgstr "Duração em ms (66000 => 1m 6s)"
 
 #, fuzzy
 msgid "Duration in seconds"
 msgstr "10 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "Dinâmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic Aggregation Function"
-msgstr ""
+msgstr "Função de Agregação Dinâmica"
 
 #, fuzzy
 msgid "Dynamic Section Label"
@@ -5713,18 +8780,28 @@ msgstr "Agrupar por"
 msgid "Dynamic section description"
 msgstr "Alternar descrição do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dynamically search all filter values"
-msgstr ""
+msgstr "Pesquisar dinamicamente todos os valores do filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "Selecionar dinamicamente colunas de agrupamento de um conjunto de dados"
 
 #, fuzzy
 msgid "ECharts"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "Opções ECharts (literais de objeto JS)"
 
 msgid "EMAIL_REPORTS_CTA"
 msgstr ""
@@ -5733,14 +8810,26 @@ msgstr ""
 msgid "ERROR"
 msgstr "Erro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length"
-msgstr ""
+msgstr "Comprimento da aresta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length between nodes"
-msgstr ""
+msgstr "Comprimento da aresta entre nós"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge symbols"
-msgstr ""
+msgstr "Símbolos de aresta"
 
 #, fuzzy
 msgid "Edge width"
@@ -5824,11 +8913,19 @@ msgstr "Editar Dashboard"
 msgid "Edit database"
 msgstr "Editar Base de Dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit email report"
-msgstr ""
+msgstr "Editar relatório de e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit formatter"
-msgstr ""
+msgstr "Editar formatador"
 
 #, fuzzy
 msgid "Edit group"
@@ -5863,8 +8960,12 @@ msgstr "Adicionar ao novo dashboard"
 msgid "Edit theme properties"
 msgstr "Editar propriedades da visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit time range"
-msgstr ""
+msgstr "Editar intervalo de tempo"
 
 #, fuzzy
 msgid "Edit user"
@@ -5873,24 +8974,44 @@ msgstr "Query vazia?"
 msgid "Edited"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Editing 1 filter:"
-msgstr ""
+msgstr "A editar 1 filtro:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the database is spelled incorrectly or does not exist."
-msgstr ""
+msgstr "O nome da base de dados está incorreto ou não existe."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Either the username \"%(username)s\" or the password is incorrect."
-msgstr ""
+msgstr "O nome de utilizador \"%(username)s\" ou a palavra-passe estão incorretos."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Either the username \"%(username)s\", password, or database name "
 "\"%(database)s\" is incorrect."
 msgstr ""
+"O nome de utilizador \"%(username)s\", a palavra-passe ou o nome da base "
+"de dados \"%(database)s\" estão incorretos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the username or the password is wrong."
-msgstr ""
+msgstr "O nome de utilizador ou a palavra-passe estão incorretos."
 
 #, fuzzy
 msgid "Elapsed"
@@ -5900,27 +9021,47 @@ msgstr "Criado em"
 msgid "Elevation"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #, fuzzy
 msgid "Email is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email link"
-msgstr ""
+msgstr "Ligação de e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Email reports active"
-msgstr ""
+msgstr "Relatórios por e-mail ativos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Email subject name (optional)"
-msgstr ""
+msgstr "Nome do assunto do e-mail (opcional)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Embed"
-msgstr ""
+msgstr "Incorporar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Embed code"
-msgstr ""
+msgstr "Código de incorporação"
 
 #, fuzzy
 msgid "Embed dashboard"
@@ -5930,14 +9071,26 @@ msgstr "Dashboard"
 msgid "Embedded dashboard could not be deleted."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Embedding deactivated."
-msgstr ""
+msgstr "Incorporação desativada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Emphasis"
-msgstr ""
+msgstr "Ênfase"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty circle"
-msgstr ""
+msgstr "Círculo vazio"
 
 #, fuzzy
 msgid "Empty collection"
@@ -5954,95 +9107,189 @@ msgstr "Query vazia?"
 msgid "Empty query?"
 msgstr "Query vazia?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty row"
-msgstr ""
+msgstr "Linha vazia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr ""
+"Ativar 'Permitir carregamento de ficheiros para a base de dados' nas "
+"definições de qualquer base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable Matrixify"
-msgstr ""
+msgstr "Ativar Matrixify"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable cross-filtering"
-msgstr ""
+msgstr "Ativar filtragem cruzada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable data zooming controls"
-msgstr ""
+msgstr "Ativar controlos de zoom de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Enable embedding"
-msgstr ""
+msgstr "Ativar incorporação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecast"
-msgstr ""
+msgstr "Ativar previsão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecasting"
-msgstr ""
+msgstr "Ativar previsão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable graph roaming"
-msgstr ""
+msgstr "Ativar deslocamento do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "Ativar modo JavaScript de ícone"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "Ativar modo JavaScript de etiqueta"
 
 #, fuzzy
 msgid "Enable labels"
 msgstr "Etiquetas de marcadores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "Ativar matrixify"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable node dragging"
-msgstr ""
+msgstr "Ativar arrastamento de nós"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable query cost estimation"
-msgstr ""
+msgstr "Ativar estimativa de custo de consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable row expansion in schemas"
-msgstr ""
+msgstr "Ativar expansão de linhas em esquemas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr ""
+"Ativar a paginação de resultados do lado do servidor (funcionalidade "
+"experimental)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "Permite a configuração personalizada de ícones via JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "Permite a configuração personalizada de etiquetas via JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "Permite a renderização de ícones para pontos GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "Permite a renderização de etiquetas para pontos GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Encountered invalid NULL spatial entry,"
 "                                        please consider filtering those "
 "out"
 msgstr ""
+"Foi encontrada uma entrada espacial NULL inválida,"
+"                                        considere filtrá-la"
 
 #, fuzzy
 msgid "Encrypted extra fields"
 msgstr "query partilhada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "End"
-msgstr ""
+msgstr "Fim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (Longitude, Latitude): "
-msgstr ""
+msgstr "Fim (Longitude, Latitude): "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (exclusive)"
-msgstr ""
+msgstr "Fim (exclusivo)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End Longitude & Latitude"
-msgstr ""
+msgstr "Longitude e Latitude Finais"
 
 #, fuzzy
 msgid "End Time"
@@ -6052,11 +9299,18 @@ msgstr "Fim"
 msgid "End angle"
 msgstr "Granularidade Temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End date"
-msgstr ""
+msgstr "Data de fim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "End date excluded from time range"
-msgstr ""
+msgstr "Data de fim excluída do intervalo de tempo"
 
 msgid "End date must be after start date"
 msgstr "Data de inicio não pode ser posterior à data de fim"
@@ -6069,24 +9323,40 @@ msgstr "Largura"
 msgid "Ends with (ILIKE %x)"
 msgstr "Largura"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
-msgstr ""
+msgstr "O motor \"%(engine)s\" não pode ser configurado através de parâmetros."
 
 #, fuzzy
 msgid "Engine Parameters"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Engine spec \"InvalidEngine\" does not support being configured via "
 "individual parameters."
 msgstr ""
+"A especificação do motor \"InvalidEngine\" não suporta configuração "
+"através de parâmetros individuais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter CA_BUNDLE"
-msgstr ""
+msgstr "Introduzir CA_BUNDLE"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter Primary Credentials"
-msgstr ""
+msgstr "Introduzir Credenciais Primárias"
 
 #, fuzzy
 msgid "Enter a name for this sheet"
@@ -6107,11 +9377,18 @@ msgstr "Tipo de gráfico"
 msgid "Enter duration in seconds"
 msgstr "10 segundos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter fullscreen"
-msgstr ""
+msgstr "Entrar em ecrã completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "Introduza os valores mínimo e máximo para o filtro de intervalo"
 
 #, fuzzy
 msgid "Enter report name"
@@ -6129,15 +9406,24 @@ msgstr "Tipo de gráfico"
 msgid "Enter the group's name"
 msgstr "Tipo de gráfico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Enter the required %(dbModelName)s credentials"
-msgstr ""
+msgstr "Introduza as credenciais %(dbModelName)s necessárias"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the unique project id for your database."
-msgstr ""
+msgstr "Introduza o id de projeto único para a sua base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's email"
-msgstr ""
+msgstr "Introduza o e-mail do utilizador"
 
 #, fuzzy
 msgid "Enter the user's first name"
@@ -6151,27 +9437,44 @@ msgstr "Tipo de gráfico"
 msgid "Enter the user's password"
 msgstr "Tipo de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's username"
-msgstr ""
+msgstr "Introduza o nome de utilizador do utilizador"
 
 #, fuzzy
 msgid "Enter theme name"
 msgstr "Tipo de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter your login and password below:"
-msgstr ""
+msgstr "Introduza o seu login e palavra-passe abaixo:"
 
 msgid "Entity"
 msgstr "Entidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal Date Sizes"
-msgstr ""
+msgstr "Tamanhos de datas iguais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal to (=)"
-msgstr ""
+msgstr "Igual a (=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Equals"
-msgstr ""
+msgstr "Igual"
 
 #, fuzzy
 msgid "Error"
@@ -6185,9 +9488,11 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "Error deleting %s"
 msgstr "O carregamento de dados falhou"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Erro ao desativar o ecrã inteiro: %s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6205,46 +9510,75 @@ msgstr "Ocorreu um erro ao criar a origem dos dados"
 msgid "Error fetching charts"
 msgstr "O carregamento de dados falhou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error importing theme."
-msgstr ""
+msgstr "Erro ao importar o tema."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in RLS filters: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja nos filtros RLS: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in WHERE clause: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja na cláusula WHERE: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja na coluna ad hoc: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja na expressão de coluna: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in datetime column: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja na coluna de data/hora: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in fetch values predicate: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja no predicado de obtenção de valores: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in metric expression: %(msg)s"
-msgstr ""
+msgstr "Erro na expressão jinja na expressão de métrica: %(msg)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Error loading chart datasources. Filters may not work correctly."
 msgstr ""
+"Erro ao carregar as fontes de dados do gráfico. Os filtros podem não "
+"funcionar corretamente."
 
 #, fuzzy
 msgid "Error message"
 msgstr "Mensagem de Aviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error parsing"
-msgstr ""
+msgstr "Erro de análise"
 
 #, fuzzy
 msgid "Error reading CSV file"
@@ -6254,8 +9588,11 @@ msgstr "Ocorreu um erro ao criar a origem dos dados"
 msgid "Error reading Columnar file"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Error reading Excel file"
-msgstr ""
+msgstr "Erro ao ler o ficheiro Excel"
 
 #, fuzzy
 msgid "Error saving dataset"
@@ -6285,30 +9622,47 @@ msgstr "O carregamento de dados falhou"
 msgid "Error while rendering virtual dataset query: %(msg)s"
 msgstr "Erro ao carregar a lista de base de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(error)s"
-msgstr ""
+msgstr "Erro: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(msg)s"
-msgstr ""
+msgstr "Erro: %(msg)s"
 
 #, fuzzy, python-format
 msgid "Error: %s"
 msgstr "Erro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error: permalink state not found"
-msgstr ""
+msgstr "Erro: estado do permalink não encontrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate cost"
-msgstr ""
+msgstr "Estimar custo"
 
 #, fuzzy
 msgid "Estimate selected query cost"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate the cost before running a query"
-msgstr ""
+msgstr "Estimar o custo antes de executar uma consulta"
 
 #, fuzzy
 msgid "Event"
@@ -6321,23 +9675,46 @@ msgstr "Fluxo de eventos"
 msgid "Event time column"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Every"
-msgstr ""
+msgstr "Cada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Evolution"
-msgstr ""
+msgstr "Evolução"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exact"
-msgstr ""
+msgstr "Exato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Correspondência exata (IN)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Example"
-msgstr ""
+msgstr "Exemplo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Examples"
-msgstr ""
+msgstr "Exemplos"
 
 #, fuzzy
 msgid "Excel Export"
@@ -6347,17 +9724,30 @@ msgstr "Janela de exibição"
 msgid "Excel XML Export"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excel file format cannot be determined"
-msgstr ""
+msgstr "O formato do ficheiro Excel não pode ser determinado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Excel upload"
-msgstr ""
+msgstr "Carregamento de Excel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exclude selected values"
-msgstr ""
+msgstr "Excluir valores selecionados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excluded roles"
-msgstr ""
+msgstr "Funções excluídas"
 
 #, fuzzy
 msgid "Executed SQL"
@@ -6374,41 +9764,74 @@ msgstr "Registo de Acções"
 msgid "Execution log"
 msgstr "Registo de Acções"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Existing dataset"
-msgstr ""
+msgstr "Conjunto de dados existente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Exit fullscreen"
-msgstr ""
+msgstr "Sair do ecrã inteiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand"
-msgstr ""
+msgstr "Expandir"
 
 #, fuzzy
 msgid "Expand All"
 msgstr "expandir barra de ferramentas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand all"
-msgstr ""
+msgstr "Expandir tudo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand data panel"
-msgstr ""
+msgstr "Expandir painel de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand row"
-msgstr ""
+msgstr "Expandir linha"
 
 #, fuzzy
 msgid "Expand row to edit"
 msgstr "Cargos a permitir ao utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
 "        in milliseconds since epoch. mathjs is used to evaluate the "
 "formulas.\n"
 "        Example: '2x+5'"
 msgstr ""
+"Espera uma fórmula com o parâmetro de tempo dependente 'x'\n"
+"        em milissegundos desde a época. mathjs é utilizado para avaliar "
+"as fórmulas.\n"
+"        Exemplo: '2x+5'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Experimental"
-msgstr ""
+msgstr "Experimental"
 
 #, fuzzy
 msgid "Expired"
@@ -6417,12 +9840,19 @@ msgstr "Explorar gráfico"
 msgid "Explore"
 msgstr "Explorar gráfico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Explore - %(table)s"
-msgstr ""
+msgstr "Explorar - %(table)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Explore the result set in the data exploration view"
-msgstr ""
+msgstr "Explorar o conjunto de resultados na vista de exploração de dados"
 
 msgid "Export"
 msgstr "Exportar"
@@ -6454,15 +9884,21 @@ msgstr "Exportar dashboards?"
 msgid "Export failed"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export failed - please try again"
-msgstr ""
+msgstr "Exportação falhada - tente novamente"
 
 #, fuzzy, python-format
 msgid "Export failed: %s"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "Exportar captura de ecrã (jpeg)"
 
 #, fuzzy, python-format
 msgid "Export successful: %s"
@@ -6504,15 +9940,23 @@ msgstr "Exportar para o formato .csv"
 msgid "Export to full Excel"
 msgstr "Exportar para .json"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Export to original .CSV"
-msgstr ""
+msgstr "Exportar para .CSV original"
 
 #, fuzzy
 msgid "Export to pivoted .CSV"
 msgstr "Exportar para o formato .csv"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expose database in SQL Lab"
-msgstr ""
+msgstr "Expor base de dados no SQL Lab"
 
 msgid "Expose in SQL Lab"
 msgstr "Expor no SQL Lab"
@@ -6521,8 +9965,11 @@ msgstr "Expor no SQL Lab"
 msgid "Expression"
 msgstr "Expressão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Expression cannot be empty"
-msgstr ""
+msgstr "A expressão não pode estar vazia"
 
 #, fuzzy
 msgid "Extensions"
@@ -6532,73 +9979,132 @@ msgstr "descrição"
 msgid "Extent"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Aviso de ligação externa"
 
 msgid "Extra"
 msgstr "Extra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra Controls"
-msgstr ""
+msgstr "Controlos extra"
 
 #, fuzzy
 msgid "Extra Parameters"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra data for JS"
-msgstr ""
+msgstr "Dados extra para JS"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "Extra data to specify table metadata. Currently supports metadata of the "
 "format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\","
 " \"details\": \"This table is the source of truth.\" }, "
 "\"warning_markdown\": \"This is a warning.\" }`."
 msgstr ""
+"Dados extra para especificar metadados de tabela. Suporta atualmente "
+"metadados do formato: `{ \"certification\": { \"certified_by\": \"Data "
+"Platform Team\", \"details\": \"This table is the source of truth.\" }, "
+"\"warning_markdown\": \"This is a warning.\" }`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra parameters for use in jinja templated queries"
-msgstr ""
+msgstr "Parâmetros extra para utilização em consultas de modelo jinja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Extra parameters that any plugins can choose to set for use in Jinja "
 "templated queries"
 msgstr ""
+"Parâmetros extra que qualquer plugin pode definir para uso em consultas "
+"com modelo Jinja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Extra url parameters for use in Jinja templated queries"
-msgstr ""
+msgstr "Parâmetros de url extra para utilização em consultas de modelo Jinja"
 
 #, fuzzy
 msgid "Extruded"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FEB"
-msgstr ""
+msgstr "FEV"
 
 #, fuzzy
 msgid "FIT DATA"
 msgstr "Editar Base de Dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Ajustar dados"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FRI"
-msgstr ""
+msgstr "SEX"
 
 #, fuzzy
 msgid "Factor"
 msgstr "Criador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Factor to multiply the metric by"
-msgstr ""
+msgstr "Fator pelo qual multiplicar a métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fail login count"
-msgstr ""
+msgstr "Contagem de falhas de login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed"
-msgstr ""
+msgstr "Falhou"
 
 msgid "Failed at retrieving results"
 msgstr "O carregamento dos resultados a partir do backend falhou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to apply theme: Invalid JSON"
-msgstr ""
+msgstr "Falha ao aplicar o tema: JSON inválido"
 
 #, fuzzy
 msgid "Failed to copy API key to clipboard"
@@ -6612,29 +10118,49 @@ msgstr "Copiar para área de transferência"
 msgid "Failed to create API key"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to create report"
-msgstr ""
+msgstr "Falha ao criar relatório"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Failed to execute %(query)s"
-msgstr ""
+msgstr "Falha ao executar %(query)s"
 
 #, fuzzy
 msgid "Failed to fetch API keys"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to generate chart edit URL"
-msgstr ""
+msgstr "Falha ao gerar URL de edição de gráfico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "Falha ao gerar download: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data"
-msgstr ""
+msgstr "Falha ao carregar dados do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data."
-msgstr ""
+msgstr "Falha ao carregar dados do gráfico."
 
 #, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
@@ -6644,16 +10170,23 @@ msgstr "Selecione uma base de dados"
 msgid "Failed to load top values"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "Falha ao abrir o ficheiro. Por favor, tente novamente."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr ""
+msgstr "Falha ao remover o tema escuro do sistema: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system default theme: %s"
-msgstr ""
+msgstr "Falha ao remover o tema predefinido do sistema: %s"
 
 #, fuzzy
 msgid "Failed to retrieve advanced type"
@@ -6663,53 +10196,86 @@ msgstr "O carregamento dos resultados a partir do backend falhou"
 msgid "Failed to revoke API key"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to save chart customization"
-msgstr ""
+msgstr "Falha ao guardar a personalização do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to save cross-filter scoping"
-msgstr ""
+msgstr "Falha ao guardar o âmbito do filtro cruzado"
 
 #, fuzzy
 msgid "Failed to save cross-filters setting"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to set local theme: Invalid JSON configuration"
-msgstr ""
+msgstr "Falha ao definir o tema local: Configuração JSON inválida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system dark theme: %s"
-msgstr ""
+msgstr "Falha ao definir o tema escuro do sistema: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system default theme: %s"
-msgstr ""
+msgstr "Falha ao definir o tema predefinido do sistema: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to start remote query on a worker."
-msgstr ""
+msgstr "Falha ao iniciar a consulta remota num worker."
 
 #, fuzzy
 msgid "Failed to stop query."
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to store query results. Please try again."
-msgstr ""
+msgstr "Falha ao guardar os resultados da consulta. Por favor, tente novamente."
 
 #, fuzzy
 msgid "Failed to tag items"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to update report"
-msgstr ""
+msgstr "Falha ao atualizar relatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to validate expression. Please try again."
-msgstr ""
+msgstr "Falha ao validar a expressão. Por favor, tente novamente."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Failed to verify select options: %s"
-msgstr ""
+msgstr "Falha ao verificar opções selecionadas: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
-msgstr ""
+msgstr "Voltando ao CSV; biblioteca de exportação para Excel não disponível."
 
 #, fuzzy
 msgid "False"
@@ -6718,75 +10284,123 @@ msgstr "Perfil"
 msgid "Favorite"
 msgstr "Favoritos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Feature Not Enabled"
-msgstr ""
+msgstr "Funcionalidade não ativada"
 
 #, fuzzy
 msgid "Featured"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Featured color palettes"
-msgstr ""
+msgstr "Paletas de cores em destaque"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "February"
-msgstr ""
+msgstr "Fevereiro"
 
 msgid "Fetch data preview"
 msgstr "Obter pré-visualização de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Fetched %s"
-msgstr ""
+msgstr "Obtido %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fetching"
-msgstr ""
+msgstr "A obter"
 
 #, fuzzy
 msgid "Fetching data..."
 msgstr "Editar Base de Dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(json_error)s"
-msgstr ""
+msgstr "O campo não pode ser descodificado por JSON. %(json_error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(msg)s"
-msgstr ""
+msgstr "O campo não pode ser descodificado por JSON. %(msg)s"
 
 #, fuzzy
 msgid "Field cannot be empty."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Field is required"
-msgstr ""
+msgstr "O campo é obrigatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "File extension is not allowed."
-msgstr ""
+msgstr "A extensão do ficheiro não é permitida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
 msgstr ""
+"O processamento de ficheiros não é suportado neste navegador. Por favor, "
+"utilize um navegador moderno como o Chrome ou o Edge."
 
 #, fuzzy
 msgid "File settings"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "File upload"
-msgstr ""
+msgstr "Carregamento de ficheiro"
 
 #, fuzzy
 msgid "Fill Color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fill all required fields to enable \"Default Value\""
-msgstr ""
+msgstr "Preencha todos os campos obrigatórios para ativar \"Valor Predefinido\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fill method"
-msgstr ""
+msgstr "Método de preenchimento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill out the registration form"
-msgstr ""
+msgstr "Preencha o formulário de registo"
 
 #, fuzzy
 msgid "Filled"
@@ -6811,8 +10425,12 @@ msgstr "Valor de filtro"
 msgid "Filter charts"
 msgstr "Controlo de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter has default value"
-msgstr ""
+msgstr "O filtro tem valor predefinido"
 
 #, fuzzy
 msgid "Filter menu"
@@ -6822,8 +10440,14 @@ msgstr "Valor de filtro"
 msgid "Filter name"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Filter only displays values relevant to selections made in other filters."
 msgstr ""
+"O filtro apresenta apenas valores relevantes para as seleções feitas "
+"noutros filtros."
 
 #, fuzzy
 msgid "Filter options"
@@ -6837,15 +10461,23 @@ msgstr "Procurar Resultados"
 msgid "Filter type"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value (case sensitive)"
-msgstr ""
+msgstr "Valor do filtro (sensível a maiúsculas/minúsculas)"
 
 #, fuzzy
 msgid "Filter value is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value list cannot be empty"
-msgstr ""
+msgstr "A lista de valores do filtro não pode estar vazia"
 
 msgid "Filter your charts"
 msgstr "Controlo de filtro"
@@ -6865,22 +10497,42 @@ msgstr "Controlo de filtro"
 msgid "Filters by metrics"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Filters for comparison must have a value"
-msgstr ""
+msgstr "Os filtros para comparação devem ter um valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values equal to this exact value."
-msgstr ""
+msgstr "Filtros para valores iguais a este valor exato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values greater than or equal."
-msgstr ""
+msgstr "Filtros para valores maiores ou iguais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values less than or equal."
-msgstr ""
+msgstr "Filtros para valores menores ou iguais."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Filters out of scope (%d)"
-msgstr ""
+msgstr "Filtros fora do âmbito (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Filters with the same group key will be ORed together within the group, "
 "while different filter groups will be ANDed together. Undefined group "
@@ -6891,16 +10543,32 @@ msgid ""
 "filter (department = 'Finance' OR department = 'Marketing') AND (region ="
 " 'Europe')."
 msgstr ""
+"Os filtros com a mesma chave de grupo serão combinados com OR dentro do "
+"grupo, enquanto grupos de filtros diferentes serão combinados com AND. As"
+" chaves de grupo indefinidas são tratadas como grupos únicos, ou seja, "
+"não são agrupadas em conjunto. Por exemplo, se uma tabela tiver três "
+"filtros, dos quais dois são para os departamentos Finance e Marketing "
+"(chave de grupo = 'department') e um se refere à região Europe (chave de "
+"grupo = 'region'), a cláusula de filtro aplicaria o filtro (department = "
+"'Finance' OR department = 'Marketing') AND (region = 'Europe')."
 
 #, fuzzy
 msgid "Find"
 msgstr "Mín"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Finish"
-msgstr ""
+msgstr "Finalizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "First"
-msgstr ""
+msgstr "Primeiro"
 
 #, fuzzy
 msgid "First Name"
@@ -6918,13 +10586,23 @@ msgstr "Origem de dados"
 msgid "Fit columns dynamically"
 msgstr "Ordenar colunas por ordem alfabética"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Fix the trend line to the full time range specified in case filtered "
 "results do not include the start or end dates"
 msgstr ""
+"Fixar a linha de tendência ao intervalo de tempo completo especificado "
+"caso os resultados filtrados não incluam as datas de início ou fim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fix to selected Time Range"
-msgstr ""
+msgstr "Fixar ao Intervalo de Tempo selecionado"
 
 #, fuzzy
 msgid "Fixed"
@@ -6937,72 +10615,146 @@ msgstr "Selecione uma cor"
 msgid "Fixed color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Fixed point radius"
-msgstr ""
+msgstr "Raio do ponto fixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Flow"
-msgstr ""
+msgstr "Fluxo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Folder with content must have a name"
-msgstr ""
+msgstr "A pasta com conteúdo deve ter um nome"
 
 #, fuzzy
 msgid "Folders"
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size"
-msgstr ""
+msgstr "Tamanho da fonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for axis labels, detail value and other text elements"
 msgstr ""
+"Tamanho da fonte para etiquetas de eixo, valor de detalhe e outros "
+"elementos de texto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the biggest value in the list"
-msgstr ""
+msgstr "Tamanho da fonte para o maior valor na lista"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the smallest value in the list"
-msgstr ""
+msgstr "Tamanho da fonte para o menor valor na lista"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For Bigquery, Presto and Postgres, shows a button to compute cost before "
 "running a query."
 msgstr ""
+"Para o Bigquery, Presto e Postgres, mostra um botão para calcular o custo"
+" antes de executar uma consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "For Trino, describe full schemas of nested ROW types, expanding them with"
 " dotted paths"
 msgstr ""
+"Para o Trino, descreve os esquemas completos dos tipos ROW aninhados, "
+"expandindo-os com caminhos com pontos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "For further instructions, consult the"
-msgstr ""
+msgstr "Para mais instruções, consulte o"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For more information about objects are in context in the scope of this "
 "function, refer to the"
 msgstr ""
+"Para mais informações sobre os objetos que estão em contexto no âmbito "
+"desta função, consulte o"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For regular filters, these are the roles this filter will be applied to. "
 "For base filters, these are the roles that the filter DOES NOT apply to, "
 "e.g. Admin if admin should see all data."
 msgstr ""
+"Para filtros regulares, estas são as funções às quais este filtro será "
+"aplicado. Para filtros base, estas são as funções às quais o filtro NÃO "
+"se aplica, por exemplo, Admin se o administrador tiver de ver todos os "
+"dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forbidden"
-msgstr ""
+msgstr "Proibido"
 
 #, fuzzy
 msgid "Force"
 msgstr "Fonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "Forçar o Grão de Tempo como Intervalo Máximo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Forçar cancelamento (interrompe a tarefa para todos os subscritores)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
 "CTAS or CVAS in SQL Lab."
 msgstr ""
+"Forçar a criação de todas as tabelas e vistas neste esquema ao clicar em "
+"CTAS ou CVAS no SQL Lab."
 
 #, fuzzy
 msgid "Force categorical"
@@ -7029,24 +10781,49 @@ msgstr "Forçar atualização de dados"
 msgid "Force refresh table list"
 msgstr "Forçar atualização de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
 msgstr ""
+"Força o Grão de Tempo selecionado como o intervalo máximo para as "
+"Etiquetas do Eixo X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Forecast periods"
-msgstr ""
+msgstr "Períodos de previsão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Foreign key"
-msgstr ""
+msgstr "Chave estrangeira"
 
 #, fuzzy
 msgid "Forest Green"
 msgstr "Cargos a permitir ao utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to chart metadata."
 msgstr ""
+"Dados do formulário não encontrados na cache, a reverter para os "
+"metadados do gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr ""
+"Dados do formulário não encontrados na cache, a reverter para os "
+"metadados do conjunto de dados."
 
 #, fuzzy
 msgid "Format"
@@ -7064,31 +10841,57 @@ msgstr "Formato D3"
 msgid "Format SQL query"
 msgstr "Formato D3"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "Format data labels. Use variables: {name}, {value}, {percent}. \\n "
 "represents a new line. ECharts compatibility:\n"
 "{a} (series), {b} (name), {c} (value), {d} (percentage)"
 msgstr ""
+"Formatar etiquetas de dados. Utilize variáveis: {name}, {value}, "
+"{percent}. \\n representa uma nova linha. Compatibilidade ECharts:\n"
+"{a} (série), {b} (nome), {c} (valor), {d} (percentagem)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"Formate métricas ou colunas com símbolos de moeda como prefixos ou "
+"sufixos. Escolha um símbolo manualmente ou utilize 'Auto-detect' para "
+"aplicar o símbolo correto com base na coluna de código de moeda do "
+"conjunto de dados. Quando estão presentes várias moedas, a formatação "
+"recorre a números neutros."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Formatted CSV attached in email"
-msgstr ""
+msgstr "CSV formatado anexado no e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Formatted date"
-msgstr ""
+msgstr "Data formatada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Formatted value"
-msgstr ""
+msgstr "Valor formatado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Formatting"
-msgstr ""
+msgstr "Formatação"
 
 #, fuzzy
 msgid "Formatting column"
@@ -7098,30 +10901,56 @@ msgstr "Coluna de tempo"
 msgid "Formatting object"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Formula"
-msgstr ""
+msgstr "Fórmula"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forward values"
-msgstr ""
+msgstr "Valores futuros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Found invalid orderby options"
-msgstr ""
+msgstr "Encontradas opções orderby inválidas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fraction digits"
-msgstr ""
+msgstr "Dígitos de fração"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Frequency"
-msgstr ""
+msgstr "Frequência"
 
 #, fuzzy
 msgid "Friction"
 msgstr "Acção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friction between nodes"
-msgstr ""
+msgstr "Atrito entre nós"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friday"
-msgstr ""
+msgstr "Sexta-feira"
 
 msgid "From date cannot be larger than to date"
 msgstr "Data de inicio não pode ser posterior à data de fim"
@@ -7130,18 +10959,29 @@ msgstr "Data de inicio não pode ser posterior à data de fim"
 msgid "Full name"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fullscreen is not supported in this browser."
-msgstr ""
+msgstr "O modo ecrã completo não é suportado neste navegador."
 
 #, fuzzy
 msgid "Funnel Chart"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each column"
-msgstr ""
+msgstr "Personalizar ainda mais a forma de apresentação de cada coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each metric"
-msgstr ""
+msgstr "Personalizar ainda mais como apresentar cada métrica"
 
 #, fuzzy
 msgid "GROUP BY"
@@ -7151,17 +10991,27 @@ msgstr "Agrupar por"
 msgid "Gantt Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Gantt chart visualizes important events over a time span. Every data "
 "point displayed as a separate event along a horizontal line."
 msgstr ""
+"O gráfico de Gantt visualiza eventos importantes ao longo de um período "
+"de tempo. Cada ponto de dados é apresentado como um evento separado ao "
+"longo de uma linha horizontal."
 
 #, fuzzy
 msgid "Gauge Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "General"
-msgstr ""
+msgstr "Geral"
 
 #, fuzzy
 msgid "General information"
@@ -7171,47 +11021,85 @@ msgstr "Metadados adicionais"
 msgid "General settings"
 msgstr "Lista de Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Generating link, please wait.."
-msgstr ""
+msgstr "A gerar ligação, por favor aguarde.."
 
 #, fuzzy
 msgid "Generic Chart"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geo"
-msgstr ""
+msgstr "Geo"
 
 #, fuzzy
 msgid "GeoJson Column"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "GeoJson Settings"
-msgstr ""
+msgstr "Configurações de GeoJson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geohash"
-msgstr ""
+msgstr "Geohash"
 
 #, fuzzy
 msgid "Geometry Column"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the last date by the date unit."
-msgstr ""
+msgstr "Obter a última data pela unidade de data."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the specify date for the holiday"
-msgstr ""
+msgstr "Obter a data específica para o feriado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Give access to multiple catalogs in a single database connection."
-msgstr ""
+msgstr "Dar acesso a múltiplos catálogos numa única ligação à base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Go to the edit mode to configure the dashboard and add charts"
-msgstr ""
+msgstr "Ir ao modo de edição para configurar o painel e adicionar gráficos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Gold"
-msgstr ""
+msgstr "Ouro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Google Sheet Name and URL"
-msgstr ""
+msgstr "Nome e URL da Folha Google"
 
 #, fuzzy
 msgid "Grace period"
@@ -7225,11 +11113,19 @@ msgstr "Granularidade Temporal"
 msgid "Graph Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Graph layout"
-msgstr ""
+msgstr "Layout do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Gravity"
-msgstr ""
+msgstr "Gravidade"
 
 #, fuzzy
 msgid "Greater Than"
@@ -7239,21 +11135,33 @@ msgstr "Criado em"
 msgid "Greater Than or Equal"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Greater or equal (>=)"
-msgstr ""
+msgstr "Maior ou igual (>=)"
 
 #, fuzzy
 msgid "Greater than (>)"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Green for increase, red for decrease"
-msgstr ""
+msgstr "Verde para aumento, vermelho para diminuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Grid"
-msgstr ""
+msgstr "Grelha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Grid Size"
-msgstr ""
+msgstr "Tamanho da Grelha"
 
 #, fuzzy
 msgid "Grid view"
@@ -7267,8 +11175,12 @@ msgstr "Agrupar por"
 msgid "Group By"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Group By, Metrics or Percentage Metrics must have a value"
-msgstr ""
+msgstr "Agrupar por, Métricas ou Métricas de Percentagem devem ter um valor"
 
 #, fuzzy
 msgid "Group Key"
@@ -7277,8 +11189,11 @@ msgstr "Agrupar por"
 msgid "Group by"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group remaining as \"Others\""
-msgstr ""
+msgstr "Agrupar restantes como \"Outros\""
 
 #, fuzzy
 msgid "Grouping"
@@ -7288,26 +11203,45 @@ msgstr "Mensagem de Aviso"
 msgid "Groups"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Groups remaining series into an \"Others\" category when series limit is "
 "reached. This prevents incomplete time series data from being displayed."
 msgstr ""
+"Agrupa as séries restantes numa categoria \"Outros\" quando o limite de "
+"séries é atingido. Isto impede que dados de séries temporais incompletos "
+"sejam apresentados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Guest user cannot modify chart payload"
-msgstr ""
+msgstr "O utilizador convidado não pode modificar o payload do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "Caminho HTTP"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Handlebars"
-msgstr ""
+msgstr "Handlebars"
 
 #, fuzzy
 msgid "Handlebars Template"
 msgstr "Carregue um modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hard value bounds applied for color coding."
-msgstr ""
+msgstr "Limites rígidos de valor aplicados para codificação de cores."
 
 #, fuzzy
 msgid "Has created by"
@@ -7334,18 +11268,28 @@ msgstr "Altura"
 msgid "Height of each row in pixels"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Height of the sparkline"
-msgstr ""
+msgstr "Altura do sparkline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Hidden"
-msgstr ""
+msgstr "Oculto"
 
 #, fuzzy
 msgid "Hide Column"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hide Line"
-msgstr ""
+msgstr "Ocultar Linha"
 
 #, fuzzy
 msgid "Hide chart description"
@@ -7370,8 +11314,12 @@ msgstr "Pesquisa"
 msgid "Histogram"
 msgstr "Histograma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Home"
-msgstr ""
+msgstr "Início"
 
 #, fuzzy
 msgid "Horizon Chart"
@@ -7380,20 +11328,39 @@ msgstr "Gráfico de Horizonte"
 msgid "Horizon Charts"
 msgstr "Gráfico de Horizonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Horizontal"
-msgstr ""
+msgstr "Horizontal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Horizontal (Top)"
-msgstr ""
+msgstr "Horizontal (topo)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Horizontal alignment"
-msgstr ""
+msgstr "Alinhamento horizontal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Host"
-msgstr ""
+msgstr "Host"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hostname or IP address"
-msgstr ""
+msgstr "Nome do host ou endereço IP"
 
 #, fuzzy
 msgid "Hour"
@@ -7403,38 +11370,79 @@ msgstr "hora"
 msgid "Hours %s"
 msgstr "hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hours offset"
-msgstr ""
+msgstr "Desvio de horas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How do you want to enter service account credentials?"
-msgstr ""
+msgstr "Como pretende introduzir as credenciais da conta de serviço?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "How many buckets should the data be grouped in."
-msgstr ""
+msgstr "Em quantos intervalos devem os dados ser agrupados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How many periods into the future do we want to predict"
-msgstr ""
+msgstr "Quantos períodos no futuro queremos prever"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "How many top values to select"
-msgstr ""
+msgstr "Quantos valores principais selecionar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "How to display time shifts: as individual lines; as the difference "
 "between the main time series and each time shift; as the percentage "
 "change; or as the ratio between series and time shifts."
 msgstr ""
+"Como apresentar os desvios temporais: como linhas individuais; como a "
+"diferença entre a série temporal principal e cada desvio temporal; como a"
+" variação percentual; ou como o rácio entre séries e desvios temporais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Huge"
-msgstr ""
+msgstr "Enorme"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 3166-2 Codes"
-msgstr ""
+msgstr "Códigos ISO 3166-2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 8601"
-msgstr ""
+msgstr "ISO 8601"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon JavaScript config generator"
-msgstr ""
+msgstr "Gerador de configuração JavaScript de ícones"
 
 #, fuzzy
 msgid "Icon URL"
@@ -7444,15 +11452,22 @@ msgstr "Coluna"
 msgid "Icon size"
 msgstr "Tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon size unit"
-msgstr ""
+msgstr "Unidade de tamanho do ícone"
 
 #, fuzzy
 msgid "Id"
 msgstr "id:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Id of root node of the tree."
-msgstr ""
+msgstr "Id do nó raiz da árvore."
 
 #, fuzzy
 msgid ""
@@ -7469,40 +11484,78 @@ msgstr ""
 "utilizador atualmente conectado recorrendo à propriedade "
 "hive.server2.proxy.user."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "If a metric is specified, sorting will be done based on the metric value"
 msgstr ""
+"Se for especificada uma métrica, a ordenação será efetuada com base no "
+"valor da métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If enabled, this control sorts the results/values descending, otherwise "
 "it sorts the results ascending."
 msgstr ""
+"Se estiver ativado, este controlo ordena os resultados/valores de forma "
+"descendente, caso contrário ordena os resultados de forma ascendente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
+"Se ficar vazio, não será guardado e será removido da lista. Para remover "
+"pastas, mova as métricas e colunas para outras pastas."
 
 #, fuzzy
 msgid "If table already exists"
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "If you don't save, changes will be lost."
-msgstr ""
+msgstr "Se não guardar, as alterações serão perdidas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ignore cache when generating report"
-msgstr ""
+msgstr "Ignorar cache ao gerar relatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore null locations"
-msgstr ""
+msgstr "Ignorar localizações nulas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore time"
-msgstr ""
+msgstr "Ignorar tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image (PNG) embedded in email"
-msgstr ""
+msgstr "Imagem (PNG) incorporada no e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image download failed, please refresh and try again."
-msgstr ""
+msgstr "A transferência da imagem falhou, por favor atualize e tente novamente."
 
 #, fuzzy
 msgid "Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)"
@@ -7519,34 +11572,58 @@ msgstr "Importar"
 msgid "Import Error"
 msgstr "Query vazia?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Import chart failed for an unknown reason"
-msgstr ""
+msgstr "A importação do gráfico falhou por um motivo desconhecido"
 
 #, fuzzy
 msgid "Import charts"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dashboard failed for an unknown reason"
-msgstr ""
+msgstr "A importação do painel falhou por um motivo desconhecido"
 
 msgid "Import dashboards"
 msgstr "Importar Dashboards"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import database failed for an unknown reason"
-msgstr ""
+msgstr "A importação da base de dados falhou por um motivo desconhecido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Import database from file"
-msgstr ""
+msgstr "Importar base de dados de um ficheiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dataset failed for an unknown reason"
-msgstr ""
+msgstr "A importação do conjunto de dados falhou por um motivo desconhecido"
 
 #, fuzzy
 msgid "Import queries"
 msgstr "Query vazia?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import saved query failed for an unknown reason."
-msgstr ""
+msgstr "A importação da consulta guardada falhou por um motivo desconhecido."
 
 #, fuzzy
 msgid "Import themes"
@@ -7564,34 +11641,56 @@ msgstr "Mover gráfico"
 msgid "In Range"
 msgstr "Granularidade Temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
 "service account or configure an OAuth2 client."
 msgstr ""
+"Para se ligar a folhas não públicas, é necessário fornecer uma conta de "
+"serviço ou configurar um cliente OAuth2."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "In this view you can preview the first 25 rows. "
-msgstr ""
+msgstr "Nesta vista pode pré-visualizar as primeiras 25 linhas. "
 
 #, fuzzy
 msgid "Inactive"
 msgstr "Acção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include Series"
-msgstr ""
+msgstr "Incluir Séries"
 
 #, fuzzy
 msgid "Include Template Parameters"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include a description that will be sent with your report"
-msgstr ""
+msgstr "Incluir uma descrição que será enviada com o seu relatório"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Include description to be sent with %s"
-msgstr ""
+msgstr "Incluir descrição a enviar com %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include series name as an axis"
-msgstr ""
+msgstr "Incluir o nome da série como eixo"
 
 #, fuzzy
 msgid "Include time"
@@ -7609,8 +11708,11 @@ msgstr "Criado em"
 msgid "Increase label"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Index"
-msgstr ""
+msgstr "Índice"
 
 #, fuzzy
 msgid "Index column"
@@ -7624,33 +11726,62 @@ msgstr "ocultar barra de ferramentas"
 msgid "Indexes (%s)"
 msgstr "Ver chaves e índices (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Info"
-msgstr ""
+msgstr "Informações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inherit range from time filter"
-msgstr ""
+msgstr "Herdar intervalo do filtro de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "Profundidade inicial da árvore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner Radius"
-msgstr ""
+msgstr "Raio Interior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner radius of donut hole"
-msgstr ""
+msgstr "Raio interior do orifício do donut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input custom width in pixels"
-msgstr ""
+msgstr "Introduzir largura personalizada em píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input field supports custom rotation. e.g. 30 for 30°"
-msgstr ""
+msgstr "O campo de entrada suporta rotação personalizada. ex.: 30 para 30°"
 
 #, fuzzy
 msgid "Insert Layer URL"
 msgstr "ocultar barra de ferramentas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer title"
-msgstr ""
+msgstr "Inserir título da camada"
 
 #, fuzzy
 msgid "Inside"
@@ -7660,11 +11791,17 @@ msgstr "Mín"
 msgid "Inside bottom"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside bottom left"
-msgstr ""
+msgstr "Interior inferior esquerdo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside bottom right"
-msgstr ""
+msgstr "Interior inferior direito"
 
 #, fuzzy
 msgid "Inside left"
@@ -7674,8 +11811,11 @@ msgstr "Eliminar"
 msgid "Inside right"
 msgstr "Altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "Interior superior"
 
 #, fuzzy
 msgid "Inside top left"
@@ -7693,11 +11833,18 @@ msgstr "Entidade"
 msgid "Intensity Radius"
 msgstr "Entidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Intensity Radius is the radius at which the weight is distributed"
-msgstr ""
+msgstr "O Raio de Intensidade é o raio no qual o peso é distribuído"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity is the value multiplied by the weight to obtain the final weight"
-msgstr ""
+msgstr "A Intensidade é o valor multiplicado pelo peso para obter o peso final"
 
 #, fuzzy
 msgid "Interval"
@@ -7723,13 +11870,22 @@ msgstr "Controlo de filtro"
 msgid "Intervals"
 msgstr "Filtrável"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid Connection String: Expecting String of the form "
 "'ocient://user:pass@host:port/database'."
 msgstr ""
+"Cadeia de Ligação Inválida: Esperada uma cadeia com o formato "
+"'ocient://user:pass@host:port/database'."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid JSON"
-msgstr ""
+msgstr "JSON inválido"
 
 #, fuzzy
 msgid "Invalid JSON configuration"
@@ -7739,122 +11895,216 @@ msgstr "Contribuição"
 msgid "Invalid JSON metadata"
 msgstr "Atualizar coluna de metadados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Invalid SQL: %(error)s"
-msgstr ""
+msgstr "SQL inválido: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid advanced data type: %(advanced_data_type)s"
-msgstr ""
+msgstr "Tipo de dados avançado inválido: %(advanced_data_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid certificate"
-msgstr ""
+msgstr "Certificado inválido"
 
 #, fuzzy
 msgid "Invalid color"
 msgstr "Esquema de cores lineares"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually follows: "
 "backend+driver://user:password@database-host/database-name"
 msgstr ""
+"Cadeia de ligação inválida, uma cadeia válida segue geralmente o formato:"
+" backend+driver://user:password@database-host/database-name"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually "
 "follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
 "NAME'<p>Example:'postgresql://user:password@your-postgres-"
 "db/database'</p>"
 msgstr ""
+"Cadeia de ligação inválida, uma cadeia válida segue geralmente o "
+"formato:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
+"NAME'<p>Exemplo:'postgresql://user:password@your-postgres-"
+"db/database'</p>"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid cron expression"
-msgstr ""
+msgstr "Expressão cron inválida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid cumulative operator: %(operator)s"
-msgstr ""
+msgstr "Operador cumulativo inválido: %(operator)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid currency code in saved metrics"
-msgstr ""
+msgstr "Código de moeda inválido nas métricas guardadas"
 
 msgid "Invalid date/timestamp format"
 msgstr "Formato da Tabela Datahora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid executor type"
-msgstr ""
+msgstr "Tipo de executor inválido"
 
 #, fuzzy
 msgid "Invalid expression"
 msgstr "Expressão"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid filter operation type: %(op)s"
-msgstr ""
+msgstr "Tipo de operação de filtro inválido: %(op)s"
 
 #, fuzzy
 msgid "Invalid formula expression"
 msgstr "Expressão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geodetic string"
-msgstr ""
+msgstr "Cadeia geodésica inválida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geohash string"
-msgstr ""
+msgstr "Cadeia geohash inválida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid input"
-msgstr ""
+msgstr "Entrada inválida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid lat/long configuration."
-msgstr ""
+msgstr "Configuração lat/long inválida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid longitude/latitude"
-msgstr ""
+msgstr "Longitude/latitude inválida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid metric object: %(metric)s"
-msgstr ""
+msgstr "Objeto de métrica inválido: %(metric)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid numpy function: %(operator)s"
-msgstr ""
+msgstr "Função numpy inválida: %(operator)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid options for %(rolling_type)s: %(options)s"
-msgstr ""
+msgstr "Opções inválidas para %(rolling_type)s: %(options)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid permalink key"
-msgstr ""
+msgstr "Chave de permalink inválida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid reference to column: \"%(column)s\""
-msgstr ""
+msgstr "Referência inválida à coluna: \"%(column)s\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid result type: %(result_type)s"
-msgstr ""
+msgstr "Tipo de resultado inválido: %(result_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid rolling_type: %(type)s"
-msgstr ""
+msgstr "rolling_type inválido: %(type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid spatial point encountered: %(latlong)s"
-msgstr ""
+msgstr "Ponto espacial inválido encontrado: %(latlong)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid state."
-msgstr ""
+msgstr "Estado inválido."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, sk,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
-msgstr ""
+msgstr "IDs de separador inválidos: %(tab_ids)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Nome de utilizador ou palavra-passe inválidos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inverse selection"
-msgstr ""
+msgstr "Seleção inversa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invert current page"
-msgstr ""
+msgstr "Inverter a página atual"
 
 #, fuzzy
 msgid "Is Active?"
@@ -7868,14 +12118,25 @@ msgstr "Nome do modelo"
 msgid "Is certified"
 msgstr "foi criado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Is custom tag"
-msgstr ""
+msgstr "É uma etiqueta personalizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is dimension"
-msgstr ""
+msgstr "É dimensão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is false"
-msgstr ""
+msgstr "É falso"
 
 msgid "Is favorite"
 msgstr "Favoritos"
@@ -7884,44 +12145,85 @@ msgstr "Favoritos"
 msgid "Is filterable"
 msgstr "Filtrável"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is not null"
-msgstr ""
+msgstr "Não é nulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is null"
-msgstr ""
+msgstr "É nulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is tagged"
-msgstr ""
+msgstr "Está etiquetado"
 
 msgid "Is temporal"
 msgstr "É temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is true"
-msgstr ""
+msgstr "É verdadeiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Isoband"
-msgstr ""
+msgstr "Isobanda"
 
 #, fuzzy
 msgid "Isoline"
 msgstr "agregado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Issue 1000 - The dataset is too large to query."
 msgstr ""
+"Problema 1000 - O conjunto de dados é demasiado grande para ser "
+"consultado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Issue 1001 - The database is under an unusual load."
-msgstr ""
+msgstr "Problema 1001 - A base de dados está sob uma carga invulgar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
 msgstr ""
+"Não será removido mesmo que esteja vazio. Não será mostrado na vista de "
+"edição de gráfico se estiver vazio."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
-msgstr ""
+msgstr "Não é recomendado truncar o eixo Y no gráfico de barras."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JAN"
-msgstr ""
+msgstr "JAN"
 
 msgid "JSON"
 msgstr "JSON"
@@ -7937,56 +12239,107 @@ msgstr "Metadados JSON"
 msgid "JSON metadata"
 msgstr "Atualizar coluna de metadados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON metadata and advanced configuration"
-msgstr ""
+msgstr "Metadados JSON e configuração avançada"
 
 #, fuzzy
 msgid "JSON metadata is invalid!"
 msgstr "Atualizar coluna de metadados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "JSON string containing additional connection configuration. This is used "
 "to provide connection information for systems like Hive, Presto and "
 "BigQuery which do not conform to the username:password syntax normally "
 "used by SQLAlchemy."
 msgstr ""
+"Cadeia de caracteres JSON com configuração de ligação adicional. É "
+"utilizada para fornecer informações de ligação para sistemas como Hive, "
+"Presto e BigQuery que não estão em conformidade com a sintaxe utilizador"
+":palavra-passe normalmente usada pelo SQLAlchemy."
 
 msgid "JUL"
 msgstr "URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JUN"
-msgstr ""
+msgstr "JUN"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "January"
-msgstr ""
+msgstr "Janeiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript data interceptor"
-msgstr ""
+msgstr "Interceptor de dados JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "JavaScript onClick href"
-msgstr ""
+msgstr "JavaScript onClick href"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript tooltip generator"
-msgstr ""
+msgstr "Gerador de dicas de ferramentas JavaScript"
 
 #, fuzzy
 msgid "Jinja templating"
 msgstr "Carregue um modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "July"
-msgstr ""
+msgstr "Julho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "June"
-msgstr ""
+msgstr "Junho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "KPI"
-msgstr ""
+msgstr "KPI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Keep control settings?"
-msgstr ""
+msgstr "Manter definições de controlo?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Keep editing"
-msgstr ""
+msgstr "Continuar a editar"
 
 #, fuzzy
 msgid "Key"
@@ -7996,11 +12349,20 @@ msgstr "Sankey"
 msgid "Key Prefix"
 msgstr "Pré-visualização de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Atalhos de teclado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
+"As chaves são apresentadas apenas uma vez na criação. Guarde-as em "
+"segurança."
 
 msgid "Keys for table"
 msgstr "Chaves para tabela"
@@ -8016,18 +12378,29 @@ msgstr "Rótulo"
 msgid "Label Contents"
 msgstr "Conteúdo Criado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label JavaScript config generator"
-msgstr ""
+msgstr "Gerador de configuração JavaScript de etiquetas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label Line"
-msgstr ""
+msgstr "Linha de Etiqueta"
 
 #, fuzzy
 msgid "Label Template"
 msgstr "Carregue um modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label Type"
-msgstr ""
+msgstr "Tipo de Etiqueta"
 
 #, fuzzy
 msgid "Label already exists"
@@ -8045,8 +12418,11 @@ msgstr "Selecione uma cor"
 msgid "Label descending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label for the index column. Don't use an existing column name."
-msgstr ""
+msgstr "Etiqueta para a coluna de índice. Não utilize um nome de coluna existente."
 
 msgid "Label for your query"
 msgstr "Rótulo para a sua query"
@@ -8067,42 +12443,73 @@ msgstr "Rótulo"
 msgid "Label size unit"
 msgstr "última partição:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label threshold"
-msgstr ""
+msgstr "Limiar de etiqueta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labelling"
-msgstr ""
+msgstr "Etiquetagem"
 
 #, fuzzy
 msgid "Labels"
 msgstr "Rótulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the marker lines"
-msgstr ""
+msgstr "Etiquetas para as linhas de marcador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the markers"
-msgstr ""
+msgstr "Etiquetas para os marcadores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the ranges"
-msgstr ""
+msgstr "Etiquetas para os intervalos"
 
 #, fuzzy
 msgid "Languages"
 msgstr "Gerir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Large"
-msgstr ""
+msgstr "Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Last"
-msgstr ""
+msgstr "Último"
 
 #, fuzzy
 msgid "Last Name"
 msgstr "nome da origem de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last Updated %s"
-msgstr ""
+msgstr "Última Atualização %s"
 
 #, fuzzy, python-format
 msgid "Last Updated %s by %s"
@@ -8112,9 +12519,12 @@ msgstr "Última Alteração"
 msgid "Last Used"
 msgstr "Número grande"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last available value seen on %s"
-msgstr ""
+msgstr "Último valor disponível visto em %s"
 
 #, fuzzy
 msgid "Last day"
@@ -8164,14 +12574,25 @@ msgstr "semana"
 msgid "Last year"
 msgstr "Cluster"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lat"
-msgstr ""
+msgstr "Lat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude"
-msgstr ""
+msgstr "Latitude"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude of default viewport"
-msgstr ""
+msgstr "Latitude do viewport predefinido"
 
 #, fuzzy
 msgid "Layer"
@@ -8181,8 +12602,11 @@ msgstr "ano"
 msgid "Layer Name"
 msgstr "Tipo de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Layer URL"
-msgstr ""
+msgstr "URL da camada"
 
 #, fuzzy
 msgid "Layer configuration"
@@ -8200,17 +12624,33 @@ msgstr "Valor de filtro"
 msgid "Layers"
 msgstr "ocultar barra de ferramentas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout"
-msgstr ""
+msgstr "Layout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout elements"
-msgstr ""
+msgstr "Elementos de layout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of graph"
-msgstr ""
+msgstr "Tipo de layout de gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of tree"
-msgstr ""
+msgstr "Tipo de layout de árvore"
 
 #, fuzzy
 msgid "Least recently modified"
@@ -8220,27 +12660,53 @@ msgstr "Última Alteração"
 msgid "Left"
 msgstr "Eliminar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left Margin"
-msgstr ""
+msgstr "Margem Esquerda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left margin, in pixels, allowing for more room for axis labels"
 msgstr ""
+"Margem esquerda, em píxeis, permitindo mais espaço para os rótulos dos "
+"eixos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left to Right"
-msgstr ""
+msgstr "Esquerda para Direita"
 
 #, fuzzy
 msgid "Left value"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legacy"
-msgstr ""
+msgstr "Legado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legend"
-msgstr ""
+msgstr "Legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Legend Format"
-msgstr ""
+msgstr "Formato de legenda"
 
 #, fuzzy
 msgid "Legend Orientation"
@@ -8254,26 +12720,51 @@ msgstr "Conexão de teste"
 msgid "Legend Type"
 msgstr "Limite de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Legend type"
-msgstr ""
+msgstr "Tipo de legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than"
-msgstr ""
+msgstr "Menor que"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than or Equal"
-msgstr ""
+msgstr "Menor ou igual"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Less or equal (<=)"
-msgstr ""
+msgstr "Menor ou igual (<=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Less than (<)"
-msgstr ""
+msgstr "Menor que (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Lift percent precision"
-msgstr ""
+msgstr "Precisão da percentagem de elevação"
 
 #, fuzzy
 msgid "Light"
@@ -8283,28 +12774,55 @@ msgstr "Altura"
 msgid "Light (Carto)"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Light mode"
-msgstr ""
+msgstr "Modo claro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like"
-msgstr ""
+msgstr "Como"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like (case insensitive)"
-msgstr ""
+msgstr "Como (sem distinção de maiúsculas/minúsculas)"
 
 #, fuzzy
 msgid "Limit"
 msgstr "Limite de linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Limit type"
-msgstr ""
+msgstr "Tipo de limite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Limits the number of cells that get retrieved."
-msgstr ""
+msgstr "Limita o número de células recuperadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Limits the number of rows that get displayed."
-msgstr ""
+msgstr "Limita o número de linhas apresentadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of series that get displayed. A joined subquery (or an "
 "extra phase where subqueries are not supported) is applied to limit the "
@@ -8312,11 +12830,22 @@ msgid ""
 "when grouping by high cardinality column(s) though does increase the "
 "query complexity and cost."
 msgstr ""
+"Limita o número de séries apresentadas. É aplicada uma subconsulta unida "
+"(ou uma fase adicional onde as subconsultas não são suportadas) para "
+"limitar o número de séries que são obtidas e apresentadas. Esta "
+"funcionalidade é útil ao agrupar por coluna(s) de alta cardinalidade, "
+"embora aumente a complexidade e o custo da consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of the rows that are computed in the query that is the "
 "source of the data used for this chart."
 msgstr ""
+"Limita o número de linhas calculadas na consulta que é a fonte dos dados "
+"utilizados para este gráfico."
 
 #, fuzzy
 msgid "Line"
@@ -8326,21 +12855,41 @@ msgstr "Mín"
 msgid "Line Chart"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line Style"
-msgstr ""
+msgstr "Estilo de linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Line chart is used to visualize measurements taken over a given category."
 " Line chart is a type of chart which displays information as a series of "
 "data points connected by straight line segments. It is a basic type of "
 "chart common in many fields."
 msgstr ""
+"O gráfico de linhas é utilizado para visualizar medições efetuadas numa "
+"determinada categoria. O gráfico de linhas é um tipo de gráfico que "
+"apresenta informações como uma série de pontos de dados ligados por "
+"segmentos de linha reta. É um tipo básico de gráfico comum em muitos "
+"domínios."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line charts on a map"
-msgstr ""
+msgstr "Gráficos de linhas num mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line interpolation as defined by d3.js"
-msgstr ""
+msgstr "Interpolação de linha conforme definido por d3.js"
 
 #, fuzzy
 msgid "Line width"
@@ -8357,8 +12906,12 @@ msgstr "Esquema de cores lineares"
 msgid "Linear color scheme"
 msgstr "Esquema de cores lineares"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear interpolation"
-msgstr ""
+msgstr "Interpolação linear"
 
 #, fuzzy
 msgid "Linear palette"
@@ -8368,8 +12921,12 @@ msgstr "Esquema de cores lineares"
 msgid "Lines column"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Lines encoding"
-msgstr ""
+msgstr "Codificação de linhas"
 
 #, fuzzy
 msgid "List"
@@ -8379,40 +12936,74 @@ msgstr "Limite de linha"
 msgid "List Groups"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List Roles"
-msgstr ""
+msgstr "Listar Funções"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List Unique Values"
-msgstr ""
+msgstr "Listar Valores Únicos"
 
 #, fuzzy
 msgid "List Users"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of extra columns made available in JavaScript functions"
-msgstr ""
+msgstr "Lista de colunas extra disponibilizadas em funções JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List of n+1 values for bucketing metric into n buckets."
-msgstr ""
+msgstr "Lista de n+1 valores para agrupar a métrica em n intervalos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List of the column names that should be read"
-msgstr ""
+msgstr "Lista dos nomes de colunas que devem ser lidos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with lines"
-msgstr ""
+msgstr "Lista de valores a marcar com linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with triangles"
-msgstr ""
+msgstr "Lista de valores a marcar com triângulos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List updated"
-msgstr ""
+msgstr "Lista atualizada"
 
 #, fuzzy
 msgid "List view"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Live render"
-msgstr ""
+msgstr "Renderização em tempo real"
 
 #, fuzzy
 msgid "Load CSS template (optional)"
@@ -8432,22 +13023,34 @@ msgstr "Login"
 msgid "Loading filter values"
 msgstr "Filtrável"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Loading timezones..."
-msgstr ""
+msgstr "A carregar fusos horários..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Loading..."
-msgstr ""
+msgstr "A carregar..."
 
 #, fuzzy
 msgid "Local"
 msgstr "Rótulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Local theme set for preview"
-msgstr ""
+msgstr "Tema local definido para pré-visualização"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Local theme set to \"%s\""
-msgstr ""
+msgstr "Tema local definido como \"%s\""
 
 #, fuzzy
 msgid "Locate the chart"
@@ -8457,27 +13060,50 @@ msgstr "Crie uma nova visualização"
 msgid "Log"
 msgstr "Login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Log Scale"
-msgstr ""
+msgstr "Escala logarítmica"
 
 #, fuzzy
 msgid "Log retention"
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Logarithmic axis"
-msgstr ""
+msgstr "Eixo logarítmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on primary y-axis"
-msgstr ""
+msgstr "Escala logarítmica no eixo y primário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on secondary y-axis"
-msgstr ""
+msgstr "Escala logarítmica no eixo y secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Logarithmic x-axis"
-msgstr ""
+msgstr "Eixo x logarítmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic y-axis"
-msgstr ""
+msgstr "Eixo y logarítmico"
 
 msgid "Login"
 msgstr "Login"
@@ -8493,45 +13119,91 @@ msgstr "Largura"
 msgid "Logout"
 msgstr "Sair"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Logs"
-msgstr ""
+msgstr "Logs"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lon"
-msgstr ""
+msgstr "Lon"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Long dashed"
-msgstr ""
+msgstr "Traço longo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude"
-msgstr ""
+msgstr "Longitude"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Longitude & Latitude"
-msgstr ""
+msgstr "Longitude e Latitude"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude & Latitude columns"
-msgstr ""
+msgstr "Colunas de longitude e latitude"
 
 #, fuzzy
 msgid "Longitude and Latitude"
 msgstr "As colunas [Longitude] e [Latitude] devem estar presentes em [Agrupar por]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude of default viewport"
-msgstr ""
+msgstr "Longitude da viewport predefinida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lower Threshold"
-msgstr ""
+msgstr "Limiar Inferior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Lower threshold must be lower than upper threshold"
-msgstr ""
+msgstr "O limiar inferior deve ser inferior ao limiar superior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAR"
-msgstr ""
+msgstr "MAR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAY"
-msgstr ""
+msgstr "MAI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MON"
-msgstr ""
+msgstr "SEG"
 
 #, fuzzy
 msgid "Main"
@@ -8541,13 +13213,22 @@ msgstr "Mín"
 msgid "Main navigation"
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Make sure that the controls are configured properly and the datasource "
 "contains data for the selected time range"
 msgstr ""
+"Certifique-se de que os controlos estão corretamente configurados e que a"
+" fonte de dados contém dados para o intervalo de tempo selecionado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Make the x-axis categorical"
-msgstr ""
+msgstr "Tornar o eixo x categórico"
 
 msgid ""
 "Malformed request. slice_id or table_name and db_name arguments are "
@@ -8559,25 +13240,49 @@ msgstr ""
 msgid "Manage"
 msgstr "Gerir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage dashboard owners and access permissions"
-msgstr ""
+msgstr "Gira os proprietários e as permissões de acesso do painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage email report"
-msgstr ""
+msgstr "Gira o relatório de e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Gira os filtros e personalizações para definir âmbito, descrições e "
+"limitações. Crie novos elementos para obter melhores informações do "
+"painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Manage your databases"
-msgstr ""
+msgstr "Gira as suas bases de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mandatory"
-msgstr ""
+msgstr "Obrigatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Manually set min/max values for the y-axis."
-msgstr ""
+msgstr "Definir manualmente os valores mínimo/máximo para o eixo y."
 
 #, fuzzy
 msgid "Map"
@@ -8591,16 +13296,28 @@ msgstr "Editar propriedades da visualização"
 msgid "Map Renderer"
 msgstr "Intervalo de atualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Map Style"
-msgstr ""
+msgstr "Estilo do mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (código aberto)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre é de código aberto e não requer chave de API. O Mapbox requer "
+"que o MAPBOX_API_KEY seja configurado no servidor."
 
 msgid "Mapbox"
 msgstr "Mapbox"
@@ -8609,8 +13326,11 @@ msgstr "Mapbox"
 msgid "Mapbox (API key required)"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "O Mapbox requer que um MAPBOX_API_KEY seja configurado no servidor."
 
 msgid "March"
 msgstr "Pesquisa"
@@ -8619,47 +13339,84 @@ msgstr "Pesquisa"
 msgid "Margin"
 msgstr "Origem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Mark a column as temporal in \"Edit datasource\" modal"
-msgstr ""
+msgstr "Marcar uma coluna como temporal no modal \"Editar fonte de dados\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker"
-msgstr ""
+msgstr "Marcador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker Size"
-msgstr ""
+msgstr "Tamanho do marcador"
 
 #, fuzzy
 msgid "Marker labels"
 msgstr "Etiquetas de marcadores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker line labels"
-msgstr ""
+msgstr "Etiquetas de linhas de marcador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker lines"
-msgstr ""
+msgstr "Linhas de marcador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker size"
-msgstr ""
+msgstr "Tamanho do marcador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Markers"
-msgstr ""
+msgstr "Marcadores"
 
 #, fuzzy
 msgid "Markup type"
 msgstr "Tipo de marcação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match system"
-msgstr ""
+msgstr "Seguir o sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match time shift color with original series"
-msgstr ""
+msgstr "Corresponder a cor do deslocamento de tempo com a série original"
 
 #, fuzzy
 msgid "Match type"
 msgstr "Tabela de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Matrixify"
-msgstr ""
+msgstr "Matrixify"
 
 msgid "Max"
 msgstr "Máx"
@@ -8672,85 +13429,164 @@ msgstr "Tamanho da bolha"
 msgid "Max value"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Max. features"
-msgstr ""
+msgstr "Máx. características"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum"
-msgstr ""
+msgstr "Máximo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Font Size"
-msgstr ""
+msgstr "Tamanho Máximo da Fonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Radius"
-msgstr ""
+msgstr "Raio Máximo"
 
 #, fuzzy
 msgid "Maximum Width"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "Profundidade máxima de aninhamento de pastas atingida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum number of features to fetch from service"
-msgstr ""
+msgstr "Número máximo de funcionalidades a obter do serviço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this maximum radius."
 msgstr ""
+"Tamanho máximo do raio do círculo, em píxeis. À medida que o nível de "
+"zoom muda, isto assegura que o círculo respeite este raio máximo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Maximum value"
-msgstr ""
+msgstr "Valor máximo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum value on the gauge axis"
-msgstr ""
+msgstr "Valor máximo no eixo do medidor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Tamanho máximo da largura do caminho, em píxeis ou metros."
 
 msgid "May"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mean of values over specified period"
-msgstr ""
+msgstr "Média dos valores durante o período especificado"
 
 #, fuzzy
 msgid "Mean values"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Median"
-msgstr ""
+msgstr "Mediana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median edge width, the thickest edge will be 4 times thicker than the "
 "thinnest."
 msgstr ""
+"Largura mediana da aresta, a aresta mais grossa será 4 vezes mais grossa "
+"do que a mais fina."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median node size, the largest node will be 4 times larger than the "
 "smallest"
-msgstr ""
+msgstr "Tamanho mediano do nó, o nó maior será 4 vezes maior do que o mais pequeno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Median values"
-msgstr ""
+msgstr "Valores medianos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Medium"
-msgstr ""
+msgstr "Médio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - binary (1024B => 1KiB)"
-msgstr ""
+msgstr "Memória em bytes - binário (1024B => 1KiB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - decimal (1024B => 1.024kB)"
-msgstr ""
+msgstr "Memória em bytes - decimal (1024B => 1.024kB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - binary (1024B => 1KiB/s)"
-msgstr ""
+msgstr "Taxa de transferência de memória em bytes - binário (1024B => 1KiB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
+msgstr "Taxa de transferência de memória em bytes - decimal (1024B => 1.024kB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Menu actions trigger"
-msgstr ""
+msgstr "Acionador de ações do menu"
 
 #, fuzzy
 msgid "Message content"
@@ -8764,37 +13600,57 @@ msgstr "Atualizar coluna de metadados"
 msgid "Metadata Parameters"
 msgstr "Nome do modelo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metadata has been synced"
-msgstr ""
+msgstr "Os metadados foram sincronizados"
 
 #, fuzzy
 msgid "Meters"
 msgstr "Parâmetros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Method"
-msgstr ""
+msgstr "Método"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Method to compute the displayed value. \"Overall value\" calculates a "
 "single metric across the entire filtered time period, ideal for non-"
 "additive metrics like ratios, averages, or distinct counts. Other methods"
 " operate over the time series data points."
 msgstr ""
+"Método para calcular o valor apresentado. \"Valor geral\" calcula uma "
+"única métrica ao longo de todo o período de tempo filtrado, ideal para "
+"métricas não aditivas como rácios, médias ou contagens distintas. Os "
+"outros métodos operam sobre os pontos de dados da série temporal."
 
 msgid "Metric"
 msgstr "Métrica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Metric '%(metric)s' does not exist"
-msgstr ""
+msgstr "A métrica '%(metric)s' não existe"
 
 #, fuzzy
 msgid "Metric Key"
 msgstr "Métrica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Metric ``%(metric_name)s`` not found in %(dataset_name)s."
-msgstr ""
+msgstr "Métrica ``%(metric_name)s`` não encontrada em %(dataset_name)s."
 
 #, fuzzy
 msgid "Metric ascending"
@@ -8806,21 +13662,37 @@ msgstr "Métrica atribuída ao eixo [X]"
 msgid "Metric assigned to the [Y] axis"
 msgstr "Metrica atribuída ao eixo [Y]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric change in value from `since` to `until`"
-msgstr ""
+msgstr "Variação do valor da métrica de `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric currency"
-msgstr ""
+msgstr "Moeda da métrica"
 
 #, fuzzy
 msgid "Metric descending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric factor change from `since` to `until`"
-msgstr ""
+msgstr "Variação do fator da métrica de `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric for node values"
-msgstr ""
+msgstr "Métrica para valores de nó"
 
 #, fuzzy
 msgid "Metric for ordering"
@@ -8830,15 +13702,26 @@ msgstr "Ordenar decrescente"
 msgid "Metric name"
 msgstr "nome da origem de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Metric name [%s] is duplicated"
-msgstr ""
+msgstr "O nome da métrica [%s] está duplicado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric percent change in value from `since` to `until`"
-msgstr ""
+msgstr "Variação percentual do valor da métrica de `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric that defines the size of the bubble"
-msgstr ""
+msgstr "Métrica que define o tamanho da bolha"
 
 #, fuzzy
 msgid "Metric to display bottom title"
@@ -8848,26 +13731,51 @@ msgstr "Selecione uma métrica para visualizar"
 msgid "Metric to use for ordering Top N values"
 msgstr "Uma métrica a utilizar para cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used as a weight for the grid's coloring"
-msgstr ""
+msgstr "Métrica utilizada como peso para a coloração da grelha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric used to calculate bubble size"
-msgstr ""
+msgstr "Métrica utilizada para calcular o tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used to control height"
-msgstr ""
+msgstr "Métrica utilizada para controlar a altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or cell "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"Métrica utilizada para definir como as séries de topo são ordenadas se "
+"estiver presente um limite de série ou de célula. Se não for definida, "
+"reverte para a primeira métrica (quando apropriado)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or row "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"Métrica utilizada para definir como as séries de topo são ordenadas se "
+"estiver presente um limite de série ou de linha. Se não for definida, "
+"reverte para a primeira métrica (quando apropriado)."
 
 msgid "Metrics"
 msgstr "Métricas"
@@ -8876,24 +13784,41 @@ msgstr "Métricas"
 msgid "Metrics (%s)"
 msgstr "Métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "As métricas não podem ser utilizadas ao mesmo tempo para linhas e colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "A pasta de métricas só pode conter itens de métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "As métricas devem estar dentro de pastas"
 
 #, fuzzy
 msgid "Metrics to show in the tooltip."
 msgstr "Incluir um filtro temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Middle"
-msgstr ""
+msgstr "Médio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Midnight"
-msgstr ""
+msgstr "Meia-noite"
 
 #, fuzzy
 msgid "Miles"
@@ -8921,54 +13846,105 @@ msgstr "Valor de filtro"
 msgid "Min value cannot be greater than max value"
 msgstr "Data de inicio não pode ser posterior à data de fim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Min value should be smaller or equal to max value"
-msgstr ""
+msgstr "O valor mínimo deve ser menor ou igual ao valor máximo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min/max (no outliers)"
-msgstr ""
+msgstr "Mín/máx (sem outliers)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mine"
-msgstr ""
+msgstr "Meu"
 
 #, fuzzy
 msgid "Minimum"
 msgstr "minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum Font Size"
-msgstr ""
+msgstr "Tamanho Mínimo da Fonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Minimum Radius"
-msgstr ""
+msgstr "Raio Mínimo"
 
 #, fuzzy
 msgid "Minimum Width"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Minimum must be strictly less than maximum"
-msgstr ""
+msgstr "O mínimo deve ser estritamente inferior ao máximo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this minimum radius."
 msgstr ""
+"Tamanho mínimo do raio do círculo, em pixels. À medida que o nível de "
+"zoom muda, isto garante que o círculo respeita este raio mínimo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum threshold in percentage points for showing labels."
-msgstr ""
+msgstr "Limiar mínimo em pontos percentuais para mostrar etiquetas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Minimum value"
-msgstr ""
+msgstr "Valor mínimo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value for label to be displayed on graph."
-msgstr ""
+msgstr "Valor mínimo para que a etiqueta seja apresentada no gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value on the gauge axis"
-msgstr ""
+msgstr "Valor mínimo no eixo do medidor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Tamanho mínimo de largura do caminho, em pixels ou metros."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minor Split Line"
-msgstr ""
+msgstr "Linha de Divisão Menor"
 
 #, fuzzy
 msgid "Minor ticks"
@@ -8986,8 +13962,11 @@ msgstr "minuto"
 msgid "Missing %s"
 msgstr "Viz está sem origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Missing OAuth2 token"
-msgstr ""
+msgstr "Token OAuth2 em falta"
 
 #, fuzzy
 msgid "Missing URL parameter"
@@ -9008,11 +13987,13 @@ msgstr "Modificado"
 msgid "Modified %s"
 msgstr "Última Alteração"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modificada 1 coluna no conjunto de dados virtual"
+msgstr[1] "Modificadas %s colunas no conjunto de dados virtual"
 
 #, fuzzy
 msgid "Modified by"
@@ -9026,8 +14007,12 @@ msgstr "Última Alteração"
 msgid "Modified from \"%s\" template"
 msgstr "Carregue um modelo CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Monday"
-msgstr ""
+msgstr "Segunda-feira"
 
 #, fuzzy
 msgid "Month"
@@ -9049,49 +14034,98 @@ msgstr "Editar propriedades da visualização"
 msgid "More filters"
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "MotherDuck token"
-msgstr ""
+msgstr "Token MotherDuck"
 
 #, fuzzy
 msgid "Move icon"
 msgstr "Editar propriedades da visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Move only"
-msgstr ""
+msgstr "Mover apenas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Moves the given set of dates by a specified interval."
-msgstr ""
+msgstr "Move o conjunto de datas especificado por um intervalo definido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Multi-Dimensions"
-msgstr ""
+msgstr "Multi-Dimensões"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Layers"
-msgstr ""
+msgstr "Múltiplas Camadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Levels"
-msgstr ""
+msgstr "Multiníveis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Variables"
-msgstr ""
+msgstr "Multi-Variáveis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multiple"
-msgstr ""
+msgstr "Múltiplo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Multiple formats accepted, look the geopy.points Python library for more "
 "details"
 msgstr ""
+"São aceites vários formatos, consulte a biblioteca Python geopy.points "
+"para mais detalhes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Multiplier"
-msgstr ""
+msgstr "Multiplicador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
 msgstr ""
+"Tem de ser o proprietário do gráfico para sobrescrever este gráfico. "
+"Guarde como um novo gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must be unique"
-msgstr ""
+msgstr "Deve ser único"
 
 #, fuzzy
 msgid "Must choose either a chart or a dashboard"
@@ -9100,14 +14134,26 @@ msgstr "Remover gráfico do dashboard"
 msgid "Must have a [Group By] column to have 'count' as the [Label]"
 msgstr "Deve ter uma coluna [Agrupar por] para ter 'count' como [Label]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Must provide credentials for the SSH Tunnel"
-msgstr ""
+msgstr "Tem de fornecer credenciais para o Túnel SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must specify a value for filters with comparison operators"
-msgstr ""
+msgstr "Deve especificar um valor para os filtros com operadores de comparação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "My beautiful colors"
-msgstr ""
+msgstr "As minhas lindas cores"
 
 #, fuzzy
 msgid "My column"
@@ -9117,15 +14163,23 @@ msgstr "Coluna"
 msgid "My metric"
 msgstr "Adicionar Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "N/A"
-msgstr ""
+msgstr "N/D"
 
 #, fuzzy
 msgid "NOT GROUPED BY"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "NOV"
-msgstr ""
+msgstr "NOV"
 
 #, fuzzy
 msgid "NUMERIC"
@@ -9134,30 +14188,57 @@ msgstr "Métrica"
 msgid "Name"
 msgstr "Nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name is required"
-msgstr ""
+msgstr "O nome é obrigatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name must be unique"
-msgstr ""
+msgstr "O nome deve ser único"
 
 #, fuzzy
 msgid "Name of table to be created"
 msgstr "Nome da tabela que existe na base de dados de origem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the column containing the id of the parent node"
-msgstr ""
+msgstr "Nome da coluna que contém o id do nó pai"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Name of the id column"
-msgstr ""
+msgstr "Nome da coluna id"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Name of the semantic layer"
-msgstr ""
+msgstr "Nome da camada semântica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the source nodes"
-msgstr ""
+msgstr "Nome dos nós de origem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the target nodes"
-msgstr ""
+msgstr "Nome dos nós de destino"
 
 #, fuzzy
 msgid "Name of your tag"
@@ -9167,21 +14248,37 @@ msgstr "Selecione uma base de dados"
 msgid "Name your database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
 msgstr ""
+"Dê um nome à sua pasta e, para a editar mais tarde, clique no nome da "
+"pasta"
 
 #, fuzzy
 msgid "Native filter column is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Native filter values has no values"
-msgstr ""
+msgstr "Os valores do filtro nativo não têm valores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn how to connect your database"
-msgstr ""
+msgstr "Precisa de ajuda? Saiba como ligar a sua base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn more about"
-msgstr ""
+msgstr "Precisa de ajuda? Saiba mais sobre"
 
 #, fuzzy
 msgid "Network Error"
@@ -9224,14 +14321,26 @@ msgstr "Mover gráfico"
 msgid "New tab"
 msgstr "fechar aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + q)"
-msgstr ""
+msgstr "Novo separador (Ctrl + q)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + t)"
-msgstr ""
+msgstr "Novo separador (Ctrl + t)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Next"
-msgstr ""
+msgstr "Seguinte"
 
 #, fuzzy
 msgid "Nightingale"
@@ -9241,12 +14350,19 @@ msgstr "Série Temporal - Gráfico de linhas"
 msgid "Nightingale Rose Chart"
 msgstr "Série Temporal - Gráfico de linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No"
-msgstr ""
+msgstr "Não"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "No %s yet"
-msgstr ""
+msgstr "Sem %s ainda"
 
 #, fuzzy
 msgid "No Data"
@@ -9302,44 +14418,75 @@ msgstr "Coluna"
 msgid "No compatible %s found"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible catalog found"
-msgstr ""
+msgstr "Nenhum catálogo compatível encontrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No compatible columns found"
-msgstr ""
+msgstr "Não foram encontradas colunas compatíveis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible schema found"
-msgstr ""
+msgstr "Nenhum esquema compatível encontrado"
 
 msgid "No data"
 msgstr "Metadados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No data after filtering or data is NULL for the latest time record"
 msgstr ""
+"Sem dados após a filtragem ou os dados são NULL para o registo de tempo "
+"mais recente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No data in file"
-msgstr ""
+msgstr "Sem dados no ficheiro"
 
 #, fuzzy
 msgid "No databases available"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No databases match your search"
-msgstr ""
+msgstr "Nenhuma base de dados corresponde à sua pesquisa"
 
 #, fuzzy
 msgid "No description available."
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No entities have this tag currently assigned"
-msgstr ""
+msgstr "Nenhuma entidade tem esta etiqueta actualmente atribuída"
 
 #, fuzzy
 msgid "No filter"
 msgstr "Adicionar filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No filter is selected."
-msgstr ""
+msgstr "Nenhum filtro está selecionado."
 
 #, fuzzy
 msgid "No filters"
@@ -9353,14 +14500,25 @@ msgstr "Filtros"
 msgid "No filters are currently added to this dashboard."
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Ainda não foram criados filtros ou personalizações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No form settings were maintained"
-msgstr ""
+msgstr "Nenhuma definição de formulário foi mantida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "No global filters are currently added"
-msgstr ""
+msgstr "Não foram adicionados filtros globais"
 
 #, fuzzy
 msgid "No groups"
@@ -9396,17 +14554,33 @@ msgstr "ver resultados"
 msgid "No results found"
 msgstr "Nenhum registo encontrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No results match your filter criteria"
-msgstr ""
+msgstr "Nenhum resultado corresponde aos seus critérios de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No results were returned for this query"
-msgstr ""
+msgstr "Não foram devolvidos resultados para esta consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "No results were returned for this query. If you expected results to be "
 "returned, ensure any filters are configured properly and the datasource "
 "contains data for the selected time range."
 msgstr ""
+"Não foram devolvidos resultados para esta consulta. Se esperava que "
+"fossem devolvidos resultados, certifique-se de que os filtros estão "
+"corretamente configurados e que a fonte de dados contém dados para o "
+"intervalo de tempo selecionado."
 
 #, fuzzy
 msgid "No roles"
@@ -9416,26 +14590,45 @@ msgstr "Mover gráfico"
 msgid "No roles yet"
 msgstr "Mover gráfico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No rows were returned for this %s"
-msgstr ""
+msgstr "Não foram devolvidas linhas para este %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No samples were returned for this %s"
-msgstr ""
+msgstr "Não foram devolvidas amostras para este %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No saved expressions found"
-msgstr ""
+msgstr "Não foram encontradas expressões guardadas"
 
 #, fuzzy
 msgid "No saved metrics found"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No stored results found, you need to re-run your query"
 msgstr ""
+"Não foram encontrados resultados armazenados, é necessário voltar a "
+"executar a consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No such column found. To filter on a metric, try the Custom SQL tab."
 msgstr ""
+"Não foi encontrada essa coluna. Para filtrar numa métrica, experimente o "
+"separador SQL personalizado."
 
 #, fuzzy
 msgid "No table columns"
@@ -9445,8 +14638,11 @@ msgstr "Ordenação original das colunas"
 msgid "No tasks yet"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No temporal columns found"
-msgstr ""
+msgstr "Não foram encontradas colunas temporais"
 
 #, fuzzy
 msgid "No time columns"
@@ -9460,49 +14656,92 @@ msgstr "Mover gráfico"
 msgid "No users yet"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No validator found (configured for the engine)"
-msgstr ""
+msgstr "Nenhum validador encontrado (configurado para o motor)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "No validator named %(validator_name)s found (configured for the "
 "%(engine_spec)s engine)"
 msgstr ""
+"Nenhum validador com o nome %(validator_name)s encontrado (configurado "
+"para o motor %(engine_spec)s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node label position"
-msgstr ""
+msgstr "Posição da etiqueta do nó"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node select mode"
-msgstr ""
+msgstr "Modo de seleção de nó"
 
 #, fuzzy
 msgid "Node size"
 msgstr "Tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None"
-msgstr ""
+msgstr "Nenhum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> Arrow"
-msgstr ""
+msgstr "Nenhum -> Seta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> None"
-msgstr ""
+msgstr "Nenhum -> Nenhum"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normal"
-msgstr ""
+msgstr "Normal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Normalize"
-msgstr ""
+msgstr "Normalizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalize Across"
-msgstr ""
+msgstr "Normalizar em"
 
 #, fuzzy
 msgid "Normalize column names"
 msgstr "Cláusula WHERE personalizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalized"
-msgstr ""
+msgstr "Normalizado"
 
 #, fuzzy
 msgid "Not Contains"
@@ -9512,8 +14751,12 @@ msgstr "Janela de exibição"
 msgid "Not Equal"
 msgstr "ver resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not Time Series"
-msgstr ""
+msgstr "Não é uma série temporal"
 
 #, fuzzy
 msgid "Not a valid ZIP file"
@@ -9523,18 +14766,30 @@ msgstr "Adicionar filtro"
 msgid "Not added to any dashboard"
 msgstr "Adicionar ao novo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not all required fields are complete. Please provide the following:"
 msgstr ""
+"Nem todos os campos obrigatórios estão preenchidos. Por favor, forneça o "
+"seguinte:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not available"
-msgstr ""
+msgstr "Não disponível"
 
 #, fuzzy
 msgid "Not defined"
 msgstr "Indefinido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Not equal to (≠)"
-msgstr ""
+msgstr "Diferente de (≠)"
 
 #, fuzzy
 msgid "Not found"
@@ -9544,25 +14799,41 @@ msgstr "Visualização %(id)s não encontrada"
 msgid "Not in"
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not null"
-msgstr ""
+msgstr "Não nulo"
 
 #, fuzzy
 msgid "Not set"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Not triggered"
-msgstr ""
+msgstr "Não acionado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not up to date"
-msgstr ""
+msgstr "Não atualizado"
 
 #, fuzzy
 msgid "Nothing here yet"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Nothing triggered"
-msgstr ""
+msgstr "Nada foi acionado"
 
 #, fuzzy
 msgid "Notification Method"
@@ -9572,93 +14843,185 @@ msgstr "Metadados adicionais"
 msgid "Notification method"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "November"
-msgstr ""
+msgstr "Novembro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Now"
-msgstr ""
+msgstr "Agora"
 
 #, fuzzy
 msgid "Null Values"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Null imputation"
-msgstr ""
+msgstr "Imputação nula"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Null or Empty"
-msgstr ""
+msgstr "Nulo ou Vazio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number Format"
-msgstr ""
+msgstr "Formato do número"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Number bounds used for color encoding from red to blue.\n"
 "               Reverse the numbers for blue to red. To get pure red or "
 "blue,\n"
 "               you can enter either only min or max."
 msgstr ""
+"Limites numéricos utilizados para a codificação de cores de vermelho para"
+" azul.\n"
+"               Inverta os números de azul para vermelho. Para obter "
+"vermelho ou azul puro,\n"
+"               pode introduzir apenas o mínimo ou o máximo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number format"
-msgstr ""
+msgstr "Formato numérico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number format string"
-msgstr ""
+msgstr "String de formato de número"
 
 #, fuzzy
 msgid "Number formatting"
 msgstr "Escolha uma métrica para o eixo direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of buckets to group data"
-msgstr ""
+msgstr "Número de intervalos para agrupar dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts per row when not fitting dynamically"
-msgstr ""
+msgstr "Número de gráficos por linha quando não se ajustam dinamicamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts to display per row"
-msgstr ""
+msgstr "Número de gráficos a apresentar por linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal digits to round numbers to"
-msgstr ""
+msgstr "Número de dígitos decimais para arredondar os números"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display lift values"
-msgstr ""
+msgstr "Número de casas decimais para apresentar valores de elevação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display p-values"
-msgstr ""
+msgstr "Número de casas decimais para apresentar valores-p"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Number of periods to compare against. You can use negative numbers to "
 "compare from the beginning of the time range."
 msgstr ""
+"Número de períodos para comparar. Pode usar números negativos para "
+"comparar desde o início do intervalo de tempo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Number of periods to ratio against"
-msgstr ""
+msgstr "Número de períodos para calcular a razão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of rows of file to read. Leave empty (default) to read all rows"
 msgstr ""
+"Número de linhas do ficheiro a ler. Deixe vazio (predefinição) para ler "
+"todas as linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of rows to skip at start of file."
-msgstr ""
+msgstr "Número de linhas a ignorar no início do ficheiro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of split segments on the axis"
-msgstr ""
+msgstr "Número de segmentos divididos no eixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the X scale"
-msgstr ""
+msgstr "Número de passos a dar entre os tiques ao apresentar a escala X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the Y scale"
-msgstr ""
+msgstr "Número de passos a dar entre os tiques ao apresentar a escala Y"
 
 #, fuzzy
 msgid "Number of top values"
 msgstr "Valor de filtro"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Numbers must be within %(min)s and %(max)s"
-msgstr ""
+msgstr "Os números devem estar entre %(min)s e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Numeric column used to calculate the histogram."
-msgstr ""
+msgstr "Coluna numérica utilizada para calcular o histograma."
 
 #, fuzzy
 msgid "Numerical range"
@@ -9668,11 +15031,19 @@ msgstr "Granularidade Temporal"
 msgid "OAuth2 client information"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OCT"
-msgstr ""
+msgstr "OUT"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #, fuzzy
 msgid "OR"
@@ -9681,29 +15052,54 @@ msgstr "hora"
 msgid "OVERWRITE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "October"
-msgstr ""
+msgstr "Outubro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Offline"
-msgstr ""
+msgstr "Offline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "On Grace"
-msgstr ""
+msgstr "No período de graça"
 
 #, fuzzy
 msgid "On dashboards"
 msgstr "Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many columns to group by. High cardinality groupings should "
 "include a series limit to limit the number of fetched and rendered "
 "series."
 msgstr ""
+"Uma ou várias colunas para agrupar. Os agrupamentos de elevada "
+"cardinalidade devem incluir um limite de séries para limitar o número de "
+"séries obtidas e renderizadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many controls to group by. If grouping, latitude and longitude "
 "columns must be present."
 msgstr ""
+"Um ou vários controlos para agrupar. Em caso de agrupamento, as colunas "
+"de latitude e longitude devem estar presentes."
 
 msgid "One or many controls to pivot as columns"
 msgstr "Um ou vários controles para pivotar como colunas"
@@ -9715,14 +15111,26 @@ msgstr "Uma ou várias métricas para exibir"
 msgid "One or more annotation layers failed loading."
 msgstr "Camadas de anotação para sobreposição na visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns already exist"
-msgstr ""
+msgstr "Uma ou mais colunas já existem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns are duplicated"
-msgstr ""
+msgstr "Uma ou mais colunas estão duplicadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns do not exist"
-msgstr ""
+msgstr "Uma ou mais colunas não existem"
 
 msgid "One or more metrics already exist"
 msgstr "Uma ou várias métricas para exibir"
@@ -9733,64 +15141,135 @@ msgstr "Uma ou várias métricas para exibir"
 msgid "One or more metrics do not exist"
 msgstr "Uma ou várias métricas para exibir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters needed to configure a database are missing."
 msgstr ""
+"Um ou mais parâmetros necessários para configurar uma base de dados estão"
+" em falta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "One or more parameters specified in the query are malformed."
-msgstr ""
+msgstr "Um ou mais parâmetros especificados na consulta estão mal formados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters specified in the query are missing."
-msgstr ""
+msgstr "Um ou mais parâmetros especificados na consulta estão em falta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Only Total"
-msgstr ""
+msgstr "Apenas Total"
 
 msgid "Only `SELECT` statements are allowed"
 msgstr "Copiar a instrução SELECT para a área de transferência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is not set to a percentage."
 msgstr ""
+"Aplica-se apenas quando o \"Tipo de Etiqueta\" não está definido como "
+"percentagem."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is set to show values."
 msgstr ""
+"Aplica-se apenas quando o \"Tipo de Etiqueta\" está definido para mostrar"
+" valores."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "Apenas a correspondência exacta está disponível para colunas não-texto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Prossiga apenas se confiar no destino ou na sua origem."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
 "selected category"
 msgstr ""
+"Mostrar apenas o valor total no gráfico empilhado, e não mostrar na "
+"categoria seleccionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Only single queries supported"
-msgstr ""
+msgstr "Apenas consultas individuais são suportadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only the default catalog is supported for this connection"
-msgstr ""
+msgstr "Apenas o catálogo predefinido é suportado para esta ligação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Oops! An error occurred!"
-msgstr ""
+msgstr "Ups! Ocorreu um erro!"
 
 msgid "Opacity"
 msgstr "Opacidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of Area Chart. Also applies to confidence band."
-msgstr ""
+msgstr "Opacidade do gráfico de áreas. Aplica-se também à banda de confiança."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of all clusters, points, and labels. Between 0 and 1."
-msgstr ""
+msgstr "Opacidade de todos os clusters, pontos e etiquetas. Entre 0 e 1."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of area chart."
-msgstr ""
+msgstr "Opacidade do gráfico de áreas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Opacity of bubbles, 0 means completely transparent, 1 means opaque"
 msgstr ""
+"Opacidade das bolhas, 0 significa completamente transparente, 1 significa"
+" opaco"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Opacity, expects values between 0 and 100"
-msgstr ""
+msgstr "Opacidade, espera valores entre 0 e 100"
 
 #, fuzzy
 msgid "Open Datasource tab"
@@ -9810,57 +15289,108 @@ msgstr "Expor no SQL Lab"
 msgid "Open query in SQL Lab"
 msgstr "Expor no SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Operate the database in asynchronous mode, meaning that the queries are "
 "executed on remote workers as opposed to on the web server itself. This "
 "assumes that you have a Celery worker setup as well as a results backend."
 " Refer to the installation docs for more information."
 msgstr ""
+"Operar a base de dados em modo assíncrono, o que significa que as "
+"consultas são executadas em workers remotos em vez de no próprio servidor"
+" Web. Isto pressupõe que tenha uma configuração do Celery worker bem como"
+" um backend de resultados. Consulte a documentação de instalação para "
+"obter mais informações."
 
 #, fuzzy
 msgid "Operator"
 msgstr "Selecione operador"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Operator undefined for aggregator: %(name)s"
-msgstr ""
+msgstr "Operador não definido para o agregador: %(name)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Optional CA_BUNDLE contents to validate HTTPS requests. Only available on"
 " certain database engines."
 msgstr ""
+"Conteúdo CA_BUNDLE opcional para validar pedidos HTTPS. Disponível apenas"
+" em determinados motores de base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Optional d3 date format string"
-msgstr ""
+msgstr "Cadeia de caracteres opcional de formato de data d3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Optional d3 number format string"
-msgstr ""
+msgstr "Cadeia de caracteres opcional de formato de número d3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional name of the data column."
-msgstr ""
+msgstr "Nome opcional da coluna de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional warning about use of this metric"
-msgstr ""
+msgstr "Aviso opcional sobre a utilização desta métrica"
 
 #, fuzzy
 msgid "Options"
 msgstr "Opções"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Or choose from a list of other databases we support:"
-msgstr ""
+msgstr "Ou escolha a partir de uma lista de outras bases de dados que suportamos:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Order results by selected columns"
-msgstr ""
+msgstr "Ordenar resultados por colunas seleccionadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ordering"
-msgstr ""
+msgstr "Ordenação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Orders the query result that generates the source data for this chart. If"
 " a series or row limit is reached, this determines what data are "
 "truncated. If undefined, defaults to the first metric (where "
 "appropriate)."
 msgstr ""
+"Ordena o resultado da consulta que gera os dados de origem para este "
+"gráfico. Se for atingido um limite de séries ou linhas, isto determina "
+"que dados são truncados. Se não estiver definido, o valor predefinido é a"
+" primeira métrica (quando aplicável)."
 
 #, fuzzy
 msgid "Orientation"
@@ -9870,11 +15400,19 @@ msgstr "Anotações"
 msgid "Orientation of bar chart"
 msgstr "Gráfico de barras"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Orientation of filter bar"
-msgstr ""
+msgstr "Orientação da barra de filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Orientation of tree"
-msgstr ""
+msgstr "Orientação da árvore"
 
 #, fuzzy
 msgid "Original"
@@ -9883,24 +15421,43 @@ msgstr "Origem"
 msgid "Original table column order"
 msgstr "Ordenação original das colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Original value"
-msgstr ""
+msgstr "Valor original"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Orthogonal"
-msgstr ""
+msgstr "Ortogonal"
 
 #, fuzzy
 msgid "Other"
 msgstr "mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Other color palettes"
-msgstr ""
+msgstr "Outras paletas de cores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outdoors"
-msgstr ""
+msgstr "Ao ar livre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outer Radius"
-msgstr ""
+msgstr "Raio Exterior"
 
 #, fuzzy
 msgid "Outer edge of Pie chart"
@@ -9941,10 +15498,16 @@ msgstr ""
 "variação temporal relativa em linguagem natural (exemplo: 24 horas, 7 "
 "dias, 56 semanas, 365 dias)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Overlays a hexagonal grid on a map, and aggregates data within the "
 "boundary of each cell."
 msgstr ""
+"Sobrepõe uma grelha hexagonal num mapa e agrega dados dentro do limite de"
+" cada célula."
 
 #, fuzzy
 msgid "Override time grain"
@@ -9964,14 +15527,21 @@ msgstr "Substitua a visualização %s"
 msgid "Overwrite Dashboard [%s]"
 msgstr "Substituir Dashboard [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Overwrite existing"
-msgstr ""
+msgstr "Sobrescrever existente"
 
 msgid "Overwrite text in the editor with a query on this table"
 msgstr "Substitua texto no editor com uma query nesta tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Owned Created or Favored"
-msgstr ""
+msgstr "Próprio, Criado ou Favorito"
 
 msgid "Owner"
 msgstr "Proprietário"
@@ -9979,8 +15549,12 @@ msgstr "Proprietário"
 msgid "Owners"
 msgstr "Proprietários"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Owners are invalid"
-msgstr ""
+msgstr "Os proprietários são inválidos"
 
 msgid "Owners is a list of users who can alter the dashboard."
 msgstr "Proprietários é uma lista de utilizadores que podem alterar o dashboard."
@@ -9990,8 +15564,11 @@ msgid ""
 " or username."
 msgstr "Proprietários é uma lista de utilizadores que podem alterar o dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "PDF download failed, please refresh and try again."
-msgstr ""
+msgstr "Falha ao descarregar o PDF, por favor actualize e tente novamente."
 
 #, fuzzy
 msgid "Page"
@@ -10001,15 +15578,23 @@ msgstr "Gerir"
 msgid "Page Size:"
 msgstr "Repor Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Page length"
-msgstr ""
+msgstr "Comprimento da página"
 
 #, fuzzy
 msgid "Page navigation"
 msgstr "Soma Agregada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paired t-test Table"
-msgstr ""
+msgstr "Tabela de teste t pareado"
 
 msgid "Pandas resample method"
 msgstr "Método de preenchimento da remistura de pandas"
@@ -10031,18 +15616,32 @@ msgstr "Parâmetros"
 msgid "Parameters "
 msgstr "Parâmetros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Parameters related to the view and perspective on the map"
-msgstr ""
+msgstr "Parâmetros relacionados com a vista e a perspectiva no mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Parent"
-msgstr ""
+msgstr "Pai"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Parsing error: %(error)s"
-msgstr ""
+msgstr "Erro de análise: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Part of a Whole"
-msgstr ""
+msgstr "Parte de um Todo"
 
 #, fuzzy
 msgid "Partition Chart"
@@ -10055,13 +15654,23 @@ msgstr "Diagrama de Partição"
 msgid "Partition Limit"
 msgstr "Diagrama de Partição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Partition Threshold"
-msgstr ""
+msgstr "Limiar de partição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Partitions whose height to parent height proportions are below this value"
 " are pruned"
 msgstr ""
+"As partições cujas proporções de altura em relação à altura do elemento "
+"pai estejam abaixo deste valor são eliminadas"
 
 #, fuzzy
 msgid "Password"
@@ -10083,14 +15692,25 @@ msgstr "Dashboards"
 msgid "Paste"
 msgstr "%s - sem título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Paste Private Key here"
-msgstr ""
+msgstr "Cole a chave privada aqui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Paste content of service credentials JSON file here"
-msgstr ""
+msgstr "Cole aqui o conteúdo do ficheiro JSON de credenciais do serviço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paste the shareable Google Sheet URL here"
-msgstr ""
+msgstr "Cole aqui o URL partilhável do Google Sheet"
 
 #, fuzzy
 msgid "Paste your access token here"
@@ -10104,11 +15724,18 @@ msgstr "Selecione uma cor"
 msgid "Path Size"
 msgstr "Repor Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pattern"
-msgstr ""
+msgstr "Padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Pausar a atualização automática se o separador estiver inativo"
 
 #, fuzzy
 msgid "Pause auto-refresh"
@@ -10130,17 +15757,29 @@ msgstr "Modificado pela última vez"
 msgid "Percent Difference format"
 msgstr "Formato de data e hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percent of total"
-msgstr ""
+msgstr "Percentagem do total"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage"
-msgstr ""
+msgstr "Percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage change"
-msgstr ""
+msgstr "Variação percentual"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage difference between the time periods"
-msgstr ""
+msgstr "Diferença percentual entre os períodos de tempo"
 
 #, fuzzy
 msgid "Percentage metric calculation"
@@ -10150,52 +15789,100 @@ msgstr "Selecione métrica"
 msgid "Percentage metrics"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Percentage threshold"
-msgstr ""
+msgstr "Limiar de percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Percentages"
-msgstr ""
+msgstr "Percentagens"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Performance"
-msgstr ""
+msgstr "Desempenho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Period average"
-msgstr ""
+msgstr "Média do período"
 
 msgid "Periods"
 msgstr "Períodos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Periods must be a whole number"
-msgstr ""
+msgstr "Os períodos devem ser um número inteiro"
 
 #, fuzzy
 msgid "Permissions"
 msgstr "Expressão"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Permissions successfully synced for %s"
-msgstr ""
+msgstr "Permissões sincronizadas com sucesso para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this chart."
-msgstr ""
+msgstr "Pessoa ou grupo que certificou este gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this dashboard."
-msgstr ""
+msgstr "Pessoa ou grupo que certificou este painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this metric"
-msgstr ""
+msgstr "Pessoa ou grupo que certificou esta métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "Informação pessoal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical"
-msgstr ""
+msgstr "Físico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical (table or view)"
-msgstr ""
+msgstr "Físico (tabela ou vista)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Pick a dimension from which categorical colors are defined"
-msgstr ""
+msgstr "Escolha uma dimensão a partir da qual as cores categóricas são definidas"
 
 msgid "Pick a metric for x, y and size"
 msgstr "Selecione uma métrica para x, y e tamanho"
@@ -10203,22 +15890,41 @@ msgstr "Selecione uma métrica para x, y e tamanho"
 msgid "Pick a metric to display"
 msgstr "Selecione uma métrica para visualizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a name to help you identify this database."
-msgstr ""
+msgstr "Escolha um nome para o ajudar a identificar esta base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pick a nickname for how the database will display in Superset."
 msgstr ""
+"Escolha um apelido para a forma como a base de dados será apresentada no "
+"Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a title for you annotation."
-msgstr ""
+msgstr "Escolha um título para a sua anotação."
 
 msgid "Pick at least one metric"
 msgstr "Selecione pelo menos uma métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Pick one or more columns that should be shown in the annotation. If you "
 "don't select a column all of them will be shown."
 msgstr ""
+"Selecione uma ou mais colunas que devem ser apresentadas na anotação. Se "
+"não selecionar uma coluna, todas serão apresentadas."
 
 msgid "Pick your favorite markup language"
 msgstr "Escolha a sua linguagem de marcação favorita"
@@ -10227,14 +15933,24 @@ msgstr "Escolha a sua linguagem de marcação favorita"
 msgid "Pie Chart"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pie charts on a map"
-msgstr ""
+msgstr "Gráficos de pizza num mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pie shape"
-msgstr ""
+msgstr "Formato de pizza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Piecewise"
-msgstr ""
+msgstr "Por partes"
 
 #, fuzzy
 msgid "Pin"
@@ -10252,11 +15968,17 @@ msgstr "Eliminar"
 msgid "Pin Right"
 msgstr "Altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "Fixar no painel de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pin to top"
-msgstr ""
+msgstr "Fixar no topo"
 
 #, fuzzy
 msgid "Pivot Mode"
@@ -10265,11 +15987,19 @@ msgstr "Editar"
 msgid "Pivot Table"
 msgstr "Tabela Pivot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation must include at least one aggregate"
-msgstr ""
+msgstr "A operação de pivot deve incluir pelo menos um agregado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation requires at least one index"
-msgstr ""
+msgstr "A operação de pivot requer pelo menos um índice"
 
 #, fuzzy
 msgid "Pivoted"
@@ -10279,54 +16009,105 @@ msgstr "Editar"
 msgid "Pivots"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixel height of each series"
-msgstr ""
+msgstr "Altura em píxeis de cada série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixels"
-msgstr ""
+msgstr "Píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Plain"
-msgstr ""
+msgstr "Simples"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Please check your query and confirm that all template parameters are "
 "surround by double braces, for example, \"{{ ds }}\". Then, try running "
 "your query again."
 msgstr ""
+"Verifique a sua consulta e confirme que todos os parâmetros do modelo "
+"estão entre chaves duplas, por exemplo, \"{{ ds }}\". De seguida, tente "
+"executar a sua consulta novamente."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors at or near "
 "\"%(syntax_error)s\". Then, try running your query again."
 msgstr ""
+"Verifique se existem erros de sintaxe na sua consulta em ou perto de "
+"\"%(syntax_error)s\". De seguida, tente executar a sua consulta "
+"novamente."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors near \"%(server_error)s\". "
 "Then, try running your query again."
 msgstr ""
+"Verifique se existem erros de sintaxe na sua consulta perto de "
+"\"%(server_error)s\". De seguida, tente executar a sua consulta "
+"novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Please check your template parameters for syntax errors and make sure "
 "they match across your SQL query and Set Parameters. Then, try running "
 "your query again."
 msgstr ""
+"Verifique se existem erros de sintaxe nos parâmetros do modelo e "
+"certifique-se de que correspondem à sua consulta SQL e aos Parâmetros "
+"Definidos. De seguida, tente executar a sua consulta novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please choose a valid value"
-msgstr ""
+msgstr "Escolha um valor válido"
 
 #, fuzzy
 msgid "Please choose at least one groupby"
 msgstr "Selecione pelo menos um campo \"Agrupar por\" "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please confirm"
-msgstr ""
+msgstr "Por favor, confirme"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please confirm the overwrite values."
-msgstr ""
+msgstr "Por favor, confirme os valores de substituição."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please confirm your password"
-msgstr ""
+msgstr "Por favor, confirme a sua palavra-passe"
 
 msgid "Please enter a SQLAlchemy URI to test"
 msgstr "Por favor insira um nome para a visualização"
@@ -10335,14 +16116,23 @@ msgstr "Por favor insira um nome para a visualização"
 msgid "Please enter a valid email"
 msgstr "Por favor insira um nome para a visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Por favor, introduza um endereço de e-mail válido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter valid text. Spaces alone are not permitted."
-msgstr ""
+msgstr "Por favor, introduza texto válido. Apenas espaços não são permitidos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter your email"
-msgstr ""
+msgstr "Por favor, introduza o seu e-mail"
 
 #, fuzzy
 msgid "Please enter your first name"
@@ -10360,58 +16150,107 @@ msgstr "Broker Port"
 msgid "Please enter your username"
 msgstr "Rótulo para a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please fix the following errors"
-msgstr ""
+msgstr "Por favor, corrija os seguintes erros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please provide a valid min or max value"
-msgstr ""
+msgstr "Por favor, forneça um valor mínimo ou máximo válido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please re-enter the password."
-msgstr ""
+msgstr "Por favor, introduza novamente a palavra-passe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please re-export your file and try importing again"
-msgstr ""
+msgstr "Por favor, reexporte o seu ficheiro e tente importar novamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# ja, lv, mi, pl, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Please reach out to the Chart Owner for assistance."
 msgid_plural "Please reach out to the Chart Owners for assistance."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Por favor, contacte o Proprietário do Gráfico para obter assistência."
+msgstr[1] "Por favor, contacte os Proprietários do Gráfico para obter assistência."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your chart first, then try creating a new email report."
 msgstr ""
+"Por favor, guarde primeiro o seu gráfico e tente criar um novo relatório "
+"de e-mail."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your dashboard first, then try creating a new email report."
 msgstr ""
+"Por favor, guarde primeiro o seu painel e tente criar um novo relatório "
+"de e-mail."
 
 #, fuzzy
 msgid "Please select at least one role or group"
 msgstr "Selecione pelo menos um campo \"Agrupar por\" "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Please select both a %s and a Chart type to proceed"
-msgstr ""
+msgstr "Por favor, selecione um %s e um tipo de Gráfico para continuar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja "
 "macro."
 msgstr ""
+"Por favor, especifique o ID do Conjunto de dados para a métrica "
+"``%(name)s`` na macro Jinja."
 
 msgid "Please use 3 different metric labels"
 msgstr "Selecione métricas diferentes para o eixo esquerdo e direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Plot the distance (like flight paths) between origin and destination."
-msgstr ""
+msgstr "Represente a distância (como rotas de voo) entre a origem e o destino."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Plots the individual metrics for each row in the data vertically and "
 "links them together as a line. This chart is useful for comparing "
 "multiple metrics across all of the samples or rows in the data."
 msgstr ""
+"Representa as métricas individuais para cada linha nos dados "
+"verticalmente e liga-as como uma linha. Este gráfico é útil para comparar"
+" várias métricas em todas as amostras ou linhas nos dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 #, fuzzy
 msgid "Point Cluster Map"
@@ -10421,30 +16260,59 @@ msgstr "Selecione uma cor"
 msgid "Point Color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius"
-msgstr ""
+msgstr "Raio do Ponto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Radius Scale"
-msgstr ""
+msgstr "Escala do Raio do Ponto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius Unit"
-msgstr ""
+msgstr "Unidade do Raio do Ponto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Point Size"
-msgstr ""
+msgstr "Tamanho do Ponto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Unit"
-msgstr ""
+msgstr "Unidade do Ponto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point to your spatial columns"
-msgstr ""
+msgstr "Aponte para as suas colunas espaciais"
 
 #, fuzzy
 msgid "Points"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Points and clusters will update as the viewport is being changed"
 msgstr ""
+"Os pontos e clusters serão atualizados à medida que a janela de "
+"visualização for alterada"
 
 #, fuzzy
 msgid "Polygon Column"
@@ -10454,50 +16322,92 @@ msgstr "Coluna"
 msgid "Polygon Encoding"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Polygon Settings"
-msgstr ""
+msgstr "Definições de Polígono"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Polyline"
-msgstr ""
+msgstr "Polilinha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Populate \"Default value\" to enable this control"
-msgstr ""
+msgstr "Preencha \"Default value\" para ativar este controlo"
 
 #, fuzzy
 msgid "Port"
 msgstr "Janela de exibição"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Port %(port)s on hostname \"%(hostname)s\" refused the connection."
-msgstr ""
+msgstr "A porta %(port)s no nome do servidor \"%(hostname)s\" recusou a ligação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Port out of range 0-65535"
-msgstr ""
+msgstr "Porta fora do intervalo 0-65535"
 
 msgid "Position JSON"
 msgstr "Posição JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of child node label on tree"
-msgstr ""
+msgstr "Posição da etiqueta do nó filho na árvore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of column level subtotal"
-msgstr ""
+msgstr "Posição do subtotal ao nível da coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Position of intermediate node label on tree"
-msgstr ""
+msgstr "Posição da etiqueta do nó intermédio na árvore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of row level subtotal"
-msgstr ""
+msgstr "Posição do subtotal ao nível da linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Powered by Apache Superset"
-msgstr ""
+msgstr "Desenvolvido por Apache Superset"
 
 #, fuzzy
 msgid "Pre-filter"
 msgstr "Filtro de data"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pre-filter available values"
-msgstr ""
+msgstr "Pré-filtrar valores disponíveis"
 
 #, fuzzy
 msgid "Pre-filter is required"
@@ -10507,20 +16417,35 @@ msgstr "Origem de dados"
 msgid "Predictive"
 msgstr "Acção"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Predictive Analytics"
-msgstr ""
+msgstr "Análise Preditiva"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix"
-msgstr ""
+msgstr "Prefixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix or suffix"
-msgstr ""
+msgstr "Prefixo ou sufixo"
 
 msgid "Preview"
 msgstr "Pré-visualização para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Preview uploaded file"
-msgstr ""
+msgstr "Pré-visualizar ficheiro carregado"
 
 msgid "Previous"
 msgstr "Pré-visualização para %s"
@@ -10529,88 +16454,162 @@ msgstr "Pré-visualização para %s"
 msgid "Previous Line"
 msgstr "Pré-visualização para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Primary"
-msgstr ""
+msgstr "Primário"
 
 #, fuzzy
 msgid "Primary Metric"
 msgstr "Selecione uma métrica!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Primary key"
-msgstr ""
+msgstr "Chave primária"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary or secondary y-axis"
-msgstr ""
+msgstr "Eixo y primário ou secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Primary y-axis Bounds"
-msgstr ""
+msgstr "Limites do eixo y Primário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary y-axis format"
-msgstr ""
+msgstr "Formato do eixo y primário"
 
 #, fuzzy
 msgid "Private"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Private Channels (Bot in channel)"
-msgstr ""
+msgstr "Canais Privados (Bot no canal)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Private Key"
-msgstr ""
+msgstr "Chave Privada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Private Key & Password"
-msgstr ""
+msgstr "Chave Privada e Palavra-passe"
 
 #, fuzzy
 msgid "Private Key Password"
 msgstr "Broker Port"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Proceed"
-msgstr ""
+msgstr "Continuar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "A processar exportação para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Processing export..."
-msgstr ""
+msgstr "A processar exportação..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progress"
-msgstr ""
+msgstr "Progresso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progressive"
-msgstr ""
+msgstr "Progressivo"
 
 #, fuzzy
 msgid "Project Id"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Proportional"
-msgstr ""
+msgstr "Proporcional"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Folhas partilhadas pública e privadamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Apenas folhas partilhadas publicamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Published"
-msgstr ""
+msgstr "Publicado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Purple"
-msgstr ""
+msgstr "Roxo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put labels outside"
-msgstr ""
+msgstr "Colocar etiquetas no exterior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put the labels outside of the pie?"
-msgstr ""
+msgstr "Colocar as etiquetas no exterior do gráfico circular?"
 
 msgid "Put your code here"
 msgstr "Insira o seu código aqui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Python datetime string pattern"
-msgstr ""
+msgstr "Padrão de cadeia de data e hora Python"
 
 #, fuzzy
 msgid "Quarter"
@@ -10627,9 +16626,12 @@ msgstr "Séries"
 msgid "Query"
 msgstr "Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Query %s: %s"
-msgstr ""
+msgstr "Consulta %s: %s"
 
 #, fuzzy
 msgid "Query A"
@@ -10662,14 +16664,21 @@ msgstr "Origem de dados %(name)s já existe"
 msgid "Query history"
 msgstr "Histórico de queries"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Query imported"
-msgstr ""
+msgstr "Consulta importada"
 
 msgid "Query in a new tab"
 msgstr "Query numa nova aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Query is too complex and takes too long to run."
-msgstr ""
+msgstr "A consulta é demasiado complexa e demora demasiado a executar."
 
 #, fuzzy
 msgid "Query mode"
@@ -10705,32 +16714,52 @@ msgstr "Modelos CSS"
 msgid "RLS rules could not be deleted."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar"
-msgstr ""
+msgstr "Radar"
 
 #, fuzzy
 msgid "Radar Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar render type, whether to display 'circle' shape."
-msgstr ""
+msgstr "Tipo de renderização do radar, se deve apresentar a forma de 'círculo'."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Radial"
-msgstr ""
+msgstr "Radial"
 
 #, fuzzy
 msgid "Radius"
 msgstr "Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Radius in kilometers"
-msgstr ""
+msgstr "Raio em quilómetros"
 
 #, fuzzy
 msgid "Radius in meters"
 msgstr "Parâmetros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radius in miles"
-msgstr ""
+msgstr "Raio em milhas"
 
 #, fuzzy
 msgid "Range"
@@ -10748,11 +16777,19 @@ msgstr "Limite de série"
 msgid "Range filter"
 msgstr "Filtro de data"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range filter plugin using AntD"
-msgstr ""
+msgstr "Plugin de filtro de intervalo usando AntD"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range labels"
-msgstr ""
+msgstr "Rótulos de intervalo"
 
 #, fuzzy
 msgid "Range type"
@@ -10762,8 +16799,12 @@ msgstr "Limite de série"
 msgid "Ranges"
 msgstr "Gerir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ranges to highlight with shading"
-msgstr ""
+msgstr "Intervalos a destacar com sombreamento"
 
 #, fuzzy
 msgid "Ranking"
@@ -10773,51 +16814,93 @@ msgstr "Mensagem de Aviso"
 msgid "Ratio"
 msgstr "Descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Raw records"
-msgstr ""
+msgstr "Registos brutos"
 
 #, fuzzy
 msgid "Recently modified"
 msgstr "Última Alteração"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Recents"
-msgstr ""
+msgstr "Recentes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Recipients are separated by \",\" or \";\""
-msgstr ""
+msgstr "Os destinatários são separados por \",\" ou \";\""
 
 #, fuzzy
 msgid "Records"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Rectangle"
-msgstr ""
+msgstr "Retângulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Recurring (every)"
-msgstr ""
+msgstr "Recorrente (a cada)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Red for increase, green for decrease"
-msgstr ""
+msgstr "Vermelho para aumento, verde para diminuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Redo the action"
-msgstr ""
+msgstr "Refazer a ação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Reduce X ticks"
-msgstr ""
+msgstr "Reduzir marcas X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Reduces the number of X-axis ticks to be rendered. If true, the x-axis "
 "will not overflow and labels may be missing. If false, a minimum width "
 "will be applied to columns and the width may overflow into an horizontal "
 "scroll."
 msgstr ""
+"Reduz o número de marcas do eixo X a serem renderizadas. Se verdadeiro, o"
+" eixo X não irá transbordar e as etiquetas podem estar em falta. Se "
+"falso, será aplicada uma largura mínima às colunas e a largura pode "
+"transbordar para um deslocamento horizontal."
 
 #, fuzzy
 msgid "Refer to the"
 msgstr "mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Referenced columns not available in DataFrame."
-msgstr ""
+msgstr "As colunas referenciadas não estão disponíveis no DataFrame."
 
 #, fuzzy
 msgid "Referrer"
@@ -10834,12 +16917,18 @@ msgstr "Sem dashboards"
 msgid "Refresh delayed"
 msgstr "Sem dashboards"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh frequency"
-msgstr ""
+msgstr "Frequência de atualização"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Refresh frequency must be at least %s seconds"
-msgstr ""
+msgstr "A frequência de atualização deve ser de pelo menos %s segundos"
 
 #, fuzzy
 msgid "Refresh interval"
@@ -10861,8 +16950,12 @@ msgstr "Lista de Métricas"
 msgid "Refresh table schema"
 msgstr "Selecione um esquema (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh the default values"
-msgstr ""
+msgstr "Atualizar os valores predefinidos"
 
 #, fuzzy
 msgid "Refreshing charts"
@@ -10880,51 +16973,91 @@ msgstr "Filtro de data"
 msgid "Registration date"
 msgstr "Início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "Registo efetuado com sucesso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Regular"
-msgstr ""
+msgstr "Regular"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Regular filters add where clauses to queries if a user belongs to a role "
 "referenced in the filter, base filters apply filters to all queries "
 "except the roles defined in the filter, and can be used to define what "
 "users can see if no RLS filters within a filter group apply to them."
 msgstr ""
+"Os filtros regulares adicionam cláusulas where às consultas se um "
+"utilizador pertencer a uma função referenciada no filtro; os filtros de "
+"base aplicam filtros a todas as consultas exceto as funções definidas no "
+"filtro, e podem ser utilizados para definir o que os utilizadores podem "
+"ver se nenhum filtro RLS dentro de um grupo de filtros lhes for "
+"aplicável."
 
 #, fuzzy
 msgid "Relational"
 msgstr "Descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relationships between community channels"
-msgstr ""
+msgstr "Relações entre canais da comunidade"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative Date/Time"
-msgstr ""
+msgstr "Data/Hora Relativa"
 
 #, fuzzy
 msgid "Relative period"
 msgstr "Períodos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative quantity"
-msgstr ""
+msgstr "Quantidade relativa"
 
 #, fuzzy
 msgid "Reload"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove"
-msgstr ""
+msgstr "Remover"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Dark Theme"
-msgstr ""
+msgstr "Remover Tema Escuro do Sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Default Theme"
-msgstr ""
+msgstr "Remover Tema Predefinido do Sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove cross-filter"
-msgstr ""
+msgstr "Remover filtro cruzado"
 
 #, fuzzy
 msgid "Remove customization"
@@ -10934,8 +17067,12 @@ msgstr "Tipo de Visualização"
 msgid "Remove filter"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove item"
-msgstr ""
+msgstr "Remover item"
 
 msgid "Remove query from log"
 msgstr "Remover query do histórico"
@@ -10943,28 +17080,45 @@ msgstr "Remover query do histórico"
 msgid "Remove table preview"
 msgstr "Remover pré-visualização de tabela"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Removida 1 coluna do conjunto de dados virtual"
+msgstr[1] "Removidas %s colunas do conjunto de dados virtual"
 
 msgid "Rename tab"
 msgstr "renomear aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render HTML"
-msgstr ""
+msgstr "Renderizar HTML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render columns in HTML format"
-msgstr ""
+msgstr "Renderizar colunas em formato HTML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Renders table cells as HTML when applicable. For example, HTML <a> tags "
 "will be rendered as hyperlinks."
 msgstr ""
+"Renderiza as células da tabela como HTML quando aplicável. Por exemplo, "
+"as etiquetas HTML <a> serão renderizadas como hiperligações."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Replace"
-msgstr ""
+msgstr "Substituir"
 
 #, fuzzy
 msgid "Report"
@@ -10979,41 +17133,90 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Report Schedule could not be updated."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule delete failed."
-msgstr ""
+msgstr "Falha ao eliminar o Agendamento de Relatório."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a csv."
-msgstr ""
+msgstr "A execução do Agendamento de Relatório falhou ao gerar um ficheiro csv."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a dataframe."
-msgstr ""
+msgstr "A execução do Agendamento de Relatório falhou ao gerar um dataframe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a pdf."
-msgstr ""
+msgstr "A execução do Agendamento de Relatório falhou ao gerar um pdf."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a screenshot."
 msgstr ""
+"A execução do Agendamento de Relatório falhou ao gerar uma captura de "
+"ecrã."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution got an unexpected error."
-msgstr ""
+msgstr "A execução do Agendamento de Relatório obteve um erro inesperado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule is still working, refusing to re-compute."
-msgstr ""
+msgstr "O Agendamento de Relatório ainda está a trabalhar, a recusar recalcular."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule log prune failed."
-msgstr ""
+msgstr "Falha ao limpar o registo do Agendamento de Relatório."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule not found."
-msgstr ""
+msgstr "Agendamento de Relatório não encontrado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule parameters are invalid."
-msgstr ""
+msgstr "Os parâmetros do Agendamento de Relatório são inválidos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule reached a working timeout."
-msgstr ""
+msgstr "O Agendamento de Relatório atingiu o tempo limite de trabalho."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule state not found"
-msgstr ""
+msgstr "Estado do Agendamento de Relatório não encontrado"
 
 #, fuzzy
 msgid "Report a bug"
@@ -11039,11 +17242,18 @@ msgstr "Nome do modelo"
 msgid "Report schedule client error"
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report schedule system error"
-msgstr ""
+msgstr "Erro de sistema no agendamento de relatórios"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report schedule unexpected error"
-msgstr ""
+msgstr "Erro inesperado no agendamento do relatório"
 
 #, fuzzy
 msgid "Report sending"
@@ -11064,51 +17274,89 @@ msgstr "Janela de exibição"
 msgid "Repulsion"
 msgstr "Expressão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Repulsion strength between nodes"
-msgstr ""
+msgstr "Força de repulsão entre nós"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request Access"
-msgstr ""
+msgstr "Solicitar Acesso"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Request is incorrect: %(error)s"
-msgstr ""
+msgstr "O pedido está incorreto: %(error)s"
 
 #, fuzzy
 msgid "Request is not JSON"
 msgstr "Requisição de Permissão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Request missing data field."
-msgstr ""
+msgstr "Pedido com campo de dados em falta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request timed out"
-msgstr ""
+msgstr "O pedido expirou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required"
-msgstr ""
+msgstr "Obrigatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required control values have been removed"
-msgstr ""
+msgstr "Os valores de controlo necessários foram removidos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Resample"
-msgstr ""
+msgstr "Reamostragem"
 
 #, fuzzy
 msgid "Resample method should be in "
 msgstr "Método de preenchimento da remistura de pandas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Resample operation requires DatetimeIndex"
-msgstr ""
+msgstr "A operação de reamostragem requer DatetimeIndex"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset"
-msgstr ""
+msgstr "Repor"
 
 #, fuzzy
 msgid "Reset Columns"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "Repor todas as pastas para as predefinições"
 
 #, fuzzy
 msgid "Reset columns"
@@ -11126,22 +17374,32 @@ msgstr "Broker Port"
 msgid "Reset state"
 msgstr "Repor Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, lv, ru,
+# sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset to default folders?"
-msgstr ""
+msgstr "Repor pastas para as predefinições?"
 
 #, fuzzy
 msgid "Resize"
 msgstr "Tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Resource already has an attached report."
-msgstr ""
+msgstr "O recurso já tem um relatório anexado."
 
 #, fuzzy
 msgid "Resource was not found."
 msgstr "Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "O recurso foi removido antes de a propriedade poder ser verificada"
 
 msgid "Restore filter"
 msgstr "Filtros de resultados"
@@ -11153,11 +17411,21 @@ msgstr "Resultados"
 msgid "Results %s"
 msgstr "Resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend is not configured."
-msgstr ""
+msgstr "O backend de resultados não está configurado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr ""
+"O backend de resultados necessário para as consultas assíncronas não está"
+" configurado."
 
 #, fuzzy
 msgid "Resume auto-refresh"
@@ -11175,14 +17443,25 @@ msgstr "Procurar Resultados"
 msgid "Return to Superset"
 msgstr "Mover gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Return to specific datetime."
-msgstr ""
+msgstr "Regressar a data/hora específica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reverse Lat & Long"
-msgstr ""
+msgstr "Inverter Lat e Long"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Reverse lat/long "
-msgstr ""
+msgstr "Inverter lat/long "
 
 #, fuzzy
 msgid "Revoke"
@@ -11192,18 +17471,29 @@ msgstr "Pré-visualização para %s"
 msgid "Revoke API Key"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Revogar esta chave de API"
 
 #, fuzzy
 msgid "Revoked"
 msgstr "Criado em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich Tooltip"
-msgstr ""
+msgstr "Dica avançada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich tooltip"
-msgstr ""
+msgstr "Dica avançada"
 
 #, fuzzy
 msgid "Right"
@@ -11224,14 +17514,28 @@ msgstr "Altura"
 msgid "Right axis metric"
 msgstr "Metric do Eixo Direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Right to Left"
-msgstr ""
+msgstr "Da direita para a esquerda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Right value"
-msgstr ""
+msgstr "Valor da direita"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Right-click on a dimension value to drill to detail by that value."
 msgstr ""
+"Clique com o botão direito do rato num valor de dimensão para detalhar "
+"por esse valor."
 
 #, fuzzy
 msgid "Role"
@@ -11248,17 +17552,31 @@ msgstr "Origem de dados"
 msgid "Roles"
 msgstr "Cargo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks. If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"As funções são uma lista que define o acesso ao painel. Conceder a uma "
+"função acesso a um painel ignorará as verificações ao nível do conjunto "
+"de dados. Se não forem definidas funções, aplicam-se as permissões de "
+"acesso normais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks.If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"As funções são uma lista que define o acesso ao painel. Conceder a uma "
+"função acesso a um painel ignorará as verificações ao nível do conjunto "
+"de dados.Se não forem definidas funções, aplicam-se as permissões de "
+"acesso normais."
 
 msgid "Rolling Function"
 msgstr "Rolling"
@@ -11274,45 +17592,84 @@ msgstr "Rolling"
 msgid "Rolling window"
 msgstr "Rolling"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root certificate"
-msgstr ""
+msgstr "Certificado raiz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root node id"
-msgstr ""
+msgstr "ID do nó raiz"
 
 #, fuzzy
 msgid "Rose Type"
 msgstr "Limite de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotate x axis label"
-msgstr ""
+msgstr "Rodar o rótulo do eixo x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Rotate y axis label"
-msgstr ""
+msgstr "Rodar o rótulo do eixo y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotation to apply to words in the cloud"
-msgstr ""
+msgstr "Rotação a aplicar às palavras na nuvem"
 
 #, fuzzy
 msgid "Round cap"
 msgstr "Mapa de País"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Row"
-msgstr ""
+msgstr "Linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Row Level Security"
-msgstr ""
+msgstr "Segurança ao nível da linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
 msgstr ""
+"Limite de linhas: as percentagens são calculadas com base no subconjunto "
+"de dados obtidos, respeitando o limite de linhas. Todos os Registos: As "
+"percentagens são calculadas com base no conjunto de dados total, "
+"ignorando o limite de linhas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row containing the headers to use as column names (0 is first line of "
 "data)."
 msgstr ""
+"Linha que contém os cabeçalhos a utilizar como nomes de colunas (0 é a "
+"primeira linha de dados)."
 
 #, fuzzy
 msgid "Row height"
@@ -11321,34 +17678,61 @@ msgstr "Altura"
 msgid "Row limit"
 msgstr "Limite de linha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Rows (vertical layout)"
-msgstr ""
+msgstr "Linhas (disposição vertical)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows per page, 0 means no pagination"
-msgstr ""
+msgstr "Linhas por página, 0 significa sem paginação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows subtotal position"
-msgstr ""
+msgstr "Posição do subtotal das linhas"
 
 #, fuzzy
 msgid "Rows to read"
 msgstr "Cargos a permitir ao utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rule"
-msgstr ""
+msgstr "Regra"
 
 #, fuzzy
 msgid "Rule Name"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Rule added"
-msgstr ""
+msgstr "Regra adicionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run"
-msgstr ""
+msgstr "Executar"
 
 #, fuzzy
 msgid "Run a query to display query history"
@@ -11368,8 +17752,12 @@ msgstr "Expor no SQL Lab"
 msgid "Run query"
 msgstr "Executar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run query (Ctrl + Return)"
-msgstr ""
+msgstr "Executar consulta (Ctrl + Return)"
 
 msgid "Run query in a new tab"
 msgstr "Executar a query em nova aba"
@@ -11378,18 +17766,32 @@ msgstr "Executar a query em nova aba"
 msgid "Run selection"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Running"
-msgstr ""
+msgstr "A executar"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "A executar o bloco %(block_num)s de %(block_count)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SAT"
-msgstr ""
+msgstr "SÁB"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SEP"
-msgstr ""
+msgstr "SET"
 
 msgid "SQL"
 msgstr "SQL"
@@ -11397,17 +17799,27 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"O SQL Lab não consegue autorizar uma instrução que não pôde ser "
+"totalmente analisada. Qualifique as tabelas explicitamente e evite SQL "
+"dinâmico dentro de procedimentos armazenados ou chamadas específicas do "
+"fornecedor."
 
 #, fuzzy
 msgid "SQL Lab queries"
 msgstr "Queries Gravadas"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "SQL Lab uses your browser's local storage to store queries and results.\n"
 "Currently, you are using %(currentUsage)s KB out of %(maxStorage)d KB "
@@ -11417,6 +17829,14 @@ msgid ""
 "delete the tab.\n"
 "Note that you will need to close other SQL Lab windows before you do this."
 msgstr ""
+"O SQL Lab usa o armazenamento local do seu browser para armazenar "
+"consultas e resultados.\n"
+"Atualmente, está a usar %(currentUsage)s KB dos %(maxStorage)d KB de "
+"espaço de armazenamento.\n"
+"Para evitar que o SQL Lab falhe, elimine alguns separadores de consulta.\n"
+"Pode voltar a aceder a estas consultas utilizando a funcionalidade "
+"Guardar antes de eliminar o separador.\n"
+"Note que terá de fechar outras janelas do SQL Lab antes de o fazer."
 
 msgid "SQL Query"
 msgstr "Gravar query"
@@ -11436,20 +17856,39 @@ msgstr "Formato do Eixo YY"
 msgid "SQLAlchemy URI"
 msgstr "URI SQLAlchemy"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Host"
-msgstr ""
+msgstr "Host SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "SSH Password"
-msgstr ""
+msgstr "Palavra-passe SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Port"
-msgstr ""
+msgstr "Porta SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel"
-msgstr ""
+msgstr "Túnel SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel configuration parameters"
-msgstr ""
+msgstr "Parâmetros de configuração do Túnel SSH"
 
 #, fuzzy
 msgid "SSH Tunnel could not be deleted."
@@ -11467,31 +17906,57 @@ msgstr "Modelos CSS"
 msgid "SSH Tunnel parameters are invalid."
 msgstr "Camadas de anotação para sobreposição na visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunneling is not enabled"
-msgstr ""
+msgstr "O Túnel SSH não está ativado"
 
 #, fuzzy
 msgid "SSL"
 msgstr "SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSL Mode \"require\" will be used."
-msgstr ""
+msgstr "O modo SSL \"require\" será utilizado."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "STEP %(stepCurr)s OF %(stepLast)s"
-msgstr ""
+msgstr "PASSO %(stepCurr)s DE %(stepLast)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "STRING"
-msgstr ""
+msgstr "STRING"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SUN"
-msgstr ""
+msgstr "DOM"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sample Standard Deviation"
-msgstr ""
+msgstr "Desvio Padrão da Amostra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sample Variance"
-msgstr ""
+msgstr "Variância da Amostra"
 
 #, fuzzy
 msgid "Samples"
@@ -11513,11 +17978,19 @@ msgstr "Gráfico de Queijo"
 msgid "Satellite"
 msgstr "Filtro de data"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Satellite Streets"
-msgstr ""
+msgstr "Ruas de Satélite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Saturday"
-msgstr ""
+msgstr "Sábado"
 
 msgid "Save"
 msgstr "Salvar"
@@ -11569,8 +18042,11 @@ msgstr "Gravar e ir para o dashboard"
 msgid "Save chart"
 msgstr "Gráfico de Queijo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Save color breakpoint values"
-msgstr ""
+msgstr "Guardar valores de pontos de quebra de cor"
 
 #, fuzzy
 msgid "Save dashboard"
@@ -11580,21 +18056,38 @@ msgstr "Gravar Dashboard"
 msgid "Save dataset"
 msgstr "Escolha uma origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save for this session"
-msgstr ""
+msgstr "Guardar para esta sessão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save or Overwrite Dataset"
-msgstr ""
+msgstr "Guardar ou Substituir Conjunto de Dados"
 
 #, fuzzy
 msgid "Save query"
 msgstr "partilhar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Guardar esta chave de API em segurança"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr ""
+"Guardar esta consulta como um conjunto de dados virtual para continuar a "
+"explorar"
 
 msgid "Saved"
 msgstr "Salvar"
@@ -11616,62 +18109,117 @@ msgstr "Queries Gravadas"
 msgid "Saved queries could not be deleted."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Saved query not found."
-msgstr ""
+msgstr "Consulta guardada não encontrada."
 
 #, fuzzy
 msgid "Saved query parameters are invalid."
 msgstr "Camadas de anotação para sobreposição na visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Saving..."
-msgstr ""
+msgstr "A guardar..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale and Move"
-msgstr ""
+msgstr "Dimensionar e Mover"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "Fator de escala aplicado às larguras de linha baseadas em métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale only"
-msgstr ""
+msgstr "Apenas dimensionar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scatter"
-msgstr ""
+msgstr "Dispersão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Scatter Plot"
-msgstr ""
+msgstr "Gráfico de Dispersão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Scatter Plot has the horizontal axis in linear units, and the points are "
 "connected in order. It shows a statistical relationship between two "
 "variables."
 msgstr ""
+"O Gráfico de Dispersão tem o eixo horizontal em unidades lineares e os "
+"pontos estão ligados por ordem. Mostra uma relação estatística entre duas"
+" variáveis."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule"
-msgstr ""
+msgstr "Agendamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Schedule a new email report"
-msgstr ""
+msgstr "Agendar um novo relatório de e-mail"
 
 #, fuzzy
 msgid "Schedule query"
 msgstr "Gravar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule the query periodically"
-msgstr ""
+msgstr "Agendar a consulta periodicamente"
 
 #, fuzzy
 msgid "Schedule type"
 msgstr "Gravar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled"
-msgstr ""
+msgstr "Agendado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled at (UTC)"
-msgstr ""
+msgstr "Agendado em (UTC)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scheduled task executor not found"
-msgstr ""
+msgstr "Executor de tarefas agendadas não encontrado"
 
 msgid "Schema"
 msgstr "Esquema"
@@ -11680,34 +18228,61 @@ msgstr "Esquema"
 msgid "Schema cache timeout"
 msgstr "Tempo limite para cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Schemas allowed for File upload"
-msgstr ""
+msgstr "Esquemas permitidos para carregamento de ficheiros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Scope"
-msgstr ""
+msgstr "Âmbito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scoping"
-msgstr ""
+msgstr "Definição de Âmbito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Screenshot width"
-msgstr ""
+msgstr "Largura da captura de ecrã"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Screenshot width must be between %(min)spx and %(max)spx"
-msgstr ""
+msgstr "A largura da captura de ecrã deve estar entre %(min)spx e %(max)spx"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scroll"
-msgstr ""
+msgstr "Deslocamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scroll down to the bottom to enable overwriting changes. "
-msgstr ""
+msgstr "Role para baixo até ao fim para ativar a substituição de alterações. "
 
 msgid "Search"
 msgstr "Pesquisa"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Search %s records"
-msgstr ""
+msgstr "Pesquisar %s registos"
 
 msgid "Search / Filter"
 msgstr "Pesquisa / Filtro"
@@ -11731,8 +18306,12 @@ msgstr "Pesquisa"
 msgid "Search by"
 msgstr "Pesquisa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Search by query text"
-msgstr ""
+msgstr "Pesquisar por texto de consulta"
 
 #, fuzzy
 msgid "Search calculated columns by name"
@@ -11789,17 +18368,31 @@ msgstr "30 segundos"
 msgid "Secondary Metric"
 msgstr "Métrica de cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary currency format"
-msgstr ""
+msgstr "Formato de moeda secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary y-axis Bounds"
-msgstr ""
+msgstr "Limites do eixo Y secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis format"
-msgstr ""
+msgstr "Formato do eixo Y secundário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis title"
-msgstr ""
+msgstr "Título do eixo Y secundário"
 
 #, fuzzy, python-format
 msgid "Seconds %s"
@@ -11816,19 +18409,29 @@ msgstr "Segurança"
 msgid "See "
 msgstr "Séries"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "See all %(tableName)s"
-msgstr ""
+msgstr "Ver todos %(tableName)s"
 
 #, fuzzy
 msgid "See less"
 msgstr "Cargo do Utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "See more"
-msgstr ""
+msgstr "Ver mais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "See query details"
-msgstr ""
+msgstr "Ver detalhes da consulta"
 
 #, fuzzy
 msgid "Select"
@@ -11849,8 +18452,12 @@ msgstr "Repor Estado"
 msgid "Select Database and Schema"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select Delivery Method"
-msgstr ""
+msgstr "Selecionar o método de entrega"
 
 #, fuzzy
 msgid "Select Filter"
@@ -11884,8 +18491,11 @@ msgstr "Por favor insira um nome para o dashboard"
 msgid "Select a database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a database table and create dataset"
-msgstr ""
+msgstr "Selecionar uma tabela de base de dados e criar um conjunto de dados"
 
 #, fuzzy
 msgid "Select a database table."
@@ -11895,8 +18505,12 @@ msgstr "Selecione uma base de dados"
 msgid "Select a database to connect"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Select a database to upload the file to"
-msgstr ""
+msgstr "Selecionar uma base de dados para carregar o ficheiro"
 
 #, fuzzy
 msgid "Select a database to write a query"
@@ -11906,8 +18520,11 @@ msgstr "Selecione uma base de dados"
 msgid "Select a delimiter for this data"
 msgstr "Insira um novo título para a aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a dimension"
-msgstr ""
+msgstr "Selecionar uma dimensão"
 
 #, fuzzy
 msgid "Select a linear color scheme"
@@ -11917,20 +18534,33 @@ msgstr "Esquema de cores lineares"
 msgid "Select a metric to display on the right axis"
 msgstr "Escolha uma métrica para o eixo direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select a metric to display. You can use an aggregation function on a "
 "column or write custom SQL to create a metric."
 msgstr ""
+"Selecionar uma métrica a apresentar. Pode utilizar uma função de "
+"agregação numa coluna ou escrever SQL personalizado para criar uma "
+"métrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr ""
+msgstr "Selecionar um modelo CSS predefinido para aplicar ao seu dashboard"
 
 #, fuzzy
 msgid "Select a schema"
 msgstr "Selecione um esquema (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a schema if the database supports this"
-msgstr ""
+msgstr "Selecionar um esquema se a base de dados suportar esta opção"
 
 #, fuzzy
 msgid "Select a semantic layer"
@@ -11940,8 +18570,11 @@ msgstr "Selecione um esquema (%s)"
 msgid "Select a semantic layer type"
 msgstr "Selecione um tipo de visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a sheet name from the uploaded file"
-msgstr ""
+msgstr "Selecionar um nome de folha do ficheiro carregado"
 
 #, fuzzy
 msgid "Select a tab"
@@ -11951,16 +18584,26 @@ msgstr "Selecione uma base de dados"
 msgid "Select a theme"
 msgstr "Selecione um esquema (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select a time grain for the visualization. The grain is the time interval"
 " represented by a single point on the chart."
 msgstr ""
+"Selecionar uma granularidade de tempo para a visualização. A "
+"granularidade é o intervalo de tempo representado por um único ponto no "
+"gráfico."
 
 msgid "Select a visualization type"
 msgstr "Selecione um tipo de visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select aggregate options"
-msgstr ""
+msgstr "Selecionar opções de agregação"
 
 #, fuzzy
 msgid "Select all"
@@ -11974,8 +18617,11 @@ msgstr "Selecione uma base de dados"
 msgid "Select all items"
 msgstr "Filtros de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select catalog or type to search catalogs"
-msgstr ""
+msgstr "Selecionar catálogo ou escrever para pesquisar catálogos"
 
 #, fuzzy
 msgid "Select channels"
@@ -12009,10 +18655,15 @@ msgstr "Coluna de tempo"
 msgid "Select column name"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
 "columns."
 msgstr ""
+"Selecionar as colunas que serão apresentadas na tabela. Pode selecionar "
+"várias colunas."
 
 #, fuzzy
 msgid "Select content type"
@@ -12042,11 +18693,18 @@ msgstr "Por favor insira um nome para o dashboard"
 msgid "Select database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select databases require additional fields to be completed in the "
 "Advanced tab to successfully connect the database. Learn what "
 "requirements your databases has "
 msgstr ""
+"Algumas bases de dados selecionadas requerem que campos adicionais sejam "
+"preenchidos no separador Avançadas para ligar com sucesso a base de "
+"dados. Saiba quais os requisitos da sua base de dados "
 
 #, fuzzy
 msgid "Select dataset source"
@@ -12080,11 +18738,19 @@ msgstr "Selecione uma base de dados"
 msgid "Select filter"
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select filter plugin using AntD"
-msgstr ""
+msgstr "Selecionar plug-in de filtro usando AntD"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select first filter value by default"
-msgstr ""
+msgstr "Selecionar o primeiro valor de filtro por predefinição"
 
 #, fuzzy
 msgid "Select format"
@@ -12094,6 +18760,9 @@ msgstr "Formato de valor"
 msgid "Select groups"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -12101,6 +18770,12 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"Selecionar as camadas pela ordem em que pretende que sejam empilhadas. A "
+"primeira selecionada aparece na parte inferior. As camadas permitem "
+"combinar várias visualizações num único mapa. Cada camada é um gráfico "
+"deck.gl guardado (como diagramas de dispersão, polígonos ou arcos) que "
+"apresenta dados ou informações diferentes. Empilhe-as para revelar "
+"padrões e relações nos seus dados."
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -12110,17 +18785,33 @@ msgstr "Gráfico de bala"
 msgid "Select object name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
 "percentages of total. Percentage metrics will be calculated only from "
 "data within the row limit. You can use an aggregation function on a "
 "column or write custom SQL to create a percentage metric."
 msgstr ""
+"Selecionar uma ou várias métricas a apresentar, que serão exibidas nas "
+"percentagens do total. As métricas percentuais serão calculadas apenas a "
+"partir dos dados dentro do limite de linhas. Pode utilizar uma função de "
+"agregação numa coluna ou escrever SQL personalizado para criar uma "
+"métrica percentual."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display. You can use an aggregation "
 "function on a column or write custom SQL to create a metric."
 msgstr ""
+"Selecionar uma ou várias métricas a apresentar. Pode utilizar uma função "
+"de agregação numa coluna ou escrever SQL personalizado para criar uma "
+"métrica."
 
 #, fuzzy
 msgid "Select operator"
@@ -12130,15 +18821,22 @@ msgstr "Selecione operador"
 msgid "Select or type a custom value..."
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select or type currency symbol"
-msgstr ""
+msgstr "Selecionar ou escrever o símbolo de moeda"
 
 #, fuzzy
 msgid "Select or type dataset name"
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select owners"
-msgstr ""
+msgstr "Selecionar proprietários"
 
 #, fuzzy
 msgid "Select page size"
@@ -12172,25 +18870,46 @@ msgstr "Selecione um esquema (%s)"
 msgid "Select semantic views"
 msgstr "Selecione um esquema (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
 "same size. \"LINEAR\" increases sizes linearly based on specified slope. "
 "\"EXP\" increases sizes exponentially based on specified exponent"
 msgstr ""
+"Selecionar a forma para calcular os valores. \"FIXED\" define todos os "
+"níveis de zoom para o mesmo tamanho. \"LINEAR\" aumenta os tamanhos "
+"linearmente com base no declive especificado. \"EXP\" aumenta os tamanhos"
+" exponencialmente com base no expoente especificado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select subject"
-msgstr ""
+msgstr "Selecionar assunto"
 
 #, fuzzy
 msgid "Select tab"
 msgstr "Repor Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select table or type to search tables"
-msgstr ""
+msgstr "Selecionar tabela ou escrever para pesquisar tabelas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the Annotation Layer you would like to use."
-msgstr ""
+msgstr "Selecionar a camada de anotação que pretende utilizar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters in this "
 "dashboard. Deselecting a chart will exclude it from being filtered when "
@@ -12198,46 +18917,97 @@ msgid ""
 "\"All charts\" to apply cross-filters to all charts that use the same "
 "dataset or contain the same column name in the dashboard."
 msgstr ""
+"Selecionar os gráficos aos quais pretende aplicar filtros cruzados neste "
+"dashboard. Desselecionar um gráfico irá excluí-lo de ser filtrado ao "
+"aplicar filtros cruzados a partir de qualquer gráfico no dashboard. Pode "
+"selecionar \"Todos os gráficos\" para aplicar filtros cruzados a todos os"
+" gráficos que utilizam o mesmo conjunto de dados ou contêm o mesmo nome "
+"de coluna no dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters when "
 "interacting with this chart. You can select \"All charts\" to apply "
 "filters to all charts that use the same dataset or contain the same "
 "column name in the dashboard."
 msgstr ""
+"Selecionar os gráficos aos quais pretende aplicar filtros cruzados ao "
+"interagir com este gráfico. Pode selecionar \"Todos os gráficos\" para "
+"aplicar filtros a todos os gráficos que utilizam o mesmo conjunto de "
+"dados ou contêm o mesmo nome de coluna no dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
 msgstr ""
+"Selecionar a cor utilizada para os valores que indicam um aumento no "
+"gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
 msgstr ""
+"Selecionar a cor utilizada para os valores que representam barras totais "
+"no gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
+"Selecionar a cor utilizada para os valores que indicam uma diminuição no "
+"gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"Selecionar a coluna que contém códigos de moeda como USD, EUR, GBP, etc. "
+"Utilizada na criação de gráficos quando a formatação de moeda \"Deteção "
+"automática\" está ativada. Se esta coluna não estiver definida ou se uma "
+"métrica de gráfico contiver várias moedas, os gráficos reverterão para a "
+"formatação numérica neutra."
 
 #, fuzzy
 msgid "Select the fixed color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the geojson column"
-msgstr ""
+msgstr "Selecionar a coluna geojson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Selecionar o fornecedor de tiles do mapa. O MapLibre é de código aberto e"
+" não requer chave de API. O Mapbox requer que o MAPBOX_API_KEY esteja "
+"configurado no Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Selecionar a métrica utilizada para determinar em que intervalo de "
+"separação de cor cada percurso se enquadra."
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -12251,17 +19021,28 @@ msgstr "Eliminar"
 msgid "Select values"
 msgstr "Selecione uma base de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Select values in highlighted field(s) in the control panel. Then run the "
 "query by clicking on the %s button."
 msgstr ""
+"Selecionar valores no(s) campo(s) destacado(s) no painel de controlo. Em "
+"seguida, execute a consulta clicando no botão %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Selecionar quais as granularidades de tempo disponíveis no controlo de "
+"filtro. Esta é apenas uma lista de permissões de interface e não adiciona"
+" condições adicionais às consultas subjacentes."
 
 #, fuzzy
 msgid "Selected"
@@ -12275,18 +19056,27 @@ msgstr "Selecione uma base de dados"
 msgid "Selection method"
 msgstr "Soma Agregada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic"
-msgstr ""
+msgstr "Semântico"
 
 #, fuzzy
 msgid "Semantic Layer"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Vista Semântica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Vistas Semânticas"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12344,29 +19134,58 @@ msgstr "Origem de dados %(name)s já existe"
 msgid "Semantic view parameters are invalid."
 msgstr "Camadas de anotação para sobreposição na visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Vista semântica atualizada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Vistas semânticas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as CSV"
-msgstr ""
+msgstr "Enviar como CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Send as PDF"
-msgstr ""
+msgstr "Enviar como PDF"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as PNG"
-msgstr ""
+msgstr "Enviar como PNG"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as text"
-msgstr ""
+msgstr "Enviar como texto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "September"
-msgstr ""
+msgstr "Setembro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sequential"
-msgstr ""
+msgstr "Sequencial"
 
 msgid "Series"
 msgstr "Séries"
@@ -12375,21 +19194,34 @@ msgstr "Séries"
 msgid "Series Height"
 msgstr "Limite de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series Order"
-msgstr ""
+msgstr "Ordem da série"
 
 #, fuzzy
 msgid "Series Style"
 msgstr "Tabela de séries temporais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Series chart type (line, bar etc)"
-msgstr ""
+msgstr "Tipo de gráfico de série (linha, barra, etc.)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "Configuração de diminuição de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "Configuração de aumento de série"
 
 msgid "Series limit"
 msgstr "Limite de série"
@@ -12406,24 +19238,44 @@ msgstr "Metadados adicionais"
 msgid "Series type"
 msgstr "Limite de série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server Page Length"
-msgstr ""
+msgstr "Comprimento da Página do Servidor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server pagination"
-msgstr ""
+msgstr "Paginação do servidor"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Server pagination needs to be enabled for values over %s"
-msgstr ""
+msgstr "A paginação do servidor tem de ser ativada para valores superiores a %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Service Account"
-msgstr ""
+msgstr "Conta de Serviço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Service version"
-msgstr ""
+msgstr "Versão do serviço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Dark Theme"
-msgstr ""
+msgstr "Definir Tema Escuro do Sistema"
 
 #, fuzzy
 msgid "Set System Default Theme"
@@ -12433,69 +19285,132 @@ msgstr "Latitude padrão"
 msgid "Set as default dark theme"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default light theme"
-msgstr ""
+msgstr "Definir como tema claro predefinido"
 
 #, fuzzy
 msgid "Set auto-refresh"
 msgstr "Intervalo de atualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Set filter mapping"
-msgstr ""
+msgstr "Definir mapeamento de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing"
-msgstr ""
+msgstr "Definir tema local para testes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing (preview only)"
-msgstr ""
+msgstr "Definir tema local para testes (apenas pré-visualização)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set refresh frequency for current session only."
-msgstr ""
+msgstr "Definir a frequência de atualização apenas para a sessão atual."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set the automatic refresh frequency for this dashboard."
-msgstr ""
+msgstr "Definir a frequência de atualização automática para este painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Set the automatic refresh frequency for this dashboard. The dashboard "
 "will reload its data at the specified interval."
 msgstr ""
+"Defina a frequência de atualização automática para este painel. O painel "
+"irá recarregar os dados no intervalo especificado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set up an email report"
-msgstr ""
+msgstr "Configurar um relatório de e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set up basic details, such as name and description."
-msgstr ""
+msgstr "Configure os detalhes básicos, como o nome e a descrição."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"Define a coluna temporal predefinida para este conjunto de dados. "
+"Selecionada automaticamente como a coluna de tempo ao criar gráficos que "
+"requerem uma dimensão temporal e utilizada nos filtros de tempo ao nível "
+"do painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
 "        represented by one ring with the innermost circle as the top of "
 "the hierarchy."
 msgstr ""
+"Define os níveis de hierarquia do gráfico. Cada nível é\n"
+"        representado por um anel, sendo o círculo mais interior o topo da"
+" hierarquia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings"
-msgstr ""
+msgstr "Configurações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings for time series"
-msgstr ""
+msgstr "Configurações para séries temporais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Shape"
-msgstr ""
+msgstr "Forma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Share"
-msgstr ""
+msgstr "Partilhar"
 
 #, fuzzy
 msgid "Share chart by email"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Share permalink by email"
-msgstr ""
+msgstr "Partilhar hiperligação permanente por e-mail"
 
 #, fuzzy
 msgid "Shared"
@@ -12513,33 +19428,63 @@ msgstr "query partilhada"
 msgid "Sheet name"
 msgstr "Nome Detalhado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Shift + Click to sort by multiple columns"
-msgstr ""
+msgstr "Shift + Clique para ordenar por múltiplas colunas"
 
 #, fuzzy
 msgid "Shift start date"
 msgstr "Início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Short description must be unique for this layer"
-msgstr ""
+msgstr "A descrição curta deve ser única para esta camada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should daily seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Deve ser aplicada a sazonalidade diária. Um valor inteiro especificará a "
+"ordem de Fourier da sazonalidade."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should weekly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Deve ser aplicada a sazonalidade semanal. Um valor inteiro especificará a"
+" ordem de Fourier da sazonalidade."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should yearly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Deve ser aplicada a sazonalidade anual. Um valor inteiro especificará a "
+"ordem de Fourier da sazonalidade."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show"
-msgstr ""
+msgstr "Mostrar"
 
 #, fuzzy, python-format
 msgid "Show %s entries"
@@ -12549,8 +19494,12 @@ msgstr "Mostrar Métrica"
 msgid "Show Bubbles"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show CREATE VIEW statement"
-msgstr ""
+msgstr "Mostrar instrução CREATE VIEW"
 
 msgid "Show Dashboard"
 msgstr "Mostrar Dashboard"
@@ -12562,8 +19511,12 @@ msgstr "Mostrar Tabela"
 msgid "Show Log"
 msgstr "Mostrar totais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Markers"
-msgstr ""
+msgstr "Mostrar Marcadores"
 
 #, fuzzy
 msgid "Show Metric Name"
@@ -12581,8 +19534,12 @@ msgstr "Filtros de resultados"
 msgid "Show SQL"
 msgstr "Mostrar totais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show Timestamp"
-msgstr ""
+msgstr "Mostrar Carimbo de Data/Hora"
 
 #, fuzzy
 msgid "Show Tooltip Labels"
@@ -12592,11 +19549,19 @@ msgstr "Mostrar Tabela"
 msgid "Show Total"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Trend Line"
-msgstr ""
+msgstr "Mostrar Linha de Tendência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Upper Labels"
-msgstr ""
+msgstr "Mostrar Rótulos Superiores"
 
 #, fuzzy
 msgid "Show Values"
@@ -12606,20 +19571,35 @@ msgstr "Mostrar Tabela"
 msgid "Show X-axis"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Y-axis"
-msgstr ""
+msgstr "Mostrar eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show Y-axis on the sparkline. Will display the manually set min/max if "
 "set or min/max values in the data otherwise."
 msgstr ""
+"Mostrar o eixo Y na sparkline. Apresentará os valores mín./máx. definidos"
+" manualmente, se definidos, ou os valores mín./máx. nos dados caso "
+"contrário."
 
 #, fuzzy
 msgid "Show all columns"
 msgstr "Mostrar Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show axis line ticks"
-msgstr ""
+msgstr "Mostrar marcas na linha do eixo"
 
 #, fuzzy
 msgid "Show cell bars"
@@ -12649,8 +19629,12 @@ msgstr "Mostrar Coluna"
 msgid "Show columns total"
 msgstr "Mostrar Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show data points as circle markers on the lines"
-msgstr ""
+msgstr "Mostrar pontos de dados como marcadores circulares nas linhas"
 
 #, fuzzy
 msgid "Show empty columns"
@@ -12660,23 +19644,41 @@ msgstr "Mostrar Coluna"
 msgid "Show entries per page"
 msgstr "Mostrar Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Show hierarchical relationships of data, with the value represented by "
 "area, showing proportion and contribution to the whole."
 msgstr ""
+"Mostrar relações hierárquicas dos dados, com o valor representado pela "
+"área, mostrando a proporção e a contribuição para o todo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show info tooltip"
-msgstr ""
+msgstr "Mostrar dica de informação"
 
 #, fuzzy
 msgid "Show label"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show labels when the node has children."
-msgstr ""
+msgstr "Mostrar rótulos quando o nó tem filhos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show legend"
-msgstr ""
+msgstr "Mostrar legenda"
 
 #, fuzzy
 msgid "Show less columns"
@@ -12686,24 +19688,43 @@ msgstr "Mostrar Coluna"
 msgid "Show min/max axis labels"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Show minor ticks on axes."
-msgstr ""
+msgstr "Mostrar marcas secundárias nos eixos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show only my charts"
-msgstr ""
+msgstr "Mostrar apenas os meus gráficos"
 
 #, fuzzy
 msgid "Show password."
 msgstr "Mostrar Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show percentage"
-msgstr ""
+msgstr "Mostrar percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show pointer"
-msgstr ""
+msgstr "Mostrar ponteiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show progress"
-msgstr ""
+msgstr "Mostrar progresso"
 
 #, fuzzy
 msgid "Show query identifiers"
@@ -12717,72 +19738,139 @@ msgstr "Mostrar Tabela"
 msgid "Show rows subtotal"
 msgstr "Mostrar Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show rows total"
-msgstr ""
+msgstr "Mostrar total de linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show series values on the chart"
-msgstr ""
+msgstr "Mostrar valores de série no gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show split lines"
-msgstr ""
+msgstr "Mostrar linhas de divisão"
 
 #, fuzzy
 msgid "Show summary"
 msgstr "Mostrar Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show the value on top of the bar"
-msgstr ""
+msgstr "Mostrar o valor no topo da barra"
 
 #, fuzzy
 msgid "Show total"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show total aggregations of selected metrics. Note that row limit does not"
 " apply to the result."
 msgstr ""
+"Mostrar as agregações totais das métricas selecionadas. Note que o limite"
+" de linhas não se aplica ao resultado."
 
 #, fuzzy
 msgid "Show value"
 msgstr "Mostrar Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single metric front-and-center. Big number is best used to "
 "call attention to a KPI or the one thing you want your audience to focus "
 "on."
 msgstr ""
+"Apresenta uma única métrica em destaque. O número grande é melhor "
+"utilizado para chamar a atenção para um KPI ou para aquilo em que "
+"pretende que o seu público se concentre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single number accompanied by a simple line chart, to call "
 "attention to an important metric along with its change over time or other"
 " dimension."
 msgstr ""
+"Apresenta um único número acompanhado de um gráfico de linhas simples, "
+"para chamar a atenção para uma métrica importante juntamente com a sua "
+"variação ao longo do tempo ou noutra dimensão."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases how a metric changes as the funnel progresses. This classic "
 "chart is useful for visualizing drop-off between stages in a pipeline or "
 "lifecycle."
 msgstr ""
+"Apresenta como uma métrica muda à medida que o funil avança. Este gráfico"
+" clássico é útil para visualizar a queda entre as fases de um pipeline ou"
+" ciclo de vida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the flow or link between categories using thickness of chords. "
 "The value and corresponding thickness can be different for each side."
 msgstr ""
+"Apresenta o fluxo ou a ligação entre categorias utilizando a espessura "
+"das cordas. O valor e a espessura correspondente podem ser diferentes "
+"para cada lado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the progress of a single metric against a given target. The "
 "higher the fill, the closer the metric is to the target."
 msgstr ""
+"Apresenta o progresso de uma única métrica em relação a um objetivo "
+"definido. Quanto maior o preenchimento, mais próxima está a métrica do "
+"objetivo."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Showing %s of %s items"
-msgstr ""
+msgstr "A mostrar %s de %s itens"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows a list of all series available at that point in time"
-msgstr ""
+msgstr "Mostra uma lista de todas as séries disponíveis nesse momento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows or hides markers for the time series"
-msgstr ""
+msgstr "Mostra ou oculta marcadores para as séries temporais"
 
 #, fuzzy
 msgid "Sign in"
@@ -12792,17 +19880,33 @@ msgstr "Anotações"
 msgid "Sign in with"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Significance Level"
-msgstr ""
+msgstr "Nível de significância"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple"
-msgstr ""
+msgstr "Simples"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple ad-hoc metrics are not enabled for this dataset"
-msgstr ""
+msgstr "As métricas ad-hoc simples não estão ativadas para este conjunto de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Single"
-msgstr ""
+msgstr "Individual"
 
 #, fuzzy
 msgid "Single Metric"
@@ -12816,20 +19920,40 @@ msgstr "Valor de filtro"
 msgid "Single value"
 msgstr "Valor de filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Single value type"
-msgstr ""
+msgstr "Tipo de valor único"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Size in pixels"
-msgstr ""
+msgstr "Tamanho em píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of edge symbols"
-msgstr ""
+msgstr "Tamanho dos símbolos de aresta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of marker. Also applies to forecast observations."
-msgstr ""
+msgstr "Tamanho do marcador. Também se aplica às observações de previsão."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip blank lines rather than interpreting them as Not A Number values"
 msgstr ""
+"Ignorar linhas em branco em vez de as interpretar como valores Não "
+"Numéricos"
 
 #, fuzzy
 msgid "Skip rows"
@@ -12839,12 +19963,17 @@ msgstr "Erro"
 msgid "Skip rows is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip spaces after delimiter"
-msgstr ""
+msgstr "Ignorar espaços após o delimitador"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Skipped %d system themes that cannot be deleted"
-msgstr ""
+msgstr "Ignorados %d temas do sistema que não podem ser eliminados"
 
 #, fuzzy
 msgid "Slice Id"
@@ -12854,52 +19983,100 @@ msgstr "Largura"
 msgid "Slider"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slider and range input"
-msgstr ""
+msgstr "Controlo deslizante e entrada de intervalo"
 
 msgid "Slug"
 msgstr "Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small"
-msgstr ""
+msgstr "Pequeno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small number format"
-msgstr ""
+msgstr "Formato de número pequeno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Smooth Line"
-msgstr ""
+msgstr "Linha Suave"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Smooth-line is a variation of the line chart. Without angles and hard "
 "edges, Smooth-line sometimes looks smarter and more professional."
 msgstr ""
+"A Linha Suave é uma variação do gráfico de linhas. Sem ângulos nem "
+"arestas acentuadas, a Linha Suave tem por vezes um aspeto mais elegante e"
+" profissional."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Solid"
-msgstr ""
+msgstr "Sólido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Alguns grupos não puderam ser resolvidos e são apresentados como IDs."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Algumas permissões não puderam ser resolvidas e são apresentadas como IDs."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
+"Alguns filtros obrigatórios noutros separadores têm valores e não serão "
+"limpos"
 
 #, fuzzy
 msgid "Some roles do not exist"
 msgstr "Dashboards"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong while saving the user info"
-msgstr ""
+msgstr "Ocorreu um erro ao guardar as informações do utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Something went wrong with embedded authentication. Check the dev console "
 "for details."
 msgstr ""
+"Ocorreu um erro com a autenticação incorporada. Verifique a consola de "
+"desenvolvimento para obter detalhes."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong."
-msgstr ""
+msgstr "Algo correu mal."
 
 #, python-format
 msgid "Sorry there was an error fetching database information: %s"
@@ -12908,26 +20085,49 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "Sorry there was an error fetching saved charts: "
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, An error occurred"
-msgstr ""
+msgstr "Desculpe, ocorreu um erro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an error occurred"
-msgstr ""
+msgstr "Desculpe, ocorreu um erro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred"
-msgstr ""
+msgstr "Desculpe, ocorreu um erro desconhecido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred."
-msgstr ""
+msgstr "Desculpe, ocorreu um erro desconhecido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Embedding could not be deactivated."
-msgstr ""
+msgstr "Desculpe, ocorreu um erro. A incorporação não pôde ser desativada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Please try again."
-msgstr ""
+msgstr "Desculpe, ocorreu um erro. Por favor, tente novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, something went wrong. Try again later."
-msgstr ""
+msgstr "Desculpe, ocorreu um erro. Tente novamente mais tarde."
 
 #, fuzzy, python-format
 msgid "Sorry, there was an error saving this %s: %s"
@@ -12961,14 +20161,25 @@ msgstr "Mostrar Métrica"
 msgid "Sort Series Ascending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sort Series By"
-msgstr ""
+msgstr "Ordenar séries por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort X Axis"
-msgstr ""
+msgstr "Ordenar Eixo X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort Y Axis"
-msgstr ""
+msgstr "Ordenar Eixo Y"
 
 #, fuzzy
 msgid "Sort ascending"
@@ -13028,18 +20239,29 @@ msgstr "Mostrar Métrica"
 msgid "Sort query by"
 msgstr "partilhar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Ordenar resultados por nome de série em ordem crescente. Quando combinado"
+" com \"Ordenar por métrica\", este funciona como critério de desempate "
+"para valores de métrica iguais. A adição desta ordenação pode reduzir o "
+"desempenho das consultas em algumas bases de dados."
 
 #, fuzzy
 msgid "Sort rows by"
 msgstr "Ordenar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sort series in ascending order"
-msgstr ""
+msgstr "Ordenar séries por ordem crescente"
 
 #, fuzzy
 msgid "Sort type"
@@ -13063,32 +20285,61 @@ msgstr "Nome da origem de dados"
 msgid "Source location"
 msgstr "Nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sparkline"
-msgstr ""
+msgstr "Minigráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Spatial"
-msgstr ""
+msgstr "Espacial"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Specific Date/Time"
-msgstr ""
+msgstr "Data/Hora Específica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE TABLE AS schema in: public"
-msgstr ""
+msgstr "Especificar o nome para o esquema CREATE TABLE AS em: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE VIEW AS schema in: public"
-msgstr ""
+msgstr "Especificar o nome para o esquema CREATE VIEW AS em: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Specify the database version. This is used with Presto for query cost "
 "estimation, and Dremio for syntax changes, among others."
 msgstr ""
+"Especifique a versão da base de dados. É utilizado com o Presto para "
+"estimativa do custo de consultas e com o Dremio para alterações de "
+"sintaxe, entre outros."
 
 #, fuzzy
 msgid "Split number"
 msgstr "Número grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Split stack by"
-msgstr ""
+msgstr "Dividir pilha por"
 
 #, fuzzy
 msgid "Square kilometers"
@@ -13098,45 +20349,84 @@ msgstr "Filtro de data"
 msgid "Square meters"
 msgstr "Parâmetros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Square miles"
-msgstr ""
+msgstr "Milhas quadradas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack"
-msgstr ""
+msgstr "Pilha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack in groups, where each group corresponds to a dimension"
-msgstr ""
+msgstr "Empilhar em grupos, onde cada grupo corresponde a uma dimensão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series"
-msgstr ""
+msgstr "Empilhar série"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series on top of each other"
-msgstr ""
+msgstr "Empilhar séries umas sobre as outras"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Stacked"
-msgstr ""
+msgstr "Empilhado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Bars"
-msgstr ""
+msgstr "Barras empilhadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Style"
-msgstr ""
+msgstr "Estilo empilhado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Standard time series"
-msgstr ""
+msgstr "Série temporal padrão"
 
 msgid "Start"
 msgstr "Início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start (Longitude, Latitude): "
-msgstr ""
+msgstr "Início (Longitude, Latitude): "
 
 #, fuzzy
 msgid "Start (inclusive)"
 msgstr "Modificado pela última vez"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start Longitude & Latitude"
-msgstr ""
+msgstr "Longitude e Latitude Iniciais"
 
 #, fuzzy
 msgid "Start Time"
@@ -13146,23 +20436,41 @@ msgstr "Início"
 msgid "Start angle"
 msgstr "Modificado pela última vez"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start at (UTC)"
-msgstr ""
+msgstr "Início em (UTC)"
 
 #, fuzzy
 msgid "Start date"
 msgstr "Início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start date included in time range"
-msgstr ""
+msgstr "Data de início incluída no intervalo de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start y-axis at 0"
-msgstr ""
+msgstr "Iniciar o eixo y em 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Start y-axis at zero. Uncheck to start y-axis at minimum value in the "
 "data."
 msgstr ""
+"Iniciar o eixo y em zero. Desmarque para iniciar o eixo y no valor mínimo"
+" dos dados."
 
 #, fuzzy
 msgid "Started"
@@ -13179,33 +20487,65 @@ msgstr "Mover gráfico"
 msgid "State"
 msgstr "Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Statistical"
-msgstr ""
+msgstr "Estatístico"
 
 msgid "Status"
 msgstr "Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - end"
-msgstr ""
+msgstr "Etapa - fim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - middle"
-msgstr ""
+msgstr "Passo - meio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - start"
-msgstr ""
+msgstr "Passo - início"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Step type"
-msgstr ""
+msgstr "Tipo de etapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stepped Line"
-msgstr ""
+msgstr "Linha escalonada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Stepped-line graph (also called step chart) is a variation of line chart "
 "but with the line forming a series of steps between data points. A step "
 "chart can be useful when you want to show the changes that occur at "
 "irregular intervals."
 msgstr ""
+"O gráfico de linhas escalonadas (também designado por gráfico de passos) "
+"é uma variação do gráfico de linhas, mas com a linha a formar uma série "
+"de passos entre os pontos de dados. Um gráfico escalonado pode ser útil "
+"quando se pretende mostrar as alterações que ocorrem em intervalos "
+"irregulares."
 
 msgid "Stop"
 msgstr "Parar"
@@ -13213,11 +20553,18 @@ msgstr "Parar"
 msgid "Stop query"
 msgstr "Query vazia?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stop running (Ctrl + e)"
-msgstr ""
+msgstr "Parar a execução (Ctrl + e)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stop running (Ctrl + x)"
-msgstr ""
+msgstr "Parar execução (Ctrl + x)"
 
 msgid "Stopped an unsafe database connection"
 msgstr "Selecione qualquer coluna para inspeção de metadados"
@@ -13226,37 +20573,63 @@ msgstr "Selecione qualquer coluna para inspeção de metadados"
 msgid "Stream"
 msgstr "Histograma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Streets"
-msgstr ""
+msgstr "Ruas"
 
 #, fuzzy
 msgid "Streets (Carto)"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Strength to pull the graph toward center"
-msgstr ""
+msgstr "Força para puxar o gráfico para o centro"
 
 #, fuzzy
 msgid "Stroke Color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stroke Width"
-msgstr ""
+msgstr "Largura do traço"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stroked"
-msgstr ""
+msgstr "Tracejado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Structural"
-msgstr ""
+msgstr "Estrutural"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
 msgstr ""
+"A estrutura é gerida pela camada semântica a montante e é apenas de "
+"leitura."
 
 msgid "Style"
 msgstr "Estilo do mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Style the ends of the progress bar with a round cap"
-msgstr ""
+msgstr "Estilizar as extremidades da barra de progresso com uma tampa redonda"
 
 #, fuzzy
 msgid "Styling"
@@ -13266,11 +20639,19 @@ msgstr "Estilo do mapa"
 msgid "Subcategories"
 msgstr "Nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Subdomain"
-msgstr ""
+msgstr "Subdomínio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Submit"
-msgstr ""
+msgstr "Enviar"
 
 #, fuzzy
 msgid "Subscribers"
@@ -13280,36 +20661,74 @@ msgstr "Nome da origem de dados"
 msgid "Subtitle"
 msgstr "%s - sem título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Subtotal"
-msgstr ""
+msgstr "Subtotal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Success"
-msgstr ""
+msgstr "Sucesso"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Successfully changed %s!"
-msgstr ""
+msgstr "%s alterado com sucesso!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix"
-msgstr ""
+msgstr "Sufixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix to apply after the percentage display"
-msgstr ""
+msgstr "Sufixo para aplicar após a apresentação da percentagem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum"
-msgstr ""
+msgstr "Soma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Columns"
-msgstr ""
+msgstr "Soma como Fração de Colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Rows"
-msgstr ""
+msgstr "Soma como Fração de Linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Total"
-msgstr ""
+msgstr "Soma como Fração do Total"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum of values over specified period"
-msgstr ""
+msgstr "Soma dos valores durante o período especificado"
 
 #, fuzzy
 msgid "Sum values"
@@ -13323,15 +20742,23 @@ msgstr "dia"
 msgid "Sunburst Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sunday"
-msgstr ""
+msgstr "Domingo"
 
 #, fuzzy
 msgid "Superset Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset Embedded SDK documentation."
-msgstr ""
+msgstr "Documentação do SDK incorporado Superset."
 
 msgid "Superset chart"
 msgstr "Explorar gráfico"
@@ -13340,11 +20767,19 @@ msgstr "Explorar gráfico"
 msgid "Superset docs link"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset encountered an error while running a command."
-msgstr ""
+msgstr "O Superset encontrou um erro ao executar um comando."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset encountered an unexpected error."
-msgstr ""
+msgstr "O Superset encontrou um erro inesperado."
 
 #, fuzzy
 msgid "Supported databases"
@@ -13354,89 +20789,156 @@ msgstr "Selecione uma base de dados"
 msgid "Swap %s"
 msgstr "Escolha uma origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Swap rows and columns"
-msgstr ""
+msgstr "Trocar linhas e colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Swiss army knife for visualizing data. Choose between step, line, "
 "scatter, and bar charts. This viz type has many customization options as "
 "well."
 msgstr ""
+"Canivete suíço para visualizar dados. Escolha entre gráficos de etapas, "
+"de linhas, de dispersão e de barras. Este tipo de visualização também tem"
+" muitas opções de personalização."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the next tab"
-msgstr ""
+msgstr "Mudar para o separador seguinte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the previous tab"
-msgstr ""
+msgstr "Mudar para o separador anterior"
 
 #, fuzzy
 msgid "Symbol"
 msgstr "parafuso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Symbol of two ends of edge line"
-msgstr ""
+msgstr "Símbolo das duas extremidades da linha de borda"
 
 #, fuzzy
 msgid "Symbol size"
 msgstr "Tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sync Permissions"
-msgstr ""
+msgstr "Sincronizar Permissões"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sync columns from source"
-msgstr ""
+msgstr "Sincronizar colunas da fonte"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s"
-msgstr ""
+msgstr "A sincronizar permissões para %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s in the background"
-msgstr ""
+msgstr "A sincronizar permissões para %s em segundo plano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Syntax"
-msgstr ""
+msgstr "Sintaxe"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
 msgstr ""
+"Erro de Sintaxe: %(qualifier)s entrada \"%(input)s\" a aguardar "
+"\"%(expected)s"
 
 #, fuzzy
 msgid "System"
 msgstr "Histograma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System Theme - Read Only"
-msgstr ""
+msgstr "Tema do sistema - Só de leitura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System dark theme removed"
-msgstr ""
+msgstr "Tema escuro do sistema removido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System default theme removed"
-msgstr ""
+msgstr "Tema predefinido do sistema removido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TABLES"
-msgstr ""
+msgstr "TABELAS"
 
 #, fuzzy
 msgid "TEMPORAL_RANGE"
 msgstr "É temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "THU"
-msgstr ""
+msgstr "QUI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TUE"
-msgstr ""
+msgstr "TER"
 
 #, fuzzy
 msgid "Tab name"
 msgstr "Nome da Tabela"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Tab schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "O esquema do separador é inválido, causado por: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tab title"
-msgstr ""
+msgstr "Título do separador"
 
 msgid "Table"
 msgstr "Tabela"
@@ -13460,10 +20962,16 @@ msgstr ""
 "Tabela [{}] não encontrada, por favor verifique conexão à base de dados, "
 "esquema e nome da tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Table already exists. You can change your 'if table already exists' "
 "strategy to append or replace or provide a different Table Name to use."
 msgstr ""
+"A tabela já existe. Pode alterar a estratégia 'se a tabela já existir' "
+"para anexar ou substituir, ou fornecer um nome de tabela diferente a "
+"utilizar."
 
 #, fuzzy
 msgid "Table cache timeout"
@@ -13488,22 +20996,40 @@ msgstr "Nome da Tabela"
 msgid "Table or View \"%(table)s\" does not exist."
 msgstr "Uma ou várias métricas para exibir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Table that visualizes paired t-tests, which are used to understand "
 "statistical differences between groups."
 msgstr ""
+"Tabela que visualiza testes t emparelhados, que são utilizados para "
+"compreender as diferenças estatísticas entre grupos."
 
 msgid "Tables"
 msgstr "Tabelas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabs"
-msgstr ""
+msgstr "Separadores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabular"
-msgstr ""
+msgstr "Tabular"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Tag"
-msgstr ""
+msgstr "Etiqueta"
 
 #, fuzzy
 msgid "Tag could not be created."
@@ -13529,8 +21055,12 @@ msgstr "foi criado"
 msgid "Tag name"
 msgstr "Nome da Tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tag name is invalid (cannot contain ':')"
-msgstr ""
+msgstr "O nome da etiqueta é inválido (não pode conter ':')"
 
 #, fuzzy
 msgid "Tag parameters are invalid."
@@ -13540,9 +21070,12 @@ msgstr "Camadas de anotação para sobreposição na visualização"
 msgid "Tag updated"
 msgstr "%s - sem título"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Tagged %s %ss"
-msgstr ""
+msgstr "Marcado %s %ss"
 
 #, fuzzy
 msgid "Tagged Object could not be deleted."
@@ -13560,11 +21093,19 @@ msgstr "Início"
 msgid "Target Color"
 msgstr "Selecione uma cor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Target category"
-msgstr ""
+msgstr "Categoria de destino"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Target value"
-msgstr ""
+msgstr "Valor alvo"
 
 #, fuzzy
 msgid "Task"
@@ -13586,10 +21127,15 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Task could not be updated."
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"A tarefa não pode ser interrompida. A tarefa está em execução mas não "
+"registou um manipulador de interrupção."
 
 #, fuzzy
 msgid "Task parameters are invalid."
@@ -13599,29 +21145,45 @@ msgstr "Camadas de anotação para sobreposição na visualização"
 msgid "Tasks"
 msgstr "Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
 msgstr ""
+"As tarefas aparecerão aqui à medida que as operações em segundo plano "
+"forem executadas."
 
 #, fuzzy
 msgid "Template"
 msgstr "Modelos CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Template for cell titles. Use Handlebars templating syntax (a popular "
 "templating library that uses double curly brackets for variable "
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
+"Modelo para títulos de células. Use a sintaxe de modelos Handlebars (uma "
+"biblioteca de modelos popular que utiliza chavetas duplas para "
+"substituição de variáveis): {{row}}, {{column}}, {{rowLabel}}, "
+"{{columnLabel}}"
 
 msgid "Template parameters"
 msgstr "Nome do modelo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Template processing error: %(error)s"
-msgstr ""
+msgstr "Erro de processamento do modelo: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "O processamento do modelo falhou: %(ex)s"
 
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
@@ -13634,11 +21196,18 @@ msgstr ""
 msgid "Temporal X-Axis"
 msgstr "É temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Terminate running queries when browser window closed or navigated to "
 "another page. Available for Presto, Hive, MySQL, Postgres and Snowflake "
 "databases."
 msgstr ""
+"Termina as consultas em execução quando a janela do browser é fechada ou "
+"se navega para outra página. Disponível para bases de dados Presto, Hive,"
+" MySQL, Postgres e Snowflake."
 
 #, fuzzy
 msgid "Test connection"
@@ -13648,14 +21217,25 @@ msgstr "Conexão de teste"
 msgid "Text"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Text / Markdown"
-msgstr ""
+msgstr "Texto / Markdown"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text align"
-msgstr ""
+msgstr "Alinhamento de texto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text embedded in email"
-msgstr ""
+msgstr "Texto incorporado no e-mail"
 
 #, fuzzy, python-format
 msgid "The %s"
@@ -13665,9 +21245,12 @@ msgstr "Tempo"
 msgid "The %s linked to this chart may have been deleted."
 msgstr "Esta origem de dados parece ter sido excluída"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
-msgstr ""
+msgstr "A resposta da API de %s não corresponde à interface IDatabaseTable."
 
 msgid ""
 "The CSS for individual dashboards can be altered here, or in the "
@@ -13676,29 +21259,57 @@ msgstr ""
 "O css para dashboards individuais pode ser alterado aqui ou na vista de "
 "dashboard, onde as mudanças são imediatamente visíveis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The CTAS (create table as select) doesn't have a SELECT statement at the "
 "end. Please make sure your query has a SELECT as its last statement. "
 "Then, try running your query again."
 msgstr ""
+"O CTAS (create table as select) não tem uma instrução SELECT no final. "
+"Certifique-se de que a sua consulta tem um SELECT como última instrução. "
+"Em seguida, tente executar a sua consulta novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The GeoJsonLayer takes in GeoJSON formatted data and renders it as "
 "interactive polygons, lines and points (circles, icons and/or texts)."
 msgstr ""
+"A GeoJsonLayer recebe dados formatados em GeoJSON e apresenta-os como "
+"polígonos, linhas e pontos interativos (círculos, ícones e/ou textos)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"O Global Task Framework não está ativado. Contacte o seu administrador "
+"para ativar a funcionalidade GLOBAL_TASK_FRAMEWORK."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"O Global Task Framework não está ativado. Defina "
+"GLOBAL_TASK_FRAMEWORK=True nas suas funcionalidades para utilizar @task. "
+"Consulte https://superset.apache.org/docs/configuration/async-queries-"
+"celery para detalhes de configuração."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
 "values across\n"
@@ -13708,18 +21319,39 @@ msgid ""
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
+"O gráfico Sankey acompanha visualmente o movimento e a transformação de "
+"valores ao longo das\n"
+"          fases do sistema. Os nós representam fases, ligados por "
+"conexões que descrevem o fluxo de valores. A altura\n"
+"          do nó corresponde à métrica visualizada, proporcionando uma "
+"representação clara da\n"
+"          distribuição e transformação dos valores."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The URL is missing the dataset_id or slice_id parameters."
-msgstr ""
+msgstr "O URL não tem os parâmetros dataset_id ou slice_id."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The X-axis is not on the filters list"
-msgstr ""
+msgstr "O eixo X não consta da lista de filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The X-axis is not on the filters list which will prevent it from being "
 "used in time range filters in dashboards. Would you like to add it to the"
 " filters list?"
 msgstr ""
+"O eixo X não consta da lista de filtros, o que impedirá a sua utilização "
+"em filtros de intervalo de tempo nos painéis. Deseja adicioná-lo à lista "
+"de filtros?"
 
 #, fuzzy
 msgid "The annotation has been saved"
@@ -13733,14 +21365,28 @@ msgstr "Dashboard gravado com sucesso."
 msgid "The background color of the charts."
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The category of source nodes used to assign colors. If a node is "
 "associated with more than one category, only the first will be used."
 msgstr ""
+"A categoria dos nós de origem utilizada para atribuir cores. Se um nó "
+"estiver associado a mais do que uma categoria, apenas a primeira será "
+"utilizada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
-msgstr ""
+msgstr "O gráfico ainda está a carregar. Aguarde um momento e tente novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
 "what demographics follow your blog, or what portion of the budget goes to"
@@ -13750,16 +21396,30 @@ msgid ""
 " relative proportion is important, consider using a bar or other chart "
 "type instead."
 msgstr ""
+"O clássico. Ótimo para mostrar quanto de uma empresa cada investidor "
+"recebe, que dados demográficos seguem o seu blogue, ou que parte do "
+"orçamento vai para o complexo industrial militar.\n"
+"\n"
+"        Os gráficos de tarte podem ser difíceis de interpretar com "
+"precisão. Se a clareza da proporção relativa for importante, considere "
+"utilizar um gráfico de barras ou outro tipo de gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The color for points and clusters in RGB"
-msgstr ""
+msgstr "A cor dos pontos e clusters em RGB"
 
 #, fuzzy
 msgid "The color of the elements border"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the isoband"
-msgstr ""
+msgstr "A cor da faixa de nível"
 
 #, fuzzy
 msgid "The color of the isoline"
@@ -13772,43 +21432,82 @@ msgstr "O id da visualização ativa"
 msgid "The color scheme for rendering chart"
 msgstr "O esquema de cores para o gráfico de renderização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The color scheme is determined by the related dashboard.\n"
 "        Edit the color scheme in the dashboard properties."
 msgstr ""
+"O esquema de cores é determinado pelo painel relacionado.\n"
+"        Edite o esquema de cores nas propriedades do painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color used when a value doesn't match any defined breakpoints."
 msgstr ""
+"A cor utilizada quando um valor não corresponde a nenhum ponto de "
+"interrupção definido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The colors of this chart might be overridden by custom label colors of "
 "the related dashboard.\n"
 "    Check the JSON metadata in the Advanced settings."
 msgstr ""
+"As cores deste gráfico podem ser substituídas pelas cores de etiqueta "
+"personalizadas do painel relacionado.\n"
+"    Verifique os metadados JSON nas definições Avançadas."
 
 #, fuzzy
 msgid "The column header label"
 msgstr "Ordenar colunas por ordem alfabética"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the source of the edge."
-msgstr ""
+msgstr "A coluna a ser utilizada como origem da aresta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the target of the edge."
-msgstr ""
+msgstr "A coluna a ser utilizada como destino da aresta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The column was deleted or renamed in the database."
-msgstr ""
+msgstr "A coluna foi eliminada ou renomeada na base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The configuration for the map layers"
-msgstr ""
+msgstr "A configuração para as camadas do mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The corner radius of the chart background"
-msgstr ""
+msgstr "O raio de canto do fundo do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The country code standard that Superset should expect to find in the "
 "[country] column"
 msgstr ""
+"O padrão de código de país que o Superset deve esperar encontrar na "
+"coluna [country]"
 
 msgid "The dashboard has been saved"
 msgstr "Dashboard gravado com sucesso."
@@ -13816,26 +21515,47 @@ msgstr "Dashboard gravado com sucesso."
 msgid "The data source seems to have been deleted"
 msgstr "Esta origem de dados parece ter sido excluída"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The database columns that contains lines information"
-msgstr ""
+msgstr "As colunas da base de dados que contêm informações sobre as linhas"
 
 #, fuzzy
 msgid "The database could not be found"
 msgstr "Visualização %(id)s não encontrada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is currently running too many queries."
-msgstr ""
+msgstr "A base de dados está atualmente a executar demasiadas consultas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is under an unusual load."
-msgstr ""
+msgstr "A base de dados está sob uma carga invulgar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The database referenced in this query was not found. Please contact an "
 "administrator for further assistance or try again."
 msgstr ""
+"A base de dados referenciada nesta consulta não foi encontrada. Contacte "
+"um administrador para obter mais assistência ou tente novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database returned an unexpected error."
-msgstr ""
+msgstr "A base de dados devolveu um erro inesperado."
 
 #, fuzzy
 msgid "The database that was used to generate this query could not be found"
@@ -13849,15 +21569,34 @@ msgstr "Esta origem de dados parece ter sido excluída"
 msgid "The database was not found."
 msgstr "Visualização %(id)s não encontrada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The dataset associated with this chart no longer exists"
-msgstr ""
+msgstr "O conjunto de dados associado a este gráfico já não existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
 msgstr ""
+"A coluna/métrica do conjunto de dados que devolve os valores no eixo x do"
+" seu gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's y-axis."
 msgstr ""
+"A coluna/métrica do conjunto de dados que devolve os valores no eixo y do"
+" seu gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
 "              based on the changes in your SQL query. If your changes "
@@ -13865,7 +21604,16 @@ msgid ""
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
+"As colunas do conjunto de dados serão automaticamente sincronizadas\n"
+"              com base nas alterações na sua consulta SQL. Se as suas "
+"alterações não\n"
+"              afectarem as definições das colunas, pode ignorar este "
+"passo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The dataset configuration exposed here\n"
 "                affects all the charts using this dataset.\n"
@@ -13873,6 +21621,12 @@ msgid ""
 "                here may affect other charts\n"
 "                in undesirable ways."
 msgstr ""
+"A configuração do conjunto de dados exposta aqui\n"
+"                afecta todos os gráficos que utilizam este conjunto de "
+"dados.\n"
+"                Tenha em conta que alterar as configurações\n"
+"                aqui pode afectar outros gráficos\n"
+"                de formas indesejáveis."
 
 msgid "The dataset has been saved"
 msgstr "Esta origem de dados parece ter sido excluída"
@@ -13884,23 +21638,39 @@ msgstr "Não foi possível carregar a query"
 msgid "The datasource is too large to query."
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default catalog that should be used for the connection."
-msgstr ""
+msgstr "O catálogo predefinido que deve ser utilizado para a ligação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default schema that should be used for the connection."
-msgstr ""
+msgstr "O esquema predefinido que deve ser utilizado para a ligação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The description can be displayed as widget headers in the dashboard view."
 " Supports markdown."
 msgstr ""
+"A descrição pode ser apresentada como cabeçalhos de widget na vista do "
+"painel. Suporta markdown."
 
 #, fuzzy
 msgid "The display name of your dashboard"
 msgstr "Gravar e ir para o dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The distance between cells, in pixels"
-msgstr ""
+msgstr "A distância entre células, em píxeis"
 
 #, fuzzy
 msgid ""
@@ -13908,55 +21678,101 @@ msgid ""
 "-1 to bypass the cache."
 msgstr "O número de segundos antes de expirar a cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The encoding format of the lines"
-msgstr ""
+msgstr "O formato de codificação das linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The engine_params object gets unpacked into the sqlalchemy.create_engine "
 "call."
 msgstr ""
+"O objeto engine_params é desempacotado na chamada "
+"sqlalchemy.create_engine."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The exponent to compute all sizes from. \"EXP\" only"
 msgstr ""
+"O expoente a partir do qual todos os tamanhos são calculados. Apenas "
+"\"EXP\""
 
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
 "the extent so that all data points are included in the viewport. CUSTOM "
 "allows users to define the extent manually."
 msgstr ""
+"A extensão do mapa no início da aplicação. FIT DATA define "
+"automaticamente a extensão de modo a que todos os pontos de dados estejam"
+" incluídos na janela de visualização. CUSTOM permite aos utilizadores "
+"definir a extensão manualmente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "A propriedade de elemento a utilizar para rótulos de pontos"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The following entries in `series_columns` are missing in `columns`: "
 "%(columns)s. "
 msgstr ""
+"As seguintes entradas em `series_columns` estão ausentes em `columns`: "
+"%(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"Os seguintes campos contêm informações sensíveis que foram mascaradas "
+"durante a exportação. Forneça os valores para importar esta base de "
+"dados."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The following filters have the 'Select first filter value by default'\n"
 "                    option checked and could not be loaded, which is "
 "preventing the dashboard\n"
 "                    from rendering: %s"
 msgstr ""
+"Os seguintes filtros têm a opção 'Seleccionar o primeiro valor de filtro "
+"por defeito'\n"
+"                    marcada e não puderam ser carregados, o que está a "
+"impedir que o painel\n"
+"                    seja renderizado: %s"
 
 #, fuzzy
 msgid "The font size of the point labels"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The function to use when aggregating points into groups"
-msgstr ""
+msgstr "A função a utilizar ao agregar pontos em grupos"
 
 #, fuzzy
 msgid "The group has been created successfully."
@@ -13966,9 +21782,17 @@ msgstr "Esta origem de dados parece ter sido excluída"
 msgid "The group has been updated successfully."
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
 msgstr ""
+"A altura do nível de zoom actual a partir da qual todas as alturas são "
+"calculadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
 "          representing the frequency or count of values within different "
@@ -13977,72 +21801,140 @@ msgid ""
 " and provides\n"
 "          insights into its shape, central tendency, and spread."
 msgstr ""
+"O gráfico de histograma apresenta a distribuição de um conjunto de dados\n"
+"          representando a frequência ou contagem de valores em diferentes"
+" intervalos ou classes.\n"
+"          Ajuda a visualizar padrões, clusters e valores atípicos nos "
+"dados e fornece\n"
+"          informações sobre a sua forma, tendência central e dispersão."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The host \"%(hostname)s\" might be down and can't be reached."
 msgstr ""
+"O anfitrião \"%(hostname)s\" pode estar inactivo e não pode ser "
+"contactado."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The host \"%(hostname)s\" might be down, and can't be reached on port "
 "%(port)s."
 msgstr ""
+"O anfitrião \"%(hostname)s\" pode estar inactivo e não pode ser "
+"contactado na porta %(port)s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The host might be down, and can't be reached on the provided port."
 msgstr ""
+"O anfitrião pode estar inactivo e não pode ser contactado na porta "
+"fornecida."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The hostname \"%(hostname)s\" cannot be resolved."
-msgstr ""
+msgstr "O nome do anfitrião \"%(hostname)s\" não pode ser resolvido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The hostname provided can't be resolved."
-msgstr ""
+msgstr "O nome do anfitrião fornecido não pode ser resolvido."
 
 msgid "The id of the active chart"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"O URL da imagem do ícone a apresentar para pontos GeoJSON. Note que o URL"
+" da imagem deve estar em conformidade com a política de segurança de "
+"conteúdo (CSP) para ser carregado correctamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
 msgstr ""
+"O nível inicial (profundidade) da árvore. Se definido como -1, todos os "
+"nós são expandidos."
 
 #, fuzzy
 msgid "The layer attribution"
 msgstr "Atributos de formulário relacionados ao tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The lower limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "O limite inferior do intervalo de limiar da Isoband"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The maximum number of subdivisions of each group; lower values are pruned"
 " first"
 msgstr ""
+"O número máximo de subdivisões de cada grupo; os valores mais baixos são "
+"removidos primeiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The maximum value of metrics. It is an optional configuration"
-msgstr ""
+msgstr "O valor máximo das métricas. É uma configuração opcional"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%(key)s is invalid."
 msgstr ""
+"O metadata_params no campo Extra não está configurado correctamente. A "
+"chave %(key)s é inválida."
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%{key}s is invalid."
 msgstr ""
+"O metadata_params no campo Extra não está configurado correctamente. A "
+"chave %{key}s é inválida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The metadata_params object gets unpacked into the sqlalchemy.MetaData "
 "call."
-msgstr ""
+msgstr "O objeto metadata_params é desempacotado na chamada sqlalchemy.MetaData."
 
 msgid ""
 "The minimum number of rolling periods required to show a value. For "
@@ -14057,55 +21949,92 @@ msgstr ""
 "mostrados sejam o total de 7 períodos. Esta opção esconde a "
 "\"aceleração\" que ocorre nos primeiros 7 períodos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The minimum value of metrics. It is an optional configuration. If not "
 "set, it will be the minimum value of the data"
 msgstr ""
+"O valor mínimo das métricas. É uma configuração opcional. Se não for "
+"definido, será o valor mínimo dos dados"
 
 #, fuzzy
 msgid "The name of the geometry column"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the layer as described in GetCapabilities"
-msgstr ""
+msgstr "O nome da camada conforme descrito em GetCapabilities"
 
 #, fuzzy
 msgid "The name of the rule must be unique"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The number color \"steps\""
-msgstr ""
+msgstr "O número de \"passos\" de cor"
 
 #, fuzzy
 msgid "The number of bins for the histogram"
 msgstr "O número de segundos antes de expirar a cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The number of hours, negative or positive, to shift the time column. This"
 " can be used to move UTC time to local time."
 msgstr ""
+"O número de horas, negativo ou positivo, para deslocar a coluna de tempo."
+" Isto pode ser utilizado para mover a hora UTC para a hora local."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of results displayed is limited to %(rows)d."
-msgstr ""
+msgstr "O número de resultados apresentados está limitado a %(rows)d."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
 msgstr ""
+"O número de linhas apresentadas está limitado a %(rows)d pelo menu "
+"pendente."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the limit dropdown."
 msgstr ""
+"O número de linhas apresentadas está limitado a %(rows)d pelo menu "
+"pendente de limite."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the query"
-msgstr ""
+msgstr "O número de linhas apresentadas está limitado a %(rows)d pela consulta"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The number of rows displayed is limited to %(rows)d by the query and "
 "limit dropdown."
 msgstr ""
+"O número de linhas apresentadas está limitado a %(rows)d pela consulta e "
+"pelo menu pendente de limite."
 
 msgid "The number of seconds before expiring the cache"
 msgstr "O número de segundos antes de expirar a cache"
@@ -14114,23 +22043,40 @@ msgstr "O número de segundos antes de expirar a cache"
 msgid "The object does not exist in the given database."
 msgstr "Nome da tabela que existe na base de dados de origem"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The parameter %(parameters)s in your query is undefined."
 msgid_plural "The following parameters in your query are undefined: %(parameters)s."
-msgstr[0] ""
+msgstr[0] "O parâmetro %(parameters)s na sua consulta não está definido."
 msgstr[1] ""
+"Os seguintes parâmetros na sua consulta não estão definidos: "
+"%(parameters)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The password provided for username \"%(username)s\" is incorrect."
 msgstr ""
+"A senha fornecida para o nome de utilizador \"%(username)s\" está "
+"incorreta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The password provided when connecting to a database is not valid."
-msgstr ""
+msgstr "A senha fornecida ao ligar a uma base de dados não é válida."
 
 #, fuzzy
 msgid "The password reset was successful"
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the charts. Please note that the \"Secure Extra\" and "
@@ -14138,7 +22084,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"As senhas das bases de dados abaixo são necessárias para as importar "
+"juntamente com os gráficos. Tenha em conta que as secções \"Secure "
+"Extra\" e \"Certificate\" da configuração da base de dados não estão "
+"presentes nos ficheiros de exportação e devem ser adicionadas manualmente"
+" após a importação, se necessário."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the dashboards. Please note that the \"Secure Extra\" and "
@@ -14146,7 +22101,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"As senhas das bases de dados abaixo são necessárias para as importar "
+"juntamente com os dashboards. Tenha em conta que as secções \"Secure "
+"Extra\" e \"Certificate\" da configuração da base de dados não estão "
+"presentes nos ficheiros de exportação e devem ser adicionadas manualmente"
+" após a importação, se necessário."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the datasets. Please note that the \"Secure Extra\" and "
@@ -14154,7 +22118,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"As senhas das bases de dados abaixo são necessárias para as importar "
+"juntamente com os conjuntos de dados. Tenha em conta que as secções "
+"\"Secure Extra\" e \"Certificate\" da configuração da base de dados não "
+"estão presentes nos ficheiros de exportação e devem ser adicionadas "
+"manualmente após a importação, se necessário."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the saved queries. Please note that the \"Secure Extra\" "
@@ -14162,34 +22135,74 @@ msgid ""
 "present in export files, and should be added manually after the import if"
 " they are needed."
 msgstr ""
+"As senhas das bases de dados abaixo são necessárias para as importar "
+"juntamente com as consultas guardadas. Tenha em conta que as secções "
+"\"Secure Extra\" e \"Certificate\" da configuração da base de dados não "
+"estão presentes nos ficheiros de exportação e devem ser adicionadas "
+"manualmente após a importação, se necessário."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
-msgstr ""
+msgstr "As senhas das bases de dados abaixo são necessárias para as importar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "The pattern of timestamp format. For strings use "
-msgstr ""
+msgstr "O padrão do formato de timestamp. Para cadeias use "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The periodicity over which to pivot time. Users can provide\n"
 "            \"Pandas\" offset alias.\n"
 "            Click on the info bubble for more details on accepted "
 "\"freq\" expressions."
 msgstr ""
+"A periodicidade sobre a qual o tempo será dinamizado. Os utilizadores "
+"podem fornecer\n"
+"            um alias de deslocamento \"Pandas\".\n"
+"            Clique no balão de informação para obter mais detalhes sobre "
+"as expressões \"freq\" aceites."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The pixel radius"
-msgstr ""
+msgstr "O raio em píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The pointer to a physical table (or view). Keep in mind that the chart is"
 " associated to this Superset logical table, and this logical table points"
 " the physical table referenced here."
 msgstr ""
+"O ponteiro para uma tabela física (ou vista). Tenha em conta que o "
+"gráfico está associado a esta tabela lógica do Superset, e esta tabela "
+"lógica aponta para a tabela física referenciada aqui."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The port is closed."
-msgstr ""
+msgstr "A porta está fechada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The port number is invalid."
-msgstr ""
+msgstr "O número da porta é inválido."
 
 #, fuzzy
 msgid "The primary metric is used to define the arc segment sizes"
@@ -14199,76 +22212,150 @@ msgstr "Métrica usada para definir a série superior"
 msgid "The provided table was not found in the provided database"
 msgstr "Nome da tabela que existe na base de dados de origem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query associated with the results was deleted."
-msgstr ""
+msgstr "A consulta associada aos resultados foi eliminada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The query associated with these results could not be found. You need to "
 "re-run the original query."
 msgstr ""
+"A consulta associada a estes resultados não pôde ser encontrada. É "
+"necessário executar novamente a consulta original."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query contains one or more malformed template parameters."
-msgstr ""
+msgstr "A consulta contém um ou mais parâmetros de modelo mal formados."
 
 msgid "The query couldn't be loaded"
 msgstr "Não foi possível carregar a query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The query estimation was killed after %(sqllab_timeout)s seconds. It "
 "might be too complex, or the database might be under heavy load."
 msgstr ""
+"A estimativa da consulta foi interrompida após %(sqllab_timeout)s "
+"segundos. Pode ser demasiado complexa, ou a base de dados pode estar sob "
+"carga elevada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query has a syntax error."
-msgstr ""
+msgstr "A consulta tem um erro de sintaxe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query returned no data"
-msgstr ""
+msgstr "A consulta não devolveu dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The query was killed after %(sqllab_timeout)s seconds. It might be too "
 "complex, or the database might be under heavy load."
 msgstr ""
+"A consulta foi interrompida após %(sqllab_timeout)s segundos. Pode ser "
+"demasiado complexa, ou a base de dados pode estar sob carga elevada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius (in pixels) the algorithm uses to define a cluster. Choose 0 "
 "to turn off clustering, but beware that a large number of points (>1000) "
 "will cause lag."
 msgstr ""
+"O raio (em píxeis) que o algoritmo usa para definir um cluster. Escolha 0"
+" para desativar o agrupamento, mas tenha em conta que um grande número de"
+" pontos (>1000) causará atraso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius of individual points (ones that are not in a cluster). Either "
 "a numerical column or `Auto`, which scales the point based on the largest"
 " cluster"
 msgstr ""
+"O raio de pontos individuais (aqueles que não estão num cluster). Uma "
+"coluna numérica ou `Auto`, que dimensiona o ponto com base no maior "
+"cluster"
 
 #, fuzzy
 msgid "The report has been created"
 msgstr "Esta origem de dados parece ter sido excluída"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The report will be sent to your email at"
-msgstr ""
+msgstr "O relatório será enviado para o seu e-mail em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The result of this query must be a value capable of numeric "
 "interpretation e.g. 1, 1.0, or \"1\" (compatible with Python's float() "
 "function)."
 msgstr ""
+"O resultado desta consulta deve ser um valor capaz de interpretação "
+"numérica, por ex. 1, 1.0 ou \"1\" (compatível com a função float() do "
+"Python)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The result size exceeds the allowed limit."
-msgstr ""
+msgstr "O tamanho do resultado excede o limite permitido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The results backend no longer has the data from the query."
-msgstr ""
+msgstr "O backend de resultados já não tem os dados da consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The results stored in the backend were stored in a different format, and "
 "no longer can be deserialized."
 msgstr ""
+"Os resultados armazenados no backend foram armazenados num formato "
+"diferente e já não podem ser desserializados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The rich tooltip shows a list of all series for that point in time"
 msgstr ""
+"O tooltip avançado mostra uma lista de todas as séries para esse ponto no"
+" tempo"
 
 #, fuzzy
 msgid "The role has been created successfully."
@@ -14282,78 +22369,149 @@ msgstr "Esta origem de dados parece ter sido excluída"
 msgid "The role has been updated successfully."
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The row limit set for the chart was reached. The chart may show partial "
 "data."
 msgstr ""
+"O limite de linhas definido para o gráfico foi atingido. O gráfico pode "
+"mostrar dados parciais."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema)s\" does not exist. A valid schema must be used to "
 "run this query."
 msgstr ""
+"O esquema \"%(schema)s\" não existe. É necessário utilizar um esquema "
+"válido para executar esta consulta."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema_name)s\" does not exist. A valid schema must be "
 "used to run this query."
 msgstr ""
+"O esquema \"%(schema_name)s\" não existe. É necessário utilizar um "
+"esquema válido para executar esta consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The schema of the submitted payload is invalid."
-msgstr ""
+msgstr "O esquema do payload enviado é inválido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The schema was deleted or renamed in the database."
-msgstr ""
+msgstr "O esquema foi eliminado ou renomeado na base de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot could not be downloaded. Please, try again later."
 msgstr ""
+"A captura de ecrã não pôde ser descarregada. Por favor, tente novamente "
+"mais tarde."
 
 #, fuzzy
 msgid "The screenshot has been downloaded."
 msgstr "Esta origem de dados parece ter sido excluída"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot is being generated. Please, do not leave the page."
-msgstr ""
+msgstr "A captura de ecrã está a ser gerada. Por favor, não abandone a página."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The service url of the layer"
-msgstr ""
+msgstr "O URL de serviço da camada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The size of each cell in meters"
-msgstr ""
+msgstr "O tamanho de cada célula em metros"
 
 #, fuzzy
 msgid "The size of the point icons"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The size of the square cell, in pixels"
-msgstr ""
+msgstr "O tamanho da célula quadrada, em píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The slope to compute all sizes from. \"LINEAR\" only"
 msgstr ""
+"A inclinação a partir da qual calcular todos os tamanhos. Apenas "
+"\"LINEAR\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The submitted payload failed validation."
-msgstr ""
+msgstr "O payload enviado falhou na validação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect format."
-msgstr ""
+msgstr "O payload enviado tem o formato incorreto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect schema."
-msgstr ""
+msgstr "O payload enviado tem o esquema incorreto."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table)s\" does not exist. A valid table must be used to run"
 " this query."
 msgstr ""
+"A tabela \"%(table)s\" não existe. É necessário utilizar uma tabela "
+"válida para executar esta consulta."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table_name)s\" does not exist. A valid table must be used "
 "to run this query."
 msgstr ""
+"A tabela \"%(table_name)s\" não existe. Deve ser utilizada uma tabela "
+"válida para executar esta consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The table was deleted or renamed in the database."
-msgstr ""
+msgstr "A tabela foi eliminada ou renomeada na base de dados."
 
 msgid ""
 "The time column for the visualization. Note that you can define arbitrary"
@@ -14393,6 +22551,10 @@ msgstr ""
 "temporal. As opções são definidas por base de dados no código-fonte do "
 "Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time range for the visualization. All relative times, e.g. \"Last "
 "month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using"
@@ -14402,14 +22564,32 @@ msgid ""
 " explicitly set the timezone per the ISO 8601 format if specifying either"
 " the start and/or end time."
 msgstr ""
+"O intervalo de tempo para a visualização. Todos os tempos relativos, como"
+" por exemplo \"Last month\", \"Last 7 days\", \"now\", etc. são avaliados"
+" no servidor utilizando a hora local do servidor (sem fuso horário). "
+"Todas as dicas de ferramentas e os tempos dos marcadores são expressos em"
+" UTC (sem fuso horário). As marcas temporais são depois avaliadas pela "
+"base de dados utilizando o fuso horário local do motor. Note que é "
+"possível definir explicitamente o fuso horário de acordo com o formato "
+"ISO 8601 ao especificar a hora de início e/ou de fim."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
+"A unidade de tempo para cada bloco. Deve ser uma unidade menor que "
+"domain_granularity. Deve ser maior ou igual ao Time Grain"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The time unit used for the grouping of blocks"
-msgstr ""
+msgstr "A unidade de tempo utilizada para o agrupamento de blocos"
 
 #, fuzzy
 msgid "The two passwords that you entered do not match!"
@@ -14426,14 +22606,25 @@ msgstr "O tipo de visualização a ser exibida"
 msgid "The unit for icon size"
 msgstr "Tamanho da bolha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "A unidade para o tamanho da etiqueta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The unit of measure for the specified point radius"
-msgstr ""
+msgstr "A unidade de medida para o raio do ponto especificado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The upper limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "O limite superior do intervalo de limiar do Isoband"
 
 #, fuzzy
 msgid "The user has been created successfully."
@@ -14450,18 +22641,34 @@ msgstr "O utilizador parece ter sido eliminado"
 msgid "The user was updated successfully"
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The user/password combination is not valid (Incorrect password for user)."
 msgstr ""
+"A combinação utilizador/palavra-passe não é válida (palavra-passe "
+"incorreta para o utilizador)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The username \"%(username)s\" does not exist."
-msgstr ""
+msgstr "O nome de utilizador \"%(username)s\" não existe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The username provided when connecting to a database is not valid."
-msgstr ""
+msgstr "O nome de utilizador fornecido ao ligar a uma base de dados não é válido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The values overlap other breakpoint values"
-msgstr ""
+msgstr "Os valores sobrepõem-se a outros valores de ponto de quebra"
 
 #, fuzzy
 msgid "The version of the service"
@@ -14471,15 +22678,24 @@ msgstr "Calcular contribuição para o total"
 msgid "The visible title of the layer"
 msgstr "Insira um novo título para a aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The way the ticks are laid out on the X-axis"
-msgstr ""
+msgstr "A forma como as marcas são dispostas no eixo X"
 
 #, fuzzy
 msgid "The width of the Isoline in pixels"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the current zoom level to compute all widths from"
 msgstr ""
+"A largura do nível de zoom atual a partir da qual todas as larguras são "
+"calculadas"
 
 #, fuzzy
 msgid "The width of the elements border"
@@ -14489,10 +22705,15 @@ msgstr "O id da visualização ativa"
 msgid "The width of the lines"
 msgstr "O id da visualização ativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
 msgstr ""
+"A largura das linhas como um valor fixo ou uma largura variável baseada "
+"numa métrica."
 
 #, fuzzy
 msgid "Theme"
@@ -14514,19 +22735,29 @@ msgstr "Tempo"
 msgid "Themes could not be deleted."
 msgstr "Não foi possível carregar a query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There are associated alerts or reports"
-msgstr ""
+msgstr "Existem alertas ou relatórios associados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There are associated alerts or reports: %(report_names)s"
-msgstr ""
+msgstr "Existem alertas ou relatórios associados: %(report_names)s"
 
 #, fuzzy
 msgid "There are no charts added to this dashboard"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "There are no components added to this tab"
-msgstr ""
+msgstr "Não foram adicionados componentes a este separador"
 
 msgid "There are no filters in this dashboard."
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
@@ -14535,30 +22766,52 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There are unsaved changes."
 msgstr "Existem alterações por gravar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is a syntax error in the SQL query. Perhaps there was a misspelling"
 " or a typo."
 msgstr ""
+"Existe um erro de sintaxe na consulta SQL. Talvez haja um erro "
+"ortográfico ou de digitação."
 
 #, fuzzy
 msgid "There is currently no information to display."
 msgstr "O tipo de visualização a ser exibida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is no chart definition associated with this component, could it "
 "have been deleted?"
 msgstr ""
+"Não existe nenhuma definição de gráfico associada a este componente; "
+"poderá ter sido eliminado?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is not enough space for this component. Try decreasing its width, "
 "or increasing the destination width."
 msgstr ""
+"Não há espaço suficiente para este componente. Tente diminuir a sua "
+"largura ou aumentar a largura de destino."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"Houve um problema ao atualizar o seu painel. Tentaremos novamente em %s, "
+"conforme agendado."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -14612,8 +22865,12 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an error loading the schemas"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error loading the tables"
-msgstr ""
+msgstr "Ocorreu um erro ao carregar as tabelas"
 
 #, fuzzy
 msgid "There was an error loading users."
@@ -14651,8 +22908,12 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an error while fetching users"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error with your request"
-msgstr ""
+msgstr "Ocorreu um erro com o seu pedido"
 
 #, fuzzy, python-format
 msgid "There was an issue cancelling the task: %s"
@@ -14662,9 +22923,12 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an issue deleting %s"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting %s: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar %s: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting registration for user: %s"
@@ -14678,36 +22942,54 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an issue deleting the selected %s"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected %s: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar o(s) %s selecionado(s): %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected annotations: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar as anotações selecionadas: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected charts: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar os gráficos selecionados: %s"
 
 msgid "There was an issue deleting the selected dashboards: "
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected layers: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar as camadas selecionadas: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected templates: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar os modelos selecionados: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting the selected themes: %s"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting: %s"
-msgstr ""
+msgstr "Ocorreu um problema ao eliminar: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue duplicating the %s."
@@ -14744,8 +23026,12 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an issue fetching reports."
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an issue fetching the favorite status of this dashboard."
-msgstr ""
+msgstr "Ocorreu um problema ao obter o estado de favorito deste painel."
 
 #, fuzzy, python-format
 msgid "There was an issue fetching your chart: %s"
@@ -14763,16 +23049,25 @@ msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 msgid "There was an issue fetching your saved queries: %s"
 msgstr "Desculpe, houve um erro ao gravar este dashbard: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query %s"
-msgstr ""
+msgstr "Ocorreu um problema ao pré-visualizar a consulta selecionada %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query. %s"
-msgstr ""
+msgstr "Ocorreu um problema ao pré-visualizar a consulta selecionada. %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "These are the datasets this filter will be applied to."
-msgstr ""
+msgstr "Estes são os conjuntos de dados aos quais este filtro será aplicado."
 
 msgid ""
 "This JSON object is generated dynamically when clicking the save or "
@@ -14783,71 +23078,148 @@ msgstr ""
 "substituir na exibição do painel. É exposto aqui para referência e para "
 "usuários avançados que desejam alterar parâmetros específicos."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "This action will permanently delete %s."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the group."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o grupo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the layer."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente a camada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the role."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o papel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the saved query."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente a consulta guardada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the template."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o modelo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the theme."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o tema."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user registration."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o registo do utilizador."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user."
-msgstr ""
+msgstr "Esta ação irá eliminar permanentemente o utilizador."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This can be either an IP address (e.g. 127.0.0.1) or a domain name (e.g. "
 "mydatabase.com)."
 msgstr ""
+"Pode ser um endereço IP (por exemplo, 127.0.0.1) ou um nome de domínio "
+"(por exemplo, mydatabase.com)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This chart applies cross-filters to charts whose datasets contain columns"
 " with the same name."
 msgstr ""
+"Este gráfico aplica filtros cruzados a gráficos cujos conjuntos de dados "
+"contêm colunas com o mesmo nome."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart has been moved to a different filter scope."
-msgstr ""
+msgstr "Este gráfico foi movido para um âmbito de filtro diferente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr ""
+msgstr "Este gráfico é gerido externamente e não pode ser substituído no Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This chart is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "Este gráfico é gerido externamente e não pode ser editado no Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
+"Este gráfico pode ser incompatível com o filtro (os conjuntos de dados "
+"não correspondem)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This chart type is not supported when using an unsaved query as a chart "
 "source. "
 msgstr ""
+"Este tipo de gráfico não é suportado ao usar uma consulta não guardada "
+"como fonte do gráfico. "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
-msgstr ""
+msgstr "Esta coluna pode ser incompatível com o/a atual %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This column might be incompatible with current dataset"
-msgstr ""
+msgstr "Esta coluna pode ser incompatível com o conjunto de dados atual"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This column must contain date/time information."
-msgstr ""
+msgstr "Esta coluna deve conter informações de data/hora."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This control filters the whole chart based on the selected time range. "
 "All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. "
@@ -14857,32 +23229,72 @@ msgid ""
 "engine's local timezone. Note one can explicitly set the timezone per the"
 " ISO 8601 format if specifying either the start and/or end time."
 msgstr ""
+"Este controlo filtra todo o gráfico com base no intervalo de tempo "
+"selecionado. Todos os tempos relativos, como por exemplo \"Último mês\", "
+"\"Últimos 7 dias\", \"agora\", etc., são avaliados no servidor usando a "
+"hora local do servidor (sem fuso horário). Todas as dicas de ferramentas "
+"e tempos de marcador são expressos em UTC (sem fuso horário). Os carimbos"
+" de data/hora são então avaliados pela base de dados usando o fuso "
+"horário local do motor. Note que é possível definir explicitamente o fuso"
+" horário de acordo com o formato ISO 8601 se especificar a hora de início"
+" e/ou de fim."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the \"time_range\" field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"Isto controla se o campo \"time_range\" da vista atual\n"
+"                  deve ser passado ao gráfico que contém os dados de "
+"anotação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the time grain field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"Isto controla se o campo de granularidade temporal da vista atual\n"
+"                  deve ser passado ao gráfico que contém os dados de "
+"anotação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dashboard is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "Este dashboard é gerido externamente e não pode ser editado no Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published which means it will not show up in the "
 "list of dashboards. Favorite it to see it there or access it by using the"
 " URL directly."
 msgstr ""
+"Este dashboard não está publicado, o que significa que não aparecerá na "
+"lista de dashboards. Adicione-o aos favoritos para o ver lá ou aceda a "
+"ele usando o URL diretamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published, it will not show up in the list of "
 "dashboards. Click here to publish this dashboard."
 msgstr ""
+"Este dashboard não está publicado e não aparecerá na lista de dashboards."
+" Clique aqui para publicar este dashboard."
 
 #, fuzzy
 msgid "This dashboard is now hidden"
@@ -14892,96 +23304,194 @@ msgstr "Editar propriedades do dashboard"
 msgid "This dashboard is now published"
 msgstr "Editar propriedades do dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is published. Click to make it a draft."
-msgstr ""
+msgstr "Este dashboard está publicado. Clique para convertê-lo em rascunho."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is ready to embed. In your application, pass the following"
 " id to the SDK:"
 msgstr ""
+"Este dashboard está pronto para ser incorporado. Na sua aplicação, passe "
+"o seguinte id ao SDK:"
 
 msgid "This dashboard was saved successfully."
 msgstr "Dashboard gravado com sucesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This database does not allow for DDL/DML, but the query mutates data. "
 "Please contact your administrator for more assistance."
 msgstr ""
+"Esta base de dados não permite DDL/DML, mas a consulta altera dados. Por "
+"favor contacte o seu administrador para obter mais assistência."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This database is managed externally, and can't be edited in Superset"
 msgstr ""
+"Esta base de dados é gerida externamente e não pode ser editada no "
+"Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This database table does not contain any data. Please select a different "
 "table."
 msgstr ""
+"Esta tabela da base de dados não contém dados. Por favor selecione uma "
+"tabela diferente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Esta base de dados utiliza OAuth2 para autenticação. Clique no link acima"
+" para conceder permissão ao Apache Superset para aceder aos dados. O seu "
+"token de acesso pessoal será armazenado de forma encriptada e utilizado "
+"apenas para consultas executadas por si."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
+"Este conjunto de dados é gerido externamente e não pode ser editado no "
+"Superset"
 
 msgid "This defines the element to be plotted on the chart"
 msgstr "Esta opção define o elemento a ser desenhado no gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This email is already associated with an account. Please choose another "
 "one."
-msgstr ""
+msgstr "Este email já está associado a uma conta. Por favor escolha outro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This feature is experimental and may change or have limitations"
-msgstr ""
+msgstr "Esta funcionalidade é experimental e pode ser alterada ou ter limitações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the calculated "
 "dimension to charts. It is also used as the alias in the SQL query."
 msgstr ""
+"Este campo é utilizado como identificador único para associar a dimensão "
+"calculada aos gráficos. Também é utilizado como alias na consulta SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the metric to charts."
 " It is also used as the alias in the SQL query."
 msgstr ""
+"Este campo é utilizado como identificador único para associar a métrica "
+"aos gráficos. Também é utilizado como alias na consulta SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This filter already exist on the report"
-msgstr ""
+msgstr "Este filtro já existe no relatório"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This filter might be incompatible with current %s"
-msgstr ""
+msgstr "Este filtro pode ser incompatível com o/a atual %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "Esta pasta está atualmente vazia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Esta pasta suporta apenas colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Esta pasta suporta apenas métricas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr ""
+"Esta funcionalidade está desativada no seu ambiente por razões de "
+"segurança."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
+"Esta é a pasta de colunas predefinida. O seu nome não pode ser alterado "
+"ou removido. Pode ficar vazia, mas só aceitará itens de coluna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
+"Esta é a pasta de métricas predefinida. O seu nome não pode ser alterado "
+"ou removido. Pode ficar vazia, mas só aceitará itens de métrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "Esta é a mensagem de erro personalizada para a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "Esta é a mensagem de erro personalizada para b"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
 "example, to only return rows for a particular client, you might define a "
@@ -14989,19 +23499,33 @@ msgid ""
 " a user belongs to a RLS filter role, a base filter can be created with "
 "the clause `1 = 0` (always false)."
 msgstr ""
+"Esta é a condição que será adicionada à cláusula WHERE. Por exemplo, para"
+" retornar apenas linhas de um cliente específico, pode definir um filtro "
+"regular com a cláusula `client_id = 9`. Para não mostrar linhas a menos "
+"que um utilizador pertença a uma função de filtro RLS, pode ser criado um"
+" filtro base com a cláusula `1 = 0` (sempre falso)."
 
 #, fuzzy
 msgid "This is the default dark theme"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default folder"
-msgstr ""
+msgstr "Esta é a pasta predefinida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "Este é o tema claro predefinido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "Esta é a única vez que verá esta chave. Guarde-a em segurança."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -15013,47 +23537,91 @@ msgstr ""
 "posicionamento de uma visualização utilizando o drag & drop na vista de "
 "dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Este link não pode ser seguido porque o seu endereço não é seguro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Este link irá levá-lo a um website externo. Não podemos garantir a "
+"segurança dos destinos externos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error."
-msgstr ""
+msgstr "Este componente markdown tem um erro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error. Please revert your recent changes."
 msgstr ""
+"Este componente markdown tem um erro. Por favor reverta as suas "
+"alterações recentes."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This may be due to the extension not being activated or the content not "
 "being available."
 msgstr ""
+"Isto pode dever-se ao facto de a extensão não estar ativada ou o conteúdo"
+" não estar disponível."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This may be triggered by:"
-msgstr ""
+msgstr "Isto pode ser desencadeado por:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This metric might be incompatible with current %s"
-msgstr ""
+msgstr "Esta métrica pode ser incompatível com o/a atual %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This name is already taken. Please choose another one."
-msgstr ""
+msgstr "Este nome já está em uso. Por favor escolha outro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This option has been disabled by the administrator."
-msgstr ""
+msgstr "Esta opção foi desativada pelo administrador."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This page is intended to be embedded in an iframe, but it looks like that"
 " is not the case."
 msgstr ""
+"Esta página destina-se a ser incorporada num iframe, mas parece que não é"
+" o caso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This section allows you to configure how to use the slice\n"
 "              to generate annotations."
 msgstr ""
+"Esta secção permite-lhe configurar como utilizar o slice\n"
+"              para gerar anotações."
 
 msgid ""
 "This section contains options that allow for advanced analytical post "
@@ -15062,37 +23630,75 @@ msgstr ""
 "Esta seção contém opções que permitem o pós-processamento analítico "
 "avançado de resultados da query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This section contains validation errors"
-msgstr ""
+msgstr "Esta secção contém erros de validação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This session has encountered an interruption, and some controls may not "
 "work as intended. If you are the developer of this app, please check that"
 " the guest token is being generated correctly."
 msgstr ""
+"Esta sessão encontrou uma interrupção e alguns controlos podem não "
+"funcionar como pretendido. Se for o programador desta aplicação, "
+"verifique se o token de convidado está a ser gerado corretamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This table already has a dataset"
-msgstr ""
+msgstr "Esta tabela já tem um conjunto de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This table already has a dataset associated with it. You can only "
 "associate one dataset with a table.\n"
 msgstr ""
+"Esta tabela já tem um conjunto de dados associado. Só pode associar um "
+"conjunto de dados a uma tabela.\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally"
-msgstr ""
+msgstr "Este tema está definido localmente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally for your session"
-msgstr ""
+msgstr "Este tema está definido localmente para a sua sessão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This username is already taken. Please choose another one."
-msgstr ""
+msgstr "Este nome de utilizador já está a ser usado. Por favor, escolha outro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be greater than the left target value"
-msgstr ""
+msgstr "Este valor deve ser maior do que o valor alvo à esquerda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be smaller than the right target value"
-msgstr ""
+msgstr "Este valor deve ser menor do que o valor alvo à direita"
 
 #, fuzzy
 msgid "This visualization type does not support cross-filtering."
@@ -15101,50 +23707,93 @@ msgstr "Escolha um tipo de visualização"
 msgid "This visualization type is not supported."
 msgstr "Escolha um tipo de visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Isto foi acionado por:"
+msgstr[1] "Isto pode ser acionado por:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "Isto irá cancelar (parar) a tarefa para todos os %s subscritores."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
 "to main columns for increase and decrease. Basic conditional formatting "
 "can be overwritten by conditional formatting below."
 msgstr ""
+"Isto será aplicado a toda a tabela. Serão adicionadas setas (↑ e ↓) às "
+"colunas principais para aumento e diminuição. A formatação condicional "
+"básica pode ser substituída pela formatação condicional abaixo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "Isto irá cancelar a tarefa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This will remove your current embed configuration."
-msgstr ""
+msgstr "Isto irá remover a sua configuração de incorporação atual."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
+"Isto irá reorganizar todas as métricas e colunas em pastas predefinidas. "
+"Quaisquer pastas personalizadas serão removidas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold"
-msgstr ""
+msgstr "Limiar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Threshold alpha level for determining significance"
-msgstr ""
+msgstr "Nível alfa do limiar para determinar a significância"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold for Other"
-msgstr ""
+msgstr "Limiar para Outros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold: "
-msgstr ""
+msgstr "Limiar: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thumbnails"
-msgstr ""
+msgstr "Miniaturas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thursday"
-msgstr ""
+msgstr "Quinta-feira"
 
 msgid "Time"
 msgstr "Tempo"
@@ -15164,8 +23813,13 @@ msgstr "Formato de data e hora"
 msgid "Time Grain"
 msgstr "Granularidade Temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time Grain must be specified when using Time Shift."
 msgstr ""
+"A granularidade temporal deve ser especificada ao utilizar o Desvio "
+"Temporal."
 
 #, fuzzy
 msgid "Time Granularity"
@@ -15214,36 +23868,65 @@ msgstr "Visualização da tabela de tempo"
 msgid "Time column"
 msgstr "Coluna de tempo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Time column \"%(col)s\" does not exist in dataset"
-msgstr ""
+msgstr "A coluna de tempo \"%(col)s\" não existe no conjunto de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time column chart customization plugin"
-msgstr ""
+msgstr "Plugin de personalização do gráfico de coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column filter plugin"
-msgstr ""
+msgstr "Plugin de filtro de coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply dependent temporal filter to"
-msgstr ""
+msgstr "Coluna de tempo à qual aplicar o filtro temporal dependente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply time range to"
-msgstr ""
+msgstr "Coluna de tempo à qual aplicar o intervalo de tempo"
 
 #, fuzzy
 msgid "Time comparison"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Time delta in natural language\n"
 "                  (example:  24 hours, 7 days, 56 weeks, 365 days)"
 msgstr ""
+"Delta de tempo em linguagem natural\n"
+"                  (exemplo:  24 horas, 7 dias, 56 semanas, 365 dias)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time delta is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
 msgstr ""
+"O delta de tempo é ambíguo. Por favor, especifique [%(human_readable)s "
+"atrás] ou [%(human_readable)s depois]."
 
 #, fuzzy
 msgid "Time filter"
@@ -15303,11 +23986,16 @@ msgstr "Colunas das séries temporais"
 msgid "Time shift"
 msgstr "Mudança de hora"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time string is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
 msgstr ""
+"A cadeia de tempo é ambígua. Por favor, especifique [%(human_readable)s "
+"atrás] ou [%(human_readable)s depois]."
 
 #, fuzzy
 msgid "Time-series Percent Change"
@@ -15328,24 +24016,41 @@ msgstr "Formato de data e hora"
 msgid "Timeline"
 msgstr "Granularidade Temporal"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Tempo limite configurado (%s segundos) mas nenhum manipulador de "
+"cancelamento definido. A tarefa continuará a ser executada após o tempo "
+"limite."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timeout error"
-msgstr ""
+msgstr "Erro de tempo limite"
 
 #, fuzzy
 msgid "Timestamp format"
 msgstr "Formato da Tabela Datahora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timezone"
-msgstr ""
+msgstr "Fuso horário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timezone selector"
-msgstr ""
+msgstr "Seletor de fuso horário"
 
 #, fuzzy
 msgid "Tiny"
@@ -15362,35 +24067,66 @@ msgstr "Coluna de tempo"
 msgid "Title is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Title or Slug"
-msgstr ""
+msgstr "Título ou Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Para começar a usar as suas Google Sheets, precisa primeiro de criar uma "
+"base de dados. As bases de dados são utilizadas como forma de identificar"
+" os seus dados para que possam ser consultados e visualizados. Esta base "
+"de dados irá conter todas as suas Google Sheets individuais que escolher "
+"ligar aqui."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
 "clicking the column header."
 msgstr ""
+"Para ativar a ordenação por várias colunas, mantenha premida a tecla ⇧ "
+"Shift enquanto clica no cabeçalho da coluna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "To filter on a metric, use Custom SQL tab."
-msgstr ""
+msgstr "Para filtrar por uma métrica, use o separador SQL personalizado."
 
 msgid "To get a readable URL for your dashboard"
 msgstr "Obter um URL legível para o seu dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "URI de pedido de token"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Tool Panel"
-msgstr ""
+msgstr "Painel de ferramentas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tooltip"
-msgstr ""
+msgstr "Dica de ferramenta"
 
 #, fuzzy
 msgid "Tooltip (columns)"
@@ -15420,29 +24156,48 @@ msgstr "Formato de data e hora"
 msgid "Top"
 msgstr "Parar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Top left"
-msgstr ""
+msgstr "Superior esquerdo"
 
 #, fuzzy
 msgid "Top n"
 msgstr "Parar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Top right"
-msgstr ""
+msgstr "Superior direito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Top to Bottom"
-msgstr ""
+msgstr "De cima para baixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggfunc)s)"
-msgstr ""
+msgstr "Total (%(aggfunc)s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggregatorName)s)"
-msgstr ""
+msgstr "Total (%(aggregatorName)s)"
 
 #, fuzzy
 msgid "Total color"
@@ -15456,32 +24211,54 @@ msgstr "Valor de filtro"
 msgid "Total value"
 msgstr "Valor de filtro"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Total: %s"
-msgstr ""
+msgstr "Total: %s"
 
 #, fuzzy
 msgid "Track job"
 msgstr "Acompanhar trabalho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transformable"
-msgstr ""
+msgstr "Transformável"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transparent"
-msgstr ""
+msgstr "Transparente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transpose pivot"
-msgstr ""
+msgstr "Transpor pivot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Treat values as categorical."
-msgstr ""
+msgstr "Tratar os valores como categóricos."
 
 #, fuzzy
 msgid "Tree Chart"
 msgstr "Explorar gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tree layout"
-msgstr ""
+msgstr "Disposição em árvore"
 
 #, fuzzy
 msgid "Tree orientation"
@@ -15490,21 +24267,37 @@ msgstr "Anotações"
 msgid "Treemap"
 msgstr "Treemap"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trend"
-msgstr ""
+msgstr "Tendência"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Triangle"
-msgstr ""
+msgstr "Triângulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trigger Alert If..."
-msgstr ""
+msgstr "Acionar Alerta Se..."
 
 #, fuzzy
 msgid "True"
 msgstr "Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate Cells"
-msgstr ""
+msgstr "Truncar Células"
 
 #, fuzzy
 msgid "Truncate Metric"
@@ -15514,34 +24307,75 @@ msgstr "Selecione métrica"
 msgid "Truncate X Axis"
 msgstr "Selecione métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
 " applicable for numerical X axis."
 msgstr ""
+"Truncar Eixo X. Pode ser substituído especificando um limite mínimo ou "
+"máximo. Apenas aplicável para eixo X numérico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis"
-msgstr ""
+msgstr "Truncar Eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
 msgstr ""
+"Truncar Eixo Y. Pode ser substituído especificando um limite mínimo ou "
+"máximo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate long cells to the \"min width\" set above"
-msgstr ""
+msgstr "Truncar células longas para a \"largura mínima\" definida acima"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr ""
+"Trunca a data especificada com a precisão especificada pela unidade de "
+"data."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Confiar neste URL e não perguntar novamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
+"Tente aplicar filtros diferentes ou certifique-se de que a sua fonte de "
+"dados tem dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Try different criteria to display results."
-msgstr ""
+msgstr "Experimente critérios diferentes para apresentar resultados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tuesday"
-msgstr ""
+msgstr "Terça-feira"
 
 #, fuzzy
 msgid "Tukey"
@@ -15550,48 +24384,82 @@ msgstr "Query"
 msgid "Type"
 msgstr "Tipo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Type \"%s\" to confirm"
-msgstr ""
+msgstr "Escreva \"%s\" para confirmar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value"
-msgstr ""
+msgstr "Escreva um valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value here"
-msgstr ""
+msgstr "Escreva um valor aqui"
 
 #, fuzzy
 msgid "Type a value..."
 msgstr "nome da origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type is required"
-msgstr ""
+msgstr "O tipo é obrigatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "Tipo de Google Sheets permitido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Type of chart to display in sparkline"
-msgstr ""
+msgstr "Tipo de gráfico a apresentar no sparkline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type of comparison, value difference or percentage"
-msgstr ""
+msgstr "Tipo de comparação, diferença de valor ou percentagem"
 
 #, fuzzy
 msgid "Type to search (contains)..."
 msgstr "Lista de Colunas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Escreva para pesquisar (termina com)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Escreva para pesquisar (começa com)..."
 
 #, fuzzy
 msgid "UI Configuration"
 msgstr "Contribuição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "UI theme administration is not enabled."
-msgstr ""
+msgstr "A administração de temas da interface não está ativada."
 
 msgid "URL"
 msgstr "URL"
@@ -15611,222 +24479,424 @@ msgstr "Slug"
 msgid "URL parameters"
 msgstr "Parâmetros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to calculate such a date delta"
-msgstr ""
+msgstr "Não é possível calcular este delta de data"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to catalog named \"%(catalog_name)s\"."
-msgstr ""
+msgstr "Não foi possível ligar ao catálogo com o nome \"%(catalog_name)s\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to database \"%(database)s\"."
-msgstr ""
+msgstr "Não foi possível ligar à base de dados \"%(database)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", "
 "\"BigQuery Job User\" and the following permissions are set "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
+"Não foi possível ligar. Verifique se as seguintes funções estão definidas"
+" na conta de serviço: \"BigQuery Data Viewer\", \"BigQuery Metadata "
+"Viewer\", \"BigQuery Job User\" e se as seguintes permissões estão "
+"definidas \"bigquery.readsessions.create\", "
+"\"bigquery.readsessions.getData\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"Não foi possível ligar. Verifique se as seguintes funções estão definidas"
+" na conta de serviço: \"Cloud Datastore Viewer\", \"Cloud Datastore "
+"User\", \"Cloud Datastore Creator\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to create chart without a query id."
-msgstr ""
+msgstr "Não é possível criar um gráfico sem um ID de consulta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"Não foi possível criar o relatório: o endereço de e-mail do utilizador é "
+"obrigatório, mas não foi encontrado. Certifique-se de que o seu perfil de"
+" utilizador tem um endereço de e-mail válido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to decode value"
-msgstr ""
+msgstr "Não foi possível descodificar o valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to encode value"
-msgstr ""
+msgstr "Não foi possível codificar o valor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
+"Não foi possível obter vistas semânticas. Verifique a configuração da "
+"camada."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
-msgstr ""
+msgstr "Não foi possível encontrar este feriado: [%(holiday)s]"
 
 #, fuzzy
 msgid "Unable to generate download payload"
 msgstr "Adicionar ao novo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
 "ensure your dataset has a properly configured time column."
 msgstr ""
+"Não foi possível identificar a coluna temporal para comparação de "
+"intervalos de datas. Certifique-se de que o seu conjunto de dados tem uma"
+" coluna de tempo devidamente configurada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
 msgstr ""
+"Não foi possível carregar as colunas para a tabela selecionada. Por "
+"favor, selecione uma tabela diferente."
 
 #, fuzzy
 msgid "Unable to load dashboard"
 msgstr "Adicionar ao novo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query editor state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Não foi possível migrar o estado do editor de consultas para o backend. O"
+" Superset tentará novamente mais tarde. Contacte o seu administrador se o"
+" problema persistir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
 msgstr ""
+"Não foi possível migrar o estado da consulta para o backend. O Superset "
+"tentará novamente mais tarde. Contacte o seu administrador se o problema "
+"persistir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate table schema state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Não foi possível migrar o estado do esquema da tabela para o backend. O "
+"Superset tentará novamente mais tarde. Contacte o seu administrador se o "
+"problema persistir."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to parse SQL"
-msgstr ""
+msgstr "Não foi possível analisar o SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to read the file, please refresh and try again."
-msgstr ""
+msgstr "Não foi possível ler o ficheiro, atualize a página e tente novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to retrieve dashboard colors"
-msgstr ""
+msgstr "Não foi possível recuperar as cores do painel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to sync permissions for this database connection."
 msgstr ""
+"Não foi possível sincronizar as permissões para esta ligação à base de "
+"dados."
 
 msgid "Undefined"
 msgstr "Indefinido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undefined window for rolling operation"
-msgstr ""
+msgstr "Janela indefinida para operação de deslizamento"
 
 #, fuzzy
 msgid "Undo the action"
 msgstr "Executar a query selecionada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undo?"
-msgstr ""
+msgstr "Desfazer?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr ""
+msgstr "Resposta HTTP 401 inesperada. Verifique as suas credenciais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error"
-msgstr ""
+msgstr "Erro inesperado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error occurred, please check your logs for details"
-msgstr ""
+msgstr "Ocorreu um erro inesperado, verifique os seus registos para mais detalhes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error: "
-msgstr ""
+msgstr "Erro inesperado: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unexpected no file extension found"
-msgstr ""
+msgstr "Extensão de ficheiro não encontrada inesperadamente"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unexpected time range: %(error)s"
-msgstr ""
+msgstr "Intervalo de tempo inesperado: %(error)s"
 
 #, fuzzy
 msgid "Ungroup By"
 msgstr "Agrupar por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Unhide"
-msgstr ""
+msgstr "Mostrar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown"
-msgstr ""
+msgstr "Desconhecido"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown Doris server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host do servidor Doris desconhecido \"%(hostname)s\"."
 
 #, fuzzy
 msgid "Unknown Error"
 msgstr "Erro de rede."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unknown MySQL server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host do servidor MySQL desconhecido \"%(hostname)s\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown OceanBase server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host do servidor OceanBase desconhecido \"%(hostname)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Presto Error"
-msgstr ""
+msgstr "Erro desconhecido do Presto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Status"
-msgstr ""
+msgstr "Estado Desconhecido"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unknown column used in orderby: %(col)s"
-msgstr ""
+msgstr "Coluna desconhecida usada em orderby: %(col)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown error"
-msgstr ""
+msgstr "Erro desconhecido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown input format"
-msgstr ""
+msgstr "Formato de entrada desconhecido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "Tokens desconhecidos serão destacados como avisos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unknown type"
-msgstr ""
+msgstr "Tipo desconhecido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Unknown value"
-msgstr ""
+msgstr "Valor desconhecido"
 
 #, fuzzy
 msgid "Unpin"
 msgstr "Mensagem de Aviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Desafixar do painel de resultados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Desafixar do topo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Ligação insegura bloqueada"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
-msgstr ""
+msgstr "Tipo de retorno inseguro para a função %(func)s: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe template value for key %(key)s: %(value_type)s"
-msgstr ""
+msgstr "Valor de modelo não seguro para a chave %(key)s: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported clause type: %(clause)s"
-msgstr ""
+msgstr "Tipo de cláusula não suportado: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
 msgstr ""
+"Tipo de ficheiro não suportado. Por favor, utilize ficheiros CSV, Excel "
+"ou Colunares."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported post processing operation: %(operation)s"
-msgstr ""
+msgstr "Operação de pós-processamento não suportada: %(operation)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported return value for method %(name)s"
-msgstr ""
+msgstr "Valor de retorno não suportado para o método %(name)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported template value for key %(key)s"
-msgstr ""
+msgstr "Valor de modelo não suportado para a chave %(key)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported time grain: %(time_grain)s"
-msgstr ""
+msgstr "Grão de tempo não suportado: %(time_grain)s"
 
 #, fuzzy
 msgid "Untitled Dataset"
@@ -15843,8 +24913,12 @@ msgstr "Query sem título"
 msgid "Unverified"
 msgstr "Indefinido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Update"
-msgstr ""
+msgstr "Atualizar"
 
 #, fuzzy
 msgid "Update auto-refresh"
@@ -15857,11 +24931,19 @@ msgstr "Explorar gráfico"
 msgid "Updating chart was stopped"
 msgstr "A atualização do gráfico parou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Upload"
-msgstr ""
+msgstr "Carregar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Upload CSV"
-msgstr ""
+msgstr "Carregar CSV"
 
 #, fuzzy
 msgid "Upload CSV to database"
@@ -15875,25 +24957,41 @@ msgstr "Adicionar Coluna"
 msgid "Upload Columnar file to database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Upload Enabled"
-msgstr ""
+msgstr "Carregamento ativado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Upload Excel"
-msgstr ""
+msgstr "Carregar Excel"
 
 #, fuzzy
 msgid "Upload Excel to database"
 msgstr "Selecione uma base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Upload JSON file"
-msgstr ""
+msgstr "Carregar ficheiro JSON"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Upload a file with a valid extension. Valid: [%s]"
-msgstr ""
+msgstr "Carregue um ficheiro com uma extensão válida. Válida: [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Upload credentials"
-msgstr ""
+msgstr "Carregar credenciais"
 
 #, fuzzy
 msgid "Upload file to database"
@@ -15907,91 +25005,182 @@ msgstr "Selecione uma base de dados"
 msgid "Uploading a file is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper Threshold"
-msgstr ""
+msgstr "Limiar Superior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper threshold must be greater than lower threshold"
-msgstr ""
+msgstr "O limiar superior deve ser maior do que o limiar inferior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Usage"
-msgstr ""
+msgstr "Utilização"
 
 #, fuzzy, python-format
 msgid "Use %s to open in a new tab."
 msgstr "Query numa nova aba"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Use Area Proportions"
-msgstr ""
+msgstr "Usar Proporções de Área"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
+"Use a sintaxe Handlebars para criar dicas de ferramenta personalizadas. "
+"As variáveis disponíveis são baseadas na seleção do conteúdo das dicas de"
+" ferramenta acima."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale"
-msgstr ""
+msgstr "Usar uma escala logarítmica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the X-axis"
-msgstr ""
+msgstr "Usar uma escala logarítmica para o eixo X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the Y-axis"
-msgstr ""
+msgstr "Usar uma escala logarítmica para o eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use an encrypted connection to the database"
-msgstr ""
+msgstr "Usar uma ligação encriptada à base de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use an ssh tunnel connection to the database"
-msgstr ""
+msgstr "Usar uma ligação por túnel SSH à base de dados"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Use another existing chart as a source for annotations and overlays.\n"
 "          Your chart must be one of these visualization types: [%s]"
 msgstr ""
+"Use outro gráfico existente como fonte para anotações e sobreposições.\n"
+"          O seu gráfico deve ser um destes tipos de visualização: [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use automatic color"
-msgstr ""
+msgstr "Usar cor automática"
 
 #, fuzzy
 msgid "Use current extent"
 msgstr "Executar query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use date formatting even when metric value is not a timestamp"
 msgstr ""
+"Usar formatação de data mesmo quando o valor da métrica não é uma marca "
+"temporal"
 
 #, fuzzy
 msgid "Use gradient"
 msgstr "Granularidade Temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use metrics as a top level group for columns or for rows"
-msgstr ""
+msgstr "Usar métricas como grupo de nível superior para colunas ou linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use only a single value."
-msgstr ""
+msgstr "Use apenas um único valor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use the Advanced Analytics options below"
-msgstr ""
+msgstr "Utilize as opções de análise avançada abaixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want a query that aggregates"
-msgstr ""
+msgstr "Use esta secção se quiser uma consulta que agregue"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want to query atomic rows"
-msgstr ""
+msgstr "Use esta secção se quiser consultar linhas atómicas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use this to define a static color for all circles"
-msgstr ""
+msgstr "Use isto para definir uma cor estática para todos os círculos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used internally to identify the plugin. Should be set to the package name"
 " from the pluginʼs package.json"
 msgstr ""
+"Usado internamente para identificar o plugin. Deve ser definido com o "
+"nome do pacote do package.json do plugin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used to summarize a set of data by grouping together multiple statistics "
 "along two axes. Examples: Sales numbers by region and month, tasks by "
 "status and assignee, active users by age and location. Not the most "
 "visually stunning visualization, but highly informative and versatile."
 msgstr ""
+"Usado para resumir um conjunto de dados, agrupando várias estatísticas ao"
+" longo de dois eixos. Exemplos: Números de vendas por região e mês, "
+"tarefas por estado e responsável, utilizadores ativos por idade e "
+"localização. Não é a visualização mais impressionante visualmente, mas é "
+"altamente informativa e versátil."
 
 msgid "User"
 msgstr "Utilizador"
@@ -16012,14 +25201,26 @@ msgstr "Não tem direitos para alterar este título."
 msgid "User info"
 msgstr "Utilizador"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the chart customization"
 msgstr ""
+"O utilizador deve selecionar um valor antes de aplicar a personalização "
+"do gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the customization"
-msgstr ""
+msgstr "O utilizador deve selecionar um valor antes de aplicar a personalização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "User must select a value before applying the filter"
-msgstr ""
+msgstr "O utilizador deve selecionar um valor antes de aplicar o filtro"
 
 msgid "User query"
 msgstr "partilhar query"
@@ -16044,29 +25245,58 @@ msgstr "Nome do país"
 msgid "Users"
 msgstr "Séries"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Users are not allowed to set a search path for security reasons."
 msgstr ""
+"Os utilizadores não têm permissão para definir um caminho de pesquisa por"
+" razões de segurança."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Uses Gaussian Kernel Density Estimation to visualize spatial distribution"
 " of data"
 msgstr ""
+"Utiliza a Estimativa de Densidade de Kernel Gaussiana para visualizar a "
+"distribuição espacial dos dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses a gauge to showcase progress of a metric towards a target. The "
 "position of the dial represents the progress and the terminal value in "
 "the gauge represents the target value."
 msgstr ""
+"Usa um medidor para mostrar o progresso de uma métrica em direção a um "
+"objetivo. A posição do mostrador representa o progresso e o valor "
+"terminal no medidor representa o valor-alvo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses circles to visualize the flow of data through different stages of a "
 "system. Hover over individual paths in the visualization to understand "
 "the stages a value took. Useful for multi-stage, multi-group visualizing "
 "funnels and pipelines."
 msgstr ""
+"Usa círculos para visualizar o fluxo de dados através de diferentes "
+"etapas de um sistema. Passe o rato sobre caminhos individuais na "
+"visualização para compreender as etapas que um valor percorreu. Útil para"
+" a visualização de funis e pipelines de várias etapas e vários grupos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Utiliza os primeiros 25 valores se a dimensão tiver mais."
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -16080,12 +25310,17 @@ msgstr "partilhar query"
 msgid "Validate your expression"
 msgstr "Expressão"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Validating connectivity for %s"
-msgstr ""
+msgstr "A validar a conectividade para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Validating..."
-msgstr ""
+msgstr "A validar..."
 
 msgid "Value"
 msgstr "Mostrar valores das barras"
@@ -16098,8 +25333,12 @@ msgstr "Soma Agregada"
 msgid "Value Columns"
 msgstr "Coluna de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value Domain"
-msgstr ""
+msgstr "Domínio de Valor"
 
 #, fuzzy
 msgid "Value Format"
@@ -16109,15 +25348,25 @@ msgstr "Formato de valor"
 msgid "Value and Percentage"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value bounds"
-msgstr ""
+msgstr "Limites de valor"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Value cannot exceed %s"
-msgstr ""
+msgstr "O valor não pode exceder %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value difference between the time periods"
-msgstr ""
+msgstr "Diferença de valor entre os períodos de tempo"
 
 #, fuzzy
 msgid "Value format"
@@ -16131,8 +25380,11 @@ msgstr "Data de inicio não pode ser posterior à data de fim"
 msgid "Value is required"
 msgstr "Origem de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value less than"
-msgstr ""
+msgstr "Valor inferior a"
 
 #, fuzzy
 msgid "Value must be 0 or greater"
@@ -16146,38 +25398,76 @@ msgstr "Data de inicio não pode ser posterior à data de fim"
 msgid "Values"
 msgstr "Mostrar valores das barras"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Values are dependent on other filters"
-msgstr ""
+msgstr "Os valores dependem de outros filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Values dependent on"
-msgstr ""
+msgstr "Valores dependentes de"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Values less than this percentage will be grouped into the Other category."
 msgstr ""
+"Os valores inferiores a esta percentagem serão agrupados na categoria "
+"Outros."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Values selected in other filters will affect the filter options to only "
 "show relevant values"
 msgstr ""
+"Os valores selecionados noutros filtros afetarão as opções de filtro para"
+" mostrar apenas os valores relevantes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version"
-msgstr ""
+msgstr "Versão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version number"
-msgstr ""
+msgstr "Número da versão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Vertical"
-msgstr ""
+msgstr "Vertical"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Vertical (Left)"
-msgstr ""
+msgstr "Vertical (Esquerda)"
 
 #, fuzzy
 msgid "View"
 msgstr "Pré-visualização para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "View All »"
-msgstr ""
+msgstr "Ver Tudo »"
 
 #, fuzzy
 msgid "View Dataset"
@@ -16205,8 +25495,12 @@ msgstr "partilhar query"
 msgid "View theme properties"
 msgstr "Editar propriedades da visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Viewed"
-msgstr ""
+msgstr "Visto"
 
 #, fuzzy, python-format
 msgid "Viewed %s"
@@ -16216,23 +25510,48 @@ msgstr "Pré-visualização para %s"
 msgid "Viewport"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Virtual"
-msgstr ""
+msgstr "Virtual"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual (SQL)"
-msgstr ""
+msgstr "Virtual (SQL)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot be empty"
-msgstr ""
+msgstr "A consulta do conjunto de dados virtual não pode estar vazia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot consist of multiple statements"
 msgstr ""
+"A consulta do conjunto de dados virtual não pode ser composta por várias "
+"instruções"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query must be read-only"
-msgstr ""
+msgstr "A consulta do conjunto de dados virtual deve ser apenas de leitura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Visual Tweaks"
-msgstr ""
+msgstr "Ajustes Visuais"
 
 #, fuzzy
 msgid "Visual formatting"
@@ -16241,71 +25560,151 @@ msgstr "Metadados adicionais"
 msgid "Visualization Type"
 msgstr "Tipo de Visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a parallel set of metrics across multiple groups. Each group is"
 " visualized using its own line of points and each metric is represented "
 "as an edge in the chart."
 msgstr ""
+"Visualize um conjunto paralelo de métricas em vários grupos. Cada grupo é"
+" visualizado usando a sua própria linha de pontos e cada métrica é "
+"representada como uma aresta no gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a related metric across pairs of groups. Heatmaps excel at "
 "showcasing the correlation or strength between two groups. Color is used "
 "to emphasize the strength of the link between each pair of groups."
 msgstr ""
+"Visualize uma métrica relacionada em pares de grupos. Os mapas de calor "
+"são excelentes para mostrar a correlação ou a força entre dois grupos. A "
+"cor é usada para enfatizar a força da ligação entre cada par de grupos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize geospatial data like 3D buildings, landscapes, or objects in "
 "grid view."
 msgstr ""
+"Visualize dados geoespaciais como edifícios 3D, paisagens ou objetos em "
+"vista de grelha."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
 "structure."
 msgstr ""
+"Visualize múltiplos níveis de hierarquia usando uma estrutura familiar "
+"semelhante a uma árvore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize two different series using the same x-axis. Note that both "
 "series can be visualized with a different chart type (e.g. 1 using bars "
 "and 1 using a line)."
 msgstr ""
+"Visualize duas séries diferentes usando o mesmo eixo x. Note que ambas as"
+" séries podem ser visualizadas com um tipo de gráfico diferente (por "
+"exemplo, uma usando barras e outra usando uma linha)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes a metric across three dimensions of data in a single chart (X "
 "axis, Y axis, and bubble size). Bubbles from the same group can be "
 "showcased using bubble color."
 msgstr ""
+"Visualiza uma métrica em três dimensões de dados num único gráfico (eixo "
+"X, eixo Y e tamanho da bolha). As bolhas do mesmo grupo podem ser "
+"apresentadas usando a cor da bolha."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Visualizes connected points, which form a path, on a map."
-msgstr ""
+msgstr "Visualiza pontos conectados, que formam um caminho, num mapa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes geographic areas from your data as polygons on a Mapbox "
 "rendered map. Polygons can be colored using a metric."
 msgstr ""
+"Visualiza áreas geográficas dos seus dados como polígonos num mapa "
+"renderizado pelo Mapbox. Os polígonos podem ser coloridos usando uma "
+"métrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes how a metric has changed over a time using a color scale and a"
 " calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
+"Visualiza como uma métrica mudou ao longo do tempo usando uma escala de "
+"cores e uma vista de calendário. Os valores a cinzento são usados para "
+"indicar valores em falta e o esquema de cores linear é usado para "
+"codificar a magnitude do valor de cada dia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes how a single metric varies across a country's principal "
 "subdivisions (states, provinces, etc) on a choropleth map. Each "
 "subdivision's value is elevated when you hover over the corresponding "
 "geographic boundary."
 msgstr ""
+"Visualiza como uma única métrica varia entre as principais subdivisões de"
+" um país (estados, províncias, etc.) num mapa coroplético. O valor de "
+"cada subdivisão é realçado quando passa o rato sobre o limite geográfico "
+"correspondente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes many different time-series objects in a single chart. This "
 "chart is being deprecated and we recommend using the Time-series Chart "
 "instead."
 msgstr ""
+"Visualiza muitos objetos de séries temporais diferentes num único "
+"gráfico. Este gráfico está a ser descontinuado e recomendamos o uso do "
+"gráfico de série temporal em sua substituição."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes the words in a column that appear the most often. Bigger font "
 "corresponds to higher frequency."
 msgstr ""
+"Visualiza as palavras numa coluna que aparecem com mais frequência. A "
+"fonte maior corresponde a uma frequência mais elevada."
 
 msgid "Viz is missing a datasource"
 msgstr "Viz está sem origem de dados"
@@ -16314,8 +25713,12 @@ msgstr "Viz está sem origem de dados"
 msgid "Viz type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "WED"
-msgstr ""
+msgstr "QUA"
 
 msgid "WFS"
 msgstr ""
@@ -16323,22 +25726,34 @@ msgstr ""
 msgid "WMS"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "A aguardar a primeira atualização"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Waiting on %s"
-msgstr ""
+msgstr "A aguardar %s"
 
 #, fuzzy
 msgid "Waiting on database..."
 msgstr "Editar Base de Dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Want to add a new database?"
-msgstr ""
+msgstr "Deseja adicionar uma nova base de dados?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "Armazém"
 
 #, fuzzy
 msgid "Warning"
@@ -16347,15 +25762,26 @@ msgstr "Mensagem de Aviso"
 msgid "Warning!"
 msgstr "Mensagem de Aviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Warning! Changing the dataset may break the chart if the metadata does "
 "not exist."
 msgstr ""
+"Atenção! Alterar o conjunto de dados pode quebrar o gráfico se os "
+"metadados não existirem."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Aviso: As consultas ILIKE podem ser lentas em conjuntos de dados grandes,"
+" pois não conseguem utilizar índices de forma eficaz."
 
 #, fuzzy
 msgid "Was unable to check your query"
@@ -16373,70 +25799,128 @@ msgstr "Rótulo para a sua query"
 msgid "We are working on your query"
 msgstr "Rótulo para a sua query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve column \"%(column)s\" at line %(location)s."
-msgstr ""
+msgstr "Não é possível resolver a coluna \"%(column)s\" na linha %(location)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve the column \"%(column_name)s\""
-msgstr ""
+msgstr "Não é possível resolver a coluna \"%(column_name)s\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We can't seem to resolve the column \"%(column_name)s\" at line "
 "%(location)s."
 msgstr ""
+"Não é possível resolver a coluna \"%(column_name)s\" na linha "
+"%(location)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "We have the following keys: %s"
-msgstr ""
+msgstr "Temos as seguintes chaves: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We were unable to activate or deactivate this report."
-msgstr ""
+msgstr "Não foi possível ativar ou desativar este relatório."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "We were unable to carry over any controls when switching to this new "
 "dataset."
 msgstr ""
+"Não foi possível transferir nenhum controlo ao mudar para este novo "
+"conjunto de dados."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We were unable to connect to your database named \"%(database)s\". Please"
 " verify your database name and try again."
 msgstr ""
+"Não foi possível ligar à sua base de dados chamada \"%(database)s\". "
+"Verifique o nome da base de dados e tente novamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Web"
-msgstr ""
+msgstr "Web"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Wednesday"
-msgstr ""
+msgstr "Quarta-feira"
 
 #, fuzzy
 msgid "Week"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week ending Saturday"
-msgstr ""
+msgstr "Semana a terminar no Sábado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Week ending Sunday"
-msgstr ""
+msgstr "Semana a terminar no Domingo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Monday"
-msgstr ""
+msgstr "Semana a começar na Segunda-feira"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Sunday"
-msgstr ""
+msgstr "Semana a começar no Domingo"
 
 #, fuzzy
 msgid "Weekly Report"
 msgstr "Janela de exibição"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Weekly Report for %s"
-msgstr ""
+msgstr "Relatório Semanal para %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Weekly seasonality"
-msgstr ""
+msgstr "Sazonalidade semanal"
 
 #, fuzzy, python-format
 msgid "Weeks %s"
@@ -16446,6 +25930,8 @@ msgstr "semana"
 msgid "Weight"
 msgstr "Altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading these results. Queries are set to timeout "
@@ -16454,8 +25940,14 @@ msgid_plural ""
 "We’re having trouble loading these results. Queries are set to timeout "
 "after %s seconds."
 msgstr[0] ""
+"Estamos com dificuldades em carregar estes resultados. As consultas estão"
+" configuradas para expirar após %s segundo."
 msgstr[1] ""
+"Estamos com dificuldades em carregar estes resultados. As consultas estão"
+" configuradas para expirar após %s segundos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading this visualization. Queries are set to "
@@ -16464,60 +25956,130 @@ msgid_plural ""
 "We’re having trouble loading this visualization. Queries are set to "
 "timeout after %s seconds."
 msgstr[0] ""
+"Estamos com dificuldades em carregar esta visualização. As consultas "
+"estão configuradas para expirar após %s segundo."
 msgstr[1] ""
+"Estamos com dificuldades em carregar esta visualização. As consultas "
+"estão configuradas para expirar após %s segundos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the label"
-msgstr ""
+msgstr "O que deve ser mostrado como etiqueta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the tooltip label"
-msgstr ""
+msgstr "O que deve ser mostrado como etiqueta de dica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "What should be shown on the label?"
-msgstr ""
+msgstr "O que deve constar na etiqueta?"
 
 #, fuzzy
 msgid "What should happen if the table already exists"
 msgstr "Origem de dados %(name)s já existe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "When `Calculation type` is set to \"Percentage change\", the Y Axis "
 "Format is forced to `.1%`"
 msgstr ""
+"Quando o `Tipo de cálculo` está definido como \"Alteração percentual\", o"
+" Formato do Eixo Y é forçado para `.1%`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When a secondary metric is provided, a linear color scale is used."
 msgstr ""
+"Quando é fornecida uma métrica secundária, é utilizada uma escala de "
+"cores linear."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When checked, the map will zoom to your data after each query"
-msgstr ""
+msgstr "Quando selecionado, o mapa fará zoom para os seus dados após cada consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When enabled, the axis will display labels for the minimum and maximum "
 "values of your data"
 msgstr ""
+"Quando ativado, o eixo apresentará etiquetas para os valores mínimo e "
+"máximo dos seus dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When enabled, users are able to visualize SQL Lab results in Explore."
 msgstr ""
+"Quando ativado, os utilizadores podem visualizar os resultados do SQL Lab"
+" no Explore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When only a primary metric is provided, a categorical color scale is used."
 msgstr ""
+"Quando apenas é fornecida uma métrica primária, é utilizada uma escala de"
+" cores categórica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When specifying SQL, the datasource acts as a view. Superset will use "
 "this statement as a subquery while grouping and filtering on the "
 "generated parent queries.If changes are made to your SQL query, columns "
 "in your dataset will be synced when saving the dataset."
 msgstr ""
+"Ao especificar SQL, a fonte de dados funciona como uma vista. O Superset "
+"utilizará esta instrução como uma subconsulta durante o agrupamento e "
+"filtragem das consultas-pai geradas. Se forem efetuadas alterações à sua "
+"consulta SQL, as colunas no seu conjunto de dados serão sincronizadas ao "
+"guardar o conjunto de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When the secondary temporal columns are filtered, apply the same filter "
 "to the main datetime column."
 msgstr ""
+"Quando as colunas temporais secundárias forem filtradas, aplique o mesmo "
+"filtro à coluna principal de data e hora."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When unchecked, colors from the selected color scheme will be used for "
 "time shifted series"
 msgstr ""
+"Quando desmarcado, as cores do esquema de cores selecionado serão "
+"utilizadas para séries com deslocamento temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When using \"Autocomplete filters\", this can be used to improve "
 "performance of the query fetching the values. Use this option to apply a "
@@ -16525,54 +26087,127 @@ msgid ""
 "the table. Typically the intent would be to limit the scan by applying a "
 "relative time filter on a partitioned or indexed time-related field."
 msgstr ""
+"Ao utilizar \"Filtros de preenchimento automático\", isto pode ser usado "
+"para melhorar o desempenho da consulta que obtém os valores. Utilize esta"
+" opção para aplicar um predicado (cláusula WHERE) à consulta que "
+"seleciona os valores distintos da tabela. Normalmente, a intenção seria "
+"limitar a pesquisa aplicando um filtro de tempo relativo a um campo "
+"relacionado com o tempo que seja particionado ou indexado."
 
 msgid "When using 'Group By' you are limited to use a single metric"
 msgstr "Utilizando 'Agrupar por' só é possível utilizar uma única métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "When using other than adaptive formatting, labels may overlap"
 msgstr ""
+"Ao utilizar uma formatação diferente da adaptativa, as etiquetas podem "
+"sobrepor-se"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
 msgstr ""
+"Ao utilizar esta opção, o valor predefinido não pode ser definido. A "
+"utilização desta opção pode afetar os tempos de carregamento do seu "
+"dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
-msgstr ""
+msgstr "Se a barra de progresso se sobrepõe quando existem vários grupos de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Whether to align background charts with both positive and negative values"
 " at 0"
 msgstr ""
+"Se os gráficos de fundo devem ser alinhados com valores positivos e "
+"negativos em 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to align positive and negative values in cell bar chart at 0"
 msgstr ""
+"Se os valores positivos e negativos no gráfico de barras de células devem"
+" ser alinhados em 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to always show the annotation label"
-msgstr ""
+msgstr "Se a etiqueta de anotação deve ser sempre apresentada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to animate the progress and the value or just display them"
-msgstr ""
+msgstr "Se deve animar o progresso e o valor ou apenas apresentá-los"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to apply a normal distribution based on rank on the color scale"
 msgstr ""
+"Se deve ser aplicada uma distribuição normal com base na classificação na"
+" escala de cores"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to colorize numeric values by if they are positive or negative"
 msgstr ""
+"Se os valores numéricos devem ser coloridos consoante são positivos ou "
+"negativos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to colorize numeric values by whether they are positive or "
 "negative"
 msgstr ""
+"Se os valores numéricos devem ser coloridos consoante são positivos ou "
+"negativos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a bar chart background in table columns"
 msgstr ""
+"Se deve ser apresentado um fundo de gráfico de barras nas colunas da "
+"tabela"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a legend for the chart"
-msgstr ""
+msgstr "Se deve ser apresentada uma legenda para o gráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display bubbles on top of countries"
-msgstr ""
+msgstr "Se deve apresentar bolhas sobre os países"
 
 #, fuzzy
 msgid "Whether to display in the chart"
@@ -16586,51 +26221,90 @@ msgstr "Selecione uma métrica para visualizar"
 msgid "Whether to display the Y Axis"
 msgstr "Selecione uma métrica para visualizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to display the aggregate count"
-msgstr ""
+msgstr "Se deve ser apresentada a contagem agregada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the interactive data table"
-msgstr ""
+msgstr "Se deve ser apresentada a tabela de dados interativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the labels."
-msgstr ""
+msgstr "Se as etiquetas devem ser apresentadas."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the legend (toggles)"
-msgstr ""
+msgstr "Se a legenda deve ser apresentada (alternâncias)"
 
 #, fuzzy
 msgid "Whether to display the metric name"
 msgstr "Selecione uma métrica para visualizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the metric name as a title"
-msgstr ""
+msgstr "Se o nome da métrica deve ser exibido como título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the X-axis"
-msgstr ""
+msgstr "Se os valores mínimo e máximo do eixo X devem ser exibidos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the Y-axis"
-msgstr ""
+msgstr "Se os valores mínimo e máximo do eixo Y devem ser exibidos"
 
 #, fuzzy
 msgid "Whether to display the numbered column"
 msgstr "Selecione uma métrica para visualizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the numerical values within the cells"
-msgstr ""
+msgstr "Se os valores numéricos devem ser exibidos dentro das células"
 
 #, fuzzy
 msgid "Whether to display the percentage value in the tooltip"
 msgstr "Incluir um filtro temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the stroke"
-msgstr ""
+msgstr "Se o traço deve ser exibido"
 
 #, fuzzy
 msgid "Whether to display the time range interactive selector"
 msgstr "Mostrar opção de seleção do intervalo temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the timestamp"
-msgstr ""
+msgstr "Se o carimbo de data/hora deve ser exibido"
 
 #, fuzzy
 msgid "Whether to display the tooltip labels."
@@ -16640,24 +26314,44 @@ msgstr "Selecione uma métrica para visualizar"
 msgid "Whether to display the total value in the tooltip"
 msgstr "Incluir um filtro temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the trend line"
-msgstr ""
+msgstr "Se a linha de tendência deve ser exibida"
 
 #, fuzzy
 msgid "Whether to display the type icon (#, Δ, %)"
 msgstr "Selecione uma métrica para visualizar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable changing graph position and scaling."
-msgstr ""
+msgstr "Se deve ser permitida a alteração da posição e da escala do gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable node dragging in force layout mode."
-msgstr ""
+msgstr "Se deve ser permitido arrastar nós no modo de disposição por força."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to fill the objects"
-msgstr ""
+msgstr "Se os objectos devem ser preenchidos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to ignore locations that are null"
-msgstr ""
+msgstr "Se as localizações nulas devem ser ignoradas"
 
 #, fuzzy
 msgid "Whether to include a client-side search box"
@@ -16667,11 +26361,21 @@ msgstr "Incluir um filtro temporal"
 msgid "Whether to include the percentage in the tooltip"
 msgstr "Incluir um filtro temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include the time granularity as defined in the time section"
 msgstr ""
+"Se deve ser incluída a granularidade temporal conforme definida na secção"
+" de tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to make the grid 3D"
-msgstr ""
+msgstr "Se a grelha deve ser em 3D"
 
 msgid "Whether to populate autocomplete filters options"
 msgstr "Incluir um filtro temporal"
@@ -16680,22 +26384,44 @@ msgstr "Incluir um filtro temporal"
 msgid "Whether to show as Nightingale chart."
 msgstr "Série Temporal - Gráfico de linhas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to show extra controls or not. Extra controls include things like"
 " making multiBar charts stacked or side by side."
 msgstr ""
+"Se devem ser mostrados controlos extra ou não. Os controlos extra incluem"
+" opções como apresentar gráficos de barras múltiplas empilhados ou lado a"
+" lado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show minor ticks on the axis"
-msgstr ""
+msgstr "Se as marcas secundárias devem ser mostradas no eixo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the pointer"
-msgstr ""
+msgstr "Se o ponteiro deve ser exibido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the progress of gauge chart"
-msgstr ""
+msgstr "Se o progresso do gráfico de medidor deve ser mostrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the split lines on the axis"
-msgstr ""
+msgstr "Se as linhas de divisão devem ser mostradas no eixo"
 
 #, fuzzy
 msgid "Whether to sort ascending or descending on the base Axis."
@@ -16704,23 +26430,51 @@ msgstr "Ordenar de forma descendente ou ascendente"
 msgid "Whether to sort descending or ascending"
 msgstr "Ordenar de forma descendente ou ascendente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort results by the selected metric in descending order."
 msgstr ""
+"Se os resultados devem ser ordenados pela métrica seleccionada por ordem "
+"decrescente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort tooltip by the selected metric in descending order."
 msgstr ""
+"Se a dica de ferramenta deve ser ordenada pela métrica seleccionada por "
+"ordem decrescente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to truncate metrics"
-msgstr ""
+msgstr "Se as métricas devem ser truncadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which country to plot the map for?"
-msgstr ""
+msgstr "Para que país traçar o mapa?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which relatives to highlight on hover"
-msgstr ""
+msgstr "Quais os elementos relacionados a destacar ao passar o rato por cima"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whisker/outlier options"
-msgstr ""
+msgstr "Opções de bigodes/valores extremos"
 
 #, fuzzy
 msgid "Why do I need to create a database?"
@@ -16729,33 +26483,64 @@ msgstr "Selecione uma base de dados"
 msgid "Width"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Width of the confidence interval. Should be between 0 and 1"
-msgstr ""
+msgstr "Largura do intervalo de confiança. Deve estar entre 0 e 1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Width of the sparkline"
-msgstr ""
+msgstr "Largura do minigráfico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Width scale multiplier"
-msgstr ""
+msgstr "Multiplicador de escala de largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Window must be > 0"
-msgstr ""
+msgstr "A janela deve ser > 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "With a subheader"
-msgstr ""
+msgstr "Com um subtítulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Word Cloud"
-msgstr ""
+msgstr "Nuvem de Palavras"
 
 #, fuzzy
 msgid "Word Rotation"
 msgstr "Anotações"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working"
-msgstr ""
+msgstr "A trabalhar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working timeout"
-msgstr ""
+msgstr "Tempo limite de processamento"
 
 msgid "World Map"
 msgstr "Mapa Mundo"
@@ -16763,21 +26548,32 @@ msgstr "Mapa Mundo"
 msgid "Write a description for your query"
 msgstr "Escreva uma descrição para sua consulta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Write a handlebars template to render the data"
-msgstr ""
+msgstr "Escreva um modelo Handlebars para apresentar os dados"
 
 msgid "X Axis"
 msgstr "Eixo XX"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X Axis Bounds"
-msgstr ""
+msgstr "Limites do Eixo X"
 
 #, fuzzy
 msgid "X Axis Format"
 msgstr "Formato do Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Axis Label"
-msgstr ""
+msgstr "Etiqueta do Eixo X"
 
 #, fuzzy
 msgid "X Axis Label Interval"
@@ -16787,77 +26583,144 @@ msgstr "última partição:"
 msgid "X Axis Number Format"
 msgstr "Formato do Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X Axis Title"
-msgstr ""
+msgstr "Título do Eixo X"
 
 #, fuzzy
 msgid "X Axis Title Margin"
 msgstr "última partição:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Log Scale"
-msgstr ""
+msgstr "Escala Logarítmica X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Tick Layout"
-msgstr ""
+msgstr "Disposição de Marcas X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "X axis title margin"
-msgstr ""
+msgstr "Margem do título do eixo X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X bounds"
-msgstr ""
+msgstr "Limites X"
 
 #, fuzzy
 msgid "X-Axis Sort Ascending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X-Axis Sort By"
-msgstr ""
+msgstr "Ordenação do Eixo X Por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X-axis"
-msgstr ""
+msgstr "Eixo X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X-scale interval"
-msgstr ""
+msgstr "Intervalo de escala X"
 
 msgid "XYZ"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y 2 bounds"
-msgstr ""
+msgstr "Limites Y 2"
 
 msgid "Y Axis"
 msgstr "Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis 2 Bounds"
-msgstr ""
+msgstr "Limites do Eixo Y 2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Bounds"
-msgstr ""
+msgstr "Limites do Eixo Y"
 
 msgid "Y Axis Format"
 msgstr "Formato do Eixo YY"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Label"
-msgstr ""
+msgstr "Etiqueta do Eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title"
-msgstr ""
+msgstr "Título do Eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title Margin"
-msgstr ""
+msgstr "Margem do Título do Eixo Y"
 
 #, fuzzy
 msgid "Y Axis Title Position"
 msgstr "última partição:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Log Scale"
-msgstr ""
+msgstr "Escala Logarítmica Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Y axis title margin"
-msgstr ""
+msgstr "Margem do título do eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y bounds"
-msgstr ""
+msgstr "Limites Y"
 
 #, fuzzy
 msgid "Y-Axis"
@@ -16867,139 +26730,280 @@ msgstr "Eixo YY"
 msgid "Y-Axis Sort Ascending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y-Axis Sort By"
-msgstr ""
+msgstr "Ordenar Eixo Y Por"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-axis"
-msgstr ""
+msgstr "Eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Y-axis bounds"
-msgstr ""
+msgstr "Limites do eixo Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Y-scale interval"
-msgstr ""
+msgstr "Intervalo da escala Y"
 
 #, fuzzy
 msgid "Year"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Year (freq=AS)"
-msgstr ""
+msgstr "Ano (freq=AS)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yearly seasonality"
-msgstr ""
+msgstr "Sazonalidade anual"
 
 #, fuzzy, python-format
 msgid "Years %s"
 msgstr "ano"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #, fuzzy
 msgid "Yes, Cancel"
 msgstr "Cancelar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes, cancel"
-msgstr ""
+msgstr "Sim, cancelar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Yes, overwrite changes"
-msgstr ""
+msgstr "Sim, substituir alterações"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "You are adding tags to %s %ss"
-msgstr ""
+msgstr "Está a adicionar etiquetas a %s %ss"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "Está a editar uma consulta do conjunto de dados virtual "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Está a importar um ou mais gráficos que já existem. A substituição poderá"
+" fazer com que perca parte do seu trabalho. Tem a certeza de que pretende"
+" substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more dashboards that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Está a importar um ou mais painéis que já existem. A substituição poderá "
+"fazer com que perca parte do seu trabalho. Tem a certeza de que pretende "
+"substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more databases that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Está a importar uma ou mais bases de dados que já existem. A substituição"
+" poderá fazer com que perca parte do seu trabalho. Tem a certeza de que "
+"pretende substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more datasets that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Está a importar um ou mais conjuntos de dados que já existem. A "
+"substituição poderá fazer com que perca parte do seu trabalho. Tem a "
+"certeza de que pretende substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more saved queries that already exist. "
 "Overwriting might cause you to lose some of your work. Are you sure you "
 "want to overwrite?"
 msgstr ""
+"Está a importar uma ou mais consultas guardadas que já existem. A "
+"substituição poderá fazer com que perca parte do seu trabalho. Tem a "
+"certeza de que pretende substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are importing one or more themes that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Está a importar um ou mais temas que já existem. A substituição poderá "
+"fazer com que perca parte do seu trabalho. Tem a certeza de que pretende "
+"substituir?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in a dashboard context with labels shared "
 "across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
+"Está a ver este gráfico num contexto de painel com etiquetas partilhadas "
+"entre vários gráficos.\n"
+"        A seleção do esquema de cores está desativada."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in the context of a dashboard that is directly"
 " affecting its colors.\n"
 "        To edit the color scheme, open this chart outside of the "
 "dashboard."
 msgstr ""
+"Está a ver este gráfico no contexto de um painel que está a afetar "
+"diretamente as suas cores.\n"
+"        Para editar o esquema de cores, abra este gráfico fora do painel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can"
-msgstr ""
+msgstr "Pode"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can add the components in the"
-msgstr ""
+msgstr "Pode adicionar os componentes no"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can add the components in the edit mode."
-msgstr ""
+msgstr "Pode adicionar os componentes no modo de edição."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can also just click on the chart to apply cross-filter."
-msgstr ""
+msgstr "Também pode simplesmente clicar no gráfico para aplicar o filtro cruzado."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can choose to display all charts that you have access to or only the "
 "ones you own.\n"
 "              Your filter selection will be saved and remain active until"
 " you choose to change it."
 msgstr ""
+"Pode optar por apresentar todos os gráficos a que tem acesso ou apenas os"
+" que possui.\n"
+"              A sua seleção de filtro será guardada e permanecerá ativa "
+"até que opte por alterá-la."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can create a new chart or use existing ones from the panel on the "
 "right"
-msgstr ""
+msgstr "Pode criar um novo gráfico ou utilizar os existentes no painel à direita"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can preview the list of dashboards in the chart settings dropdown."
 msgstr ""
+"Pode pré-visualizar a lista de painéis no menu pendente de definições do "
+"gráfico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can't apply cross-filter on this data point."
-msgstr ""
+msgstr "Não é possível aplicar o filtro cruzado neste ponto de dados."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You cannot delete the last temporal filter as it's used for time range "
 "filters in dashboards."
 msgstr ""
+"Não é possível eliminar o último filtro temporal, pois é utilizado para "
+"filtros de intervalo de tempo nos painéis."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You cannot use 45° tick layout along with the time range filter"
 msgstr ""
+"Não é possível utilizar o esquema de marcações de 45° em conjunto com o "
+"filtro de intervalo de tempo"
 
 #, fuzzy, python-format
 msgid "You do not have permission to edit this %s"
@@ -17089,12 +27093,18 @@ msgstr "Não tem direitos para alterar este título."
 msgid "You don't have the rights to export data"
 msgstr "Não tem direitos para alterar este título."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "You have been removed from task: %s"
-msgstr ""
+msgstr "Foi removido da tarefa: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You have removed this filter."
-msgstr ""
+msgstr "Removeu este filtro."
 
 #, fuzzy
 msgid "You have unsaved changes"
@@ -17103,67 +27113,131 @@ msgstr "Existem alterações por gravar."
 msgid "You have unsaved changes."
 msgstr "Existem alterações por gravar."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid ""
 "You have used all %(historyLength)s undo slots and will not be able to "
 "fully undo subsequent actions. You may save your current state to reset "
 "the history."
 msgstr ""
+"Utilizou todos os %(historyLength)s espaços de anulação e não será "
+"possível desfazer completamente as ações subsequentes. Pode guardar o "
+"estado atual para repor o histórico."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You must be a %s owner in order to edit. Please reach out to a %s owner "
 "to request modifications or edit access."
 msgstr ""
+"Tem de ser proprietário de %s para poder editar. Por favor, contacte um "
+"proprietário de %s para solicitar modificações ou acesso de edição."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
 "dataset owner to request modifications or edit access."
 msgstr ""
+"Tem de ser proprietário do conjunto de dados para poder editar. Por "
+"favor, contacte um proprietário do conjunto de dados para solicitar "
+"modificações ou acesso de edição."
 
 msgid "You must pick a name for the new dashboard"
 msgstr "Escolha um nome para o novo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You must run the query successfully first"
-msgstr ""
+msgstr "Tem de executar a consulta com sucesso primeiro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Precisa de"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You updated the values in the control panel, but the chart was not "
 "updated automatically. Run the query by clicking on the \"Update chart\" "
 "button or"
 msgstr ""
+"Atualizou os valores no painel de controlo, mas o gráfico não foi "
+"atualizado automaticamente. Execute a consulta clicando no botão "
+"\"Atualizar gráfico\" ou"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Será removido desta tarefa. Continuará a ser executada para %s outro(s) "
+"subscritor(es)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
 msgstr ""
+"Alterou os conjuntos de dados. Todos os controlos com dados (colunas, "
+"métricas) correspondentes a este novo conjunto de dados foram mantidos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "A sua conta está ativada. Pode iniciar sessão com as suas credenciais."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "As suas alterações serão perdidas se sair sem guardar."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Your chart is not up to date"
-msgstr ""
+msgstr "O seu gráfico não está atualizado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your chart is ready to go!"
-msgstr ""
+msgstr "O seu gráfico está pronto!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your dashboard is near the size limit."
-msgstr ""
+msgstr "O seu painel está próximo do limite de tamanho."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your dashboard is too large. Please reduce its size before saving it."
 msgstr ""
+"O seu painel é demasiado grande. Por favor, reduza o seu tamanho antes de"
+" o guardar."
 
 msgid "Your query could not be saved"
 msgstr "Não foi possível gravar a sua query"
@@ -17174,10 +27248,16 @@ msgstr "Não foi possível gravar a sua query"
 msgid "Your query could not be updated"
 msgstr "Não foi possível gravar a sua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Your query has been scheduled. To see details of your query, navigate to "
 "Saved queries"
 msgstr ""
+"A sua consulta foi agendada. Para ver os detalhes da sua consulta, "
+"navegue até Consultas guardadas"
 
 #, fuzzy
 msgid "Your query was not properly saved"
@@ -17197,24 +27277,41 @@ msgstr "Não foi possível carregar a query"
 msgid "Your user information"
 msgstr "Metadados adicionais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Z-A"
-msgstr ""
+msgstr "Z-A"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ZIP file contains multiple file types"
-msgstr ""
+msgstr "O ficheiro ZIP contém vários tipos de ficheiro"
 
 #, fuzzy
 msgid "Zero imputation"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Zoom level"
-msgstr ""
+msgstr "Nível de zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom level of the map"
-msgstr ""
+msgstr "Nível de zoom do mapa"
 
 #, fuzzy
 msgid "[ untitled dashboard ]"
@@ -17234,62 +27331,125 @@ msgstr "Viz está sem origem de dados"
 msgid "[Untitled]"
 msgstr "%s - sem título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[asc]"
-msgstr ""
+msgstr "[asc]"
 
 msgid "[dashboard name]"
 msgstr "[Nome do dashboard]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "[desc]"
-msgstr ""
+msgstr "[desc]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "[optional] this secondary metric is used to define the color as a ratio "
 "against the primary metric. When omitted, the color is categorical and "
 "based on labels"
 msgstr ""
+"[opcional] esta métrica secundária é utilizada para definir a cor como "
+"uma proporção em relação à métrica primária. Quando omitida, a cor é "
+"categórica e baseada em etiquetas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[personalização sem título]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_columns` must have the same length as `source_columns`."
-msgstr ""
+msgstr "`compare_columns` deve ter o mesmo comprimento que `source_columns`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_type` must be `difference`, `percentage` or `ratio`"
-msgstr ""
+msgstr "`compare_type` deve ser `difference`, `percentage` ou `ratio`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`confidence_interval` must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "`confidence_interval` deve estar entre 0 e 1 (exclusivo)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "`count` is COUNT(*) if a group by is used. Numerical columns will be "
 "aggregated with the aggregator. Non-numerical columns will be used to "
 "label points. Leave empty to get a count of points in each cluster."
 msgstr ""
+"`count` é COUNT(*) se for utilizado um group by. As colunas numéricas "
+"serão agregadas com o agregador. As colunas não numéricas serão "
+"utilizadas para etiquetar pontos. Deixe em branco para obter uma contagem"
+" de pontos em cada cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`operation` property of post processing object undefined"
-msgstr ""
+msgstr "Propriedade `operation` do objeto de pós-processamento indefinida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` deve estar entre 1 e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`prophet` package not installed"
-msgstr ""
+msgstr "Pacote `prophet` não instalado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "`rename_columns` must have the same length as `columns` + "
 "`time_shift_columns`."
 msgstr ""
+"`rename_columns` deve ter o mesmo comprimento que `columns` + "
+"`time_shift_columns`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_limit` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_limit` deve ser maior ou igual a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_offset` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_offset` deve ser maior ou igual a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`width` must be greater or equal to 0"
-msgstr ""
+msgstr "`width` deve ser maior ou igual a 0"
 
 #, fuzzy
 msgid "a few seconds"
@@ -17298,24 +27458,44 @@ msgstr "30 segundos"
 msgid "aggregate"
 msgstr "Soma Agregada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alert"
-msgstr ""
+msgstr "alerta"
 
 #, fuzzy
 msgid "alert condition"
 msgstr "Conexão de teste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alerts"
-msgstr ""
+msgstr "alertas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "all"
-msgstr ""
+msgstr "todos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "also copy (duplicate) charts"
-msgstr ""
+msgstr "também copiar (duplicar) gráficos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ancestor"
-msgstr ""
+msgstr "ancestral"
 
 msgid "annotation"
 msgstr "Anotações"
@@ -17323,42 +27503,71 @@ msgstr "Anotações"
 msgid "annotation_layer"
 msgstr "Camadas de anotação"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "asfreq"
-msgstr ""
+msgstr "asfreq"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "at"
-msgstr ""
+msgstr "em"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "auto"
-msgstr ""
+msgstr "automático"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "background"
-msgstr ""
+msgstr "fundo"
 
 #, fuzzy
 msgid "background color"
 msgstr "Colunas das séries temporais"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "basis"
-msgstr ""
+msgstr "base"
 
 #, fuzzy
 msgid "begins with"
 msgstr "Largura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "below (example:"
-msgstr ""
+msgstr "abaixo (exemplo:"
 
 #, fuzzy
 msgid "beta"
 msgstr "Extra"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "between {down} and {up} {name}"
-msgstr ""
+msgstr "entre {down} e {up} {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "bfill"
-msgstr ""
+msgstr "bfill"
 
 msgid "bolt"
 msgstr "parafuso"
@@ -17367,24 +27576,43 @@ msgstr "parafuso"
 msgid "boolean"
 msgstr "Mín"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "boolean type icon"
-msgstr ""
+msgstr "ícone do tipo booleano"
 
 #, fuzzy
 msgid "bottom"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "button (cmd + z) until you save your changes."
-msgstr ""
+msgstr "botão (cmd + z) até guardar as suas alterações."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "by using"
-msgstr ""
+msgstr "usando"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "cannot be empty"
-msgstr ""
+msgstr "não pode estar vazio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "cardinal"
-msgstr ""
+msgstr "cardinal"
 
 #, fuzzy
 msgid "cell bar"
@@ -17401,23 +27629,46 @@ msgstr "Mover gráfico"
 msgid "charts"
 msgstr "Gráfico de Queijo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "choose WHERE or HAVING..."
-msgstr ""
+msgstr "escolha WHERE ou HAVING..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "click here"
-msgstr ""
+msgstr "clique aqui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "close"
-msgstr ""
+msgstr "fechar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-2 (cca2)"
-msgstr ""
+msgstr "código ISO 3166-1 alpha-2 (cca2)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-3 (cca3)"
-msgstr ""
+msgstr "código ISO 3166-1 alpha-3 (cca3)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code International Olympic Committee (cioc)"
-msgstr ""
+msgstr "código do Comité Olímpico Internacional (cioc)"
 
 #, fuzzy
 msgid "color scheme for comparison"
@@ -17430,9 +27681,11 @@ msgstr "Ordenar por"
 msgid "column"
 msgstr "Coluna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "connecting to %(dbModelName)s"
-msgstr ""
+msgstr "a ligar a %(dbModelName)s"
 
 #, fuzzy
 msgid "containing"
@@ -17454,21 +27707,37 @@ msgstr "Criado em"
 msgid "create a new chart"
 msgstr "Crie uma nova visualização"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "create dataset from SQL query"
-msgstr ""
+msgstr "criar conjunto de dados a partir de uma consulta SQL"
 
 #, fuzzy
 msgid "crontab"
 msgstr "Coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css"
-msgstr ""
+msgstr "css"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css_template"
-msgstr ""
+msgstr "css_template"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "cumsum"
-msgstr ""
+msgstr "soma acumulada"
 
 msgid "dashboard"
 msgstr "Dashboard"
@@ -17492,8 +27761,12 @@ msgstr "Base de dados"
 msgid "databases"
 msgstr "Bases de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "dataset"
-msgstr ""
+msgstr "conjunto de dados"
 
 msgid "dataset name"
 msgstr "nome da origem de dados"
@@ -17510,66 +27783,114 @@ msgstr "Fonte de dados"
 msgid "datasources"
 msgstr "Fonte de dados"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "date"
-msgstr ""
+msgstr "data"
 
 msgid "day"
 msgstr "dia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the month"
-msgstr ""
+msgstr "dia do mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the week"
-msgstr ""
+msgstr "dia da semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl 3D Hexagon"
-msgstr ""
+msgstr "deck.gl Hexágono 3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "deck.gl Arc"
-msgstr ""
+msgstr "deck.gl Arco"
 
 #, fuzzy
 msgid "deck.gl Contour"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Geojson"
-msgstr ""
+msgstr "deck.gl Geojson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Grid"
-msgstr ""
+msgstr "deck.gl Grelha"
 
 #, fuzzy
 msgid "deck.gl Heatmap"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Multiple Layers"
-msgstr ""
+msgstr "deck.gl Múltiplas Camadas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Path"
-msgstr ""
+msgstr "deck.gl Caminho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Polygon"
-msgstr ""
+msgstr "deck.gl Polígono"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Scatterplot"
-msgstr ""
+msgstr "deck.gl Diagrama de Dispersão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Screen Grid"
-msgstr ""
+msgstr "deck.gl Grelha de Ecrã"
 
 #, fuzzy
 msgid "deck.gl layers (charts)"
 msgstr "Gráfico de bala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "deckGL"
-msgstr ""
+msgstr "deckGL"
 
 #, fuzzy
 msgid "default"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "descendant"
-msgstr ""
+msgstr "descendente"
 
 msgid "description"
 msgstr "descrição"
@@ -17578,8 +27899,12 @@ msgstr "descrição"
 msgid "deviation"
 msgstr "descrição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "dialect+driver://username:password@host:port/database"
-msgstr ""
+msgstr "dialect+driver://username:password@host:port/database"
 
 #, fuzzy
 msgid "documentation"
@@ -17588,51 +27913,104 @@ msgstr "Anotações"
 msgid "dttm"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. ********"
-msgstr ""
+msgstr "ex. ********"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 127.0.0.1"
-msgstr ""
+msgstr "ex. 127.0.0.1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 5432"
-msgstr ""
+msgstr "ex. 5432"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. AccountAdmin"
-msgstr ""
+msgstr "ex. AccountAdmin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "e.g. Analytics"
-msgstr ""
+msgstr "ex. Analytics"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. compute_wh"
-msgstr ""
+msgstr "ex. compute_wh"
 
 #, fuzzy
 msgid "e.g. default"
 msgstr "Latitude padrão"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "e.g. hive_metastore"
-msgstr ""
+msgstr "ex. hive_metastore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "e.g. param1=value1&param2=value2"
-msgstr ""
+msgstr "ex. param1=value1&param2=value2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. sql/protocolv1/o/12345"
-msgstr ""
+msgstr "ex. sql/protocolv1/o/12345"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. world_population"
-msgstr ""
+msgstr "ex. world_population"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. xy12345.us-east-2.aws"
-msgstr ""
+msgstr "ex. xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "ex., CI/CD Pipeline, Script de Análise"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "edit mode"
-msgstr ""
+msgstr "modo de edição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "email subject"
-msgstr ""
+msgstr "assunto do email"
 
 #, fuzzy
 msgid "ends with"
@@ -17658,17 +28036,29 @@ msgstr "Erro"
 msgid "error_message"
 msgstr "Mensagem de Aviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every"
-msgstr ""
+msgstr "cada"
 
 msgid "every day of the month"
 msgstr "Código de 3 letras do país"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every day of the week"
-msgstr ""
+msgstr "todos os dias da semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "every hour"
-msgstr ""
+msgstr "cada hora"
 
 #, fuzzy
 msgid "every minute"
@@ -17677,44 +28067,75 @@ msgstr "mês"
 msgid "every month"
 msgstr "mês"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "expand"
-msgstr ""
+msgstr "expandir"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard deve ser um objeto"
 
 #, fuzzy
 msgid "failed"
 msgstr "Perfil"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "adeus"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "fetching"
-msgstr ""
+msgstr "a obter"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ffill"
-msgstr ""
+msgstr "ffill"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "flat"
-msgstr ""
+msgstr "plano"
 
 #, fuzzy
 msgid "for a list of available helpers."
 msgstr "Filtros"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "for more information on how to structure your URI."
-msgstr ""
+msgstr "para obter mais informações sobre como estruturar o seu URI."
 
 #, fuzzy
 msgid "formatted"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "function type icon"
-msgstr ""
+msgstr "ícone de tipo de função"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "geohash (square)"
-msgstr ""
+msgstr "geohash (quadrado)"
 
 #, fuzzy
 msgid "greeting"
@@ -17724,11 +28145,18 @@ msgstr "Anotações"
 msgid "heatmap"
 msgstr "Mapa de Calor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "heatmap: values are normalized across the entire heatmap"
-msgstr ""
+msgstr "mapa de calor: os valores são normalizados em todo o mapa de calor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "olá"
 
 #, fuzzy
 msgid "here"
@@ -17740,62 +28168,109 @@ msgstr "hora"
 msgid "in"
 msgstr "Mín"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "para executar esta operação."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "invalid email"
-msgstr ""
+msgstr "email inválido"
 
 #, fuzzy
 msgid "is"
 msgstr "Mín"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
 msgstr ""
+"é esperado que seja um URL Mapbox/OSM (ex. mapbox://styles/...) ou um URL"
+" de servidor de tiles (ex. tile://http...)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be a number"
-msgstr ""
+msgstr "é esperado que seja um número"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be an integer"
-msgstr ""
+msgstr "é esperado que seja um número inteiro"
 
 #, fuzzy
 msgid "is false"
 msgstr "Favoritos"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards and users have %s SQL"
 " Lab tabs using this database open. Are you sure you want to continue? "
 "Deleting the database will break those objects."
 msgstr ""
+"está ligado a %s gráficos que aparecem em %s painéis e os utilizadores "
+"têm %s separadores do SQL Lab abertos a usar esta base de dados. Tem a "
+"certeza de que quer continuar? Eliminar a base de dados irá danificar "
+"esses objetos."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
 msgstr ""
+"está ligado a %s gráficos que aparecem em %s painéis. Tem a certeza de "
+"que quer continuar? Eliminar o conjunto de dados irá danificar esses "
+"objetos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not"
-msgstr ""
+msgstr "não é"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not null"
-msgstr ""
+msgstr "não é nulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is null"
-msgstr ""
+msgstr "é nulo"
 
 #, fuzzy
 msgid "is true"
 msgstr "Query vazia?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key a-z"
-msgstr ""
+msgstr "chave a-z"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key z-a"
-msgstr ""
+msgstr "chave z-a"
 
 #, fuzzy
 msgid "label"
@@ -17808,9 +28283,12 @@ msgstr "última partição:"
 msgid "left"
 msgstr "Eliminar"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "less than {min} {name}"
-msgstr ""
+msgstr "menos que {min} {name}"
 
 #, fuzzy
 msgid "linear"
@@ -17820,23 +28298,40 @@ msgstr "ano"
 msgid "locale_key"
 msgstr "Rótulo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "log"
-msgstr ""
+msgstr "log"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "lower percentile must be greater than 0 and less than 100. Must be lower "
 "than upper percentile."
 msgstr ""
+"o percentil inferior deve ser maior que 0 e menor que 100. Deve ser menor"
+" que o percentil superior."
 
 #, fuzzy
 msgid "max"
 msgstr "Máx"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "mean"
-msgstr ""
+msgstr "média"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "median"
-msgstr ""
+msgstr "mediana"
 
 #, fuzzy
 msgid "meters"
@@ -17868,48 +28363,73 @@ msgstr "mês"
 msgid "month"
 msgstr "mês"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "more than {max} {name}"
-msgstr ""
+msgstr "mais de {max} {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "must have a value"
-msgstr ""
+msgstr "deve ter um valor"
 
 #, fuzzy
 msgid "name"
 msgstr "Nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters deve ser uma lista"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] com chaves obrigatórias em falta: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] deve ser um objeto"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues deve ser uma lista"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' não existe no painel"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId deve ser uma string não vazia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "no SQL validator is configured"
-msgstr ""
+msgstr "nenhum validador SQL está configurado"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "no SQL validator is configured for %(engine_spec)s"
-msgstr ""
+msgstr "nenhum validador SQL está configurado para %(engine_spec)s"
 
 #, fuzzy
 msgid "not containing"
@@ -17919,28 +28439,47 @@ msgstr "Anotações"
 msgid "numeric"
 msgstr "Métrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "numeric type icon"
-msgstr ""
+msgstr "ícone de tipo numérico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "nvd3"
-msgstr ""
+msgstr "nvd3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "of"
-msgstr ""
+msgstr "de"
 
 #, fuzzy
 msgid "offline"
 msgstr "agregado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "on"
-msgstr ""
+msgstr "em"
 
 #, fuzzy
 msgid "or"
 msgstr "hora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "or use existing ones from the panel on the right"
-msgstr ""
+msgstr "ou use os existentes no painel à direita"
 
 #, fuzzy
 msgid "orderby column must be populated"
@@ -17950,36 +28489,61 @@ msgstr "Não foi possível gravar a sua query"
 msgid "original"
 msgstr "Origem"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "overall"
-msgstr ""
+msgstr "geral"
 
 #, fuzzy
 msgid "owners"
 msgstr "Proprietários"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "p-value precision"
-msgstr ""
+msgstr "precisão do valor-p"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "p1"
-msgstr ""
+msgstr "p1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "p5"
-msgstr ""
+msgstr "p5"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "p95"
-msgstr ""
+msgstr "p95"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "p99"
-msgstr ""
+msgstr "p99"
 
 #, fuzzy
 msgid "pending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "percentiles must be a list or tuple with two numeric values, of which the"
 " first is lower than the second value"
 msgstr ""
+"os percentis devem ser uma lista ou tupla com dois valores numéricos, dos"
+" quais o primeiro é menor que o segundo valor"
 
 #, fuzzy
 msgid "permalink state not found"
@@ -17989,23 +28553,45 @@ msgstr "Modelos CSS"
 msgid "pivoted_xlsx"
 msgstr "Editar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "pixels"
-msgstr ""
+msgstr "píxeis"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar month"
-msgstr ""
+msgstr "mês anterior do calendário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "previous calendar quarter"
-msgstr ""
+msgstr "trimestre anterior do calendário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar week"
-msgstr ""
+msgstr "semana anterior do calendário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar year"
-msgstr ""
+msgstr "ano anterior do calendário"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "fornecer autorização"
 
 #, fuzzy
 msgid "quarter"
@@ -18014,17 +28600,30 @@ msgstr "Query"
 msgid "query"
 msgstr "Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "random"
-msgstr ""
+msgstr "aleatório"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "reboot"
-msgstr ""
+msgstr "reiniciar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "recent"
-msgstr ""
+msgstr "recente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "recipients"
-msgstr ""
+msgstr "destinatários"
 
 msgid "report"
 msgstr "Janela de exibição"
@@ -18032,15 +28631,22 @@ msgstr "Janela de exibição"
 msgid "reports"
 msgstr "Janela de exibição"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "restore zoom"
-msgstr ""
+msgstr "restaurar zoom"
 
 #, fuzzy
 msgid "right"
 msgstr "Altura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "rowlevelsecurity"
-msgstr ""
+msgstr "segurança ao nível de linha"
 
 #, fuzzy
 msgid "running"
@@ -18061,26 +28667,46 @@ msgstr "30 segundos"
 msgid "series"
 msgstr "Séries"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "series: Treat each series independently; overall: All series use the same"
 " scale; change: Show changes compared to the first data point in each "
 "series"
 msgstr ""
+"séries: Tratar cada série de forma independente; geral: Todas as séries "
+"usam a mesma escala; alteração: Mostrar alterações em comparação com o "
+"primeiro ponto de dados em cada série"
 
 msgid "sql"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "square"
-msgstr ""
+msgstr "quadrado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stack"
-msgstr ""
+msgstr "pilha"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "staggered"
-msgstr ""
+msgstr "escalonado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "std"
-msgstr ""
+msgstr "std"
 
 #, fuzzy
 msgid "step-after"
@@ -18089,8 +28715,11 @@ msgstr "Modelos CSS"
 msgid "step-before"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stopped"
-msgstr ""
+msgstr "interrompido"
 
 #, fuzzy
 msgid "stream"
@@ -18100,31 +28729,50 @@ msgstr "Histograma"
 msgid "string"
 msgstr "Estilo do mapa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "string type icon"
-msgstr ""
+msgstr "ícone do tipo string"
 
 #, fuzzy
 msgid "success"
 msgstr "Não há acesso!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "sum"
-msgstr ""
+msgstr "soma"
 
 msgid "superset.example.com"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "syntax."
-msgstr ""
+msgstr "sintaxe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "tag"
-msgstr ""
+msgstr "etiqueta"
 
 #, fuzzy
 msgid "task"
 msgstr "Estado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "temporal type icon"
-msgstr ""
+msgstr "ícone de tipo temporal"
 
 #, fuzzy
 msgid "text color"
@@ -18133,8 +28781,11 @@ msgstr "Selecione uma cor"
 msgid "textarea"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "a documentação do gráfico Handlebars"
 
 #, fuzzy
 msgid "theme"
@@ -18152,11 +28803,17 @@ msgstr "Parar"
 msgid "top"
 msgstr "Parar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "undo"
-msgstr ""
+msgstr "desfazer"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "unknown type icon"
-msgstr ""
+msgstr "ícone de tipo desconhecido"
 
 #, fuzzy
 msgid "unset"
@@ -18166,10 +28823,16 @@ msgstr "Coluna"
 msgid "updated"
 msgstr "%s - sem título"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "upper percentile must be greater than 0 and less than 100. Must be higher"
 " than lower percentile."
 msgstr ""
+"o percentil superior deve ser maior que 0 e menor que 100. Deve ser "
+"superior ao percentil inferior."
 
 #, fuzzy
 msgid "use latest_partition template"
@@ -18187,8 +28850,11 @@ msgstr "Ordenar decrescente"
 msgid "value descending"
 msgstr "Ordenar decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "var"
-msgstr ""
+msgstr "var"
 
 #, fuzzy
 msgid "variance"
@@ -18208,26 +28874,51 @@ msgstr "foi criado"
 msgid "week"
 msgstr "semana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week ending Saturday"
-msgstr ""
+msgstr "semana que termina no sábado"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week starting Sunday"
-msgstr ""
+msgstr "semana que começa no domingo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "working timeout"
-msgstr ""
+msgstr "tempo limite de trabalho"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x"
-msgstr ""
+msgstr "x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x: values are normalized within each column"
-msgstr ""
+msgstr "x: os valores são normalizados em cada coluna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y"
-msgstr ""
+msgstr "y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y: values are normalized within each row"
-msgstr ""
+msgstr "y: os valores são normalizados em cada linha"
 
 msgid "year"
 msgstr "ano"
@@ -18235,11 +28926,21 @@ msgstr "ano"
 msgid "your-project-1234-a1"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "zoom area"
-msgstr ""
+msgstr "área de zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "© Layer attribution"
-msgstr ""
+msgstr "© Atribuição da camada"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Portuguese (`pt`) catalog using `scripts/translations/backfill_po.py`, which drafts translations with Claude using every other language's existing translation of the same string as cross-language disambiguation context (per `docs/developer_docs/contributing/howtos.md`). Do-not-translate tokens (icon names, enum values, SQL keywords, API field names, placeholders) are skipped.

All generated strings are marked `#, fuzzy` with a `Machine-translated via backfill_po.py` attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend builds include fuzzy entries, so these translations render in the UI once built; reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only, no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l pt` succeeds.
- Portuguese native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API