### PR TITLE
feat(i18n): backfill Italian (it) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -28,6 +28,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The cumulative option allows you to see how your data "
@@ -41,7 +44,21 @@ msgid ""
 "                original data, it just changes the way the histogram is "
 "displayed."
 msgstr ""
+"\n"
+"                L'opzione cumulativa consente di vedere come i dati si "
+"accumulano su valori\n"
+"                diversi. Quando abilitata, le barre dell'istogramma "
+"rappresentano il totale cumulativo delle frequenze\n"
+"                fino a ciascun intervallo. Questo aiuta a capire quanto "
+"sia probabile incontrare valori\n"
+"                al di sotto di un certo punto. Tieni presente che "
+"l'abilitazione del cumulativo non modifica i\n"
+"                dati originali, cambia solo il modo in cui viene "
+"visualizzato l'istogramma."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The normalize option transforms the histogram values into"
@@ -55,15 +72,37 @@ msgid ""
 "                clearer understanding of the proportion of data points "
 "within each bin."
 msgstr ""
+"\n"
+"                L'opzione normalizza trasforma i valori dell'istogramma "
+"in proporzioni o\n"
+"                probabilità dividendo il conteggio di ciascun intervallo "
+"per il totale dei punti dati.\n"
+"                Questo processo di normalizzazione garantisce che la "
+"somma dei valori risultanti sia 1,\n"
+"                consentendo un confronto relativo della distribuzione dei"
+" dati e fornendo una\n"
+"                comprensione più chiara della proporzione dei punti dati "
+"all'interno di ciascun intervallo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "\n"
 "                This filter was inherited from the dashboard's context.\n"
 "                It won't be saved when saving the chart.\n"
 "              "
 msgstr ""
+"\n"
+"                Questo filtro è stato ereditato dal contesto del "
+"dashboard.\n"
+"                Non verrà salvato durante il salvataggio del grafico.\n"
+"              "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "\n"
 "            <p>Your report/alert was unable to be generated because of "
@@ -72,14 +111,31 @@ msgid ""
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
+"\n"
+"            <p>Il report/avviso non ha potuto essere generato a causa del"
+" seguente errore: %(text)s</p>\n"
+"            <p>Si prega di verificare il dashboard/grafico per eventuali "
+"errori.</p>\n"
+"            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
+"            "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " (excluded)"
-msgstr ""
+msgstr " (escluso)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " Set the opacity to 0 if you do not want to override the color specified "
 "in the GeoJSON"
 msgstr ""
+" Imposta l'opacità a 0 se non vuoi sovrascrivere il colore specificato "
+"nel GeoJSON"
 
 #, fuzzy
 msgid " a dashboard OR "
@@ -89,24 +145,39 @@ msgstr "Salva e vai alla dashboard"
 msgid " a new one"
 msgstr "Cambiato il"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " at line %(line)d"
-msgstr ""
+msgstr " alla riga %(line)d"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " expression which needs to adhere to the "
-msgstr ""
+msgstr " espressione che deve essere conforme al "
 
 #, fuzzy
 msgid " for details."
 msgstr "Query salvate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " near '%(highlight)s'"
-msgstr ""
+msgstr " vicino a '%(highlight)s'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " source code of Superset's sandboxed parser"
-msgstr ""
+msgstr " codice sorgente del parser sandbox di Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " standard to ensure that the lexicographical ordering\n"
 "                      coincides with the chronological ordering. If the\n"
@@ -123,6 +194,21 @@ msgid ""
 "defaults on a per\n"
 "                      database/column name level via the extra parameter."
 msgstr ""
+" standard per garantire che l'ordinamento lessicografico\n"
+"                      coincida con l'ordinamento cronologico. Se il\n"
+"                      formato del timestamp non è conforme allo standard "
+"ISO 8601\n"
+"                      sarà necessario definire un'espressione e un tipo "
+"per\n"
+"                      trasformare la stringa in una data o timestamp. "
+"Nota:\n"
+"                      le zone orarie non sono attualmente supportate. Se "
+"il tempo è memorizzato\n"
+"                      in formato epoch, inserire `epoch_s` o `epoch_ms`. "
+"Se non viene\n"
+"                      specificato alcun pattern, si utilizzano i valori "
+"predefiniti opzionali a livello di\n"
+"                      nome database/colonna tramite il parametro extra."
 
 #, fuzzy
 msgid " to add calculated columns"
@@ -132,102 +218,167 @@ msgstr "Visualizza colonne"
 msgid " to add metrics"
 msgstr "Aggiungi metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to check for details."
-msgstr ""
+msgstr " per verificare i dettagli."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to edit or add columns and metrics."
-msgstr ""
+msgstr " per modificare o aggiungere colonne e metriche."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh_TW]
+#, fuzzy
 msgid " to mark a column as a time column"
-msgstr ""
+msgstr " per contrassegnare una colonna come colonna temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " to open SQL Lab. From there you can save the query as a dataset."
-msgstr ""
+msgstr " per aprire SQL Lab. Da lì è possibile salvare la query come dataset."
 
 #, fuzzy
 msgid " to see details."
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to visualize your data."
-msgstr ""
+msgstr " per visualizzare i tuoi dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "!= (Is not equal)"
-msgstr ""
+msgstr "!= (Non è uguale)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system dark theme"
-msgstr ""
+msgstr "\"%s\" è ora il tema scuro del sistema"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system default theme"
-msgstr ""
+msgstr "\"%s\" è ora il tema predefinito del sistema"
 
 #, fuzzy, python-format
 msgid "% calculation"
 msgstr "Seleziona un tipo di visualizzazione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "% of parent"
-msgstr ""
+msgstr "% del genitore"
 
 #, fuzzy, python-format
 msgid "% of total"
 msgstr "Mostra colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(dialect)s cannot be used as a data source for security reasons."
 msgstr ""
+"%(dialect)s non può essere utilizzato come sorgente dati per motivi di "
+"sicurezza."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(label)s file"
-msgstr ""
+msgstr "file %(label)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(name)s.csv"
-msgstr ""
+msgstr "%(name)s.csv"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(name)s.pdf"
-msgstr ""
+msgstr "%(name)s.pdf"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(object)s does not exist in this database."
-msgstr ""
+msgstr "%(object)s non esiste in questo database."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(prefix)s %(title)s"
-msgstr ""
+msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sRisultati troncati a %(row_count)s righe a causa di limitazioni"
+" di memoria."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%(report_type)s schedule frequency exceeding limit. Please configure a "
 "schedule with a minimum interval of %(minimum_interval)d minutes per "
 "execution."
 msgstr ""
+"La frequenza di pianificazione per %(report_type)s supera il limite. "
+"Configurare una pianificazione con un intervallo minimo di "
+"%(minimum_interval)d minuti per esecuzione."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(rows)d rows returned"
-msgstr ""
+msgstr "%(rows)d righe restituite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, lv,
+# mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid "%(suggestion)s instead of \"%(undefinedParameter)s?\""
 msgid_plural ""
 "%(firstSuggestions)s or %(lastSuggestion)s instead of "
 "\"%(undefinedParameter)s\"?"
-msgstr[0] ""
+msgstr[0] "%(suggestion)s invece di \"%(undefinedParameter)s?\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "%(validator)s was unable to check your query.\n"
 "Please recheck your query.\n"
 "Exception: %(ex)s"
 msgstr ""
+"%(validator)s non è riuscito a verificare la query.\n"
+"Si prega di ricontrollare la query.\n"
+"Eccezione: %(ex)s"
 
 #, fuzzy, python-format
 msgid "%s %s"
@@ -245,21 +396,32 @@ msgstr "Errore..."
 msgid "%s PASSWORD"
 msgstr "Porta Broker"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Physical"
-msgstr ""
+msgstr "%s Fisico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PASSWORD"
-msgstr ""
+msgstr "%s PASSWORD TUNNEL SSH"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY"
-msgstr ""
+msgstr "%s CHIAVE PRIVATA TUNNEL SSH"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY PASSWORD"
-msgstr ""
+msgstr "%s PASSWORD CHIAVE PRIVATA TUNNEL SSH"
 
 #, python-format
 msgid "%s Selected"
@@ -269,17 +431,25 @@ msgstr "Seleziona data finale"
 msgid "%s Selected (%s)"
 msgstr "Seleziona data finale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Physical)"
-msgstr ""
+msgstr "%s Selezionato (Fisico)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Virtual)"
-msgstr ""
+msgstr "%s Selezionato (Virtuale)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Vista semantica"
 
 #, fuzzy, python-format
 msgid "%s URL"
@@ -289,9 +459,12 @@ msgstr "Errore..."
 msgid "%s Virtual"
 msgstr "Errore..."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s aggregates(s)"
-msgstr ""
+msgstr "%s aggregato(i)"
 
 #, fuzzy, python-format
 msgid "%s column"
@@ -302,10 +475,12 @@ msgstr[0] "Visualizza colonne"
 msgid "%s column(s)"
 msgstr "Visualizza colonne"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
+msgstr[0] "%s giorno fa"
 
 #, fuzzy, python-format
 msgid "%s hr ago"
@@ -325,11 +500,15 @@ msgstr[0] "Visualizza colonne"
 msgid "%s item(s)"
 msgstr "Visualizza colonne"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%s items could not be tagged because you don’t have edit permissions to "
 "all selected objects."
 msgstr ""
+"%s elementi non hanno potuto essere etichettati perché non si dispone dei"
+" permessi di modifica per tutti gli oggetti selezionati."
 
 #, fuzzy, python-format
 msgid "%s metric"
@@ -350,9 +529,12 @@ msgid "%s option"
 msgid_plural "%s options"
 msgstr[0] "Seleziona operatore"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s option(s)"
-msgstr ""
+msgstr "%s opzione(i)"
 
 #, fuzzy, python-format
 msgid "%s out of %s column"
@@ -368,9 +550,11 @@ msgstr[0] "Mostra metrica"
 msgid "%s out of %s selected"
 msgstr "Seleziona data finale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "%s recipients"
-msgstr ""
+msgstr "%s destinatari"
 
 #, fuzzy, python-format
 msgid "%s record"
@@ -387,31 +571,42 @@ msgid "%s row"
 msgid_plural "%s rows"
 msgstr[0] "Errore..."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s s ago"
 msgid_plural "%s s ago"
-msgstr[0] ""
+msgstr[0] "%s s fa"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s saved metric(s)"
-msgstr ""
+msgstr "%s metrica/e salvata/e"
 
 #, fuzzy, python-format
 msgid "%s second"
 msgid_plural "%s seconds"
 msgstr[0] "Errore..."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s vista/e semantica/e aggiunta/e"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "Aggiunta di %s vista/e semantica/e non riuscita"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "Aggiunta di %s vista/e semantica/e non riuscita: %s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
@@ -421,23 +616,44 @@ msgstr "Seleziona data finale"
 msgid "%s updated"
 msgstr "%s - senza nome"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s%s"
-msgstr ""
+msgstr "%s%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(Removed)"
-msgstr ""
+msgstr "(Rimosso)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(deleted or invalid type)"
-msgstr ""
+msgstr "(eliminato o tipo non valido)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(no description, click to see stack trace)"
-msgstr ""
+msgstr "(nessuna descrizione, fare clic per visualizzare la traccia dello stack)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "), and they become available in your SQL (example:"
-msgstr ""
+msgstr "), e diventano disponibili nel tuo SQL (esempio:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -446,8 +662,16 @@ msgid ""
 "    Error: %(text)s\n"
 "    "
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"    %(description)s\n"
+"\n"
+"    Errore: %(text)s\n"
+"    "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -457,92 +681,165 @@ msgid ""
 "\n"
 "%(table)s\n"
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"%(description)s\n"
+"\n"
+"<%(url)s|Esplora in Superset>\n"
+"\n"
+"%(table)s\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "+ %s more"
-msgstr ""
+msgstr "+ altri %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ", then paste the JSON below. See our"
-msgstr ""
+msgstr ", quindi incolla il JSON qui sotto. Consulta il nostro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "-- Note: Unless you save your query, these tabs will NOT persist if you "
 "clear your cookies or change browsers.\n"
 "\n"
 msgstr ""
+"-- Nota: A meno che non salvi la tua query, queste schede NON verranno "
+"mantenute se elimini i cookie o cambi browser.\n"
+"\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... e altri %d"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %s more records"
-msgstr ""
+msgstr "... e altri %s record"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "... and %s others"
-msgstr ""
+msgstr "... e altri %s"
 
 msgid "0 Selected"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 calendar day frequency"
-msgstr ""
+msgstr "Frequenza di 1 giorno di calendario"
 
 #, fuzzy
 msgid "1 day"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 day ago"
-msgstr ""
+msgstr "1 giorno fa"
 
 msgid "1 hour"
 msgstr "ora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 hourly frequency"
-msgstr ""
+msgstr "Frequenza di 1 ora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "1 minute"
-msgstr ""
+msgstr "1 minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 minutely frequency"
-msgstr ""
+msgstr "Frequenza di 1 minuto"
 
 #, fuzzy
 msgid "1 month ago"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month end frequency"
-msgstr ""
+msgstr "Frequenza di fine mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month start frequency"
-msgstr ""
+msgstr "Frequenza di inizio mese"
 
 #, fuzzy
 msgid "1 week"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 week ago"
-msgstr ""
+msgstr "1 settimana fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Monday (freq=W-MON)"
-msgstr ""
+msgstr "1 settimana con inizio lunedì (freq=W-MON)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Sunday (freq=W-SUN)"
-msgstr ""
+msgstr "1 settimana con inizio domenica (freq=W-SUN)"
 
 #, fuzzy
 msgid "1 year"
 msgstr "anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 year ago"
-msgstr ""
+msgstr "1 anno fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year end frequency"
-msgstr ""
+msgstr "Frequenza di fine anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year start frequency"
-msgstr ""
+msgstr "Frequenza di inizio anno"
 
 #, fuzzy
 msgid "10 minute"
@@ -552,8 +849,11 @@ msgstr "10 minuti"
 msgid "10 seconds"
 msgstr "JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "10/90 percentiles"
-msgstr ""
+msgstr "10/90 percentili"
 
 msgid "10000"
 msgstr ""
@@ -562,8 +862,12 @@ msgstr ""
 msgid "104 weeks"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "104 weeks ago"
-msgstr ""
+msgstr "104 settimane fa"
 
 #, fuzzy
 msgid "12 hours"
@@ -577,36 +881,71 @@ msgstr "minuto"
 msgid "156 weeks"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "156 weeks ago"
-msgstr ""
+msgstr "156 settimane fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1AS"
-msgstr ""
+msgstr "1AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1D"
-msgstr ""
+msgstr "1D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1H"
-msgstr ""
+msgstr "1H"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1M"
-msgstr ""
+msgstr "1M"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1T"
-msgstr ""
+msgstr "1T"
 
 #, fuzzy
 msgid "2 years"
 msgstr "anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2 years ago"
-msgstr ""
+msgstr "2 anni fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2/98 percentiles"
-msgstr ""
+msgstr "2/98 percentili"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "22"
-msgstr ""
+msgstr "22"
 
 #, fuzzy
 msgid "24 hours"
@@ -616,11 +955,19 @@ msgstr "ora"
 msgid "28 days"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "28 days ago"
-msgstr ""
+msgstr "28 giorni fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #, fuzzy
 msgid "3 letter code of the country"
@@ -630,14 +977,25 @@ msgstr "Codice a 3 lettere della nazione"
 msgid "3 years"
 msgstr "anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "3 years ago"
-msgstr ""
+msgstr "3 anni fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "30 days"
-msgstr ""
+msgstr "30 giorni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "30 days ago"
-msgstr ""
+msgstr "30 giorni fa"
 
 #, fuzzy
 msgid "30 minute"
@@ -646,43 +1004,80 @@ msgstr "10 minuti"
 msgid "30 minutes"
 msgstr "10 minuti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "30 second"
-msgstr ""
+msgstr "30 secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "30 seconds"
-msgstr ""
+msgstr "30 secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "4 weeks (freq=4W-MON)"
-msgstr ""
+msgstr "4 settimane (freq=4W-MON)"
 
 #, fuzzy
 msgid "5 minute"
 msgstr "minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "5 minutes"
-msgstr ""
+msgstr "5 minuti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "5 second"
-msgstr ""
+msgstr "5 secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "5 seconds"
-msgstr ""
+msgstr "5 secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "5/95 percentiles"
-msgstr ""
+msgstr "5/95 percentili"
 
 #, fuzzy
 msgid "52 weeks"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "52 weeks ago"
-msgstr ""
+msgstr "52 settimane fa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "52 weeks starting Monday (freq=52W-MON)"
-msgstr ""
+msgstr "52 settimane con inizio lunedì (freq=52W-MON)"
 
 #, fuzzy
 msgid "6 hour"
@@ -692,36 +1087,72 @@ msgstr "ora"
 msgid "6 hours"
 msgstr "ora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "60 days"
-msgstr ""
+msgstr "60 giorni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "7 calendar day frequency"
-msgstr ""
+msgstr "Frequenza di 7 giorni di calendario"
 
 #, fuzzy
 msgid "7 days"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "7D"
-msgstr ""
+msgstr "7G"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "9/91 percentiles"
-msgstr ""
+msgstr "9/91 percentili"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "90 days"
-msgstr ""
+msgstr "90 giorni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ":"
-msgstr ""
+msgstr ":"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "< (Smaller than)"
-msgstr ""
+msgstr "< (Minore di)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<= (Smaller or equal)"
-msgstr ""
+msgstr "<= (Minore o uguale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<enter SQL expression here>"
-msgstr ""
+msgstr "<inserisci l'espressione SQL qui>"
 
 #, fuzzy
 msgid "<new column>"
@@ -731,39 +1162,70 @@ msgstr "Colonna del Tempo"
 msgid "<new metric>"
 msgstr "Seleziona una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "<new spatial>"
-msgstr ""
+msgstr "<nuovo spaziale>"
 
 #, fuzzy
 msgid "<no type>"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "== (Is equal)"
-msgstr ""
+msgstr "== (È uguale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "> (Larger than)"
-msgstr ""
+msgstr "> (Maggiore di)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ">= (Larger or equal)"
-msgstr ""
+msgstr ">= (Maggiore o uguale)"
 
 #, fuzzy
 msgid "A Big Number"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
 msgstr ""
+"Una funzione JavaScript che genera un oggetto di configurazione delle "
+"etichette"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
 msgstr ""
+"Una funzione JavaScript che genera un oggetto di configurazione delle "
+"icone"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"Un oggetto JavaScript conforme alla specifica delle opzioni ECharts, che "
+"sovrascrive le altre opzioni di controllo con priorità più elevata. (ad "
+"es. { title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). "
+"Dettagli: https://echarts.apache.org/en/option.html. "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
@@ -771,43 +1233,91 @@ msgstr ""
 "Selezionare i nomi delle colonne da elaborare come date dall'elenco a "
 "discesa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr ""
+"Un elenco di schemi separati da virgola in cui i file possono essere "
+"caricati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A database port is required when connecting via SSH Tunnel."
 msgstr ""
+"È necessaria una porta del database quando ci si connette tramite tunnel "
+"SSH."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A database with the same name already exists."
-msgstr ""
+msgstr "Esiste già un database con lo stesso nome."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A date is required when using custom date shift"
 msgstr ""
+"È necessaria una data quando si utilizza lo spostamento di data "
+"personalizzato"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "A dictionary with column names and their data types if you need to change"
 " the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas "
 "library for supported data types."
 msgstr ""
+"Un dizionario con nomi di colonne e relativi tipi di dati se è necessario"
+" modificare i valori predefiniti. Esempio: {\"user_id\":\"int\"}. "
+"Consulta la libreria Pandas di Python per i tipi di dati supportati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A full URL pointing to the location of the built plugin (could be hosted "
 "on a CDN for example)"
 msgstr ""
+"Un URL completo che punta alla posizione del plugin compilato (ad esempio"
+" potrebbe essere ospitato su un CDN)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A handlebars template that is applied to the data"
-msgstr ""
+msgstr "Un template Handlebars applicato ai dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A human-friendly name"
-msgstr ""
+msgstr "Un nome intuitivo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A list of domain names that can embed this dashboard. Leaving this field "
 "empty will allow embedding from any domain."
 msgstr ""
+"Un elenco di nomi di dominio che possono incorporare questa dashboard. "
+"Lasciando questo campo vuoto si consentirà l'incorporamento da qualsiasi "
+"dominio."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A list of tags that have been applied to this chart."
-msgstr ""
+msgstr "Un elenco di tag applicati a questo grafico."
 
 #, fuzzy
 msgid "A list of tags that have been applied to this dashboard."
@@ -816,16 +1326,30 @@ msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 msgid "A list of users who can alter the chart. Searchable by name or username."
 msgstr "Proprietari è una lista di utenti che può alterare la dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A map of the world, that can indicate values in different countries."
-msgstr ""
+msgstr "Una mappa del mondo che può indicare valori in diversi paesi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A map that takes rendering circles with a variable radius at "
 "latitude/longitude coordinates"
 msgstr ""
+"Una mappa che visualizza cerchi con raggio variabile nelle coordinate di "
+"latitudine/longitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A metric to use for color"
-msgstr ""
+msgstr "Una metrica da usare per il colore"
 
 #, fuzzy
 msgid "A new chart and dashboard will be created."
@@ -839,29 +1363,52 @@ msgstr "La tua query non può essere salvata"
 msgid "A new dashboard will be created."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A polar coordinate chart where the circle is broken into wedges of equal "
 "angle, and the value represented by any wedge is illustrated by its area,"
 " rather than its radius or sweep angle."
 msgstr ""
+"Un grafico a coordinate polari in cui il cerchio è diviso in spicchi di "
+"uguale angolo e il valore rappresentato da ciascuno spicchio è illustrato"
+" dalla sua area, anziché dal suo raggio o angolo di apertura."
 
 msgid "A readable URL for your dashboard"
 msgstr "ottenere una URL leggibile per la tua dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A reference to the [Time] configuration, taking granularity into account"
-msgstr ""
+msgstr "Un riferimento alla configurazione [Time], tenendo conto della granularità"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "A report named \"%(name)s\" already exists"
-msgstr ""
+msgstr "Esiste già un report denominato \"%(name)s\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A reusable dataset will be saved with your chart."
-msgstr ""
+msgstr "Un set di dati riutilizzabile verrà salvato con il tuo grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
+"Un insieme di parametri che diventano disponibili nella query utilizzando"
+" la sintassi di template Jinja"
 
 #, fuzzy
 msgid "A timeout occurred while executing the query."
@@ -879,9 +1426,17 @@ msgstr "Errore nel creare il datasource"
 msgid "A timeout occurred while taking a screenshot."
 msgstr "Errore nel recupero dei metadati della tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A valid color scheme is required"
-msgstr ""
+msgstr "È necessario uno schema di colori valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A waterfall chart is a form of data visualization that helps in "
 "understanding\n"
@@ -890,9 +1445,18 @@ msgid ""
 "          These intermediate values can either be time based or category "
 "based."
 msgstr ""
+"Un grafico a cascata è una forma di visualizzazione dei dati che aiuta a "
+"comprendere\n"
+"          l'effetto cumulativo di valori positivi o negativi introdotti "
+"sequenzialmente.\n"
+"          Questi valori intermedi possono essere basati sul tempo o sulla"
+" categoria."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 #, fuzzy
 msgid "AND"
@@ -914,23 +1478,47 @@ msgstr "La tua query non può essere salvata"
 msgid "API key name is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "Chiave API revocata con successo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
 msgstr ""
+"Le chiavi API consentono l'accesso programmatico con ambito limitato a "
+"Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APPLY"
-msgstr ""
+msgstr "APPLICA"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APR"
-msgstr ""
+msgstr "APR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "AQE"
-msgstr ""
+msgstr "AQE"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "AUG"
-msgstr ""
+msgstr "AGO"
 
 #, fuzzy
 msgid "Aborted"
@@ -940,14 +1528,25 @@ msgstr "Creato il"
 msgid "Aborting"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "About"
-msgstr ""
+msgstr "Informazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Access & ownership"
-msgstr ""
+msgstr "Accesso e proprietà"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Access token"
-msgstr ""
+msgstr "Token di accesso"
 
 #, fuzzy
 msgid "Account"
@@ -956,8 +1555,12 @@ msgstr "Colonna"
 msgid "Action"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Action Log"
-msgstr ""
+msgstr "Registro delle azioni"
 
 #, fuzzy
 msgid "Action Logs"
@@ -977,8 +1580,12 @@ msgstr "Valore del filtro"
 msgid "Actual range for comparison"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Actual time range"
-msgstr ""
+msgstr "Intervallo di tempo effettivo"
 
 #, fuzzy
 msgid "Actual value"
@@ -992,24 +1599,38 @@ msgstr "Valore del filtro"
 msgid "Adaptive formatting"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add"
-msgstr ""
+msgstr "Aggiungi"
 
 #, fuzzy, python-format
 msgid "Add %s view(s)"
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add BCC Recipients"
-msgstr ""
+msgstr "Aggiungi destinatari CCN"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add CC Recipients"
-msgstr ""
+msgstr "Aggiungi destinatari CC"
 
 msgid "Add CSS template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Add Dashboard"
-msgstr ""
+msgstr "Aggiungi Dashboard"
 
 #, fuzzy
 msgid "Add Group"
@@ -1019,13 +1640,22 @@ msgstr "Formato Datetime"
 msgid "Add Layer"
 msgstr "Aggiungi grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Add Log"
-msgstr ""
+msgstr "Aggiungi registro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Add Query A and Query B identifiers to tooltips to help differentiate "
 "series"
 msgstr ""
+"Aggiungi gli identificatori Query A e Query B ai tooltip per aiutare a "
+"differenziare le serie"
 
 #, fuzzy
 msgid "Add Role"
@@ -1039,8 +1669,12 @@ msgstr "Formato Datetime"
 msgid "Add Semantic View"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add Tag"
-msgstr ""
+msgstr "Aggiungi etichetta"
 
 #, fuzzy
 msgid "Add User"
@@ -1057,11 +1691,19 @@ msgstr "Aggiungi Database"
 msgid "Add a new tab"
 msgstr "Query in un nuovo tab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add a new tab to create SQL Query"
-msgstr ""
+msgstr "Aggiungi una nuova scheda per creare una query SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add additional custom parameters"
-msgstr ""
+msgstr "Aggiungi parametri personalizzati aggiuntivi"
 
 #, fuzzy
 msgid "Add alert"
@@ -1081,54 +1723,104 @@ msgstr "Azione"
 msgid "Add annotation layer"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add another notification method"
-msgstr ""
+msgstr "Aggiungi un altro metodo di notifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr ""
+"Aggiungi colonne calcolate al set di dati nel modale \"Modifica sorgente "
+"dati\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
 msgstr ""
+"Aggiungi colonne temporali calcolate al set di dati nel modale \"Modifica"
+" sorgente dati\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fr,
+# ja, lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add certification details for this dashboard"
-msgstr ""
+msgstr "Aggiungi i dettagli di certificazione per questo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Add color for positive/negative change"
-msgstr ""
+msgstr "Aggiungi colore per variazione positiva/negativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "Aggiungi colori alle barre delle celle per +/- per tutte le colonne"
 
 #, fuzzy
 msgid "Add cross-filter"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add custom scoping"
-msgstr ""
+msgstr "Aggiungi ambito personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add dataset columns here to group the pivot table columns."
 msgstr ""
+"Aggiungi qui le colonne del set di dati per raggruppare le colonne della "
+"tabella pivot."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add delivery method"
-msgstr ""
+msgstr "Aggiungi metodo di consegna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add description of your tag"
-msgstr ""
+msgstr "Aggiungi la descrizione del tuo tag"
 
 #, fuzzy
 msgid "Add display control"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add divider"
-msgstr ""
+msgstr "Aggiungi separatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add extra connection information."
-msgstr ""
+msgstr "Aggiungi informazioni di connessione aggiuntive."
 
 #, fuzzy
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Add filter clauses to control the filter's source query,\n"
 "                    though only in the context of the autocomplete i.e., "
@@ -1140,6 +1832,16 @@ msgid ""
 "                    of the underlying data or limit the available values "
 "displayed in the filter."
 msgstr ""
+"Aggiungi clausole di filtro per controllare la query sorgente del filtro,"
+"\n"
+"                    ma solo nel contesto del completamento automatico, "
+"ovvero queste condizioni\n"
+"                    non influiscono sul modo in cui il filtro viene "
+"applicato al dashboard. Ciò è utile\n"
+"                    quando si desidera migliorare le prestazioni della "
+"query esaminando solo un sottoinsieme\n"
+"                    dei dati sottostanti o limitare i valori disponibili "
+"visualizzati nel filtro."
 
 #, fuzzy
 msgid "Add folder"
@@ -1151,14 +1853,25 @@ msgstr "Aggiungi filtro"
 msgid "Add metric"
 msgstr "Aggiungi metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "Aggiungi metriche al set di dati nel modale \"Modifica sorgente dati\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new color formatter"
-msgstr ""
+msgstr "Aggiungi nuovo formattatore di colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new formatter"
-msgstr ""
+msgstr "Aggiungi nuovo formattatore"
 
 #, fuzzy
 msgid "Add numbered column"
@@ -1176,21 +1889,38 @@ msgstr "Aggiungi filtro"
 msgid "Add report"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to preview chart"
 msgstr ""
+"Aggiungi i valori di controllo richiesti per visualizzare l'anteprima del"
+" grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to save chart"
-msgstr ""
+msgstr "Aggiungi i valori di controllo richiesti per salvare il grafico"
 
 #, fuzzy
 msgid "Add sheet"
 msgstr "Aggiungi Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add tag to entities"
-msgstr ""
+msgstr "Aggiungi tag alle entità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add the name of the chart"
-msgstr ""
+msgstr "Aggiungi il nome del grafico"
 
 #, fuzzy
 msgid "Add the name of the dashboard"
@@ -1207,13 +1937,19 @@ msgstr "Aggiungi ad una nuova dashboard"
 msgid "Add to tabs"
 msgstr "Aggiungi ad una nuova dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Added"
-msgstr ""
+msgstr "Aggiunto"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
+msgstr[0] "Aggiunta 1 nuova colonna al set di dati virtuale"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"
@@ -1224,14 +1960,26 @@ msgstr[0] "Aggiungi ad una nuova dashboard"
 msgid "Additional Parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional fields may be required"
-msgstr ""
+msgstr "Potrebbero essere necessari campi aggiuntivi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional information"
-msgstr ""
+msgstr "Informazioni aggiuntive"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Additional padding for legend."
-msgstr ""
+msgstr "Spaziatura aggiuntiva per la legenda."
 
 #, fuzzy
 msgid "Additional parameters"
@@ -1241,26 +1989,47 @@ msgstr "Parametri"
 msgid "Additional settings."
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional text to add before or after the value, e.g. unit"
-msgstr ""
+msgstr "Testo aggiuntivo da aggiungere prima o dopo il valore, ad es. unità"
 
 #, fuzzy
 msgid "Additive"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Adds color to the chart symbols based on the positive or negative change "
 "from the comparison value."
 msgstr ""
+"Aggiunge colore ai simboli del grafico in base alla variazione positiva o"
+" negativa rispetto al valore di confronto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust how this database will interact with SQL Lab."
-msgstr ""
+msgstr "Regola il modo in cui questo database interagirà con SQL Lab."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust performance settings of this database."
-msgstr ""
+msgstr "Regola le impostazioni delle prestazioni di questo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Advanced"
-msgstr ""
+msgstr "Avanzato"
 
 #, fuzzy
 msgid "Advanced Analytics"
@@ -1309,35 +2078,66 @@ msgstr "Importa dashboard"
 msgid "After"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "After making the changes, copy the query and paste in the virtual dataset"
 " SQL snippet settings."
 msgstr ""
+"Dopo aver apportato le modifiche, copia la query e incollala nelle "
+"impostazioni dello snippet SQL del set di dati virtuale."
 
 #, fuzzy
 msgid "Aggregate"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Aggregate Mean"
-msgstr ""
+msgstr "Media aggregata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Aggregate Sum"
-msgstr ""
+msgstr "Somma aggregata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function applied to the list of points in each cluster to "
 "produce the cluster label."
 msgstr ""
+"Funzione di aggregazione applicata all'elenco dei punti in ciascun "
+"cluster per produrre l'etichetta del cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function to apply when pivoting and computing the total rows "
 "and columns"
 msgstr ""
+"Funzione di aggregazione da applicare durante il pivoting e il calcolo "
+"delle righe e colonne totali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Aggregates data within the boundary of grid cells and maps the aggregated"
 " values to a dynamic color scale"
 msgstr ""
+"Aggrega i dati all'interno dei limiti delle celle della griglia e mappa i"
+" valori aggregati su una scala di colori dinamica"
 
 #, fuzzy
 msgid "Aggregation"
@@ -1355,8 +2155,12 @@ msgstr "Testa la Connessione"
 msgid "Alert"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert Triggered, In Grace Period"
-msgstr ""
+msgstr "Avviso attivato, nel periodo di tolleranza"
 
 msgid "Alert condition"
 msgstr "Testa la Connessione"
@@ -1365,84 +2169,155 @@ msgstr "Testa la Connessione"
 msgid "Alert contents"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert ended grace period."
-msgstr ""
+msgstr "L'avviso ha terminato il periodo di tolleranza."
 
 msgid "Alert failed"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert fired during grace period."
-msgstr ""
+msgstr "Avviso attivato durante il periodo di tolleranza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert found an error while executing a query."
-msgstr ""
+msgstr "L'avviso ha rilevato un errore durante l'esecuzione di una query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Alert is active"
-msgstr ""
+msgstr "L'avviso è attivo"
 
 msgid "Alert name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert on grace period"
-msgstr ""
+msgstr "Avviso nel periodo di tolleranza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned a non-number value."
-msgstr ""
+msgstr "La query dell'avviso ha restituito un valore non numerico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one column."
-msgstr ""
+msgstr "La query di avviso ha restituito più di una colonna."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one column. %(num_cols)s columns returned"
 msgstr ""
+"La query di avviso ha restituito più di una colonna. %(num_cols)s colonne"
+" restituite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one row."
-msgstr ""
+msgstr "La query di avviso ha restituito più di una riga."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one row. %(num_rows)s rows returned"
 msgstr ""
+"La query di avviso ha restituito più di una riga. %(num_rows)s righe "
+"restituite"
 
 msgid "Alert running"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert triggered, notification sent"
-msgstr ""
+msgstr "Avviso attivato, notifica inviata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert validator config error."
-msgstr ""
+msgstr "Errore di configurazione del validatore di avviso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alerts"
-msgstr ""
+msgstr "Avvisi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alerts & Reports"
-msgstr ""
+msgstr "Avvisi e Report"
 
 msgid "Alerts & reports"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Align +/-"
-msgstr ""
+msgstr "Allinea +/-"
 
 #, fuzzy
 msgid "Align +/- for all columns"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All"
-msgstr ""
+msgstr "Tutto"
 
 #, fuzzy, python-format
 msgid "All %s hidden columns"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All Text"
-msgstr ""
+msgstr "Tutto il testo"
 
 msgid "All charts"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All charts/global scoping"
-msgstr ""
+msgstr "Tutti i grafici/ambito globale"
 
 #, fuzzy
 msgid "All dimensions"
@@ -1451,8 +2326,12 @@ msgstr "descrizione"
 msgid "All filters"
 msgstr "Filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "All panels"
-msgstr ""
+msgstr "Tutti i pannelli"
 
 #, fuzzy
 msgid "All records"
@@ -1464,77 +2343,159 @@ msgstr "Permetti CREATE TABLE AS"
 msgid "Allow CREATE VIEW AS"
 msgstr "Permetti CREATE TABLE AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow DDL and DML"
-msgstr ""
+msgstr "Consenti DDL e DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow changing catalogs"
-msgstr ""
+msgstr "Consenti la modifica dei cataloghi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow column names to be changed to case insensitive format, if supported"
 " (e.g. Oracle, Snowflake)."
 msgstr ""
+"Consenti la modifica dei nomi delle colonne in formato senza distinzione "
+"tra maiuscole e minuscole, se supportato (ad es. Oracle, Snowflake)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow columns to be rearranged"
-msgstr ""
+msgstr "Consenti il riordinamento delle colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new tables based on queries"
-msgstr ""
+msgstr "Consenti la creazione di nuove tabelle basate su query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow creation of new values"
-msgstr ""
+msgstr "Consenti la creazione di nuovi valori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new views based on queries"
-msgstr ""
+msgstr "Consenti la creazione di nuove viste basate su query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow data manipulation language"
-msgstr ""
+msgstr "Consenti il linguaggio di manipolazione dei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow end user to drag-and-drop column headers to rearrange them. Note "
 "their changes won't persist for the next time they open the chart."
 msgstr ""
+"Consenti all'utente finale di trascinare le intestazioni delle colonne "
+"per riorganizzarle. Si noti che le modifiche non verranno mantenute alla "
+"prossima apertura del grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow file uploads to database"
-msgstr ""
+msgstr "Consenti il caricamento di file nel database"
 
 #, fuzzy
 msgid "Allow node selections"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Allow the execution of DDL (Data Definition Language: CREATE, DROP, "
 "TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, "
 "DELETE, etc)"
 msgstr ""
+"Consenti l'esecuzione di DDL (Linguaggio di Definizione dei Dati: CREATE,"
+" DROP, TRUNCATE, ecc.) e DML (Linguaggio di Modifica dei Dati: INSERT, "
+"UPDATE, DELETE, ecc.)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be explored"
-msgstr ""
+msgstr "Consenti l'esplorazione di questo database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be queried in SQL Lab"
-msgstr ""
+msgstr "Consenti l'interrogazione di questo database in SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Allow users to select multiple values"
-msgstr ""
+msgstr "Consenti agli utenti di selezionare più valori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allowed Domains (comma separated)"
-msgstr ""
+msgstr "Domini consentiti (separati da virgola)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alphabetical"
-msgstr ""
+msgstr "Alfabetico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Also known as a box and whisker plot, this visualization compares the "
 "distributions of a related metric across multiple groups. The box in the "
 "middle emphasizes the mean, median, and inner 2 quartiles. The whiskers "
 "around each box visualize the min, max, range, and outer 2 quartiles."
 msgstr ""
+"Noto anche come diagramma a scatola e baffi, questa visualizzazione "
+"confronta le distribuzioni di una metrica correlata in più gruppi. Il "
+"riquadro al centro evidenzia la media, la mediana e i 2 quartili interni."
+" I baffi attorno a ciascun riquadro visualizzano il minimo, il massimo, "
+"l'intervallo e i 2 quartili esterni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Altered"
-msgstr ""
+msgstr "Modificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Always filter main datetime column"
-msgstr ""
+msgstr "Filtra sempre la colonna data/ora principale"
 
 #, fuzzy
 msgid "An Error Occurred"
@@ -1544,21 +2505,41 @@ msgstr "Errore nel creare il datasource"
 msgid "An alert named \"%(name)s\" already exists"
 msgstr "Una o più metriche da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An enclosed time range (both start and end) must be specified when using "
 "a Time Comparison."
 msgstr ""
+"Quando si utilizza un Confronto Temporale, è necessario specificare un "
+"intervallo di tempo chiuso (sia inizio che fine)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An engine must be specified when passing individual parameters to a "
 "database."
 msgstr ""
+"È necessario specificare un motore quando si passano parametri "
+"individuali a un database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error has occurred"
-msgstr ""
+msgstr "Si è verificato un errore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred"
-msgstr ""
+msgstr "Si è verificato un errore"
 
 msgid "An error occurred saving dataset"
 msgstr "Errore nel creare il datasource"
@@ -1815,11 +2796,18 @@ msgstr "Errore nel creare il datasource"
 msgid "An error occurred while starring this chart"
 msgstr "Errore nel creare il datasource"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while storing your query in the backend. To avoid "
 "losing your changes, please save your query using the \"Save Query\" "
 "button."
 msgstr ""
+"Si è verificato un errore durante il salvataggio della query nel backend."
+" Per evitare di perdere le modifiche, salvare la query utilizzando il "
+"pulsante \"Salva Query\"."
 
 #, fuzzy, python-format
 msgid "An error occurred while syncing permissions for %s: %s"
@@ -1845,17 +2833,33 @@ msgstr "Errore nel creare il datasource"
 msgid "An error occurred while upserting the value."
 msgstr "Errore nel creare il datasource"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "An unexpected error occurred"
-msgstr ""
+msgstr "Si è verificato un errore imprevisto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Anchor to"
-msgstr ""
+msgstr "Ancora a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to end progress axis"
-msgstr ""
+msgstr "Angolo al quale terminare l'asse di avanzamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to start progress axis"
-msgstr ""
+msgstr "Angolo al quale iniziare l'asse di avanzamento"
 
 #, fuzzy
 msgid "Animation"
@@ -1868,18 +2872,30 @@ msgstr "Azione"
 msgid "Annotation Layer %s"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation Layers"
-msgstr ""
+msgstr "Livelli di annotazione"
 
 #, fuzzy
 msgid "Annotation Slice Configuration"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be created."
-msgstr ""
+msgstr "Impossibile creare l'annotazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be updated."
-msgstr ""
+msgstr "Impossibile aggiornare l'annotazione."
 
 msgid "Annotation layer"
 msgstr "Azione"
@@ -1894,8 +2910,12 @@ msgstr "La tua query non può essere salvata"
 msgid "Annotation layer description columns"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer has associated annotations."
-msgstr ""
+msgstr "Il livello di annotazione ha annotazioni associate."
 
 #, fuzzy
 msgid "Annotation layer interval end"
@@ -1904,15 +2924,23 @@ msgstr "La tua query non può essere salvata"
 msgid "Annotation layer name"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer not found."
-msgstr ""
+msgstr "Livello di annotazione non trovato."
 
 #, fuzzy
 msgid "Annotation layer opacity"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer parameters are invalid."
-msgstr ""
+msgstr "I parametri del livello di annotazione non sono validi."
 
 #, fuzzy
 msgid "Annotation layer stroke"
@@ -1936,18 +2964,30 @@ msgstr "La tua query non può essere salvata"
 msgid "Annotation layers"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layers are still loading."
-msgstr ""
+msgstr "I livelli di annotazione sono ancora in caricamento."
 
 #, fuzzy
 msgid "Annotation layers could not be deleted."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation not found."
-msgstr ""
+msgstr "Annotazione non trovata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation parameters are invalid."
-msgstr ""
+msgstr "I parametri dell'annotazione non sono validi."
 
 #, fuzzy
 msgid "Annotation source"
@@ -1972,39 +3012,78 @@ msgstr "Azione"
 msgid "Annotations and layers"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotations could not be deleted."
-msgstr ""
+msgstr "Le annotazioni non possono essere eliminate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ant Design Theme Editor"
-msgstr ""
+msgstr "Editor tema Ant Design"
 
 #, fuzzy
 msgid "Any"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Any additional detail to show in the certification tooltip."
-msgstr ""
+msgstr "Qualsiasi dettaglio aggiuntivo da mostrare nel tooltip di certificazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Any color palette selected here will override the colors applied to this "
 "dashboard's individual charts"
 msgstr ""
+"Qualsiasi tavolozza colori selezionata qui sovrascriverà i colori "
+"applicati ai singoli grafici di questo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Any dashboards using these themes will be automatically dissociated from "
 "them."
 msgstr ""
+"Tutti i dashboard che utilizzano questi temi verranno automaticamente "
+"dissociati da essi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Any dashboards using this theme will be automatically dissociated from it."
 msgstr ""
+"Tutti i dashboard che utilizzano questo tema verranno automaticamente "
+"dissociati da esso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
 msgstr ""
+"È possibile aggiungere qualsiasi database che consenta connessioni "
+"tramite URI SQL Alchemy. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Any databases that allow connections via SQL Alchemy URIs can be added. "
 "Learn about how to connect a database driver "
 msgstr ""
+"È possibile aggiungere qualsiasi database che consenta connessioni "
+"tramite URI SQL Alchemy. Scopri come connettere un driver del database "
 
 #, fuzzy, python-format
 msgid "Applied cross-filters (%d)"
@@ -2022,16 +3101,29 @@ msgstr "Aggiungi filtro"
 msgid "Applied filters: %s"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Applied rolling window did not return any data. Please make sure the "
 "source query satisfies the minimum periods defined in the rolling window."
 msgstr ""
+"La finestra mobile applicata non ha restituito alcun dato. Assicurati che"
+" la query di origine soddisfi i periodi minimi definiti nella finestra "
+"mobile."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"Si applica solo quando è selezionata la formattazione \"Barre nelle "
+"celle\": lo sfondo delle colonne dell'istogramma viene visualizzato se il"
+" flag \"Mostra barre nelle celle\" è abilitato."
 
 msgid "Apply"
 msgstr "Applica"
@@ -2044,19 +3136,35 @@ msgstr "Filtri"
 msgid "Apply another dashboard filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Apply conditional color formatting to metric"
-msgstr ""
+msgstr "Applica formattazione colore condizionale alla metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to metrics"
-msgstr ""
+msgstr "Applica formattazione colore condizionale alle metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to numeric columns"
-msgstr ""
+msgstr "Applica formattazione colore condizionale alle colonne numeriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Apply custom CSS to the dashboard. Use class names or element selectors "
 "to target specific components."
 msgstr ""
+"Applica CSS personalizzato al dashboard. Usa nomi di classe o selettori "
+"di elementi per individuare componenti specifici."
 
 #, fuzzy
 msgid "Apply filters"
@@ -2066,95 +3174,189 @@ msgstr "Filtri"
 msgid "Apply metrics on"
 msgstr "Metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "April"
-msgstr ""
+msgstr "Aprile"
 
 #, fuzzy
 msgid "Arc"
 msgstr "Cerca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you intend to overwrite the following values?"
-msgstr ""
+msgstr "Sei sicuro di voler sovrascrivere i seguenti valori?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to cancel?"
-msgstr ""
+msgstr "Sei sicuro di voler annullare?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete %s?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare %s?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete the selected %s?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare il/la %s selezionato/a?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected annotations?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare le annotazioni selezionate?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected charts?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i grafici selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected dashboards?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i dashboard selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected groups?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i gruppi selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected layers?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i livelli selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected roles?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i ruoli selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected rules?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare le regole selezionate?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected tags?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i tag selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected templates?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i modelli selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected themes?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare i temi selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected users?"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare gli utenti selezionati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to overwrite this dataset?"
-msgstr ""
+msgstr "Sei sicuro di voler sovrascrivere questo set di dati?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system dark theme? The application "
 "will fall back to the configuration file dark theme."
 msgstr ""
+"Sei sicuro di voler rimuovere il tema scuro di sistema? L'applicazione "
+"tornerà al tema scuro del file di configurazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system default theme? The application"
 " will fall back to the configuration file default."
 msgstr ""
+"Sei sicuro di voler rimuovere il tema predefinito di sistema? "
+"L'applicazione tornerà al valore predefinito del file di configurazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
+"Sei sicuro di voler revocare questa chiave API? Questa azione non può "
+"essere annullata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to save and apply changes?"
-msgstr ""
+msgstr "Sei sicuro di voler salvare e applicare le modifiche?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system dark theme? This will "
 "apply to all users who haven't set a personal preference."
 msgstr ""
+"Sei sicuro di voler impostare \"%s\" come tema scuro di sistema? Verrà "
+"applicato a tutti gli utenti che non hanno impostato una preferenza "
+"personale."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system default theme? This "
 "will apply to all users who haven't set a personal preference."
 msgstr ""
+"Sei sicuro di voler impostare \"%s\" come tema predefinito di sistema? "
+"Verrà applicato a tutti gli utenti che non hanno impostato una preferenza"
+" personale."
 
 #, fuzzy
 msgid "Area"
@@ -2172,73 +3374,138 @@ msgstr "Esplora grafico"
 msgid "Area chart opacity"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Area charts are similar to line charts in that they represent variables "
 "with the same scale, but area charts stack the metrics on top of each "
 "other."
 msgstr ""
+"I grafici ad area sono simili ai grafici a linee nel senso che "
+"rappresentano variabili con la stessa scala, ma i grafici ad area "
+"sovrappongono le metriche una sull'altra."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Arrow"
-msgstr ""
+msgstr "Freccia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Assign a set of parameters as"
-msgstr ""
+msgstr "Assegna un insieme di parametri come"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Assist"
-msgstr ""
+msgstr "Assistenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Asynchronous query execution"
-msgstr ""
+msgstr "Esecuzione di query asincrona"
 
 #, fuzzy
 msgid "Attribution"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "August"
-msgstr ""
+msgstr "Agosto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization Request URI"
-msgstr ""
+msgstr "URI di richiesta autorizzazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization needed"
-msgstr ""
+msgstr "Autorizzazione richiesta"
 
 #, fuzzy
 msgid "Auto"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Auto Zoom"
-msgstr ""
+msgstr "Zoom automatico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Aggiornamento automatico in pausa (impostato a %s secondi)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
 msgstr ""
+"Aggiornamento automatico in pausa - scheda inattiva (impostato a %s "
+"secondi)"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
 msgstr "Abilita il filtro di Select"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Auto-detect"
-msgstr ""
+msgstr "Rilevamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete"
-msgstr ""
+msgstr "Completamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete filters"
-msgstr ""
+msgstr "Filtri di completamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete query predicate"
-msgstr ""
+msgstr "Predicato query di completamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on available space"
 msgstr ""
+"Regola automaticamente la larghezza della colonna in base allo spazio "
+"disponibile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on content"
-msgstr ""
+msgstr "Regola automaticamente la larghezza della colonna in base al contenuto"
 
 #, fuzzy
 msgid "Automatically sync columns"
@@ -2260,8 +3527,12 @@ msgstr "Visualizza colonne"
 msgid "Autosize all columns"
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Available sorting modes:"
-msgstr ""
+msgstr "Modalità di ordinamento disponibili:"
 
 #, fuzzy
 msgid "Average"
@@ -2275,8 +3546,12 @@ msgstr "Valore del filtro"
 msgid "Awaiting filter selection"
 msgstr "Abilita il filtro di Select"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis"
-msgstr ""
+msgstr "Asse"
 
 #, fuzzy
 msgid "Axis Bounds"
@@ -2290,36 +3565,70 @@ msgstr "Formato Datetime"
 msgid "Axis Title"
 msgstr "%s - senza nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis ascending"
-msgstr ""
+msgstr "Asse crescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis descending"
-msgstr ""
+msgstr "Asse decrescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Axis title margin"
-msgstr ""
+msgstr "Margine del titolo dell'asse"
 
 #, fuzzy
 msgid "Axis title position"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "BCC recipients"
-msgstr ""
+msgstr "Destinatari in Ccn"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "BOOLEAN"
-msgstr ""
+msgstr "BOOLEANO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back"
-msgstr ""
+msgstr "Indietro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back to all"
-msgstr ""
+msgstr "Torna a tutti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Backend"
-msgstr ""
+msgstr "Backend"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Background Color"
-msgstr ""
+msgstr "Colore di sfondo"
 
 #, fuzzy
 msgid "Backward values"
@@ -2329,18 +3638,32 @@ msgstr "Valore del filtro"
 msgid "Bad formula."
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bad spatial key"
-msgstr ""
+msgstr "Chiave spaziale non valida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bar"
-msgstr ""
+msgstr "Barra"
 
 #, fuzzy
 msgid "Bar Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bar Charts are used to show metrics as a series of bars."
 msgstr ""
+"I grafici a barre vengono utilizzati per mostrare le metriche come una "
+"serie di barre."
 
 #, fuzzy
 msgid "Bar Values"
@@ -2362,18 +3685,35 @@ msgstr "Database"
 msgid "Base height"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr ""
+"Stile della mappa del livello base. Accetta un URL di stile compatibile "
+"con MapLibre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Stile della mappa del livello base. Accetta un URL di stile Mapbox "
+"(mapbox://styles/...)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
 msgstr ""
+"Stile della mappa del livello base. Vedere la documentazione di MapLibre:"
+" %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Base slope"
-msgstr ""
+msgstr "Pendenza base"
 
 #, fuzzy
 msgid "Base width"
@@ -2383,37 +3723,67 @@ msgstr "Larghezza"
 msgid "Based on a metric"
 msgstr "Seleziona una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Based on granularity, number of time periods to compare against"
-msgstr ""
+msgstr "In base alla granularità, numero di periodi di tempo con cui confrontare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Based on what should series be ordered on the chart and legend"
-msgstr ""
+msgstr "In base a cosa le serie devono essere ordinate nel grafico e nella legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Basic"
-msgstr ""
+msgstr "Di base"
 
 #, fuzzy
 msgid "Basic conditional formatting"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Basic information about the chart"
-msgstr ""
+msgstr "Informazioni di base sul grafico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Batch editing %d filters:"
-msgstr ""
+msgstr "Modifica in blocco di %d filtri:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Be careful."
-msgstr ""
+msgstr "Fare attenzione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Before"
-msgstr ""
+msgstr "Prima"
 
 msgid "Big Number"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Big Number with Time Period Comparison"
-msgstr ""
+msgstr "Numero grande con confronto periodo di tempo"
 
 msgid "Big Number with Trendline"
 msgstr "Numero Grande con Linea del Trend"
@@ -2426,9 +3796,11 @@ msgstr "Min"
 msgid "Blanks"
 msgstr "Min"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "Blocco %(block_num)s di %(block_count)s"
 
 #, fuzzy
 msgid "Border color"
@@ -2442,59 +3814,113 @@ msgstr "Larghezza"
 msgid "Bottom"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom Margin"
-msgstr ""
+msgstr "Margine inferiore"
 
 #, fuzzy
 msgid "Bottom left"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom margin, in pixels, allowing for more room for axis labels"
 msgstr ""
+"Margine inferiore, in pixel, per consentire più spazio alle etichette "
+"degli assi"
 
 #, fuzzy
 msgid "Bottom right"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom to Top"
-msgstr ""
+msgstr "Dal basso verso l'alto"
 
 #, fuzzy
 msgid "Bounds"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for numerical X axis. Not applicable for temporal or categorical "
 "axes. When left empty, the bounds are dynamically defined based on the "
 "min/max of the data. Note that this feature will only expand the axis "
 "range. It won't narrow the data's extent."
 msgstr ""
+"Limiti per l'asse X numerico. Non applicabile per assi temporali o "
+"categorici. Quando viene lasciato vuoto, i limiti vengono definiti "
+"dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
+"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the X-axis. Selected time merges with min/max date of the "
 "data. When left empty, bounds dynamically defined based on the min/max of"
 " the data."
 msgstr ""
+"Limiti per l'asse X. Il tempo selezionato si unisce alla data min/max dei"
+" dati. Quando viene lasciato vuoto, i limiti vengono definiti "
+"dinamicamente in base al minimo/massimo dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Bounds for the Y-axis. When left empty, the bounds are dynamically "
 "defined based on the min/max of the data. Note that this feature will "
 "only expand the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limiti per l'asse Y. Quando viene lasciato vuoto, i limiti vengono "
+"definiti dinamicamente in base al minimo/massimo dei dati. Si noti che "
+"questa funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Bounds for the axis. When left empty, the bounds are dynamically defined "
 "based on the min/max of the data. Note that this feature will only expand"
 " the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limiti per l'asse. Quando viene lasciato vuoto, i limiti vengono definiti"
+" dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
+"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the primary Y-axis. When left empty, the bounds are "
 "dynamically defined based on the min/max of the data. Note that this "
 "feature will only expand the axis range. It won't narrow the data's "
 "extent."
 msgstr ""
+"Limiti per l'asse Y primario. Quando viene lasciato vuoto, i limiti "
+"vengono definiti dinamicamente in base al minimo/massimo dei dati. Si "
+"noti che questa funzionalità espanderà solo l'intervallo dell'asse. Non "
+"ridurrà l'estensione dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the secondary Y-axis. Only works when Independent Y-axis\n"
 "                bounds are enabled. When left empty, the bounds are "
@@ -2503,6 +3929,13 @@ msgid ""
 "will only expand\n"
 "                the axis range. It won't narrow the data's extent."
 msgstr ""
+"Limiti per l'asse Y secondario. Funziona solo quando i limiti dell'asse Y"
+" indipendente\n"
+"                sono abilitati. Quando viene lasciato vuoto, i limiti "
+"vengono definiti dinamicamente\n"
+"                in base al minimo/massimo dei dati. Si noti che questa "
+"funzionalità espanderà solo\n"
+"                l'intervallo dell'asse. Non ridurrà l'estensione dei dati."
 
 msgid "Box Plot"
 msgstr "Box Plot"
@@ -2515,11 +3948,17 @@ msgstr "Creato il"
 msgid "Breakpoint Metric"
 msgstr "Seleziona una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
 "      This can help viewers understand how each category affects the "
 "overall value."
 msgstr ""
+"Suddivide le serie per la categoria specificata in questo controllo.\n"
+"      Questo può aiutare gli utenti a capire come ogni categoria "
+"influenza il valore complessivo."
 
 msgid "Bubble Chart"
 msgstr "Grafico a Bolle"
@@ -2528,8 +3967,12 @@ msgstr "Grafico a Bolle"
 msgid "Bubble Chart (legacy)"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bubble Color"
-msgstr ""
+msgstr "Colore della bolla"
 
 #, fuzzy
 msgid "Bubble Opacity"
@@ -2546,46 +3989,91 @@ msgstr "Grandezza della bolla"
 msgid "Bubble size number format"
 msgstr "Seleziona una metrica per l'asse destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bucket break points"
-msgstr ""
+msgstr "Punti di interruzione degli intervalli"
 
 msgid "Bulk select"
 msgstr "Seleziona %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bulk tag"
-msgstr ""
+msgstr "Etichettatura in blocco"
 
 msgid "Bullet Chart"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Business"
-msgstr ""
+msgstr "Business"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "By default, each filter loads at most 1000 choices at the initial page "
 "load. Check this box if you have more than 1000 filter values and want to"
 " enable dynamically searching that loads filter values as users type (may"
 " add stress to your database)."
 msgstr ""
+"Per impostazione predefinita, ogni filtro carica al massimo 1000 opzioni "
+"al caricamento iniziale della pagina. Seleziona questa casella se hai più"
+" di 1000 valori di filtro e vuoi abilitare la ricerca dinamica che carica"
+" i valori del filtro mentre gli utenti digitano (potrebbe aggiungere "
+"carico al tuo database)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use column names as sorting key"
-msgstr ""
+msgstr "Per chiave: usa i nomi delle colonne come chiave di ordinamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use row names as sorting key"
-msgstr ""
+msgstr "Per chiave: usa i nomi delle righe come chiave di ordinamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By value: use metric values as sorting key"
-msgstr ""
+msgstr "Per valore: usa i valori delle metriche come chiave di ordinamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CANCEL"
-msgstr ""
+msgstr "ANNULLA"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CC recipients"
-msgstr ""
+msgstr "Destinatari in CC"
 
 #, fuzzy
 msgid "COPY QUERY"
 msgstr "Query vuota?"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Copia query"
 
 msgid "CREATE TABLE AS"
 msgstr "Permetti CREATE TABLE AS"
@@ -2593,8 +4081,12 @@ msgstr "Permetti CREATE TABLE AS"
 msgid "CREATE VIEW AS"
 msgstr "Permetti CREATE TABLE AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CREATE VIEW statement"
-msgstr ""
+msgstr "Istruzione CREATE VIEW"
 
 #, fuzzy
 msgid "CRON Schedule"
@@ -2606,20 +4098,34 @@ msgstr "Espressione"
 msgid "CSS"
 msgstr "CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS Styles"
-msgstr ""
+msgstr "Stili CSS"
 
 msgid "CSS Templates"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS applied to the chart"
-msgstr ""
+msgstr "CSS applicato al grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"Gli stili CSS potrebbero essere rimossi dalla sanitizzazione HTML lato "
+"server. Se gli stili non vengono applicati, chiedere all'amministratore "
+"di Superset di modificare la configurazione della sanitizzazione HTML."
 
 msgid "CSS template"
 msgstr "Template CSS"
@@ -2638,44 +4144,87 @@ msgstr "La query non può essere caricata"
 msgid "CSV Export"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CSV file downloaded successfully"
-msgstr ""
+msgstr "File CSV scaricato con successo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CSV upload"
-msgstr ""
+msgstr "Caricamento CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CTAS & CVAS SCHEMA"
-msgstr ""
+msgstr "SCHEMA CTAS E CVAS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CTAS (create table as select) can only be run with a query where the last"
 " statement is a SELECT. Please make sure your query has a SELECT as its "
 "last statement. Then, try running your query again."
 msgstr ""
+"CTAS (create table as select) può essere eseguito solo con una query in "
+"cui l'ultima istruzione è un SELECT. Assicurarsi che la query abbia un "
+"SELECT come ultima istruzione. Quindi, provare a eseguire nuovamente la "
+"query."
 
 #, fuzzy
 msgid "CUSTOM"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CVAS (create view as select) can only be run with a query with a single "
 "SELECT statement. Please make sure your query has only a SELECT "
 "statement. Then, try running your query again."
 msgstr ""
+"CVAS (create view as select) può essere eseguito solo con una query con "
+"una singola istruzione SELECT. Assicurarsi che la query contenga solo "
+"un'istruzione SELECT. Quindi, provare a eseguire nuovamente la query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query has more than one statement."
-msgstr ""
+msgstr "La query CVAS (create view as select) contiene più di un'istruzione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query is not a SELECT statement."
-msgstr ""
+msgstr "La query CVAS (create view as select) non è un'istruzione SELECT."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Cache Timeout (seconds)"
-msgstr ""
+msgstr "Timeout cache (secondi)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
+"Memorizza i dati nella cache separatamente per ogni utente in base ai "
+"ruoli e alle autorizzazioni di accesso ai dati. Se disabilitato, verrà "
+"utilizzata un'unica cache per tutti gli utenti."
 
 msgid "Cache timeout"
 msgstr "Cache Timeout"
@@ -2684,28 +4233,54 @@ msgstr "Cache Timeout"
 msgid "Cache timeout must be a number"
 msgstr "Cache Timeout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cached"
-msgstr ""
+msgstr "In cache"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cached %s"
-msgstr ""
+msgstr "In cache %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Cached value not found"
-msgstr ""
+msgstr "Valore in cache non trovato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate contribution per series or row"
-msgstr ""
+msgstr "Calcola il contributo per serie o riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from first step"
-msgstr ""
+msgstr "Calcola dal primo passaggio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from previous step"
-msgstr ""
+msgstr "Calcola dal passaggio precedente"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Calculated column [%s] requires an expression"
-msgstr ""
+msgstr "La colonna calcolata [%s] richiede un'espressione"
 
 msgid "Calculated columns"
 msgstr "Visualizza colonne"
@@ -2716,11 +4291,19 @@ msgstr "Seleziona un tipo di visualizzazione"
 msgid "Calendar Heatmap"
 msgstr "Calendario di Intensità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Can not move top level tab into nested tabs"
-msgstr ""
+msgstr "Impossibile spostare la scheda di primo livello in schede nidificate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Can select multiple values"
-msgstr ""
+msgstr "È possibile selezionare più valori"
 
 msgid "Cancel"
 msgstr "Annulla"
@@ -2729,47 +4312,90 @@ msgstr "Annulla"
 msgid "Cancel Task"
 msgstr "Annulla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cancel query on window unload event"
-msgstr ""
+msgstr "Annulla query all'evento di scaricamento della finestra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "Annullamento non disponibile per mancanza del gestore di interruzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot access the query"
-msgstr ""
+msgstr "Impossibile accedere alla query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot delete a database that has datasets attached"
-msgstr ""
+msgstr "Impossibile eliminare un database a cui sono collegati dei dataset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete system themes"
-msgstr ""
+msgstr "Impossibile eliminare i temi di sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
 msgstr ""
+"Impossibile eliminare il tema impostato come tema predefinito o scuro del"
+" sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
 msgstr ""
+"Impossibile eliminare il tema impostato come tema predefinito o scuro del"
+" sistema."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Cannot find the table (%s) metadata."
-msgstr ""
+msgstr "Impossibile trovare i metadati della tabella (%s)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cannot have multiple credentials for the SSH Tunnel"
-msgstr ""
+msgstr "Non è possibile avere più credenziali per il tunnel SSH"
 
 #, fuzzy
 msgid "Cannot load filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot modify system themes."
-msgstr ""
+msgstr "Impossibile modificare i temi di sistema."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "Impossibile annidare cartelle nelle cartelle predefinite"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
-msgstr ""
+msgstr "Impossibile analizzare la stringa di tempo [%(human_readable)s]"
 
 #, fuzzy
 msgid "Captcha"
@@ -2779,80 +4405,145 @@ msgstr "Esplora grafico"
 msgid "Cartodiagram"
 msgstr "Login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Catalog"
-msgstr ""
+msgstr "Catalogo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categorical"
-msgstr ""
+msgstr "Categorico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Categorical Color"
-msgstr ""
+msgstr "Colore categorico"
 
 #, fuzzy
 msgid "Categorical palette"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categories to group by on the x-axis."
-msgstr ""
+msgstr "Categorie per raggruppare sull'asse x."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category"
-msgstr ""
+msgstr "Categoria"
 
 #, fuzzy
 msgid "Category Name"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Percentage"
-msgstr ""
+msgstr "Categoria e percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Value"
-msgstr ""
+msgstr "Categoria e valore"
 
 #, fuzzy
 msgid "Category name"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category of target nodes"
-msgstr ""
+msgstr "Categoria dei nodi di destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category, Value and Percentage"
-msgstr ""
+msgstr "Categoria, valore e percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Padding"
-msgstr ""
+msgstr "Spaziatura interna cella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Radius"
-msgstr ""
+msgstr "Raggio cella"
 
 #, fuzzy
 msgid "Cell Size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell content"
-msgstr ""
+msgstr "Contenuto cella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "Layout e stile delle celle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cell limit"
-msgstr ""
+msgstr "Limite di cella"
 
 #, fuzzy
 msgid "Cell title template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Centroid (Longitude and Latitude): "
-msgstr ""
+msgstr "Centroide (Longitudine e Latitudine): "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certification"
-msgstr ""
+msgstr "Certificazione"
 
 #, fuzzy
 msgid "Certification and additional settings"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certification details"
-msgstr ""
+msgstr "Dettagli certificazione"
 
 #, fuzzy
 msgid "Certified"
@@ -2865,15 +4556,26 @@ msgstr "Modificato"
 msgid "Certified by"
 msgstr "Modificato"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Certified by %s"
-msgstr ""
+msgstr "Certificato da %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of columns."
-msgstr ""
+msgstr "Cambia l'ordine delle colonne."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of rows."
-msgstr ""
+msgstr "Cambia l'ordine delle righe."
 
 #, fuzzy
 msgid "Changed by"
@@ -2883,68 +4585,142 @@ msgstr "Modificato da"
 msgid "Changed on"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changes saved."
-msgstr ""
+msgstr "Modifiche salvate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changes the sort value of the items in the legend only"
-msgstr ""
+msgstr "Modifica il valore di ordinamento solo per gli elementi nella legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changing one or more of these dashboards is forbidden"
-msgstr ""
+msgstr "La modifica di uno o più di questi dashboard è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing the dataset may break the chart if the chart relies on columns "
 "or metadata that does not exist in the target dataset"
 msgstr ""
+"La modifica del dataset potrebbe danneggiare il grafico se il grafico "
+"dipende da colonne o metadati che non esistono nel dataset di "
+"destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing these settings will affect all charts using this dataset, "
 "including charts owned by other people."
 msgstr ""
+"La modifica di queste impostazioni influenzerà tutti i grafici che "
+"utilizzano questo dataset, inclusi i grafici di proprietà di altre "
+"persone."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this Dashboard is forbidden"
-msgstr ""
+msgstr "La modifica di questo Dashboard è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this chart is forbidden"
-msgstr ""
+msgstr "La modifica di questo grafico è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this control takes effect instantly"
-msgstr ""
+msgstr "La modifica di questo controllo ha effetto immediato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this dataset is forbidden"
-msgstr ""
+msgstr "La modifica di questo dataset è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Changing this dataset is forbidden."
-msgstr ""
+msgstr "La modifica di questo dataset è vietata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Changing this datasource is forbidden"
-msgstr ""
+msgstr "La modifica di questa sorgente dati è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this report is forbidden"
-msgstr ""
+msgstr "La modifica di questo report è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic layer is forbidden"
-msgstr ""
+msgstr "La modifica di questo livello semantico è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic view is forbidden"
-msgstr ""
+msgstr "La modifica di questa vista semantica è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this task is forbidden"
-msgstr ""
+msgstr "La modifica di questo task è vietata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Character to interpret as decimal point"
-msgstr ""
+msgstr "Carattere da interpretare come punto decimale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart"
-msgstr ""
+msgstr "Grafico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "Il grafico %(chart_id)s non è nel dashboard %(dashboard_id)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Chart %(id)s not found"
-msgstr ""
+msgstr "Grafico %(id)s non trovato"
 
 #, fuzzy, python-format
 msgid "Chart Data: %s"
@@ -2978,17 +4754,23 @@ msgstr "Grafici"
 msgid "Chart Type"
 msgstr "Grafici"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] has been overwritten"
-msgstr ""
+msgstr "Il grafico [%s] è stato sovrascritto"
 
 #, fuzzy, python-format
 msgid "Chart [%s] has been saved"
 msgstr "La tua query non può essere salvata"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] was added to dashboard [%s]"
-msgstr ""
+msgstr "Il grafico [%s] è stato aggiunto al dashboard [%s]"
 
 msgid "Chart cache timeout"
 msgstr "Cache Timeout"
@@ -3002,18 +4784,33 @@ msgstr "La tua query non può essere salvata"
 msgid "Chart could not be updated."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
 msgstr ""
+"Personalizzazione del grafico per controllare la visibilità dei livelli "
+"deck.gl"
 
 #, fuzzy
 msgid "Chart customization value is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart does not exist"
-msgstr ""
+msgstr "Il grafico non esiste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart has no query context saved. Please save the chart again."
 msgstr ""
+"Il grafico non ha un contesto di query salvato. Salva nuovamente il "
+"grafico."
 
 #, fuzzy
 msgid "Chart height"
@@ -3042,8 +4839,12 @@ msgstr "Azione"
 msgid "Chart owners"
 msgstr "Opzioni del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart parameters are invalid."
-msgstr ""
+msgstr "I parametri del grafico non sono validi."
 
 #, fuzzy
 msgid "Chart properties"
@@ -3065,8 +4866,12 @@ msgstr "Grafici"
 msgid "Chart type"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart type requires a dataset"
-msgstr ""
+msgstr "Il tipo di grafico richiede un dataset"
 
 #, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
@@ -3086,13 +4891,23 @@ msgstr "La query non può essere caricata"
 msgid "Charts per row"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Check for sorting ascending"
-msgstr ""
+msgstr "Seleziona per ordinamento crescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Check if the Rose Chart should use segment area instead of segment radius"
 " for proportioning"
 msgstr ""
+"Verifica se il grafico a rosa deve utilizzare l'area del segmento invece "
+"del raggio del segmento per le proporzioni"
 
 msgid "Check out this chart in dashboard:"
 msgstr "Rimuovi il grafico dalla dashboard"
@@ -3104,17 +4919,33 @@ msgstr "Guarda questa slice: %s"
 msgid "Check out this dashboard: "
 msgstr "Guarda questa slice: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Check to force date partitions to have the same height"
-msgstr ""
+msgstr "Seleziona per forzare le partizioni di date ad avere la stessa altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Child label position"
-msgstr ""
+msgstr "Posizione dell'etichetta figlia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choice of [Label] must be present in [Group By]"
-msgstr ""
+msgstr "La scelta di [Etichetta] deve essere presente in [Raggruppa per]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choice of [Point Radius] must be present in [Group By]"
-msgstr ""
+msgstr "La scelta di [Raggio punto] deve essere presente in [Raggruppa per]"
 
 #, fuzzy, python-format
 msgid "Choose a %s"
@@ -3158,105 +4989,199 @@ msgstr "Una o più metriche da mostrare"
 msgid "Choose chart type"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose columns to be parsed as dates"
-msgstr ""
+msgstr "Scegli le colonne da analizzare come date"
 
 #, fuzzy
 msgid "Choose columns to read"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
 msgstr ""
+"Scegli tra i filtri del dashboard esistenti e seleziona un valore per "
+"affinare i risultati del report."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose how many X-Axis labels to show"
-msgstr ""
+msgstr "Scegli quante etichette dell'asse X mostrare"
 
 #, fuzzy
 msgid "Choose index column"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
+"Scegli i livelli da nascondere da tutti i grafici deck.gl a più livelli "
+"in questo dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose notification method and recipients."
-msgstr ""
+msgstr "Scegli il metodo di notifica e i destinatari."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Choose numbers between %(min)s and %(max)s"
-msgstr ""
+msgstr "Scegli numeri tra %(min)s e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose one of the available databases from the panel on the left."
-msgstr ""
+msgstr "Scegli uno dei database disponibili dal pannello a sinistra."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose one of the available databases on the left panel."
-msgstr ""
+msgstr "Scegli uno dei database disponibili nel pannello a sinistra."
 
 #, fuzzy
 msgid "Choose sheet name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose the annotation layer type"
-msgstr ""
+msgstr "Scegli il tipo di livello di annotazione"
 
 #, fuzzy
 msgid "Choose the format for legend values"
 msgstr "Seleziona una metrica per l'asse destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose the position of the legend"
-msgstr ""
+msgstr "Scegli la posizione della legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose the source of your annotations"
-msgstr ""
+msgstr "Scegli la fonte delle tue annotazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose values that should be treated as null. Warning: Hive database "
 "supports only a single value"
 msgstr ""
+"Scegli i valori che devono essere trattati come null. Avviso: il database"
+" Hive supporta solo un singolo valore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Choose whether a country should be shaded by the metric, or assigned a "
 "color based on a categorical color palette"
 msgstr ""
+"Scegli se un paese deve essere ombreggiato in base alla metrica, o se gli"
+" deve essere assegnato un colore basato su una palette di colori "
+"categorica"
 
 #, fuzzy
 msgid "Choose..."
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chord Diagram"
-msgstr ""
+msgstr "Diagramma a corde"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chosen non-numeric column"
-msgstr ""
+msgstr "Colonna non numerica selezionata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Circle"
-msgstr ""
+msgstr "Cerchio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Arrow"
-msgstr ""
+msgstr "Cerchio -> Freccia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Circle"
-msgstr ""
+msgstr "Cerchio -> Cerchio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle radar shape"
-msgstr ""
+msgstr "Forma radar circolare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circular"
-msgstr ""
+msgstr "Circolare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
+"Vista classica di un set di dati a righe e colonne come in un foglio di "
+"calcolo. Usa le tabelle per mostrare una vista dei dati sottostanti o per"
+" visualizzare metriche aggregate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clause"
-msgstr ""
+msgstr "Clausola"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear"
-msgstr ""
+msgstr "Cancella"
 
 #, fuzzy, python-format
 msgid "Clear %s filter"
@@ -3266,8 +5191,12 @@ msgstr "Cerca / Filtra"
 msgid "Clear Sort"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear all"
-msgstr ""
+msgstr "Cancella tutto"
 
 #, fuzzy
 msgid "Clear all data"
@@ -3281,8 +5210,11 @@ msgstr "Cerca / Filtra"
 msgid "Clear default dark theme"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "Cancella il tema chiaro predefinito"
 
 #, fuzzy
 msgid "Clear form"
@@ -3292,68 +5224,141 @@ msgstr "Formato D3"
 msgid "Clear local theme"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear the selection to revert to the system default theme"
-msgstr ""
+msgstr "Cancella la selezione per tornare al tema predefinito del sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid ""
 "Click on \"Add or edit filters and controls\" option in Settings to "
 "create new dashboard filters"
 msgstr ""
+"Fai clic sull'opzione \"Aggiungi o modifica filtri e controlli\" nelle "
+"Impostazioni per creare nuovi filtri del dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Click on \"Create chart\" button in the control panel on the left to "
 "preview a visualization or"
 msgstr ""
+"Fai clic sul pulsante \"Crea grafico\" nel pannello di controllo a "
+"sinistra per visualizzare un'anteprima di una visualizzazione o"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to make changes."
-msgstr ""
+msgstr "Fai clic sul lucchetto per apportare modifiche."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to prevent further changes."
-msgstr ""
+msgstr "Fai clic sul lucchetto per impedire ulteriori modifiche."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that allows you to input "
 "the SQLAlchemy URL for this database manually."
 msgstr ""
+"Fai clic su questo link per passare a un modulo alternativo che consente "
+"di inserire manualmente l'URL SQLAlchemy per questo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that exposes only the "
 "required fields needed to connect this database."
 msgstr ""
+"Fai clic su questo link per passare a un modulo alternativo che mostra "
+"solo i campi obbligatori necessari per connettere questo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to add a contour"
-msgstr ""
+msgstr "Fai clic per aggiungere un contorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Click to add new breakpoint"
-msgstr ""
+msgstr "Fai clic per aggiungere un nuovo punto di interruzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Click to add new layer"
-msgstr ""
+msgstr "Fai clic per aggiungere un nuovo livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to cancel sorting"
-msgstr ""
+msgstr "Fai clic per annullare l'ordinamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to edit"
-msgstr ""
+msgstr "Fai clic per modificare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Click to edit %s."
-msgstr ""
+msgstr "Fai clic per modificare %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Click to edit chart."
-msgstr ""
+msgstr "Fai clic per modificare il grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to edit label"
-msgstr ""
+msgstr "Fai clic per modificare l'etichetta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to favorite/unfavorite"
-msgstr ""
+msgstr "Fai clic per aggiungere/rimuovere dai preferiti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to force-refresh"
-msgstr ""
+msgstr "Fai clic per forzare l'aggiornamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to see difference"
-msgstr ""
+msgstr "Fai clic per vedere la differenza"
 
 #, fuzzy
 msgid "Click to sort ascending"
@@ -3371,125 +5376,238 @@ msgstr "Larghezza"
 msgid "Client Secret"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close"
-msgstr ""
+msgstr "Chiudi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close all other tabs"
-msgstr ""
+msgstr "Chiudi tutte le altre schede"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Close color breakpoint editor"
-msgstr ""
+msgstr "Chiudi l'editor dei punti di interruzione colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Close tab"
-msgstr ""
+msgstr "Chiudi scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cluster label aggregator"
-msgstr ""
+msgstr "Aggregatore di etichette cluster"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clustering Radius"
-msgstr ""
+msgstr "Raggio di raggruppamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Code"
-msgstr ""
+msgstr "Codice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Code Copied!"
-msgstr ""
+msgstr "Codice copiato!"
 
 #, fuzzy
 msgid "Collapse"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Collapse All"
-msgstr ""
+msgstr "Comprimi tutto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Collapse all"
-msgstr ""
+msgstr "Comprimi tutto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse data panel"
-msgstr ""
+msgstr "Comprimi pannello dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse row"
-msgstr ""
+msgstr "Comprimi riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse tab content"
-msgstr ""
+msgstr "Comprimi contenuto scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color"
-msgstr ""
+msgstr "Colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Color +/-"
-msgstr ""
+msgstr "Colore +/-"
 
 #, fuzzy
 msgid "Color By X-Axis"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By Y-Axis"
-msgstr ""
+msgstr "Colore per asse Y"
 
 #, fuzzy
 msgid "Color Metric"
 msgstr "Seleziona la metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Color Scheme"
-msgstr ""
+msgstr "Schema colori"
 
 #, fuzzy
 msgid "Color Scheme Type"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Color Steps"
-msgstr ""
+msgstr "Passi colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Colora le barre per asse x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Colora le barre per asse y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Color bounds"
-msgstr ""
+msgstr "Limiti di colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color breakpoints"
-msgstr ""
+msgstr "Punti di interruzione del colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color by"
-msgstr ""
+msgstr "Colore per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
 msgstr ""
+"Il campo colore deve essere un colore esadecimale (#rrggbb) o 'rgb(r, g, "
+"b)'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color for breakpoint"
-msgstr ""
+msgstr "Colore per punto di interruzione"
 
 msgid "Color metric"
 msgstr "Seleziona la metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color of the source location"
-msgstr ""
+msgstr "Colore della posizione di origine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color of the target location"
-msgstr ""
+msgstr "Colore della posizione di destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color scheme"
-msgstr ""
+msgstr "Schema di colori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Color will be shaded based the normalized (0% to 100%) value of a given "
 "cell against the other cells in the selected range: "
 msgstr ""
+"Il colore sarà ombreggiato in base al valore normalizzato (da 0% a 100%) "
+"di una determinata cella rispetto alle altre celle nell'intervallo "
+"selezionato: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color: "
-msgstr ""
+msgstr "Colore: "
 
 msgid "Column"
 msgstr "Colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Column \"%(column)s\" is not numeric or does not exists in the query "
 "results."
 msgstr ""
+"La colonna \"%(column)s\" non è numerica o non esiste nei risultati della"
+" query."
 
 #, fuzzy
 msgid "Column Configuration"
@@ -3503,23 +5621,41 @@ msgstr "Formato Datetime"
 msgid "Column Settings"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Column containing ISO 3166-2 codes of region/province/department in your "
 "table."
 msgstr ""
+"Colonna contenente i codici ISO 3166-2 di regione/provincia/dipartimento "
+"nella tua tabella."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing latitude data"
-msgstr ""
+msgstr "Colonna contenente dati di latitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing longitude data"
-msgstr ""
+msgstr "Colonna contenente dati di longitudine"
 
 #, fuzzy
 msgid "Column data types"
 msgstr "Analytics avanzate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Column header tooltip"
-msgstr ""
+msgstr "Suggerimento dell'intestazione di colonna"
 
 #, fuzzy
 msgid "Column is required"
@@ -3529,13 +5665,19 @@ msgstr "Sorgente Dati"
 msgid "Column name"
 msgstr "Colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column name [%s] is duplicated"
-msgstr ""
+msgstr "Il nome della colonna [%s] è duplicato"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column referenced by aggregate is undefined: %(column)s"
-msgstr ""
+msgstr "La colonna referenziata dall'aggregazione non è definita: %(column)s"
 
 #, fuzzy
 msgid "Column select"
@@ -3545,10 +5687,15 @@ msgstr "Seleziona una colonna"
 msgid "Column to group by"
 msgstr "Uno o più controlli per 'Raggruppa per'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Column to use as the index of the dataframe. If None is given, Index "
 "label is used."
 msgstr ""
+"Colonna da utilizzare come indice del dataframe. Se non viene fornito "
+"alcun valore, viene utilizzata l'etichetta Index."
 
 #, fuzzy
 msgid "Column type"
@@ -3558,8 +5705,12 @@ msgstr "Colonna"
 msgid "Columnar upload"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Colonne"
 
 #, fuzzy, python-format
 msgid "Columns (%s)"
@@ -3577,28 +5728,50 @@ msgstr "Aggiungi metrica"
 msgid "Columns and metrics should be inside folders"
 msgstr "Aggiungi metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "La cartella delle colonne può contenere solo elementi di colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
-msgstr ""
+msgstr "Colonne mancanti nel set di dati: %(invalid_columns)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Columns missing in datasource: %(invalid_columns)s"
-msgstr ""
+msgstr "Colonne mancanti nell'origine dati: %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "Le colonne dovrebbero essere all'interno di cartelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns subtotal position"
-msgstr ""
+msgstr "Posizione del subtotale delle colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to be parsed as dates"
-msgstr ""
+msgstr "Colonne da analizzare come date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Columns to calculate distribution across."
-msgstr ""
+msgstr "Colonne su cui calcolare la distribuzione."
 
 #, fuzzy
 msgid "Columns to display"
@@ -3608,66 +5781,126 @@ msgstr "Seleziona una metrica da visualizzare"
 msgid "Columns to group by"
 msgstr "Uno o più controlli per 'Raggruppa per'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the columns"
-msgstr ""
+msgstr "Colonne per raggruppare sulle colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the rows"
-msgstr ""
+msgstr "Colonne per raggruppare sulle righe"
 
 #, fuzzy
 msgid "Columns to read"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to show in the tooltip."
-msgstr ""
+msgstr "Colonne da mostrare nel suggerimento."
 
 #, fuzzy
 msgid "Combine metrics"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated color picks for the intervals, e.g. 1,2,4. Integers "
 "denote colors from the chosen color scheme and are 1-indexed. Length must"
 " be matching that of interval bounds."
 msgstr ""
+"Selezioni di colore separate da virgola per gli intervalli, ad es. 1,2,4."
+" I numeri interi indicano i colori dello schema di colori scelto e sono "
+"indicizzati a partire da 1. La lunghezza deve corrispondere a quella dei "
+"limiti degli intervalli."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and "
 "4-5. Last number should match the value provided for MAX."
 msgstr ""
+"Limiti degli intervalli separati da virgola, ad es. 2,4,5 per gli "
+"intervalli 0-2, 2-4 e 4-5. L'ultimo numero deve corrispondere al valore "
+"fornito per MAX."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparator option"
-msgstr ""
+msgstr "Opzione di confronto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compare multiple time series charts (as sparklines) and related metrics "
 "quickly."
 msgstr ""
+"Confronta rapidamente più grafici di serie temporali (come sparkline) e "
+"metriche correlate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Compare results with other time periods."
-msgstr ""
+msgstr "Confronta i risultati con altri periodi di tempo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Compare the same summarized metric across multiple groups."
-msgstr ""
+msgstr "Confronta la stessa metrica riassunta tra più gruppi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compares how a metric changes over time between different groups. Each "
 "group is mapped to a row and change over time is visualized bar lengths "
 "and color."
 msgstr ""
+"Confronta come una metrica cambia nel tempo tra diversi gruppi. Ogni "
+"gruppo è mappato su una riga e il cambiamento nel tempo è visualizzato "
+"tramite lunghezze delle barre e colore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
 msgstr ""
+"Confronta le metriche tra diversi periodi di tempo. Visualizza i dati di "
+"serie temporali su più periodi (come settimane o mesi) per mostrare "
+"tendenze e modelli periodo su periodo."
 
 #, fuzzy
 msgid "Comparison"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparison Period Lag"
-msgstr ""
+msgstr "Ritardo del periodo di confronto"
 
 #, fuzzy
 msgid "Comparison font size"
@@ -3677,11 +5910,19 @@ msgstr "Colonna del Tempo"
 msgid "Comparison suffix"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Compose multiple layers together to form complex visuals."
-msgstr ""
+msgstr "Componi più livelli insieme per formare visualizzazioni complesse."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Compute the contribution to the total"
-msgstr ""
+msgstr "Calcola il contributo al totale"
 
 #, fuzzy
 msgid "Condition"
@@ -3691,60 +5932,123 @@ msgstr "Testa la Connessione"
 msgid "Conditional Formatting"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Conditional formatting"
-msgstr ""
+msgstr "Formattazione condizionale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Confidence interval"
-msgstr ""
+msgstr "Intervallo di confidenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confidence interval must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "L'intervallo di confidenza deve essere compreso tra 0 e 1 (esclusi)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Configuration"
-msgstr ""
+msgstr "Configurazione"
 
 #, fuzzy, python-format
 msgid "Configure %s"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Configure Advanced Time Range "
-msgstr ""
+msgstr "Configura intervallo di tempo avanzato "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure Time Range: Current..."
-msgstr ""
+msgstr "Configura intervallo di tempo: Corrente..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Last..."
-msgstr ""
+msgstr "Configura intervallo di tempo: Ultimo..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Previous..."
-msgstr ""
+msgstr "Configura intervallo di tempo: Precedente..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure automatic dashboard refresh"
-msgstr ""
+msgstr "Configura il refresh automatico del pannello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure caching and performance settings"
-msgstr ""
+msgstr "Configura le impostazioni di cache e prestazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure custom time range"
-msgstr ""
+msgstr "Configura intervallo di tempo personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure dashboard appearance, colors, and custom CSS"
-msgstr ""
+msgstr "Configura aspetto, colori e CSS personalizzato del pannello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure filter scopes"
-msgstr ""
+msgstr "Configura gli ambiti dei filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure the basics of your Annotation Layer."
-msgstr ""
+msgstr "Configura le impostazioni di base del tuo Livello di Annotazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure the chart size for each zoom level"
-msgstr ""
+msgstr "Configura le dimensioni del grafico per ogni livello di zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure this dashboard to embed it into an external web application."
-msgstr ""
+msgstr "Configura questo pannello per incorporarlo in un'applicazione web esterna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure your how you overlay is displayed here."
-msgstr ""
+msgstr "Configura qui come viene visualizzato il tuo overlay."
 
 #, fuzzy
 msgid "Confirm"
@@ -3762,21 +6066,36 @@ msgstr "Sovrascrivi la slice %s"
 msgid "Confirm password"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confirm save"
-msgstr ""
+msgstr "Conferma salvataggio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm the user's password"
-msgstr ""
+msgstr "Conferma la password dell'utente"
 
 #, fuzzy
 msgid "Connect"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Connect Google Sheet"
-msgstr ""
+msgstr "Connetti Google Sheet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect Google Sheets as tables to this database"
-msgstr ""
+msgstr "Connetti Google Sheets come tabelle a questo database"
 
 #, fuzzy
 msgid "Connect a database"
@@ -3786,11 +6105,19 @@ msgstr "Database"
 msgid "Connect database"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database using the dynamic form instead"
-msgstr ""
+msgstr "Connetti questo database utilizzando il modulo dinamico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database with a SQLAlchemy URI string instead"
-msgstr ""
+msgstr "Connetti questo database con una stringa URI SQLAlchemy"
 
 #, fuzzy
 msgid "Connect to engine"
@@ -3799,19 +6126,28 @@ msgstr "Testa la Connessione"
 msgid "Connection"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Connection failed, please check your connection settings"
-msgstr ""
+msgstr "Connessione non riuscita, controlla le impostazioni di connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Connection failed, please check your connection settings."
-msgstr ""
+msgstr "Connessione non riuscita, controlla le impostazioni di connessione."
 
 #, fuzzy
 msgid "Contains"
 msgstr "Colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Contiene testo (ILIKE %x%)"
 
 #, fuzzy
 msgid "Content format"
@@ -3825,50 +6161,87 @@ msgstr "Tipo"
 msgid "Continue"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Continuous"
-msgstr ""
+msgstr "Continuo"
 
 #, fuzzy
 msgid "Contours"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Contribution"
-msgstr ""
+msgstr "Contributo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Contribution Mode"
-msgstr ""
+msgstr "Modalità contributo"
 
 #, fuzzy
 msgid "Control"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Control labeled "
-msgstr ""
+msgstr "Controllo con etichetta "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Controls labeled "
-msgstr ""
+msgstr "Controlli con etichetta "
 
 #, fuzzy
 msgid "Copied to clipboard!"
 msgstr "copia URL in appunti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Copied!"
-msgstr ""
+msgstr "Copiato!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy"
-msgstr ""
+msgstr "Copia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy SELECT statement"
-msgstr ""
+msgstr "Copia istruzione SELECT"
 
 msgid "Copy SELECT statement to the clipboard"
 msgstr "copia URL in appunti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy URL"
-msgstr ""
+msgstr "Copia URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy and Paste JSON credentials"
-msgstr ""
+msgstr "Copia e incolla le credenziali JSON"
 
 #, fuzzy
 msgid "Copy code to clipboard"
@@ -3882,8 +6255,12 @@ msgstr "Colonna"
 msgid "Copy of %s"
 msgstr "Copia di %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy partition query to clipboard"
-msgstr ""
+msgstr "Copia la query di partizione negli appunti"
 
 #, fuzzy
 msgid "Copy permalink to clipboard"
@@ -3892,50 +6269,87 @@ msgstr "copia URL in appunti"
 msgid "Copy query link to your clipboard"
 msgstr "copia URL in appunti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the current data"
-msgstr ""
+msgstr "Copia i dati correnti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the identifier of the account you are trying to connect to."
-msgstr ""
+msgstr "Copia l'identificatore dell'account a cui stai cercando di connetterti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Copy the name of the HTTP Path of your cluster."
-msgstr ""
+msgstr "Copia il nome del percorso HTTP del tuo cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the name of the database you are trying to connect to."
-msgstr ""
+msgstr "Copia il nome del database a cui stai cercando di connetterti."
 
 #, fuzzy
 msgid "Copy to Clipboard"
 msgstr "copia URL in appunti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Copia negli appunti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy with Headers"
-msgstr ""
+msgstr "Copia con intestazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Corner Radius"
-msgstr ""
+msgstr "Raggio degli angoli"
 
 #, fuzzy
 msgid "Correlation"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cost estimate"
-msgstr ""
+msgstr "Stima del costo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Could not connect to database: \"%(database)s\""
-msgstr ""
+msgstr "Impossibile connettersi al database: \"%(database)s\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not determine datasource type"
-msgstr ""
+msgstr "Impossibile determinare il tipo di fonte dati"
 
 msgid "Could not fetch all saved charts"
 msgstr "Non posso connettermi al server"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not find viz object"
-msgstr ""
+msgstr "Impossibile trovare l'oggetto viz"
 
 msgid "Could not load database driver"
 msgstr "Non posso connettermi al server"
@@ -3944,12 +6358,18 @@ msgstr "Non posso connettermi al server"
 msgid "Could not load database driver for: %(engine)s"
 msgstr "Non posso connettermi al server"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Could not resolve hostname: \"%(host)s\"."
-msgstr ""
+msgstr "Impossibile risolvere il nome host: \"%(host)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Could not validate the user in the current session."
-msgstr ""
+msgstr "Impossibile validare l'utente nella sessione corrente."
 
 #, fuzzy
 msgid "Count"
@@ -3959,28 +6379,48 @@ msgstr "Colonna"
 msgid "Count Unique Values"
 msgstr "Filtrabile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Columns"
-msgstr ""
+msgstr "Conteggio come frazione delle colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Rows"
-msgstr ""
+msgstr "Conteggio come frazione delle righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Total"
-msgstr ""
+msgstr "Conteggio come frazione del totale"
 
 #, fuzzy
 msgid "Country"
 msgstr "Mappa della Nazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Country Color Scheme"
-msgstr ""
+msgstr "Schema di colori del paese"
 
 #, fuzzy
 msgid "Country Column"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Country Field Type"
-msgstr ""
+msgstr "Tipo di campo paese"
 
 msgid "Country Map"
 msgstr "Mappa della Nazione"
@@ -4001,17 +6441,28 @@ msgstr "Seleziona una destinazione"
 msgid "Create a dataset"
 msgstr "Mostra database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
+"Crea un dataset per iniziare a visualizzare i tuoi dati come grafico o "
+"vai a\n"
+"          SQL Lab per interrogare i tuoi dati."
 
 #, fuzzy
 msgid "Create a new Tag"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Create a new chart"
-msgstr ""
+msgstr "Crea un nuovo grafico"
 
 #, fuzzy
 msgid "Create and explore dataset"
@@ -4032,8 +6483,12 @@ msgstr "Seleziona una destinazione"
 msgid "Create new chart"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Create or select schema..."
-msgstr ""
+msgstr "Crea o seleziona schema..."
 
 msgid "Created"
 msgstr "Creato il"
@@ -4052,11 +6507,18 @@ msgstr "Creato il"
 msgid "Created on"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Creating SSH Tunnel failed for an unknown reason"
-msgstr ""
+msgstr "La creazione del tunnel SSH è fallita per un motivo sconosciuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Creating a data source and creating a new tab"
-msgstr ""
+msgstr "Creazione di una sorgente dati e di una nuova scheda"
 
 msgid "Creator"
 msgstr "Creatore"
@@ -4069,11 +6531,20 @@ msgstr "Azione"
 msgid "Cross-filter column"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
+"Il filtro incrociato verrà applicato a tutti i grafici che utilizzano "
+"questo set di dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cross-filtering is not enabled for this dashboard."
-msgstr ""
+msgstr "Il filtraggio incrociato non è abilitato per questa dashboard."
 
 #, fuzzy
 msgid "Cross-filtering is not enabled in this dashboard"
@@ -4091,8 +6562,12 @@ msgstr "Cerca / Filtra"
 msgid "Cumulative"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency"
-msgstr ""
+msgstr "Valuta"
 
 #, fuzzy
 msgid "Currency code column"
@@ -4102,11 +6577,19 @@ msgstr "Formato Datetime"
 msgid "Currency format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency prefix or suffix"
-msgstr ""
+msgstr "Prefisso o suffisso della valuta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency symbol"
-msgstr ""
+msgstr "Simbolo della valuta"
 
 #, fuzzy
 msgid "Current"
@@ -4136,39 +6619,82 @@ msgstr "condividi query"
 msgid "Current year"
 msgstr "condividi query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Currently rendered: %s"
-msgstr ""
+msgstr "Attualmente visualizzato: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom"
-msgstr ""
+msgstr "Personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom Plugin"
-msgstr ""
+msgstr "Plugin personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom Plugins"
-msgstr ""
+msgstr "Plugin personalizzati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL"
-msgstr ""
+msgstr "SQL personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr ""
+"Le metriche SQL ad-hoc personalizzate non sono abilitate per questo set "
+"di dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
+"I campi SQL personalizzati non possono essere analizzati come una singola"
+" istruzione SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "I campi SQL personalizzati non possono contenere operazioni sugli insiemi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Custom SQL fields cannot contain sub-queries."
-msgstr ""
+msgstr "I campi SQL personalizzati non possono contenere sottoquery."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Custom color palettes"
-msgstr ""
+msgstr "Palette di colori personalizzate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom column name (leave blank for default)"
-msgstr ""
+msgstr "Nome colonna personalizzato (lasciare vuoto per il valore predefinito)"
 
 #, fuzzy
 msgid "Custom conditional formatting"
@@ -4178,14 +6704,24 @@ msgstr "Formato Datetime"
 msgid "Custom date"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
-msgstr ""
+msgstr "I campi personalizzati non sono disponibili nelle celle heatmap aggregate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom time filter plugin"
-msgstr ""
+msgstr "Plugin del filtro temporale personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom width of the screenshot in pixels"
-msgstr ""
+msgstr "Larghezza personalizzata dello screenshot in pixel"
 
 #, fuzzy
 msgid "Custom..."
@@ -4203,109 +6739,195 @@ msgstr "Tipo di Visualizzazione"
 msgid "Customization value is required"
 msgstr "Sorgente Dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Customizations out of scope (%d)"
-msgstr ""
+msgstr "Personalizzazioni fuori ambito (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Customize"
-msgstr ""
+msgstr "Personalizza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Customize Metrics"
-msgstr ""
+msgstr "Personalizza metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize cell titles using Handlebars template syntax. Available "
 "variables: {{rowLabel}}, {{colLabel}}"
 msgstr ""
+"Personalizza i titoli delle celle usando la sintassi del template "
+"Handlebars. Variabili disponibili: {{rowLabel}}, {{colLabel}}"
 
 #, fuzzy
 msgid "Customize columns"
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Customize data source, filters, and layout."
-msgstr ""
+msgstr "Personalizza la sorgente dati, i filtri e il layout."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personalizza l'etichetta visualizzata per i valori decrescenti nei "
+"tooltip e nella legenda del grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
 msgstr ""
+"Personalizza l'etichetta visualizzata per i valori crescenti nei tooltip "
+"e nella legenda del grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
+"Personalizza l'etichetta visualizzata per i valori totali nei tooltip del"
+" grafico, nella legenda e sull'asse del grafico."
 
 #, fuzzy
 msgid "Customize tooltips template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cyclic dependency detected"
-msgstr ""
+msgstr "Dipendenza ciclica rilevata"
 
 msgid "D3 format"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 format syntax: https://github.com/d3/d3-format"
-msgstr ""
+msgstr "Sintassi del formato D3: https://github.com/d3/d3-format"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "D3 number format for numbers between -1.0 and 1.0, useful when you want "
 "to have different significant digits for small and large numbers"
 msgstr ""
+"Formato numerico D3 per numeri compresi tra -1.0 e 1.0, utile quando si "
+"desidera avere cifre significative diverse per numeri piccoli e grandi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format for datetime columns"
-msgstr ""
+msgstr "Formato temporale D3 per colonne datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
-msgstr ""
+msgstr "Sintassi del formato temporale D3: https://github.com/d3/d3-time-format"
 
 #, fuzzy
 msgid "DATETIME"
 msgstr "Tempo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "DB column %(col_name)s has unknown type: %(value_type)s"
-msgstr ""
+msgstr "La colonna DB %(col_name)s ha un tipo sconosciuto: %(value_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "DD/MM format dates, international and European format"
-msgstr ""
+msgstr "Date in formato GG/MM, formato internazionale ed europeo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DEC"
-msgstr ""
+msgstr "DIC"
 
 msgid "DELETE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DML"
-msgstr ""
+msgstr "DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Daily seasonality"
-msgstr ""
+msgstr "Stagionalità giornaliera"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dark"
-msgstr ""
+msgstr "Scuro"
 
 #, fuzzy
 msgid "Dark (Carto)"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dark Cyan"
-msgstr ""
+msgstr "Ciano scuro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dark mode"
-msgstr ""
+msgstr "Modalità scura"
 
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Dashboard %(dashboard_id)s not found"
-msgstr ""
+msgstr "Dashboard %(dashboard_id)s non trovata"
 
 #, fuzzy
 msgid "Dashboard Filter"
@@ -4315,12 +6937,17 @@ msgstr "Elenco Dashboard"
 msgid "Dashboard Id"
 msgstr "Dashboard"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Dashboard [%s] just got created and chart [%s] was added to it"
-msgstr ""
+msgstr "La dashboard [%s] è stata appena creata e il grafico [%s] è stato aggiunto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard cannot be copied due to invalid parameters."
-msgstr ""
+msgstr "La dashboard non può essere copiata a causa di parametri non validi."
 
 #, fuzzy
 msgid "Dashboard cannot be favorited."
@@ -4341,17 +6968,26 @@ msgstr "La tua query non può essere salvata"
 msgid "Dashboard could not be deleted."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "Impossibile ripristinare la dashboard."
 
 msgid "Dashboard could not be updated."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dashboard does not exist"
-msgstr ""
+msgstr "La dashboard non esiste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Dashboard exported as example successfully"
-msgstr ""
+msgstr "Dashboard esportata come esempio con successo"
 
 #, fuzzy
 msgid "Dashboard exported successfully"
@@ -4361,8 +6997,11 @@ msgstr "Elenco Dashboard"
 msgid "Dashboard imported"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard name and URL configuration"
-msgstr ""
+msgstr "Nome della dashboard e configurazione URL"
 
 #, fuzzy
 msgid "Dashboard name is required"
@@ -4372,8 +7011,12 @@ msgstr "Sorgente Dati"
 msgid "Dashboard native filters could not be patched."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dashboard parameters are invalid."
-msgstr ""
+msgstr "I parametri della dashboard non sono validi."
 
 msgid "Dashboard properties"
 msgstr "Elenco Dashboard"
@@ -4386,12 +7029,22 @@ msgstr "Elenco Dashboard"
 msgid "Dashboard scheme"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Dashboard time range filters apply to temporal columns defined in\n"
 "          the filter section of each chart. Add temporal columns to the "
 "chart\n"
 "          filters to have this dashboard filter impact those charts."
 msgstr ""
+"I filtri dell'intervallo temporale del dashboard si applicano alle "
+"colonne temporali definite nella\n"
+"          sezione dei filtri di ogni grafico. Aggiungere colonne "
+"temporali ai filtri del\n"
+"          grafico per fare in modo che questo filtro del dashboard "
+"influenzi quei grafici."
 
 #, fuzzy
 msgid "Dashboard title"
@@ -4434,11 +7087,19 @@ msgstr "Azione"
 msgid "Data Table"
 msgstr "Modifica Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data URI is not allowed."
-msgstr ""
+msgstr "L'URI dati non è consentito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Data Zoom"
-msgstr ""
+msgstr "Zoom dei dati"
 
 #, fuzzy
 msgid "Data connection"
@@ -4448,34 +7109,57 @@ msgstr "Testa la Connessione"
 msgid "Data connections"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
 "format might have changed, rendering the old data stake. You need to re-"
 "run the original query."
 msgstr ""
+"Impossibile deserializzare i dati dal backend dei risultati. Il formato "
+"di archiviazione potrebbe essere cambiato, rendendo i dati precedenti non"
+" validi. È necessario rieseguire la query originale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be retrieved from the results backend. You need to re-run "
 "the original query."
 msgstr ""
+"Impossibile recuperare i dati dal backend dei risultati. È necessario "
+"rieseguire la query originale."
 
 #, fuzzy
 msgid "Data error"
 msgstr "Espressione del Database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Data for %s"
-msgstr ""
+msgstr "Dati per %s"
 
 #, fuzzy
 msgid "Data imported"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Data preview"
-msgstr ""
+msgstr "Anteprima dei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data refreshed"
-msgstr ""
+msgstr "Dati aggiornati"
 
 msgid "Data type"
 msgstr "Tipo"
@@ -4483,8 +7167,12 @@ msgstr "Tipo"
 msgid "DataFrame include at least one series"
 msgstr "Seleziona almeno una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DataFrame must include temporal column"
-msgstr ""
+msgstr "Il DataFrame deve includere una colonna temporale"
 
 msgid "Database"
 msgstr "Database"
@@ -4504,26 +7192,44 @@ msgstr "La tua query non può essere salvata"
 msgid "Database could not be created."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database could not be deleted."
-msgstr ""
+msgstr "Impossibile eliminare il database."
 
 msgid "Database could not be updated."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not allow data manipulation."
-msgstr ""
+msgstr "Il database non consente la manipolazione dei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not exist"
-msgstr ""
+msgstr "Il database non esiste"
 
 #, fuzzy
 msgid "Database does not support subqueries"
 msgstr "Sorgente dati e tipo di grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Database driver for importing maybe not installed. Visit the Superset "
 "documentation page for installation instructions: "
 msgstr ""
+"Il driver del database per l'importazione potrebbe non essere installato."
+" Visita la pagina della documentazione di Superset per le istruzioni di "
+"installazione: "
 
 msgid "Database error"
 msgstr "Espressione del Database"
@@ -4532,17 +7238,29 @@ msgstr "Espressione del Database"
 msgid "Database is offline."
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database is required for alerts"
-msgstr ""
+msgstr "Il database è obbligatorio per gli avvisi"
 
 msgid "Database name"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Database not found."
-msgstr ""
+msgstr "Database non trovato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database parameters are invalid."
-msgstr ""
+msgstr "I parametri del database non sono validi."
 
 #, fuzzy
 msgid "Database passwords"
@@ -4552,11 +7270,17 @@ msgstr "Database"
 msgid "Database port"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Database reference is not allowed on a report"
-msgstr ""
+msgstr "Il riferimento al database non è consentito in un report"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database schema is not allowed for csv uploads."
-msgstr ""
+msgstr "Lo schema del database non è consentito per il caricamento di file CSV."
 
 #, fuzzy
 msgid "Database settings updated"
@@ -4566,15 +7290,22 @@ msgstr "La tua query non può essere salvata"
 msgid "Database type does not support file uploads."
 msgstr "Sorgente dati e tipo di grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "Il file caricato nel database supera la dimensione massima consentita."
 
 #, fuzzy
 msgid "Database upload file failed"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database upload file failed, while saving metadata"
 msgstr ""
+"Caricamento del file nel database non riuscito durante il salvataggio dei"
+" metadati"
 
 msgid "Databases"
 msgstr "Basi di dati"
@@ -4615,8 +7346,12 @@ msgstr "Sorgente dati e tipo di grafico"
 msgid "Dataset is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset metric delete failed."
-msgstr ""
+msgstr "Eliminazione della metrica del set di dati non riuscita."
 
 #, fuzzy
 msgid "Dataset metric not found."
@@ -4625,27 +7360,44 @@ msgstr "Dashboard"
 msgid "Dataset name"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset parameters are invalid."
-msgstr ""
+msgstr "I parametri del set di dati non sono validi."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "Lo schema del set di dati non è valido, causato da: %(error)s"
 
 msgid "Datasets"
 msgstr "Basi di dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Datasets can be created from database tables or SQL queries. Select a "
 "database table to the left or "
 msgstr ""
+"I set di dati possono essere creati da tabelle di database o query SQL. "
+"Selezionare una tabella di database a sinistra o "
 
 #, fuzzy
 msgid "Datasets could not be deleted."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasets do not contain a temporal column"
-msgstr ""
+msgstr "I set di dati non contengono una colonna temporale"
 
 msgid "Datasource"
 msgstr "Sorgente Dati"
@@ -4666,11 +7418,19 @@ msgstr "Sorgente Dati"
 msgid "Datasource is required for validation"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Datasource type is invalid"
-msgstr ""
+msgstr "Il tipo di origine dati non è valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasource type is required when datasource_id is given"
-msgstr ""
+msgstr "Il tipo di origine dati è obbligatorio quando viene fornito datasource_id"
 
 #, fuzzy
 msgid "Datasources"
@@ -4705,67 +7465,121 @@ msgstr "Formato Datetime"
 msgid "Day"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Day (freq=D)"
-msgstr ""
+msgstr "Giorno (freq=D)"
 
 #, fuzzy, python-format
 msgid "Days %s"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Db engine did not return all queried columns"
-msgstr ""
+msgstr "Il motore del database non ha restituito tutte le colonne richieste"
 
 #, fuzzy
 msgid "Deactivate"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "December"
-msgstr ""
+msgstr "Dicembre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Decides which column or measure to sort the base axis by."
-msgstr ""
+msgstr "Determina quale colonna o misura usare per ordinare l'asse di base."
 
 #, fuzzy
 msgid "Decimal character"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D Grid"
-msgstr ""
+msgstr "Deck.gl - Griglia 3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D HEX"
-msgstr ""
+msgstr "Deck.gl - 3D HEX"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Arc"
-msgstr ""
+msgstr "Deck.gl - Arco"
 
 #, fuzzy
 msgid "Deck.gl - Contour"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - GeoJSON"
-msgstr ""
+msgstr "Deck.gl - GeoJSON"
 
 #, fuzzy
 msgid "Deck.gl - Heatmap"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Multiple Layers"
-msgstr ""
+msgstr "Deck.gl - Livelli multipli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Paths"
-msgstr ""
+msgstr "Deck.gl - Percorsi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Polygon"
-msgstr ""
+msgstr "Deck.gl - Poligono"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Scatter plot"
-msgstr ""
+msgstr "Deck.gl - Grafico a dispersione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Screen Grid"
-msgstr ""
+msgstr "Deck.gl - Griglia dello schermo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Deck.gl Layer Visibility"
-msgstr ""
+msgstr "Visibilità livello Deck.gl"
 
 #, fuzzy
 msgid "Deckgl"
@@ -4802,10 +7616,15 @@ msgstr "Valore del filtro"
 msgid "Default URL"
 msgstr "URL del Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# pt_BR, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
 msgstr ""
+"URL predefinito a cui reindirizzare quando si accede dalla pagina "
+"dell'elenco dei set di dati. Accetta URL relativi come"
 
 #, fuzzy
 msgid "Default Value"
@@ -4823,108 +7642,224 @@ msgstr "Valore del filtro"
 msgid "Default folders cannot be nested"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Default latitude"
-msgstr ""
+msgstr "Latitudine predefinita"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Default longitude"
-msgstr ""
+msgstr "Longitudine predefinita"
 
 #, fuzzy
 msgid "Default message"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Default minimal column width in pixels, actual width may still be larger "
 "than this if other columns don't need much space"
 msgstr ""
+"Larghezza minima predefinita della colonna in pixel; la larghezza "
+"effettiva può essere ancora maggiore se le altre colonne non richiedono "
+"molto spazio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Default value must be set when \"Filter has default value\" is checked"
 msgstr ""
+"Il valore predefinito deve essere impostato quando è selezionato \"Il "
+"filtro ha un valore predefinito\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Default value must be set when \"Filter value is required\" is checked"
 msgstr ""
+"Il valore predefinito deve essere impostato quando è selezionata \"Il "
+"valore del filtro è obbligatorio\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default value set automatically when \"Select first filter value by "
 "default\" is checked"
 msgstr ""
+"Il valore predefinito viene impostato automaticamente quando è "
+"selezionato \"Seleziona il primo valore del filtro per impostazione "
+"predefinita\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a function that receives the input and outputs the content for a "
 "tooltip"
 msgstr ""
+"Definire una funzione che riceve l'input e restituisce il contenuto per "
+"un tooltip"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Define a function that returns a URL to navigate to when user clicks"
 msgstr ""
+"Definire una funzione che restituisce un URL a cui navigare quando "
+"l'utente fa clic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a javascript function that receives the data array used in the "
 "visualization and is expected to return a modified version of that array."
 " This can be used to alter properties of the data, filter, or enrich the "
 "array."
 msgstr ""
+"Definisci una funzione JavaScript che riceve l'array di dati utilizzato "
+"nella visualizzazione e che dovrebbe restituire una versione modificata "
+"di quell'array. Può essere usata per modificare le proprietà dei dati, "
+"filtrare o arricchire l'array."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define color breakpoints for the data"
-msgstr ""
+msgstr "Definisci i punti di interruzione del colore per i dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define contour layers. Isolines represent a collection of line segments "
 "that serparate the area above and below a given threshold. Isobands "
 "represent a collection of polygons that fill the are containing values in"
 " a given threshold range."
 msgstr ""
+"Definisci i livelli di contorno. Le isolinee rappresentano un insieme di "
+"segmenti di linea che separano l'area al di sopra e al di sotto di una "
+"soglia specificata. Le isobande rappresentano un insieme di poligoni che "
+"riempiono l'area contenente valori in un determinato intervallo di "
+"soglia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define delivery schedule, timezone, and frequency settings."
 msgstr ""
+"Definisci la pianificazione della consegna, il fuso orario e le "
+"impostazioni di frequenza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define the database, SQL query, and triggering conditions for alert."
 msgstr ""
+"Definisci il database, la query SQL e le condizioni di attivazione per "
+"l'avviso."
 
 #, fuzzy
 msgid "Defined through system configuration."
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines a rolling window function to apply, works along with the "
 "[Periods] text box"
 msgstr ""
+"Definisce una funzione di finestra mobile da applicare, funziona insieme "
+"alla casella di testo [Periodi]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Defines the grid size in pixels"
-msgstr ""
+msgstr "Definisce la dimensione della griglia in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Defines the grouping of entities. Each series is represented by a "
 "specific color in the chart."
 msgstr ""
+"Definisce il raggruppamento delle entità. Ogni serie è rappresentata da "
+"un colore specifico nel grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines the grouping of entities. Each series is shown as a specific "
 "color on the chart and has a legend toggle"
 msgstr ""
+"Definisce il raggruppamento delle entità. Ogni serie viene mostrata con "
+"un colore specifico nel grafico e ha un interruttore di legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines the size of the rolling window function, relative to the time "
 "granularity selected"
 msgstr ""
+"Definisce la dimensione della funzione di finestra mobile, relativa alla "
+"granularità temporale selezionata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Defines the value that determines the boundary between different regions "
 "or levels in the data "
 msgstr ""
+"Definisce il valore che determina il confine tra le diverse regioni o "
+"livelli nei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines whether the step should appear at the beginning, middle or end "
 "between two data points"
 msgstr ""
+"Definisce se il gradino deve apparire all'inizio, al centro o alla fine "
+"tra due punti dati"
 
 #, fuzzy
 msgid "Definition"
 msgstr "descrizione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
+msgstr[0] "In ritardo (%s aggiornamento perso)"
 
 msgid "Delete"
 msgstr "Cancella"
@@ -4937,8 +7872,12 @@ msgstr "Cancella"
 msgid "Delete %s?"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete Annotation?"
-msgstr ""
+msgstr "Eliminare l'annotazione?"
 
 #, fuzzy
 msgid "Delete Group?"
@@ -4977,8 +7916,12 @@ msgstr "Template CSS"
 msgid "Delete User?"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete all Really?"
-msgstr ""
+msgstr "Eliminare davvero tutto?"
 
 msgid "Delete annotation"
 msgstr "Azione"
@@ -5002,15 +7945,23 @@ msgstr "Template CSS"
 msgid "Delete role"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete template"
-msgstr ""
+msgstr "Elimina modello"
 
 #, fuzzy
 msgid "Delete theme"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete this container and save to remove this message."
-msgstr ""
+msgstr "Elimina questo contenitore e salva per rimuovere questo messaggio."
 
 #, fuzzy
 msgid "Delete user"
@@ -5028,25 +7979,37 @@ msgstr "Cancella"
 msgid "Deleted"
 msgstr "Cancella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d annotation"
 msgid_plural "Deleted %(num)d annotations"
-msgstr[0] ""
+msgstr[0] "Eliminata %(num)d annotazione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d annotation layer"
 msgid_plural "Deleted %(num)d annotation layers"
-msgstr[0] ""
+msgstr[0] "Eliminato %(num)d livello di annotazione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d chart"
 msgid_plural "Deleted %(num)d charts"
-msgstr[0] ""
+msgstr[0] "Eliminato %(num)d grafico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d css template"
 msgid_plural "Deleted %(num)d css templates"
-msgstr[0] ""
+msgstr[0] "Eliminato %(num)d modello CSS"
 
 #, python-format
 msgid "Deleted %(num)d dashboard"
@@ -5058,25 +8021,35 @@ msgid "Deleted %(num)d dataset"
 msgid_plural "Deleted %(num)d datasets"
 msgstr[0] "Seleziona data finale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d report schedule"
 msgid_plural "Deleted %(num)d report schedules"
-msgstr[0] ""
+msgstr[0] "Eliminata %(num)d pianificazione report"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, nl, ro, ru, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid "Deleted %(num)d rules"
 msgid_plural "Deleted %(num)d rules"
-msgstr[0] ""
+msgstr[0] "Eliminata %(num)d regola"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d saved query"
 msgid_plural "Deleted %(num)d saved queries"
-msgstr[0] ""
+msgstr[0] "Eliminata %(num)d query salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
 #, fuzzy, python-format
 msgid "Deleted %(num)d semantic view"
 msgid_plural "Deleted %(num)d semantic views"
-msgstr[0] ""
+msgstr[0] "Eliminata %(num)d vista semantica"
 
 #, fuzzy, python-format
 msgid "Deleted %(num)d theme"
@@ -5123,39 +8096,69 @@ msgstr "Cancella"
 msgid "Deleted: %s"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Deleting a tab will remove all content within it and will deactivate any "
 "related alerts or reports. You may still reverse this action with the"
 msgstr ""
+"L'eliminazione di una scheda rimuoverà tutti i contenuti al suo interno e"
+" disattiverà eventuali avvisi o report correlati. Puoi ancora annullare "
+"questa azione con il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delimited long & lat single column"
-msgstr ""
+msgstr "Longitudine e latitudine delimitate in colonna singola"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delimiter"
-msgstr ""
+msgstr "Delimitatore"
 
 #, fuzzy
 msgid "Delivery method"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Density"
-msgstr ""
+msgstr "Densità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dependent on"
-msgstr ""
+msgstr "Dipendente da"
 
 msgid "Description"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description (this can be seen in the list)"
-msgstr ""
+msgstr "Descrizione (visibile nell'elenco)"
 
 #, fuzzy
 msgid "Description Columns"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description text that shows up below your Big Number"
-msgstr ""
+msgstr "Testo descrittivo che appare sotto il tuo Numero Grande"
 
 msgid "Deselect all"
 msgstr "Seleziona data finale"
@@ -5164,48 +8167,95 @@ msgstr "Seleziona data finale"
 msgid "Design with"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Details"
-msgstr ""
+msgstr "Dettagli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Details of the certification"
-msgstr ""
+msgstr "Dettagli della certificazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Determina come il filtro abbina i valori. \"Corrispondenza esatta\" "
+"utilizza l'operatore IN (predefinito). Le opzioni ILIKE abilitano la "
+"corrispondenza parziale del testo con un input a testo libero. "
+"Attenzione: le query ILIKE potrebbero essere lente su dataset di grandi "
+"dimensioni poiché non possono utilizzare gli indici in modo efficace."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Determines how whiskers and outliers are calculated."
-msgstr ""
+msgstr "Determina come vengono calcolati i baffi e i valori anomali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Determines whether or not this dashboard is visible in the list of all "
 "dashboards"
 msgstr ""
+"Determina se questo dashboard è visibile o meno nell'elenco di tutti i "
+"dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Diamond"
-msgstr ""
+msgstr "Diamante"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Did you mean:"
-msgstr ""
+msgstr "Intendevi dire:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Difference"
-msgstr ""
+msgstr "Differenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dim Gray"
-msgstr ""
+msgstr "Grigio Scuro"
 
 #, fuzzy
 msgid "Dimension"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Colonna dimensione emessa come filtro incrociato quando si fa clic su un "
+"elemento. Gli altri grafici nel dashboard vengono confrontati con questa "
+"colonna. Se non impostata, viene utilizzata la colonna geometria "
+"(comportamento legacy, spesso non confrontabile)."
 
 #, fuzzy
 msgid "Dimension is required"
@@ -5219,28 +8269,47 @@ msgstr "descrizione"
 msgid "Dimension selection"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on x-axis."
-msgstr ""
+msgstr "Dimensione da utilizzare sull'asse x."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on y-axis."
-msgstr ""
+msgstr "Dimensione da utilizzare sull'asse y."
 
 #, fuzzy
 msgid "Dimension values"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dimensions"
-msgstr ""
+msgstr "Dimensioni"
 
 #, fuzzy, python-format
 msgid "Dimensions (%s)"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Dimensions contain qualitative values such as names, dates, or "
 "geographical data. Use dimensions to categorize, segment, and reveal the "
 "details in your data. Dimensions affect the level of detail in the view."
 msgstr ""
+"Le dimensioni contengono valori qualitativi come nomi, date o dati "
+"geografici. Usa le dimensioni per categorizzare, segmentare e rivelare i "
+"dettagli nei tuoi dati. Le dimensioni influenzano il livello di dettaglio"
+" nella visualizzazione."
 
 msgid "Directed Force Layout"
 msgstr "Disposizione a Forza Diretta"
@@ -5249,30 +8318,54 @@ msgstr "Disposizione a Forza Diretta"
 msgid "Directional"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable SQL Lab data preview queries"
-msgstr ""
+msgstr "Disabilita le query di anteprima dati di SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Disable data preview when fetching table metadata in SQL Lab.  Useful to "
 "avoid browser performance issues when using  databases with very wide "
 "tables."
 msgstr ""
+"Disabilita l'anteprima dei dati durante il recupero dei metadati delle "
+"tabelle in SQL Lab. Utile per evitare problemi di prestazioni del browser"
+" quando si utilizzano database con tabelle molto ampie."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disable drill to detail"
-msgstr ""
+msgstr "Disabilita il drill al dettaglio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable embedding?"
-msgstr ""
+msgstr "Disabilitare l'incorporamento?"
 
 #, fuzzy
 msgid "Disabled"
 msgstr "Modifica Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disables the drill to detail feature for this database."
-msgstr ""
+msgstr "Disabilita la funzione drill to detail per questo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Discard"
-msgstr ""
+msgstr "Scarta"
 
 #, fuzzy
 msgid "Display Name"
@@ -5282,28 +8375,45 @@ msgstr "Valore del filtro"
 msgid "Display all"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column in the chart"
-msgstr ""
+msgstr "Mostra colonna nel grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column level subtotal"
-msgstr ""
+msgstr "Mostra subtotale a livello di colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display column level total"
-msgstr ""
+msgstr "Mostra totale a livello di colonna"
 
 #, fuzzy
 msgid "Display column name"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display configuration"
-msgstr ""
+msgstr "Configurazione di visualizzazione"
 
 #, fuzzy
 msgid "Display control configuration"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control has default value"
-msgstr ""
+msgstr "Il controllo di visualizzazione ha un valore predefinito"
 
 #, fuzzy
 msgid "Display control name"
@@ -5329,73 +8439,139 @@ msgstr "Colonna"
 msgid "Display controls (%s)"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display cumulative total at end"
-msgstr ""
+msgstr "Mostra totale cumulativo alla fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
+msgstr "Mostra intestazioni per ogni colonna nella parte superiore della matrice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display labels for each row on the left side of the matrix"
-msgstr ""
+msgstr "Mostra etichette per ogni riga sul lato sinistro della matrice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Display metrics side by side within each column, as opposed to each "
 "column being displayed side by side for each metric."
 msgstr ""
+"Mostra le metriche affiancate all'interno di ogni colonna, anziché "
+"mostrare ogni colonna affiancata per ogni metrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Display percents in the label and tooltip as the percent of the total "
 "value, from the first step of the funnel, or from the previous step in "
 "the funnel."
 msgstr ""
+"Mostra le percentuali nell'etichetta e nel tooltip come percentuale del "
+"valore totale, dal primo passo del funnel, o dal passo precedente nel "
+"funnel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display row level subtotal"
-msgstr ""
+msgstr "Mostra subtotale a livello di riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display row level total"
-msgstr ""
+msgstr "Mostra totale a livello di riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
 msgstr ""
+"Mostra il timestamp dell'ultima interrogazione sui grafici nella vista "
+"dashboard"
 
 #, fuzzy
 msgid "Display type icon"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Displays connections between entities in a graph structure. Useful for "
 "mapping relationships and showing which nodes are important in a network."
 " Graph charts can be configured to be force-directed or circulate. If "
 "your data has a geospatial component, try the deck.gl Arc chart."
 msgstr ""
+"Mostra le connessioni tra entità in una struttura a grafo. Utile per "
+"mappare le relazioni e mostrare quali nodi sono importanti in una rete. I"
+" grafici a grafo possono essere configurati come diretti da forza o "
+"circolari. Se i tuoi dati hanno una componente geospaziale, prova il "
+"grafico Arc di deck.gl."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Distribute across"
-msgstr ""
+msgstr "Distribuisci su"
 
 #, fuzzy
 msgid "Distribution"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Divider"
-msgstr ""
+msgstr "Divisore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
 msgstr ""
+"Divide ogni categoria in sottocategorie in base ai valori della "
+"dimensione. Può essere utilizzato per escludere le intersezioni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Do you want a donut or a pie?"
-msgstr ""
+msgstr "Vuoi un grafico a ciambella o a torta?"
 
 #, fuzzy
 msgid "Documentation"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Domain"
-msgstr ""
+msgstr "Dominio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Don't refresh"
-msgstr ""
+msgstr "Non aggiornare"
 
 #, fuzzy
 msgid "Done"
@@ -5409,131 +8585,262 @@ msgstr "mese"
 msgid "Dotted"
 msgstr "Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Download"
-msgstr ""
+msgstr "Scarica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download as Image"
-msgstr ""
+msgstr "Scarica come Immagine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download as image"
-msgstr ""
+msgstr "Scarica come immagine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download is on the way"
-msgstr ""
+msgstr "Download in corso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download to CSV"
-msgstr ""
+msgstr "Scarica in CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Download to client"
-msgstr ""
+msgstr "Scarica sul client"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Downloading %(rows)s rows based on the LIMIT configuration. If you want "
 "the entire result set, you need to adjust the LIMIT."
 msgstr ""
+"Download di %(rows)s righe in base alla configurazione LIMIT. Se si "
+"desidera l'intero set di risultati, è necessario modificare il LIMIT."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draft"
-msgstr ""
+msgstr "Bozza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components and charts to the dashboard"
-msgstr ""
+msgstr "Trascina e rilascia componenti e grafici nella dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components to this tab"
-msgstr ""
+msgstr "Trascina e rilascia componenti in questa scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
+"Trascina colonne e metriche qui per personalizzare il contenuto del "
+"tooltip. L'ordine è importante: gli elementi appariranno nello stesso "
+"ordine nei tooltip. Clicca il pulsante per selezionare manualmente "
+"colonne e metriche."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Trascina per riordinare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw a marker on data points. Only applicable for line types."
-msgstr ""
+msgstr "Disegna un marcatore sui punti dati. Applicabile solo ai tipi di linea."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw area under curves. Only applicable for line types."
-msgstr ""
+msgstr "Disegna l'area sotto le curve. Applicabile solo ai tipi di linea."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw line from Pie to label when labels outside?"
 msgstr ""
+"Tracciare una linea dalla torta all'etichetta quando le etichette sono "
+"all'esterno?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Draw split lines for minor axis ticks"
-msgstr ""
+msgstr "Traccia linee di divisione per i segni dell'asse minore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw split lines for minor y-axis ticks"
-msgstr ""
+msgstr "Traccia linee di divisione per i segni minori dell'asse y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by"
-msgstr ""
+msgstr "Drill by"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not available for this data point"
-msgstr ""
+msgstr "Drill by non è disponibile per questo punto dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not yet supported for this chart type"
-msgstr ""
+msgstr "Drill by non è ancora supportato per questo tipo di grafico"
 
 #, fuzzy, python-format
 msgid "Drill by: %s"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail"
-msgstr ""
+msgstr "Drill to detail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by"
-msgstr ""
+msgstr "Drill to detail per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by value is not yet supported for this chart type."
 msgstr ""
+"Il drill to detail per valore non è ancora supportato per questo tipo di "
+"grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled because this chart does not group data by "
 "dimension value."
 msgstr ""
+"Il drill to detail è disabilitato perché questo grafico non raggruppa i "
+"dati per valore di dimensione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled for this database. Change the database "
 "settings to enable it."
 msgstr ""
+"Il drill to detail è disabilitato per questo database. Modifica le "
+"impostazioni del database per abilitarlo."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Drill to detail: %s"
-msgstr ""
+msgstr "Drill to detail: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column here or click"
 msgid_plural "Drop columns here or click"
-msgstr[0] ""
+msgstr[0] "Rilascia una colonna qui o fai clic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column/metric here or click"
 msgid_plural "Drop columns/metrics here or click"
-msgstr[0] ""
+msgstr[0] "Rilascia una colonna/metrica qui o fai clic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Drop a temporal column here or click"
-msgstr ""
+msgstr "Rilascia una colonna temporale qui o fai clic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drop columns/metrics here or click"
-msgstr ""
+msgstr "Rilascia colonne/metriche qui o fai clic"
 
 #, fuzzy
 msgid "Dttm"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Duplicate column name(s): %(columns)s"
-msgstr ""
+msgstr "Nome/i di colonna duplicato/i: %(columns)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Duplicate column/metric labels: %(labels)s. Please make sure all columns "
 "and metrics have a unique label."
 msgstr ""
+"Etichette duplicate di colonna/metrica: %(labels)s. Assicurarsi che tutte"
+" le colonne e le metriche abbiano un'etichetta univoca."
 
 #, fuzzy
 msgid "Duplicate dataset"
@@ -5547,21 +8854,34 @@ msgstr "Mostra database"
 msgid "Duplicate role"
 msgstr "Mostra database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Duplicate role %(name)s"
-msgstr ""
+msgstr "Duplica ruolo %(name)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duplicate tab"
-msgstr ""
+msgstr "Duplica scheda"
 
 msgid "Duration"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the caching timeout for charts of this database."
 " A timeout of 0 indicates that the cache never expires, and -1 bypasses "
 "the cache. Note this defaults to the global timeout if undefined."
 msgstr ""
+"Durata (in secondi) del timeout della cache per i grafici di questo "
+"database. Un timeout di 0 indica che la cache non scade mai, mentre -1 "
+"ignora la cache. Si noti che il valore predefinito è il timeout globale "
+"se non definito."
 
 #, fuzzy
 msgid ""
@@ -5586,24 +8906,41 @@ msgstr "Durata (in secondi) per il timeout della cache per questa slice."
 msgid "Duration Ms"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (1.40008 => 1ms 400µs 80ns)"
-msgstr ""
+msgstr "Durata in ms (1.40008 => 1ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duration in ms (100.40008 => 100ms 400µs 80ns)"
-msgstr ""
+msgstr "Durata in ms (100.40008 => 100ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Duration in ms (10500 => 0:00:10.5)"
-msgstr ""
+msgstr "Durata in ms (10500 => 0:00:10.5)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (66000 => 1m 6s)"
-msgstr ""
+msgstr "Durata in ms (66000 => 1m 6s)"
 
 #, fuzzy
 msgid "Duration in seconds"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "Dinamico"
 
 #, fuzzy
 msgid "Dynamic Aggregation Function"
@@ -5621,18 +8958,28 @@ msgstr "Uno o più controlli per 'Raggruppa per'"
 msgid "Dynamic section description"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dynamically search all filter values"
-msgstr ""
+msgstr "Cerca dinamicamente tutti i valori del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "Seleziona dinamicamente le colonne di raggruppamento da un set di dati"
 
 #, fuzzy
 msgid "ECharts"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "Opzioni ECharts (letterali oggetto JS)"
 
 #, fuzzy
 msgid "EMAIL_REPORTS_CTA"
@@ -5642,14 +8989,26 @@ msgstr "Importa"
 msgid "ERROR"
 msgstr "Errore..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length"
-msgstr ""
+msgstr "Lunghezza del bordo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length between nodes"
-msgstr ""
+msgstr "Lunghezza del bordo tra i nodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge symbols"
-msgstr ""
+msgstr "Simboli del bordo"
 
 #, fuzzy
 msgid "Edge width"
@@ -5703,8 +9062,12 @@ msgstr "Modifica Tabella"
 msgid "Edit annotation"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit annotation layer"
-msgstr ""
+msgstr "Modifica livello di annotazione"
 
 msgid "Edit annotation layer properties"
 msgstr "Template CSS"
@@ -5713,8 +9076,12 @@ msgstr "Template CSS"
 msgid "Edit chart"
 msgstr "Modifica grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit chart properties"
-msgstr ""
+msgstr "Modifica proprietà del grafico"
 
 #, fuzzy
 msgid "Edit dashboard"
@@ -5723,8 +9090,12 @@ msgstr "Aggiungi ad una nuova dashboard"
 msgid "Edit database"
 msgstr "Mostra database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit email report"
-msgstr ""
+msgstr "Modifica report via email"
 
 #, fuzzy
 msgid "Edit formatter"
@@ -5734,8 +9105,12 @@ msgstr "Formato D3"
 msgid "Edit group"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit properties"
-msgstr ""
+msgstr "Modifica proprietà"
 
 #, fuzzy
 msgid "Edit report"
@@ -5752,8 +9127,12 @@ msgstr "Modifica"
 msgid "Edit template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit template parameters"
-msgstr ""
+msgstr "Modifica parametri del modello"
 
 #, fuzzy
 msgid "Edit the dashboard"
@@ -5763,8 +9142,12 @@ msgstr "Aggiungi ad una nuova dashboard"
 msgid "Edit theme properties"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit time range"
-msgstr ""
+msgstr "Modifica intervallo di tempo"
 
 #, fuzzy
 msgid "Edit user"
@@ -5773,24 +9156,44 @@ msgstr "Query vuota?"
 msgid "Edited"
 msgstr "Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Editing 1 filter:"
-msgstr ""
+msgstr "Modifica di 1 filtro:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the database is spelled incorrectly or does not exist."
-msgstr ""
+msgstr "Il nome del database è scritto in modo errato o non esiste."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Either the username \"%(username)s\" or the password is incorrect."
-msgstr ""
+msgstr "Il nome utente \"%(username)s\" o la password non sono corretti."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Either the username \"%(username)s\", password, or database name "
 "\"%(database)s\" is incorrect."
 msgstr ""
+"Il nome utente \"%(username)s\", la password o il nome del database "
+"\"%(database)s\" non sono corretti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the username or the password is wrong."
-msgstr ""
+msgstr "Il nome utente o la password non sono corretti."
 
 #, fuzzy
 msgid "Elapsed"
@@ -5800,27 +9203,47 @@ msgstr "Creato il"
 msgid "Elevation"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #, fuzzy
 msgid "Email is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email link"
-msgstr ""
+msgstr "Link email"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Email reports active"
-msgstr ""
+msgstr "Report via email attivi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Email subject name (optional)"
-msgstr ""
+msgstr "Oggetto dell'email (facoltativo)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Embed"
-msgstr ""
+msgstr "Incorpora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Embed code"
-msgstr ""
+msgstr "Codice di incorporamento"
 
 #, fuzzy
 msgid "Embed dashboard"
@@ -5830,14 +9253,26 @@ msgstr "Salva e vai alla dashboard"
 msgid "Embedded dashboard could not be deleted."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Embedding deactivated."
-msgstr ""
+msgstr "Incorporamento disattivato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Emphasis"
-msgstr ""
+msgstr "Enfasi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty circle"
-msgstr ""
+msgstr "Cerchio vuoto"
 
 #, fuzzy
 msgid "Empty collection"
@@ -5854,109 +9289,213 @@ msgstr "Query vuota?"
 msgid "Empty query?"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty row"
-msgstr ""
+msgstr "Riga vuota"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr ""
+"Abilita 'Consenti il caricamento di file nel database' nelle impostazioni"
+" di qualsiasi database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable Matrixify"
-msgstr ""
+msgstr "Abilita Matrixify"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable cross-filtering"
-msgstr ""
+msgstr "Abilita il filtraggio incrociato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable data zooming controls"
-msgstr ""
+msgstr "Abilita i controlli di zoom dei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Enable embedding"
-msgstr ""
+msgstr "Abilita incorporamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecast"
-msgstr ""
+msgstr "Abilita previsione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecasting"
-msgstr ""
+msgstr "Abilita previsioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable graph roaming"
-msgstr ""
+msgstr "Abilita il roaming del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "Abilita la modalità JavaScript per le icone"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "Abilita la modalità JavaScript per le etichette"
 
 #, fuzzy
 msgid "Enable labels"
 msgstr "Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "Abilita matrixify"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable node dragging"
-msgstr ""
+msgstr "Abilita il trascinamento dei nodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable query cost estimation"
-msgstr ""
+msgstr "Abilita la stima del costo della query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable row expansion in schemas"
-msgstr ""
+msgstr "Abilita l'espansione delle righe negli schemi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr ""
+"Abilita la paginazione lato server dei risultati (funzionalità "
+"sperimentale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "Abilita la configurazione personalizzata delle icone tramite JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
 msgstr ""
+"Abilita la configurazione personalizzata delle etichette tramite "
+"JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "Abilita il rendering delle icone per i punti GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "Abilita il rendering delle etichette per i punti GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Encountered invalid NULL spatial entry,"
 "                                        please consider filtering those "
 "out"
 msgstr ""
+"È stata rilevata una voce spaziale NULL non valida, si consiglia di "
+"filtrarla"
 
 #, fuzzy
 msgid "Encrypted extra fields"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "End"
-msgstr ""
+msgstr "Fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (Longitude, Latitude): "
-msgstr ""
+msgstr "Fine (Longitudine, Latitudine): "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (exclusive)"
-msgstr ""
+msgstr "Fine (escluso)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End Longitude & Latitude"
-msgstr ""
+msgstr "Longitudine e Latitudine finale"
 
 #, fuzzy
 msgid "End Time"
 msgstr "Aggiungi Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "End angle"
-msgstr ""
+msgstr "Angolo finale"
 
 #, fuzzy
 msgid "End date"
 msgstr "Aggiungi Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "End date excluded from time range"
-msgstr ""
+msgstr "Data di fine esclusa dall'intervallo di tempo"
 
 msgid "End date must be after start date"
 msgstr "La data di inizio non può essere dopo la data di fine"
@@ -5969,30 +9508,54 @@ msgstr "Larghezza"
 msgid "Ends with (ILIKE %x)"
 msgstr "Larghezza"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
-msgstr ""
+msgstr "Il motore \"%(engine)s\" non può essere configurato tramite parametri."
 
 #, fuzzy
 msgid "Engine Parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Engine spec \"InvalidEngine\" does not support being configured via "
 "individual parameters."
 msgstr ""
+"La specifica del motore \"InvalidEngine\" non supporta la configurazione "
+"tramite parametri individuali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter CA_BUNDLE"
-msgstr ""
+msgstr "Inserisci CA_BUNDLE"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter Primary Credentials"
-msgstr ""
+msgstr "Inserisci le credenziali primarie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter a name for this sheet"
-msgstr ""
+msgstr "Inserisci un nome per questo foglio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter a new title for the tab"
-msgstr ""
+msgstr "Inserisci un nuovo titolo per la scheda"
 
 #, fuzzy
 msgid "Enter a part of the object name"
@@ -6002,14 +9565,25 @@ msgstr "Nome Completo"
 msgid "Enter alert name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter duration in seconds"
-msgstr ""
+msgstr "Inserisci la durata in secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter fullscreen"
-msgstr ""
+msgstr "Entra in modalità schermo intero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "Inserisci i valori minimo e massimo per il filtro intervallo"
 
 #, fuzzy
 msgid "Enter report name"
@@ -6027,15 +9601,24 @@ msgstr "Nome Completo"
 msgid "Enter the group's name"
 msgstr "Nome Completo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Enter the required %(dbModelName)s credentials"
-msgstr ""
+msgstr "Inserisci le credenziali %(dbModelName)s richieste"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the unique project id for your database."
-msgstr ""
+msgstr "Inserisci l'ID univoco del progetto per il tuo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's email"
-msgstr ""
+msgstr "Inserisci l'email dell'utente"
 
 #, fuzzy
 msgid "Enter the user's first name"
@@ -6049,27 +9632,48 @@ msgstr "Nome Completo"
 msgid "Enter the user's password"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's username"
-msgstr ""
+msgstr "Inserisci il nome utente dell'utente"
 
 #, fuzzy
 msgid "Enter theme name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter your login and password below:"
-msgstr ""
+msgstr "Inserisci il tuo nome utente e la password qui sotto:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Entity"
-msgstr ""
+msgstr "Entità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal Date Sizes"
-msgstr ""
+msgstr "Dimensioni date uguali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal to (=)"
-msgstr ""
+msgstr "Uguale a (=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Equals"
-msgstr ""
+msgstr "Uguale"
 
 #, fuzzy
 msgid "Error"
@@ -6083,9 +9687,11 @@ msgstr "Errore nel recupero dei metadati della tabella"
 msgid "Error deleting %s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Errore nella disabilitazione della modalità schermo intero: %s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6103,45 +9709,78 @@ msgstr "Errore nel creare il datasource"
 msgid "Error fetching charts"
 msgstr "Errore nel recupero dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error importing theme."
-msgstr ""
+msgstr "Errore durante l'importazione del tema."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in RLS filters: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nei filtri RLS: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in WHERE clause: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nella clausola WHERE: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nella colonna ad hoc: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nell'espressione di colonna: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in datetime column: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nella colonna datetime: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in fetch values predicate: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nel predicato di recupero valori: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in metric expression: %(msg)s"
-msgstr ""
+msgstr "Errore nell'espressione jinja nell'espressione della metrica: %(msg)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Error loading chart datasources. Filters may not work correctly."
 msgstr ""
+"Errore nel caricamento delle sorgenti dati del grafico. I filtri "
+"potrebbero non funzionare correttamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Error message"
-msgstr ""
+msgstr "Messaggio di errore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error parsing"
-msgstr ""
+msgstr "Errore di analisi"
 
 #, fuzzy
 msgid "Error reading CSV file"
@@ -6151,8 +9790,11 @@ msgstr "Errore nel creare il datasource"
 msgid "Error reading Columnar file"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Error reading Excel file"
-msgstr ""
+msgstr "Errore nella lettura del file Excel"
 
 #, fuzzy
 msgid "Error saving dataset"
@@ -6182,58 +9824,106 @@ msgstr "Errore nel recupero dati"
 msgid "Error while rendering virtual dataset query: %(msg)s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(error)s"
-msgstr ""
+msgstr "Errore: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(msg)s"
-msgstr ""
+msgstr "Errore: %(msg)s"
 
 #, fuzzy, python-format
 msgid "Error: %s"
 msgstr "Errore..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error: permalink state not found"
-msgstr ""
+msgstr "Errore: stato del permalink non trovato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate cost"
-msgstr ""
+msgstr "Stima del costo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate selected query cost"
-msgstr ""
+msgstr "Stima il costo della query selezionata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate the cost before running a query"
-msgstr ""
+msgstr "Stima il costo prima di eseguire una query"
 
 #, fuzzy
 msgid "Event"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Event flow"
-msgstr ""
+msgstr "Flusso di eventi"
 
 #, fuzzy
 msgid "Event time column"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Every"
-msgstr ""
+msgstr "Ogni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Evolution"
-msgstr ""
+msgstr "Evoluzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exact"
-msgstr ""
+msgstr "Esatto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Corrispondenza esatta (IN)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Example"
-msgstr ""
+msgstr "Esempio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Examples"
-msgstr ""
+msgstr "Esempi"
 
 #, fuzzy
 msgid "Excel Export"
@@ -6243,17 +9933,30 @@ msgstr "Importa"
 msgid "Excel XML Export"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excel file format cannot be determined"
-msgstr ""
+msgstr "Impossibile determinare il formato del file Excel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Excel upload"
-msgstr ""
+msgstr "Caricamento Excel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exclude selected values"
-msgstr ""
+msgstr "Escludi i valori selezionati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excluded roles"
-msgstr ""
+msgstr "Ruoli esclusi"
 
 #, fuzzy
 msgid "Executed SQL"
@@ -6262,47 +9965,88 @@ msgstr "query condivisa"
 msgid "Executed query"
 msgstr "query condivisa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Execution ID"
-msgstr ""
+msgstr "ID esecuzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Execution log"
-msgstr ""
+msgstr "Registro di esecuzione"
 
 #, fuzzy
 msgid "Existing dataset"
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Exit fullscreen"
-msgstr ""
+msgstr "Esci dalla modalità schermo intero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand"
-msgstr ""
+msgstr "Espandi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Expand All"
-msgstr ""
+msgstr "Espandi tutto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand all"
-msgstr ""
+msgstr "Espandi tutto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand data panel"
-msgstr ""
+msgstr "Espandi il pannello dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand row"
-msgstr ""
+msgstr "Espandi riga"
 
 #, fuzzy
 msgid "Expand row to edit"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
 "        in milliseconds since epoch. mathjs is used to evaluate the "
 "formulas.\n"
 "        Example: '2x+5'"
 msgstr ""
+"Si aspetta una formula con il parametro temporale dipendente 'x'\n"
+"        in millisecondi dall'epoca. mathjs viene utilizzato per valutare "
+"le formule.\n"
+"        Esempio: '2x+5'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Experimental"
-msgstr ""
+msgstr "Sperimentale"
 
 #, fuzzy
 msgid "Expired"
@@ -6311,15 +10055,26 @@ msgstr "Esplora grafico"
 msgid "Explore"
 msgstr "Esplora grafico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Explore - %(table)s"
-msgstr ""
+msgstr "Esplora - %(table)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Explore the result set in the data exploration view"
-msgstr ""
+msgstr "Esplora il set di risultati nella vista di esplorazione dei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Export"
-msgstr ""
+msgstr "Esporta"
 
 #, fuzzy
 msgid "Export All Data"
@@ -6341,26 +10096,38 @@ msgstr "Esporta in YAML"
 msgid "Export cancelled"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Export dashboards?"
-msgstr ""
+msgstr "Esportare i dashboard?"
 
 #, fuzzy
 msgid "Export failed"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export failed - please try again"
-msgstr ""
+msgstr "Esportazione non riuscita - riprova"
 
 #, fuzzy, python-format
 msgid "Export failed: %s"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "Esporta screenshot (jpeg)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Export successful: %s"
-msgstr ""
+msgstr "Esportazione riuscita: %s"
 
 #, fuzzy
 msgid "Export to .CSV"
@@ -6390,21 +10157,36 @@ msgstr "Esporta in YAML"
 msgid "Export to Pivoted Excel"
 msgstr "Esporta in YAML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export to full .CSV"
-msgstr ""
+msgstr "Esporta in .CSV completo"
 
 #, fuzzy
 msgid "Export to full Excel"
 msgstr "Esporta in YAML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Export to original .CSV"
-msgstr ""
+msgstr "Esporta in .CSV originale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Export to pivoted .CSV"
-msgstr ""
+msgstr "Esporta in .CSV pivot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expose database in SQL Lab"
-msgstr ""
+msgstr "Esponi il database in SQL Lab"
 
 msgid "Expose in SQL Lab"
 msgstr "Esponi in SQL Lab"
@@ -6413,8 +10195,11 @@ msgstr "Esponi in SQL Lab"
 msgid "Expression"
 msgstr "Espressione SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Expression cannot be empty"
-msgstr ""
+msgstr "L'espressione non può essere vuota"
 
 #, fuzzy
 msgid "Extensions"
@@ -6424,73 +10209,132 @@ msgstr "descrizione"
 msgid "Extent"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Avviso link esterno"
 
 msgid "Extra"
 msgstr "Extra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra Controls"
-msgstr ""
+msgstr "Controlli aggiuntivi"
 
 #, fuzzy
 msgid "Extra Parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra data for JS"
-msgstr ""
+msgstr "Dati aggiuntivi per JS"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "Extra data to specify table metadata. Currently supports metadata of the "
 "format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\","
 " \"details\": \"This table is the source of truth.\" }, "
 "\"warning_markdown\": \"This is a warning.\" }`."
 msgstr ""
+"Dati aggiuntivi per specificare i metadati della tabella. Attualmente "
+"supporta metadati nel formato: `{ \"certification\": { \"certified_by\": "
+"\"Data Platform Team\", \"details\": \"This table is the source of "
+"truth.\" }, \"warning_markdown\": \"This is a warning.\" }`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra parameters for use in jinja templated queries"
-msgstr ""
+msgstr "Parametri aggiuntivi da usare nelle query con template jinja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Extra parameters that any plugins can choose to set for use in Jinja "
 "templated queries"
 msgstr ""
+"Parametri aggiuntivi che qualsiasi plugin può scegliere di impostare per "
+"l'uso nelle query con template Jinja"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Extra url parameters for use in Jinja templated queries"
-msgstr ""
+msgstr "Parametri URL aggiuntivi da usare nelle query con template Jinja"
 
 #, fuzzy
 msgid "Extruded"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FEB"
-msgstr ""
+msgstr "FEB"
 
 #, fuzzy
 msgid "FIT DATA"
 msgstr "Mostra database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Adatta dati"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FRI"
-msgstr ""
+msgstr "VEN"
 
 #, fuzzy
 msgid "Factor"
 msgstr "Creatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Factor to multiply the metric by"
-msgstr ""
+msgstr "Fattore per cui moltiplicare la metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fail login count"
-msgstr ""
+msgstr "Conteggio accessi falliti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed"
-msgstr ""
+msgstr "Non riuscito"
 
 msgid "Failed at retrieving results"
 msgstr "Errore nel recupero dei dati dal backend"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to apply theme: Invalid JSON"
-msgstr ""
+msgstr "Impossibile applicare il tema: JSON non valido"
 
 #, fuzzy
 msgid "Failed to copy API key to clipboard"
@@ -6504,29 +10348,49 @@ msgstr "copia URL in appunti"
 msgid "Failed to create API key"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to create report"
-msgstr ""
+msgstr "Impossibile creare il report"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Failed to execute %(query)s"
-msgstr ""
+msgstr "Impossibile eseguire %(query)s"
 
 #, fuzzy
 msgid "Failed to fetch API keys"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to generate chart edit URL"
-msgstr ""
+msgstr "Impossibile generare l'URL di modifica del grafico"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "Impossibile generare il download: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data"
-msgstr ""
+msgstr "Impossibile caricare i dati del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data."
-msgstr ""
+msgstr "Impossibile caricare i dati del grafico."
 
 #, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
@@ -6536,16 +10400,23 @@ msgstr "Mostra database"
 msgid "Failed to load top values"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "Impossibile aprire il file. Riprova."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr ""
+msgstr "Impossibile rimuovere il tema scuro di sistema: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system default theme: %s"
-msgstr ""
+msgstr "Impossibile rimuovere il tema predefinito di sistema: %s"
 
 #, fuzzy
 msgid "Failed to retrieve advanced type"
@@ -6567,119 +10438,207 @@ msgstr "Cerca / Filtra"
 msgid "Failed to save cross-filters setting"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to set local theme: Invalid JSON configuration"
-msgstr ""
+msgstr "Impossibile impostare il tema locale: configurazione JSON non valida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system dark theme: %s"
-msgstr ""
+msgstr "Impossibile impostare il tema scuro di sistema: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system default theme: %s"
-msgstr ""
+msgstr "Impossibile impostare il tema predefinito di sistema: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to start remote query on a worker."
-msgstr ""
+msgstr "Impossibile avviare la query remota su un worker."
 
 #, fuzzy
 msgid "Failed to stop query."
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to store query results. Please try again."
-msgstr ""
+msgstr "Impossibile salvare i risultati della query. Riprova."
 
 #, fuzzy
 msgid "Failed to tag items"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to update report"
-msgstr ""
+msgstr "Impossibile aggiornare il report"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to validate expression. Please try again."
-msgstr ""
+msgstr "Impossibile convalidare l'espressione. Riprova."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Failed to verify select options: %s"
-msgstr ""
+msgstr "Impossibile verificare le opzioni di selezione: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
 msgstr ""
+"Utilizzo del CSV come fallback; libreria di esportazione Excel non "
+"disponibile."
 
 #, fuzzy
 msgid "False"
 msgstr "Modifica Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Favorite"
-msgstr ""
+msgstr "Preferito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Feature Not Enabled"
-msgstr ""
+msgstr "Funzione non abilitata"
 
 #, fuzzy
 msgid "Featured"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Featured color palettes"
-msgstr ""
+msgstr "Palette di colori in evidenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "February"
-msgstr ""
+msgstr "Febbraio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Fetch data preview"
-msgstr ""
+msgstr "Recupera anteprima dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Fetched %s"
-msgstr ""
+msgstr "Recuperato %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fetching"
-msgstr ""
+msgstr "Recupero in corso"
 
 #, fuzzy
 msgid "Fetching data..."
 msgstr "Database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(json_error)s"
-msgstr ""
+msgstr "Il campo non può essere decodificato da JSON. %(json_error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(msg)s"
-msgstr ""
+msgstr "Il campo non può essere decodificato da JSON. %(msg)s"
 
 #, fuzzy
 msgid "Field cannot be empty."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Field is required"
-msgstr ""
+msgstr "Il campo è obbligatorio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "File extension is not allowed."
-msgstr ""
+msgstr "L'estensione del file non è consentita."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
 msgstr ""
+"La gestione dei file non è supportata in questo browser. Utilizza un "
+"browser moderno come Chrome o Edge."
 
 #, fuzzy
 msgid "File settings"
 msgstr "Abilita il filtro di Select"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "File upload"
-msgstr ""
+msgstr "Caricamento file"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill Color"
-msgstr ""
+msgstr "Colore di riempimento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fill all required fields to enable \"Default Value\""
-msgstr ""
+msgstr "Compila tutti i campi obbligatori per abilitare \"Valore predefinito\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fill method"
-msgstr ""
+msgstr "Metodo di riempimento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill out the registration form"
-msgstr ""
+msgstr "Compila il modulo di registrazione"
 
 #, fuzzy
 msgid "Filled"
@@ -6705,8 +10664,12 @@ msgstr "Valore del filtro"
 msgid "Filter charts"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter has default value"
-msgstr ""
+msgstr "Il filtro ha un valore predefinito"
 
 #, fuzzy
 msgid "Filter menu"
@@ -6715,8 +10678,14 @@ msgstr "Valore del filtro"
 msgid "Filter name"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Filter only displays values relevant to selections made in other filters."
 msgstr ""
+"Il filtro visualizza solo i valori rilevanti per le selezioni effettuate "
+"in altri filtri."
 
 #, fuzzy
 msgid "Filter options"
@@ -6729,15 +10698,23 @@ msgstr "Risultati della ricerca"
 msgid "Filter type"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value (case sensitive)"
-msgstr ""
+msgstr "Valore del filtro (distinzione maiuscole/minuscole)"
 
 #, fuzzy
 msgid "Filter value is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value list cannot be empty"
-msgstr ""
+msgstr "La lista dei valori del filtro non può essere vuota"
 
 msgid "Filter your charts"
 msgstr "Controlli del filtro"
@@ -6755,22 +10732,42 @@ msgstr "Controlli del filtro"
 msgid "Filters by metrics"
 msgstr "Lista Metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Filters for comparison must have a value"
-msgstr ""
+msgstr "I filtri per il confronto devono avere un valore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values equal to this exact value."
-msgstr ""
+msgstr "Filtra i valori uguali a questo valore esatto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values greater than or equal."
-msgstr ""
+msgstr "Filtra i valori maggiori o uguali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values less than or equal."
-msgstr ""
+msgstr "Filtra i valori minori o uguali."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Filters out of scope (%d)"
-msgstr ""
+msgstr "Filtri fuori ambito (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Filters with the same group key will be ORed together within the group, "
 "while different filter groups will be ANDed together. Undefined group "
@@ -6781,16 +10778,32 @@ msgid ""
 "filter (department = 'Finance' OR department = 'Marketing') AND (region ="
 " 'Europe')."
 msgstr ""
+"I filtri con la stessa chiave di gruppo verranno uniti con OR all'interno"
+" del gruppo, mentre i diversi gruppi di filtri verranno uniti con AND. Le"
+" chiavi di gruppo non definite vengono trattate come gruppi univoci, "
+"ovvero non vengono raggruppate insieme. Ad esempio, se una tabella ha tre"
+" filtri, di cui due per i reparti Finanza e Marketing (chiave di gruppo ="
+" 'department') e uno si riferisce alla regione Europa (chiave di gruppo ="
+" 'region'), la clausola di filtro applicherà il filtro (department = "
+"'Finance' OR department = 'Marketing') AND (region = 'Europe')."
 
 #, fuzzy
 msgid "Find"
 msgstr "Min"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Finish"
-msgstr ""
+msgstr "Termina"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "First"
-msgstr ""
+msgstr "Primo"
 
 #, fuzzy
 msgid "First Name"
@@ -6804,93 +10817,188 @@ msgstr "Grafici"
 msgid "First name is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fit columns dynamically"
-msgstr ""
+msgstr "Adatta le colonne dinamicamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Fix the trend line to the full time range specified in case filtered "
 "results do not include the start or end dates"
 msgstr ""
+"Fissa la linea di tendenza all'intero intervallo di tempo specificato nel"
+" caso in cui i risultati filtrati non includano le date di inizio o di "
+"fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fix to selected Time Range"
-msgstr ""
+msgstr "Fissa all'intervallo di tempo selezionato"
 
 #, fuzzy
 msgid "Fixed"
 msgstr "Modificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fixed Color"
-msgstr ""
+msgstr "Colore Fisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Fixed color"
-msgstr ""
+msgstr "Colore fisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Fixed point radius"
-msgstr ""
+msgstr "Raggio del punto fisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Flow"
-msgstr ""
+msgstr "Flusso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Folder with content must have a name"
-msgstr ""
+msgstr "Una cartella con contenuto deve avere un nome"
 
 #, fuzzy
 msgid "Folders"
 msgstr "Filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size"
-msgstr ""
+msgstr "Dimensione carattere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for axis labels, detail value and other text elements"
 msgstr ""
+"Dimensione carattere per le etichette degli assi, il valore di dettaglio "
+"e altri elementi di testo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the biggest value in the list"
-msgstr ""
+msgstr "Dimensione carattere per il valore più grande nella lista"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the smallest value in the list"
-msgstr ""
+msgstr "Dimensione carattere per il valore più piccolo nella lista"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For Bigquery, Presto and Postgres, shows a button to compute cost before "
 "running a query."
 msgstr ""
+"Per Bigquery, Presto e Postgres, mostra un pulsante per calcolare il "
+"costo prima di eseguire una query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "For Trino, describe full schemas of nested ROW types, expanding them with"
 " dotted paths"
 msgstr ""
+"Per Trino, descrivi gli schemi completi dei tipi ROW nidificati, "
+"espandendoli con percorsi puntati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "For further instructions, consult the"
-msgstr ""
+msgstr "Per ulteriori istruzioni, consultare il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For more information about objects are in context in the scope of this "
 "function, refer to the"
 msgstr ""
+"Per ulteriori informazioni sugli oggetti nel contesto di questa funzione,"
+" fare riferimento a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For regular filters, these are the roles this filter will be applied to. "
 "For base filters, these are the roles that the filter DOES NOT apply to, "
 "e.g. Admin if admin should see all data."
 msgstr ""
+"Per i filtri regolari, questi sono i ruoli a cui verrà applicato questo "
+"filtro. Per i filtri base, questi sono i ruoli a cui il filtro NON si "
+"applica, ad esempio Admin se l'amministratore deve vedere tutti i dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forbidden"
-msgstr ""
+msgstr "Vietato"
 
 #, fuzzy
 msgid "Force"
 msgstr "Sorgente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "Forza la granularità temporale come intervallo massimo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Forza l'interruzione (interrompe l'attività per tutti gli abbonati)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
 "CTAS or CVAS in SQL Lab."
 msgstr ""
+"Forza la creazione di tutte le tabelle e le viste in questo schema quando"
+" si fa clic su CTAS o CVAS in SQL Lab."
 
 #, fuzzy
 msgid "Force categorical"
@@ -6900,39 +11008,82 @@ msgstr "Formato Datetime"
 msgid "Force date format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh"
-msgstr ""
+msgstr "Forza aggiornamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Force refresh Slack channels list"
-msgstr ""
+msgstr "Forza aggiornamento lista canali Slack"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Force refresh catalog list"
-msgstr ""
+msgstr "Forza aggiornamento lista cataloghi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh schema list"
-msgstr ""
+msgstr "Forza aggiornamento lista schemi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh table list"
-msgstr ""
+msgstr "Forza aggiornamento lista tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
 msgstr ""
+"Forza la granularità temporale selezionata come intervallo massimo per le"
+" etichette dell'asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Forecast periods"
-msgstr ""
+msgstr "Periodi di previsione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Foreign key"
-msgstr ""
+msgstr "Chiave esterna"
 
 #, fuzzy
 msgid "Forest Green"
 msgstr "Ruoli per l'accesso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to chart metadata."
 msgstr ""
+"Dati del modulo non trovati nella cache, ripristino dei metadati del "
+"grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr ""
+"Dati del modulo non trovati nella cache, ripristino dei metadati del "
+"dataset."
 
 #, fuzzy
 msgid "Format"
@@ -6950,22 +11101,39 @@ msgstr "Formato D3"
 msgid "Format SQL query"
 msgstr "Formato D3"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "Format data labels. Use variables: {name}, {value}, {percent}. \\n "
 "represents a new line. ECharts compatibility:\n"
 "{a} (series), {b} (name), {c} (value), {d} (percentage)"
 msgstr ""
+"Formatta le etichette dei dati. Usa le variabili: {name}, {value}, "
+"{percent}. \\n rappresenta una nuova riga. Compatibilità ECharts:\n"
+"{a} (serie), {b} (nome), {c} (valore), {d} (percentuale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"Formatta le metriche o le colonne con simboli di valuta come prefissi o "
+"suffissi. Scegli un simbolo manualmente o usa 'Rilevamento automatico' "
+"per applicare il simbolo corretto in base alla colonna del codice valuta "
+"del dataset. Quando sono presenti più valute, la formattazione torna a "
+"numeri neutri."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Formatted CSV attached in email"
-msgstr ""
+msgstr "CSV formattato allegato nell'email"
 
 #, fuzzy
 msgid "Formatted date"
@@ -6995,24 +11163,44 @@ msgstr "Formato D3"
 msgid "Forward values"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Found invalid orderby options"
-msgstr ""
+msgstr "Trovate opzioni orderby non valide"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fraction digits"
-msgstr ""
+msgstr "Cifre decimali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Frequency"
-msgstr ""
+msgstr "Frequenza"
 
 #, fuzzy
 msgid "Friction"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friction between nodes"
-msgstr ""
+msgstr "Attrito tra i nodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friday"
-msgstr ""
+msgstr "Venerdì"
 
 msgid "From date cannot be larger than to date"
 msgstr "La data di inizio non può essere dopo la data di fine"
@@ -7021,18 +11209,29 @@ msgstr "La data di inizio non può essere dopo la data di fine"
 msgid "Full name"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fullscreen is not supported in this browser."
-msgstr ""
+msgstr "La modalità a schermo intero non è supportata in questo browser."
 
 #, fuzzy
 msgid "Funnel Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each column"
-msgstr ""
+msgstr "Personalizza ulteriormente come visualizzare ogni colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each metric"
-msgstr ""
+msgstr "Personalizza ulteriormente come visualizzare ogni metrica"
 
 #, fuzzy
 msgid "GROUP BY"
@@ -7042,17 +11241,27 @@ msgstr "Raggruppa per"
 msgid "Gantt Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Gantt chart visualizes important events over a time span. Every data "
 "point displayed as a separate event along a horizontal line."
 msgstr ""
+"Il diagramma di Gantt visualizza gli eventi importanti nel corso di un "
+"periodo di tempo. Ogni punto dati viene visualizzato come un evento "
+"separato lungo una linea orizzontale."
 
 #, fuzzy
 msgid "Gauge Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "General"
-msgstr ""
+msgstr "Generale"
 
 #, fuzzy
 msgid "General information"
@@ -7062,15 +11271,23 @@ msgstr "Formato D3"
 msgid "General settings"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Generating link, please wait.."
-msgstr ""
+msgstr "Generazione del link in corso, attendere prego.."
 
 #, fuzzy
 msgid "Generic Chart"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geo"
-msgstr ""
+msgstr "Geo"
 
 #, fuzzy
 msgid "GeoJson Column"
@@ -7080,33 +11297,66 @@ msgstr "Colonna"
 msgid "GeoJson Settings"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geohash"
-msgstr ""
+msgstr "Geohash"
 
 #, fuzzy
 msgid "Geometry Column"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the last date by the date unit."
-msgstr ""
+msgstr "Ottieni l'ultima data in base all'unità di data."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the specify date for the holiday"
-msgstr ""
+msgstr "Ottieni la data specificata per la festività"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Give access to multiple catalogs in a single database connection."
-msgstr ""
+msgstr "Consenti l'accesso a più cataloghi in un'unica connessione al database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Go to the edit mode to configure the dashboard and add charts"
 msgstr ""
+"Vai alla modalità di modifica per configurare il dashboard e aggiungere "
+"grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Gold"
-msgstr ""
+msgstr "Oro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Google Sheet Name and URL"
-msgstr ""
+msgstr "Nome e URL del Foglio Google"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Grace period"
-msgstr ""
+msgstr "Periodo di grazia"
 
 #, fuzzy
 msgid "Grain"
@@ -7116,11 +11366,19 @@ msgstr "Min"
 msgid "Graph Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Graph layout"
-msgstr ""
+msgstr "Layout del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Gravity"
-msgstr ""
+msgstr "Gravità"
 
 #, fuzzy
 msgid "Greater Than"
@@ -7130,17 +11388,29 @@ msgstr "La data di inizio non può essere dopo la data di fine"
 msgid "Greater Than or Equal"
 msgstr "La data di inizio non può essere dopo la data di fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Greater or equal (>=)"
-msgstr ""
+msgstr "Maggiore o uguale (>=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Greater than (>)"
-msgstr ""
+msgstr "Maggiore di (>)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Green for increase, red for decrease"
-msgstr ""
+msgstr "Verde per l'aumento, rosso per la diminuzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Grid"
-msgstr ""
+msgstr "Griglia"
 
 #, fuzzy
 msgid "Grid Size"
@@ -7158,8 +11428,12 @@ msgstr "Raggruppa per"
 msgid "Group By"
 msgstr "Raggruppa per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Group By, Metrics or Percentage Metrics must have a value"
-msgstr ""
+msgstr "Raggruppa per, Metriche o Metriche percentuali devono avere un valore"
 
 #, fuzzy
 msgid "Group Key"
@@ -7168,8 +11442,11 @@ msgstr "Raggruppa per"
 msgid "Group by"
 msgstr "Raggruppa per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group remaining as \"Others\""
-msgstr ""
+msgstr "Raggruppa i rimanenti come \"Altri\""
 
 #, fuzzy
 msgid "Grouping"
@@ -7179,33 +11456,56 @@ msgstr "Testa la Connessione"
 msgid "Groups"
 msgstr "Raggruppa per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Groups remaining series into an \"Others\" category when series limit is "
 "reached. This prevents incomplete time series data from being displayed."
 msgstr ""
+"Raggruppa le serie rimanenti in una categoria \"Altri\" quando viene "
+"raggiunto il limite delle serie. Questo impedisce la visualizzazione di "
+"dati di serie temporali incompleti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Guest user cannot modify chart payload"
-msgstr ""
+msgstr "L'utente ospite non può modificare i dati del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "Percorso HTTP"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Handlebars"
-msgstr ""
+msgstr "Handlebars"
 
 #, fuzzy
 msgid "Handlebars Template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hard value bounds applied for color coding."
-msgstr ""
+msgstr "Limiti di valore fissi applicati per la codifica a colori."
 
 #, fuzzy
 msgid "Has created by"
 msgstr "è stata creata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Header"
-msgstr ""
+msgstr "Intestazione"
 
 #, fuzzy
 msgid "Header row"
@@ -7221,35 +11521,55 @@ msgstr "Mappa di Intensità"
 msgid "Height"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Height of each row in pixels"
-msgstr ""
+msgstr "Altezza di ogni riga in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Height of the sparkline"
-msgstr ""
+msgstr "Altezza dello sparkline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Hidden"
-msgstr ""
+msgstr "Nascosto"
 
 #, fuzzy
 msgid "Hide Column"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hide Line"
-msgstr ""
+msgstr "Nascondi linea"
 
 #, fuzzy
 msgid "Hide chart description"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hide layer"
-msgstr ""
+msgstr "Nascondi livello"
 
 #, fuzzy
 msgid "Hide password."
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hides the Line for the time series"
-msgstr ""
+msgstr "Nasconde la linea per la serie temporale"
 
 #, fuzzy
 msgid "Hierarchy"
@@ -7258,8 +11578,12 @@ msgstr "Cerca"
 msgid "Histogram"
 msgstr "Istogramma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #, fuzzy
 msgid "Horizon Chart"
@@ -7272,17 +11596,33 @@ msgstr "Grafici d'orizzonte"
 msgid "Horizontal"
 msgstr "Grafici d'orizzonte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Horizontal (Top)"
-msgstr ""
+msgstr "Orizzontale (In alto)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Horizontal alignment"
-msgstr ""
+msgstr "Allineamento orizzontale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Host"
-msgstr ""
+msgstr "Host"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hostname or IP address"
-msgstr ""
+msgstr "Nome host o indirizzo IP"
 
 #, fuzzy
 msgid "Hour"
@@ -7292,38 +11632,80 @@ msgstr "ora"
 msgid "Hours %s"
 msgstr "ora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hours offset"
-msgstr ""
+msgstr "Offset in ore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How do you want to enter service account credentials?"
-msgstr ""
+msgstr "Come vuoi inserire le credenziali dell'account di servizio?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "How many buckets should the data be grouped in."
-msgstr ""
+msgstr "In quanti bucket devono essere raggruppati i dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How many periods into the future do we want to predict"
-msgstr ""
+msgstr "Quanti periodi nel futuro vogliamo prevedere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "How many top values to select"
-msgstr ""
+msgstr "Quanti valori principali selezionare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "How to display time shifts: as individual lines; as the difference "
 "between the main time series and each time shift; as the percentage "
 "change; or as the ratio between series and time shifts."
 msgstr ""
+"Come visualizzare gli spostamenti temporali: come linee individuali; come"
+" differenza tra la serie temporale principale e ogni spostamento "
+"temporale; come variazione percentuale; o come rapporto tra serie e "
+"spostamenti temporali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Huge"
-msgstr ""
+msgstr "Enorme"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 3166-2 Codes"
-msgstr ""
+msgstr "Codici ISO 3166-2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 8601"
-msgstr ""
+msgstr "ISO 8601"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon JavaScript config generator"
-msgstr ""
+msgstr "Generatore di configurazione JavaScript per icone"
 
 #, fuzzy
 msgid "Icon URL"
@@ -7333,15 +11715,30 @@ msgstr "Colonna"
 msgid "Icon size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon size unit"
-msgstr ""
+msgstr "Unità di dimensione icona"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Id"
-msgstr ""
+msgstr "Id"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Id of root node of the tree."
-msgstr ""
+msgstr "Id del nodo radice dell'albero."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "If Presto or Trino, all the queries in SQL Lab are going to be executed "
 "as the currently logged on user who must have permission to run them. If "
@@ -7349,44 +11746,93 @@ msgid ""
 "service account, but impersonate the currently logged on user via "
 "hive.server2.proxy.user property."
 msgstr ""
+"Se si utilizza Presto o Trino, tutte le query in SQL Lab verranno "
+"eseguite come l'utente attualmente connesso, che deve avere il permesso "
+"per eseguirle. Se è abilitato Hive e hive.server2.enable.doAs, le query "
+"verranno eseguite come account di servizio, ma con la rappresentazione "
+"dell'utente attualmente connesso tramite la proprietà "
+"hive.server2.proxy.user."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "If a metric is specified, sorting will be done based on the metric value"
 msgstr ""
+"Se viene specificata una metrica, l'ordinamento verrà effettuato in base "
+"al valore della metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If enabled, this control sorts the results/values descending, otherwise "
 "it sorts the results ascending."
 msgstr ""
+"Se abilitato, questo controllo ordina i risultati/valori in modo "
+"decrescente, altrimenti ordina i risultati in modo crescente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
+"Se rimane vuoto, non verrà salvato e verrà rimosso dall'elenco. Per "
+"rimuovere le cartelle, spostare le metriche e le colonne in altre "
+"cartelle."
 
 #, fuzzy
 msgid "If table already exists"
 msgstr "Una o più metriche da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "If you don't save, changes will be lost."
-msgstr ""
+msgstr "Se non salvi, le modifiche andranno perse."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ignore cache when generating report"
-msgstr ""
+msgstr "Ignora la cache durante la generazione del report"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore null locations"
-msgstr ""
+msgstr "Ignora le posizioni nulle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore time"
-msgstr ""
+msgstr "Ignora il tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image (PNG) embedded in email"
-msgstr ""
+msgstr "Immagine (PNG) incorporata nell'e-mail"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image download failed, please refresh and try again."
-msgstr ""
+msgstr "Download dell'immagine non riuscito, aggiorna la pagina e riprova."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)"
-msgstr ""
+msgstr "Impersona l'utente connesso (Presto, Trino, Drill, Hive e Google Sheets)"
 
 msgid "Import"
 msgstr "Importa"
@@ -7399,35 +11845,55 @@ msgstr "Importa"
 msgid "Import Error"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Import chart failed for an unknown reason"
-msgstr ""
+msgstr "Importazione del grafico non riuscita per un motivo sconosciuto"
 
 #, fuzzy
 msgid "Import charts"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dashboard failed for an unknown reason"
-msgstr ""
+msgstr "Importazione del dashboard non riuscita per un motivo sconosciuto"
 
 msgid "Import dashboards"
 msgstr "Importa dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import database failed for an unknown reason"
-msgstr ""
+msgstr "Importazione del database non riuscita per un motivo sconosciuto"
 
 #, fuzzy
 msgid "Import database from file"
 msgstr "Mostra database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dataset failed for an unknown reason"
-msgstr ""
+msgstr "Importazione del dataset non riuscita per un motivo sconosciuto"
 
 #, fuzzy
 msgid "Import queries"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import saved query failed for an unknown reason."
-msgstr ""
+msgstr "Importazione della query salvata non riuscita per un motivo sconosciuto."
 
 #, fuzzy
 msgid "Import themes"
@@ -7445,37 +11911,63 @@ msgstr "Elenco Dashboard"
 msgid "In Range"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
 "service account or configure an OAuth2 client."
 msgstr ""
+"Per connettersi a fogli non pubblici è necessario fornire un account di "
+"servizio o configurare un client OAuth2."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "In this view you can preview the first 25 rows. "
-msgstr ""
+msgstr "In questa vista puoi visualizzare in anteprima le prime 25 righe. "
 
 #, fuzzy
 msgid "Inactive"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include Series"
-msgstr ""
+msgstr "Includi serie"
 
 #, fuzzy
 msgid "Include Template Parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include a description that will be sent with your report"
-msgstr ""
+msgstr "Includi una descrizione che verrà inviata con il tuo report"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Include description to be sent with %s"
-msgstr ""
+msgstr "Includi descrizione da inviare con %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include series name as an axis"
-msgstr ""
+msgstr "Includi il nome della serie come asse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Include time"
-msgstr ""
+msgstr "Includi tempo"
 
 #, fuzzy
 msgid "Increase"
@@ -7505,32 +11997,64 @@ msgstr "Tabella"
 msgid "Indexes (%s)"
 msgstr "minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Info"
-msgstr ""
+msgstr "Informazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inherit range from time filter"
-msgstr ""
+msgstr "Eredita intervallo dal filtro temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "Profondità iniziale dell'albero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner Radius"
-msgstr ""
+msgstr "Raggio interno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner radius of donut hole"
-msgstr ""
+msgstr "Raggio interno del foro del donut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input custom width in pixels"
-msgstr ""
+msgstr "Inserisci larghezza personalizzata in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input field supports custom rotation. e.g. 30 for 30°"
-msgstr ""
+msgstr "Il campo di input supporta la rotazione personalizzata. es. 30 per 30°"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer URL"
-msgstr ""
+msgstr "Inserisci URL del livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer title"
-msgstr ""
+msgstr "Inserisci titolo del livello"
 
 #, fuzzy
 msgid "Inside"
@@ -7556,8 +12080,11 @@ msgstr "Cancella"
 msgid "Inside right"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "Interno in alto"
 
 #, fuzzy
 msgid "Inside top left"
@@ -7567,17 +12094,33 @@ msgstr "Cancella"
 msgid "Inside top right"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Intensity"
-msgstr ""
+msgstr "Intensità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity Radius"
-msgstr ""
+msgstr "Raggio di intensità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Intensity Radius is the radius at which the weight is distributed"
-msgstr ""
+msgstr "Il raggio di intensità è il raggio al quale il peso viene distribuito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity is the value multiplied by the weight to obtain the final weight"
 msgstr ""
+"L'intensità è il valore moltiplicato per il peso per ottenere il peso "
+"finale"
 
 #, fuzzy
 msgid "Interval"
@@ -7591,8 +12134,12 @@ msgstr "Controlli del filtro"
 msgid "Interval bounds"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Interval colors"
-msgstr ""
+msgstr "Colori dell'intervallo"
 
 #, fuzzy
 msgid "Interval start column"
@@ -7602,13 +12149,22 @@ msgstr "Controlli del filtro"
 msgid "Intervals"
 msgstr "Filtrabile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid Connection String: Expecting String of the form "
 "'ocient://user:pass@host:port/database'."
 msgstr ""
+"Stringa di connessione non valida: è prevista una stringa nella forma "
+"'ocient://user:pass@host:port/database'."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid JSON"
-msgstr ""
+msgstr "JSON non valido"
 
 #, fuzzy
 msgid "Invalid JSON configuration"
@@ -7618,119 +12174,214 @@ msgstr "Controlli del filtro"
 msgid "Invalid JSON metadata"
 msgstr "Metadati JSON"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Invalid SQL: %(error)s"
-msgstr ""
+msgstr "SQL non valido: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid advanced data type: %(advanced_data_type)s"
-msgstr ""
+msgstr "Tipo di dati avanzato non valido: %(advanced_data_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid certificate"
-msgstr ""
+msgstr "Certificato non valido"
 
 #, fuzzy
 msgid "Invalid color"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually follows: "
 "backend+driver://user:password@database-host/database-name"
 msgstr ""
+"Stringa di connessione non valida, una stringa valida segue solitamente: "
+"backend+driver://user:password@database-host/database-name"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually "
 "follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
 "NAME'<p>Example:'postgresql://user:password@your-postgres-"
 "db/database'</p>"
 msgstr ""
+"Stringa di connessione non valida, una stringa valida segue "
+"solitamente:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
+"NAME'<p>Esempio:'postgresql://user:password@your-postgres-"
+"db/database'</p>"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid cron expression"
-msgstr ""
+msgstr "Espressione cron non valida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid cumulative operator: %(operator)s"
-msgstr ""
+msgstr "Operatore cumulativo non valido: %(operator)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid currency code in saved metrics"
-msgstr ""
+msgstr "Codice valuta non valido nelle metriche salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid date/timestamp format"
-msgstr ""
+msgstr "Formato data/timestamp non valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid executor type"
-msgstr ""
+msgstr "Tipo di executor non valido"
 
 #, fuzzy
 msgid "Invalid expression"
 msgstr "Espressione SQL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid filter operation type: %(op)s"
-msgstr ""
+msgstr "Tipo di operazione filtro non valido: %(op)s"
 
 #, fuzzy
 msgid "Invalid formula expression"
 msgstr "Espressione SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geodetic string"
-msgstr ""
+msgstr "Stringa geodetica non valida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geohash string"
-msgstr ""
+msgstr "Stringa geohash non valida"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid input"
-msgstr ""
+msgstr "Input non valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid lat/long configuration."
-msgstr ""
+msgstr "Configurazione lat/long non valida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid longitude/latitude"
-msgstr ""
+msgstr "Longitudine/latitudine non valida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid metric object: %(metric)s"
-msgstr ""
+msgstr "Oggetto metrica non valido: %(metric)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid numpy function: %(operator)s"
-msgstr ""
+msgstr "Funzione numpy non valida: %(operator)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid options for %(rolling_type)s: %(options)s"
-msgstr ""
+msgstr "Opzioni non valide per %(rolling_type)s: %(options)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid permalink key"
-msgstr ""
+msgstr "Chiave permalink non valida"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid reference to column: \"%(column)s\""
-msgstr ""
+msgstr "Riferimento non valido alla colonna: \"%(column)s\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid result type: %(result_type)s"
-msgstr ""
+msgstr "Tipo di risultato non valido: %(result_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid rolling_type: %(type)s"
-msgstr ""
+msgstr "rolling_type non valido: %(type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid spatial point encountered: %(latlong)s"
-msgstr ""
+msgstr "Punto spaziale non valido rilevato: %(latlong)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid state."
-msgstr ""
+msgstr "Stato non valido."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, sk,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
-msgstr ""
+msgstr "ID scheda non validi: %(tab_ids)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Nome utente o password non validi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inverse selection"
-msgstr ""
+msgstr "Selezione inversa"
 
 #, fuzzy
 msgid "Invert current page"
@@ -7748,60 +12399,110 @@ msgstr "Nome Completo"
 msgid "Is certified"
 msgstr "Modificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Is custom tag"
-msgstr ""
+msgstr "È un tag personalizzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is dimension"
-msgstr ""
+msgstr "È una dimensione"
 
 #, fuzzy
 msgid "Is false"
 msgstr "Modifica Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Is favorite"
-msgstr ""
+msgstr "È un preferito"
 
 msgid "Is filterable"
 msgstr "Filtrabile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is not null"
-msgstr ""
+msgstr "Non è null"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is null"
-msgstr ""
+msgstr "È null"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is tagged"
-msgstr ""
+msgstr "È taggato"
 
 msgid "Is temporal"
 msgstr "è temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is true"
-msgstr ""
+msgstr "È vero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Isoband"
-msgstr ""
+msgstr "Isoband"
 
 #, fuzzy
 msgid "Isoline"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Issue 1000 - The dataset is too large to query."
-msgstr ""
+msgstr "Problema 1000 - Il dataset è troppo grande per essere interrogato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Issue 1001 - The database is under an unusual load."
-msgstr ""
+msgstr "Problema 1001 - Il database è sotto un carico insolito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
 msgstr ""
+"Non verrà rimosso anche se vuoto. Non verrà mostrato nella vista di "
+"modifica del grafico se vuoto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
-msgstr ""
+msgstr "Non è consigliato troncare l'asse Y nel grafico a barre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JAN"
-msgstr ""
+msgstr "GEN"
 
 msgid "JSON"
 msgstr "JSON"
@@ -7816,89 +12517,171 @@ msgstr "Metadati JSON"
 msgid "JSON metadata"
 msgstr "Metadati JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON metadata and advanced configuration"
-msgstr ""
+msgstr "Metadati JSON e configurazione avanzata"
 
 #, fuzzy
 msgid "JSON metadata is invalid!"
 msgstr "json non è valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "JSON string containing additional connection configuration. This is used "
 "to provide connection information for systems like Hive, Presto and "
 "BigQuery which do not conform to the username:password syntax normally "
 "used by SQLAlchemy."
 msgstr ""
+"Stringa JSON contenente la configurazione di connessione aggiuntiva. "
+"Viene utilizzata per fornire informazioni di connessione per sistemi come"
+" Hive, Presto e BigQuery che non sono conformi alla sintassi "
+"username:password normalmente utilizzata da SQLAlchemy."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "JUL"
-msgstr ""
+msgstr "LUG"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JUN"
-msgstr ""
+msgstr "GIU"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "January"
-msgstr ""
+msgstr "Gennaio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript data interceptor"
-msgstr ""
+msgstr "Intercettore dati JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "JavaScript onClick href"
-msgstr ""
+msgstr "JavaScript onClick href"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript tooltip generator"
-msgstr ""
+msgstr "Generatore di tooltip JavaScript"
 
 #, fuzzy
 msgid "Jinja templating"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "July"
-msgstr ""
+msgstr "Luglio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "June"
-msgstr ""
+msgstr "Giugno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "KPI"
-msgstr ""
+msgstr "KPI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Keep control settings?"
-msgstr ""
+msgstr "Mantenere le impostazioni di controllo?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Keep editing"
-msgstr ""
+msgstr "Continua a modificare"
 
 #, fuzzy
 msgid "Key"
 msgstr "Sankey"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Key Prefix"
-msgstr ""
+msgstr "Prefisso chiave"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Scorciatoie da tastiera"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
+"Le chiavi vengono mostrate solo una volta alla creazione. Conservale in "
+"modo sicuro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Keys for table"
-msgstr ""
+msgstr "Chiavi per la tabella"
 
 #, fuzzy
 msgid "Kilometers"
 msgstr "Filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Label"
-msgstr ""
+msgstr "Etichetta"
 
 #, fuzzy
 msgid "Label Contents"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label JavaScript config generator"
-msgstr ""
+msgstr "Generatore di configurazione JavaScript per le etichette"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label Line"
-msgstr ""
+msgstr "Linea etichetta"
 
 #, fuzzy
 msgid "Label Template"
@@ -7924,11 +12707,20 @@ msgstr "Colonna del Tempo"
 msgid "Label descending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label for the index column. Don't use an existing column name."
 msgstr ""
+"Etichetta per la colonna indice. Non utilizzare un nome di colonna "
+"esistente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Label for your query"
-msgstr ""
+msgstr "Etichetta per la tua query"
 
 #, fuzzy
 msgid "Label position"
@@ -7946,42 +12738,73 @@ msgstr "Tabelle"
 msgid "Label size unit"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label threshold"
-msgstr ""
+msgstr "Soglia etichetta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labelling"
-msgstr ""
+msgstr "Etichettatura"
 
 #, fuzzy
 msgid "Labels"
 msgstr "Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the marker lines"
-msgstr ""
+msgstr "Etichette per le linee marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the markers"
-msgstr ""
+msgstr "Etichette per i marcatori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the ranges"
-msgstr ""
+msgstr "Etichette per gli intervalli"
 
 #, fuzzy
 msgid "Languages"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Large"
-msgstr ""
+msgstr "Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Last"
-msgstr ""
+msgstr "Ultimo"
 
 #, fuzzy
 msgid "Last Name"
 msgstr "Database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last Updated %s"
-msgstr ""
+msgstr "Ultimo aggiornamento %s"
 
 #, fuzzy, python-format
 msgid "Last Updated %s by %s"
@@ -7991,9 +12814,12 @@ msgstr "Ultima Modifica"
 msgid "Last Used"
 msgstr "Numero Grande"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last available value seen on %s"
-msgstr ""
+msgstr "Ultimo valore disponibile visto il %s"
 
 #, fuzzy
 msgid "Last day"
@@ -8041,14 +12867,25 @@ msgstr "settimana"
 msgid "Last year"
 msgstr "Cluster"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lat"
-msgstr ""
+msgstr "Lat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude"
-msgstr ""
+msgstr "Latitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude of default viewport"
-msgstr ""
+msgstr "Latitudine del viewport predefinito"
 
 #, fuzzy
 msgid "Layer"
@@ -8058,8 +12895,11 @@ msgstr "anno"
 msgid "Layer Name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Layer URL"
-msgstr ""
+msgstr "URL del livello"
 
 msgid "Layer configuration"
 msgstr "Controlli del filtro"
@@ -8076,17 +12916,33 @@ msgstr "Valore del filtro"
 msgid "Layers"
 msgstr "Filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout"
-msgstr ""
+msgstr "Layout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout elements"
-msgstr ""
+msgstr "Elementi di layout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of graph"
-msgstr ""
+msgstr "Tipo di layout del grafo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of tree"
-msgstr ""
+msgstr "Tipo di layout dell'albero"
 
 #, fuzzy
 msgid "Least recently modified"
@@ -8096,24 +12952,46 @@ msgstr "Ultima Modifica"
 msgid "Left"
 msgstr "Cancella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left Margin"
-msgstr ""
+msgstr "Margine sinistro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left margin, in pixels, allowing for more room for axis labels"
 msgstr ""
+"Margine sinistro, in pixel, che consente più spazio per le etichette "
+"degli assi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left to Right"
-msgstr ""
+msgstr "Da sinistra a destra"
 
 #, fuzzy
 msgid "Left value"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legacy"
-msgstr ""
+msgstr "Legacy"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legend"
-msgstr ""
+msgstr "Legenda"
 
 #, fuzzy
 msgid "Legend Format"
@@ -8131,26 +13009,51 @@ msgstr "Testa la Connessione"
 msgid "Legend Type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Legend type"
-msgstr ""
+msgstr "Tipo di legenda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than"
-msgstr ""
+msgstr "Minore di"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than or Equal"
-msgstr ""
+msgstr "Minore o uguale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Less or equal (<=)"
-msgstr ""
+msgstr "Minore o uguale (<=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Less than (<)"
-msgstr ""
+msgstr "Minore di (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Lift percent precision"
-msgstr ""
+msgstr "Precisione percentuale di incremento"
 
 #, fuzzy
 msgid "Light"
@@ -8160,14 +13063,26 @@ msgstr "Altezza"
 msgid "Light (Carto)"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Light mode"
-msgstr ""
+msgstr "Modalità chiara"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like"
-msgstr ""
+msgstr "Like"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like (case insensitive)"
-msgstr ""
+msgstr "Like (senza distinzione tra maiuscole e minuscole)"
 
 #, fuzzy
 msgid "Limit"
@@ -8177,12 +13092,23 @@ msgstr "Tipo"
 msgid "Limit type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Limits the number of cells that get retrieved."
-msgstr ""
+msgstr "Limita il numero di celle recuperate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Limits the number of rows that get displayed."
-msgstr ""
+msgstr "Limita il numero di righe visualizzate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of series that get displayed. A joined subquery (or an "
 "extra phase where subqueries are not supported) is applied to limit the "
@@ -8190,11 +13116,22 @@ msgid ""
 "when grouping by high cardinality column(s) though does increase the "
 "query complexity and cost."
 msgstr ""
+"Limita il numero di serie visualizzate. Viene applicata una sottoquery "
+"unita (o una fase aggiuntiva dove le sottoquery non sono supportate) per "
+"limitare il numero di serie recuperate e renderizzate. Questa "
+"funzionalità è utile quando si raggruppa per colonne ad alta cardinalità,"
+" anche se aumenta la complessità e il costo della query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of the rows that are computed in the query that is the "
 "source of the data used for this chart."
 msgstr ""
+"Limita il numero di righe calcolate nella query che è la fonte dei dati "
+"utilizzati per questo grafico."
 
 #, fuzzy
 msgid "Line"
@@ -8204,21 +13141,40 @@ msgstr "Min"
 msgid "Line Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line Style"
-msgstr ""
+msgstr "Stile linea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Line chart is used to visualize measurements taken over a given category."
 " Line chart is a type of chart which displays information as a series of "
 "data points connected by straight line segments. It is a basic type of "
 "chart common in many fields."
 msgstr ""
+"Il grafico a linee è utilizzato per visualizzare le misurazioni prese su "
+"una determinata categoria. Il grafico a linee è un tipo di grafico che "
+"mostra le informazioni come una serie di punti dati collegati da segmenti"
+" di linea retta. È un tipo di grafico di base comune in molti campi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line charts on a map"
-msgstr ""
+msgstr "Grafici a linee su una mappa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line interpolation as defined by d3.js"
-msgstr ""
+msgstr "Interpolazione della linea come definita da d3.js"
 
 msgid "Line width"
 msgstr "Larghezza"
@@ -8231,11 +13187,19 @@ msgstr "Larghezza"
 msgid "Linear Color Scheme"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear color scheme"
-msgstr ""
+msgstr "Schema di colori lineare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear interpolation"
-msgstr ""
+msgstr "Interpolazione lineare"
 
 #, fuzzy
 msgid "Linear palette"
@@ -8257,8 +13221,11 @@ msgstr "Altezza"
 msgid "List Groups"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List Roles"
-msgstr ""
+msgstr "Elenco ruoli"
 
 #, fuzzy
 msgid "List Unique Values"
@@ -8268,40 +13235,75 @@ msgstr "Filtrabile"
 msgid "List Users"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of extra columns made available in JavaScript functions"
-msgstr ""
+msgstr "Elenco delle colonne aggiuntive rese disponibili nelle funzioni JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List of n+1 values for bucketing metric into n buckets."
-msgstr ""
+msgstr "Elenco di n+1 valori per raggruppare la metrica in n bucket."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List of the column names that should be read"
-msgstr ""
+msgstr "Elenco dei nomi di colonna da leggere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with lines"
-msgstr ""
+msgstr "Elenco dei valori da contrassegnare con linee"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with triangles"
-msgstr ""
+msgstr "Elenco dei valori da contrassegnare con triangoli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List updated"
-msgstr ""
+msgstr "Elenco aggiornato"
 
 #, fuzzy
 msgid "List view"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Live render"
-msgstr ""
+msgstr "Rendering in tempo reale"
 
 #, fuzzy
 msgid "Load CSS template (optional)"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Loaded data cached"
-msgstr ""
+msgstr "Dati caricati nella cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Loaded from cache"
-msgstr ""
+msgstr "Caricato dalla cache"
 
 #, fuzzy
 msgid "Loading"
@@ -8311,22 +13313,34 @@ msgstr "Login"
 msgid "Loading filter values"
 msgstr "Filtrabile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Loading timezones..."
-msgstr ""
+msgstr "Caricamento dei fusi orari..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Loading..."
-msgstr ""
+msgstr "Caricamento..."
 
 #, fuzzy
 msgid "Local"
 msgstr "Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Local theme set for preview"
-msgstr ""
+msgstr "Tema locale impostato per l'anteprima"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Local theme set to \"%s\""
-msgstr ""
+msgstr "Tema locale impostato su \"%s\""
 
 #, fuzzy
 msgid "Locate the chart"
@@ -8336,26 +13350,53 @@ msgstr "Creato il"
 msgid "Log"
 msgstr "Login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Log Scale"
-msgstr ""
+msgstr "Scala logaritmica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Log retention"
-msgstr ""
+msgstr "Conservazione dei log"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Logarithmic axis"
-msgstr ""
+msgstr "Asse logaritmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on primary y-axis"
-msgstr ""
+msgstr "Scala logaritmica sull'asse y primario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on secondary y-axis"
-msgstr ""
+msgstr "Scala logaritmica sull'asse y secondario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Logarithmic x-axis"
-msgstr ""
+msgstr "Asse x logaritmico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic y-axis"
-msgstr ""
+msgstr "Asse y logaritmico"
 
 msgid "Login"
 msgstr "Login"
@@ -8371,44 +13412,94 @@ msgstr "Larghezza"
 msgid "Logout"
 msgstr "Logout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Logs"
-msgstr ""
+msgstr "Registri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lon"
-msgstr ""
+msgstr "Lon"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Long dashed"
-msgstr ""
+msgstr "Tratteggio lungo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude"
-msgstr ""
+msgstr "Longitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Longitude & Latitude"
-msgstr ""
+msgstr "Longitudine e Latitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude & Latitude columns"
-msgstr ""
+msgstr "Colonne Longitudine e Latitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Longitude and Latitude"
-msgstr ""
+msgstr "Longitudine e Latitudine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude of default viewport"
-msgstr ""
+msgstr "Longitudine del viewport predefinito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lower Threshold"
-msgstr ""
+msgstr "Soglia Inferiore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Lower threshold must be lower than upper threshold"
-msgstr ""
+msgstr "La soglia inferiore deve essere inferiore alla soglia superiore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAR"
-msgstr ""
+msgstr "MAR"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAY"
-msgstr ""
+msgstr "MAG"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MON"
-msgstr ""
+msgstr "LUN"
 
 #, fuzzy
 msgid "Main"
@@ -8418,43 +13509,75 @@ msgstr "Min"
 msgid "Main navigation"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Make sure that the controls are configured properly and the datasource "
 "contains data for the selected time range"
 msgstr ""
+"Assicurarsi che i controlli siano configurati correttamente e che la "
+"sorgente dati contenga dati per l'intervallo di tempo selezionato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Make the x-axis categorical"
-msgstr ""
+msgstr "Rendi l'asse x categoriale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Malformed request. slice_id or table_name and db_name arguments are "
 "expected"
 msgstr ""
+"Richiesta non valida. Sono attesi gli argomenti slice_id o table_name e "
+"db_name"
 
 msgid "Manage"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage dashboard owners and access permissions"
-msgstr ""
+msgstr "Gestisci i proprietari del dashboard e le autorizzazioni di accesso"
 
 #, fuzzy
 msgid "Manage email report"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Gestisci filtri e personalizzazioni per impostare l'ambito, le "
+"descrizioni e i limiti. Crea nuovi elementi per una migliore comprensione"
+" del dashboard."
 
 #, fuzzy
 msgid "Manage your databases"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mandatory"
-msgstr ""
+msgstr "Obbligatorio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Manually set min/max values for the y-axis."
-msgstr ""
+msgstr "Imposta manualmente i valori min/max per l'asse y."
 
 #, fuzzy
 msgid "Map"
@@ -8468,16 +13591,28 @@ msgstr "Azione"
 msgid "Map Renderer"
 msgstr "Errore..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Map Style"
-msgstr ""
+msgstr "Stile Mappa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (open-source)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre è open-source e non richiede alcuna chiave API. Mapbox richiede "
+"che MAPBOX_API_KEY sia configurato sul server."
 
 msgid "Mapbox"
 msgstr "Mapbox"
@@ -8486,54 +13621,108 @@ msgstr "Mapbox"
 msgid "Mapbox (API key required)"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox richiede che un MAPBOX_API_KEY sia configurato sul server."
 
 msgid "March"
 msgstr "Cerca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Margin"
-msgstr ""
+msgstr "Margine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Mark a column as temporal in \"Edit datasource\" modal"
 msgstr ""
+"Contrassegna una colonna come temporale nel modal \"Modifica sorgente "
+"dati\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker"
-msgstr ""
+msgstr "Marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker Size"
-msgstr ""
+msgstr "Dimensione Marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker labels"
-msgstr ""
+msgstr "Etichette marcatori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker line labels"
-msgstr ""
+msgstr "Etichette linee marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker lines"
-msgstr ""
+msgstr "Linee marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker size"
-msgstr ""
+msgstr "Dimensione marcatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Markers"
-msgstr ""
+msgstr "Marcatori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Markup type"
-msgstr ""
+msgstr "Tipo di markup"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match system"
-msgstr ""
+msgstr "Segui il sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match time shift color with original series"
-msgstr ""
+msgstr "Abbina il colore dello scostamento temporale alla serie originale"
 
 #, fuzzy
 msgid "Match type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Matrixify"
-msgstr ""
+msgstr "Matrixify"
 
 msgid "Max"
 msgstr "Max"
@@ -8546,90 +13735,169 @@ msgstr "Grandezza della bolla"
 msgid "Max value"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Max. features"
-msgstr ""
+msgstr "Elementi max."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum"
-msgstr ""
+msgstr "Massimo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Font Size"
-msgstr ""
+msgstr "Dimensione Font Massima"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Radius"
-msgstr ""
+msgstr "Raggio Massimo"
 
 #, fuzzy
 msgid "Maximum Width"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "Raggiunta la profondità massima di nidificazione delle cartelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum number of features to fetch from service"
-msgstr ""
+msgstr "Numero massimo di elementi da recuperare dal servizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this maximum radius."
 msgstr ""
+"Dimensione massima del raggio del cerchio, in pixel. Al variare del "
+"livello di zoom, questo garantisce che il cerchio rispetti questo raggio "
+"massimo."
 
 #, fuzzy
 msgid "Maximum value"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum value on the gauge axis"
-msgstr ""
+msgstr "Valore massimo sull'asse del quadrante"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Larghezza massima del percorso, in pixel o metri."
 
 msgid "May"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mean of values over specified period"
-msgstr ""
+msgstr "Media dei valori nel periodo specificato"
 
 #, fuzzy
 msgid "Mean values"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Median"
-msgstr ""
+msgstr "Mediana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median edge width, the thickest edge will be 4 times thicker than the "
 "thinnest."
 msgstr ""
+"Larghezza mediana del bordo; il bordo più spesso sarà 4 volte più spesso "
+"di quello più sottile."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median node size, the largest node will be 4 times larger than the "
 "smallest"
 msgstr ""
+"Dimensione mediana del nodo; il nodo più grande sarà 4 volte più grande "
+"del più piccolo"
 
 #, fuzzy
 msgid "Median values"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Medium"
-msgstr ""
+msgstr "Medio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - binary (1024B => 1KiB)"
-msgstr ""
+msgstr "Memoria in byte - binario (1024B => 1KiB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - decimal (1024B => 1.024kB)"
-msgstr ""
+msgstr "Memoria in byte - decimale (1024B => 1.024kB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - binary (1024B => 1KiB/s)"
-msgstr ""
+msgstr "Velocità di trasferimento memoria in byte - binario (1024B => 1KiB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
+msgstr "Velocità di trasferimento memoria in byte - decimale (1024B => 1.024kB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Menu actions trigger"
-msgstr ""
+msgstr "Attivatore delle azioni del menu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Message content"
-msgstr ""
+msgstr "Contenuto del messaggio"
 
 #, fuzzy
 msgid "Metadata"
@@ -8639,63 +13907,107 @@ msgstr "Metadati JSON"
 msgid "Metadata Parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metadata has been synced"
-msgstr ""
+msgstr "I metadati sono stati sincronizzati"
 
 #, fuzzy
 msgid "Meters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Method"
-msgstr ""
+msgstr "Metodo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Method to compute the displayed value. \"Overall value\" calculates a "
 "single metric across the entire filtered time period, ideal for non-"
 "additive metrics like ratios, averages, or distinct counts. Other methods"
 " operate over the time series data points."
 msgstr ""
+"Metodo per calcolare il valore visualizzato. \"Valore complessivo\" "
+"calcola una singola metrica sull'intero periodo di tempo filtrato, ideale"
+" per metriche non additive come rapporti, medie o conteggi distinti. Gli "
+"altri metodi operano sui punti dati della serie temporale."
 
 msgid "Metric"
 msgstr "Metrica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Metric '%(metric)s' does not exist"
-msgstr ""
+msgstr "La metrica '%(metric)s' non esiste"
 
 #, fuzzy
 msgid "Metric Key"
 msgstr "Metrica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Metric ``%(metric_name)s`` not found in %(dataset_name)s."
-msgstr ""
+msgstr "Metrica ``%(metric_name)s`` non trovata in %(dataset_name)s."
 
 #, fuzzy
 msgid "Metric ascending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric assigned to the [X] axis"
-msgstr ""
+msgstr "Metrica assegnata all'asse [X]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric assigned to the [Y] axis"
-msgstr ""
+msgstr "Metrica assegnata all'asse [Y]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric change in value from `since` to `until`"
-msgstr ""
+msgstr "Variazione del valore della metrica da `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric currency"
-msgstr ""
+msgstr "Valuta della metrica"
 
 #, fuzzy
 msgid "Metric descending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric factor change from `since` to `until`"
-msgstr ""
+msgstr "Variazione del fattore della metrica da `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric for node values"
-msgstr ""
+msgstr "Metrica per i valori dei nodi"
 
 #, fuzzy
 msgid "Metric for ordering"
@@ -8705,43 +14017,82 @@ msgstr "Importa"
 msgid "Metric name"
 msgstr "Ricerca Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Metric name [%s] is duplicated"
-msgstr ""
+msgstr "Il nome della metrica [%s] è duplicato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric percent change in value from `since` to `until`"
-msgstr ""
+msgstr "Variazione percentuale del valore della metrica da `since` a `until`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric that defines the size of the bubble"
-msgstr ""
+msgstr "Metrica che definisce la dimensione della bolla"
 
 #, fuzzy
 msgid "Metric to display bottom title"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metric to use for ordering Top N values"
-msgstr ""
+msgstr "Metrica da utilizzare per ordinare i valori Top N"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used as a weight for the grid's coloring"
-msgstr ""
+msgstr "Metrica utilizzata come peso per la colorazione della griglia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric used to calculate bubble size"
-msgstr ""
+msgstr "Metrica utilizzata per calcolare la dimensione della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used to control height"
-msgstr ""
+msgstr "Metrica utilizzata per controllare l'altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or cell "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"Metrica utilizzata per definire come vengono ordinate le serie principali"
+" se è presente un limite di serie o celle. Se non definita, si ripristina"
+" la prima metrica (dove appropriato)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or row "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"Metrica utilizzata per definire come vengono ordinate le serie principali"
+" se è presente un limite di serie o righe. Se non definita, si ripristina"
+" la prima metrica (dove appropriato)."
 
 msgid "Metrics"
 msgstr "Metriche"
@@ -8750,24 +14101,43 @@ msgstr "Metriche"
 msgid "Metrics (%s)"
 msgstr "Metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
 msgstr ""
+"Le metriche non possono essere utilizzate contemporaneamente per righe e "
+"colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "La cartella delle metriche può contenere solo elementi metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "Le metriche devono essere all'interno delle cartelle"
 
 #, fuzzy
 msgid "Metrics to show in the tooltip."
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Middle"
-msgstr ""
+msgstr "Centro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Midnight"
-msgstr ""
+msgstr "Mezzanotte"
 
 #, fuzzy
 msgid "Miles"
@@ -8776,15 +14146,23 @@ msgstr "Filtri"
 msgid "Min"
 msgstr "Min"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Min Periods"
-msgstr ""
+msgstr "Periodi minimi"
 
 #, fuzzy
 msgid "Min Width"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min periods"
-msgstr ""
+msgstr "Periodi minimi"
 
 #, fuzzy
 msgid "Min value"
@@ -8794,55 +14172,103 @@ msgstr "Valore del filtro"
 msgid "Min value cannot be greater than max value"
 msgstr "La data di inizio non può essere dopo la data di fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Min value should be smaller or equal to max value"
-msgstr ""
+msgstr "Il valore minimo deve essere minore o uguale al valore massimo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min/max (no outliers)"
-msgstr ""
+msgstr "Min/max (senza valori anomali)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mine"
-msgstr ""
+msgstr "Miei"
 
 #, fuzzy
 msgid "Minimum"
 msgstr "minuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum Font Size"
-msgstr ""
+msgstr "Dimensione minima del carattere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Minimum Radius"
-msgstr ""
+msgstr "Raggio minimo"
 
 #, fuzzy
 msgid "Minimum Width"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Minimum must be strictly less than maximum"
-msgstr ""
+msgstr "Il minimo deve essere strettamente inferiore al massimo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this minimum radius."
 msgstr ""
+"Dimensione minima del raggio del cerchio, in pixel. Al variare del "
+"livello di zoom, questo garantisce che il cerchio rispetti tale raggio "
+"minimo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum threshold in percentage points for showing labels."
-msgstr ""
+msgstr "Soglia minima in punti percentuali per la visualizzazione delle etichette."
 
 #, fuzzy
 msgid "Minimum value"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value for label to be displayed on graph."
-msgstr ""
+msgstr "Valore minimo affinché l'etichetta venga visualizzata sul grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value on the gauge axis"
-msgstr ""
+msgstr "Valore minimo sull'asse del misuratore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Larghezza minima del percorso, in pixel o metri."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minor Split Line"
-msgstr ""
+msgstr "Linea di divisione secondaria"
 
 #, fuzzy
 msgid "Minor ticks"
@@ -8860,8 +14286,11 @@ msgstr "minuto"
 msgid "Missing %s"
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Missing OAuth2 token"
-msgstr ""
+msgstr "Token OAuth2 mancante"
 
 #, fuzzy
 msgid "Missing URL parameter"
@@ -8882,10 +14311,12 @@ msgstr "Modificato"
 msgid "Modified %s"
 msgstr "Ultima Modifica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
+msgstr[0] "Modificata 1 colonna nel dataset virtuale"
 
 msgid "Modified by"
 msgstr "Modificato"
@@ -8898,8 +14329,12 @@ msgstr "Ultima Modifica"
 msgid "Modified from \"%s\" template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Monday"
-msgstr ""
+msgstr "Lunedì"
 
 #, fuzzy
 msgid "Month"
@@ -8921,66 +14356,130 @@ msgstr "Azione"
 msgid "More filters"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "MotherDuck token"
-msgstr ""
+msgstr "Token MotherDuck"
 
 #, fuzzy
 msgid "Move icon"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Move only"
-msgstr ""
+msgstr "Solo spostamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Moves the given set of dates by a specified interval."
-msgstr ""
+msgstr "Sposta l'insieme di date specificato di un intervallo definito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Multi-Dimensions"
-msgstr ""
+msgstr "Multi-Dimensioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Layers"
-msgstr ""
+msgstr "Multi-Strati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Levels"
-msgstr ""
+msgstr "Multi-Livelli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Variables"
-msgstr ""
+msgstr "Multi-Variabili"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multiple"
-msgstr ""
+msgstr "Multiplo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Multiple formats accepted, look the geopy.points Python library for more "
 "details"
 msgstr ""
+"Sono accettati più formati; consulta la libreria Python geopy.points per "
+"ulteriori dettagli"
 
 #, fuzzy
 msgid "Multiplier"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
 msgstr ""
+"Devi essere il proprietario del grafico per sovrascriverlo. Salva come "
+"nuovo grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must be unique"
-msgstr ""
+msgstr "Deve essere univoco"
 
 #, fuzzy
 msgid "Must choose either a chart or a dashboard"
 msgstr "Rimuovi il grafico dalla dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Must have a [Group By] column to have 'count' as the [Label]"
 msgstr ""
+"È necessaria una colonna [Raggruppa per] per avere 'count' come "
+"[Etichetta]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Must provide credentials for the SSH Tunnel"
-msgstr ""
+msgstr "È necessario fornire le credenziali per il Tunnel SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must specify a value for filters with comparison operators"
-msgstr ""
+msgstr "È necessario specificare un valore per i filtri con operatori di confronto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "My beautiful colors"
-msgstr ""
+msgstr "I miei bellissimi colori"
 
 #, fuzzy
 msgid "My column"
@@ -8989,15 +14488,23 @@ msgstr "Colonna"
 msgid "My metric"
 msgstr "Metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "N/A"
-msgstr ""
+msgstr "N/D"
 
 #, fuzzy
 msgid "NOT GROUPED BY"
 msgstr "Uno o più controlli per 'Raggruppa per'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "NOV"
-msgstr ""
+msgstr "NOV"
 
 #, fuzzy
 msgid "NUMERIC"
@@ -9006,18 +14513,30 @@ msgstr "Metrica"
 msgid "Name"
 msgstr "Nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name is required"
-msgstr ""
+msgstr "Il nome è obbligatorio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name must be unique"
-msgstr ""
+msgstr "Il nome deve essere univoco"
 
 #, fuzzy
 msgid "Name of table to be created"
 msgstr "Nome delle tabella esistente nella sorgente del database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the column containing the id of the parent node"
-msgstr ""
+msgstr "Nome della colonna contenente l'ID del nodo padre"
 
 #, fuzzy
 msgid "Name of the id column"
@@ -9027,11 +14546,19 @@ msgstr "Colonna del Tempo"
 msgid "Name of the semantic layer"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the source nodes"
-msgstr ""
+msgstr "Nome dei nodi sorgente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the target nodes"
-msgstr ""
+msgstr "Nome dei nodi di destinazione"
 
 #, fuzzy
 msgid "Name of your tag"
@@ -9041,21 +14568,37 @@ msgstr "Database"
 msgid "Name your database"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
 msgstr ""
+"Assegna un nome alla tua cartella; per modificarla in seguito, clicca sul"
+" nome della cartella"
 
 #, fuzzy
 msgid "Native filter column is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Native filter values has no values"
-msgstr ""
+msgstr "I valori del filtro nativo non contengono valori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn how to connect your database"
-msgstr ""
+msgstr "Hai bisogno di aiuto? Scopri come connettere il tuo database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn more about"
-msgstr ""
+msgstr "Hai bisogno di aiuto? Scopri di più su"
 
 #, fuzzy
 msgid "Network Error"
@@ -9072,8 +14615,11 @@ msgstr "Errore nel creare il datasource"
 msgid "Network error."
 msgstr "Errore di rete."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "New"
-msgstr ""
+msgstr "Nuovo"
 
 #, fuzzy
 msgid "New Semantic Layer"
@@ -9094,17 +14640,33 @@ msgstr "Database"
 msgid "New header"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab"
-msgstr ""
+msgstr "Nuova scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + q)"
-msgstr ""
+msgstr "Nuova scheda (Ctrl + q)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + t)"
-msgstr ""
+msgstr "Nuova scheda (Ctrl + t)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Next"
-msgstr ""
+msgstr "Avanti"
 
 #, fuzzy
 msgid "Nightingale"
@@ -9114,12 +14676,19 @@ msgstr "Esplora grafico"
 msgid "Nightingale Rose Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No"
-msgstr ""
+msgstr "No"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "No %s yet"
-msgstr ""
+msgstr "Nessun %s ancora"
 
 #, fuzzy
 msgid "No Data"
@@ -9153,11 +14722,19 @@ msgstr "Seleziona una colonna"
 msgid "No annotation layers"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No annotation layers yet"
-msgstr ""
+msgstr "Nessun livello di annotazione ancora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No annotation yet"
-msgstr ""
+msgstr "Nessuna annotazione ancora"
 
 #, fuzzy
 msgid "No applied filters"
@@ -9175,44 +14752,75 @@ msgstr "Colonna del Tempo"
 msgid "No compatible %s found"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible catalog found"
-msgstr ""
+msgstr "Nessun catalogo compatibile trovato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No compatible columns found"
-msgstr ""
+msgstr "Nessuna colonna compatibile trovata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible schema found"
-msgstr ""
+msgstr "Nessuno schema compatibile trovato"
 
 msgid "No data"
 msgstr "Metadati JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No data after filtering or data is NULL for the latest time record"
 msgstr ""
+"Nessun dato dopo il filtraggio oppure i dati sono NULL per l'ultimo "
+"record temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No data in file"
-msgstr ""
+msgstr "Nessun dato nel file"
 
 #, fuzzy
 msgid "No databases available"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No databases match your search"
-msgstr ""
+msgstr "Nessun database corrisponde alla tua ricerca"
 
 #, fuzzy
 msgid "No description available."
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No entities have this tag currently assigned"
-msgstr ""
+msgstr "Nessuna entità ha attualmente questo tag assegnato"
 
 #, fuzzy
 msgid "No filter"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No filter is selected."
-msgstr ""
+msgstr "Nessun filtro selezionato."
 
 #, fuzzy
 msgid "No filters"
@@ -9226,14 +14834,25 @@ msgstr "Aggiungi filtro"
 msgid "No filters are currently added to this dashboard."
 msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Nessun filtro o personalizzazione ancora creato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No form settings were maintained"
-msgstr ""
+msgstr "Nessuna impostazione del modulo è stata mantenuta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "No global filters are currently added"
-msgstr ""
+msgstr "Non sono stati aggiunti filtri globali"
 
 #, fuzzy
 msgid "No groups"
@@ -9269,17 +14888,33 @@ msgstr "visualizza risultati"
 msgid "No results found"
 msgstr "Nessun record trovato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No results match your filter criteria"
-msgstr ""
+msgstr "Nessun risultato corrisponde ai tuoi criteri di filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No results were returned for this query"
-msgstr ""
+msgstr "Nessun risultato è stato restituito per questa query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "No results were returned for this query. If you expected results to be "
 "returned, ensure any filters are configured properly and the datasource "
 "contains data for the selected time range."
 msgstr ""
+"Nessun risultato è stato restituito per questa query. Se ti aspettavi che"
+" venissero restituiti risultati, assicurati che i filtri siano "
+"configurati correttamente e che la sorgente dati contenga dati per "
+"l'intervallo di tempo selezionato."
 
 #, fuzzy
 msgid "No roles"
@@ -9289,13 +14924,17 @@ msgstr "Grafici"
 msgid "No roles yet"
 msgstr "Grafici"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No rows were returned for this %s"
-msgstr ""
+msgstr "Nessuna riga è stata restituita per questo %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No samples were returned for this %s"
-msgstr ""
+msgstr "Nessun campione è stato restituito per questo %s"
 
 #, fuzzy
 msgid "No saved expressions found"
@@ -9305,11 +14944,21 @@ msgstr "Espressione SQL"
 msgid "No saved metrics found"
 msgstr "Seleziona una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No stored results found, you need to re-run your query"
-msgstr ""
+msgstr "Nessun risultato archiviato trovato, è necessario rieseguire la query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No such column found. To filter on a metric, try the Custom SQL tab."
 msgstr ""
+"Nessuna colonna trovata. Per filtrare su una metrica, prova la scheda SQL"
+" personalizzato."
 
 #, fuzzy
 msgid "No table columns"
@@ -9335,17 +14984,29 @@ msgstr "Grafici"
 msgid "No users yet"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No validator found (configured for the engine)"
-msgstr ""
+msgstr "Nessun validatore trovato (configurato per il motore)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "No validator named %(validator_name)s found (configured for the "
 "%(engine_spec)s engine)"
 msgstr ""
+"Nessun validatore denominato %(validator_name)s trovato (configurato per "
+"il motore %(engine_spec)s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node label position"
-msgstr ""
+msgstr "Posizione dell'etichetta del nodo"
 
 #, fuzzy
 msgid "Node select mode"
@@ -9355,30 +15016,57 @@ msgstr "Seleziona una colonna"
 msgid "Node size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None"
-msgstr ""
+msgstr "Nessuno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> Arrow"
-msgstr ""
+msgstr "Nessuno -> Freccia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> None"
-msgstr ""
+msgstr "Nessuno -> Nessuno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normal"
-msgstr ""
+msgstr "Normale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Normalize"
-msgstr ""
+msgstr "Normalizza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalize Across"
-msgstr ""
+msgstr "Normalizza su"
 
 #, fuzzy
 msgid "Normalize column names"
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalized"
-msgstr ""
+msgstr "Normalizzato"
 
 #, fuzzy
 msgid "Not Contains"
@@ -9388,8 +15076,12 @@ msgstr "Importa"
 msgid "Not Equal"
 msgstr "visualizza risultati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not Time Series"
-msgstr ""
+msgstr "Non serie temporale"
 
 #, fuzzy
 msgid "Not a valid ZIP file"
@@ -9399,8 +15091,11 @@ msgstr "Aggiungi filtro"
 msgid "Not added to any dashboard"
 msgstr "Aggiungi ad una nuova dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not all required fields are complete. Please provide the following:"
-msgstr ""
+msgstr "Non tutti i campi obbligatori sono compilati. Fornisci i seguenti:"
 
 #, fuzzy
 msgid "Not available"
@@ -9410,8 +15105,12 @@ msgstr "descrizione"
 msgid "Not defined"
 msgstr "Modificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Not equal to (≠)"
-msgstr ""
+msgstr "Diverso da (≠)"
 
 #, fuzzy
 msgid "Not found"
@@ -9421,36 +15120,70 @@ msgstr "Azione"
 msgid "Not in"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not null"
-msgstr ""
+msgstr "Non nullo"
 
 #, fuzzy
 msgid "Not set"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Not triggered"
-msgstr ""
+msgstr "Non attivato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not up to date"
-msgstr ""
+msgstr "Non aggiornato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Nothing here yet"
-msgstr ""
+msgstr "Ancora niente qui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Nothing triggered"
-msgstr ""
+msgstr "Niente attivato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Notification Method"
-msgstr ""
+msgstr "Metodo di notifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Notification method"
-msgstr ""
+msgstr "Metodo di notifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "November"
-msgstr ""
+msgstr "Novembre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Now"
-msgstr ""
+msgstr "Ora"
 
 #, fuzzy
 msgid "Null Values"
@@ -9460,19 +15193,31 @@ msgstr "Valore del filtro"
 msgid "Null imputation"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Null or Empty"
-msgstr ""
+msgstr "Null o vuoto"
 
 #, fuzzy
 msgid "Number Format"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Number bounds used for color encoding from red to blue.\n"
 "               Reverse the numbers for blue to red. To get pure red or "
 "blue,\n"
 "               you can enter either only min or max."
 msgstr ""
+"Limiti numerici utilizzati per la codifica dei colori dal rosso al blu.\n"
+"               Inverti i numeri per passare dal blu al rosso. Per "
+"ottenere rosso o blu puro,\n"
+"               puoi inserire solo il min o il max."
 
 #, fuzzy
 msgid "Number format"
@@ -9486,70 +15231,143 @@ msgstr "Formato D3"
 msgid "Number formatting"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of buckets to group data"
-msgstr ""
+msgstr "Numero di bucket per raggruppare i dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts per row when not fitting dynamically"
-msgstr ""
+msgstr "Numero di grafici per riga quando non si adattano dinamicamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts to display per row"
-msgstr ""
+msgstr "Numero di grafici da visualizzare per riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal digits to round numbers to"
-msgstr ""
+msgstr "Numero di cifre decimali a cui arrotondare i numeri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display lift values"
-msgstr ""
+msgstr "Numero di cifre decimali con cui visualizzare i valori di lift"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display p-values"
-msgstr ""
+msgstr "Numero di cifre decimali con cui visualizzare i valori p"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Number of periods to compare against. You can use negative numbers to "
 "compare from the beginning of the time range."
 msgstr ""
+"Numero di periodi con cui confrontare. Puoi utilizzare numeri negativi "
+"per confrontare dall'inizio dell'intervallo di tempo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Number of periods to ratio against"
-msgstr ""
+msgstr "Numero di periodi con cui calcolare il rapporto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of rows of file to read. Leave empty (default) to read all rows"
 msgstr ""
+"Numero di righe del file da leggere. Lascia vuoto (predefinito) per "
+"leggere tutte le righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of rows to skip at start of file."
-msgstr ""
+msgstr "Numero di righe da saltare all'inizio del file."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of split segments on the axis"
-msgstr ""
+msgstr "Numero di segmenti divisi sull'asse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the X scale"
 msgstr ""
+"Numero di passi da effettuare tra le tacche durante la visualizzazione "
+"della scala X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the Y scale"
 msgstr ""
+"Numero di passi da effettuare tra le tacche durante la visualizzazione "
+"della scala Y"
 
 #, fuzzy
 msgid "Number of top values"
 msgstr "Formato D3"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Numbers must be within %(min)s and %(max)s"
-msgstr ""
+msgstr "I numeri devono essere compresi tra %(min)s e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Numeric column used to calculate the histogram."
-msgstr ""
+msgstr "Colonna numerica utilizzata per calcolare l'istogramma."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Numerical range"
-msgstr ""
+msgstr "Intervallo numerico"
 
 #, fuzzy
 msgid "OAuth2 client information"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OCT"
-msgstr ""
+msgstr "OTT"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #, fuzzy
 msgid "OR"
@@ -9558,47 +15376,91 @@ msgstr "ora"
 msgid "OVERWRITE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "October"
-msgstr ""
+msgstr "Ottobre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Offline"
-msgstr ""
+msgstr "Non in linea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "On Grace"
-msgstr ""
+msgstr "In periodo di grazia"
 
 #, fuzzy
 msgid "On dashboards"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many columns to group by. High cardinality groupings should "
 "include a series limit to limit the number of fetched and rendered "
 "series."
 msgstr ""
+"Una o più colonne per il raggruppamento. I raggruppamenti con alta "
+"cardinalità dovrebbero includere un limite di serie per limitare il "
+"numero di serie recuperate e visualizzate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many controls to group by. If grouping, latitude and longitude "
 "columns must be present."
 msgstr ""
+"Uno o più controlli per il raggruppamento. In caso di raggruppamento, le "
+"colonne di latitudine e longitudine devono essere presenti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or many controls to pivot as columns"
-msgstr ""
+msgstr "Uno o più controlli da ruotare come colonne"
 
 msgid "One or many metrics to display"
 msgstr "Una o più metriche da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "One or more annotation layers failed loading."
-msgstr ""
+msgstr "Uno o più livelli di annotazione non sono stati caricati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns already exist"
-msgstr ""
+msgstr "Una o più colonne esistono già"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns are duplicated"
-msgstr ""
+msgstr "Una o più colonne sono duplicate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more columns do not exist"
-msgstr ""
+msgstr "Una o più colonne non esistono"
 
 msgid "One or more metrics already exist"
 msgstr "Una o più metriche da mostrare"
@@ -9609,64 +15471,141 @@ msgstr "Una o più metriche da mostrare"
 msgid "One or more metrics do not exist"
 msgstr "Una o più metriche da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters needed to configure a database are missing."
-msgstr ""
+msgstr "Mancano uno o più parametri necessari per configurare un database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "One or more parameters specified in the query are malformed."
-msgstr ""
+msgstr "Uno o più parametri specificati nella query non sono validi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters specified in the query are missing."
-msgstr ""
+msgstr "Mancano uno o più parametri specificati nella query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Only Total"
-msgstr ""
+msgstr "Solo Totale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Only `SELECT` statements are allowed"
-msgstr ""
+msgstr "Sono consentite solo istruzioni `SELECT`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is not set to a percentage."
 msgstr ""
+"Si applica solo quando \"Tipo di etichetta\" non è impostato su "
+"percentuale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is set to show values."
 msgstr ""
+"Si applica solo quando \"Tipo di etichetta\" è impostato per mostrare i "
+"valori."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "Solo la corrispondenza esatta è disponibile per le colonne non stringa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Procedere solo se si ha fiducia nella destinazione o nella sua fonte."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
 "selected category"
 msgstr ""
+"Mostra solo il valore totale nel grafico a barre impilate, senza "
+"mostrarlo nella categoria selezionata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Only single queries supported"
-msgstr ""
+msgstr "Sono supportate solo query singole"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only the default catalog is supported for this connection"
-msgstr ""
+msgstr "Solo il catalogo predefinito è supportato per questa connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Oops! An error occurred!"
-msgstr ""
+msgstr "Ops! Si è verificato un errore!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity"
-msgstr ""
+msgstr "Opacità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of Area Chart. Also applies to confidence band."
-msgstr ""
+msgstr "Opacità del grafico ad area. Si applica anche alla banda di confidenza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of all clusters, points, and labels. Between 0 and 1."
-msgstr ""
+msgstr "Opacità di tutti i cluster, punti ed etichette. Tra 0 e 1."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of area chart."
-msgstr ""
+msgstr "Opacità del grafico ad area."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Opacity of bubbles, 0 means completely transparent, 1 means opaque"
 msgstr ""
+"Opacità delle bolle, 0 significa completamente trasparente, 1 significa "
+"opaco"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Opacity, expects values between 0 and 100"
-msgstr ""
+msgstr "Opacità, si aspettano valori tra 0 e 100"
 
 msgid "Open Datasource tab"
 msgstr "Sorgente Dati"
@@ -9685,25 +15624,43 @@ msgstr "Esponi in SQL Lab"
 msgid "Open query in SQL Lab"
 msgstr "Esponi in SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Operate the database in asynchronous mode, meaning that the queries are "
 "executed on remote workers as opposed to on the web server itself. This "
 "assumes that you have a Celery worker setup as well as a results backend."
 " Refer to the installation docs for more information."
 msgstr ""
+"Gestisce il database in modalità asincrona, il che significa che le query"
+" vengono eseguite su worker remoti anziché sul server web stesso. Questo "
+"presuppone che sia stato configurato un worker Celery e un backend dei "
+"risultati. Per ulteriori informazioni, consultare la documentazione di "
+"installazione."
 
 #, fuzzy
 msgid "Operator"
 msgstr "Seleziona operatore"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Operator undefined for aggregator: %(name)s"
-msgstr ""
+msgstr "Operatore non definito per l'aggregatore: %(name)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Optional CA_BUNDLE contents to validate HTTPS requests. Only available on"
 " certain database engines."
 msgstr ""
+"Contenuto CA_BUNDLE opzionale per convalidare le richieste HTTPS. "
+"Disponibile solo su alcuni motori di database."
 
 #, fuzzy
 msgid "Optional d3 date format string"
@@ -9713,31 +15670,58 @@ msgstr "Formato Datetime"
 msgid "Optional d3 number format string"
 msgstr "Seleziona una metrica per l'asse destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional name of the data column."
-msgstr ""
+msgstr "Nome opzionale della colonna di dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional warning about use of this metric"
-msgstr ""
+msgstr "Avviso opzionale sull'utilizzo di questa metrica"
 
 #, fuzzy
 msgid "Options"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Or choose from a list of other databases we support:"
-msgstr ""
+msgstr "Oppure scegli da un elenco di altri database supportati:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Order results by selected columns"
-msgstr ""
+msgstr "Ordina i risultati per colonne selezionate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ordering"
-msgstr ""
+msgstr "Ordinamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Orders the query result that generates the source data for this chart. If"
 " a series or row limit is reached, this determines what data are "
 "truncated. If undefined, defaults to the first metric (where "
 "appropriate)."
 msgstr ""
+"Ordina il risultato della query che genera i dati sorgente per questo "
+"grafico. Se viene raggiunto un limite di serie o di righe, questo "
+"determina quali dati vengono troncati. Se non definito, viene utilizzata "
+"la prima metrica come predefinita (dove appropriato)."
 
 #, fuzzy
 msgid "Orientation"
@@ -9747,57 +15731,108 @@ msgstr "Azione"
 msgid "Orientation of bar chart"
 msgstr "Distribuzione - Grafico Barre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Orientation of filter bar"
-msgstr ""
+msgstr "Orientamento della barra dei filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Orientation of tree"
-msgstr ""
+msgstr "Orientamento dell'albero"
 
 #, fuzzy
 msgid "Original"
 msgstr "Login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Original table column order"
-msgstr ""
+msgstr "Ordine originale delle colonne della tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Original value"
-msgstr ""
+msgstr "Valore originale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Orthogonal"
-msgstr ""
+msgstr "Ortogonale"
 
 #, fuzzy
 msgid "Other"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Other color palettes"
-msgstr ""
+msgstr "Altre tavolozze di colori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outdoors"
-msgstr ""
+msgstr "All'aperto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outer Radius"
-msgstr ""
+msgstr "Raggio esterno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outer edge of Pie chart"
-msgstr ""
+msgstr "Bordo esterno del grafico a torta"
 
 #, fuzzy
 msgid "Overlap"
 msgstr "Mappa del Mondo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Overlay one or more timeseries from a relative time period. Expects "
 "relative time deltas in natural language (example:  24 hours, 7 days, 52 "
 "weeks, 365 days). Free text is supported."
 msgstr ""
+"Sovrapponi una o più serie temporali da un periodo di tempo relativo. Si "
+"aspetta differenze di tempo relative in linguaggio naturale (esempio:  24"
+" ore, 7 giorni, 52 settimane, 365 giorni). Il testo libero è supportato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Overlay one or more timeseries from a relative time period. Expects "
 "relative time deltas in natural language (example: 24 hours, 7 days, 52 "
 "weeks, 365 days). Free text is supported."
 msgstr ""
+"Sovrapponi una o più serie temporali da un periodo di tempo relativo. Si "
+"aspetta differenze di tempo relative in linguaggio naturale (esempio: 24 "
+"ore, 7 giorni, 52 settimane, 365 giorni). Il testo libero è supportato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Overlay results from a relative time period. Expects relative time deltas"
 " in natural language (example:  24 hours, 7 days, 52 weeks, 365 days). "
@@ -9805,17 +15840,36 @@ msgid ""
 "the comparison time range by the same length as your time range and use "
 "\"Custom\" to set a custom comparison range."
 msgstr ""
+"Sovrapponi i risultati da un periodo di tempo relativo. Si aspetta "
+"differenze di tempo relative in linguaggio naturale (esempio:  24 ore, 7 "
+"giorni, 52 settimane, 365 giorni). Il testo libero è supportato. Usa "
+"\"Eredita intervallo dai filtri temporali\" per spostare l'intervallo di "
+"tempo di comparazione della stessa lunghezza del tuo intervallo temporale"
+" e usa \"Personalizzato\" per impostare un intervallo di comparazione "
+"personalizzato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Overlays a hexagonal grid on a map, and aggregates data within the "
 "boundary of each cell."
 msgstr ""
+"Sovrappone una griglia esagonale su una mappa e aggrega i dati "
+"all'interno dei confini di ogni cella."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Override time grain"
-msgstr ""
+msgstr "Sostituisci la granularità temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Override time range"
-msgstr ""
+msgstr "Sostituisci l'intervallo di tempo"
 
 msgid "Overwrite"
 msgstr "Sovrascrivi la slice %s"
@@ -9823,18 +15877,32 @@ msgstr "Sovrascrivi la slice %s"
 msgid "Overwrite & Explore"
 msgstr "Sovrascrivi la slice %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Overwrite Dashboard [%s]"
-msgstr ""
+msgstr "Sovrascrivi Dashboard [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Overwrite existing"
-msgstr ""
+msgstr "Sovrascrivi esistente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Overwrite text in the editor with a query on this table"
-msgstr ""
+msgstr "Sovrascrivi il testo nell'editor con una query su questa tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Owned Created or Favored"
-msgstr ""
+msgstr "Di proprietà, Creato o Preferito"
 
 msgid "Owner"
 msgstr "Proprietario"
@@ -9842,8 +15910,12 @@ msgstr "Proprietario"
 msgid "Owners"
 msgstr "Proprietari"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Owners are invalid"
-msgstr ""
+msgstr "I proprietari non sono validi"
 
 msgid "Owners is a list of users who can alter the dashboard."
 msgstr "Proprietari è una lista di utenti che può alterare la dashboard."
@@ -9853,8 +15925,11 @@ msgid ""
 " or username."
 msgstr "Proprietari è una lista di utenti che può alterare la dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "PDF download failed, please refresh and try again."
-msgstr ""
+msgstr "Download PDF fallito, aggiorna la pagina e riprova."
 
 #, fuzzy
 msgid "Page"
@@ -9864,21 +15939,37 @@ msgstr "Gestisci"
 msgid "Page Size:"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Page length"
-msgstr ""
+msgstr "Lunghezza pagina"
 
 #, fuzzy
 msgid "Page navigation"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paired t-test Table"
-msgstr ""
+msgstr "Tabella del test t accoppiato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pandas resample method"
-msgstr ""
+msgstr "Metodo di ricampionamento Pandas"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pandas resample rule"
-msgstr ""
+msgstr "Regola di ricampionamento Pandas"
 
 msgid "Parallel Coordinates"
 msgstr "Coordinate Parallele"
@@ -9893,36 +15984,68 @@ msgstr "Parametri"
 msgid "Parameters "
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Parameters related to the view and perspective on the map"
-msgstr ""
+msgstr "Parametri relativi alla visualizzazione e alla prospettiva sulla mappa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Parent"
-msgstr ""
+msgstr "Padre"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Parsing error: %(error)s"
-msgstr ""
+msgstr "Errore di analisi: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Part of a Whole"
-msgstr ""
+msgstr "Parte di un intero"
 
 #, fuzzy
 msgid "Partition Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Partition Diagram"
-msgstr ""
+msgstr "Diagramma di partizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Partition Limit"
-msgstr ""
+msgstr "Limite di partizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Partition Threshold"
-msgstr ""
+msgstr "Soglia di partizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Partitions whose height to parent height proportions are below this value"
 " are pruned"
 msgstr ""
+"Le partizioni il cui rapporto tra l'altezza e l'altezza del genitore è "
+"inferiore a questo valore vengono rimosse"
 
 #, fuzzy
 msgid "Password"
@@ -9944,17 +16067,31 @@ msgstr "Elenco Dashboard"
 msgid "Paste"
 msgstr "%s - senza nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Paste Private Key here"
-msgstr ""
+msgstr "Incolla qui la chiave privata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Paste content of service credentials JSON file here"
-msgstr ""
+msgstr "Incolla qui il contenuto del file JSON delle credenziali del servizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paste the shareable Google Sheet URL here"
-msgstr ""
+msgstr "Incolla qui l'URL condivisibile di Google Sheet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Paste your access token here"
-msgstr ""
+msgstr "Incolla qui il tuo token di accesso"
 
 #, fuzzy
 msgid "Path Color"
@@ -9964,14 +16101,24 @@ msgstr "Valore del filtro"
 msgid "Path Size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pattern"
-msgstr ""
+msgstr "Modello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Sospendi l'aggiornamento automatico se la scheda è inattiva"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto-refresh"
-msgstr ""
+msgstr "Sospendi l'aggiornamento automatico"
 
 #, fuzzy
 msgid "Pending"
@@ -9989,8 +16136,11 @@ msgstr "Ultima Modifica"
 msgid "Percent Difference format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percent of total"
-msgstr ""
+msgstr "Percentuale del totale"
 
 #, fuzzy
 msgid "Percentage"
@@ -10000,8 +16150,11 @@ msgstr "Ultima Modifica"
 msgid "Percentage change"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage difference between the time periods"
-msgstr ""
+msgstr "Differenza percentuale tra i periodi di tempo"
 
 #, fuzzy
 msgid "Percentage metric calculation"
@@ -10011,52 +16164,104 @@ msgstr "Mostra metrica"
 msgid "Percentage metrics"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Percentage threshold"
-msgstr ""
+msgstr "Soglia percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Percentages"
-msgstr ""
+msgstr "Percentuali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Performance"
-msgstr ""
+msgstr "Prestazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Period average"
-msgstr ""
+msgstr "Media del periodo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Periods"
-msgstr ""
+msgstr "Periodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Periods must be a whole number"
-msgstr ""
+msgstr "I periodi devono essere un numero intero"
 
 #, fuzzy
 msgid "Permissions"
 msgstr "Espressione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Permissions successfully synced for %s"
-msgstr ""
+msgstr "Autorizzazioni sincronizzate con successo per %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this chart."
-msgstr ""
+msgstr "Persona o gruppo che ha certificato questo grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this dashboard."
-msgstr ""
+msgstr "Persona o gruppo che ha certificato questo dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this metric"
-msgstr ""
+msgstr "Persona o gruppo che ha certificato questa metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "Informazioni personali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical"
-msgstr ""
+msgstr "Fisico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical (table or view)"
-msgstr ""
+msgstr "Fisico (tabella o vista)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Pick a dimension from which categorical colors are defined"
-msgstr ""
+msgstr "Seleziona una dimensione da cui sono definiti i colori per categoria"
 
 msgid "Pick a metric for x, y and size"
 msgstr "Seleziona una metrica per x, y e grandezza"
@@ -10064,38 +16269,69 @@ msgstr "Seleziona una metrica per x, y e grandezza"
 msgid "Pick a metric to display"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a name to help you identify this database."
-msgstr ""
+msgstr "Scegli un nome per aiutarti a identificare questo database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pick a nickname for how the database will display in Superset."
-msgstr ""
+msgstr "Scegli un soprannome per la visualizzazione del database in Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a title for you annotation."
-msgstr ""
+msgstr "Scegli un titolo per la tua annotazione."
 
 msgid "Pick at least one metric"
 msgstr "Seleziona almeno una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Pick one or more columns that should be shown in the annotation. If you "
 "don't select a column all of them will be shown."
 msgstr ""
+"Seleziona una o più colonne da mostrare nell'annotazione. Se non "
+"selezioni una colonna, verranno mostrate tutte."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick your favorite markup language"
-msgstr ""
+msgstr "Scegli il tuo linguaggio di markup preferito"
 
 #, fuzzy
 msgid "Pie Chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pie charts on a map"
-msgstr ""
+msgstr "Grafici a torta su una mappa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pie shape"
-msgstr ""
+msgstr "Forma a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Piecewise"
-msgstr ""
+msgstr "A tratti"
 
 #, fuzzy
 msgid "Pin"
@@ -10113,11 +16349,17 @@ msgstr "Cancella"
 msgid "Pin Right"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "Fissa al pannello dei risultati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pin to top"
-msgstr ""
+msgstr "Fissa in cima"
 
 #, fuzzy
 msgid "Pivot Mode"
@@ -10126,11 +16368,19 @@ msgstr "Ricerca Query"
 msgid "Pivot Table"
 msgstr "Vista Pivot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation must include at least one aggregate"
-msgstr ""
+msgstr "L'operazione pivot deve includere almeno un aggregato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation requires at least one index"
-msgstr ""
+msgstr "L'operazione pivot richiede almeno un indice"
 
 #, fuzzy
 msgid "Pivoted"
@@ -10140,54 +16390,103 @@ msgstr "Modifica"
 msgid "Pivots"
 msgstr "Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixel height of each series"
-msgstr ""
+msgstr "Altezza in pixel di ogni serie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixels"
-msgstr ""
+msgstr "Pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Plain"
-msgstr ""
+msgstr "Normale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Please check your query and confirm that all template parameters are "
 "surround by double braces, for example, \"{{ ds }}\". Then, try running "
 "your query again."
 msgstr ""
+"Controlla la tua query e conferma che tutti i parametri del modello siano"
+" circondati da doppie parentesi graffe, ad esempio \"{{ ds }}\". Poi, "
+"prova a eseguire di nuovo la query."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors at or near "
 "\"%(syntax_error)s\". Then, try running your query again."
 msgstr ""
+"Controlla la tua query per rilevare errori di sintassi in corrispondenza "
+"o vicino a \"%(syntax_error)s\". Poi, prova a eseguire di nuovo la query."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors near \"%(server_error)s\". "
 "Then, try running your query again."
 msgstr ""
+"Controlla la tua query per rilevare errori di sintassi vicino a "
+"\"%(server_error)s\". Poi, prova a eseguire di nuovo la query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Please check your template parameters for syntax errors and make sure "
 "they match across your SQL query and Set Parameters. Then, try running "
 "your query again."
 msgstr ""
+"Controlla i parametri del modello per rilevare errori di sintassi e "
+"assicurati che corrispondano nella tua query SQL e nei Parametri "
+"impostati. Poi, prova a eseguire di nuovo la query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please choose a valid value"
-msgstr ""
+msgstr "Scegli un valore valido"
 
 #, fuzzy
 msgid "Please choose at least one groupby"
 msgstr "Seleziona almeno una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please confirm"
-msgstr ""
+msgstr "Conferma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please confirm the overwrite values."
-msgstr ""
+msgstr "Conferma i valori di sovrascrittura."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please confirm your password"
-msgstr ""
+msgstr "Conferma la tua password"
 
 msgid "Please enter a SQLAlchemy URI to test"
 msgstr "Inserisci un nome per la slice"
@@ -10196,14 +16495,23 @@ msgstr "Inserisci un nome per la slice"
 msgid "Please enter a valid email"
 msgstr "Inserisci un nome per la slice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Inserisci un indirizzo email valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter valid text. Spaces alone are not permitted."
-msgstr ""
+msgstr "Inserisci un testo valido. Gli spazi da soli non sono consentiti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter your email"
-msgstr ""
+msgstr "Inserisci la tua email"
 
 #, fuzzy
 msgid "Please enter your first name"
@@ -10221,89 +16529,167 @@ msgstr "Porta Broker"
 msgid "Please enter your username"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please fix the following errors"
-msgstr ""
+msgstr "Correggi i seguenti errori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please provide a valid min or max value"
-msgstr ""
+msgstr "Fornisci un valore minimo o massimo valido"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please re-enter the password."
-msgstr ""
+msgstr "Reinserisci la password."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please re-export your file and try importing again"
-msgstr ""
+msgstr "Esporta nuovamente il tuo file e prova a importarlo di nuovo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# ja, lv, mi, pl, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Please reach out to the Chart Owner for assistance."
 msgid_plural "Please reach out to the Chart Owners for assistance."
-msgstr[0] ""
+msgstr[0] "Contatta il Proprietario del Grafico per assistenza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your chart first, then try creating a new email report."
-msgstr ""
+msgstr "Salva prima il tuo grafico, poi prova a creare un nuovo report via email."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your dashboard first, then try creating a new email report."
 msgstr ""
+"Salva prima il tuo dashboard, poi prova a creare un nuovo report via "
+"email."
 
 #, fuzzy
 msgid "Please select at least one role or group"
 msgstr "Seleziona almeno una metrica"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Please select both a %s and a Chart type to proceed"
-msgstr ""
+msgstr "Seleziona sia un %s che un tipo di grafico per procedere"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja "
 "macro."
-msgstr ""
+msgstr "Specifica l'ID del Dataset per la metrica ``%(name)s`` nella macro Jinja."
 
 msgid "Please use 3 different metric labels"
 msgstr "Seleziona metriche differenti per gli assi destro e sinistro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Plot the distance (like flight paths) between origin and destination."
-msgstr ""
+msgstr "Traccia la distanza (come i percorsi di volo) tra origine e destinazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Plots the individual metrics for each row in the data vertically and "
 "links them together as a line. This chart is useful for comparing "
 "multiple metrics across all of the samples or rows in the data."
 msgstr ""
+"Traccia le metriche individuali per ogni riga nei dati verticalmente e le"
+" collega come una linea. Questo grafico è utile per confrontare più "
+"metriche su tutti i campioni o le righe nei dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Plugins"
-msgstr ""
+msgstr "Plugin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Point Cluster Map"
-msgstr ""
+msgstr "Mappa a cluster di punti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Color"
-msgstr ""
+msgstr "Colore del punto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius"
-msgstr ""
+msgstr "Raggio del punto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Radius Scale"
-msgstr ""
+msgstr "Scala del raggio del punto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius Unit"
-msgstr ""
+msgstr "Unità del raggio del punto"
 
 #, fuzzy
 msgid "Point Size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Unit"
-msgstr ""
+msgstr "Unità del punto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point to your spatial columns"
-msgstr ""
+msgstr "Indica le tue colonne spaziali"
 
 #, fuzzy
 msgid "Points"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Points and clusters will update as the viewport is being changed"
 msgstr ""
+"I punti e i cluster si aggiorneranno man mano che il viewport viene "
+"modificato"
 
 #, fuzzy
 msgid "Polygon Column"
@@ -10317,47 +16703,88 @@ msgstr "Importa"
 msgid "Polygon Settings"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Polyline"
-msgstr ""
+msgstr "Polilinea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Populate \"Default value\" to enable this control"
-msgstr ""
+msgstr "Compila \"Valore predefinito\" per abilitare questo controllo"
 
 #, fuzzy
 msgid "Port"
 msgstr "Importa"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Port %(port)s on hostname \"%(hostname)s\" refused the connection."
 msgstr ""
+"La porta %(port)s sull'hostname \"%(hostname)s\" ha rifiutato la "
+"connessione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Port out of range 0-65535"
-msgstr ""
+msgstr "Porta fuori dall'intervallo 0-65535"
 
 msgid "Position JSON"
 msgstr "Posizione del JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of child node label on tree"
-msgstr ""
+msgstr "Posizione dell'etichetta del nodo figlio nell'albero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of column level subtotal"
-msgstr ""
+msgstr "Posizione del subtotale a livello di colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Position of intermediate node label on tree"
-msgstr ""
+msgstr "Posizione dell'etichetta del nodo intermedio nell'albero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of row level subtotal"
-msgstr ""
+msgstr "Posizione del subtotale a livello di riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Powered by Apache Superset"
-msgstr ""
+msgstr "Sviluppato da Apache Superset"
 
 #, fuzzy
 msgid "Pre-filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pre-filter available values"
-msgstr ""
+msgstr "Prefiltra i valori disponibili"
 
 #, fuzzy
 msgid "Pre-filter is required"
@@ -10371,26 +16798,52 @@ msgstr "Azione"
 msgid "Predictive Analytics"
 msgstr "Analytics avanzate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix"
-msgstr ""
+msgstr "Prefisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix or suffix"
-msgstr ""
+msgstr "Prefisso o suffisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Preview"
-msgstr ""
+msgstr "Anteprima"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Preview uploaded file"
-msgstr ""
+msgstr "Anteprima del file caricato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Previous"
-msgstr ""
+msgstr "Precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Previous Line"
-msgstr ""
+msgstr "Riga precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Primary"
-msgstr ""
+msgstr "Primario"
 
 #, fuzzy
 msgid "Primary Metric"
@@ -10400,27 +16853,49 @@ msgstr "Metrica"
 msgid "Primary key"
 msgstr "Metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary or secondary y-axis"
-msgstr ""
+msgstr "Asse y primario o secondario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Primary y-axis Bounds"
-msgstr ""
+msgstr "Limiti dell'asse y primario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary y-axis format"
-msgstr ""
+msgstr "Formato dell'asse y primario"
 
 #, fuzzy
 msgid "Private"
 msgstr "Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Private Channels (Bot in channel)"
-msgstr ""
+msgstr "Canali privati (Bot nel canale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Private Key"
-msgstr ""
+msgstr "Chiave privata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Private Key & Password"
-msgstr ""
+msgstr "Chiave privata e password"
 
 #, fuzzy
 msgid "Private Key Password"
@@ -10430,49 +16905,95 @@ msgstr "Porta Broker"
 msgid "Proceed"
 msgstr "Creato il"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "Elaborazione esportazione per %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Processing export..."
-msgstr ""
+msgstr "Elaborazione esportazione..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progress"
-msgstr ""
+msgstr "Progresso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progressive"
-msgstr ""
+msgstr "Progressivo"
 
 #, fuzzy
 msgid "Project Id"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Proportional"
-msgstr ""
+msgstr "Proporzionale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Fogli condivisi pubblicamente e privatamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Solo fogli condivisi pubblicamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Published"
-msgstr ""
+msgstr "Pubblicato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Purple"
-msgstr ""
+msgstr "Viola"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put labels outside"
-msgstr ""
+msgstr "Posiziona le etichette all'esterno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put the labels outside of the pie?"
-msgstr ""
+msgstr "Posizionare le etichette all'esterno della torta?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Put your code here"
-msgstr ""
+msgstr "Inserisci il tuo codice qui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Python datetime string pattern"
-msgstr ""
+msgstr "Schema della stringa datetime di Python"
 
 #, fuzzy
 msgid "Quarter"
@@ -10486,12 +17007,19 @@ msgstr "Opzioni del grafico"
 msgid "Queries"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query"
-msgstr ""
+msgstr "Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Query %s: %s"
-msgstr ""
+msgstr "Query %s: %s"
 
 #, fuzzy
 msgid "Query A"
@@ -10501,8 +17029,12 @@ msgstr "condividi query"
 msgid "Query B"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query History"
-msgstr ""
+msgstr "Cronologia query"
 
 #, fuzzy
 msgid "Query State"
@@ -10530,8 +17062,12 @@ msgstr "Ricerca Query"
 msgid "Query in a new tab"
 msgstr "Query in un nuovo tab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Query is too complex and takes too long to run."
-msgstr ""
+msgstr "La query è troppo complessa e richiede troppo tempo per essere eseguita."
 
 #, fuzzy
 msgid "Query mode"
@@ -10540,8 +17076,12 @@ msgstr "Ricerca Query"
 msgid "Query name"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query preview"
-msgstr ""
+msgstr "Anteprima query"
 
 #, fuzzy
 msgid "Query was stopped"
@@ -10554,8 +17094,12 @@ msgstr "La query è stata fermata."
 msgid "Queued"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "RGB Color"
-msgstr ""
+msgstr "Colore RGB"
 
 #, fuzzy
 msgid "RLS Rule not found."
@@ -10565,31 +17109,54 @@ msgstr "Template CSS"
 msgid "RLS rules could not be deleted."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar"
-msgstr ""
+msgstr "Radar"
 
 #, fuzzy
 msgid "Radar Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar render type, whether to display 'circle' shape."
-msgstr ""
+msgstr "Tipo di rendering del radar, se visualizzare la forma 'cerchio'."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Radial"
-msgstr ""
+msgstr "Radiale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Radius"
-msgstr ""
+msgstr "Raggio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Radius in kilometers"
-msgstr ""
+msgstr "Raggio in chilometri"
 
 #, fuzzy
 msgid "Radius in meters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radius in miles"
-msgstr ""
+msgstr "Raggio in miglia"
 
 #, fuzzy
 msgid "Range"
@@ -10607,11 +17174,19 @@ msgstr "Tipo"
 msgid "Range filter"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range filter plugin using AntD"
-msgstr ""
+msgstr "Plugin filtro intervallo con AntD"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range labels"
-msgstr ""
+msgstr "Etichette di intervallo"
 
 #, fuzzy
 msgid "Range type"
@@ -10621,61 +17196,111 @@ msgstr "Tipo"
 msgid "Ranges"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ranges to highlight with shading"
-msgstr ""
+msgstr "Intervalli da evidenziare con ombreggiatura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Ranking"
-msgstr ""
+msgstr "Classificazione"
 
 #, fuzzy
 msgid "Ratio"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Raw records"
-msgstr ""
+msgstr "Record grezzi"
 
 #, fuzzy
 msgid "Recently modified"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Recents"
-msgstr ""
+msgstr "Recenti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Recipients are separated by \",\" or \";\""
-msgstr ""
+msgstr "I destinatari sono separati da \",\" o \";\""
 
 #, fuzzy
 msgid "Records"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Rectangle"
-msgstr ""
+msgstr "Rettangolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Recurring (every)"
-msgstr ""
+msgstr "Ricorrente (ogni)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Red for increase, green for decrease"
-msgstr ""
+msgstr "Rosso per aumento, verde per diminuzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Redo the action"
-msgstr ""
+msgstr "Ripeti l'azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Reduce X ticks"
-msgstr ""
+msgstr "Riduci le tacche dell'asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Reduces the number of X-axis ticks to be rendered. If true, the x-axis "
 "will not overflow and labels may be missing. If false, a minimum width "
 "will be applied to columns and the width may overflow into an horizontal "
 "scroll."
 msgstr ""
+"Riduce il numero di tacche dell'asse X da visualizzare. Se vero, l'asse x"
+" non andrà in overflow e alcune etichette potrebbero mancare. Se falso, "
+"verrà applicata una larghezza minima alle colonne e la larghezza potrebbe"
+" andare in overflow in uno scorrimento orizzontale."
 
 #, fuzzy
 msgid "Refer to the"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Referenced columns not available in DataFrame."
-msgstr ""
+msgstr "Le colonne referenziate non sono disponibili nel DataFrame."
 
 #, fuzzy
 msgid "Referrer"
@@ -10691,31 +17316,54 @@ msgstr "Ricarica la dashboard"
 msgid "Refresh delayed"
 msgstr "Ricarica la dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh frequency"
-msgstr ""
+msgstr "Frequenza di aggiornamento"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Refresh frequency must be at least %s seconds"
-msgstr ""
+msgstr "La frequenza di aggiornamento deve essere di almeno %s secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh interval"
-msgstr ""
+msgstr "Intervallo di aggiornamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Refresh interval saved"
-msgstr ""
+msgstr "Intervallo di aggiornamento salvato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Refresh interval set for this session"
-msgstr ""
+msgstr "Intervallo di aggiornamento impostato per questa sessione"
 
 #, fuzzy
 msgid "Refresh settings"
 msgstr "Abilita il filtro di Select"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Refresh table schema"
-msgstr ""
+msgstr "Aggiorna schema tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh the default values"
-msgstr ""
+msgstr "Aggiorna i valori predefiniti"
 
 #, fuzzy
 msgid "Refreshing charts"
@@ -10733,47 +17381,87 @@ msgstr "Cerca / Filtra"
 msgid "Registration date"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "Registrazione completata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Regular"
-msgstr ""
+msgstr "Normale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Regular filters add where clauses to queries if a user belongs to a role "
 "referenced in the filter, base filters apply filters to all queries "
 "except the roles defined in the filter, and can be used to define what "
 "users can see if no RLS filters within a filter group apply to them."
 msgstr ""
+"I filtri normali aggiungono clausole WHERE alle query se un utente "
+"appartiene a un ruolo referenziato nel filtro; i filtri di base applicano"
+" filtri a tutte le query tranne i ruoli definiti nel filtro, e possono "
+"essere utilizzati per definire cosa possono vedere gli utenti se nessun "
+"filtro RLS all'interno di un gruppo di filtri si applica a loro."
 
 #, fuzzy
 msgid "Relational"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relationships between community channels"
-msgstr ""
+msgstr "Relazioni tra i canali della comunità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative Date/Time"
-msgstr ""
+msgstr "Data/ora relativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative period"
-msgstr ""
+msgstr "Periodo relativo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative quantity"
-msgstr ""
+msgstr "Quantità relativa"
 
 #, fuzzy
 msgid "Reload"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove"
-msgstr ""
+msgstr "Rimuovi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Dark Theme"
-msgstr ""
+msgstr "Rimuovi tema scuro del sistema"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Default Theme"
-msgstr ""
+msgstr "Rimuovi tema predefinito del sistema"
 
 #, fuzzy
 msgid "Remove cross-filter"
@@ -10787,36 +17475,70 @@ msgstr "Tipo di Visualizzazione"
 msgid "Remove filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove item"
-msgstr ""
+msgstr "Rimuovi elemento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove query from log"
-msgstr ""
+msgstr "Rimuovi query dal registro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove table preview"
-msgstr ""
+msgstr "Rimuovi anteprima tabella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] ""
+msgstr[0] "Rimossa 1 colonna dal dataset virtuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Rename tab"
-msgstr ""
+msgstr "Rinomina scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render HTML"
-msgstr ""
+msgstr "Visualizza HTML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render columns in HTML format"
-msgstr ""
+msgstr "Visualizza le colonne in formato HTML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Renders table cells as HTML when applicable. For example, HTML <a> tags "
 "will be rendered as hyperlinks."
 msgstr ""
+"Visualizza le celle della tabella come HTML quando applicabile. Ad "
+"esempio, i tag HTML <a> verranno visualizzati come collegamenti "
+"ipertestuali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Replace"
-msgstr ""
+msgstr "Sostituisci"
 
 #, fuzzy
 msgid "Report"
@@ -10832,41 +17554,100 @@ msgstr "La tua query non può essere salvata"
 msgid "Report Schedule could not be updated."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule delete failed."
-msgstr ""
+msgstr "Eliminazione della pianificazione del report non riuscita."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a csv."
 msgstr ""
+"L'esecuzione della pianificazione del report non è riuscita durante la "
+"generazione di un file CSV."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a dataframe."
 msgstr ""
+"L'esecuzione della pianificazione del report non è riuscita durante la "
+"generazione di un dataframe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a pdf."
 msgstr ""
+"L'esecuzione della pianificazione del report non è riuscita durante la "
+"generazione di un PDF."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a screenshot."
 msgstr ""
+"L'esecuzione della pianificazione del report non è riuscita durante la "
+"generazione di uno screenshot."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution got an unexpected error."
 msgstr ""
+"L'esecuzione della pianificazione del report ha riscontrato un errore "
+"imprevisto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule is still working, refusing to re-compute."
 msgstr ""
+"La pianificazione del report è ancora in esecuzione, rifiuto di "
+"ricalcolare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule log prune failed."
-msgstr ""
+msgstr "Eliminazione del registro della pianificazione del report non riuscita."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule not found."
-msgstr ""
+msgstr "Pianificazione del report non trovata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule parameters are invalid."
-msgstr ""
+msgstr "I parametri della pianificazione del report non sono validi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule reached a working timeout."
-msgstr ""
+msgstr "La pianificazione del report ha raggiunto il timeout di lavoro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule state not found"
-msgstr ""
+msgstr "Stato della pianificazione del report non trovato"
 
 #, fuzzy
 msgid "Report a bug"
@@ -10894,8 +17675,12 @@ msgstr "Importa"
 msgid "Report schedule system error"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report schedule unexpected error"
-msgstr ""
+msgstr "Errore imprevisto nella pianificazione del report"
 
 msgid "Report sending"
 msgstr "Importa"
@@ -10914,50 +17699,92 @@ msgstr "Importa"
 msgid "Repulsion"
 msgstr "Espressione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Repulsion strength between nodes"
-msgstr ""
+msgstr "Forza di repulsione tra i nodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request Access"
-msgstr ""
+msgstr "Richiedi accesso"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Request is incorrect: %(error)s"
-msgstr ""
+msgstr "La richiesta non è corretta: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Request is not JSON"
-msgstr ""
+msgstr "La richiesta non è JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Request missing data field."
-msgstr ""
+msgstr "Campo dati mancante nella richiesta."
 
 #, fuzzy
 msgid "Request timed out"
 msgstr "Cache Timeout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required"
-msgstr ""
+msgstr "Obbligatorio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required control values have been removed"
-msgstr ""
+msgstr "I valori di controllo obbligatori sono stati rimossi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Resample"
-msgstr ""
+msgstr "Ricampiona"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Resample method should be in "
-msgstr ""
+msgstr "Il metodo di ricampionamento deve essere in "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Resample operation requires DatetimeIndex"
-msgstr ""
+msgstr "L'operazione di ricampionamento richiede DatetimeIndex"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset"
-msgstr ""
+msgstr "Reimposta"
 
 #, fuzzy
 msgid "Reset Columns"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "Reimposta tutte le cartelle ai valori predefiniti"
 
 #, fuzzy
 msgid "Reset columns"
@@ -10971,45 +17798,78 @@ msgstr "Porta Broker"
 msgid "Reset password"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Reset state"
-msgstr ""
+msgstr "Reimposta stato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, lv, ru,
+# sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset to default folders?"
-msgstr ""
+msgstr "Reimpostare le cartelle predefinite?"
 
 #, fuzzy
 msgid "Resize"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Resource already has an attached report."
-msgstr ""
+msgstr "La risorsa ha già un report allegato."
 
 #, fuzzy
 msgid "Resource was not found."
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
 msgstr ""
+"La risorsa è stata rimossa prima che la proprietà potesse essere "
+"verificata"
 
 #, fuzzy
 msgid "Restore filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Results"
-msgstr ""
+msgstr "Risultati"
 
 #, fuzzy, python-format
 msgid "Results %s"
 msgstr "visualizza risultati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend is not configured."
-msgstr ""
+msgstr "Il backend dei risultati non è configurato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr ""
+"Il backend dei risultati necessario per le query asincrone non è "
+"configurato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resume auto-refresh"
-msgstr ""
+msgstr "Riprendi aggiornamento automatico"
 
 #, fuzzy
 msgid "Retry"
@@ -11023,14 +17883,25 @@ msgstr "Risultati della ricerca"
 msgid "Return to Superset"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Return to specific datetime."
-msgstr ""
+msgstr "Torna alla data e ora specifica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reverse Lat & Long"
-msgstr ""
+msgstr "Inverti Lat e Long"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Reverse lat/long "
-msgstr ""
+msgstr "Inverti lat/long "
 
 #, fuzzy
 msgid "Revoke"
@@ -11040,18 +17911,29 @@ msgstr "Creato il"
 msgid "Revoke API Key"
 msgstr "Raggruppa per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Revoca questa chiave API"
 
 #, fuzzy
 msgid "Revoked"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich Tooltip"
-msgstr ""
+msgstr "Tooltip avanzato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich tooltip"
-msgstr ""
+msgstr "Tooltip avanzato"
 
 #, fuzzy
 msgid "Right"
@@ -11072,14 +17954,28 @@ msgstr "Altezza"
 msgid "Right axis metric"
 msgstr "Metrica asse destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Right to Left"
-msgstr ""
+msgstr "Da destra a sinistra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Right value"
-msgstr ""
+msgstr "Valore destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Right-click on a dimension value to drill to detail by that value."
 msgstr ""
+"Fare clic con il tasto destro su un valore di dimensione per eseguire il "
+"drill-down al dettaglio in base a quel valore."
 
 #, fuzzy
 msgid "Role"
@@ -11096,17 +17992,31 @@ msgstr "Sorgente Dati"
 msgid "Roles"
 msgstr "Ruoli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks. If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"I ruoli sono un elenco che definisce l'accesso al dashboard. Concedere a "
+"un ruolo l'accesso a un dashboard bypasserà i controlli a livello di "
+"dataset. Se non sono definiti ruoli, si applicano le normali "
+"autorizzazioni di accesso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks.If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"I ruoli sono un elenco che definisce l'accesso al dashboard. Concedere a "
+"un ruolo l'accesso a un dashboard bypasserà i controlli a livello di "
+"dataset.Se non sono definiti ruoli, si applicano le normali "
+"autorizzazioni di accesso."
 
 #, fuzzy
 msgid "Rolling Function"
@@ -11119,90 +18029,171 @@ msgstr "Testa la Connessione"
 msgid "Rolling function"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rolling window"
-msgstr ""
+msgstr "Finestra scorrevole"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root certificate"
-msgstr ""
+msgstr "Certificato radice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root node id"
-msgstr ""
+msgstr "ID nodo radice"
 
 #, fuzzy
 msgid "Rose Type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotate x axis label"
-msgstr ""
+msgstr "Ruota l'etichetta dell'asse x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Rotate y axis label"
-msgstr ""
+msgstr "Ruota l'etichetta dell'asse y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotation to apply to words in the cloud"
-msgstr ""
+msgstr "Rotazione da applicare alle parole nel cloud"
 
 #, fuzzy
 msgid "Round cap"
 msgstr "Mappa della Nazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Row"
-msgstr ""
+msgstr "Riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Row Level Security"
-msgstr ""
+msgstr "Sicurezza a livello di riga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
 msgstr ""
+"Limite di righe: le percentuali vengono calcolate in base al sottoinsieme"
+" di dati recuperati, rispettando il limite di righe. Tutti i record: le "
+"percentuali vengono calcolate in base al dataset totale, ignorando il "
+"limite di righe."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row containing the headers to use as column names (0 is first line of "
 "data)."
 msgstr ""
+"Riga contenente le intestazioni da utilizzare come nomi di colonna (0 è "
+"la prima riga di dati)."
 
 #, fuzzy
 msgid "Row height"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Row limit"
-msgstr ""
+msgstr "Limite di righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Rows (vertical layout)"
-msgstr ""
+msgstr "Righe (layout verticale)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows per page, 0 means no pagination"
-msgstr ""
+msgstr "Righe per pagina, 0 significa nessuna paginazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows subtotal position"
-msgstr ""
+msgstr "Posizione del subtotale delle righe"
 
 #, fuzzy
 msgid "Rows to read"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rule"
-msgstr ""
+msgstr "Regola"
 
 #, fuzzy
 msgid "Rule Name"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Rule added"
-msgstr ""
+msgstr "Regola aggiunta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run"
-msgstr ""
+msgstr "Esegui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Run a query to display query history"
-msgstr ""
+msgstr "Esegui una query per visualizzare la cronologia delle query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Run a query to display results"
-msgstr ""
+msgstr "Esegui una query per visualizzare i risultati"
 
 #, fuzzy
 msgid "Run current query"
@@ -11214,45 +18205,84 @@ msgstr "Esponi in SQL Lab"
 msgid "Run query"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run query (Ctrl + Return)"
-msgstr ""
+msgstr "Esegui query (Ctrl + Return)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Run query in a new tab"
-msgstr ""
+msgstr "Esegui query in una nuova scheda"
 
 msgid "Run selection"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Running"
-msgstr ""
+msgstr "In esecuzione"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "Esecuzione del blocco %(block_num)s di %(block_count)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SAT"
-msgstr ""
+msgstr "SAB"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SEP"
-msgstr ""
+msgstr "SET"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQL Lab"
-msgstr ""
+msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab non può autorizzare un'istruzione che non è stata completamente "
+"analizzata. Qualificare esplicitamente le tabelle ed evitare SQL dinamico"
+" nelle stored procedure o nelle chiamate specifiche del vendor."
 
 #, fuzzy
 msgid "SQL Lab queries"
 msgstr "Query salvate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "SQL Lab uses your browser's local storage to store queries and results.\n"
 "Currently, you are using %(currentUsage)s KB out of %(maxStorage)d KB "
@@ -11262,9 +18292,22 @@ msgid ""
 "delete the tab.\n"
 "Note that you will need to close other SQL Lab windows before you do this."
 msgstr ""
+"SQL Lab utilizza la memoria locale del browser per memorizzare le query e"
+" i risultati.\n"
+"Attualmente stai utilizzando %(currentUsage)s KB su %(maxStorage)d KB di "
+"spazio di archiviazione.\n"
+"Per evitare che SQL Lab vada in crash, elimina alcune schede di query.\n"
+"Puoi accedere nuovamente a queste query utilizzando la funzione Salva "
+"prima di eliminare la scheda.\n"
+"Tieni presente che dovrai chiudere altre finestre di SQL Lab prima di "
+"farlo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQL Query"
-msgstr ""
+msgstr "Query SQL"
 
 msgid "SQL expression"
 msgstr "Espressione SQL"
@@ -11279,21 +18322,37 @@ msgstr "Formato Datetime"
 msgid "SQLAlchemy URI"
 msgstr "URI SQLAlchemy"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Host"
-msgstr ""
+msgstr "Host SSH"
 
 #, fuzzy
 msgid "SSH Password"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Port"
-msgstr ""
+msgstr "Porta SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel"
-msgstr ""
+msgstr "Tunnel SSH"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel configuration parameters"
-msgstr ""
+msgstr "Parametri di configurazione del tunnel SSH"
 
 #, fuzzy
 msgid "SSH Tunnel could not be deleted."
@@ -11307,34 +18366,63 @@ msgstr "La tua query non può essere salvata"
 msgid "SSH Tunnel not found."
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "SSH Tunnel parameters are invalid."
-msgstr ""
+msgstr "I parametri del tunnel SSH non sono validi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunneling is not enabled"
-msgstr ""
+msgstr "Il tunneling SSH non è abilitato"
 
 #, fuzzy
 msgid "SSL"
 msgstr "CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSL Mode \"require\" will be used."
-msgstr ""
+msgstr "Verrà utilizzata la modalità SSL \"require\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "STEP %(stepCurr)s OF %(stepLast)s"
-msgstr ""
+msgstr "PASSO %(stepCurr)s DI %(stepLast)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "STRING"
-msgstr ""
+msgstr "STRINGA"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SUN"
-msgstr ""
+msgstr "DOM"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sample Standard Deviation"
-msgstr ""
+msgstr "Deviazione Standard del Campione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sample Variance"
-msgstr ""
+msgstr "Varianza del Campione"
 
 #, fuzzy
 msgid "Samples"
@@ -11356,14 +18444,26 @@ msgstr "Grafico a torta"
 msgid "Satellite"
 msgstr "Aggiungi filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Satellite Streets"
-msgstr ""
+msgstr "Strade Satellite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Saturday"
-msgstr ""
+msgstr "Sabato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Save"
-msgstr ""
+msgstr "Salva"
 
 msgid "Save & Explore"
 msgstr "Salva una slice"
@@ -11392,8 +18492,12 @@ msgstr "Salva una slice"
 msgid "Save as..."
 msgstr "Salva come"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Save as:"
-msgstr ""
+msgstr "Salva come:"
 
 #, fuzzy
 msgid "Save changes"
@@ -11410,8 +18514,11 @@ msgstr "Salva e vai alla dashboard"
 msgid "Save chart"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Save color breakpoint values"
-msgstr ""
+msgstr "Salva i valori dei punti di interruzione del colore"
 
 msgid "Save dashboard"
 msgstr "Salva e vai alla dashboard"
@@ -11420,20 +18527,35 @@ msgstr "Salva e vai alla dashboard"
 msgid "Save dataset"
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save for this session"
-msgstr ""
+msgstr "Salva per questa sessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save or Overwrite Dataset"
-msgstr ""
+msgstr "Salva o Sovrascrivi Dataset"
 
 msgid "Save query"
 msgstr "query condivisa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Salva questa chiave API in modo sicuro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save this query as a virtual dataset to continue exploring"
-msgstr ""
+msgstr "Salva questa query come dataset virtuale per continuare l'esplorazione"
 
 msgid "Saved"
 msgstr "Salva come"
@@ -11454,38 +18576,81 @@ msgstr "Query salvate"
 msgid "Saved queries could not be deleted."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Saved query not found."
-msgstr ""
+msgstr "Query salvata non trovata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Saved query parameters are invalid."
-msgstr ""
+msgstr "I parametri della query salvata non sono validi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Saving..."
-msgstr ""
+msgstr "Salvataggio in corso..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale and Move"
-msgstr ""
+msgstr "Scala e Sposta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
 msgstr ""
+"Fattore di scala applicato alle larghezze delle linee basate sulle "
+"metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale only"
-msgstr ""
+msgstr "Solo scala"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scatter"
-msgstr ""
+msgstr "Dispersione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Scatter Plot"
-msgstr ""
+msgstr "Grafico a Dispersione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Scatter Plot has the horizontal axis in linear units, and the points are "
 "connected in order. It shows a statistical relationship between two "
 "variables."
 msgstr ""
+"Il grafico a dispersione ha l'asse orizzontale in unità lineari e i punti"
+" sono collegati in ordine. Mostra una relazione statistica tra due "
+"variabili."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule"
-msgstr ""
+msgstr "Pianificazione"
 
 #, fuzzy
 msgid "Schedule a new email report"
@@ -11494,21 +18659,36 @@ msgstr "Importa"
 msgid "Schedule query"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule the query periodically"
-msgstr ""
+msgstr "Pianifica la query periodicamente"
 
 #, fuzzy
 msgid "Schedule type"
 msgstr "Mostra query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled"
-msgstr ""
+msgstr "Pianificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled at (UTC)"
-msgstr ""
+msgstr "Pianificato alle (UTC)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scheduled task executor not found"
-msgstr ""
+msgstr "Esecutore di attività pianificate non trovato"
 
 msgid "Schema"
 msgstr "Schema"
@@ -11517,40 +18697,73 @@ msgstr "Schema"
 msgid "Schema cache timeout"
 msgstr "Cache Timeout"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Schemas allowed for File upload"
-msgstr ""
+msgstr "Schemi consentiti per il caricamento di file"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Scope"
-msgstr ""
+msgstr "Ambito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scoping"
-msgstr ""
+msgstr "Definizione dell'ambito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Screenshot width"
-msgstr ""
+msgstr "Larghezza screenshot"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Screenshot width must be between %(min)spx and %(max)spx"
 msgstr ""
+"La larghezza dello screenshot deve essere compresa tra %(min)spx e "
+"%(max)spx"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scroll"
-msgstr ""
+msgstr "Scorrimento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scroll down to the bottom to enable overwriting changes. "
-msgstr ""
+msgstr "Scorri fino in fondo per abilitare la sovrascrittura delle modifiche. "
 
 msgid "Search"
 msgstr "Cerca"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Search %s records"
-msgstr ""
+msgstr "Cerca %s record"
 
 msgid "Search / Filter"
 msgstr "Cerca / Filtra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Search Metrics & Columns"
-msgstr ""
+msgstr "Cerca metriche e colonne"
 
 #, fuzzy
 msgid "Search all charts"
@@ -11568,8 +18781,12 @@ msgstr "Cerca"
 msgid "Search by"
 msgstr "Cerca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Search by query text"
-msgstr ""
+msgstr "Cerca per testo della query"
 
 #, fuzzy
 msgid "Search calculated columns by name"
@@ -11614,31 +18831,56 @@ msgstr "Seleziona data finale"
 msgid "Search..."
 msgstr "Cerca"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Second"
-msgstr ""
+msgstr "Secondo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Secondary"
-msgstr ""
+msgstr "Secondario"
 
 #, fuzzy
 msgid "Secondary Metric"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary currency format"
-msgstr ""
+msgstr "Formato della valuta secondaria"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary y-axis Bounds"
-msgstr ""
+msgstr "Limiti dell'asse y secondario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis format"
-msgstr ""
+msgstr "Formato dell'asse y secondario"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis title"
-msgstr ""
+msgstr "Titolo dell'asse y secondario"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Seconds %s"
-msgstr ""
+msgstr "Secondi %s"
 
 msgid "Secure extra"
 msgstr "Sicurezza"
@@ -11650,15 +18892,26 @@ msgstr "Sicurezza"
 msgid "See "
 msgstr "Query salvate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "See all %(tableName)s"
-msgstr ""
+msgstr "Vedi tutti %(tableName)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "See less"
-msgstr ""
+msgstr "Vedi meno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "See more"
-msgstr ""
+msgstr "Vedi di più"
 
 #, fuzzy
 msgid "See query details"
@@ -11672,8 +18925,12 @@ msgstr "Seleziona %s"
 msgid "Select %s or type to search %s"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Select ..."
-msgstr ""
+msgstr "Seleziona ..."
 
 #, fuzzy
 msgid "Select All"
@@ -11683,8 +18940,12 @@ msgstr "Seleziona data finale"
 msgid "Select Database and Schema"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select Delivery Method"
-msgstr ""
+msgstr "Seleziona il metodo di consegna"
 
 #, fuzzy
 msgid "Select Filter"
@@ -11718,8 +18979,11 @@ msgstr "Importa dashboard"
 msgid "Select a database"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a database table and create dataset"
-msgstr ""
+msgstr "Seleziona una tabella del database e crea un dataset"
 
 #, fuzzy
 msgid "Select a database table."
@@ -11729,14 +18993,25 @@ msgstr "Database"
 msgid "Select a database to connect"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Select a database to upload the file to"
-msgstr ""
+msgstr "Seleziona un database a cui caricare il file"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select a database to write a query"
-msgstr ""
+msgstr "Seleziona un database per scrivere una query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a delimiter for this data"
-msgstr ""
+msgstr "Seleziona un delimitatore per questi dati"
 
 #, fuzzy
 msgid "Select a dimension"
@@ -11750,20 +19025,33 @@ msgstr "Testa la Connessione"
 msgid "Select a metric to display on the right axis"
 msgstr "Seleziona una metrica per l'asse destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select a metric to display. You can use an aggregation function on a "
 "column or write custom SQL to create a metric."
 msgstr ""
+"Seleziona una metrica da visualizzare. Puoi utilizzare una funzione di "
+"aggregazione su una colonna o scrivere SQL personalizzato per creare una "
+"metrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr ""
+msgstr "Seleziona un modello CSS predefinito da applicare alla tua dashboard"
 
 #, fuzzy
 msgid "Select a schema"
 msgstr "Schema CTAS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a schema if the database supports this"
-msgstr ""
+msgstr "Seleziona uno schema se il database lo supporta"
 
 #, fuzzy
 msgid "Select a semantic layer"
@@ -11773,8 +19061,11 @@ msgstr "Schema CTAS"
 msgid "Select a semantic layer type"
 msgstr "Seleziona un tipo di visualizzazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a sheet name from the uploaded file"
-msgstr ""
+msgstr "Seleziona il nome di un foglio dal file caricato"
 
 #, fuzzy
 msgid "Select a tab"
@@ -11784,16 +19075,26 @@ msgstr "Database"
 msgid "Select a theme"
 msgstr "Schema CTAS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select a time grain for the visualization. The grain is the time interval"
 " represented by a single point on the chart."
 msgstr ""
+"Seleziona una granularità temporale per la visualizzazione. La "
+"granularità è l'intervallo di tempo rappresentato da un singolo punto sul"
+" grafico."
 
 msgid "Select a visualization type"
 msgstr "Seleziona un tipo di visualizzazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select aggregate options"
-msgstr ""
+msgstr "Seleziona le opzioni di aggregazione"
 
 #, fuzzy
 msgid "Select all"
@@ -11807,8 +19108,11 @@ msgstr "Seleziona data finale"
 msgid "Select all items"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select catalog or type to search catalogs"
-msgstr ""
+msgstr "Seleziona un catalogo o digita per cercare cataloghi"
 
 #, fuzzy
 msgid "Select channels"
@@ -11842,10 +19146,15 @@ msgstr "Colonna del Tempo"
 msgid "Select column name"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
 "columns."
 msgstr ""
+"Seleziona le colonne che verranno visualizzate nella tabella. Puoi "
+"selezionare più colonne."
 
 #, fuzzy
 msgid "Select content type"
@@ -11875,11 +19184,18 @@ msgstr "Importa dashboard"
 msgid "Select database"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select databases require additional fields to be completed in the "
 "Advanced tab to successfully connect the database. Learn what "
 "requirements your databases has "
 msgstr ""
+"Alcuni database selezionati richiedono la compilazione di campi "
+"aggiuntivi nella scheda Avanzate per connettersi correttamente al "
+"database. Scopri i requisiti del tuo database "
 
 #, fuzzy
 msgid "Select dataset source"
@@ -11913,11 +19229,19 @@ msgstr "Seleziona data finale"
 msgid "Select filter"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select filter plugin using AntD"
-msgstr ""
+msgstr "Seleziona il plugin di filtro utilizzando AntD"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select first filter value by default"
-msgstr ""
+msgstr "Seleziona il primo valore del filtro per impostazione predefinita"
 
 #, fuzzy
 msgid "Select format"
@@ -11927,6 +19251,9 @@ msgstr "Formato Datetime"
 msgid "Select groups"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -11934,6 +19261,12 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"Seleziona i livelli nell'ordine in cui vuoi che siano sovrapposti. Il "
+"primo selezionato appare in basso. I livelli consentono di combinare più "
+"visualizzazioni su una mappa. Ogni livello è un grafico deck.gl salvato "
+"(come grafici a dispersione, poligoni o archi) che mostra dati o "
+"informazioni diversi. Sovrapponili per rivelare schemi e relazioni nei "
+"tuoi dati."
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -11943,30 +19276,55 @@ msgstr "Grafico a Proiettile"
 msgid "Select object name"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
 "percentages of total. Percentage metrics will be calculated only from "
 "data within the row limit. You can use an aggregation function on a "
 "column or write custom SQL to create a percentage metric."
 msgstr ""
+"Seleziona una o più metriche da visualizzare, che verranno mostrate come "
+"percentuali del totale. Le metriche percentuali saranno calcolate solo "
+"dai dati entro il limite di righe. Puoi utilizzare una funzione di "
+"aggregazione su una colonna o scrivere SQL personalizzato per creare una "
+"metrica percentuale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display. You can use an aggregation "
 "function on a column or write custom SQL to create a metric."
 msgstr ""
+"Seleziona una o più metriche da visualizzare. Puoi utilizzare una "
+"funzione di aggregazione su una colonna o scrivere SQL personalizzato per"
+" creare una metrica."
 
 #, fuzzy
 msgid "Select operator"
 msgstr "Seleziona operatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select or type a custom value..."
-msgstr ""
+msgstr "Seleziona o digita un valore personalizzato..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select or type currency symbol"
-msgstr ""
+msgstr "Seleziona o digita il simbolo della valuta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select or type dataset name"
-msgstr ""
+msgstr "Seleziona o digita il nome del dataset"
 
 #, fuzzy
 msgid "Select owners"
@@ -11996,32 +19354,57 @@ msgstr "Seleziona una metrica"
 msgid "Select schema"
 msgstr "Schema CTAS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select scheme"
-msgstr ""
+msgstr "Seleziona schema"
 
 #, fuzzy
 msgid "Select semantic views"
 msgstr "Seleziona una metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
 "same size. \"LINEAR\" increases sizes linearly based on specified slope. "
 "\"EXP\" increases sizes exponentially based on specified exponent"
 msgstr ""
+"Seleziona la forma per il calcolo dei valori. \"FIXED\" imposta tutti i "
+"livelli di zoom alla stessa dimensione. \"LINEAR\" aumenta le dimensioni "
+"linearmente in base alla pendenza specificata. \"EXP\" aumenta le "
+"dimensioni esponenzialmente in base all'esponente specificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select subject"
-msgstr ""
+msgstr "Seleziona oggetto"
 
 #, fuzzy
 msgid "Select tab"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select table or type to search tables"
-msgstr ""
+msgstr "Seleziona una tabella o digita per cercare tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the Annotation Layer you would like to use."
-msgstr ""
+msgstr "Seleziona il livello di annotazione che desideri utilizzare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters in this "
 "dashboard. Deselecting a chart will exclude it from being filtered when "
@@ -12029,29 +19412,66 @@ msgid ""
 "\"All charts\" to apply cross-filters to all charts that use the same "
 "dataset or contain the same column name in the dashboard."
 msgstr ""
+"Seleziona i grafici a cui vuoi applicare i filtri incrociati in questa "
+"dashboard. La deselezione di un grafico lo escluderà dal filtraggio "
+"quando si applicano filtri incrociati da qualsiasi grafico nella "
+"dashboard. Puoi selezionare \"Tutti i grafici\" per applicare filtri "
+"incrociati a tutti i grafici che utilizzano lo stesso dataset o "
+"contengono lo stesso nome di colonna nella dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters when "
 "interacting with this chart. You can select \"All charts\" to apply "
 "filters to all charts that use the same dataset or contain the same "
 "column name in the dashboard."
 msgstr ""
+"Seleziona i grafici a cui vuoi applicare i filtri incrociati quando "
+"interagisci con questo grafico. Puoi selezionare \"Tutti i grafici\" per "
+"applicare filtri a tutti i grafici che utilizzano lo stesso dataset o "
+"contengono lo stesso nome di colonna nella dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
 msgstr ""
+"Seleziona il colore utilizzato per i valori che indicano un aumento nel "
+"grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
 msgstr ""
+"Seleziona il colore utilizzato per i valori che rappresentano le barre "
+"totali nel grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
+"Seleziona il colore utilizzato per i valori che indicano una diminuzione "
+"nel grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"Seleziona la colonna contenente i codici valuta come USD, EUR, GBP, ecc. "
+"Utilizzata durante la creazione di grafici quando è abilitata la "
+"formattazione valuta 'Rilevamento automatico'. Se questa colonna non è "
+"impostata o se una metrica del grafico contiene più valute, i grafici "
+"utilizzeranno la formattazione numerica neutra."
 
 #, fuzzy
 msgid "Select the fixed color"
@@ -12061,15 +19481,26 @@ msgstr "Seleziona data finale"
 msgid "Select the geojson column"
 msgstr "Seleziona data finale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Seleziona il provider di tile per la mappa. MapLibre è open-source e non "
+"richiede una chiave API. Mapbox richiede che MAPBOX_API_KEY sia "
+"configurato in Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Seleziona la metrica utilizzata per determinare in quale intervallo di "
+"colore rientra ciascun percorso."
 
 #, fuzzy
 msgid "Select the type of color scheme to use."
@@ -12083,17 +19514,28 @@ msgstr "Seleziona una colonna"
 msgid "Select values"
 msgstr "Seleziona una colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Select values in highlighted field(s) in the control panel. Then run the "
 "query by clicking on the %s button."
 msgstr ""
+"Seleziona i valori nei campi evidenziati nel pannello di controllo. "
+"Quindi esegui la query facendo clic sul pulsante %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Seleziona quali granularità temporali sono disponibili nel controllo "
+"filtro. Questa è solo una lista consentita dell'interfaccia utente e non "
+"aggiunge condizioni aggiuntive alle query sottostanti."
 
 #, fuzzy
 msgid "Selected"
@@ -12107,18 +19549,27 @@ msgstr "Sorgente Dati"
 msgid "Selection method"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic"
-msgstr ""
+msgstr "Semantico"
 
 #, fuzzy
 msgid "Semantic Layer"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Vista semantica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Viste semantiche"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12144,8 +19595,11 @@ msgstr "La tua query non può essere salvata"
 msgid "Semantic layer does not exist"
 msgstr "Sorgente dati e tipo di grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic layer parameters are invalid."
-msgstr ""
+msgstr "I parametri del livello semantico non sono validi."
 
 #, fuzzy
 msgid "Semantic layer type"
@@ -12171,38 +19625,78 @@ msgstr "La tua query non può essere salvata"
 msgid "Semantic view does not exist"
 msgstr "Sorgente dati e tipo di grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view parameters are invalid."
-msgstr ""
+msgstr "I parametri della vista semantica non sono validi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Vista semantica aggiornata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Viste semantiche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as CSV"
-msgstr ""
+msgstr "Invia come CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Send as PDF"
-msgstr ""
+msgstr "Invia come PDF"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as PNG"
-msgstr ""
+msgstr "Invia come PNG"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as text"
-msgstr ""
+msgstr "Invia come testo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "September"
-msgstr ""
+msgstr "Settembre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sequential"
-msgstr ""
+msgstr "Sequenziale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Series"
-msgstr ""
+msgstr "Serie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Series Height"
-msgstr ""
+msgstr "Altezza serie"
 
 #, fuzzy
 msgid "Series Order"
@@ -12212,17 +19706,31 @@ msgstr "Query salvate"
 msgid "Series Style"
 msgstr "Serie Temporali - Stacked"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Series chart type (line, bar etc)"
-msgstr ""
+msgstr "Tipo di grafico della serie (linea, barra, ecc.)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "Impostazione diminuzione serie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "Impostazione aumento serie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Series limit"
-msgstr ""
+msgstr "Limite serie"
 
 #, fuzzy
 msgid "Series settings"
@@ -12236,24 +19744,44 @@ msgstr "Parametri"
 msgid "Series type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server Page Length"
-msgstr ""
+msgstr "Lunghezza pagina server"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server pagination"
-msgstr ""
+msgstr "Paginazione server"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Server pagination needs to be enabled for values over %s"
-msgstr ""
+msgstr "La paginazione server deve essere abilitata per valori superiori a %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Service Account"
-msgstr ""
+msgstr "Account di servizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Service version"
-msgstr ""
+msgstr "Versione del servizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Dark Theme"
-msgstr ""
+msgstr "Imposta tema scuro di sistema"
 
 #, fuzzy
 msgid "Set System Default Theme"
@@ -12263,63 +19791,119 @@ msgstr "Valore del filtro"
 msgid "Set as default dark theme"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default light theme"
-msgstr ""
+msgstr "Imposta come tema chiaro predefinito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set auto-refresh"
-msgstr ""
+msgstr "Imposta aggiornamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Set filter mapping"
-msgstr ""
+msgstr "Imposta mappatura filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing"
-msgstr ""
+msgstr "Imposta tema locale per i test"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing (preview only)"
-msgstr ""
+msgstr "Imposta tema locale per i test (solo anteprima)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set refresh frequency for current session only."
-msgstr ""
+msgstr "Imposta la frequenza di aggiornamento solo per la sessione corrente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set the automatic refresh frequency for this dashboard."
-msgstr ""
+msgstr "Imposta la frequenza di aggiornamento automatico per questo pannello."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Set the automatic refresh frequency for this dashboard. The dashboard "
 "will reload its data at the specified interval."
 msgstr ""
+"Imposta la frequenza di aggiornamento automatico per questo pannello. Il "
+"pannello ricaricherà i dati all'intervallo specificato."
 
 #, fuzzy
 msgid "Set up an email report"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set up basic details, such as name and description."
-msgstr ""
+msgstr "Configura i dettagli di base, come nome e descrizione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"Imposta la colonna temporale predefinita per questo dataset. Viene "
+"selezionata automaticamente come colonna temporale durante la creazione "
+"di grafici che richiedono una dimensione temporale e viene utilizzata nei"
+" filtri temporali a livello di pannello."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
 "        represented by one ring with the innermost circle as the top of "
 "the hierarchy."
 msgstr ""
+"Imposta i livelli di gerarchia del grafico. Ogni livello è\n"
+"        rappresentato da un anello con il cerchio più interno come "
+"vertice della gerarchia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings"
-msgstr ""
+msgstr "Impostazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings for time series"
-msgstr ""
+msgstr "Impostazioni per le serie temporali"
 
 #, fuzzy
 msgid "Shape"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Share"
-msgstr ""
+msgstr "Condividi"
 
 #, fuzzy
 msgid "Share chart by email"
@@ -12344,33 +19928,63 @@ msgstr "Query salvate"
 msgid "Sheet name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Shift + Click to sort by multiple columns"
-msgstr ""
+msgstr "Shift + Clic per ordinare per più colonne"
 
 #, fuzzy
 msgid "Shift start date"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Short description must be unique for this layer"
-msgstr ""
+msgstr "La descrizione breve deve essere univoca per questo livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should daily seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Specifica se applicare la stagionalità giornaliera. Un valore intero "
+"specificherà l'ordine di Fourier della stagionalità."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should weekly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Specifica se applicare la stagionalità settimanale. Un valore intero "
+"specificherà l'ordine di Fourier della stagionalità."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should yearly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
 msgstr ""
+"Specifica se applicare la stagionalità annuale. Un valore intero "
+"specificherà l'ordine di Fourier della stagionalità."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show"
-msgstr ""
+msgstr "Mostra"
 
 #, fuzzy, python-format
 msgid "Show %s entries"
@@ -12380,11 +19994,19 @@ msgstr "Mostra metrica"
 msgid "Show Bubbles"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show CREATE VIEW statement"
-msgstr ""
+msgstr "Mostra istruzione CREATE VIEW"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Dashboard"
-msgstr ""
+msgstr "Mostra dashboard"
 
 #, fuzzy
 msgid "Show Labels"
@@ -12393,8 +20015,12 @@ msgstr "Mostra Tabelle"
 msgid "Show Log"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Markers"
-msgstr ""
+msgstr "Mostra marcatori"
 
 #, fuzzy
 msgid "Show Metric Name"
@@ -12412,8 +20038,12 @@ msgstr "Cerca / Filtra"
 msgid "Show SQL"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show Timestamp"
-msgstr ""
+msgstr "Mostra timestamp"
 
 #, fuzzy
 msgid "Show Tooltip Labels"
@@ -12423,11 +20053,19 @@ msgstr "Mostra Tabelle"
 msgid "Show Total"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Trend Line"
-msgstr ""
+msgstr "Mostra linea di tendenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Upper Labels"
-msgstr ""
+msgstr "Mostra etichette superiori"
 
 #, fuzzy
 msgid "Show Values"
@@ -12437,20 +20075,34 @@ msgstr "Mostra Tabelle"
 msgid "Show X-axis"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Y-axis"
-msgstr ""
+msgstr "Mostra asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show Y-axis on the sparkline. Will display the manually set min/max if "
 "set or min/max values in the data otherwise."
 msgstr ""
+"Mostra l'asse Y sul grafico sparkline. Visualizzerà i valori min/max "
+"impostati manualmente se impostati, altrimenti i valori min/max nei dati."
 
 #, fuzzy
 msgid "Show all columns"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show axis line ticks"
-msgstr ""
+msgstr "Mostra i segni di graduazione sull'asse"
 
 #, fuzzy
 msgid "Show cell bars"
@@ -12480,8 +20132,12 @@ msgstr "Mostra colonna"
 msgid "Show columns total"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show data points as circle markers on the lines"
-msgstr ""
+msgstr "Mostra i punti dati come marcatori circolari sulle linee"
 
 #, fuzzy
 msgid "Show empty columns"
@@ -12491,23 +20147,41 @@ msgstr "Colonna del Tempo"
 msgid "Show entries per page"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Show hierarchical relationships of data, with the value represented by "
 "area, showing proportion and contribution to the whole."
 msgstr ""
+"Mostra le relazioni gerarchiche dei dati, con il valore rappresentato "
+"dall'area, mostrando la proporzione e il contributo al tutto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show info tooltip"
-msgstr ""
+msgstr "Mostra il tooltip informativo"
 
 #, fuzzy
 msgid "Show label"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show labels when the node has children."
-msgstr ""
+msgstr "Mostra le etichette quando il nodo ha figli."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show legend"
-msgstr ""
+msgstr "Mostra legenda"
 
 #, fuzzy
 msgid "Show less columns"
@@ -12517,21 +20191,36 @@ msgstr "Colonna del Tempo"
 msgid "Show min/max axis labels"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Show minor ticks on axes."
-msgstr ""
+msgstr "Mostra le tacche minori sugli assi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show only my charts"
-msgstr ""
+msgstr "Mostra solo i miei grafici"
 
 #, fuzzy
 msgid "Show password."
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show percentage"
-msgstr ""
+msgstr "Mostra percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show pointer"
-msgstr ""
+msgstr "Mostra il puntatore"
 
 #, fuzzy
 msgid "Show progress"
@@ -12549,72 +20238,138 @@ msgstr "Mostra Tabelle"
 msgid "Show rows subtotal"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show rows total"
-msgstr ""
+msgstr "Mostra totale righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show series values on the chart"
-msgstr ""
+msgstr "Mostra i valori delle serie sul grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show split lines"
-msgstr ""
+msgstr "Mostra le linee di divisione"
 
 #, fuzzy
 msgid "Show summary"
 msgstr "Mostra grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show the value on top of the bar"
-msgstr ""
+msgstr "Mostra il valore in cima alla barra"
 
 #, fuzzy
 msgid "Show total"
 msgstr "Mostra colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show total aggregations of selected metrics. Note that row limit does not"
 " apply to the result."
 msgstr ""
+"Mostra le aggregazioni totali delle metriche selezionate. Si noti che il "
+"limite di righe non si applica al risultato."
 
 #, fuzzy
 msgid "Show value"
 msgstr "Mostra Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single metric front-and-center. Big number is best used to "
 "call attention to a KPI or the one thing you want your audience to focus "
 "on."
 msgstr ""
+"Mette in evidenza una singola metrica al centro. Il numero grande è "
+"ideale per attirare l'attenzione su un KPI o sull'elemento su cui si "
+"desidera che il pubblico si concentri."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single number accompanied by a simple line chart, to call "
 "attention to an important metric along with its change over time or other"
 " dimension."
 msgstr ""
+"Mette in evidenza un singolo numero accompagnato da un semplice grafico a"
+" linee, per attirare l'attenzione su una metrica importante insieme alla "
+"sua variazione nel tempo o in un'altra dimensione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases how a metric changes as the funnel progresses. This classic "
 "chart is useful for visualizing drop-off between stages in a pipeline or "
 "lifecycle."
 msgstr ""
+"Mostra come una metrica cambia man mano che l'imbuto progredisce. Questo "
+"grafico classico è utile per visualizzare il calo tra le fasi di una "
+"pipeline o di un ciclo di vita."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the flow or link between categories using thickness of chords. "
 "The value and corresponding thickness can be different for each side."
 msgstr ""
+"Mostra il flusso o il collegamento tra categorie utilizzando lo spessore "
+"delle corde. Il valore e lo spessore corrispondente possono essere "
+"diversi per ciascun lato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the progress of a single metric against a given target. The "
 "higher the fill, the closer the metric is to the target."
 msgstr ""
+"Mostra il progresso di una singola metrica rispetto a un obiettivo dato. "
+"Maggiore è il riempimento, più la metrica è vicina all'obiettivo."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Showing %s of %s items"
-msgstr ""
+msgstr "Visualizzazione di %s di %s elementi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows a list of all series available at that point in time"
-msgstr ""
+msgstr "Mostra un elenco di tutte le serie disponibili in quel momento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows or hides markers for the time series"
-msgstr ""
+msgstr "Mostra o nasconde i marcatori per la serie temporale"
 
 #, fuzzy
 msgid "Sign in"
@@ -12624,17 +20379,33 @@ msgstr "Azione"
 msgid "Sign in with"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Significance Level"
-msgstr ""
+msgstr "Livello di significatività"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple"
-msgstr ""
+msgstr "Semplice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple ad-hoc metrics are not enabled for this dataset"
-msgstr ""
+msgstr "Le metriche ad-hoc semplici non sono abilitate per questo set di dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Single"
-msgstr ""
+msgstr "Singolo"
 
 #, fuzzy
 msgid "Single Metric"
@@ -12648,20 +20419,40 @@ msgstr "Valore del filtro"
 msgid "Single value"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Single value type"
-msgstr ""
+msgstr "Tipo di valore singolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Size in pixels"
-msgstr ""
+msgstr "Dimensione in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of edge symbols"
-msgstr ""
+msgstr "Dimensione dei simboli dei bordi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of marker. Also applies to forecast observations."
 msgstr ""
+"Dimensione del marcatore. Si applica anche alle osservazioni di "
+"previsione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip blank lines rather than interpreting them as Not A Number values"
-msgstr ""
+msgstr "Salta le righe vuote invece di interpretarle come valori Non un Numero"
 
 #, fuzzy
 msgid "Skip rows"
@@ -12671,12 +20462,17 @@ msgstr "Errore..."
 msgid "Skip rows is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip spaces after delimiter"
-msgstr ""
+msgstr "Salta gli spazi dopo il delimitatore"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Skipped %d system themes that cannot be deleted"
-msgstr ""
+msgstr "Saltati %d temi di sistema che non possono essere eliminati"
 
 #, fuzzy
 msgid "Slice Id"
@@ -12686,94 +20482,197 @@ msgstr "Larghezza"
 msgid "Slider"
 msgstr "Grafico a torta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slider and range input"
-msgstr ""
+msgstr "Dispositivo di scorrimento e input intervallo"
 
 msgid "Slug"
 msgstr "Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small"
-msgstr ""
+msgstr "Piccolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small number format"
-msgstr ""
+msgstr "Formato numero piccolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Smooth Line"
-msgstr ""
+msgstr "Linea Smussata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Smooth-line is a variation of the line chart. Without angles and hard "
 "edges, Smooth-line sometimes looks smarter and more professional."
 msgstr ""
+"La linea smussata è una variante del grafico a linee. Senza angoli e "
+"bordi netti, la linea smussata appare a volte più elegante e "
+"professionale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Solid"
-msgstr ""
+msgstr "Pieno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
 msgstr ""
+"Alcuni gruppi non hanno potuto essere risolti e vengono visualizzati come"
+" ID."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
 msgstr ""
+"Alcune autorizzazioni non hanno potuto essere risolte e vengono "
+"visualizzate come ID."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
+"Alcuni filtri obbligatori in altre schede hanno valori e non verranno "
+"cancellati"
 
 #, fuzzy
 msgid "Some roles do not exist"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong while saving the user info"
-msgstr ""
+msgstr "Si è verificato un errore durante il salvataggio delle informazioni utente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Something went wrong with embedded authentication. Check the dev console "
 "for details."
 msgstr ""
+"Si è verificato un errore con l'autenticazione incorporata. Controlla la "
+"console di sviluppo per i dettagli."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong."
-msgstr ""
+msgstr "Qualcosa è andato storto."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Sorry there was an error fetching database information: %s"
 msgstr ""
+"Spiacente, si è verificato un errore nel recupero delle informazioni del "
+"database: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Sorry there was an error fetching saved charts: "
-msgstr ""
+msgstr "Spiacente, si è verificato un errore nel recupero dei grafici salvati: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, An error occurred"
-msgstr ""
+msgstr "Spiacente, si è verificato un errore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an error occurred"
-msgstr ""
+msgstr "Spiacente, si è verificato un errore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred"
-msgstr ""
+msgstr "Spiacente, si è verificato un errore sconosciuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred."
-msgstr ""
+msgstr "Spiacente, si è verificato un errore sconosciuto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Embedding could not be deactivated."
 msgstr ""
+"Spiacenti, si è verificato un errore. L'incorporazione non è stata "
+"possibile disattivare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Please try again."
-msgstr ""
+msgstr "Spiacenti, si è verificato un errore. Riprova."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, something went wrong. Try again later."
-msgstr ""
+msgstr "Spiacenti, si è verificato un errore. Riprova più tardi."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Sorry, there was an error saving this %s: %s"
 msgstr ""
+"Spiacenti, si è verificato un errore durante il salvataggio di questo %s:"
+" %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Sorry, there was an error saving this dashboard: %s"
 msgstr ""
+"Spiacenti, si è verificato un errore durante il salvataggio di questa "
+"dashboard: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, your browser does not support copying."
-msgstr ""
+msgstr "Spiacenti, il browser non supporta la copia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, your browser does not support copying. Use Ctrl / Cmd + C!"
-msgstr ""
+msgstr "Spiacenti, il browser non supporta la copia. Usa Ctrl / Cmd + C!"
 
 #, fuzzy
 msgid "Sort"
@@ -12799,17 +20698,33 @@ msgstr "Importa"
 msgid "Sort Series By"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort X Axis"
-msgstr ""
+msgstr "Ordina asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort Y Axis"
-msgstr ""
+msgstr "Ordina asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort ascending"
-msgstr ""
+msgstr "Ordina in modo crescente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort by"
-msgstr ""
+msgstr "Ordina per"
 
 #, fuzzy, python-format
 msgid "Sort by %s"
@@ -12823,22 +20738,33 @@ msgstr "Importa"
 msgid "Sort by metric"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Sort by original table order"
-msgstr ""
+msgstr "Ordina per ordine originale della tabella"
 
 #, fuzzy
 msgid "Sort by series"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort columns alphabetically"
-msgstr ""
+msgstr "Ordina colonne in ordine alfabetico"
 
 #, fuzzy
 msgid "Sort columns by"
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort descending"
-msgstr ""
+msgstr "Ordina in modo decrescente"
 
 #, fuzzy
 msgid "Sort display control values"
@@ -12859,17 +20785,32 @@ msgstr "Mostra metrica"
 msgid "Sort query by"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Ordina i risultati per nome della serie in ordine crescente. Se combinato"
+" con \"Ordina per metrica\", funge da criterio di spareggio per valori di"
+" metrica uguali. L'aggiunta di questo ordinamento potrebbe ridurre le "
+"prestazioni delle query su alcuni database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Sort rows by"
-msgstr ""
+msgstr "Ordina righe per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sort series in ascending order"
-msgstr ""
+msgstr "Ordina serie in ordine crescente"
 
 #, fuzzy
 msgid "Sort type"
@@ -12882,42 +20823,79 @@ msgstr "Sorgente"
 msgid "Source Color"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Source SQL"
-msgstr ""
+msgstr "SQL sorgente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Source category"
-msgstr ""
+msgstr "Categoria sorgente"
 
 #, fuzzy
 msgid "Source location"
 msgstr "Porta Broker"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sparkline"
-msgstr ""
+msgstr "Sparkline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Spatial"
-msgstr ""
+msgstr "Spaziale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Specific Date/Time"
-msgstr ""
+msgstr "Data/Ora specifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE TABLE AS schema in: public"
-msgstr ""
+msgstr "Specificare il nome per CREATE TABLE AS nello schema: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE VIEW AS schema in: public"
-msgstr ""
+msgstr "Specificare il nome per CREATE VIEW AS nello schema: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Specify the database version. This is used with Presto for query cost "
 "estimation, and Dremio for syntax changes, among others."
 msgstr ""
+"Specificare la versione del database. Viene utilizzata con Presto per la "
+"stima dei costi delle query e con Dremio per le modifiche alla sintassi, "
+"tra le altre cose."
 
 #, fuzzy
 msgid "Split number"
 msgstr "Numero Grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Split stack by"
-msgstr ""
+msgstr "Dividi stack per"
 
 #, fuzzy
 msgid "Square kilometers"
@@ -12931,42 +20909,82 @@ msgstr "Parametri"
 msgid "Square miles"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack"
-msgstr ""
+msgstr "Impila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack in groups, where each group corresponds to a dimension"
-msgstr ""
+msgstr "Impila in gruppi, dove ogni gruppo corrisponde a una dimensione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series"
-msgstr ""
+msgstr "Impila serie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series on top of each other"
-msgstr ""
+msgstr "Impila le serie una sopra l'altra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Stacked"
-msgstr ""
+msgstr "Impilato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Bars"
-msgstr ""
+msgstr "Barre impilate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Style"
-msgstr ""
+msgstr "Stile impilato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Standard time series"
-msgstr ""
+msgstr "Serie temporale standard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Start"
-msgstr ""
+msgstr "Inizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start (Longitude, Latitude): "
-msgstr ""
+msgstr "Inizio (Longitudine, Latitudine): "
 
 #, fuzzy
 msgid "Start (inclusive)"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start Longitude & Latitude"
-msgstr ""
+msgstr "Longitudine e Latitudine iniziali"
 
 #, fuzzy
 msgid "Start Time"
@@ -12976,23 +20994,41 @@ msgstr "Ultima Modifica"
 msgid "Start angle"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start at (UTC)"
-msgstr ""
+msgstr "Inizia alle (UTC)"
 
 #, fuzzy
 msgid "Start date"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start date included in time range"
-msgstr ""
+msgstr "Data di inizio inclusa nell'intervallo di tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start y-axis at 0"
-msgstr ""
+msgstr "Inizia l'asse y da 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Start y-axis at zero. Uncheck to start y-axis at minimum value in the "
 "data."
 msgstr ""
+"Inizia l'asse y da zero. Deseleziona per iniziare l'asse y dal valore "
+"minimo nei dati."
 
 #, fuzzy
 msgid "Started"
@@ -13006,23 +21042,47 @@ msgstr "Grafici"
 msgid "Starts with (ILIKE x%)"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "State"
-msgstr ""
+msgstr "Stato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Statistical"
-msgstr ""
+msgstr "Statistico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Status"
-msgstr ""
+msgstr "Stato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - end"
-msgstr ""
+msgstr "Passo - fine"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - middle"
-msgstr ""
+msgstr "Passo - metà"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - start"
-msgstr ""
+msgstr "Passo - inizio"
 
 #, fuzzy
 msgid "Step type"
@@ -13032,41 +21092,72 @@ msgstr "Tipo"
 msgid "Stepped Line"
 msgstr "Serie Temporali - Stacked"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Stepped-line graph (also called step chart) is a variation of line chart "
 "but with the line forming a series of steps between data points. A step "
 "chart can be useful when you want to show the changes that occur at "
 "irregular intervals."
 msgstr ""
+"Il grafico a linee a gradini (detto anche grafico a scalini) è una "
+"variante del grafico a linee in cui la linea forma una serie di gradini "
+"tra i punti dati. Un grafico a scalini può essere utile quando si "
+"desidera mostrare le variazioni che si verificano a intervalli "
+"irregolari."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Stop"
-msgstr ""
+msgstr "Interrompi"
 
 msgid "Stop query"
 msgstr "Query vuota?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stop running (Ctrl + e)"
-msgstr ""
+msgstr "Interrompi esecuzione (Ctrl + e)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stop running (Ctrl + x)"
-msgstr ""
+msgstr "Interrompi esecuzione (Ctrl + x)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Stopped an unsafe database connection"
-msgstr ""
+msgstr "Interrotta una connessione al database non sicura"
 
 #, fuzzy
 msgid "Stream"
 msgstr "Istogramma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Streets"
-msgstr ""
+msgstr "Strade"
 
 #, fuzzy
 msgid "Streets (Carto)"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Strength to pull the graph toward center"
-msgstr ""
+msgstr "Forza per attirare il grafico verso il centro"
 
 #, fuzzy
 msgid "Stroke Color"
@@ -13080,30 +21171,56 @@ msgstr "Larghezza"
 msgid "Stroked"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Structural"
-msgstr ""
+msgstr "Strutturale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
-msgstr ""
+msgstr "La struttura è gestita dal livello semantico a monte ed è di sola lettura."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Style"
-msgstr ""
+msgstr "Stile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Style the ends of the progress bar with a round cap"
-msgstr ""
+msgstr "Applica un'estremità arrotondata agli estremi della barra di avanzamento"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Styling"
-msgstr ""
+msgstr "Stilizzazione"
 
 #, fuzzy
 msgid "Subcategories"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Subdomain"
-msgstr ""
+msgstr "Sottodominio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Submit"
-msgstr ""
+msgstr "Invia"
 
 #, fuzzy
 msgid "Subscribers"
@@ -13113,36 +21230,72 @@ msgstr "Query salvate"
 msgid "Subtitle"
 msgstr "%s - senza nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Subtotal"
-msgstr ""
+msgstr "Subtotale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Success"
-msgstr ""
+msgstr "Successo"
 
 #, fuzzy, python-format
 msgid "Successfully changed %s!"
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix"
-msgstr ""
+msgstr "Suffisso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix to apply after the percentage display"
-msgstr ""
+msgstr "Suffisso da applicare dopo la visualizzazione della percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum"
-msgstr ""
+msgstr "Somma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Columns"
-msgstr ""
+msgstr "Somma come Frazione delle Colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Rows"
-msgstr ""
+msgstr "Somma come Frazione delle Righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Total"
-msgstr ""
+msgstr "Somma come Frazione del Totale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum of values over specified period"
-msgstr ""
+msgstr "Somma dei valori nel periodo specificato"
 
 #, fuzzy
 msgid "Sum values"
@@ -13156,15 +21309,23 @@ msgstr "condividi query"
 msgid "Sunburst Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sunday"
-msgstr ""
+msgstr "Domenica"
 
 #, fuzzy
 msgid "Superset Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset Embedded SDK documentation."
-msgstr ""
+msgstr "Documentazione di Superset Embedded SDK."
 
 msgid "Superset chart"
 msgstr "Esplora grafico"
@@ -13173,11 +21334,19 @@ msgstr "Esplora grafico"
 msgid "Superset docs link"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset encountered an error while running a command."
-msgstr ""
+msgstr "Superset ha incontrato un errore durante l'esecuzione di un comando."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset encountered an unexpected error."
-msgstr ""
+msgstr "Superset ha incontrato un errore imprevisto."
 
 #, fuzzy
 msgid "Supported databases"
@@ -13187,112 +21356,200 @@ msgstr "Database"
 msgid "Swap %s"
 msgstr "Seleziona una destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Swap rows and columns"
-msgstr ""
+msgstr "Scambia righe e colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Swiss army knife for visualizing data. Choose between step, line, "
 "scatter, and bar charts. This viz type has many customization options as "
 "well."
 msgstr ""
+"Coltellino svizzero per la visualizzazione dei dati. Scegli tra grafici a"
+" gradini, a linee, a dispersione e a barre. Questo tipo di "
+"visualizzazione offre anche molte opzioni di personalizzazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the next tab"
-msgstr ""
+msgstr "Passa alla scheda successiva"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the previous tab"
-msgstr ""
+msgstr "Passa alla scheda precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Symbol"
-msgstr ""
+msgstr "Simbolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Symbol of two ends of edge line"
-msgstr ""
+msgstr "Simbolo delle due estremità della linea del bordo"
 
 #, fuzzy
 msgid "Symbol size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sync Permissions"
-msgstr ""
+msgstr "Sincronizza Permessi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sync columns from source"
-msgstr ""
+msgstr "Sincronizza colonne dalla sorgente"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s"
-msgstr ""
+msgstr "Sincronizzazione dei permessi per %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s in the background"
-msgstr ""
+msgstr "Sincronizzazione dei permessi per %s in background"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Syntax"
-msgstr ""
+msgstr "Sintassi"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
 msgstr ""
+"Errore di sintassi: %(qualifier)s input \"%(input)s\" atteso "
+"\"%(expected)s"
 
 #, fuzzy
 msgid "System"
 msgstr "Istogramma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System Theme - Read Only"
-msgstr ""
+msgstr "Tema di sistema - Sola lettura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System dark theme removed"
-msgstr ""
+msgstr "Tema scuro di sistema rimosso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System default theme removed"
-msgstr ""
+msgstr "Tema predefinito di sistema rimosso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TABLES"
-msgstr ""
+msgstr "TABELLE"
 
 #, fuzzy
 msgid "TEMPORAL_RANGE"
 msgstr "è temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "THU"
-msgstr ""
+msgstr "GIO"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TUE"
-msgstr ""
+msgstr "MAR"
 
 msgid "Tab name"
 msgstr "Nome"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Tab schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "Lo schema della scheda non è valido, causato da: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tab title"
-msgstr ""
+msgstr "Titolo scheda"
 
 msgid "Table"
 msgstr "Tabella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Table %(table)s wasn't found in the database %(db)s"
-msgstr ""
+msgstr "La tabella %(table)s non è stata trovata nel database %(db)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Table Name"
-msgstr ""
+msgstr "Nome Tabella"
 
 #, fuzzy
 msgid "Table V2"
 msgstr "Tabella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Table [%(table)s] could not be found, please double check your database "
 "connection, schema, and table name"
 msgstr ""
+"La tabella [%(table)s] non è stata trovata, verificare la connessione al "
+"database, lo schema e il nome della tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Table already exists. You can change your 'if table already exists' "
 "strategy to append or replace or provide a different Table Name to use."
 msgstr ""
+"La tabella esiste già. È possibile modificare la strategia 'se la tabella"
+" esiste già' in aggiungi o sostituisci, oppure fornire un nome di tabella"
+" diverso da utilizzare."
 
 #, fuzzy
 msgid "Table cache timeout"
@@ -13310,29 +21567,51 @@ msgstr "Database"
 msgid "Table name is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Table name undefined"
-msgstr ""
+msgstr "Nome tabella non definito"
 
 #, fuzzy, python-format
 msgid "Table or View \"%(table)s\" does not exist."
 msgstr "Una o più metriche da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Table that visualizes paired t-tests, which are used to understand "
 "statistical differences between groups."
 msgstr ""
+"Tabella che visualizza i test t a coppie, utilizzati per comprendere le "
+"differenze statistiche tra i gruppi."
 
 msgid "Tables"
 msgstr "Tabelle"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabs"
-msgstr ""
+msgstr "Schede"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabular"
-msgstr ""
+msgstr "Tabulare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Tag"
-msgstr ""
+msgstr "Etichetta"
 
 #, fuzzy
 msgid "Tag could not be created."
@@ -13358,39 +21637,64 @@ msgstr "è stata creata"
 msgid "Tag name"
 msgstr "Nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tag name is invalid (cannot contain ':')"
-msgstr ""
+msgstr "Il nome dell'etichetta non è valido (non può contenere ':')"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Tag parameters are invalid."
-msgstr ""
+msgstr "I parametri dell'etichetta non sono validi."
 
 #, fuzzy
 msgid "Tag updated"
 msgstr "%s - senza nome"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Tagged %s %ss"
-msgstr ""
+msgstr "Etichettato %s %ss"
 
 #, fuzzy
 msgid "Tagged Object could not be deleted."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tags"
-msgstr ""
+msgstr "Etichette"
 
 #, fuzzy
 msgid "Target"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Target Color"
-msgstr ""
+msgstr "Colore di destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Target category"
-msgstr ""
+msgstr "Categoria di destinazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Target value"
-msgstr ""
+msgstr "Valore di destinazione"
 
 #, fuzzy
 msgid "Task"
@@ -13412,56 +21716,93 @@ msgstr "La tua query non può essere salvata"
 msgid "Task could not be updated."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"L'attività non è interrompibile. L'attività è in corso ma non ha "
+"registrato un gestore di interruzione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Task parameters are invalid."
-msgstr ""
+msgstr "I parametri dell'attività non sono validi."
 
 #, fuzzy
 msgid "Tasks"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
 msgstr ""
+"Le attività appariranno qui man mano che vengono eseguite le operazioni "
+"in background."
 
 #, fuzzy
 msgid "Template"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Template for cell titles. Use Handlebars templating syntax (a popular "
 "templating library that uses double curly brackets for variable "
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
+"Modello per i titoli delle celle. Utilizza la sintassi dei modelli "
+"Handlebars (una popolare libreria di template che usa le doppie parentesi"
+" graffe per la sostituzione delle variabili): {{row}}, {{column}}, "
+"{{rowLabel}}, {{columnLabel}}"
 
 msgid "Template parameters"
 msgstr "Parametri"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Template processing error: %(error)s"
-msgstr ""
+msgstr "Errore di elaborazione del modello: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "Elaborazione del modello non riuscita: %(ex)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
 "coming from the controls."
 msgstr ""
+"Collegamento basato su modello, è possibile includere {{ metric }} o "
+"altri valori provenienti dai controlli."
 
 #, fuzzy
 msgid "Temporal X-Axis"
 msgstr "è temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Terminate running queries when browser window closed or navigated to "
 "another page. Available for Presto, Hive, MySQL, Postgres and Snowflake "
 "databases."
 msgstr ""
+"Termina le query in esecuzione quando la finestra del browser viene "
+"chiusa o si naviga verso un'altra pagina. Disponibile per i database "
+"Presto, Hive, MySQL, Postgres e Snowflake."
 
 msgid "Test connection"
 msgstr "Testa la Connessione"
@@ -13470,26 +21811,42 @@ msgstr "Testa la Connessione"
 msgid "Text"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Text / Markdown"
-msgstr ""
+msgstr "Testo / Markdown"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text align"
-msgstr ""
+msgstr "Allineamento testo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text embedded in email"
-msgstr ""
+msgstr "Testo incorporato nell'e-mail"
 
 #, fuzzy, python-format
 msgid "The %s"
 msgstr "Tempo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "The %s linked to this chart may have been deleted."
-msgstr ""
+msgstr "Il %s collegato a questo grafico potrebbe essere stato eliminato."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
-msgstr ""
+msgstr "La risposta API da %s non corrisponde all'interfaccia IDatabaseTable."
 
 msgid ""
 "The CSS for individual dashboards can be altered here, or in the "
@@ -13498,29 +21855,57 @@ msgstr ""
 "Il CSS di ogni singola dashboard può essere modificato qui, oppure nella "
 "vista della dashboard dove i cambiamenti sono visibili immediatamente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The CTAS (create table as select) doesn't have a SELECT statement at the "
 "end. Please make sure your query has a SELECT as its last statement. "
 "Then, try running your query again."
 msgstr ""
+"Il CTAS (create table as select) non ha un'istruzione SELECT alla fine. "
+"Assicurati che la tua query abbia un SELECT come ultima istruzione. Poi, "
+"prova a eseguire nuovamente la tua query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The GeoJsonLayer takes in GeoJSON formatted data and renders it as "
 "interactive polygons, lines and points (circles, icons and/or texts)."
 msgstr ""
+"Il GeoJsonLayer accetta dati in formato GeoJSON e li visualizza come "
+"poligoni interattivi, linee e punti (cerchi, icone e/o testi)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Il Global Task Framework non è abilitato. Contatta il tuo amministratore "
+"per abilitare il flag di funzionalità GLOBAL_TASK_FRAMEWORK."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Il Global Task Framework non è abilitato. Imposta "
+"GLOBAL_TASK_FRAMEWORK=True nei flag di funzionalità per utilizzare @task."
+" Consulta https://superset.apache.org/docs/configuration/async-queries-"
+"celery per i dettagli di configurazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
 "values across\n"
@@ -13530,18 +21915,39 @@ msgid ""
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
+"Il diagramma di Sankey traccia visivamente il movimento e la "
+"trasformazione dei valori attraverso\n"
+"          le fasi del sistema. I nodi rappresentano le fasi, collegati da"
+" link che illustrano il flusso di valori. L'altezza\n"
+"          del nodo corrisponde alla metrica visualizzata, fornendo una "
+"rappresentazione chiara della\n"
+"          distribuzione e trasformazione dei valori."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The URL is missing the dataset_id or slice_id parameters."
-msgstr ""
+msgstr "All'URL mancano i parametri dataset_id o slice_id."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The X-axis is not on the filters list"
-msgstr ""
+msgstr "L'asse X non è nell'elenco dei filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The X-axis is not on the filters list which will prevent it from being "
 "used in time range filters in dashboards. Would you like to add it to the"
 " filters list?"
 msgstr ""
+"L'asse X non è nell'elenco dei filtri, il che impedirà il suo utilizzo "
+"nei filtri per intervallo di tempo nei dashboard. Desideri aggiungerlo "
+"all'elenco dei filtri?"
 
 #, fuzzy
 msgid "The annotation has been saved"
@@ -13551,17 +21957,33 @@ msgstr "La tua query non può essere salvata"
 msgid "The annotation has been updated"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The background color of the charts."
-msgstr ""
+msgstr "Il colore di sfondo dei grafici."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The category of source nodes used to assign colors. If a node is "
 "associated with more than one category, only the first will be used."
 msgstr ""
+"La categoria dei nodi sorgente utilizzata per assegnare i colori. Se un "
+"nodo è associato a più di una categoria, verrà utilizzata solo la prima."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
-msgstr ""
+msgstr "Il grafico è ancora in caricamento. Attendi un momento e riprova."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
 "what demographics follow your blog, or what portion of the budget goes to"
@@ -13571,110 +21993,228 @@ msgid ""
 " relative proportion is important, consider using a bar or other chart "
 "type instead."
 msgstr ""
+"Il classico. Ottimo per mostrare quanto di un'azienda ottiene ciascun "
+"investitore, quali dati demografici seguono il tuo blog, o quale parte "
+"del budget va al complesso militare-industriale.\n"
+"\n"
+"        I grafici a torta possono essere difficili da interpretare con "
+"precisione. Se la chiarezza della proporzione relativa è importante, "
+"considera l'utilizzo di un grafico a barre o di un altro tipo di grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The color for points and clusters in RGB"
-msgstr ""
+msgstr "Il colore per i punti e i cluster in RGB"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the elements border"
-msgstr ""
+msgstr "Il colore del bordo degli elementi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the isoband"
-msgstr ""
+msgstr "Il colore dell'isobanda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the isoline"
-msgstr ""
+msgstr "Il colore dell'isolinea"
 
 #, fuzzy
 msgid "The color of the point labels"
 msgstr "Salva e vai alla dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The color scheme for rendering chart"
-msgstr ""
+msgstr "La combinazione di colori per il rendering del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The color scheme is determined by the related dashboard.\n"
 "        Edit the color scheme in the dashboard properties."
 msgstr ""
+"La combinazione di colori è determinata dal dashboard correlato.\n"
+"        Modifica la combinazione di colori nelle proprietà del dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color used when a value doesn't match any defined breakpoints."
 msgstr ""
+"Il colore utilizzato quando un valore non corrisponde a nessun punto di "
+"interruzione definito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The colors of this chart might be overridden by custom label colors of "
 "the related dashboard.\n"
 "    Check the JSON metadata in the Advanced settings."
 msgstr ""
+"I colori di questo grafico potrebbero essere sovrascritti dai colori "
+"delle etichette personalizzate del dashboard correlato.\n"
+"    Controlla i metadati JSON nelle impostazioni Avanzate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column header label"
-msgstr ""
+msgstr "L'etichetta dell'intestazione di colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the source of the edge."
-msgstr ""
+msgstr "La colonna da utilizzare come sorgente del bordo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the target of the edge."
-msgstr ""
+msgstr "La colonna da utilizzare come destinazione del bordo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The column was deleted or renamed in the database."
-msgstr ""
+msgstr "La colonna è stata eliminata o rinominata nel database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The configuration for the map layers"
-msgstr ""
+msgstr "La configurazione per i livelli della mappa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The corner radius of the chart background"
-msgstr ""
+msgstr "Il raggio degli angoli dello sfondo del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The country code standard that Superset should expect to find in the "
 "[country] column"
 msgstr ""
+"Lo standard del codice paese che Superset dovrebbe aspettarsi di trovare "
+"nella colonna [country]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The dashboard has been saved"
-msgstr ""
+msgstr "Il dashboard è stato salvato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The data source seems to have been deleted"
-msgstr ""
+msgstr "L'origine dati sembra essere stata eliminata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The database columns that contains lines information"
-msgstr ""
+msgstr "Le colonne del database che contengono informazioni sulle linee"
 
 #, fuzzy
 msgid "The database could not be found"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is currently running too many queries."
-msgstr ""
+msgstr "Il database sta eseguendo troppe query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is under an unusual load."
-msgstr ""
+msgstr "Il database è sotto un carico insolito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The database referenced in this query was not found. Please contact an "
 "administrator for further assistance or try again."
 msgstr ""
+"Il database a cui si fa riferimento in questa query non è stato trovato. "
+"Contattare un amministratore per ulteriore assistenza o riprovare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database returned an unexpected error."
-msgstr ""
+msgstr "Il database ha restituito un errore imprevisto."
 
 #, fuzzy
 msgid "The database that was used to generate this query could not be found"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database was deleted."
-msgstr ""
+msgstr "Il database è stato eliminato."
 
 #, fuzzy
 msgid "The database was not found."
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The dataset associated with this chart no longer exists"
-msgstr ""
+msgstr "Il dataset associato a questo grafico non esiste più"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
 msgstr ""
+"La colonna/metrica del dataset che restituisce i valori sull'asse x del "
+"grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's y-axis."
 msgstr ""
+"La colonna/metrica del dataset che restituisce i valori sull'asse y del "
+"grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
 "              based on the changes in your SQL query. If your changes "
@@ -13682,7 +22222,16 @@ msgid ""
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
+"Le colonne del dataset verranno sincronizzate automaticamente\n"
+"              in base alle modifiche nella query SQL. Se le modifiche non"
+"\n"
+"              influiscono sulle definizioni delle colonne, è possibile "
+"saltare questo passaggio."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The dataset configuration exposed here\n"
 "                affects all the charts using this dataset.\n"
@@ -13690,9 +22239,19 @@ msgid ""
 "                here may affect other charts\n"
 "                in undesirable ways."
 msgstr ""
+"La configurazione del dataset esposta qui\n"
+"                influisce su tutti i grafici che utilizzano questo "
+"dataset.\n"
+"                Tenere presente che la modifica delle impostazioni\n"
+"                qui potrebbe influire su altri grafici\n"
+"                in modi indesiderati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The dataset has been saved"
-msgstr ""
+msgstr "Il dataset è stato salvato"
 
 msgid "The datasource couldn't be loaded"
 msgstr "La query non può essere caricata"
@@ -13701,23 +22260,39 @@ msgstr "La query non può essere caricata"
 msgid "The datasource is too large to query."
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default catalog that should be used for the connection."
-msgstr ""
+msgstr "Il catalogo predefinito da utilizzare per la connessione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default schema that should be used for the connection."
-msgstr ""
+msgstr "Lo schema predefinito da utilizzare per la connessione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The description can be displayed as widget headers in the dashboard view."
 " Supports markdown."
 msgstr ""
+"La descrizione può essere visualizzata come intestazione dei widget nella"
+" vista del dashboard. Supporta il markdown."
 
 #, fuzzy
 msgid "The display name of your dashboard"
 msgstr "Salva e vai alla dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The distance between cells, in pixels"
-msgstr ""
+msgstr "La distanza tra le celle, in pixel"
 
 #, fuzzy
 msgid ""
@@ -13725,66 +22300,119 @@ msgid ""
 "-1 to bypass the cache."
 msgstr "Durata (in secondi) per il timeout della cache per questa slice."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The encoding format of the lines"
-msgstr ""
+msgstr "Il formato di codifica delle linee"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The engine_params object gets unpacked into the sqlalchemy.create_engine "
 "call."
 msgstr ""
+"L'oggetto engine_params viene decompresso nella chiamata "
+"sqlalchemy.create_engine."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The exponent to compute all sizes from. \"EXP\" only"
-msgstr ""
+msgstr "L'esponente da cui calcolare tutte le dimensioni. Solo \"EXP\""
 
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
 "the extent so that all data points are included in the viewport. CUSTOM "
 "allows users to define the extent manually."
 msgstr ""
+"L'estensione della mappa all'avvio dell'applicazione. FIT DATA imposta "
+"automaticamente l'estensione in modo che tutti i punti dati siano inclusi"
+" nel viewport. CUSTOM consente agli utenti di definire l'estensione "
+"manualmente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "La proprietà dell'elemento da utilizzare per le etichette dei punti"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The following entries in `series_columns` are missing in `columns`: "
 "%(columns)s. "
 msgstr ""
+"Le seguenti voci in `series_columns` sono mancanti in `columns`: "
+"%(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"I seguenti campi contengono informazioni sensibili che sono state "
+"mascherate durante l'esportazione. Fornire i valori per importare questo "
+"database."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The following filters have the 'Select first filter value by default'\n"
 "                    option checked and could not be loaded, which is "
 "preventing the dashboard\n"
 "                    from rendering: %s"
 msgstr ""
+"I seguenti filtri hanno l'opzione 'Seleziona il primo valore del filtro "
+"per impostazione predefinita'\n"
+"                    attivata e non è stato possibile caricarli, il che "
+"impedisce al dashboard\n"
+"                    di essere visualizzato: %s"
 
 #, fuzzy
 msgid "The font size of the point labels"
 msgstr "Salva e vai alla dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The function to use when aggregating points into groups"
-msgstr ""
+msgstr "La funzione da utilizzare per aggregare i punti in gruppi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The group has been created successfully."
-msgstr ""
+msgstr "Il gruppo è stato creato con successo."
 
 #, fuzzy
 msgid "The group has been updated successfully."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
-msgstr ""
+msgstr "L'altezza del livello di zoom corrente da cui calcolare tutte le altezze"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
 "          representing the frequency or count of values within different "
@@ -13793,73 +22421,147 @@ msgid ""
 " and provides\n"
 "          insights into its shape, central tendency, and spread."
 msgstr ""
+"Il grafico a istogramma visualizza la distribuzione di un dataset\n"
+"          rappresentando la frequenza o il conteggio dei valori "
+"all'interno di diversi intervalli o bin.\n"
+"          Aiuta a visualizzare pattern, cluster e valori anomali nei dati"
+" e fornisce\n"
+"          informazioni sulla sua forma, tendenza centrale e dispersione."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The host \"%(hostname)s\" might be down and can't be reached."
-msgstr ""
+msgstr "L'host \"%(hostname)s\" potrebbe essere inattivo e non raggiungibile."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The host \"%(hostname)s\" might be down, and can't be reached on port "
 "%(port)s."
 msgstr ""
+"L'host \"%(hostname)s\" potrebbe essere inattivo e non raggiungibile "
+"sulla porta %(port)s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The host might be down, and can't be reached on the provided port."
-msgstr ""
+msgstr "L'host potrebbe essere inattivo e non raggiungibile sulla porta fornita."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The hostname \"%(hostname)s\" cannot be resolved."
-msgstr ""
+msgstr "Il nome host \"%(hostname)s\" non può essere risolto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The hostname provided can't be resolved."
-msgstr ""
+msgstr "Il nome host fornito non può essere risolto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The id of the active chart"
-msgstr ""
+msgstr "L'id del grafico attivo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"L'URL dell'immagine dell'icona da visualizzare per i punti GeoJSON. "
+"Tenere presente che l'URL dell'immagine deve essere conforme alla "
+"politica di sicurezza dei contenuti (CSP) per caricarsi correttamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
 msgstr ""
+"Il livello iniziale (profondità) dell'albero. Se impostato a -1, tutti i "
+"nodi sono espansi."
 
 #, fuzzy
 msgid "The layer attribution"
 msgstr "Attributi relativi al tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The lower limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "Il limite inferiore dell'intervallo di soglia dell'Isoband"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The maximum number of subdivisions of each group; lower values are pruned"
 " first"
 msgstr ""
+"Il numero massimo di suddivisioni di ciascun gruppo; i valori più bassi "
+"vengono eliminati per primi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The maximum value of metrics. It is an optional configuration"
-msgstr ""
+msgstr "Il valore massimo delle metriche. È una configurazione opzionale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%(key)s is invalid."
 msgstr ""
+"Il parametro metadata_params nel campo Extra non è configurato "
+"correttamente. La chiave %(key)s non è valida."
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%{key}s is invalid."
 msgstr ""
+"Il parametro metadata_params nel campo Extra non è configurato "
+"correttamente. La chiave %{key}s non è valida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The metadata_params object gets unpacked into the sqlalchemy.MetaData "
 "call."
 msgstr ""
+"L'oggetto metadata_params viene decompresso nella chiamata "
+"sqlalchemy.MetaData."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The minimum number of rolling periods required to show a value. For "
 "instance if you do a cumulative sum on 7 days you may want your \"Min "
@@ -13867,77 +22569,143 @@ msgid ""
 "periods. This will hide the \"ramp up\" taking place over the first 7 "
 "periods"
 msgstr ""
+"Il numero minimo di periodi di scorrimento necessari per visualizzare un "
+"valore. Ad esempio, se si esegue una somma cumulativa su 7 giorni, si "
+"potrebbe voler impostare il \"Periodo minimo\" su 7, in modo che tutti i "
+"punti dati visualizzati siano il totale di 7 periodi. Questo nasconderà "
+"l'\"avvio progressivo\" che avviene durante i primi 7 periodi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The minimum value of metrics. It is an optional configuration. If not "
 "set, it will be the minimum value of the data"
 msgstr ""
+"Il valore minimo delle metriche. È una configurazione opzionale. Se non "
+"impostato, sarà il valore minimo dei dati"
 
 #, fuzzy
 msgid "The name of the geometry column"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the layer as described in GetCapabilities"
-msgstr ""
+msgstr "Il nome del layer come descritto in GetCapabilities"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the rule must be unique"
-msgstr ""
+msgstr "Il nome della regola deve essere univoco"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The number color \"steps\""
-msgstr ""
+msgstr "Il numero di \"passi\" del colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The number of bins for the histogram"
-msgstr ""
+msgstr "Il numero di bin per l'istogramma"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The number of hours, negative or positive, to shift the time column. This"
 " can be used to move UTC time to local time."
 msgstr ""
+"Il numero di ore, negative o positive, per spostare la colonna temporale."
+" Può essere utilizzato per convertire l'ora UTC in ora locale."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of results displayed is limited to %(rows)d."
-msgstr ""
+msgstr "Il numero di risultati visualizzati è limitato a %(rows)d."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
-msgstr ""
+msgstr "Il numero di righe visualizzate è limitato a %(rows)d dal menu a discesa."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the limit dropdown."
 msgstr ""
+"Il numero di righe visualizzate è limitato a %(rows)d dal menu a discesa "
+"del limite."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the query"
-msgstr ""
+msgstr "Il numero di righe visualizzate è limitato a %(rows)d dalla query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The number of rows displayed is limited to %(rows)d by the query and "
 "limit dropdown."
 msgstr ""
+"Il numero di righe visualizzate è limitato a %(rows)d dalla query e dal "
+"menu a discesa del limite."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The number of seconds before expiring the cache"
-msgstr ""
+msgstr "Il numero di secondi prima della scadenza della cache"
 
 #, fuzzy
 msgid "The object does not exist in the given database."
 msgstr "Nome delle tabella esistente nella sorgente del database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The parameter %(parameters)s in your query is undefined."
 msgid_plural "The following parameters in your query are undefined: %(parameters)s."
-msgstr[0] ""
+msgstr[0] "Il parametro %(parameters)s nella tua query non è definito."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The password provided for username \"%(username)s\" is incorrect."
-msgstr ""
+msgstr "La password fornita per il nome utente \"%(username)s\" non è corretta."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The password provided when connecting to a database is not valid."
-msgstr ""
+msgstr "La password fornita durante la connessione a un database non è valida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The password reset was successful"
-msgstr ""
+msgstr "Il ripristino della password è avvenuto con successo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the charts. Please note that the \"Secure Extra\" and "
@@ -13945,7 +22713,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"Le password per i database elencati di seguito sono necessarie per "
+"importarli insieme ai grafici. Si noti che le sezioni \"Secure Extra\" e "
+"\"Certificate\" della configurazione del database non sono presenti nei "
+"file di esportazione e dovrebbero essere aggiunte manualmente dopo "
+"l'importazione, se necessario."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the dashboards. Please note that the \"Secure Extra\" and "
@@ -13953,7 +22730,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"Le password per i database elencati di seguito sono necessarie per "
+"importarli insieme alle dashboard. Si noti che le sezioni \"Secure "
+"Extra\" e \"Certificate\" della configurazione del database non sono "
+"presenti nei file di esportazione e dovrebbero essere aggiunte "
+"manualmente dopo l'importazione, se necessario."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the datasets. Please note that the \"Secure Extra\" and "
@@ -13961,7 +22747,16 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"Le password per i database elencati di seguito sono necessarie per "
+"importarli insieme ai dataset. Si noti che le sezioni \"Secure Extra\" e "
+"\"Certificate\" della configurazione del database non sono presenti nei "
+"file di esportazione e dovrebbero essere aggiunte manualmente dopo "
+"l'importazione, se necessario."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the saved queries. Please note that the \"Secure Extra\" "
@@ -13969,219 +22764,453 @@ msgid ""
 "present in export files, and should be added manually after the import if"
 " they are needed."
 msgstr ""
+"Le password per i database elencati di seguito sono necessarie per "
+"importarli insieme alle query salvate. Si noti che le sezioni \"Secure "
+"Extra\" e \"Certificate\" della configurazione del database non sono "
+"presenti nei file di esportazione e dovrebbero essere aggiunte "
+"manualmente dopo l'importazione, se necessario."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
 msgstr ""
+"Le password per i database elencati di seguito sono necessarie per "
+"importarli."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "The pattern of timestamp format. For strings use "
-msgstr ""
+msgstr "Il modello del formato del timestamp. Per le stringhe usa "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The periodicity over which to pivot time. Users can provide\n"
 "            \"Pandas\" offset alias.\n"
 "            Click on the info bubble for more details on accepted "
 "\"freq\" expressions."
 msgstr ""
+"La periodicità su cui effettuare il pivot del tempo. Gli utenti possono "
+"fornire\n"
+"            un alias di offset \"Pandas\".\n"
+"            Fare clic sulla bolla informativa per ulteriori dettagli "
+"sulle espressioni \"freq\" accettate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The pixel radius"
-msgstr ""
+msgstr "Il raggio in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The pointer to a physical table (or view). Keep in mind that the chart is"
 " associated to this Superset logical table, and this logical table points"
 " the physical table referenced here."
 msgstr ""
+"Il puntatore a una tabella fisica (o vista). Tenere presente che il "
+"grafico è associato a questa tabella logica di Superset, e questa tabella"
+" logica punta alla tabella fisica a cui si fa riferimento qui."
 
 #, fuzzy
 msgid "The port is closed."
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The port number is invalid."
-msgstr ""
+msgstr "Il numero di porta non è valido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The primary metric is used to define the arc segment sizes"
 msgstr ""
+"La metrica principale viene utilizzata per definire le dimensioni dei "
+"segmenti dell'arco"
 
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "Nome delle tabella esistente nella sorgente del database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query associated with the results was deleted."
-msgstr ""
+msgstr "La query associata ai risultati è stata eliminata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The query associated with these results could not be found. You need to "
 "re-run the original query."
 msgstr ""
+"La query associata a questi risultati non è stata trovata. È necessario "
+"rieseguire la query originale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query contains one or more malformed template parameters."
-msgstr ""
+msgstr "La query contiene uno o più parametri di template non validi."
 
 msgid "The query couldn't be loaded"
 msgstr "La query non può essere caricata"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The query estimation was killed after %(sqllab_timeout)s seconds. It "
 "might be too complex, or the database might be under heavy load."
 msgstr ""
+"La stima della query è stata interrotta dopo %(sqllab_timeout)s secondi. "
+"Potrebbe essere troppo complessa, o il database potrebbe essere sotto "
+"carico elevato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query has a syntax error."
-msgstr ""
+msgstr "La query ha un errore di sintassi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query returned no data"
-msgstr ""
+msgstr "La query non ha restituito dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The query was killed after %(sqllab_timeout)s seconds. It might be too "
 "complex, or the database might be under heavy load."
 msgstr ""
+"La query è stata interrotta dopo %(sqllab_timeout)s secondi. Potrebbe "
+"essere troppo complessa, o il database potrebbe essere sotto carico "
+"elevato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius (in pixels) the algorithm uses to define a cluster. Choose 0 "
 "to turn off clustering, but beware that a large number of points (>1000) "
 "will cause lag."
 msgstr ""
+"Il raggio (in pixel) che l'algoritmo utilizza per definire un cluster. "
+"Scegliere 0 per disattivare il clustering, ma attenzione che un numero "
+"elevato di punti (>1000) causerà rallentamenti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius of individual points (ones that are not in a cluster). Either "
 "a numerical column or `Auto`, which scales the point based on the largest"
 " cluster"
 msgstr ""
+"Il raggio dei punti individuali (quelli che non si trovano in un "
+"cluster). Una colonna numerica oppure `Auto`, che ridimensiona il punto "
+"in base al cluster più grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The report has been created"
-msgstr ""
+msgstr "Il report è stato creato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The report will be sent to your email at"
-msgstr ""
+msgstr "Il report verrà inviato alla tua email a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The result of this query must be a value capable of numeric "
 "interpretation e.g. 1, 1.0, or \"1\" (compatible with Python's float() "
 "function)."
 msgstr ""
+"Il risultato di questa query deve essere un valore interpretabile "
+"numericamente, ad esempio 1, 1.0, o \"1\" (compatibile con la funzione "
+"float() di Python)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The result size exceeds the allowed limit."
-msgstr ""
+msgstr "La dimensione del risultato supera il limite consentito."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The results backend no longer has the data from the query."
-msgstr ""
+msgstr "Il backend dei risultati non dispone più dei dati dalla query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The results stored in the backend were stored in a different format, and "
 "no longer can be deserialized."
 msgstr ""
+"I risultati memorizzati nel backend sono stati salvati in un formato "
+"diverso e non possono più essere deserializzati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The rich tooltip shows a list of all series for that point in time"
 msgstr ""
+"Il tooltip avanzato mostra un elenco di tutte le serie per quel punto nel"
+" tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The role has been created successfully."
-msgstr ""
+msgstr "Il ruolo è stato creato con successo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The role has been duplicated successfully."
-msgstr ""
+msgstr "Il ruolo è stato duplicato con successo."
 
 #, fuzzy
 msgid "The role has been updated successfully."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The row limit set for the chart was reached. The chart may show partial "
 "data."
 msgstr ""
+"È stato raggiunto il limite di righe impostato per il grafico. Il grafico"
+" potrebbe mostrare dati parziali."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema)s\" does not exist. A valid schema must be used to "
 "run this query."
 msgstr ""
+"Lo schema \"%(schema)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare uno schema valido."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema_name)s\" does not exist. A valid schema must be "
 "used to run this query."
 msgstr ""
+"Lo schema \"%(schema_name)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare uno schema valido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The schema of the submitted payload is invalid."
-msgstr ""
+msgstr "Lo schema del payload inviato non è valido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The schema was deleted or renamed in the database."
-msgstr ""
+msgstr "Lo schema è stato eliminato o rinominato nel database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot could not be downloaded. Please, try again later."
 msgstr ""
+"Lo screenshot non ha potuto essere scaricato. Si prega di riprovare più "
+"tardi."
 
 #, fuzzy
 msgid "The screenshot has been downloaded."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot is being generated. Please, do not leave the page."
 msgstr ""
+"Lo screenshot è in fase di generazione. Si prega di non abbandonare la "
+"pagina."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The service url of the layer"
-msgstr ""
+msgstr "L'URL del servizio del livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The size of each cell in meters"
-msgstr ""
+msgstr "La dimensione di ogni cella in metri"
 
 #, fuzzy
 msgid "The size of the point icons"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The size of the square cell, in pixels"
-msgstr ""
+msgstr "La dimensione della cella quadrata, in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The slope to compute all sizes from. \"LINEAR\" only"
-msgstr ""
+msgstr "La pendenza da cui calcolare tutte le dimensioni. Solo \"LINEAR\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The submitted payload failed validation."
-msgstr ""
+msgstr "Il payload inviato non ha superato la validazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect format."
-msgstr ""
+msgstr "Il payload inviato ha un formato non corretto."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect schema."
-msgstr ""
+msgstr "Il payload inviato ha uno schema non corretto."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table)s\" does not exist. A valid table must be used to run"
 " this query."
 msgstr ""
+"La tabella \"%(table)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare una tabella valida."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table_name)s\" does not exist. A valid table must be used "
 "to run this query."
 msgstr ""
+"La tabella \"%(table_name)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare una tabella valida."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The table was deleted or renamed in the database."
-msgstr ""
+msgstr "La tabella è stata eliminata o rinominata nel database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time column for the visualization. Note that you can define arbitrary"
 " expression that return a DATETIME column in the table. Also note that "
 "the filter below is applied against this column or expression"
 msgstr ""
+"La colonna temporale per la visualizzazione. Si noti che è possibile "
+"definire espressioni arbitrarie che restituiscono una colonna DATETIME "
+"nella tabella. Si noti inoltre che il filtro sottostante viene applicato "
+"a questa colonna o espressione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. Note that you can type and "
 "use simple natural language as in `10 seconds`, `1 day` or `56 weeks`"
 msgstr ""
+"La granularità temporale per la visualizzazione. Si noti che è possibile "
+"digitare e utilizzare un linguaggio naturale semplice come `10 seconds`, "
+"`1 day` o `56 weeks`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. Note that you can type and "
 "use simple natural language as in `10 seconds`,`1 day` or `56 weeks`"
 msgstr ""
+"La granularità temporale per la visualizzazione. Si noti che è possibile "
+"digitare e utilizzare un linguaggio naturale semplice come `10 "
+"seconds`,`1 day` o `56 weeks`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. This applies a date "
 "transformation to alter your time column and defines a new time "
 "granularity. The options here are defined on a per database engine basis "
 "in the Superset source code."
 msgstr ""
+"La granularità temporale per la visualizzazione. Viene applicata una "
+"trasformazione della data per modificare la colonna temporale e viene "
+"definita una nuova granularità temporale. Le opzioni disponibili sono "
+"definite per ogni motore di database nel codice sorgente di Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time range for the visualization. All relative times, e.g. \"Last "
 "month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using"
@@ -14191,14 +23220,32 @@ msgid ""
 " explicitly set the timezone per the ISO 8601 format if specifying either"
 " the start and/or end time."
 msgstr ""
+"L'intervallo di tempo per la visualizzazione. Tutti i tempi relativi, ad "
+"es. \"Ultimo mese\", \"Ultimi 7 giorni\", \"ora\", ecc. vengono calcolati"
+" sul server utilizzando l'ora locale del server (senza fuso orario). "
+"Tutti i tooltip e i tempi segnaposto sono espressi in UTC (senza fuso "
+"orario). I timestamp vengono quindi elaborati dal database utilizzando il"
+" fuso orario locale del motore. Si noti che è possibile impostare "
+"esplicitamente il fuso orario nel formato ISO 8601 se si specifica l'ora "
+"di inizio e/o di fine."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
+"L'unità di tempo per ogni blocco. Dovrebbe essere un'unità più piccola di"
+" domain_granularity. Dovrebbe essere maggiore o uguale a Time Grain"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The time unit used for the grouping of blocks"
-msgstr ""
+msgstr "L'unità di tempo utilizzata per il raggruppamento dei blocchi"
 
 #, fuzzy
 msgid "The two passwords that you entered do not match!"
@@ -14215,14 +23262,25 @@ msgstr "Il tipo di visualizzazione da mostrare"
 msgid "The unit for icon size"
 msgstr "Grandezza della bolla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "L'unità per la dimensione dell'etichetta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The unit of measure for the specified point radius"
-msgstr ""
+msgstr "L'unità di misura per il raggio del punto specificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The upper limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "Il limite superiore dell'intervallo di soglia dell'Isoband"
 
 #, fuzzy
 msgid "The user has been created successfully."
@@ -14232,50 +23290,102 @@ msgstr "La tua query non può essere salvata"
 msgid "The user has been updated successfully."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The user seems to have been deleted"
-msgstr ""
+msgstr "L'utente sembra essere stato eliminato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The user was updated successfully"
-msgstr ""
+msgstr "L'utente è stato aggiornato con successo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The user/password combination is not valid (Incorrect password for user)."
 msgstr ""
+"La combinazione utente/password non è valida (password errata per "
+"l'utente)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The username \"%(username)s\" does not exist."
-msgstr ""
+msgstr "Il nome utente \"%(username)s\" non esiste."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The username provided when connecting to a database is not valid."
-msgstr ""
+msgstr "Il nome utente fornito durante la connessione al database non è valido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The values overlap other breakpoint values"
-msgstr ""
+msgstr "I valori si sovrappongono ad altri valori di breakpoint"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The version of the service"
-msgstr ""
+msgstr "La versione del servizio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The visible title of the layer"
-msgstr ""
+msgstr "Il titolo visibile del livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The way the ticks are laid out on the X-axis"
-msgstr ""
+msgstr "Il modo in cui le tacche sono disposte sull'asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the Isoline in pixels"
-msgstr ""
+msgstr "La larghezza dell'Isoline in pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the current zoom level to compute all widths from"
 msgstr ""
+"La larghezza del livello di zoom corrente da cui calcolare tutte le "
+"larghezze"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the elements border"
-msgstr ""
+msgstr "La larghezza del bordo degli elementi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the lines"
-msgstr ""
+msgstr "La larghezza delle linee"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
 msgstr ""
+"La larghezza delle linee come valore fisso o larghezza variabile basata "
+"su una metrica."
 
 #, fuzzy
 msgid "Theme"
@@ -14297,50 +23407,90 @@ msgstr "Tempo"
 msgid "Themes could not be deleted."
 msgstr "La query non può essere caricata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There are associated alerts or reports"
-msgstr ""
+msgstr "Ci sono avvisi o report associati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There are associated alerts or reports: %(report_names)s"
-msgstr ""
+msgstr "Ci sono avvisi o report associati: %(report_names)s"
 
 #, fuzzy
 msgid "There are no charts added to this dashboard"
 msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "There are no components added to this tab"
-msgstr ""
+msgstr "Non ci sono componenti aggiunti a questa scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There are no filters in this dashboard."
-msgstr ""
+msgstr "Non ci sono filtri in questo dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There are unsaved changes."
-msgstr ""
+msgstr "Ci sono modifiche non salvate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is a syntax error in the SQL query. Perhaps there was a misspelling"
 " or a typo."
 msgstr ""
+"C'è un errore di sintassi nella query SQL. Forse c'è stato un errore "
+"ortografico o un refuso."
 
 #, fuzzy
 msgid "There is currently no information to display."
 msgstr "Il tipo di visualizzazione da mostrare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is no chart definition associated with this component, could it "
 "have been deleted?"
 msgstr ""
+"Non esiste una definizione di grafico associata a questo componente, "
+"potrebbe essere stata eliminata?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is not enough space for this component. Try decreasing its width, "
 "or increasing the destination width."
 msgstr ""
+"Non c'è abbastanza spazio per questo componente. Prova a ridurne la "
+"larghezza o ad aumentare la larghezza della destinazione."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"Si è verificato un problema durante l'aggiornamento del dashboard. "
+"Riproveremo tra %s, come previsto."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -14366,9 +23516,14 @@ msgstr "Errore nel creare il datasource"
 msgid "There was an error fetching dataset's related objects"
 msgstr "Errore nel recupero dei metadati della tabella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "There was an error fetching the favorite status: %s"
 msgstr ""
+"Si è verificato un errore durante il recupero dello stato dei preferiti: "
+"%s"
 
 #, fuzzy
 msgid "There was an error fetching the filtered charts and dashboards:"
@@ -14390,11 +23545,19 @@ msgstr "Errore nel creare il datasource"
 msgid "There was an error loading the chart data"
 msgstr "Errore nel creare il datasource"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error loading the schemas"
-msgstr ""
+msgstr "Si è verificato un errore durante il caricamento degli schemi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error loading the tables"
-msgstr ""
+msgstr "Si è verificato un errore durante il caricamento delle tabelle"
 
 #, fuzzy
 msgid "There was an error loading users."
@@ -14404,9 +23567,14 @@ msgstr "Errore nel creare il datasource"
 msgid "There was an error retrieving dashboard tabs."
 msgstr "Errore nel creare il datasource"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "There was an error saving the favorite status: %s"
 msgstr ""
+"Si è verificato un errore durante il salvataggio dello stato dei "
+"preferiti: %s"
 
 #, fuzzy
 msgid "There was an error updating the group. Please, try again."
@@ -14432,8 +23600,12 @@ msgstr "Errore nel creare il datasource"
 msgid "There was an error while fetching users"
 msgstr "Errore nel creare il datasource"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error with your request"
-msgstr ""
+msgstr "Si è verificato un errore con la tua richiesta"
 
 #, fuzzy, python-format
 msgid "There was an issue cancelling the task: %s"
@@ -14443,9 +23615,12 @@ msgstr "Errore nel recupero dati"
 msgid "There was an issue deleting %s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting %s: %s"
-msgstr ""
+msgstr "Si è verificato un problema durante l'eliminazione di %s: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting registration for user: %s"
@@ -14459,36 +23634,68 @@ msgstr "Errore nel recupero dati"
 msgid "There was an issue deleting the selected %s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected %s: %s"
-msgstr ""
+msgstr "Si è verificato un problema durante l'eliminazione dei %s selezionati: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected annotations: %s"
 msgstr ""
+"Si è verificato un problema durante l'eliminazione delle annotazioni "
+"selezionate: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected charts: %s"
 msgstr ""
+"Si è verificato un problema durante l'eliminazione dei grafici "
+"selezionati: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "There was an issue deleting the selected dashboards: "
 msgstr ""
+"Si è verificato un problema durante l'eliminazione dei dashboard "
+"selezionati: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected layers: %s"
 msgstr ""
+"Si è verificato un problema durante l'eliminazione dei livelli "
+"selezionati: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected templates: %s"
 msgstr ""
+"Si è verificato un problema durante l'eliminazione dei modelli "
+"selezionati: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting the selected themes: %s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting: %s"
-msgstr ""
+msgstr "Si è verificato un problema durante l'eliminazione: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue duplicating the %s."
@@ -14518,42 +23725,76 @@ msgstr "Errore nel creare il datasource"
 msgid "There was an issue exporting the selected themes"
 msgstr "Errore nel recupero dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an issue favoriting this dashboard."
 msgstr ""
+"Si è verificato un problema durante l'aggiunta di questa dashboard ai "
+"preferiti."
 
 #, fuzzy
 msgid "There was an issue fetching reports."
 msgstr "Errore nel recupero dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an issue fetching the favorite status of this dashboard."
 msgstr ""
+"Si è verificato un problema durante il recupero dello stato dei preferiti"
+" di questa dashboard."
 
 #, fuzzy, python-format
 msgid "There was an issue fetching your chart: %s"
 msgstr "Errore nel recupero dati"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There was an issue fetching your dashboards: %s"
-msgstr ""
+msgstr "Si è verificato un problema durante il recupero delle tue dashboard: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue fetching your recent activity: %s"
 msgstr ""
+"Si è verificato un problema durante il recupero della tua attività "
+"recente: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There was an issue fetching your saved queries: %s"
 msgstr ""
+"Si è verificato un problema durante il recupero delle tue query salvate: "
+"%s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query %s"
-msgstr ""
+msgstr "Si è verificato un problema durante l'anteprima della query selezionata %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query. %s"
 msgstr ""
+"Si è verificato un problema durante l'anteprima della query selezionata. "
+"%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "These are the datasets this filter will be applied to."
-msgstr ""
+msgstr "Questi sono i set di dati a cui verrà applicato questo filtro."
 
 msgid ""
 "This JSON object is generated dynamically when clicking the save or "
@@ -14565,71 +23806,152 @@ msgstr ""
 "qui come riferimento e per gli utenti esperti che vogliono modificare "
 "parametri specifici."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "This action will permanently delete %s."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the group."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente il gruppo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the layer."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente il livello."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the role."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente il ruolo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the saved query."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente la query salvata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the template."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente il modello."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the theme."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente il tema."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user registration."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente la registrazione utente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user."
-msgstr ""
+msgstr "Questa azione eliminerà definitivamente l'utente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This can be either an IP address (e.g. 127.0.0.1) or a domain name (e.g. "
 "mydatabase.com)."
 msgstr ""
+"Può essere un indirizzo IP (ad es. 127.0.0.1) o un nome di dominio (ad "
+"es. mydatabase.com)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This chart applies cross-filters to charts whose datasets contain columns"
 " with the same name."
 msgstr ""
+"Questo grafico applica filtri incrociati ai grafici i cui set di dati "
+"contengono colonne con lo stesso nome."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart has been moved to a different filter scope."
-msgstr ""
+msgstr "Questo grafico è stato spostato in un ambito di filtro diverso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
 msgstr ""
+"Questo grafico è gestito esternamente e non può essere sovrascritto in "
+"Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This chart is managed externally, and can't be edited in Superset"
 msgstr ""
+"Questo grafico è gestito esternamente e non può essere modificato in "
+"Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
+"Questo grafico potrebbe essere incompatibile con il filtro (i set di dati"
+" non corrispondono)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This chart type is not supported when using an unsaved query as a chart "
 "source. "
 msgstr ""
+"Questo tipo di grafico non è supportato quando si utilizza una query non "
+"salvata come sorgente del grafico. "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
-msgstr ""
+msgstr "Questa colonna potrebbe essere incompatibile con l'attuale %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This column might be incompatible with current dataset"
-msgstr ""
+msgstr "Questa colonna potrebbe essere incompatibile con il set di dati corrente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This column must contain date/time information."
-msgstr ""
+msgstr "Questa colonna deve contenere informazioni di data/ora."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This control filters the whole chart based on the selected time range. "
 "All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. "
@@ -14639,129 +23961,290 @@ msgid ""
 "engine's local timezone. Note one can explicitly set the timezone per the"
 " ISO 8601 format if specifying either the start and/or end time."
 msgstr ""
+"Questo controllo filtra l'intero grafico in base all'intervallo di tempo "
+"selezionato. Tutti i tempi relativi, ad es. \"Ultimo mese\", \"Ultimi 7 "
+"giorni\", \"adesso\", ecc. vengono valutati sul server utilizzando l'ora "
+"locale del server (senza fuso orario). Tutti i tooltip e i segnaposto "
+"temporali sono espressi in UTC (senza fuso orario). I timestamp vengono "
+"poi valutati dal database utilizzando il fuso orario locale del motore. "
+"Si noti che è possibile impostare esplicitamente il fuso orario nel "
+"formato ISO 8601 specificando l'ora di inizio e/o di fine."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the \"time_range\" field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"Questo controlla se il campo \"time_range\" dalla vista corrente\n"
+"                  debba essere trasmesso al grafico contenente i dati "
+"delle annotazioni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the time grain field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"Questo controlla se il campo della granularità temporale dalla vista "
+"corrente\n"
+"                  debba essere trasmesso al grafico contenente i dati "
+"delle annotazioni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dashboard is managed externally, and can't be edited in Superset"
 msgstr ""
+"Questa dashboard è gestita esternamente e non può essere modificata in "
+"Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published which means it will not show up in the "
 "list of dashboards. Favorite it to see it there or access it by using the"
 " URL directly."
 msgstr ""
+"Questa dashboard non è pubblicata, il che significa che non apparirà "
+"nell'elenco delle dashboard. Aggiungila ai preferiti per vederla lì "
+"oppure accedi direttamente tramite URL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published, it will not show up in the list of "
 "dashboards. Click here to publish this dashboard."
 msgstr ""
+"Questa dashboard non è pubblicata e non apparirà nell'elenco delle "
+"dashboard. Clicca qui per pubblicare questa dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is now hidden"
-msgstr ""
+msgstr "Questa dashboard è ora nascosta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is now published"
-msgstr ""
+msgstr "Questa dashboard è ora pubblicata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is published. Click to make it a draft."
-msgstr ""
+msgstr "Questa dashboard è pubblicata. Clicca per renderla una bozza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is ready to embed. In your application, pass the following"
 " id to the SDK:"
 msgstr ""
+"Questa dashboard è pronta per essere incorporata. Nella tua applicazione,"
+" passa il seguente ID all'SDK:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "This dashboard was saved successfully."
-msgstr ""
+msgstr "Questa dashboard è stata salvata con successo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This database does not allow for DDL/DML, but the query mutates data. "
 "Please contact your administrator for more assistance."
 msgstr ""
+"Questo database non consente operazioni DDL/DML, ma la query modifica i "
+"dati. Contatta il tuo amministratore per ulteriore assistenza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This database is managed externally, and can't be edited in Superset"
 msgstr ""
+"Questo database è gestito esternamente e non può essere modificato in "
+"Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This database table does not contain any data. Please select a different "
 "table."
 msgstr ""
+"Questa tabella del database non contiene dati. Seleziona una tabella "
+"diversa."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Questo database utilizza OAuth2 per l'autenticazione. Fai clic sul link "
+"sopra per concedere ad Apache Superset il permesso di accedere ai dati. "
+"Il tuo token di accesso personale verrà memorizzato in forma "
+"crittografata e utilizzato solo per le query eseguite da te."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
+"Questo set di dati è gestito esternamente e non può essere modificato in "
+"Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "This defines the element to be plotted on the chart"
-msgstr ""
+msgstr "Questo definisce l'elemento da tracciare sul grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This email is already associated with an account. Please choose another "
 "one."
-msgstr ""
+msgstr "Questo indirizzo email è già associato a un account. Sceglierne un altro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This feature is experimental and may change or have limitations"
 msgstr ""
+"Questa funzionalità è sperimentale e potrebbe cambiare o presentare "
+"limitazioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the calculated "
 "dimension to charts. It is also used as the alias in the SQL query."
 msgstr ""
+"Questo campo viene utilizzato come identificatore univoco per collegare "
+"la dimensione calcolata ai grafici. Viene anche utilizzato come alias "
+"nella query SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the metric to charts."
 " It is also used as the alias in the SQL query."
 msgstr ""
+"Questo campo viene utilizzato come identificatore univoco per associare "
+"la metrica ai grafici. Viene utilizzato anche come alias nella query SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This filter already exist on the report"
-msgstr ""
+msgstr "Questo filtro esiste già nel report"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This filter might be incompatible with current %s"
-msgstr ""
+msgstr "Questo filtro potrebbe non essere compatibile con il/la %s attuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "Questa cartella è attualmente vuota"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Questa cartella supporta solo colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Questa cartella supporta solo metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr ""
+"Questa funzionalità è disabilitata nel tuo ambiente per motivi di "
+"sicurezza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
+"Questa è la cartella predefinita per le colonne. Il suo nome non può "
+"essere modificato o rimosso. Può rimanere vuota ma accetterà solo "
+"elementi di tipo colonna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
+"Questa è la cartella predefinita per le metriche. Il suo nome non può "
+"essere modificato o rimosso. Può rimanere vuota ma accetterà solo "
+"elementi di tipo metrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "Questo è un messaggio di errore personalizzato per a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "Questo è un messaggio di errore personalizzato per b"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
 "example, to only return rows for a particular client, you might define a "
@@ -14769,19 +24252,36 @@ msgid ""
 " a user belongs to a RLS filter role, a base filter can be created with "
 "the clause `1 = 0` (always false)."
 msgstr ""
+"Questa è la condizione che verrà aggiunta alla clausola WHERE. Ad "
+"esempio, per restituire solo le righe di un determinato cliente, è "
+"possibile definire un filtro normale con la clausola `client_id = 9`. Per"
+" non visualizzare alcuna riga a meno che un utente non appartenga a un "
+"ruolo di filtro RLS, è possibile creare un filtro base con la clausola `1"
+" = 0` (sempre falso)."
 
 #, fuzzy
 msgid "This is the default dark theme"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default folder"
-msgstr ""
+msgstr "Questa è la cartella predefinita"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "Questo è il tema chiaro predefinito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
 msgstr ""
+"Questa è l'unica volta che vedrai questa chiave. Conservala in modo "
+"sicuro."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -14793,134 +24293,274 @@ msgstr ""
 "la dimensione usando la funzione di drag & drop nella vista della "
 "dashboard. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "Impossibile seguire questo collegamento perché l'indirizzo non è sicuro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Questo collegamento ti porterà a un sito web esterno. Non possiamo "
+"garantire la sicurezza delle destinazioni esterne."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error."
-msgstr ""
+msgstr "Questo componente markdown contiene un errore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error. Please revert your recent changes."
 msgstr ""
+"Questo componente markdown contiene un errore. Annulla le modifiche "
+"recenti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This may be due to the extension not being activated or the content not "
 "being available."
 msgstr ""
+"Ciò potrebbe essere dovuto al fatto che l'estensione non è attivata o il "
+"contenuto non è disponibile."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This may be triggered by:"
-msgstr ""
+msgstr "Questo potrebbe essere causato da:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This metric might be incompatible with current %s"
-msgstr ""
+msgstr "Questa metrica potrebbe non essere compatibile con il/la %s attuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This name is already taken. Please choose another one."
-msgstr ""
+msgstr "Questo nome è già in uso. Sceglierne un altro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This option has been disabled by the administrator."
-msgstr ""
+msgstr "Questa opzione è stata disabilitata dall'amministratore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This page is intended to be embedded in an iframe, but it looks like that"
 " is not the case."
 msgstr ""
+"Questa pagina è destinata a essere incorporata in un iframe, ma sembra "
+"che non sia così."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This section allows you to configure how to use the slice\n"
 "              to generate annotations."
 msgstr ""
+"Questa sezione consente di configurare come utilizzare il grafico\n"
+"              per generare annotazioni."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This section contains options that allow for advanced analytical post "
 "processing of query results"
 msgstr ""
+"Questa sezione contiene opzioni che consentono un'elaborazione analitica "
+"avanzata dei risultati delle query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This section contains validation errors"
-msgstr ""
+msgstr "Questa sezione contiene errori di validazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This session has encountered an interruption, and some controls may not "
 "work as intended. If you are the developer of this app, please check that"
 " the guest token is being generated correctly."
 msgstr ""
+"Questa sessione ha subito un'interruzione e alcuni controlli potrebbero "
+"non funzionare come previsto. Se sei lo sviluppatore di questa app, "
+"verifica che il token ospite venga generato correttamente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This table already has a dataset"
-msgstr ""
+msgstr "Questa tabella ha già un dataset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This table already has a dataset associated with it. You can only "
 "associate one dataset with a table.\n"
 msgstr ""
+"Questa tabella ha già un dataset associato. È possibile associare un solo"
+" dataset a una tabella.\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally"
-msgstr ""
+msgstr "Questo tema è impostato localmente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally for your session"
-msgstr ""
+msgstr "Questo tema è impostato localmente per la tua sessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This username is already taken. Please choose another one."
-msgstr ""
+msgstr "Questo nome utente è già in uso. Sceglierne un altro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be greater than the left target value"
-msgstr ""
+msgstr "Questo valore deve essere maggiore del valore target sinistro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be smaller than the right target value"
-msgstr ""
+msgstr "Questo valore deve essere minore del valore target destro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This visualization type does not support cross-filtering."
-msgstr ""
+msgstr "Questo tipo di visualizzazione non supporta il filtro incrociato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "This visualization type is not supported."
-msgstr ""
+msgstr "Questo tipo di visualizzazione non è supportato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
-msgstr[0] ""
+msgstr[0] "Questo è stato causato da:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "Questo interromperà (arresterà) il task per tutti i %s iscritti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
 "to main columns for increase and decrease. Basic conditional formatting "
 "can be overwritten by conditional formatting below."
 msgstr ""
+"Verrà applicato all'intera tabella. Le frecce (↑ e ↓) verranno aggiunte "
+"alle colonne principali per indicare aumento e diminuzione. La "
+"formattazione condizionale di base può essere sovrascritta dalla "
+"formattazione condizionale sottostante."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "Questo annullerà il task."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This will remove your current embed configuration."
-msgstr ""
+msgstr "Questa operazione rimuoverà la configurazione di incorporamento attuale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
+"Questo riorganizzerà tutte le metriche e le colonne nelle cartelle "
+"predefinite. Tutte le cartelle personalizzate verranno rimosse."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold"
-msgstr ""
+msgstr "Soglia"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Threshold alpha level for determining significance"
-msgstr ""
+msgstr "Livello alfa della soglia per determinare la significatività"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold for Other"
-msgstr ""
+msgstr "Soglia per Altro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold: "
-msgstr ""
+msgstr "Soglia: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thumbnails"
-msgstr ""
+msgstr "Miniature"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thursday"
-msgstr ""
+msgstr "Giovedì"
 
 msgid "Time"
 msgstr "Tempo"
@@ -14937,20 +24577,40 @@ msgstr "Colonna del Tempo"
 msgid "Time Format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time Grain"
-msgstr ""
+msgstr "Granularità Temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time Grain must be specified when using Time Shift."
 msgstr ""
+"La Granularità Temporale deve essere specificata quando si utilizza lo "
+"Spostamento Temporale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time Granularity"
-msgstr ""
+msgstr "Granularità Temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time Lag"
-msgstr ""
+msgstr "Ritardo Temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Time Range"
-msgstr ""
+msgstr "Intervallo di Tempo"
 
 #, fuzzy
 msgid "Time Ratio"
@@ -14963,17 +24623,29 @@ msgstr "Colonna del Tempo"
 msgid "Time Series - Line Chart"
 msgstr "Serie Temporali - Grafico Lineare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Nightingale Rose Chart"
-msgstr ""
+msgstr "Serie Temporale - Grafico Rosa di Nightingale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Paired t-test"
-msgstr ""
+msgstr "Serie Temporale - Test t accoppiato"
 
 msgid "Time Series - Percent Change"
 msgstr "Serie Temporali - Cambiamento Percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Period Pivot"
-msgstr ""
+msgstr "Serie Temporale - Pivot Periodo"
 
 #, fuzzy
 msgid "Time Series Options"
@@ -14983,41 +24655,74 @@ msgstr "Colonna del Tempo"
 msgid "Time Shift"
 msgstr "Offset temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Table View"
-msgstr ""
+msgstr "Vista Tabella Temporale"
 
 msgid "Time column"
 msgstr "Colonna del Tempo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Time column \"%(col)s\" does not exist in dataset"
-msgstr ""
+msgstr "La colonna temporale \"%(col)s\" non esiste nel dataset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time column chart customization plugin"
-msgstr ""
+msgstr "Plugin di personalizzazione del grafico a colonne temporali"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column filter plugin"
-msgstr ""
+msgstr "Plugin di filtro per colonna temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply dependent temporal filter to"
-msgstr ""
+msgstr "Colonna temporale a cui applicare il filtro temporale dipendente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply time range to"
-msgstr ""
+msgstr "Colonna temporale a cui applicare l'intervallo di tempo"
 
 msgid "Time comparison"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Time delta in natural language\n"
 "                  (example:  24 hours, 7 days, 56 weeks, 365 days)"
 msgstr ""
+"Delta temporale in linguaggio naturale\n"
+"                  (esempio: 24 ore, 7 giorni, 56 settimane, 365 giorni)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time delta is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
 msgstr ""
+"Il delta temporale è ambiguo. Specificare [%(human_readable)s fa] o "
+"[%(human_readable)s dopo]."
 
 #, fuzzy
 msgid "Time filter"
@@ -15027,33 +24732,63 @@ msgstr "Aggiungi filtro"
 msgid "Time format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time grain"
-msgstr ""
+msgstr "Granularità temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time grain chart customization plugin"
-msgstr ""
+msgstr "Plugin di personalizzazione del grafico per granularità temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time grain filter plugin"
-msgstr ""
+msgstr "Plugin di filtro per granularità temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time grain missing"
-msgstr ""
+msgstr "Granularità temporale mancante"
 
 #, fuzzy
 msgid "Time grain options"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time granularity"
-msgstr ""
+msgstr "Granularità temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time in seconds"
-msgstr ""
+msgstr "Tempo in secondi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time lag"
-msgstr ""
+msgstr "Ritardo temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time range"
-msgstr ""
+msgstr "Intervallo di tempo"
 
 #, fuzzy
 msgid "Time ratio"
@@ -15072,18 +24807,27 @@ msgstr "Colonna del Tempo"
 msgid "Time shift"
 msgstr "Offset temporale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time string is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
 msgstr ""
+"La stringa temporale è ambigua. Specificare [%(human_readable)s fa] o "
+"[%(human_readable)s dopo]."
 
 #, fuzzy
 msgid "Time-series Percent Change"
 msgstr "Serie Temporali - Cambiamento Percentuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time-series Period Pivot"
-msgstr ""
+msgstr "Pivot Periodo Serie Temporale"
 
 msgid "Time-series Table"
 msgstr "Serie Temporali - Stacked"
@@ -15096,21 +24840,33 @@ msgstr "Formato Datetime"
 msgid "Timeline"
 msgstr "Tempo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Timeout configurato (%s secondi) ma nessun gestore di interruzione "
+"definito. L'attività continuerà a essere eseguita oltre il timeout."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timeout error"
-msgstr ""
+msgstr "Errore di timeout"
 
 #, fuzzy
 msgid "Timestamp format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timezone"
-msgstr ""
+msgstr "Fuso orario"
 
 #, fuzzy
 msgid "Timezone selector"
@@ -15131,35 +24887,66 @@ msgstr "Colonna del Tempo"
 msgid "Title is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Title or Slug"
-msgstr ""
+msgstr "Titolo o Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Per iniziare a utilizzare i tuoi Google Sheets, devi prima creare un "
+"database. I database vengono utilizzati come metodo per identificare i "
+"tuoi dati in modo che possano essere interrogati e visualizzati. Questo "
+"database conterrà tutti i singoli Google Sheets che sceglierai di "
+"collegare qui."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
 "clicking the column header."
 msgstr ""
+"Per abilitare l'ordinamento per più colonne, tieni premuto il tasto ⇧ "
+"Shift mentre fai clic sull'intestazione della colonna."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "To filter on a metric, use Custom SQL tab."
-msgstr ""
+msgstr "Per filtrare una metrica, usa la scheda SQL personalizzato."
 
 msgid "To get a readable URL for your dashboard"
 msgstr "ottenere una URL leggibile per la tua dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "URI Richiesta Token"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Tool Panel"
-msgstr ""
+msgstr "Pannello Strumenti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tooltip"
-msgstr ""
+msgstr "Tooltip"
 
 #, fuzzy
 msgid "Tooltip (columns)"
@@ -15169,8 +24956,11 @@ msgstr "Colonna del Tempo"
 msgid "Tooltip (metrics)"
 msgstr "Lista Metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Tooltip Contents"
-msgstr ""
+msgstr "Contenuto del Tooltip"
 
 #, fuzzy
 msgid "Tooltip contents"
@@ -15184,8 +24974,12 @@ msgstr "Lista Metriche"
 msgid "Tooltip time format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Top"
-msgstr ""
+msgstr "In alto"
 
 #, fuzzy
 msgid "Top left"
@@ -15199,19 +24993,32 @@ msgstr "Cancella"
 msgid "Top right"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Top to Bottom"
-msgstr ""
+msgstr "Dall'alto verso il basso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Total"
-msgstr ""
+msgstr "Totale"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggfunc)s)"
-msgstr ""
+msgstr "Totale (%(aggfunc)s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggregatorName)s)"
-msgstr ""
+msgstr "Totale (%(aggregatorName)s)"
 
 #, fuzzy
 msgid "Total color"
@@ -15225,31 +25032,57 @@ msgstr "Valore del filtro"
 msgid "Total value"
 msgstr "Valore del filtro"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Total: %s"
-msgstr ""
+msgstr "Totale: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Track job"
-msgstr ""
+msgstr "Traccia attività"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transformable"
-msgstr ""
+msgstr "Trasformabile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transparent"
-msgstr ""
+msgstr "Trasparente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transpose pivot"
-msgstr ""
+msgstr "Trasponi pivot"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Treat values as categorical."
-msgstr ""
+msgstr "Tratta i valori come categorici."
 
 #, fuzzy
 msgid "Tree Chart"
 msgstr "Esplora grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tree layout"
-msgstr ""
+msgstr "Layout ad albero"
 
 #, fuzzy
 msgid "Tree orientation"
@@ -15258,21 +25091,37 @@ msgstr "Azione"
 msgid "Treemap"
 msgstr "Treemap"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trend"
-msgstr ""
+msgstr "Tendenza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Triangle"
-msgstr ""
+msgstr "Triangolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trigger Alert If..."
-msgstr ""
+msgstr "Attiva avviso se..."
 
 #, fuzzy
 msgid "True"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate Cells"
-msgstr ""
+msgstr "Tronca celle"
 
 #, fuzzy
 msgid "Truncate Metric"
@@ -15282,34 +25131,73 @@ msgstr "Mostra metrica"
 msgid "Truncate X Axis"
 msgstr "Mostra metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
 " applicable for numerical X axis."
 msgstr ""
+"Tronca l'asse X. Può essere ignorato specificando un limite minimo o "
+"massimo. Applicabile solo per l'asse X numerico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis"
-msgstr ""
+msgstr "Tronca l'asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
 msgstr ""
+"Tronca l'asse Y. Può essere ignorato specificando un limite minimo o "
+"massimo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate long cells to the \"min width\" set above"
-msgstr ""
+msgstr "Tronca le celle lunghe alla \"larghezza minima\" impostata sopra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncates the specified date to the accuracy specified by the date unit."
-msgstr ""
+msgstr "Tronca la data specificata alla precisione specificata dall'unità di data."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Considera attendibile questo URL e non chiedere più"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
+"Prova ad applicare filtri diversi o assicurati che la tua fonte di dati "
+"contenga dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Try different criteria to display results."
-msgstr ""
+msgstr "Prova criteri diversi per visualizzare i risultati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tuesday"
-msgstr ""
+msgstr "Martedì"
 
 #, fuzzy
 msgid "Tukey"
@@ -15318,51 +25206,89 @@ msgstr "condividi query"
 msgid "Type"
 msgstr "Tipo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Type \"%s\" to confirm"
-msgstr ""
+msgstr "Digita \"%s\" per confermare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value"
-msgstr ""
+msgstr "Inserisci un valore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value here"
-msgstr ""
+msgstr "Inserisci un valore qui"
 
 #, fuzzy
 msgid "Type a value..."
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type is required"
-msgstr ""
+msgstr "Il tipo è obbligatorio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "Tipo di Google Sheets consentito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Type of chart to display in sparkline"
-msgstr ""
+msgstr "Tipo di grafico da visualizzare nello sparkline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type of comparison, value difference or percentage"
-msgstr ""
+msgstr "Tipo di confronto, differenza di valore o percentuale"
 
 #, fuzzy
 msgid "Type to search (contains)..."
 msgstr "Visualizza colonne"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Digita per cercare (termina con)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Digita per cercare (inizia con)..."
 
 #, fuzzy
 msgid "UI Configuration"
 msgstr "Controlli del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "UI theme administration is not enabled."
-msgstr ""
+msgstr "L'amministrazione dei temi dell'interfaccia utente non è abilitata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #, fuzzy
 msgid "URL Filters"
@@ -15379,224 +25305,421 @@ msgstr "Slug"
 msgid "URL parameters"
 msgstr "Parametri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to calculate such a date delta"
-msgstr ""
+msgstr "Impossibile calcolare tale differenza di date"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to catalog named \"%(catalog_name)s\"."
-msgstr ""
+msgstr "Impossibile connettersi al catalogo denominato \"%(catalog_name)s\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to database \"%(database)s\"."
-msgstr ""
+msgstr "Impossibile connettersi al database \"%(database)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", "
 "\"BigQuery Job User\" and the following permissions are set "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
+"Impossibile connettersi. Verifica che i seguenti ruoli siano impostati "
+"sull'account di servizio: \"BigQuery Data Viewer\", \"BigQuery Metadata "
+"Viewer\", \"BigQuery Job User\" e che i seguenti permessi siano "
+"impostati: \"bigquery.readsessions.create\", "
+"\"bigquery.readsessions.getData\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"Impossibile connettersi. Verifica che i seguenti ruoli siano impostati "
+"sull'account di servizio: \"Cloud Datastore Viewer\", \"Cloud Datastore "
+"User\", \"Cloud Datastore Creator\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to create chart without a query id."
-msgstr ""
+msgstr "Impossibile creare il grafico senza un ID di query."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"Impossibile creare il report: l'indirizzo email dell'utente è "
+"obbligatorio ma non è stato trovato. Assicurati che il tuo profilo utente"
+" abbia un indirizzo email valido."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to decode value"
-msgstr ""
+msgstr "Impossibile decodificare il valore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to encode value"
-msgstr ""
+msgstr "Impossibile codificare il valore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
+"Impossibile recuperare le viste semantiche. Controlla la configurazione "
+"del livello."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
-msgstr ""
+msgstr "Impossibile trovare questa festività: [%(holiday)s]"
 
 #, fuzzy
 msgid "Unable to generate download payload"
 msgstr "Aggiungi ad una nuova dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
 "ensure your dataset has a properly configured time column."
 msgstr ""
+"Impossibile identificare la colonna temporale per il confronto degli "
+"intervalli di date. Assicurati che il tuo dataset abbia una colonna "
+"temporale correttamente configurata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
 msgstr ""
+"Impossibile caricare le colonne per la tabella selezionata. Seleziona una"
+" tabella diversa."
 
 #, fuzzy
 msgid "Unable to load dashboard"
 msgstr "Aggiungi ad una nuova dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query editor state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Impossibile migrare lo stato dell'editor di query nel backend. Superset "
+"riproverà più tardi. Contatta il tuo amministratore se il problema "
+"persiste."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
 msgstr ""
+"Impossibile migrare lo stato della query nel backend. Superset riproverà "
+"più tardi. Contatta il tuo amministratore se il problema persiste."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate table schema state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"Impossibile migrare lo stato dello schema della tabella nel backend. "
+"Superset riproverà più tardi. Contatta il tuo amministratore se il "
+"problema persiste."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to parse SQL"
-msgstr ""
+msgstr "Impossibile analizzare SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to read the file, please refresh and try again."
-msgstr ""
+msgstr "Impossibile leggere il file, aggiorna la pagina e riprova."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to retrieve dashboard colors"
-msgstr ""
+msgstr "Impossibile recuperare i colori del dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to sync permissions for this database connection."
 msgstr ""
+"Impossibile sincronizzare le autorizzazioni per questa connessione al "
+"database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Undefined"
-msgstr ""
+msgstr "Non definito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undefined window for rolling operation"
-msgstr ""
+msgstr "Finestra non definita per l'operazione di scorrimento"
 
 #, fuzzy
 msgid "Undo the action"
 msgstr "Seleziona una colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undo?"
-msgstr ""
+msgstr "Annullare?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr ""
+msgstr "Risposta HTTP 401 inattesa. Controlla le tue credenziali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error"
-msgstr ""
+msgstr "Errore imprevisto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error occurred, please check your logs for details"
-msgstr ""
+msgstr "Si è verificato un errore imprevisto, controlla i tuoi log per i dettagli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error: "
-msgstr ""
+msgstr "Errore imprevisto: "
 
 #, fuzzy
 msgid "Unexpected no file extension found"
 msgstr "Espressione SQL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unexpected time range: %(error)s"
-msgstr ""
+msgstr "Intervallo di tempo imprevisto: %(error)s"
 
 #, fuzzy
 msgid "Ungroup By"
 msgstr "Raggruppa per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Unhide"
-msgstr ""
+msgstr "Mostra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown"
-msgstr ""
+msgstr "Sconosciuto"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown Doris server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host del server Doris sconosciuto \"%(hostname)s\"."
 
 #, fuzzy
 msgid "Unknown Error"
 msgstr "Grafici"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unknown MySQL server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host del server MySQL sconosciuto \"%(hostname)s\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown OceanBase server host \"%(hostname)s\"."
-msgstr ""
+msgstr "Host del server OceanBase sconosciuto \"%(hostname)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Presto Error"
-msgstr ""
+msgstr "Errore Presto sconosciuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Status"
-msgstr ""
+msgstr "Stato sconosciuto"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unknown column used in orderby: %(col)s"
-msgstr ""
+msgstr "Colonna sconosciuta utilizzata nell'ordinamento: %(col)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown error"
-msgstr ""
+msgstr "Errore sconosciuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown input format"
-msgstr ""
+msgstr "Formato di input sconosciuto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "I token sconosciuti verranno evidenziati come avvisi."
 
 #, fuzzy
 msgid "Unknown type"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Unknown value"
-msgstr ""
+msgstr "Valore sconosciuto"
 
 #, fuzzy
 msgid "Unpin"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Rimuovi dal pannello dei risultati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Rimuovi dalla parte superiore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "Collegamento non sicuro bloccato"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
-msgstr ""
+msgstr "Tipo di ritorno non sicuro per la funzione %(func)s: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe template value for key %(key)s: %(value_type)s"
-msgstr ""
+msgstr "Valore di template non sicuro per la chiave %(key)s: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported clause type: %(clause)s"
-msgstr ""
+msgstr "Tipo di clausola non supportato: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
-msgstr ""
+msgstr "Tipo di file non supportato. Utilizzare file CSV, Excel o colonnari."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported post processing operation: %(operation)s"
-msgstr ""
+msgstr "Operazione di post-elaborazione non supportata: %(operation)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported return value for method %(name)s"
-msgstr ""
+msgstr "Valore di ritorno non supportato per il metodo %(name)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported template value for key %(key)s"
-msgstr ""
+msgstr "Valore di template non supportato per la chiave %(key)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported time grain: %(time_grain)s"
-msgstr ""
+msgstr "Granularità temporale non supportata: %(time_grain)s"
 
 #, fuzzy
 msgid "Untitled Dataset"
@@ -15613,11 +25736,18 @@ msgstr "Query senza nome"
 msgid "Unverified"
 msgstr "Modificato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Update"
-msgstr ""
+msgstr "Aggiorna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Update auto-refresh"
-msgstr ""
+msgstr "Aggiorna aggiornamento automatico"
 
 #, fuzzy
 msgid "Update chart"
@@ -15626,11 +25756,19 @@ msgstr "Grafico a torta"
 msgid "Updating chart was stopped"
 msgstr "L'aggiornamento del grafico è stato fermato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Upload"
-msgstr ""
+msgstr "Carica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Upload CSV"
-msgstr ""
+msgstr "Carica CSV"
 
 #, fuzzy
 msgid "Upload CSV to database"
@@ -15644,25 +25782,41 @@ msgstr "Colonna"
 msgid "Upload Columnar file to database"
 msgstr "Mostra database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Upload Enabled"
-msgstr ""
+msgstr "Caricamento abilitato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Upload Excel"
-msgstr ""
+msgstr "Carica Excel"
 
 #, fuzzy
 msgid "Upload Excel to database"
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Upload JSON file"
-msgstr ""
+msgstr "Carica file JSON"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Upload a file with a valid extension. Valid: [%s]"
-msgstr ""
+msgstr "Carica un file con un'estensione valida. Valide: [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Upload credentials"
-msgstr ""
+msgstr "Carica credenziali"
 
 #, fuzzy
 msgid "Upload file to database"
@@ -15676,11 +25830,17 @@ msgstr "Mostra database"
 msgid "Uploading a file is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper Threshold"
-msgstr ""
+msgstr "Soglia superiore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper threshold must be greater than lower threshold"
-msgstr ""
+msgstr "La soglia superiore deve essere maggiore della soglia inferiore"
 
 #, fuzzy
 msgid "Usage"
@@ -15694,74 +25854,159 @@ msgstr "Query in un nuovo tab"
 msgid "Use Area Proportions"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
+"Usa la sintassi Handlebars per creare tooltip personalizzati. Le "
+"variabili disponibili si basano sulla selezione del contenuto del tooltip"
+" sopra."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale"
-msgstr ""
+msgstr "Usa una scala logaritmica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the X-axis"
-msgstr ""
+msgstr "Usa una scala logaritmica per l'asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the Y-axis"
-msgstr ""
+msgstr "Usa una scala logaritmica per l'asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use an encrypted connection to the database"
-msgstr ""
+msgstr "Usa una connessione crittografata al database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use an ssh tunnel connection to the database"
-msgstr ""
+msgstr "Usa una connessione tramite tunnel SSH al database"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Use another existing chart as a source for annotations and overlays.\n"
 "          Your chart must be one of these visualization types: [%s]"
 msgstr ""
+"Usa un altro grafico esistente come sorgente per annotazioni e "
+"sovrapposizioni.\n"
+"          Il tuo grafico deve essere uno di questi tipi di "
+"visualizzazione: [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use automatic color"
-msgstr ""
+msgstr "Usa colore automatico"
 
 #, fuzzy
 msgid "Use current extent"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use date formatting even when metric value is not a timestamp"
 msgstr ""
+"Usa la formattazione della data anche quando il valore della metrica non "
+"è un timestamp"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use gradient"
-msgstr ""
+msgstr "Usa gradiente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use metrics as a top level group for columns or for rows"
 msgstr ""
+"Usa le metriche come gruppo di livello superiore per le colonne o per le "
+"righe"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use only a single value."
-msgstr ""
+msgstr "Usa solo un singolo valore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use the Advanced Analytics options below"
-msgstr ""
+msgstr "Usa le opzioni di Analisi Avanzata di seguito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want a query that aggregates"
-msgstr ""
+msgstr "Usa questa sezione se vuoi una query che aggreghi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want to query atomic rows"
-msgstr ""
+msgstr "Usa questa sezione se vuoi interrogare righe atomiche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use this to define a static color for all circles"
-msgstr ""
+msgstr "Usa questo per definire un colore statico per tutti i cerchi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used internally to identify the plugin. Should be set to the package name"
 " from the pluginʼs package.json"
 msgstr ""
+"Usato internamente per identificare il plugin. Deve essere impostato sul "
+"nome del pacchetto dal package.json del plugin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used to summarize a set of data by grouping together multiple statistics "
 "along two axes. Examples: Sales numbers by region and month, tasks by "
 "status and assignee, active users by age and location. Not the most "
 "visually stunning visualization, but highly informative and versatile."
 msgstr ""
+"Utilizzato per riepilogare un insieme di dati raggruppando più "
+"statistiche lungo due assi. Esempi: numeri di vendita per regione e mese,"
+" attività per stato e assegnatario, utenti attivi per età e posizione. "
+"Non è la visualizzazione più spettacolare dal punto di vista visivo, ma è"
+" molto informativa e versatile."
 
 msgid "User"
 msgstr "Utente"
@@ -15774,21 +26019,39 @@ msgstr "Ricerca Query"
 msgid "User Registrations"
 msgstr "Elenco Dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "User doesn't have the proper permissions."
-msgstr ""
+msgstr "L'utente non dispone delle autorizzazioni appropriate."
 
 #, fuzzy
 msgid "User info"
 msgstr "Utente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the chart customization"
 msgstr ""
+"L'utente deve selezionare un valore prima di applicare la "
+"personalizzazione del grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the customization"
 msgstr ""
+"L'utente deve selezionare un valore prima di applicare la "
+"personalizzazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "User must select a value before applying the filter"
-msgstr ""
+msgstr "L'utente deve selezionare un valore prima di applicare il filtro"
 
 msgid "User query"
 msgstr "condividi query"
@@ -15813,29 +26076,58 @@ msgstr "Ricerca Query"
 msgid "Users"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Users are not allowed to set a search path for security reasons."
 msgstr ""
+"Per motivi di sicurezza, agli utenti non è consentito impostare un "
+"percorso di ricerca."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Uses Gaussian Kernel Density Estimation to visualize spatial distribution"
 " of data"
 msgstr ""
+"Utilizza la stima della densità del kernel gaussiano per visualizzare la "
+"distribuzione spaziale dei dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses a gauge to showcase progress of a metric towards a target. The "
 "position of the dial represents the progress and the terminal value in "
 "the gauge represents the target value."
 msgstr ""
+"Utilizza un indicatore per mostrare l'avanzamento di una metrica verso un"
+" obiettivo. La posizione del quadrante rappresenta il progresso e il "
+"valore finale nell'indicatore rappresenta il valore obiettivo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses circles to visualize the flow of data through different stages of a "
 "system. Hover over individual paths in the visualization to understand "
 "the stages a value took. Useful for multi-stage, multi-group visualizing "
 "funnels and pipelines."
 msgstr ""
+"Utilizza cerchi per visualizzare il flusso di dati attraverso le diverse "
+"fasi di un sistema. Passa il mouse sui singoli percorsi nella "
+"visualizzazione per comprendere le fasi attraversate da un valore. Utile "
+"per la visualizzazione di imbuti e pipeline a più fasi e gruppi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Utilizza i primi 25 valori se la dimensione ne contiene di più."
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -15849,15 +26141,24 @@ msgstr "condividi query"
 msgid "Validate your expression"
 msgstr "Espressione SQL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Validating connectivity for %s"
-msgstr ""
+msgstr "Validazione della connettività per %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Validating..."
-msgstr ""
+msgstr "Validazione in corso..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Value"
-msgstr ""
+msgstr "Valore"
 
 #, fuzzy
 msgid "Value Aggregation"
@@ -15867,8 +26168,12 @@ msgstr "Creato il"
 msgid "Value Columns"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value Domain"
-msgstr ""
+msgstr "Dominio del valore"
 
 #, fuzzy
 msgid "Value Format"
@@ -15878,15 +26183,25 @@ msgstr "Formato Datetime"
 msgid "Value and Percentage"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value bounds"
-msgstr ""
+msgstr "Limiti del valore"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Value cannot exceed %s"
-msgstr ""
+msgstr "Il valore non può superare %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value difference between the time periods"
-msgstr ""
+msgstr "Differenza di valore tra i periodi di tempo"
 
 #, fuzzy
 msgid "Value format"
@@ -15900,8 +26215,11 @@ msgstr "La data di inizio non può essere dopo la data di fine"
 msgid "Value is required"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value less than"
-msgstr ""
+msgstr "Valore inferiore a"
 
 #, fuzzy
 msgid "Value must be 0 or greater"
@@ -15915,38 +26233,75 @@ msgstr "La data di inizio non può essere dopo la data di fine"
 msgid "Values"
 msgstr "Valore del filtro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Values are dependent on other filters"
-msgstr ""
+msgstr "I valori dipendono da altri filtri"
 
 #, fuzzy
 msgid "Values dependent on"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Values less than this percentage will be grouped into the Other category."
 msgstr ""
+"I valori inferiori a questa percentuale verranno raggruppati nella "
+"categoria Altro."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Values selected in other filters will affect the filter options to only "
 "show relevant values"
 msgstr ""
+"I valori selezionati in altri filtri influenzeranno le opzioni del filtro"
+" per mostrare solo i valori rilevanti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version"
-msgstr ""
+msgstr "Versione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version number"
-msgstr ""
+msgstr "Numero di versione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Vertical"
-msgstr ""
+msgstr "Verticale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Vertical (Left)"
-msgstr ""
+msgstr "Verticale (sinistra)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "View"
-msgstr ""
+msgstr "Visualizza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "View All »"
-msgstr ""
+msgstr "Visualizza tutto »"
 
 #, fuzzy
 msgid "View Dataset"
@@ -15956,15 +26311,21 @@ msgstr "Mostra database"
 msgid "View all charts"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "View as table"
-msgstr ""
+msgstr "Visualizza come tabella"
 
 msgid "View in SQL Lab"
 msgstr "Esponi in SQL Lab"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "View keys & indexes (%s)"
-msgstr ""
+msgstr "Visualizza chiavi e indici (%s)"
 
 msgid "View query"
 msgstr "condividi query"
@@ -15973,8 +26334,12 @@ msgstr "condividi query"
 msgid "View theme properties"
 msgstr "Template CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Viewed"
-msgstr ""
+msgstr "Visualizzato"
 
 #, fuzzy, python-format
 msgid "Viewed %s"
@@ -15984,23 +26349,46 @@ msgstr "Cancella"
 msgid "Viewport"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Virtual"
-msgstr ""
+msgstr "Virtuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual (SQL)"
-msgstr ""
+msgstr "Virtuale (SQL)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot be empty"
-msgstr ""
+msgstr "La query del dataset virtuale non può essere vuota"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot consist of multiple statements"
-msgstr ""
+msgstr "La query del dataset virtuale non può essere composta da più istruzioni"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query must be read-only"
-msgstr ""
+msgstr "La query del dataset virtuale deve essere di sola lettura"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Visual Tweaks"
-msgstr ""
+msgstr "Ottimizzazioni visive"
 
 #, fuzzy
 msgid "Visual formatting"
@@ -16009,71 +26397,152 @@ msgstr "Formato Datetime"
 msgid "Visualization Type"
 msgstr "Tipo di Visualizzazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a parallel set of metrics across multiple groups. Each group is"
 " visualized using its own line of points and each metric is represented "
 "as an edge in the chart."
 msgstr ""
+"Visualizza un insieme parallelo di metriche su più gruppi. Ogni gruppo "
+"viene visualizzato con la propria linea di punti e ogni metrica è "
+"rappresentata come un arco nel grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a related metric across pairs of groups. Heatmaps excel at "
 "showcasing the correlation or strength between two groups. Color is used "
 "to emphasize the strength of the link between each pair of groups."
 msgstr ""
+"Visualizza una metrica correlata tra coppie di gruppi. Le mappe di calore"
+" eccellono nel mostrare la correlazione o la forza tra due gruppi. Il "
+"colore viene utilizzato per enfatizzare la forza del collegamento tra "
+"ciascuna coppia di gruppi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize geospatial data like 3D buildings, landscapes, or objects in "
 "grid view."
 msgstr ""
+"Visualizza dati geospaziali come edifici 3D, paesaggi o oggetti in vista "
+"a griglia."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
 "structure."
 msgstr ""
+"Visualizza più livelli di gerarchia utilizzando una familiare struttura "
+"ad albero."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize two different series using the same x-axis. Note that both "
 "series can be visualized with a different chart type (e.g. 1 using bars "
 "and 1 using a line)."
 msgstr ""
+"Visualizza due serie diverse utilizzando lo stesso asse x. Si noti che "
+"entrambe le serie possono essere visualizzate con un tipo di grafico "
+"diverso (ad es. una con barre e una con una linea)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes a metric across three dimensions of data in a single chart (X "
 "axis, Y axis, and bubble size). Bubbles from the same group can be "
 "showcased using bubble color."
 msgstr ""
+"Visualizza una metrica su tre dimensioni di dati in un unico grafico "
+"(asse X, asse Y e dimensione della bolla). Le bolle dello stesso gruppo "
+"possono essere mostrate usando il colore della bolla."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Visualizes connected points, which form a path, on a map."
-msgstr ""
+msgstr "Visualizza su una mappa i punti collegati che formano un percorso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes geographic areas from your data as polygons on a Mapbox "
 "rendered map. Polygons can be colored using a metric."
 msgstr ""
+"Visualizza le aree geografiche dei tuoi dati come poligoni su una mappa "
+"renderizzata da Mapbox. I poligoni possono essere colorati utilizzando "
+"una metrica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes how a metric has changed over a time using a color scale and a"
 " calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
+"Visualizza come una metrica è cambiata nel tempo utilizzando una scala di"
+" colori e una vista calendario. I valori grigi vengono utilizzati per "
+"indicare i valori mancanti e la scala di colori lineare viene utilizzata "
+"per codificare la grandezza del valore di ogni giorno."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes how a single metric varies across a country's principal "
 "subdivisions (states, provinces, etc) on a choropleth map. Each "
 "subdivision's value is elevated when you hover over the corresponding "
 "geographic boundary."
 msgstr ""
+"Visualizza come una singola metrica varia nelle principali suddivisioni "
+"di un paese (stati, province, ecc.) su una mappa coropletica. Il valore "
+"di ogni suddivisione viene evidenziato quando si passa il mouse sul "
+"confine geografico corrispondente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes many different time-series objects in a single chart. This "
 "chart is being deprecated and we recommend using the Time-series Chart "
 "instead."
 msgstr ""
+"Visualizza molti oggetti di serie temporali diversi in un unico grafico. "
+"Questo grafico è in fase di deprecazione e si consiglia di utilizzare "
+"invece il grafico delle serie temporali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes the words in a column that appear the most often. Bigger font "
 "corresponds to higher frequency."
 msgstr ""
+"Visualizza le parole di una colonna che compaiono più frequentemente. Un "
+"carattere più grande corrisponde a una frequenza più alta."
 
 msgid "Viz is missing a datasource"
 msgstr "Datasource mancante per la visualizzazione"
@@ -16081,8 +26550,12 @@ msgstr "Datasource mancante per la visualizzazione"
 msgid "Viz type"
 msgstr "Tipo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "WED"
-msgstr ""
+msgstr "MER"
 
 msgid "WFS"
 msgstr ""
@@ -16090,116 +26563,216 @@ msgstr ""
 msgid "WMS"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "In attesa del primo aggiornamento"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Waiting on %s"
-msgstr ""
+msgstr "In attesa di %s"
 
 #, fuzzy
 msgid "Waiting on database..."
 msgstr "Database"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Want to add a new database?"
-msgstr ""
+msgstr "Vuoi aggiungere un nuovo database?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "Warehouse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Warning"
-msgstr ""
+msgstr "Avviso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Warning!"
-msgstr ""
+msgstr "Attenzione!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Warning! Changing the dataset may break the chart if the metadata does "
 "not exist."
 msgstr ""
+"Attenzione! La modifica del dataset potrebbe danneggiare il grafico se i "
+"metadati non esistono."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Avviso: le query ILIKE potrebbero essere lente su dataset di grandi "
+"dimensioni poiché non possono utilizzare gli indici in modo efficace."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Was unable to check your query"
-msgstr ""
+msgstr "Impossibile verificare la query"
 
 #, fuzzy
 msgid "Waterfall Chart"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We are unable to connect to your database."
-msgstr ""
+msgstr "Impossibile connettersi al database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We are working on your query"
-msgstr ""
+msgstr "Stiamo elaborando la tua query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve column \"%(column)s\" at line %(location)s."
 msgstr ""
+"Non è possibile risolvere la colonna \"%(column)s\" alla riga "
+"%(location)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve the column \"%(column_name)s\""
-msgstr ""
+msgstr "Non è possibile risolvere la colonna \"%(column_name)s\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We can't seem to resolve the column \"%(column_name)s\" at line "
 "%(location)s."
 msgstr ""
+"Non è possibile risolvere la colonna \"%(column_name)s\" alla riga "
+"%(location)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "We have the following keys: %s"
-msgstr ""
+msgstr "Abbiamo le seguenti chiavi: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We were unable to activate or deactivate this report."
-msgstr ""
+msgstr "Impossibile attivare o disattivare questo report."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "We were unable to carry over any controls when switching to this new "
 "dataset."
 msgstr ""
+"Non è stato possibile trasferire alcun controllo durante il passaggio a "
+"questo nuovo dataset."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We were unable to connect to your database named \"%(database)s\". Please"
 " verify your database name and try again."
 msgstr ""
+"Impossibile connettersi al database denominato \"%(database)s\". Verifica"
+" il nome del database e riprova."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Web"
-msgstr ""
+msgstr "Web"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Wednesday"
-msgstr ""
+msgstr "Mercoledì"
 
 #, fuzzy
 msgid "Week"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week ending Saturday"
-msgstr ""
+msgstr "Settimana che termina sabato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Week ending Sunday"
-msgstr ""
+msgstr "Settimana che termina domenica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Monday"
-msgstr ""
+msgstr "Settimana che inizia lunedì"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Sunday"
-msgstr ""
+msgstr "Settimana che inizia domenica"
 
 #, fuzzy
 msgid "Weekly Report"
 msgstr "Importa"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Weekly Report for %s"
-msgstr ""
+msgstr "Report settimanale per %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Weekly seasonality"
-msgstr ""
+msgstr "Stagionalità settimanale"
 
 #, fuzzy, python-format
 msgid "Weeks %s"
@@ -16209,6 +26782,8 @@ msgstr "settimana"
 msgid "Weight"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading these results. Queries are set to timeout "
@@ -16217,7 +26792,11 @@ msgid_plural ""
 "We’re having trouble loading these results. Queries are set to timeout "
 "after %s seconds."
 msgstr[0] ""
+"Si è verificato un problema durante il caricamento di questi risultati. "
+"Le query sono impostate per scadere dopo %s secondo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading this visualization. Queries are set to "
@@ -16226,58 +26805,129 @@ msgid_plural ""
 "We’re having trouble loading this visualization. Queries are set to "
 "timeout after %s seconds."
 msgstr[0] ""
+"Si è verificato un problema durante il caricamento di questa "
+"visualizzazione. Le query sono impostate per scadere dopo %s secondo."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the label"
-msgstr ""
+msgstr "Cosa deve essere mostrato come etichetta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the tooltip label"
-msgstr ""
+msgstr "Cosa deve essere mostrato come etichetta del tooltip"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "What should be shown on the label?"
-msgstr ""
+msgstr "Cosa deve essere mostrato sull'etichetta?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should happen if the table already exists"
-msgstr ""
+msgstr "Cosa deve succedere se la tabella esiste già"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "When `Calculation type` is set to \"Percentage change\", the Y Axis "
 "Format is forced to `.1%`"
 msgstr ""
+"Quando il `Tipo di calcolo` è impostato su \"Variazione percentuale\", il"
+" Formato dell'asse Y è forzato a `.1%`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When a secondary metric is provided, a linear color scale is used."
 msgstr ""
+"Quando viene fornita una metrica secondaria, viene utilizzata una scala "
+"di colori lineare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When checked, the map will zoom to your data after each query"
-msgstr ""
+msgstr "Se selezionato, la mappa farà zoom sui tuoi dati dopo ogni query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When enabled, the axis will display labels for the minimum and maximum "
 "values of your data"
 msgstr ""
+"Se abilitato, l'asse mostrerà le etichette per i valori minimi e massimi "
+"dei tuoi dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When enabled, users are able to visualize SQL Lab results in Explore."
 msgstr ""
+"Se abilitato, gli utenti possono visualizzare i risultati di SQL Lab in "
+"Explore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When only a primary metric is provided, a categorical color scale is used."
 msgstr ""
+"Quando viene fornita solo una metrica primaria, viene utilizzata una "
+"scala di colori categoriale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When specifying SQL, the datasource acts as a view. Superset will use "
 "this statement as a subquery while grouping and filtering on the "
 "generated parent queries.If changes are made to your SQL query, columns "
 "in your dataset will be synced when saving the dataset."
 msgstr ""
+"Quando si specifica SQL, la sorgente dati funge da vista. Superset "
+"utilizzerà questa istruzione come sottoquery durante il raggruppamento e "
+"il filtraggio delle query padre generate. Se vengono apportate modifiche "
+"alla query SQL, le colonne nel dataset verranno sincronizzate durante il "
+"salvataggio del dataset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When the secondary temporal columns are filtered, apply the same filter "
 "to the main datetime column."
 msgstr ""
+"Quando le colonne temporali secondarie vengono filtrate, applica lo "
+"stesso filtro alla colonna datetime principale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When unchecked, colors from the selected color scheme will be used for "
 "time shifted series"
 msgstr ""
+"Se deselezionato, verranno utilizzati i colori dello schema colori "
+"selezionato per le serie con spostamento temporale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When using \"Autocomplete filters\", this can be used to improve "
 "performance of the query fetching the values. Use this option to apply a "
@@ -16285,54 +26935,130 @@ msgid ""
 "the table. Typically the intent would be to limit the scan by applying a "
 "relative time filter on a partitioned or indexed time-related field."
 msgstr ""
+"Quando si utilizzano i \"Filtri di completamento automatico\", questa "
+"opzione può essere usata per migliorare le prestazioni della query che "
+"recupera i valori. Utilizza questa opzione per applicare un predicato "
+"(clausola WHERE) alla query che seleziona i valori distinti dalla "
+"tabella. In genere, l'intento è limitare la scansione applicando un "
+"filtro temporale relativo su un campo temporale partizionato o "
+"indicizzato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "When using 'Group By' you are limited to use a single metric"
 msgstr ""
+"Quando si utilizza 'Raggruppa per' si è limitati all'uso di una singola "
+"metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "When using other than adaptive formatting, labels may overlap"
 msgstr ""
+"Quando si utilizza un formato diverso da quello adattivo, le etichette "
+"potrebbero sovrapporsi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
 msgstr ""
+"Quando si utilizza questa opzione, non è possibile impostare un valore "
+"predefinito. L'utilizzo di questa opzione può influire sui tempi di "
+"caricamento della tua dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
-msgstr ""
+msgstr "Se la barra di avanzamento si sovrappone quando ci sono più gruppi di dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Whether to align background charts with both positive and negative values"
 " at 0"
-msgstr ""
+msgstr "Se allineare i grafici di sfondo con valori sia positivi che negativi a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to align positive and negative values in cell bar chart at 0"
 msgstr ""
+"Se allineare i valori positivi e negativi nel grafico a barre della cella"
+" a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to always show the annotation label"
-msgstr ""
+msgstr "Se mostrare sempre l'etichetta di annotazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to animate the progress and the value or just display them"
-msgstr ""
+msgstr "Se animare il progresso e il valore o semplicemente visualizzarli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to apply a normal distribution based on rank on the color scale"
 msgstr ""
+"Se applicare una distribuzione normale basata sul rango sulla scala dei "
+"colori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to colorize numeric values by if they are positive or negative"
 msgstr ""
+"Se colorare i valori numerici in base al fatto che siano positivi o "
+"negativi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to colorize numeric values by whether they are positive or "
 "negative"
 msgstr ""
+"Se colorare i valori numerici in base al fatto che siano positivi o "
+"negativi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a bar chart background in table columns"
-msgstr ""
+msgstr "Se visualizzare uno sfondo a grafico a barre nelle colonne della tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a legend for the chart"
-msgstr ""
+msgstr "Se visualizzare una legenda per il grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display bubbles on top of countries"
-msgstr ""
+msgstr "Se visualizzare bolle sopra i paesi"
 
 #, fuzzy
 msgid "Whether to display in the chart"
@@ -16346,50 +27072,93 @@ msgstr "Seleziona una metrica da visualizzare"
 msgid "Whether to display the Y Axis"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to display the aggregate count"
-msgstr ""
+msgstr "Se visualizzare il conteggio aggregato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the interactive data table"
-msgstr ""
+msgstr "Se visualizzare la tabella dati interattiva"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the labels."
-msgstr ""
+msgstr "Se visualizzare le etichette."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the legend (toggles)"
-msgstr ""
+msgstr "Se visualizzare la legenda (interruttori)"
 
 #, fuzzy
 msgid "Whether to display the metric name"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the metric name as a title"
-msgstr ""
+msgstr "Se visualizzare il nome della metrica come titolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the X-axis"
-msgstr ""
+msgstr "Se visualizzare i valori minimo e massimo dell'asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the Y-axis"
-msgstr ""
+msgstr "Se visualizzare i valori minimo e massimo dell'asse Y"
 
 #, fuzzy
 msgid "Whether to display the numbered column"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the numerical values within the cells"
-msgstr ""
+msgstr "Se visualizzare i valori numerici all'interno delle celle"
 
 #, fuzzy
 msgid "Whether to display the percentage value in the tooltip"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the stroke"
-msgstr ""
+msgstr "Se visualizzare il tratto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the time range interactive selector"
-msgstr ""
+msgstr "Se visualizzare il selettore interattivo dell'intervallo di tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the timestamp"
-msgstr ""
+msgstr "Se visualizzare il timestamp"
 
 #, fuzzy
 msgid "Whether to display the tooltip labels."
@@ -16399,83 +27168,183 @@ msgstr "Seleziona una metrica da visualizzare"
 msgid "Whether to display the total value in the tooltip"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the trend line"
-msgstr ""
+msgstr "Se visualizzare la linea di tendenza"
 
 #, fuzzy
 msgid "Whether to display the type icon (#, Δ, %)"
 msgstr "Seleziona una metrica da visualizzare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable changing graph position and scaling."
-msgstr ""
+msgstr "Se abilitare la modifica della posizione e della scala del grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable node dragging in force layout mode."
-msgstr ""
+msgstr "Se abilitare il trascinamento dei nodi in modalità layout forza."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to fill the objects"
-msgstr ""
+msgstr "Se riempire gli oggetti"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to ignore locations that are null"
-msgstr ""
+msgstr "Se ignorare le posizioni che sono null"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include a client-side search box"
-msgstr ""
+msgstr "Se includere una casella di ricerca lato client"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include the percentage in the tooltip"
-msgstr ""
+msgstr "Se includere la percentuale nel tooltip"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include the time granularity as defined in the time section"
-msgstr ""
+msgstr "Se includere la granularità temporale come definita nella sezione tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to make the grid 3D"
-msgstr ""
+msgstr "Se rendere la griglia 3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to populate autocomplete filters options"
-msgstr ""
+msgstr "Se popolare le opzioni dei filtri di completamento automatico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to show as Nightingale chart."
-msgstr ""
+msgstr "Se visualizzare come grafico Nightingale."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to show extra controls or not. Extra controls include things like"
 " making multiBar charts stacked or side by side."
 msgstr ""
+"Se mostrare o meno i controlli aggiuntivi. I controlli aggiuntivi "
+"includono opzioni come rendere i grafici a più barre impilati o "
+"affiancati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show minor ticks on the axis"
-msgstr ""
+msgstr "Se visualizzare i segni di graduazione minori sull'asse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the pointer"
-msgstr ""
+msgstr "Se visualizzare il puntatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the progress of gauge chart"
-msgstr ""
+msgstr "Se visualizzare il progresso del grafico a indicatore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the split lines on the axis"
-msgstr ""
+msgstr "Se visualizzare le linee di divisione sull'asse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to sort ascending or descending on the base Axis."
-msgstr ""
+msgstr "Se ordinare in modo ascendente o discendente sull'asse base."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort descending or ascending"
-msgstr ""
+msgstr "Se ordinare in modo discendente o ascendente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort results by the selected metric in descending order."
 msgstr ""
+"Se ordinare i risultati in base alla metrica selezionata in ordine "
+"decrescente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort tooltip by the selected metric in descending order."
 msgstr ""
+"Se ordinare il tooltip in base alla metrica selezionata in ordine "
+"decrescente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to truncate metrics"
-msgstr ""
+msgstr "Se troncare le metriche"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which country to plot the map for?"
-msgstr ""
+msgstr "Per quale paese tracciare la mappa?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which relatives to highlight on hover"
-msgstr ""
+msgstr "Quali elementi correlati evidenziare al passaggio del mouse"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whisker/outlier options"
-msgstr ""
+msgstr "Opzioni baffi/valori anomali"
 
 #, fuzzy
 msgid "Why do I need to create a database?"
@@ -16484,46 +27353,86 @@ msgstr "Database"
 msgid "Width"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Width of the confidence interval. Should be between 0 and 1"
-msgstr ""
+msgstr "Ampiezza dell'intervallo di confidenza. Deve essere compresa tra 0 e 1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Width of the sparkline"
-msgstr ""
+msgstr "Larghezza dello sparkline"
 
 #, fuzzy
 msgid "Width scale multiplier"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Window must be > 0"
-msgstr ""
+msgstr "La finestra deve essere > 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "With a subheader"
-msgstr ""
+msgstr "Con un sottotitolo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Word Cloud"
-msgstr ""
+msgstr "Nuvola di parole"
 
 #, fuzzy
 msgid "Word Rotation"
 msgstr "Azione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working"
-msgstr ""
+msgstr "In elaborazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working timeout"
-msgstr ""
+msgstr "Timeout di elaborazione"
 
 msgid "World Map"
 msgstr "Mappa del Mondo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Write a description for your query"
-msgstr ""
+msgstr "Scrivi una descrizione per la tua query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Write a handlebars template to render the data"
-msgstr ""
+msgstr "Scrivi un template Handlebars per visualizzare i dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "X Axis"
-msgstr ""
+msgstr "Asse X"
 
 #, fuzzy
 msgid "X Axis Bounds"
@@ -16533,8 +27442,12 @@ msgstr "Controlli del filtro"
 msgid "X Axis Format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Axis Label"
-msgstr ""
+msgstr "Etichetta asse X"
 
 #, fuzzy
 msgid "X Axis Label Interval"
@@ -16544,219 +27457,440 @@ msgstr "Testa la Connessione"
 msgid "X Axis Number Format"
 msgstr "Formato Datetime"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X Axis Title"
-msgstr ""
+msgstr "Titolo asse X"
 
 #, fuzzy
 msgid "X Axis Title Margin"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Log Scale"
-msgstr ""
+msgstr "Scala logaritmica X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Tick Layout"
-msgstr ""
+msgstr "Layout tacche X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "X axis title margin"
-msgstr ""
+msgstr "Margine titolo asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X bounds"
-msgstr ""
+msgstr "Limiti X"
 
 #, fuzzy
 msgid "X-Axis Sort Ascending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X-Axis Sort By"
-msgstr ""
+msgstr "Ordina asse X per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X-axis"
-msgstr ""
+msgstr "Asse X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X-scale interval"
-msgstr ""
+msgstr "Intervallo scala X"
 
 msgid "XYZ"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y 2 bounds"
-msgstr ""
+msgstr "Limiti Y 2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis"
-msgstr ""
+msgstr "Asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis 2 Bounds"
-msgstr ""
+msgstr "Limiti asse Y 2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Bounds"
-msgstr ""
+msgstr "Limiti asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Format"
-msgstr ""
+msgstr "Formato asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Label"
-msgstr ""
+msgstr "Etichetta asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title"
-msgstr ""
+msgstr "Titolo asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title Margin"
-msgstr ""
+msgstr "Margine titolo asse Y"
 
 #, fuzzy
 msgid "Y Axis Title Position"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Log Scale"
-msgstr ""
+msgstr "Scala logaritmica Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Y axis title margin"
-msgstr ""
+msgstr "Margine titolo asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y bounds"
-msgstr ""
+msgstr "Limiti Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-Axis"
-msgstr ""
+msgstr "Asse Y"
 
 #, fuzzy
 msgid "Y-Axis Sort Ascending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y-Axis Sort By"
-msgstr ""
+msgstr "Ordina asse Y per"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-axis"
-msgstr ""
+msgstr "Asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Y-axis bounds"
-msgstr ""
+msgstr "Limiti asse Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Y-scale interval"
-msgstr ""
+msgstr "Intervallo scala Y"
 
 #, fuzzy
 msgid "Year"
 msgstr "anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Year (freq=AS)"
-msgstr ""
+msgstr "Anno (freq=AS)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yearly seasonality"
-msgstr ""
+msgstr "Stagionalità annuale"
 
 #, fuzzy, python-format
 msgid "Years %s"
 msgstr "anno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes"
-msgstr ""
+msgstr "Sì"
 
 #, fuzzy
 msgid "Yes, Cancel"
 msgstr "Annulla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes, cancel"
-msgstr ""
+msgstr "Sì, annulla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Yes, overwrite changes"
-msgstr ""
+msgstr "Sì, sovrascrivi le modifiche"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "You are adding tags to %s %ss"
-msgstr ""
+msgstr "Stai aggiungendo tag a %s %ss"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "Stai modificando una query dal dataset virtuale "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Stai importando uno o più grafici che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more dashboards that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Stai importando uno o più dashboard che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more databases that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Stai importando uno o più database che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more datasets that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Stai importando uno o più dataset che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more saved queries that already exist. "
 "Overwriting might cause you to lose some of your work. Are you sure you "
 "want to overwrite?"
 msgstr ""
+"Stai importando una o più query salvate che esistono già. La "
+"sovrascrittura potrebbe causare la perdita di parte del tuo lavoro. Sei "
+"sicuro di voler sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are importing one or more themes that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
+"Stai importando uno o più temi che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"sovrascrivere?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in a dashboard context with labels shared "
 "across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
+"Stai visualizzando questo grafico in un contesto di dashboard con "
+"etichette condivise tra più grafici.\n"
+"        La selezione dello schema colori è disabilitata."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in the context of a dashboard that is directly"
 " affecting its colors.\n"
 "        To edit the color scheme, open this chart outside of the "
 "dashboard."
 msgstr ""
+"Stai visualizzando questo grafico nel contesto di un dashboard che "
+"influenza direttamente i suoi colori.\n"
+"        Per modificare lo schema colori, apri questo grafico al di fuori "
+"del dashboard."
 
 #, fuzzy
 msgid "You can"
 msgstr "Mappa della Nazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can add the components in the"
-msgstr ""
+msgstr "Puoi aggiungere i componenti nel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can add the components in the edit mode."
-msgstr ""
+msgstr "Puoi aggiungere i componenti in modalità di modifica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can also just click on the chart to apply cross-filter."
 msgstr ""
+"Puoi anche semplicemente fare clic sul grafico per applicare il filtro "
+"incrociato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can choose to display all charts that you have access to or only the "
 "ones you own.\n"
 "              Your filter selection will be saved and remain active until"
 " you choose to change it."
 msgstr ""
+"Puoi scegliere di visualizzare tutti i grafici a cui hai accesso o solo "
+"quelli di tua proprietà.\n"
+"              La selezione del filtro verrà salvata e rimarrà attiva "
+"finché non decidi di cambiarla."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can create a new chart or use existing ones from the panel on the "
 "right"
 msgstr ""
+"Puoi creare un nuovo grafico o utilizzare quelli esistenti dal pannello a"
+" destra"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can preview the list of dashboards in the chart settings dropdown."
 msgstr ""
+"Puoi visualizzare in anteprima l'elenco dei dashboard nel menu a discesa "
+"delle impostazioni del grafico."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can't apply cross-filter on this data point."
-msgstr ""
+msgstr "Non puoi applicare il filtro incrociato su questo punto dati."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You cannot delete the last temporal filter as it's used for time range "
 "filters in dashboards."
 msgstr ""
+"Non puoi eliminare l'ultimo filtro temporale poiché viene utilizzato per "
+"i filtri dell'intervallo di tempo nei dashboard."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You cannot use 45° tick layout along with the time range filter"
 msgstr ""
+"Non è possibile utilizzare il layout di graduazione a 45° insieme al "
+"filtro dell'intervallo di tempo"
 
 #, fuzzy, python-format
 msgid "You do not have permission to edit this %s"
@@ -16819,9 +27953,11 @@ msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 msgid "You don't have permission to modify the value."
 msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "You don't have the rights to alter %(resource)s"
-msgstr ""
+msgstr "Non hai i diritti per modificare %(resource)s"
 
 #, fuzzy
 msgid "You don't have the rights to alter this chart"
@@ -16831,8 +27967,12 @@ msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 msgid "You don't have the rights to alter this dashboard"
 msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You don't have the rights to alter this title."
-msgstr ""
+msgstr "Non hai i diritti per modificare questo titolo."
 
 #, fuzzy
 msgid "You don't have the rights to create a chart"
@@ -16846,81 +27986,159 @@ msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 msgid "You don't have the rights to export data"
 msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "You have been removed from task: %s"
-msgstr ""
+msgstr "Sei stato rimosso dall'attività: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You have removed this filter."
-msgstr ""
+msgstr "Hai rimosso questo filtro."
 
 #, fuzzy
 msgid "You have unsaved changes"
 msgstr "Ultima Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You have unsaved changes."
-msgstr ""
+msgstr "Hai delle modifiche non salvate."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid ""
 "You have used all %(historyLength)s undo slots and will not be able to "
 "fully undo subsequent actions. You may save your current state to reset "
 "the history."
 msgstr ""
+"Hai utilizzato tutti i %(historyLength)s slot di annullamento e non sarai"
+" in grado di annullare completamente le azioni successive. Puoi salvare "
+"il tuo stato attuale per reimpostare la cronologia."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You must be a %s owner in order to edit. Please reach out to a %s owner "
 "to request modifications or edit access."
 msgstr ""
+"Devi essere un proprietario di %s per poter modificare. Contatta un "
+"proprietario di %s per richiedere modifiche o accesso alla modifica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
 "dataset owner to request modifications or edit access."
 msgstr ""
+"Devi essere un proprietario del dataset per poter modificare. Contatta un"
+" proprietario del dataset per richiedere modifiche o accesso alla "
+"modifica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You must pick a name for the new dashboard"
-msgstr ""
+msgstr "Devi scegliere un nome per il nuovo dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You must run the query successfully first"
-msgstr ""
+msgstr "Devi prima eseguire la query con successo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Devi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You updated the values in the control panel, but the chart was not "
 "updated automatically. Run the query by clicking on the \"Update chart\" "
 "button or"
 msgstr ""
+"Hai aggiornato i valori nel pannello di controllo, ma il grafico non è "
+"stato aggiornato automaticamente. Esegui la query facendo clic sul "
+"pulsante \"Aggiorna grafico\" o"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Verrai rimosso da questa attività. Continuerà a essere eseguita per %s "
+"altro/i abbonato/i."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
 msgstr ""
+"Hai cambiato dataset. Tutti i controlli con dati (colonne, metriche) che "
+"corrispondono a questo nuovo dataset sono stati mantenuti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "Il tuo account è stato attivato. Puoi accedere con le tue credenziali."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "Le tue modifiche andranno perse se esci senza salvare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Your chart is not up to date"
-msgstr ""
+msgstr "Il tuo grafico non è aggiornato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your chart is ready to go!"
-msgstr ""
+msgstr "Il tuo grafico è pronto!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your dashboard is near the size limit."
-msgstr ""
+msgstr "Il tuo dashboard è vicino al limite di dimensione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your dashboard is too large. Please reduce its size before saving it."
 msgstr ""
+"Il tuo dashboard è troppo grande. Riduci le sue dimensioni prima di "
+"salvarlo."
 
 msgid "Your query could not be saved"
 msgstr "La tua query non può essere salvata"
@@ -16931,10 +28149,16 @@ msgstr "La tua query non può essere salvata"
 msgid "Your query could not be updated"
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Your query has been scheduled. To see details of your query, navigate to "
 "Saved queries"
 msgstr ""
+"La tua query è stata pianificata. Per visualizzare i dettagli della "
+"query, vai a Query salvate"
 
 #, fuzzy
 msgid "Your query was not properly saved"
@@ -16954,34 +28178,59 @@ msgstr "La query non può essere caricata"
 msgid "Your user information"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Z-A"
-msgstr ""
+msgstr "Z-A"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ZIP file contains multiple file types"
-msgstr ""
+msgstr "Il file ZIP contiene più tipi di file"
 
 #, fuzzy
 msgid "Zero imputation"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Zoom level"
-msgstr ""
+msgstr "Livello di zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom level of the map"
-msgstr ""
+msgstr "Livello di zoom della mappa"
 
 #, fuzzy
 msgid "[ untitled dashboard ]"
 msgstr "Aggiungi ad una nuova dashboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[Longitude] and [Latitude] columns must be present in [Group By]"
-msgstr ""
+msgstr "Le colonne [Longitude] e [Latitude] devono essere presenti in [Group By]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[Longitude] and [Latitude] must be set"
-msgstr ""
+msgstr "[Longitude] e [Latitude] devono essere impostati"
 
 #, fuzzy
 msgid "[Missing Dataset]"
@@ -16991,132 +28240,257 @@ msgstr "Seleziona una destinazione"
 msgid "[Untitled]"
 msgstr "%s - senza nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[asc]"
-msgstr ""
+msgstr "[asc]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[dashboard name]"
-msgstr ""
+msgstr "[nome del dashboard]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "[desc]"
-msgstr ""
+msgstr "[desc]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "[optional] this secondary metric is used to define the color as a ratio "
 "against the primary metric. When omitted, the color is categorical and "
 "based on labels"
 msgstr ""
+"[opzionale] questa metrica secondaria viene utilizzata per definire il "
+"colore come rapporto rispetto alla metrica primaria. Se omessa, il colore"
+" è categorico e basato sulle etichette"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[personalizzazione senza titolo]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_columns` must have the same length as `source_columns`."
-msgstr ""
+msgstr "`compare_columns` deve avere la stessa lunghezza di `source_columns`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_type` must be `difference`, `percentage` or `ratio`"
-msgstr ""
+msgstr "`compare_type` deve essere `difference`, `percentage` o `ratio`"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`confidence_interval` must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "`confidence_interval` deve essere compreso tra 0 e 1 (esclusi)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "`count` is COUNT(*) if a group by is used. Numerical columns will be "
 "aggregated with the aggregator. Non-numerical columns will be used to "
 "label points. Leave empty to get a count of points in each cluster."
 msgstr ""
+"`count` è COUNT(*) se viene utilizzato un raggruppamento. Le colonne "
+"numeriche verranno aggregate con l'aggregatore. Le colonne non numeriche "
+"verranno utilizzate per etichettare i punti. Lascia vuoto per ottenere un"
+" conteggio dei punti in ogni cluster."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`operation` property of post processing object undefined"
-msgstr ""
+msgstr "La proprietà `operation` dell'oggetto di post-elaborazione non è definita"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` deve essere compreso tra 1 e %(max)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`prophet` package not installed"
-msgstr ""
+msgstr "Pacchetto `prophet` non installato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "`rename_columns` must have the same length as `columns` + "
 "`time_shift_columns`."
 msgstr ""
+"`rename_columns` deve avere la stessa lunghezza di `columns` + "
+"`time_shift_columns`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_limit` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_limit` deve essere maggiore o uguale a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_offset` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_offset` deve essere maggiore o uguale a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`width` must be greater or equal to 0"
-msgstr ""
+msgstr "`width` deve essere maggiore o uguale a 0"
 
 #, fuzzy
 msgid "a few seconds"
 msgstr "JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "aggregate"
-msgstr ""
+msgstr "aggregato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alert"
-msgstr ""
+msgstr "avviso"
 
 #, fuzzy
 msgid "alert condition"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alerts"
-msgstr ""
+msgstr "avvisi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "all"
-msgstr ""
+msgstr "tutto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "also copy (duplicate) charts"
-msgstr ""
+msgstr "copia (duplica) anche i grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ancestor"
-msgstr ""
+msgstr "antenato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "annotation"
-msgstr ""
+msgstr "annotazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "annotation_layer"
-msgstr ""
+msgstr "livello_annotazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "asfreq"
-msgstr ""
+msgstr "asfreq"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "at"
-msgstr ""
+msgstr "alle"
 
 #, fuzzy
 msgid "auto"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "background"
-msgstr ""
+msgstr "sfondo"
 
 #, fuzzy
 msgid "background color"
 msgstr "Colonna del Tempo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "basis"
-msgstr ""
+msgstr "base"
 
 #, fuzzy
 msgid "begins with"
 msgstr "Larghezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "below (example:"
-msgstr ""
+msgstr "di seguito (esempio:"
 
 #, fuzzy
 msgid "beta"
 msgstr "Extra"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "between {down} and {up} {name}"
-msgstr ""
+msgstr "tra {down} e {up} {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "bfill"
-msgstr ""
+msgstr "bfill"
 
 msgid "bolt"
 msgstr ""
@@ -17125,21 +28499,37 @@ msgstr ""
 msgid "boolean"
 msgstr "Min"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "boolean type icon"
-msgstr ""
+msgstr "icona tipo booleano"
 
 #, fuzzy
 msgid "bottom"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "button (cmd + z) until you save your changes."
-msgstr ""
+msgstr "pulsante (cmd + z) finché non salvi le modifiche."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "by using"
-msgstr ""
+msgstr "usando"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "cannot be empty"
-msgstr ""
+msgstr "non può essere vuoto"
 
 #, fuzzy
 msgid "cardinal"
@@ -17153,30 +28543,57 @@ msgstr "Grafico a Proiettile"
 msgid "change"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "chart"
-msgstr ""
+msgstr "grafico"
 
 #, fuzzy
 msgid "charts"
 msgstr "Grafici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "choose WHERE or HAVING..."
-msgstr ""
+msgstr "scegli WHERE o HAVING..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "click here"
-msgstr ""
+msgstr "clicca qui"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "close"
-msgstr ""
+msgstr "chiudi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-2 (cca2)"
-msgstr ""
+msgstr "codice ISO 3166-1 alpha-2 (cca2)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-3 (cca3)"
-msgstr ""
+msgstr "codice ISO 3166-1 alpha-3 (cca3)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code International Olympic Committee (cioc)"
-msgstr ""
+msgstr "codice Comitato Olimpico Internazionale (cioc)"
 
 #, fuzzy
 msgid "color scheme for comparison"
@@ -17189,9 +28606,11 @@ msgstr "Grafici"
 msgid "column"
 msgstr "Colonna"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "connecting to %(dbModelName)s"
-msgstr ""
+msgstr "connessione a %(dbModelName)s"
 
 #, fuzzy
 msgid "containing"
@@ -17213,24 +28632,44 @@ msgstr "Creato il"
 msgid "create a new chart"
 msgstr "Creato il"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "create dataset from SQL query"
-msgstr ""
+msgstr "crea dataset dalla query SQL"
 
 #, fuzzy
 msgid "crontab"
 msgstr "Colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css"
-msgstr ""
+msgstr "css"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css_template"
-msgstr ""
+msgstr "css_template"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "cumsum"
-msgstr ""
+msgstr "somma cumulativa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "dashboard"
-msgstr ""
+msgstr "dashboard"
 
 #, fuzzy
 msgid "dashboards"
@@ -17251,8 +28690,12 @@ msgstr "Database"
 msgid "databases"
 msgstr "Basi di dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "dataset"
-msgstr ""
+msgstr "dataset"
 
 #, fuzzy
 msgid "dataset name"
@@ -17270,23 +28713,42 @@ msgstr "Sorgente Dati"
 msgid "datasources"
 msgstr "Sorgente Dati"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "date"
-msgstr ""
+msgstr "data"
 
 msgid "day"
 msgstr "giorno"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the month"
-msgstr ""
+msgstr "giorno del mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the week"
-msgstr ""
+msgstr "giorno della settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl 3D Hexagon"
-msgstr ""
+msgstr "deck.gl Esagono 3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "deck.gl Arc"
-msgstr ""
+msgstr "deck.gl Arco"
 
 #, fuzzy
 msgid "deck.gl Contour"
@@ -17295,41 +28757,67 @@ msgstr "Grafico a Proiettile"
 msgid "deck.gl Geojson"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Grid"
-msgstr ""
+msgstr "deck.gl Griglia"
 
 #, fuzzy
 msgid "deck.gl Heatmap"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Multiple Layers"
-msgstr ""
+msgstr "deck.gl Livelli Multipli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Path"
-msgstr ""
+msgstr "deck.gl Percorso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Polygon"
-msgstr ""
+msgstr "deck.gl Poligono"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Scatterplot"
-msgstr ""
+msgstr "deck.gl Grafico a dispersione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Screen Grid"
-msgstr ""
+msgstr "deck.gl Griglia Schermo"
 
 #, fuzzy
 msgid "deck.gl layers (charts)"
 msgstr "Grafico a Proiettile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "deckGL"
-msgstr ""
+msgstr "deckGL"
 
 #, fuzzy
 msgid "default"
 msgstr "Endpoint predefinito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "descendant"
-msgstr ""
+msgstr "discendente"
 
 msgid "description"
 msgstr "descrizione"
@@ -17338,8 +28826,12 @@ msgstr "descrizione"
 msgid "deviation"
 msgstr "descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "dialect+driver://username:password@host:port/database"
-msgstr ""
+msgstr "dialect+driver://username:password@host:port/database"
 
 #, fuzzy
 msgid "documentation"
@@ -17348,53 +28840,98 @@ msgstr "Azione"
 msgid "dttm"
 msgstr "dttm"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. ********"
-msgstr ""
+msgstr "es. ********"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 127.0.0.1"
-msgstr ""
+msgstr "es. 127.0.0.1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 5432"
-msgstr ""
+msgstr "es. 5432"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. AccountAdmin"
-msgstr ""
+msgstr "es. AccountAdmin"
 
 #, fuzzy
 msgid "e.g. Analytics"
 msgstr "Analytics avanzate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. compute_wh"
-msgstr ""
+msgstr "es. compute_wh"
 
 #, fuzzy
 msgid "e.g. default"
 msgstr "Endpoint predefinito"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "e.g. hive_metastore"
-msgstr ""
+msgstr "es. hive_metastore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "e.g. param1=value1&param2=value2"
-msgstr ""
+msgstr "es. param1=value1&param2=value2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. sql/protocolv1/o/12345"
-msgstr ""
+msgstr "es. sql/protocolv1/o/12345"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. world_population"
-msgstr ""
+msgstr "ad es. world_population"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. xy12345.us-east-2.aws"
-msgstr ""
+msgstr "ad es. xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "ad es., CI/CD Pipeline, Script di Analisi"
 
 #, fuzzy
 msgid "edit mode"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "email subject"
-msgstr ""
+msgstr "oggetto dell'email"
 
 #, fuzzy
 msgid "ends with"
@@ -17419,17 +28956,29 @@ msgstr "Errore..."
 msgid "error_message"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every"
-msgstr ""
+msgstr "ogni"
 
 msgid "every day of the month"
 msgstr "Codice a 3 lettere della nazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every day of the week"
-msgstr ""
+msgstr "ogni giorno della settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "every hour"
-msgstr ""
+msgstr "ogni ora"
 
 #, fuzzy
 msgid "every minute"
@@ -17438,44 +28987,75 @@ msgstr "mese"
 msgid "every month"
 msgstr "mese"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "expand"
-msgstr ""
+msgstr "espandi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard deve essere un oggetto"
 
 #, fuzzy
 msgid "failed"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "addio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "fetching"
-msgstr ""
+msgstr "recupero in corso"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ffill"
-msgstr ""
+msgstr "ffill"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "flat"
-msgstr ""
+msgstr "piatto"
 
 #, fuzzy
 msgid "for a list of available helpers."
 msgstr "Filtri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "for more information on how to structure your URI."
-msgstr ""
+msgstr "per ulteriori informazioni su come strutturare il tuo URI."
 
 #, fuzzy
 msgid "formatted"
 msgstr "Formato D3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "function type icon"
-msgstr ""
+msgstr "icona tipo funzione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "geohash (square)"
-msgstr ""
+msgstr "geohash (quadrato)"
 
 #, fuzzy
 msgid "greeting"
@@ -17485,14 +29065,24 @@ msgstr "Creato il"
 msgid "heatmap"
 msgstr "Mappa di Intensità"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "heatmap: values are normalized across the entire heatmap"
-msgstr ""
+msgstr "mappa di calore: i valori sono normalizzati su tutta la mappa di calore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "ciao"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "here"
-msgstr ""
+msgstr "qui"
 
 msgid "hour"
 msgstr "ora"
@@ -17500,77 +29090,129 @@ msgstr "ora"
 msgid "in"
 msgstr "Min"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "per eseguire questa operazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "invalid email"
-msgstr ""
+msgstr "email non valida"
 
 #, fuzzy
 msgid "is"
 msgstr "Min"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
 msgstr ""
+"dovrebbe essere un URL Mapbox/OSM (ad es. mapbox://styles/...) o un URL "
+"di server di tile (ad es. tile://http...)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be a number"
-msgstr ""
+msgstr "dovrebbe essere un numero"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be an integer"
-msgstr ""
+msgstr "dovrebbe essere un numero intero"
 
 #, fuzzy
 msgid "is false"
 msgstr "Modifica Tabella"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards and users have %s SQL"
 " Lab tabs using this database open. Are you sure you want to continue? "
 "Deleting the database will break those objects."
 msgstr ""
+"è collegato a %s grafici che appaiono su %s dashboard e gli utenti hanno "
+"%s schede SQL Lab che utilizzano questo database aperte. Sei sicuro di "
+"voler continuare? L'eliminazione del database danneggerà quegli oggetti."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
 msgstr ""
+"è collegato a %s grafici che appaiono su %s dashboard. Sei sicuro di "
+"voler continuare? L'eliminazione del dataset danneggerà quegli oggetti."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not"
-msgstr ""
+msgstr "non è"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not null"
-msgstr ""
+msgstr "non è null"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is null"
-msgstr ""
+msgstr "è null"
 
 #, fuzzy
 msgid "is true"
 msgstr "Ricerca Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key a-z"
-msgstr ""
+msgstr "chiave a-z"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key z-a"
-msgstr ""
+msgstr "chiave z-a"
 
 #, fuzzy
 msgid "label"
 msgstr "Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "latest partition:"
-msgstr ""
+msgstr "ultima partizione:"
 
 #, fuzzy
 msgid "left"
 msgstr "Cancella"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "less than {min} {name}"
-msgstr ""
+msgstr "meno di {min} {name}"
 
 #, fuzzy
 msgid "linear"
@@ -17580,23 +29222,40 @@ msgstr "Grafico a torta"
 msgid "locale_key"
 msgstr "Tabella"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "log"
-msgstr ""
+msgstr "log"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "lower percentile must be greater than 0 and less than 100. Must be lower "
 "than upper percentile."
 msgstr ""
+"il percentile inferiore deve essere maggiore di 0 e minore di 100. Deve "
+"essere inferiore al percentile superiore."
 
 #, fuzzy
 msgid "max"
 msgstr "Max"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "mean"
-msgstr ""
+msgstr "media"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "median"
-msgstr ""
+msgstr "mediana"
 
 #, fuzzy
 msgid "meters"
@@ -17628,48 +29287,75 @@ msgstr "mese"
 msgid "month"
 msgstr "mese"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "more than {max} {name}"
-msgstr ""
+msgstr "più di {max} {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "must have a value"
-msgstr ""
+msgstr "deve avere un valore"
 
 #, fuzzy
 msgid "name"
 msgstr "Nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters deve essere una lista"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] mancano le chiavi obbligatorie: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] deve essere un oggetto"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues deve essere una lista"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
 msgstr ""
+"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' non esiste nella "
+"dashboard"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId deve essere una stringa non vuota"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "no SQL validator is configured"
-msgstr ""
+msgstr "nessun validatore SQL è configurato"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "no SQL validator is configured for %(engine_spec)s"
-msgstr ""
+msgstr "nessun validatore SQL è configurato per %(engine_spec)s"
 
 #, fuzzy
 msgid "not containing"
@@ -17679,27 +29365,49 @@ msgstr "Azione"
 msgid "numeric"
 msgstr "Metrica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "numeric type icon"
-msgstr ""
+msgstr "icona tipo numerico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "nvd3"
-msgstr ""
+msgstr "nvd3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "of"
-msgstr ""
+msgstr "di"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "offline"
-msgstr ""
+msgstr "offline"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "on"
-msgstr ""
+msgstr "su"
 
 #, fuzzy
 msgid "or"
 msgstr "ora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "or use existing ones from the panel on the right"
-msgstr ""
+msgstr "o usa quelli esistenti dal pannello a destra"
 
 #, fuzzy
 msgid "orderby column must be populated"
@@ -17709,15 +29417,22 @@ msgstr "La tua query non può essere salvata"
 msgid "original"
 msgstr "Login"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "overall"
-msgstr ""
+msgstr "generale"
 
 #, fuzzy
 msgid "owners"
 msgstr "Proprietari"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "p-value precision"
-msgstr ""
+msgstr "precisione del valore p"
 
 msgid "p1"
 msgstr ""
@@ -17735,10 +29450,16 @@ msgstr ""
 msgid "pending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "percentiles must be a list or tuple with two numeric values, of which the"
 " first is lower than the second value"
 msgstr ""
+"i percentili devono essere una lista o una tupla con due valori numerici,"
+" di cui il primo è inferiore al secondo valore"
 
 #, fuzzy
 msgid "permalink state not found"
@@ -17748,23 +29469,45 @@ msgstr "Template CSS"
 msgid "pivoted_xlsx"
 msgstr "Modifica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "pixels"
-msgstr ""
+msgstr "pixel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar month"
-msgstr ""
+msgstr "mese del calendario precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "previous calendar quarter"
-msgstr ""
+msgstr "trimestre del calendario precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar week"
-msgstr ""
+msgstr "settimana del calendario precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar year"
-msgstr ""
+msgstr "anno del calendario precedente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "fornire l'autorizzazione"
 
 #, fuzzy
 msgid "quarter"
@@ -17773,17 +29516,30 @@ msgstr "condividi query"
 msgid "query"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "random"
-msgstr ""
+msgstr "casuale"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "reboot"
-msgstr ""
+msgstr "riavvio"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "recent"
-msgstr ""
+msgstr "recente"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "recipients"
-msgstr ""
+msgstr "destinatari"
 
 msgid "report"
 msgstr "Importa"
@@ -17791,15 +29547,22 @@ msgstr "Importa"
 msgid "reports"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "restore zoom"
-msgstr ""
+msgstr "ripristina zoom"
 
 #, fuzzy
 msgid "right"
 msgstr "Altezza"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "rowlevelsecurity"
-msgstr ""
+msgstr "sicurezza_a_livello_di_riga"
 
 #, fuzzy
 msgid "running"
@@ -17812,18 +29575,28 @@ msgstr "Gestisci"
 msgid "schema1,schema2"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "seconds"
-msgstr ""
+msgstr "secondi"
 
 #, fuzzy
 msgid "series"
 msgstr "Query salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "series: Treat each series independently; overall: All series use the same"
 " scale; change: Show changes compared to the first data point in each "
 "series"
 msgstr ""
+"serie: Tratta ogni serie indipendentemente; generale: Tutte le serie "
+"usano la stessa scala; variazione: Mostra le variazioni rispetto al primo"
+" punto dati di ogni serie"
 
 msgid "sql"
 msgstr ""
@@ -17832,14 +29605,24 @@ msgstr ""
 msgid "square"
 msgstr "condividi query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stack"
-msgstr ""
+msgstr "pila"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "staggered"
-msgstr ""
+msgstr "sfalsato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "std"
-msgstr ""
+msgstr "std"
 
 #, fuzzy
 msgid "step-after"
@@ -17848,8 +29631,11 @@ msgstr "Cerca / Filtra"
 msgid "step-before"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stopped"
-msgstr ""
+msgstr "interrotto"
 
 #, fuzzy
 msgid "stream"
@@ -17859,31 +29645,50 @@ msgstr "Istogramma"
 msgid "string"
 msgstr "Testa la Connessione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "string type icon"
-msgstr ""
+msgstr "icona tipo stringa"
 
 #, fuzzy
 msgid "success"
 msgstr "Nessun Accesso!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "sum"
-msgstr ""
+msgstr "somma"
 
 msgid "superset.example.com"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "syntax."
-msgstr ""
+msgstr "sintassi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "tag"
-msgstr ""
+msgstr "tag"
 
 #, fuzzy
 msgid "task"
 msgstr "Gestisci"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "temporal type icon"
-msgstr ""
+msgstr "icona tipo temporale"
 
 #, fuzzy
 msgid "text color"
@@ -17892,8 +29697,11 @@ msgstr "Porta Broker"
 msgid "textarea"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "la documentazione del grafico Handlebars"
 
 #, fuzzy
 msgid "theme"
@@ -17907,14 +29715,23 @@ msgstr "Formato Datetime"
 msgid "to"
 msgstr "Descrizione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "top"
-msgstr ""
+msgstr "in alto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "undo"
-msgstr ""
+msgstr "annulla"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "unknown type icon"
-msgstr ""
+msgstr "icona tipo sconosciuto"
 
 #, fuzzy
 msgid "unset"
@@ -17924,13 +29741,22 @@ msgstr "Colonna"
 msgid "updated"
 msgstr "%s - senza nome"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "upper percentile must be greater than 0 and less than 100. Must be higher"
 " than lower percentile."
 msgstr ""
+"il percentile superiore deve essere maggiore di 0 e minore di 100. Deve "
+"essere superiore al percentile inferiore."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "use latest_partition template"
-msgstr ""
+msgstr "usa il modello latest_partition"
 
 #, fuzzy
 msgid "username"
@@ -17944,11 +29770,17 @@ msgstr "Importa"
 msgid "value descending"
 msgstr "Importa"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "var"
-msgstr ""
+msgstr "var"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "variance"
-msgstr ""
+msgstr "varianza"
 
 #, fuzzy
 msgid "view instructions"
@@ -17964,26 +29796,51 @@ msgstr "è stata creata"
 msgid "week"
 msgstr "settimana"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week ending Saturday"
-msgstr ""
+msgstr "settimana che termina di sabato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week starting Sunday"
-msgstr ""
+msgstr "settimana che inizia di domenica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "working timeout"
-msgstr ""
+msgstr "timeout di lavoro"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x"
-msgstr ""
+msgstr "x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x: values are normalized within each column"
-msgstr ""
+msgstr "x: i valori sono normalizzati all'interno di ogni colonna"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y"
-msgstr ""
+msgstr "y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y: values are normalized within each row"
-msgstr ""
+msgstr "y: i valori sono normalizzati all'interno di ogni riga"
 
 msgid "year"
 msgstr "anno"
@@ -17991,11 +29848,21 @@ msgstr "anno"
 msgid "your-project-1234-a1"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "zoom area"
-msgstr ""
+msgstr "area di zoom"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "© Layer attribution"
-msgstr ""
+msgstr "© Attribuzione del livello"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -1949,7 +1949,7 @@ msgstr "Aggiunto"
 #, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] "Aggiunta 1 nuova colonna al set di dati virtuale"
+msgstr[0] "Aggiunte %s nuove colonne al dataset virtuale"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"
@@ -14316,7 +14316,7 @@ msgstr "Ultima Modifica"
 #, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] "Modificata 1 colonna nel dataset virtuale"
+msgstr[0] "Modificate %s colonne nel dataset virtuale"
 
 msgid "Modified by"
 msgstr "Modificato"
@@ -17501,7 +17501,7 @@ msgstr "Rimuovi anteprima tabella"
 #, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] "Rimossa 1 colonna dal dataset virtuale"
+msgstr[0] "Rimosse %s colonne dal dataset virtuale"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Italian (`it`) catalog using `scripts/translations/backfill_po.py`, which drafts translations with Claude using every other language's existing translation of the same string as cross-language disambiguation context (per `docs/developer_docs/contributing/howtos.md`). Do-not-translate tokens (icon names, enum values, SQL keywords, API field names, placeholders) are skipped.

All generated strings are marked `#, fuzzy` with a `Machine-translated via backfill_po.py` attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend builds include fuzzy entries, so these translations render in the UI once built; reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only, no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l it` succeeds.
- Italian native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API