### PR TITLE
feat(i18n): backfill Korean (ko) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgstr "추가됨"
 #, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] "가상 데이터셋에 새 열 1개가 추가되었습니다"
+msgstr[0] "%s개의 새 열이 가상 데이터셋에 추가되었습니다"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -28,6 +28,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The cumulative option allows you to see how your data "
@@ -41,7 +44,14 @@ msgid ""
 "                original data, it just changes the way the histogram is "
 "displayed."
 msgstr ""
+"\n"
+"                누적 옵션을 사용하면 데이터가 여러 값에 걸쳐 어떻게 누적되는지 확인할 수 있습니다. 활성화하면 "
+"히스토그램 막대가 각 구간(bin)까지의 빈도 누적 합계를 나타냅니다. 이를 통해 특정 지점 아래의 값을 만날 확률을 파악하는 데 "
+"도움이 됩니다. 누적을 활성화해도 원본 데이터는 변경되지 않으며, 히스토그램 표시 방식만 변경된다는 점을 유의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "\n"
 "                The normalize option transforms the histogram values into"
@@ -55,15 +65,29 @@ msgid ""
 "                clearer understanding of the proportion of data points "
 "within each bin."
 msgstr ""
+"\n"
+"                정규화 옵션은 각 구간(bin)의 개수를 전체 데이터 포인트 수로 나누어 히스토그램 값을 비율 또는 "
+"확률로 변환합니다. 이 정규화 과정을 통해 결과 값의 합이 1이 되어 데이터 분포를 상대적으로 비교할 수 있으며, 각 구간 내 "
+"데이터 포인트의 비율을 더 명확하게 이해할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "\n"
 "                This filter was inherited from the dashboard's context.\n"
 "                It won't be saved when saving the chart.\n"
 "              "
 msgstr ""
+"\n"
+"                이 필터는 대시보드 컨텍스트에서 상속되었습니다.\n"
+"                차트를 저장할 때 저장되지 않습니다.\n"
+"              "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "\n"
 "            <p>Your report/alert was unable to be generated because of "
@@ -72,40 +96,71 @@ msgid ""
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
+"\n"
+"            <p>다음 오류로 인해 보고서/알림을 생성할 수 없었습니다: %(text)s</p>\n"
+"            <p>대시보드/차트에서 오류를 확인해 주세요.</p>\n"
+"            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
+"            "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " (excluded)"
-msgstr ""
+msgstr " (제외됨)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " Set the opacity to 0 if you do not want to override the color specified "
 "in the GeoJSON"
-msgstr ""
+msgstr " GeoJSON에 지정된 색상을 재정의하지 않으려면 불투명도를 0으로 설정하세요"
 
 #, fuzzy
 msgid " a dashboard OR "
 msgstr "대시보드 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " a new one"
-msgstr ""
+msgstr " 새로 만들기"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " at line %(line)d"
-msgstr ""
+msgstr " %(line)d번째 줄에서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " expression which needs to adhere to the "
-msgstr ""
+msgstr " 규칙을 준수해야 하는 표현식"
 
 #, fuzzy
 msgid " for details."
 msgstr "저장된 Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid " near '%(highlight)s'"
-msgstr ""
+msgstr " '%(highlight)s' 근처"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " source code of Superset's sandboxed parser"
-msgstr ""
+msgstr " Superset 샌드박스 파서의 소스 코드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 " standard to ensure that the lexicographical ordering\n"
 "                      coincides with the chronological ordering. If the\n"
@@ -122,6 +177,10 @@ msgid ""
 "defaults on a per\n"
 "                      database/column name level via the extra parameter."
 msgstr ""
+" 표준, 사전적 정렬이 시간순 정렬과 일치하도록 보장합니다. 타임스탬프 형식이 ISO 8601 표준을 따르지 않는 경우, 문자열을 "
+"날짜 또는 타임스탬프로 변환하기 위한 표현식과 유형을 정의해야 합니다. 현재 시간대는 지원되지 않습니다. 시간이 epoch 형식으로"
+" 저장된 경우 `epoch_s` 또는 `epoch_ms`를 입력하세요. 패턴이 지정되지 않은 경우 추가 매개변수를 통해 "
+"데이터베이스/열 이름 수준별 선택적 기본값을 사용합니다."
 
 #, fuzzy
 msgid " to add calculated columns"
@@ -131,102 +190,162 @@ msgstr "컬럼 목록"
 msgid " to add metrics"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to check for details."
-msgstr ""
+msgstr " 세부 정보를 확인하려면."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to edit or add columns and metrics."
-msgstr ""
+msgstr " 열과 지표를 편집하거나 추가하려면."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh_TW]
+#, fuzzy
 msgid " to mark a column as a time column"
-msgstr ""
+msgstr " 열을 시간 열로 표시하려면"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid " to open SQL Lab. From there you can save the query as a dataset."
-msgstr ""
+msgstr " SQL Lab을 열려면. 거기서 쿼리를 데이터셋으로 저장할 수 있습니다."
 
 #, fuzzy
 msgid " to see details."
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid " to visualize your data."
-msgstr ""
+msgstr " 데이터를 시각화하려면."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "!= (Is not equal)"
-msgstr ""
+msgstr "!= (같지 않음)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system dark theme"
-msgstr ""
+msgstr "\"%s\"이(가) 시스템 다크 테마로 설정되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "\"%s\" is now the system default theme"
-msgstr ""
+msgstr "\"%s\"이(가) 시스템 기본 테마로 설정되었습니다"
 
 #, fuzzy, python-format
 msgid "% calculation"
 msgstr "시각화 유형 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "% of parent"
-msgstr ""
+msgstr "상위 항목의 %"
 
 #, fuzzy, python-format
 msgid "% of total"
 msgstr "컬럼 보기"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(dialect)s cannot be used as a data source for security reasons."
-msgstr ""
+msgstr "%(dialect)s은(는) 보안상의 이유로 데이터 소스로 사용할 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(label)s file"
-msgstr ""
+msgstr "%(label)s 파일"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(name)s.csv"
-msgstr ""
+msgstr "%(name)s.csv"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%(name)s.pdf"
-msgstr ""
+msgstr "%(name)s.pdf"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(object)s does not exist in this database."
-msgstr ""
+msgstr "%(object)s이(가) 이 데이터베이스에 존재하지 않습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "%(prefix)s %(title)s"
-msgstr ""
+msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
-msgstr ""
+msgstr "%(prefix)s메모리 제약으로 인해 결과가 %(row_count)s행으로 잘렸습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%(report_type)s schedule frequency exceeding limit. Please configure a "
 "schedule with a minimum interval of %(minimum_interval)d minutes per "
 "execution."
 msgstr ""
+"%(report_type)s 스케줄 빈도가 제한을 초과했습니다. 실행당 최소 %(minimum_interval)d분 간격으로 "
+"스케줄을 구성해 주세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%(rows)d rows returned"
-msgstr ""
+msgstr "%(rows)d개 행이 반환되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, lv,
+# mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid "%(suggestion)s instead of \"%(undefinedParameter)s?\""
 msgid_plural ""
 "%(firstSuggestions)s or %(lastSuggestion)s instead of "
 "\"%(undefinedParameter)s\"?"
-msgstr[0] ""
+msgstr[0] "%(suggestion)s 대신 \"%(undefinedParameter)s?\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "%(validator)s was unable to check your query.\n"
 "Please recheck your query.\n"
 "Exception: %(ex)s"
 msgstr ""
+"%(validator)s에서 쿼리를 확인할 수 없었습니다.\n"
+"쿼리를 다시 확인해 주세요.\n"
+"예외: %(ex)s"
 
 #, fuzzy, python-format
 msgid "%s %s"
@@ -244,41 +363,63 @@ msgstr "%s 에러"
 msgid "%s PASSWORD"
 msgstr "비밀번호"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Physical"
-msgstr ""
+msgstr "%s 물리적"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PASSWORD"
-msgstr ""
+msgstr "%s SSH 터널 비밀번호"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY"
-msgstr ""
+msgstr "%s SSH 터널 개인 키"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s SSH TUNNEL PRIVATE KEY PASSWORD"
-msgstr ""
+msgstr "%s SSH 터널 개인 키 비밀번호"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected"
-msgstr ""
+msgstr "%s개 선택됨"
 
 #, fuzzy, python-format
 msgid "%s Selected (%s)"
 msgstr "테이블 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Physical)"
-msgstr ""
+msgstr "%s개 선택됨 (물리적)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s Selected (Virtual)"
-msgstr ""
+msgstr "%s개 선택됨 (가상)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s 시맨틱 뷰"
 
 #, fuzzy, python-format
 msgid "%s URL"
@@ -288,23 +429,31 @@ msgstr "%s 에러"
 msgid "%s Virtual"
 msgstr "%s 에러"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s aggregates(s)"
-msgstr ""
+msgstr "%s개 집계"
 
 #, fuzzy, python-format
 msgid "%s column"
 msgid_plural "%s columns"
 msgstr[0] "컬럼 추가"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s column(s)"
-msgstr ""
+msgstr "%s개 열"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
+msgstr[0] "%s일 전"
 
 #, fuzzy, python-format
 msgid "%s hr ago"
@@ -324,11 +473,13 @@ msgstr[0] "5분"
 msgid "%s item(s)"
 msgstr "5분"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "%s items could not be tagged because you don’t have edit permissions to "
 "all selected objects."
-msgstr ""
+msgstr "선택한 모든 개체에 대한 편집 권한이 없어 %s개 항목에 태그를 지정할 수 없습니다."
 
 #, fuzzy, python-format
 msgid "%s metric"
@@ -340,18 +491,26 @@ msgid "%s min ago"
 msgid_plural "%s min ago"
 msgstr[0] "월"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s operator(s)"
-msgstr ""
+msgstr "%s개 연산자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid "%s option"
 msgid_plural "%s options"
-msgstr[0] ""
+msgstr[0] "%s개 옵션"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s option(s)"
-msgstr ""
+msgstr "%s개 옵션"
 
 #, fuzzy, python-format
 msgid "%s out of %s column"
@@ -367,9 +526,11 @@ msgstr[0] "메트릭"
 msgid "%s out of %s selected"
 msgstr "테이블 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "%s recipients"
-msgstr ""
+msgstr "%s명 수신자"
 
 #, fuzzy, python-format
 msgid "%s record"
@@ -386,57 +547,91 @@ msgid "%s row"
 msgid_plural "%s rows"
 msgstr[0] "%s 에러"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s s ago"
 msgid_plural "%s s ago"
-msgstr[0] ""
+msgstr[0] "%s초 전"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s saved metric(s)"
-msgstr ""
+msgstr "%s개 저장된 지표"
 
 #, fuzzy, python-format
 msgid "%s second"
 msgid_plural "%s seconds"
 msgstr[0] "30초"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s 시맨틱 뷰가 추가되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "%s 시맨틱 뷰 추가에 실패했습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "%s 시맨틱 뷰 추가에 실패했습니다: %s"
 
 #, fuzzy, python-format
 msgid "%s tab selected"
 msgstr "테이블 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "%s updated"
-msgstr ""
+msgstr "%s 업데이트됨"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "%s%s"
-msgstr ""
+msgstr "%s%s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(Removed)"
-msgstr ""
+msgstr "(제거됨)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(deleted or invalid type)"
-msgstr ""
+msgstr "(삭제되었거나 유효하지 않은 유형)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "(no description, click to see stack trace)"
-msgstr ""
+msgstr "(설명 없음, 스택 트레이스를 보려면 클릭하세요)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "), and they become available in your SQL (example:"
-msgstr ""
+msgstr "), SQL에서 사용 가능해집니다 (예:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -445,8 +640,16 @@ msgid ""
 "    Error: %(text)s\n"
 "    "
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"    %(description)s\n"
+"\n"
+"    오류: %(text)s\n"
+"    "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "*%(name)s*\n"
 "\n"
@@ -456,92 +659,160 @@ msgid ""
 "\n"
 "%(table)s\n"
 msgstr ""
+"*%(name)s*\n"
+"\n"
+"%(description)s\n"
+"\n"
+"<%(url)s|Superset에서 탐색>\n"
+"\n"
+"%(table)s\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "+ %s more"
-msgstr ""
+msgstr "+ %s 더"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ", then paste the JSON below. See our"
-msgstr ""
+msgstr ", 그런 다음 아래의 JSON을 붙여넣으세요. 저희"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "-- Note: Unless you save your query, these tabs will NOT persist if you "
 "clear your cookies or change browsers.\n"
 "\n"
 msgstr ""
+"-- 참고: 쿼리를 저장하지 않으면, 쿠키를 지우거나 브라우저를 변경할 경우 이 탭들이 유지되지 않습니다.\n"
+"\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... 그리고 %d 개 더"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "... and %s more records"
-msgstr ""
+msgstr "... 그리고 %s 개의 레코드 더"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "... and %s others"
-msgstr ""
+msgstr "... 그리고 %s 개 더"
 
 msgid "0 Selected"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 calendar day frequency"
-msgstr ""
+msgstr "1 달력일 빈도"
 
 #, fuzzy
 msgid "1 day"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 day ago"
-msgstr ""
+msgstr "1일 전"
 
 msgid "1 hour"
 msgstr "1시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 hourly frequency"
-msgstr ""
+msgstr "1시간 빈도"
 
 msgid "1 minute"
 msgstr "1분"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 minutely frequency"
-msgstr ""
+msgstr "1분 빈도"
 
 #, fuzzy
 msgid "1 month ago"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month end frequency"
-msgstr ""
+msgstr "월말 빈도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 month start frequency"
-msgstr ""
+msgstr "월초 빈도"
 
 #, fuzzy
 msgid "1 week"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 week ago"
-msgstr ""
+msgstr "1주일 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Monday (freq=W-MON)"
-msgstr ""
+msgstr "월요일 시작 1주 (freq=W-MON)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 week starting Sunday (freq=W-SUN)"
-msgstr ""
+msgstr "일요일 시작 1주 (freq=W-SUN)"
 
 #, fuzzy
 msgid "1 year"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "1 year ago"
-msgstr ""
+msgstr "1년 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year end frequency"
-msgstr ""
+msgstr "연말 빈도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1 year start frequency"
-msgstr ""
+msgstr "연초 빈도"
 
 msgid "10 minute"
 msgstr "10분"
@@ -550,8 +821,11 @@ msgstr "10분"
 msgid "10 seconds"
 msgstr "30초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "10/90 percentiles"
-msgstr ""
+msgstr "10/90 백분위수"
 
 msgid "10000"
 msgstr ""
@@ -560,8 +834,12 @@ msgstr ""
 msgid "104 weeks"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "104 weeks ago"
-msgstr ""
+msgstr "104주 전"
 
 #, fuzzy
 msgid "12 hours"
@@ -574,36 +852,71 @@ msgstr "15분"
 msgid "156 weeks"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "156 weeks ago"
-msgstr ""
+msgstr "156주 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1AS"
-msgstr ""
+msgstr "1AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "1D"
-msgstr ""
+msgstr "1D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1H"
-msgstr ""
+msgstr "1H"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1M"
-msgstr ""
+msgstr "1M"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "1T"
-msgstr ""
+msgstr "1T"
 
 #, fuzzy
 msgid "2 years"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2 years ago"
-msgstr ""
+msgstr "2년 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2/98 percentiles"
-msgstr ""
+msgstr "2/98 백분위수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "22"
-msgstr ""
+msgstr "22"
 
 #, fuzzy
 msgid "24 hours"
@@ -613,27 +926,50 @@ msgstr "6시간"
 msgid "28 days"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "28 days ago"
-msgstr ""
+msgstr "28일 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "3 letter code of the country"
-msgstr ""
+msgstr "국가 3자리 코드"
 
 #, fuzzy
 msgid "3 years"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "3 years ago"
-msgstr ""
+msgstr "3년 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "30 days"
-msgstr ""
+msgstr "30일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "30 days ago"
-msgstr ""
+msgstr "30일 전"
 
 #, fuzzy
 msgid "30 minute"
@@ -649,11 +985,19 @@ msgstr "30초"
 msgid "30 seconds"
 msgstr "30초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "4 weeks (freq=4W-MON)"
-msgstr ""
+msgstr "4주 (freq=4W-MON)"
 
 msgid "5 minute"
 msgstr "5분"
@@ -669,18 +1013,28 @@ msgstr "30초"
 msgid "5 seconds"
 msgstr "30초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "5/95 percentiles"
-msgstr ""
+msgstr "5/95 백분위수"
 
 #, fuzzy
 msgid "52 weeks"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "52 weeks ago"
-msgstr ""
+msgstr "52주 전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "52 weeks starting Monday (freq=52W-MON)"
-msgstr ""
+msgstr "52주 월요일 시작 (빈도=52W-MON)"
 
 #, fuzzy
 msgid "6 hour"
@@ -690,36 +1044,72 @@ msgstr "6시간"
 msgid "6 hours"
 msgstr "6시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "60 days"
-msgstr ""
+msgstr "60일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "7 calendar day frequency"
-msgstr ""
+msgstr "7 달력 일 빈도"
 
 #, fuzzy
 msgid "7 days"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "7D"
-msgstr ""
+msgstr "7일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "9/91 percentiles"
-msgstr ""
+msgstr "9/91 백분위수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "90 days"
-msgstr ""
+msgstr "90일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ":"
-msgstr ""
+msgstr ":"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "< (Smaller than)"
-msgstr ""
+msgstr "< (보다 작음)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<= (Smaller or equal)"
-msgstr ""
+msgstr "<= (보다 작거나 같음)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "<enter SQL expression here>"
-msgstr ""
+msgstr "<여기에 SQL 표현식을 입력하세요>"
 
 #, fuzzy
 msgid "<new column>"
@@ -729,99 +1119,176 @@ msgstr "컬럼 수정"
 msgid "<new metric>"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "<new spatial>"
-msgstr ""
+msgstr "<새 공간>"
 
 #, fuzzy
 msgid "<no type>"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "== (Is equal)"
-msgstr ""
+msgstr "== (같음)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "> (Larger than)"
-msgstr ""
+msgstr "> (보다 큼)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ">= (Larger or equal)"
-msgstr ""
+msgstr ">= (보다 크거나 같음)"
 
 #, fuzzy
 msgid "A Big Number"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "레이블 구성 객체를 생성하는 JavaScript 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "아이콘 구성 객체를 생성하는 JavaScript 함수"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"ECharts 옵션 사양을 따르는 JavaScript 객체로, 더 높은 우선순위로 다른 컨트롤 옵션을 재정의합니다. (예: { "
+"title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). 자세히 보기:"
+" https://echarts.apache.org/en/option.html. "
 
 #, fuzzy
 msgid "A comma separated list of columns that should be parsed as dates"
 msgstr "드롭다운 목록에서 날짜로 처리할 열 이름을 선택합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A comma-separated list of schemas that files are allowed to upload to."
-msgstr ""
+msgstr "파일을 업로드할 수 있는 스키마의 쉼표로 구분된 목록입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A database port is required when connecting via SSH Tunnel."
-msgstr ""
+msgstr "SSH 터널을 통해 연결할 때 데이터베이스 포트가 필요합니다."
 
 #, fuzzy
 msgid "A database with the same name already exists."
 msgstr "같은 이름의 데이터베이스가 이미 존재합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A date is required when using custom date shift"
-msgstr ""
+msgstr "사용자 정의 날짜 이동을 사용할 때 날짜가 필요합니다"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "A dictionary with column names and their data types if you need to change"
 " the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas "
 "library for supported data types."
 msgstr ""
+"기본값을 변경해야 하는 경우 열 이름과 데이터 유형을 포함하는 딕셔너리입니다. 예: {\"user_id\":\"int\"}. "
+"지원되는 데이터 유형은 Python의 Pandas 라이브러리를 확인하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A full URL pointing to the location of the built plugin (could be hosted "
 "on a CDN for example)"
-msgstr ""
+msgstr "빌드된 플러그인의 위치를 가리키는 전체 URL (예: CDN에서 호스팅될 수 있음)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A handlebars template that is applied to the data"
-msgstr ""
+msgstr "데이터에 적용되는 Handlebars 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A human-friendly name"
-msgstr ""
+msgstr "사람이 이해하기 쉬운 이름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A list of domain names that can embed this dashboard. Leaving this field "
 "empty will allow embedding from any domain."
-msgstr ""
+msgstr "이 대시보드를 삽입할 수 있는 도메인 이름 목록입니다. 이 필드를 비워두면 모든 도메인에서 삽입이 허용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A list of tags that have been applied to this chart."
-msgstr ""
+msgstr "이 차트에 적용된 태그 목록입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "A list of tags that have been applied to this dashboard."
-msgstr ""
+msgstr "이 대시보드에 적용된 태그 목록입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A list of users who can alter the chart. Searchable by name or username."
-msgstr ""
+msgstr "차트를 수정할 수 있는 사용자 목록입니다. 이름 또는 사용자명으로 검색 가능합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A map of the world, that can indicate values in different countries."
-msgstr ""
+msgstr "여러 국가의 값을 표시할 수 있는 세계 지도입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A map that takes rendering circles with a variable radius at "
 "latitude/longitude coordinates"
-msgstr ""
+msgstr "위도/경도 좌표에서 가변 반지름의 원을 렌더링하는 지도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A metric to use for color"
-msgstr ""
+msgstr "색상에 사용할 지표"
 
 #, fuzzy
 msgid "A new chart and dashboard will be created."
@@ -835,32 +1302,56 @@ msgstr "차트를 생성할 수 없습니다."
 msgid "A new dashboard will be created."
 msgstr "대시보드를 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A polar coordinate chart where the circle is broken into wedges of equal "
 "angle, and the value represented by any wedge is illustrated by its area,"
 " rather than its radius or sweep angle."
-msgstr ""
+msgstr "원을 동일한 각도의 쐐기형으로 나누고, 각 쐐기가 나타내는 값이 반지름이나 소인각이 아닌 면적으로 표현되는 극좌표 차트입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A readable URL for your dashboard"
-msgstr ""
+msgstr "대시보드의 읽기 쉬운 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "A reference to the [Time] configuration, taking granularity into account"
-msgstr ""
+msgstr "세분성을 고려한 [시간] 구성에 대한 참조"
 
 #, fuzzy, python-format
 msgid "A report named \"%(name)s\" already exists"
 msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "A reusable dataset will be saved with your chart."
-msgstr ""
+msgstr "재사용 가능한 데이터셋이 차트와 함께 저장됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
-msgstr ""
+msgstr "Jinja 템플릿 구문을 사용하여 쿼리에서 사용할 수 있게 되는 매개변수 집합"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A timeout occurred while executing the query."
-msgstr ""
+msgstr "쿼리 실행 중 시간 초과가 발생했습니다."
 
 #, fuzzy
 msgid "A timeout occurred while generating a csv."
@@ -870,12 +1361,24 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "A timeout occurred while generating a dataframe."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A timeout occurred while taking a screenshot."
-msgstr ""
+msgstr "스크린샷 촬영 중 시간 초과가 발생했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "A valid color scheme is required"
-msgstr ""
+msgstr "유효한 색상 구성표가 필요합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "A waterfall chart is a form of data visualization that helps in "
 "understanding\n"
@@ -884,9 +1387,15 @@ msgid ""
 "          These intermediate values can either be time based or category "
 "based."
 msgstr ""
+"폭포 차트는 순차적으로 도입된 양수 또는 음수 값의\n"
+"          누적 효과를 이해하는 데 도움이 되는 데이터 시각화 형식입니다.\n"
+"          이러한 중간값은 시간 기반 또는 카테고리 기반일 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 #, fuzzy
 msgid "AND"
@@ -908,23 +1417,45 @@ msgstr "주석 레이어"
 msgid "API key name is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "API 키가 성공적으로 취소되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "API 키는 Superset에 대한 범위가 지정된 프로그래밍 방식 액세스를 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APPLY"
-msgstr ""
+msgstr "적용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "APR"
-msgstr ""
+msgstr "4월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "AQE"
-msgstr ""
+msgstr "비동기 쿼리 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "AUG"
-msgstr ""
+msgstr "8월"
 
 #, fuzzy
 msgid "Aborted"
@@ -934,14 +1465,25 @@ msgstr "상태"
 msgid "Aborting"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "About"
-msgstr ""
+msgstr "정보"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Access & ownership"
-msgstr ""
+msgstr "액세스 및 소유권"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Access token"
-msgstr ""
+msgstr "액세스 토큰"
 
 #, fuzzy
 msgid "Account"
@@ -960,8 +1502,12 @@ msgstr "활동 기록"
 msgid "Actions"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Active"
-msgstr ""
+msgstr "활성"
 
 #, fuzzy
 msgid "Actual Values"
@@ -971,8 +1517,12 @@ msgstr "원본 값"
 msgid "Actual range for comparison"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Actual time range"
-msgstr ""
+msgstr "실제 시간 범위"
 
 #, fuzzy
 msgid "Actual value"
@@ -982,21 +1532,35 @@ msgstr "원본 값"
 msgid "Actual values"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Adaptive formatting"
-msgstr ""
+msgstr "적응형 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add"
-msgstr ""
+msgstr "추가"
 
 #, fuzzy, python-format
 msgid "Add %s view(s)"
 msgstr "5분"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add BCC Recipients"
-msgstr ""
+msgstr "숨은 참조(BCC) 수신자 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add CC Recipients"
-msgstr ""
+msgstr "참조(CC) 수신자 추가"
 
 msgid "Add CSS template"
 msgstr "CSS 템플릿"
@@ -1015,10 +1579,13 @@ msgstr "차트 추가"
 msgid "Add Log"
 msgstr "로그 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Add Query A and Query B identifiers to tooltips to help differentiate "
 "series"
-msgstr ""
+msgstr "시리즈를 구분하기 위해 툴팁에 쿼리 A 및 쿼리 B 식별자 추가"
 
 #, fuzzy
 msgid "Add Role"
@@ -1032,8 +1599,12 @@ msgstr "D3 포멧"
 msgid "Add Semantic View"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add Tag"
-msgstr ""
+msgstr "태그 추가"
 
 #, fuzzy
 msgid "Add User"
@@ -1050,11 +1621,19 @@ msgstr "차트 추가"
 msgid "Add a new tab"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add a new tab to create SQL Query"
-msgstr ""
+msgstr "SQL 쿼리 생성을 위한 새 탭 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add additional custom parameters"
-msgstr ""
+msgstr "추가 사용자 정의 파라미터 추가"
 
 #, fuzzy
 msgid "Add alert"
@@ -1078,43 +1657,77 @@ msgstr "주석 레이어"
 msgid "Add another notification method"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "\"데이터 소스 편집\" 모달에서 데이터셋에 계산된 열 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "\"데이터 소스 편집\" 모달에서 데이터셋에 계산된 시간 열 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fr,
+# ja, lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add certification details for this dashboard"
-msgstr ""
+msgstr "이 대시보드의 인증 세부 정보 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Add color for positive/negative change"
-msgstr ""
+msgstr "양수/음수 변화에 색상 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "모든 열의 +/- 셀 막대에 색상 추가"
 
 #, fuzzy
 msgid "Add cross-filter"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add custom scoping"
-msgstr ""
+msgstr "사용자 정의 범위 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add dataset columns here to group the pivot table columns."
-msgstr ""
+msgstr "피벗 테이블 열을 그룹화하려면 여기에 데이터셋 열을 추가하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add delivery method"
-msgstr ""
+msgstr "전송 방법 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add description of your tag"
-msgstr ""
+msgstr "태그 설명 추가"
 
 #, fuzzy
 msgid "Add display control"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add divider"
-msgstr ""
+msgstr "구분선 추가"
 
 #, fuzzy
 msgid "Add extra connection information."
@@ -1124,6 +1737,10 @@ msgstr "주석"
 msgid "Add filter"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Add filter clauses to control the filter's source query,\n"
 "                    though only in the context of the autocomplete i.e., "
@@ -1135,6 +1752,11 @@ msgid ""
 "                    of the underlying data or limit the available values "
 "displayed in the filter."
 msgstr ""
+"필터의 소스 쿼리를 제어하기 위한 필터 조건을 추가하세요,\n"
+"                    단, 자동 완성 컨텍스트에서만 적용되며, 즉 이 조건들은\n"
+"                    필터가 대시보드에 적용되는 방식에는 영향을 주지 않습니다. 이 기능은\n"
+"                    기본 데이터의 일부만 스캔하여 쿼리 성능을 향상시키거나 필터에\n"
+"                    표시되는 가용 값을 제한하고자 할 때 유용합니다."
 
 #, fuzzy
 msgid "Add folder"
@@ -1146,14 +1768,25 @@ msgstr "테이블 추가"
 msgid "Add metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
-msgstr ""
+msgstr "\"데이터 소스 편집\" 모달에서 데이터셋에 지표 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new color formatter"
-msgstr ""
+msgstr "새 색상 서식 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add new formatter"
-msgstr ""
+msgstr "새 서식 추가"
 
 #, fuzzy
 msgid "Add numbered column"
@@ -1171,18 +1804,30 @@ msgstr "테이블 추가"
 msgid "Add report"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to preview chart"
-msgstr ""
+msgstr "차트를 미리 보려면 필수 제어 값을 추가하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add required control values to save chart"
-msgstr ""
+msgstr "차트를 저장하려면 필수 제어 값을 추가하세요"
 
 #, fuzzy
 msgid "Add sheet"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Add tag to entities"
-msgstr ""
+msgstr "엔티티에 태그 추가"
 
 #, fuzzy
 msgid "Add the name of the chart"
@@ -1203,13 +1848,19 @@ msgstr "대시보드 추가"
 msgid "Add to tabs"
 msgstr "대시보드 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Added"
-msgstr ""
+msgstr "추가됨"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Added 1 new column to the virtual dataset"
 msgid_plural "Added %s new columns to the virtual dataset"
-msgstr[0] ""
+msgstr[0] "가상 데이터셋에 새 열 1개가 추가되었습니다"
 
 #, fuzzy, python-format
 msgid "Added to 1 dashboard"
@@ -1220,8 +1871,12 @@ msgstr[0] "대시보드 추가"
 msgid "Additional Parameters"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional fields may be required"
-msgstr ""
+msgstr "추가 필드가 필요할 수 있습니다"
 
 msgid "Additional information"
 msgstr "주석"
@@ -1238,54 +1893,100 @@ msgstr "주석"
 msgid "Additional settings."
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Additional text to add before or after the value, e.g. unit"
-msgstr ""
+msgstr "값 앞이나 뒤에 추가할 텍스트, 예: 단위"
 
 #, fuzzy
 msgid "Additive"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Adds color to the chart symbols based on the positive or negative change "
 "from the comparison value."
-msgstr ""
+msgstr "비교 값에서의 양수 또는 음수 변화를 기반으로 차트 기호에 색상을 추가합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust how this database will interact with SQL Lab."
-msgstr ""
+msgstr "이 데이터베이스가 SQL 랩과 상호 작용하는 방식을 조정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Adjust performance settings of this database."
-msgstr ""
+msgstr "이 데이터베이스의 성능 설정을 조정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Advanced"
-msgstr ""
+msgstr "고급"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Advanced Analytics"
-msgstr ""
+msgstr "고급 분석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Advanced Data type"
-msgstr ""
+msgstr "고급 데이터 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Advanced analytics"
-msgstr ""
+msgstr "고급 분석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Advanced analytics Query A"
-msgstr ""
+msgstr "고급 분석 쿼리 A"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Advanced analytics Query B"
-msgstr ""
+msgstr "고급 분석 쿼리 B"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Advanced analytics post processing"
-msgstr ""
+msgstr "고급 분석 후처리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Advanced data type"
-msgstr ""
+msgstr "고급 데이터 유형"
 
 #, fuzzy
 msgid "Advanced settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Advanced-Analytics"
-msgstr ""
+msgstr "고급-분석"
 
 #, fuzzy
 msgid "Affected Charts"
@@ -1299,35 +2000,58 @@ msgstr "대시보드 저장"
 msgid "After"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "After making the changes, copy the query and paste in the virtual dataset"
 " SQL snippet settings."
-msgstr ""
+msgstr "변경 사항을 적용한 후 쿼리를 복사하여 가상 데이터셋 SQL 스니펫 설정에 붙여넣으세요."
 
 #, fuzzy
 msgid "Aggregate"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Aggregate Mean"
-msgstr ""
+msgstr "집계 평균"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Aggregate Sum"
-msgstr ""
+msgstr "집계 합계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function applied to the list of points in each cluster to "
 "produce the cluster label."
-msgstr ""
+msgstr "클러스터 레이블을 생성하기 위해 각 클러스터의 포인트 목록에 적용되는 집계 함수입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Aggregate function to apply when pivoting and computing the total rows "
 "and columns"
-msgstr ""
+msgstr "피벗 처리 및 총 행과 열 계산 시 적용할 집계 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Aggregates data within the boundary of grid cells and maps the aggregated"
 " values to a dynamic color scale"
-msgstr ""
+msgstr "그리드 셀 경계 내의 데이터를 집계하고 집계된 값을 동적 색상 스케일에 매핑합니다"
 
 #, fuzzy
 msgid "Aggregation"
@@ -1337,69 +2061,128 @@ msgstr "생성자"
 msgid "Aggregation Method"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Aggregation function"
-msgstr ""
+msgstr "집계 함수"
 
 #, fuzzy
 msgid "Alert"
 msgstr "경고"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert Triggered, In Grace Period"
-msgstr ""
+msgstr "알림 트리거됨, 유예 기간 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert condition"
-msgstr ""
+msgstr "알림 조건"
 
 #, fuzzy
 msgid "Alert contents"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert ended grace period."
-msgstr ""
+msgstr "알림 유예 기간이 종료되었습니다."
 
 msgid "Alert failed"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert fired during grace period."
-msgstr ""
+msgstr "유예 기간 중에 알림이 실행되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert found an error while executing a query."
-msgstr ""
+msgstr "알림이 쿼리 실행 중 오류를 발견했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Alert is active"
-msgstr ""
+msgstr "알림이 활성화됨"
 
 msgid "Alert name"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert on grace period"
-msgstr ""
+msgstr "유예 기간 중인 알림"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned a non-number value."
-msgstr ""
+msgstr "알림 쿼리가 숫자가 아닌 값을 반환했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one column."
-msgstr ""
+msgstr "알림 쿼리가 두 개 이상의 열을 반환했습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one column. %(num_cols)s columns returned"
-msgstr ""
+msgstr "알림 쿼리가 두 개 이상의 열을 반환했습니다. %(num_cols)s 열이 반환됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert query returned more than one row."
-msgstr ""
+msgstr "알림 쿼리가 두 개 이상의 행을 반환했습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Alert query returned more than one row. %(num_rows)s rows returned"
-msgstr ""
+msgstr "알림 쿼리가 두 개 이상의 행을 반환했습니다. %(num_rows)s 행이 반환됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert running"
-msgstr ""
+msgstr "알림 실행 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert triggered, notification sent"
-msgstr ""
+msgstr "알림 트리거됨, 통보 전송됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alert validator config error."
-msgstr ""
+msgstr "알림 유효성 검사기 구성 오류."
 
 msgid "Alerts"
 msgstr "경고"
@@ -1407,31 +2190,51 @@ msgstr "경고"
 msgid "Alerts & Reports"
 msgstr "경고 및 리포트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Alerts & reports"
-msgstr ""
+msgstr "알림 및 보고서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Align +/-"
-msgstr ""
+msgstr "+/- 정렬"
 
 #, fuzzy
 msgid "Align +/- for all columns"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All"
-msgstr ""
+msgstr "전체"
 
 #, fuzzy, python-format
 msgid "All %s hidden columns"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All Text"
-msgstr ""
+msgstr "모든 텍스트"
 
 msgid "All charts"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "All charts/global scoping"
-msgstr ""
+msgstr "모든 차트/전역 범위"
 
 #, fuzzy
 msgid "All dimensions"
@@ -1440,115 +2243,227 @@ msgstr "대시보드 저장"
 msgid "All filters"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "All panels"
-msgstr ""
+msgstr "모든 패널"
 
 #, fuzzy
 msgid "All records"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow CREATE TABLE AS"
-msgstr ""
+msgstr "CREATE TABLE AS 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow CREATE VIEW AS"
-msgstr ""
+msgstr "CREATE VIEW AS 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow DDL and DML"
-msgstr ""
+msgstr "DDL 및 DML 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow changing catalogs"
-msgstr ""
+msgstr "카탈로그 변경 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow column names to be changed to case insensitive format, if supported"
 " (e.g. Oracle, Snowflake)."
-msgstr ""
+msgstr "지원되는 경우(예: Oracle, Snowflake) 열 이름을 대소문자 구분 없는 형식으로 변경하도록 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow columns to be rearranged"
-msgstr ""
+msgstr "열 재정렬 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new tables based on queries"
-msgstr ""
+msgstr "쿼리를 기반으로 새 테이블 생성 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow creation of new values"
-msgstr ""
+msgstr "새 값 생성 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow creation of new views based on queries"
-msgstr ""
+msgstr "쿼리를 기반으로 새 뷰 생성 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow data manipulation language"
-msgstr ""
+msgstr "데이터 조작 언어 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Allow end user to drag-and-drop column headers to rearrange them. Note "
 "their changes won't persist for the next time they open the chart."
-msgstr ""
+msgstr "최종 사용자가 열 헤더를 드래그 앤 드롭하여 재정렬할 수 있도록 허용합니다. 변경 사항은 다음에 차트를 열 때 유지되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Allow file uploads to database"
-msgstr ""
+msgstr "데이터베이스에 파일 업로드 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Allow node selections"
-msgstr ""
+msgstr "노드 선택 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Allow the execution of DDL (Data Definition Language: CREATE, DROP, "
 "TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, "
 "DELETE, etc)"
 msgstr ""
+"DDL(데이터 정의 언어: CREATE, DROP, TRUNCATE 등) 및 DML(데이터 수정 언어: INSERT, UPDATE,"
+" DELETE 등)의 실행 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be explored"
-msgstr ""
+msgstr "이 데이터베이스 탐색 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allow this database to be queried in SQL Lab"
-msgstr ""
+msgstr "SQL Lab에서 이 데이터베이스 쿼리 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Allow users to select multiple values"
-msgstr ""
+msgstr "사용자가 여러 값을 선택하도록 허용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Allowed Domains (comma separated)"
-msgstr ""
+msgstr "허용된 도메인 (쉼표로 구분)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Alphabetical"
-msgstr ""
+msgstr "알파벳 순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Also known as a box and whisker plot, this visualization compares the "
 "distributions of a related metric across multiple groups. The box in the "
 "middle emphasizes the mean, median, and inner 2 quartiles. The whiskers "
 "around each box visualize the min, max, range, and outer 2 quartiles."
 msgstr ""
+"상자 수염 그림이라고도 하는 이 시각화는 여러 그룹에 걸쳐 관련 지표의 분포를 비교합니다. 중간의 상자는 평균, 중앙값 및 내부 "
+"2개의 사분위수를 강조합니다. 각 상자 주위의 수염은 최솟값, 최댓값, 범위 및 외부 2개의 사분위수를 시각화합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Altered"
-msgstr ""
+msgstr "변경됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Always filter main datetime column"
-msgstr ""
+msgstr "항상 기본 날짜/시간 열 필터링"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "An Error Occurred"
-msgstr ""
+msgstr "오류가 발생했습니다"
 
 #, fuzzy, python-format
 msgid "An alert named \"%(name)s\" already exists"
 msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An enclosed time range (both start and end) must be specified when using "
 "a Time Comparison."
-msgstr ""
+msgstr "시간 비교를 사용할 때는 시작과 끝이 모두 있는 닫힌 시간 범위를 지정해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An engine must be specified when passing individual parameters to a "
 "database."
-msgstr ""
+msgstr "데이터베이스에 개별 매개변수를 전달할 때는 엔진을 지정해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error has occurred"
-msgstr ""
+msgstr "오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred"
-msgstr ""
+msgstr "오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred saving dataset"
-msgstr ""
+msgstr "데이터셋 저장 중 오류가 발생했습니다"
 
 #, fuzzy
 msgid "An error occurred when running alert query"
@@ -1570,10 +2485,14 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while adding semantic views"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
 "administrator."
-msgstr ""
+msgstr "테이블 스키마를 축소하는 중 오류가 발생했습니다. 관리자에게 문의하세요."
 
 #, fuzzy, python-format
 msgid "An error occurred while creating %ss: %s"
@@ -1583,8 +2502,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while creating the copy link."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred while creating the data source"
-msgstr ""
+msgstr "데이터 소스를 생성하는 중 오류가 발생했습니다"
 
 #, fuzzy
 msgid "An error occurred while creating the extension."
@@ -1606,10 +2529,14 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while deleting the value."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while expanding the table schema. Please contact your "
 "administrator."
-msgstr ""
+msgstr "테이블 스키마를 확장하는 중 오류가 발생했습니다. 관리자에게 문의하십시오."
 
 #, fuzzy, python-format
 msgid "An error occurred while fetching %s"
@@ -1650,9 +2577,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while fetching available views"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "An error occurred while fetching chart owners values: %s"
-msgstr ""
+msgstr "차트 소유자 값을 가져오는 중 오류가 발생했습니다: %s"
 
 #, fuzzy
 msgid "An error occurred while fetching connections"
@@ -1690,16 +2620,23 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while fetching dataset related data: %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred while fetching function names."
-msgstr ""
+msgstr "함수 이름을 가져오는 중 오류가 발생했습니다."
 
 #, fuzzy, python-format
 msgid "An error occurred while fetching owners values: %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "An error occurred while fetching schema values: %s"
-msgstr ""
+msgstr "스키마 값을 가져오는 중 오류가 발생했습니다: %s"
 
 #, fuzzy
 msgid "An error occurred while fetching semantic layer types"
@@ -1719,10 +2656,14 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while fetching table metadata for %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while fetching table metadata. Please contact your "
 "administrator."
-msgstr ""
+msgstr "테이블 메타데이터를 가져오는 중 오류가 발생했습니다. 관리자에게 문의하십시오."
 
 #, fuzzy
 msgid "An error occurred while fetching the configuration schema"
@@ -1764,8 +2705,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while loading dashboard information."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred while loading the SQL"
-msgstr ""
+msgstr "SQL을 불러오는 중 오류가 발생했습니다"
 
 #, fuzzy
 msgid "An error occurred while overwriting the dataset"
@@ -1775,20 +2720,32 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while parsing the key."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred while pruning logs "
-msgstr ""
+msgstr "로그를 정리하는 중 오류가 발생했습니다 "
 
 #, fuzzy
 msgid "An error occurred while refreshing the configuration schema"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "An error occurred while removing query. Please contact your administrator."
-msgstr ""
+msgstr "쿼리를 제거하는 중 오류가 발생했습니다. 관리자에게 문의하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while removing the table schema. Please contact your "
 "administrator."
-msgstr ""
+msgstr "테이블 스키마를 제거하는 중 오류가 발생했습니다. 관리자에게 문의하십시오."
 
 #, fuzzy, python-format
 msgid "An error occurred while rendering the visualization: %s"
@@ -1802,11 +2759,15 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while starring this chart"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "An error occurred while storing your query in the backend. To avoid "
 "losing your changes, please save your query using the \"Save Query\" "
 "button."
-msgstr ""
+msgstr "백엔드에 쿼리를 저장하는 중 오류가 발생했습니다. 변경 사항을 잃지 않으려면 \"쿼리 저장\" 버튼을 사용하여 쿼리를 저장하십시오."
 
 #, fuzzy, python-format
 msgid "An error occurred while syncing permissions for %s: %s"
@@ -1832,17 +2793,33 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "An error occurred while upserting the value."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "An unexpected error occurred"
-msgstr ""
+msgstr "예기치 않은 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Anchor to"
-msgstr ""
+msgstr "앵커 대상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to end progress axis"
-msgstr ""
+msgstr "진행 축을 종료할 각도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Angle at which to start progress axis"
-msgstr ""
+msgstr "진행 축을 시작할 각도"
 
 #, fuzzy
 msgid "Animation"
@@ -1858,30 +2835,54 @@ msgstr "주석 레이어"
 msgid "Annotation Layers"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation Slice Configuration"
-msgstr ""
+msgstr "어노테이션 슬라이스 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be created."
-msgstr ""
+msgstr "어노테이션을 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation could not be updated."
-msgstr ""
+msgstr "어노테이션을 업데이트할 수 없습니다."
 
 msgid "Annotation layer"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer could not be created."
-msgstr ""
+msgstr "어노테이션 레이어를 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer could not be updated."
-msgstr ""
+msgstr "어노테이션 레이어를 업데이트할 수 없습니다."
 
 #, fuzzy
 msgid "Annotation layer description columns"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer has associated annotations."
-msgstr ""
+msgstr "어노테이션 레이어에 연결된 어노테이션이 있습니다."
 
 #, fuzzy
 msgid "Annotation layer interval end"
@@ -1897,8 +2898,12 @@ msgstr "주석 레이어"
 msgid "Annotation layer opacity"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layer parameters are invalid."
-msgstr ""
+msgstr "어노테이션 레이어 매개변수가 유효하지 않습니다."
 
 #, fuzzy
 msgid "Annotation layer stroke"
@@ -1922,8 +2927,12 @@ msgstr "주석 레이어"
 msgid "Annotation layers"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation layers are still loading."
-msgstr ""
+msgstr "어노테이션 레이어를 아직 불러오는 중입니다."
 
 #, fuzzy
 msgid "Annotation layers could not be deleted."
@@ -1932,8 +2941,12 @@ msgstr "대시보드를 삭제할 수 없습니다."
 msgid "Annotation not found."
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotation parameters are invalid."
-msgstr ""
+msgstr "어노테이션 매개변수가 유효하지 않습니다."
 
 #, fuzzy
 msgid "Annotation source"
@@ -1958,46 +2971,87 @@ msgstr "주석 레이어"
 msgid "Annotations and layers"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Annotations could not be deleted."
-msgstr ""
+msgstr "어노테이션을 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ant Design Theme Editor"
-msgstr ""
+msgstr "Ant Design 테마 편집기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Any"
-msgstr ""
+msgstr "모두"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Any additional detail to show in the certification tooltip."
-msgstr ""
+msgstr "인증 툴팁에 표시할 추가 세부 정보."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Any color palette selected here will override the colors applied to this "
 "dashboard's individual charts"
-msgstr ""
+msgstr "여기서 선택한 색상 팔레트는 이 대시보드의 개별 차트에 적용된 색상을 재정의합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Any dashboards using these themes will be automatically dissociated from "
 "them."
-msgstr ""
+msgstr "이 테마들을 사용하는 모든 대시보드는 자동으로 연결 해제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Any dashboards using this theme will be automatically dissociated from it."
-msgstr ""
+msgstr "이 테마를 사용하는 모든 대시보드는 자동으로 연결 해제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
-msgstr ""
+msgstr "SQL Alchemy URI를 통해 연결을 허용하는 모든 데이터베이스를 추가할 수 있습니다. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Any databases that allow connections via SQL Alchemy URIs can be added. "
 "Learn about how to connect a database driver "
 msgstr ""
+"SQL Alchemy URI를 통해 연결을 허용하는 모든 데이터베이스를 추가할 수 있습니다. 데이터베이스 드라이버 연결 방법 "
+"알아보기 "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Applied cross-filters (%d)"
-msgstr ""
+msgstr "적용된 교차 필터 (%d)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Applied filters (%d)"
-msgstr ""
+msgstr "적용된 필터 (%d)"
 
 #, fuzzy, python-format
 msgid "Applied filters (%s)"
@@ -2007,19 +3061,30 @@ msgstr "테이블 추가"
 msgid "Applied filters: %s"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Applied rolling window did not return any data. Please make sure the "
 "source query satisfies the minimum periods defined in the rolling window."
-msgstr ""
+msgstr "적용된 롤링 윈도우가 데이터를 반환하지 않았습니다. 소스 쿼리가 롤링 윈도우에 정의된 최소 기간을 충족하는지 확인하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
-msgstr ""
+msgstr "\"셀 막대\" 형식이 선택된 경우에만 적용됩니다: \"셀 막대 표시\" 플래그가 활성화된 경우 히스토그램 열의 배경이 표시됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply"
-msgstr ""
+msgstr "적용"
 
 #, fuzzy
 msgid "Apply Filter"
@@ -2033,16 +3098,27 @@ msgstr "대시보드를 생성할 수 없습니다."
 msgid "Apply conditional color formatting to metric"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to metrics"
-msgstr ""
+msgstr "지표에 조건부 색상 서식 적용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Apply conditional color formatting to numeric columns"
-msgstr ""
+msgstr "숫자 열에 조건부 색상 서식 적용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Apply custom CSS to the dashboard. Use class names or element selectors "
 "to target specific components."
-msgstr ""
+msgstr "대시보드에 사용자 정의 CSS를 적용합니다. 클래스 이름이나 요소 선택자를 사용하여 특정 구성요소를 대상으로 지정합니다."
 
 #, fuzzy
 msgid "Apply filters"
@@ -2052,95 +3128,177 @@ msgstr "필터"
 msgid "Apply metrics on"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "April"
-msgstr ""
+msgstr "4월"
 
 #, fuzzy
 msgid "Arc"
 msgstr "검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you intend to overwrite the following values?"
-msgstr ""
+msgstr "다음 값을 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to cancel?"
-msgstr ""
+msgstr "취소하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete"
-msgstr ""
+msgstr "정말로 삭제하시겠습니까"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete %s?"
-msgstr ""
+msgstr "%s을(를) 삭제하시겠습니까?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Are you sure you want to delete the selected %s?"
-msgstr ""
+msgstr "선택한 %s을(를) 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected annotations?"
-msgstr ""
+msgstr "선택한 어노테이션을 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected charts?"
-msgstr ""
+msgstr "선택한 차트를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected dashboards?"
-msgstr ""
+msgstr "선택한 대시보드를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected groups?"
-msgstr ""
+msgstr "선택한 그룹을 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected layers?"
-msgstr ""
+msgstr "선택한 레이어를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected roles?"
-msgstr ""
+msgstr "선택한 역할을 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected rules?"
-msgstr ""
+msgstr "선택한 규칙을 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected tags?"
-msgstr ""
+msgstr "선택한 태그를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to delete the selected templates?"
-msgstr ""
+msgstr "선택한 템플릿을 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected themes?"
-msgstr ""
+msgstr "선택한 테마를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Are you sure you want to delete the selected users?"
-msgstr ""
+msgstr "선택한 사용자를 삭제하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Are you sure you want to overwrite this dataset?"
-msgstr ""
+msgstr "이 데이터셋을 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system dark theme? The application "
 "will fall back to the configuration file dark theme."
-msgstr ""
+msgstr "시스템 다크 테마를 제거하시겠습니까? 애플리케이션이 구성 파일의 다크 테마로 돌아갑니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Are you sure you want to remove the system default theme? The application"
 " will fall back to the configuration file default."
-msgstr ""
+msgstr "시스템 기본 테마를 제거하시겠습니까? 애플리케이션이 구성 파일의 기본값으로 돌아갑니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
-msgstr ""
+msgstr "이 API 키를 취소하시겠습니까? 이 작업은 취소할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Are you sure you want to save and apply changes?"
-msgstr ""
+msgstr "변경 사항을 저장하고 적용하시겠습니까?"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system dark theme? This will "
 "apply to all users who haven't set a personal preference."
-msgstr ""
+msgstr "\"%s\"을(를) 시스템 다크 테마로 설정하시겠습니까? 개인 설정을 하지 않은 모든 사용자에게 적용됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Are you sure you want to set \"%s\" as the system default theme? This "
 "will apply to all users who haven't set a personal preference."
-msgstr ""
+msgstr "\"%s\"을(를) 시스템 기본 테마로 설정하시겠습니까? 개인 설정을 하지 않은 모든 사용자에게 적용됩니다."
 
 #, fuzzy
 msgid "Area"
@@ -2154,76 +3312,138 @@ msgstr "차트 보기"
 msgid "Area chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Area chart opacity"
-msgstr ""
+msgstr "영역 차트 불투명도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Area charts are similar to line charts in that they represent variables "
 "with the same scale, but area charts stack the metrics on top of each "
 "other."
-msgstr ""
+msgstr "영역 차트는 동일한 척도로 변수를 나타낸다는 점에서 선형 차트와 유사하지만, 영역 차트는 지표들을 서로 겹쳐 쌓습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Arrow"
-msgstr ""
+msgstr "화살표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Assign a set of parameters as"
-msgstr ""
+msgstr "매개변수 세트를 다음으로 할당"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Assist"
-msgstr ""
+msgstr "어시스트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Asynchronous query execution"
-msgstr ""
+msgstr "비동기 쿼리 실행"
 
 #, fuzzy
 msgid "Attribution"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "August"
-msgstr ""
+msgstr "8월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization Request URI"
-msgstr ""
+msgstr "인가 요청 URI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization needed"
-msgstr ""
+msgstr "인가 필요"
 
 #, fuzzy
 msgid "Auto"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Auto Zoom"
-msgstr ""
+msgstr "자동 줌"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "자동 새로고침 일시 정지(%s초로 설정됨)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
-msgstr ""
+msgstr "자동 새로고침 일시 정지 - 탭 비활성화(%s초로 설정됨)"
 
 #, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Auto-detect"
-msgstr ""
+msgstr "자동 감지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete"
-msgstr ""
+msgstr "자동 완성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete filters"
-msgstr ""
+msgstr "자동 완성 필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Autocomplete query predicate"
-msgstr ""
+msgstr "자동 완성 쿼리 조건"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on available space"
-msgstr ""
+msgstr "사용 가능한 공간을 기반으로 열 너비 자동 조정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Automatically adjust column width based on content"
-msgstr ""
+msgstr "콘텐츠를 기반으로 열 너비 자동 조정"
 
 #, fuzzy
 msgid "Automatically sync columns"
@@ -2245,8 +3465,12 @@ msgstr "컬럼 목록"
 msgid "Autosize all columns"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Available sorting modes:"
-msgstr ""
+msgstr "사용 가능한 정렬 모드:"
 
 #, fuzzy
 msgid "Average"
@@ -2260,8 +3484,12 @@ msgstr "원본 값"
 msgid "Awaiting filter selection"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis"
-msgstr ""
+msgstr "축"
 
 #, fuzzy
 msgid "Axis Bounds"
@@ -2271,61 +3499,122 @@ msgstr "컬럼 목록"
 msgid "Axis Format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Axis Title"
-msgstr ""
+msgstr "축 제목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis ascending"
-msgstr ""
+msgstr "축 오름차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Axis descending"
-msgstr ""
+msgstr "축 내림차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Axis title margin"
-msgstr ""
+msgstr "축 제목 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Axis title position"
-msgstr ""
+msgstr "축 제목 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "BCC recipients"
-msgstr ""
+msgstr "숨은 참조(BCC) 수신자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "BOOLEAN"
-msgstr ""
+msgstr "불리언(BOOLEAN)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back"
-msgstr ""
+msgstr "뒤로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Back to all"
-msgstr ""
+msgstr "전체로 돌아가기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Backend"
-msgstr ""
+msgstr "백엔드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Background Color"
-msgstr ""
+msgstr "배경색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Backward values"
-msgstr ""
+msgstr "이전 값"
 
 #, fuzzy
 msgid "Bad formula."
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bad spatial key"
-msgstr ""
+msgstr "잘못된 공간 키"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bar"
-msgstr ""
+msgstr "막대"
 
 #, fuzzy
 msgid "Bar Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bar Charts are used to show metrics as a series of bars."
-msgstr ""
+msgstr "막대 차트는 지표를 일련의 막대로 표시하는 데 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bar Values"
-msgstr ""
+msgstr "막대 값"
 
 #, fuzzy
 msgid "Bar orientation"
@@ -2343,61 +3632,110 @@ msgstr "데이터베이스"
 msgid "Base height"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
-msgstr ""
+msgstr "기본 레이어 맵 스타일. MapLibre 호환 스타일 URL을 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
-msgstr ""
+msgstr "기본 레이어 맵 스타일. Mapbox 스타일 URL(mapbox://styles/...)을 허용합니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
-msgstr ""
+msgstr "기본 레이어 맵 스타일. MapLibre 문서를 참조하세요: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Base slope"
-msgstr ""
+msgstr "기본 기울기"
 
 #, fuzzy
 msgid "Base width"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Based on a metric"
-msgstr ""
+msgstr "지표를 기반으로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Based on granularity, number of time periods to compare against"
-msgstr ""
+msgstr "세분성에 따른 비교할 시간 기간 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Based on what should series be ordered on the chart and legend"
-msgstr ""
+msgstr "차트와 범례에서 계열의 정렬 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Basic"
-msgstr ""
+msgstr "기본"
 
 #, fuzzy
 msgid "Basic conditional formatting"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Basic information about the chart"
-msgstr ""
+msgstr "차트에 대한 기본 정보"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Batch editing %d filters:"
-msgstr ""
+msgstr "%d개의 필터 일괄 편집:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Be careful."
-msgstr ""
+msgstr "주의하세요."
 
 #, fuzzy
 msgid "Before"
 msgstr "새로고침 간격"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Big Number"
-msgstr ""
+msgstr "큰 숫자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Big Number with Time Period Comparison"
-msgstr ""
+msgstr "기간 비교가 있는 큰 숫자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Big Number with Trendline"
-msgstr ""
+msgstr "추세선이 있는 큰 숫자"
 
 #, fuzzy
 msgid "Bins"
@@ -2407,9 +3745,11 @@ msgstr "활동"
 msgid "Blanks"
 msgstr "활동"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "%(block_count)s 중 %(block_num)s번째 블록"
 
 #, fuzzy
 msgid "Border color"
@@ -2423,59 +3763,99 @@ msgstr "차트 유형"
 msgid "Bottom"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom Margin"
-msgstr ""
+msgstr "하단 여백"
 
 #, fuzzy
 msgid "Bottom left"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom margin, in pixels, allowing for more room for axis labels"
-msgstr ""
+msgstr "축 레이블을 위한 공간을 더 확보하는 하단 여백(픽셀 단위)"
 
 #, fuzzy
 msgid "Bottom right"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bottom to Top"
-msgstr ""
+msgstr "아래에서 위로"
 
 #, fuzzy
 msgid "Bounds"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for numerical X axis. Not applicable for temporal or categorical "
 "axes. When left empty, the bounds are dynamically defined based on the "
 "min/max of the data. Note that this feature will only expand the axis "
 "range. It won't narrow the data's extent."
 msgstr ""
+"수치형 X축의 범위. 시간적 또는 범주형 축에는 적용되지 않습니다. 비어 있으면 데이터의 최솟값/최댓값을 기반으로 동적으로 "
+"정의됩니다. 이 기능은 축 범위만 확장합니다. 데이터의 범위를 좁히지는 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the X-axis. Selected time merges with min/max date of the "
 "data. When left empty, bounds dynamically defined based on the min/max of"
 " the data."
-msgstr ""
+msgstr "X축 범위. 선택한 시간은 데이터의 최소/최대 날짜와 병합됩니다. 비어 있으면 데이터의 최솟값/최댓값을 기반으로 동적으로 정의됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Bounds for the Y-axis. When left empty, the bounds are dynamically "
 "defined based on the min/max of the data. Note that this feature will "
 "only expand the axis range. It won't narrow the data's extent."
 msgstr ""
+"Y축의 범위. 비어 있으면 데이터의 최솟값/최댓값을 기반으로 동적으로 정의됩니다. 이 기능은 축 범위만 확장합니다. 데이터의 범위를"
+" 좁히지는 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Bounds for the axis. When left empty, the bounds are dynamically defined "
 "based on the min/max of the data. Note that this feature will only expand"
 " the axis range. It won't narrow the data's extent."
 msgstr ""
+"축의 범위. 비어 있으면 데이터의 최솟값/최댓값을 기반으로 동적으로 정의됩니다. 이 기능은 축 범위만 확장합니다. 데이터의 범위를 "
+"좁히지는 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the primary Y-axis. When left empty, the bounds are "
 "dynamically defined based on the min/max of the data. Note that this "
 "feature will only expand the axis range. It won't narrow the data's "
 "extent."
 msgstr ""
+"기본 Y축의 범위. 비어 있으면 데이터의 최솟값/최댓값을 기반으로 동적으로 정의됩니다. 이 기능은 축 범위만 확장합니다. 데이터의 "
+"범위를 좁히지는 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Bounds for the secondary Y-axis. Only works when Independent Y-axis\n"
 "                bounds are enabled. When left empty, the bounds are "
@@ -2484,9 +3864,17 @@ msgid ""
 "will only expand\n"
 "                the axis range. It won't narrow the data's extent."
 msgstr ""
+"보조 Y축의 범위. 독립 Y축 범위가 활성화된 경우에만 작동합니다.\n"
+"                비어 있으면 데이터의 최솟값/최댓값을 기반으로\n"
+"                동적으로 정의됩니다. 이 기능은 축 범위만\n"
+"                확장합니다. 데이터의 범위를 좁히지는 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Box Plot"
-msgstr ""
+msgstr "상자 그림"
 
 #, fuzzy
 msgid "Breakdowns"
@@ -2496,11 +3884,16 @@ msgstr "생성자"
 msgid "Breakpoint Metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
 "      This can help viewers understand how each category affects the "
 "overall value."
 msgstr ""
+"이 컨트롤에 지정된 범주별로 계열을 분류합니다.\n"
+"      이를 통해 각 범주가 전체 값에 미치는 영향을 파악할 수 있습니다."
 
 msgid "Bubble Chart"
 msgstr "버블 차트"
@@ -2509,95 +3902,197 @@ msgstr "버블 차트"
 msgid "Bubble Chart (legacy)"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bubble Color"
-msgstr ""
+msgstr "버블 색상"
 
 #, fuzzy
 msgid "Bubble Opacity"
 msgstr "버블 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bubble Size"
-msgstr ""
+msgstr "버블 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Bubble size"
-msgstr ""
+msgstr "버블 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Bubble size number format"
-msgstr ""
+msgstr "버블 크기 숫자 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Bucket break points"
-msgstr ""
+msgstr "버킷 분할점"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Bulk select"
-msgstr ""
+msgstr "일괄 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Bulk tag"
-msgstr ""
+msgstr "일괄 태그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Bullet Chart"
-msgstr ""
+msgstr "불릿 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Business"
-msgstr ""
+msgstr "비즈니스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "By default, each filter loads at most 1000 choices at the initial page "
 "load. Check this box if you have more than 1000 filter values and want to"
 " enable dynamically searching that loads filter values as users type (may"
 " add stress to your database)."
 msgstr ""
+"기본적으로 각 필터는 초기 페이지 로드 시 최대 1000개의 항목을 로드합니다. 필터 값이 1000개를 초과하고 사용자가 입력하는 "
+"동안 필터 값을 로드하는 동적 검색을 활성화하려면 이 확인란을 선택하세요(데이터베이스에 부하를 줄 수 있습니다)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use column names as sorting key"
-msgstr ""
+msgstr "키 기준: 열 이름을 정렬 키로 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By key: use row names as sorting key"
-msgstr ""
+msgstr "키 기준: 행 이름을 정렬 키로 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "By value: use metric values as sorting key"
-msgstr ""
+msgstr "값 기준: 지표 값을 정렬 키로 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CANCEL"
-msgstr ""
+msgstr "취소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CC recipients"
-msgstr ""
+msgstr "참조 수신자"
 
 #, fuzzy
 msgid "COPY QUERY"
 msgstr "Query 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "쿼리 복사"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "CREATE TABLE AS"
-msgstr ""
+msgstr "CREATE TABLE AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "CREATE VIEW AS"
-msgstr ""
+msgstr "CREATE VIEW AS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CREATE VIEW statement"
-msgstr ""
+msgstr "CREATE VIEW 구문"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CRON Schedule"
-msgstr ""
+msgstr "CRON 일정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "CRON expression"
-msgstr ""
+msgstr "CRON 표현식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS Styles"
-msgstr ""
+msgstr "CSS 스타일"
 
 msgid "CSS Templates"
 msgstr "CSS 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "CSS applied to the chart"
-msgstr ""
+msgstr "차트에 적용된 CSS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"CSS 스타일은 서버 측 HTML 정리에 의해 제거될 수 있습니다. 스타일이 적용되지 않는 경우, Superset 관리자에게 "
+"HTML 정리 구성을 조정하도록 요청하세요."
 
 msgid "CSS template"
 msgstr "CSS 템플릿"
@@ -2616,74 +4111,139 @@ msgstr "CSS 템플릿을 삭제할 수 없습니다."
 msgid "CSV Export"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "CSV file downloaded successfully"
-msgstr ""
+msgstr "CSV 파일이 성공적으로 다운로드되었습니다"
 
 #, fuzzy
 msgid "CSV upload"
 msgstr "CSV 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CTAS & CVAS SCHEMA"
-msgstr ""
+msgstr "CTAS 및 CVAS 스키마"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CTAS (create table as select) can only be run with a query where the last"
 " statement is a SELECT. Please make sure your query has a SELECT as its "
 "last statement. Then, try running your query again."
 msgstr ""
+"CTAS (create table as select)는 마지막 구문이 SELECT인 쿼리에서만 실행할 수 있습니다. 쿼리의 마지막 "
+"구문이 SELECT인지 확인하세요. 그런 다음 쿼리를 다시 실행해 보세요."
 
 #, fuzzy
 msgid "CUSTOM"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "CVAS (create view as select) can only be run with a query with a single "
 "SELECT statement. Please make sure your query has only a SELECT "
 "statement. Then, try running your query again."
 msgstr ""
+"CVAS (create view as select)는 단일 SELECT 구문이 포함된 쿼리에서만 실행할 수 있습니다. 쿼리에 "
+"SELECT 구문만 있는지 확인하세요. 그런 다음 쿼리를 다시 실행해 보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query has more than one statement."
-msgstr ""
+msgstr "CVAS (create view as select) 쿼리에 구문이 두 개 이상 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "CVAS (create view as select) query is not a SELECT statement."
-msgstr ""
+msgstr "CVAS (create view as select) 쿼리가 SELECT 구문이 아닙니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Cache Timeout (seconds)"
-msgstr ""
+msgstr "캐시 만료 시간(초)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
+"각 사용자의 데이터 접근 역할과 권한에 따라 사용자별로 데이터를 별도로 캐시합니다. 비활성화하면 모든 사용자에게 단일 캐시가 "
+"사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Cache timeout"
-msgstr ""
+msgstr "캐시 만료 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Cache timeout must be a number"
-msgstr ""
+msgstr "캐시 만료 시간은 숫자여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cached"
-msgstr ""
+msgstr "캐시됨"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cached %s"
-msgstr ""
+msgstr "캐시됨 %s"
 
 msgid "Cached value not found"
 msgstr "캐시된 값을 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate contribution per series or row"
-msgstr ""
+msgstr "계열 또는 행별 기여도 계산"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from first step"
-msgstr ""
+msgstr "첫 번째 단계부터 계산"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Calculate from previous step"
-msgstr ""
+msgstr "이전 단계부터 계산"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Calculated column [%s] requires an expression"
-msgstr ""
+msgstr "계산된 열 [%s]에는 수식이 필요합니다"
 
 msgid "Calculated columns"
 msgstr "컬럼 목록"
@@ -2694,11 +4254,19 @@ msgstr "시각화 유형 선택"
 msgid "Calendar Heatmap"
 msgstr "달력 히트캡"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Can not move top level tab into nested tabs"
-msgstr ""
+msgstr "최상위 탭을 중첩 탭으로 이동할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Can select multiple values"
-msgstr ""
+msgstr "여러 값을 선택할 수 있습니다"
 
 msgid "Cancel"
 msgstr "취소"
@@ -2707,46 +4275,89 @@ msgstr "취소"
 msgid "Cancel Task"
 msgstr "취소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cancel query on window unload event"
-msgstr ""
+msgstr "창 닫기 이벤트 시 쿼리 취소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "중단 핸들러가 없어 취소를 사용할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot access the query"
-msgstr ""
+msgstr "쿼리에 접근할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot delete a database that has datasets attached"
-msgstr ""
+msgstr "데이터셋이 연결된 데이터베이스는 삭제할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete system themes"
-msgstr ""
+msgstr "시스템 테마를 삭제할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
-msgstr ""
+msgstr "시스템 기본 테마 또는 다크 테마로 설정된 테마는 삭제할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
-msgstr ""
+msgstr "시스템 기본 테마 또는 다크 테마로 설정된 테마는 삭제할 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Cannot find the table (%s) metadata."
-msgstr ""
+msgstr "테이블 (%s) 메타데이터를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cannot have multiple credentials for the SSH Tunnel"
-msgstr ""
+msgstr "SSH 터널에 대한 자격 증명이 여러 개일 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cannot load filter"
-msgstr ""
+msgstr "필터를 불러올 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot modify system themes."
-msgstr ""
+msgstr "시스템 테마를 수정할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "기본 폴더 안에 폴더를 중첩할 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
-msgstr ""
+msgstr "시간 문자열 [%(human_readable)s]을(를) 파싱할 수 없습니다"
 
 #, fuzzy
 msgid "Captcha"
@@ -2756,59 +4367,113 @@ msgstr "차트 보기"
 msgid "Cartodiagram"
 msgstr "실패"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Catalog"
-msgstr ""
+msgstr "카탈로그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categorical"
-msgstr ""
+msgstr "범주형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Categorical Color"
-msgstr ""
+msgstr "범주형 색상"
 
 #, fuzzy
 msgid "Categorical palette"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Categories to group by on the x-axis."
-msgstr ""
+msgstr "X축에서 그룹화할 카테고리."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category"
-msgstr ""
+msgstr "카테고리"
 
 #, fuzzy
 msgid "Category Name"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Percentage"
-msgstr ""
+msgstr "카테고리 및 백분율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category and Value"
-msgstr ""
+msgstr "카테고리 및 값"
 
 #, fuzzy
 msgid "Category name"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Category of target nodes"
-msgstr ""
+msgstr "대상 노드의 카테고리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Category, Value and Percentage"
-msgstr ""
+msgstr "카테고리, 값 및 백분율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Padding"
-msgstr ""
+msgstr "셀 패딩"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Radius"
-msgstr ""
+msgstr "셀 반경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell Size"
-msgstr ""
+msgstr "셀 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cell content"
-msgstr ""
+msgstr "셀 내용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cell layout & styling"
-msgstr ""
+msgstr "셀 레이아웃 및 스타일"
 
 #, fuzzy
 msgid "Cell limit"
@@ -2818,8 +4483,11 @@ msgstr "구분자"
 msgid "Cell title template"
 msgstr "템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Centroid (Longitude and Latitude): "
-msgstr ""
+msgstr "중심점(경도 및 위도): "
 
 #, fuzzy
 msgid "Certification"
@@ -2829,8 +4497,12 @@ msgstr "주석 레이어"
 msgid "Certification and additional settings"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Certification details"
-msgstr ""
+msgstr "인증 세부 정보"
 
 #, fuzzy
 msgid "Certified"
@@ -2843,15 +4515,26 @@ msgstr "수정됨"
 msgid "Certified by"
 msgstr "수정됨"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Certified by %s"
-msgstr ""
+msgstr "%s에 의해 인증됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of columns."
-msgstr ""
+msgstr "열 순서를 변경합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Change order of rows."
-msgstr ""
+msgstr "행 순서를 변경합니다."
 
 #, fuzzy
 msgid "Changed by"
@@ -2861,47 +4544,82 @@ msgstr "관리"
 msgid "Changed on"
 msgstr "관리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changes saved."
-msgstr ""
+msgstr "변경 사항이 저장되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Changes the sort value of the items in the legend only"
-msgstr ""
+msgstr "범례의 항목 정렬 값만 변경합니다"
 
 #, fuzzy
 msgid "Changing one or more of these dashboards is forbidden"
 msgstr "이 차트를 변경하는 것은 불가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing the dataset may break the chart if the chart relies on columns "
 "or metadata that does not exist in the target dataset"
-msgstr ""
+msgstr "대상 데이터셋에 존재하지 않는 열이나 메타데이터에 차트가 의존하는 경우, 데이터셋을 변경하면 차트가 손상될 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Changing these settings will affect all charts using this dataset, "
 "including charts owned by other people."
-msgstr ""
+msgstr "이 설정을 변경하면 다른 사람이 소유한 차트를 포함하여 이 데이터셋을 사용하는 모든 차트에 영향을 미칩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this Dashboard is forbidden"
-msgstr ""
+msgstr "이 대시보드를 변경하는 것은 금지되어 있습니다"
 
 msgid "Changing this chart is forbidden"
 msgstr "이 차트를 변경하는 것은 불가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this control takes effect instantly"
-msgstr ""
+msgstr "이 컨트롤의 변경 사항은 즉시 적용됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this dataset is forbidden"
-msgstr ""
+msgstr "이 데이터셋을 변경하는 것은 금지되어 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Changing this dataset is forbidden."
-msgstr ""
+msgstr "이 데이터셋을 변경하는 것은 금지되어 있습니다."
 
 #, fuzzy
 msgid "Changing this datasource is forbidden"
 msgstr "이 차트를 변경하는 것은 불가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Changing this report is forbidden"
-msgstr ""
+msgstr "이 보고서를 변경하는 것은 금지되어 있습니다"
 
 #, fuzzy
 msgid "Changing this semantic layer is forbidden"
@@ -2915,26 +4633,39 @@ msgstr "이 차트를 변경하는 것은 불가능합니다"
 msgid "Changing this task is forbidden"
 msgstr "이 차트를 변경하는 것은 불가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Character to interpret as decimal point"
-msgstr ""
+msgstr "소수점으로 해석할 문자"
 
 msgid "Chart"
 msgstr "차트"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "차트 %(chart_id)s는 대시보드 %(dashboard_id)s에 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Chart %(id)s not found"
-msgstr ""
+msgstr "차트 %(id)s를 찾을 수 없습니다"
 
 #, fuzzy, python-format
 msgid "Chart Data: %s"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart ID"
-msgstr ""
+msgstr "차트 ID"
 
 #, fuzzy
 msgid "Chart Options"
@@ -2944,10 +4675,12 @@ msgstr "주석"
 msgid "Chart Orientation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fr, ja, lv, mi, pl, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid "Chart Owner: %s"
 msgid_plural "Chart Owners: %s"
-msgstr[0] ""
+msgstr[0] "차트 소유자: %s"
 
 #, fuzzy
 msgid "Chart Source"
@@ -2961,23 +4694,33 @@ msgstr "차트 유형"
 msgid "Chart Type"
 msgstr "차트 유형"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] has been overwritten"
-msgstr ""
+msgstr "차트 [%s]가 덮어쓰여졌습니다"
 
 #, fuzzy, python-format
 msgid "Chart [%s] has been saved"
 msgstr "주석 레이어"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Chart [%s] was added to dashboard [%s]"
-msgstr ""
+msgstr "차트 [%s]가 대시보드 [%s]에 추가되었습니다"
 
 msgid "Chart cache timeout"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart changes"
-msgstr ""
+msgstr "차트 변경 사항"
 
 msgid "Chart could not be created."
 msgstr "차트를 생성할 수 없습니다."
@@ -2985,8 +4728,11 @@ msgstr "차트를 생성할 수 없습니다."
 msgid "Chart could not be updated."
 msgstr "차트를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
-msgstr ""
+msgstr "deck.gl 레이어 가시성을 제어하는 차트 사용자 정의"
 
 #, fuzzy
 msgid "Chart customization value is required"
@@ -2995,8 +4741,12 @@ msgstr "데이터소스"
 msgid "Chart does not exist"
 msgstr "차트가 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chart has no query context saved. Please save the chart again."
-msgstr ""
+msgstr "차트에 저장된 쿼리 컨텍스트가 없습니다. 차트를 다시 저장하십시오."
 
 #, fuzzy
 msgid "Chart height"
@@ -3048,8 +4798,12 @@ msgstr "차트 유형"
 msgid "Chart type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Chart type requires a dataset"
-msgstr ""
+msgstr "차트 유형에는 데이터셋이 필요합니다"
 
 #, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
@@ -3069,44 +4823,87 @@ msgstr "차트를 삭제할 수 없습니다."
 msgid "Charts per row"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Check for sorting ascending"
-msgstr ""
+msgstr "오름차순 정렬 확인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Check if the Rose Chart should use segment area instead of segment radius"
 " for proportioning"
-msgstr ""
+msgstr "로즈 차트가 비율 계산에 세그먼트 반지름 대신 세그먼트 면적을 사용해야 하는지 확인하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Check out this chart in dashboard:"
-msgstr ""
+msgstr "대시보드에서 이 차트를 확인하십시오:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Check out this chart: "
-msgstr ""
+msgstr "이 차트를 확인하십시오: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Check out this dashboard: "
-msgstr ""
+msgstr "이 대시보드를 확인하십시오: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Check to force date partitions to have the same height"
-msgstr ""
+msgstr "날짜 파티션의 높이를 동일하게 강제하려면 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Child label position"
-msgstr ""
+msgstr "하위 레이블 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choice of [Label] must be present in [Group By]"
-msgstr ""
+msgstr "[레이블]의 선택 항목이 [그룹화 기준]에 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choice of [Point Radius] must be present in [Group By]"
-msgstr ""
+msgstr "[포인트 반경]의 선택 항목이 [그룹화 기준]에 있어야 합니다"
 
 #, fuzzy, python-format
 msgid "Choose a %s"
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose a chart for displaying on the map"
-msgstr ""
+msgstr "지도에 표시할 차트를 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose a chart or dashboard not both"
-msgstr ""
+msgstr "차트 또는 대시보드 중 하나만 선택하십시오"
 
 #, fuzzy
 msgid "Choose a database..."
@@ -3116,11 +4913,19 @@ msgstr "데이터소스 선택"
 msgid "Choose a delimiter"
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose a metric for right axis"
-msgstr ""
+msgstr "오른쪽 축에 사용할 지표를 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose a number format"
-msgstr ""
+msgstr "숫자 형식을 선택하십시오"
 
 #, fuzzy
 msgid "Choose a source"
@@ -3138,42 +4943,66 @@ msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 msgid "Choose chart type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose columns to be parsed as dates"
-msgstr ""
+msgstr "날짜로 파싱할 열을 선택하십시오"
 
 #, fuzzy
 msgid "Choose columns to read"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
-msgstr ""
+msgstr "기존 대시보드 필터에서 선택하고 값을 지정하여 보고서 결과를 세분화하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose how many X-Axis labels to show"
-msgstr ""
+msgstr "X축 레이블을 몇 개 표시할지 선택하십시오"
 
 #, fuzzy
 msgid "Choose index column"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
-msgstr ""
+msgstr "이 대시보드의 모든 deck.gl 다중 레이어 차트에서 숨길 레이어를 선택하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose notification method and recipients."
-msgstr ""
+msgstr "알림 방법과 수신자를 선택하십시오."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Choose numbers between %(min)s and %(max)s"
-msgstr ""
+msgstr "%(min)s와 %(max)s 사이의 숫자를 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose one of the available databases from the panel on the left."
-msgstr ""
+msgstr "왼쪽 패널에서 사용 가능한 데이터베이스 중 하나를 선택하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose one of the available databases on the left panel."
-msgstr ""
+msgstr "왼쪽 패널에서 사용 가능한 데이터베이스 중 하나를 선택하십시오."
 
 #, fuzzy
 msgid "Choose sheet name"
@@ -3182,61 +5011,114 @@ msgstr "테이블 명"
 msgid "Choose the annotation layer type"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose the format for legend values"
-msgstr ""
+msgstr "범례 값의 형식을 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Choose the position of the legend"
-msgstr ""
+msgstr "범례의 위치를 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Choose the source of your annotations"
-msgstr ""
+msgstr "주석의 소스를 선택하십시오"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose values that should be treated as null. Warning: Hive database "
 "supports only a single value"
-msgstr ""
+msgstr "null로 처리할 값을 선택하십시오. 경고: Hive 데이터베이스는 단일 값만 지원합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Choose whether a country should be shaded by the metric, or assigned a "
 "color based on a categorical color palette"
-msgstr ""
+msgstr "국가를 지표에 따라 음영 처리할지, 또는 범주형 색상 팔레트에 따라 색상을 지정할지 선택하십시오"
 
 #, fuzzy
 msgid "Choose..."
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chord Diagram"
-msgstr ""
+msgstr "코드 다이어그램"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Chosen non-numeric column"
-msgstr ""
+msgstr "선택된 비수치 열"
 
 #, fuzzy
 msgid "Circle"
 msgstr "CSV 파일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Arrow"
-msgstr ""
+msgstr "원 -> 화살표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle -> Circle"
-msgstr ""
+msgstr "원 -> 원"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circle radar shape"
-msgstr ""
+msgstr "원형 레이더 모양"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Circular"
-msgstr ""
+msgstr "원형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
-msgstr ""
+msgstr "데이터셋의 고전적인 행별 열 스프레드시트 형식 보기입니다. 기본 데이터를 보거나 집계된 지표를 표시하려면 테이블을 사용하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clause"
-msgstr ""
+msgstr "조건"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear"
-msgstr ""
+msgstr "지우기"
 
 #, fuzzy, python-format
 msgid "Clear %s filter"
@@ -3246,8 +5128,12 @@ msgstr "필터"
 msgid "Clear Sort"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clear all"
-msgstr ""
+msgstr "모두 지우기"
 
 #, fuzzy
 msgid "Clear all data"
@@ -3261,47 +5147,83 @@ msgstr "필터"
 msgid "Clear default dark theme"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "기본 라이트 테마 지우기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear form"
-msgstr ""
+msgstr "양식 지우기"
 
 #, fuzzy
 msgid "Clear local theme"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear the selection to revert to the system default theme"
-msgstr ""
+msgstr "선택을 지워 시스템 기본 테마로 되돌리기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid ""
 "Click on \"Add or edit filters and controls\" option in Settings to "
 "create new dashboard filters"
-msgstr ""
+msgstr "새 대시보드 필터를 만들려면 설정에서 \"필터 및 컨트롤 추가 또는 편집\" 옵션을 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Click on \"Create chart\" button in the control panel on the left to "
 "preview a visualization or"
-msgstr ""
+msgstr "시각화를 미리 보려면 왼쪽 제어판의 \"차트 만들기\" 버튼을 클릭하거나"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to make changes."
-msgstr ""
+msgstr "변경하려면 잠금을 클릭하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click the lock to prevent further changes."
-msgstr ""
+msgstr "추가 변경을 방지하려면 잠금을 클릭하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that allows you to input "
 "the SQLAlchemy URL for this database manually."
-msgstr ""
+msgstr "이 데이터베이스의 SQLAlchemy URL을 수동으로 입력할 수 있는 대체 양식으로 전환하려면 이 링크를 클릭하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Click this link to switch to an alternate form that exposes only the "
 "required fields needed to connect this database."
-msgstr ""
+msgstr "이 데이터베이스를 연결하는 데 필요한 필수 필드만 표시하는 대체 양식으로 전환하려면 이 링크를 클릭하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to add a contour"
-msgstr ""
+msgstr "등고선을 추가하려면 클릭하세요"
 
 #, fuzzy
 msgid "Click to add new breakpoint"
@@ -3311,8 +5233,12 @@ msgstr "클릭하여 제목 수정하기"
 msgid "Click to add new layer"
 msgstr "클릭하여 제목 수정하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to cancel sorting"
-msgstr ""
+msgstr "정렬을 취소하려면 클릭하세요"
 
 msgid "Click to edit"
 msgstr "클릭하여 제목 수정하기"
@@ -3329,21 +5255,36 @@ msgstr "클릭하여 제목 수정하기"
 msgid "Click to edit label"
 msgstr "클릭하여 제목 수정하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to favorite/unfavorite"
-msgstr ""
+msgstr "즐겨찾기 추가/제거하려면 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to force-refresh"
-msgstr ""
+msgstr "강제 새로고침하려면 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Click to see difference"
-msgstr ""
+msgstr "차이를 보려면 클릭하세요"
 
 #, fuzzy
 msgid "Click to sort ascending"
 msgstr "클릭하여 제목 수정하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Click to sort descending"
-msgstr ""
+msgstr "내림차순 정렬하려면 클릭하세요"
 
 #, fuzzy
 msgid "Client ID"
@@ -3353,26 +5294,49 @@ msgstr "Query 실행"
 msgid "Client Secret"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close"
-msgstr ""
+msgstr "닫기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Close all other tabs"
-msgstr ""
+msgstr "다른 탭 모두 닫기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Close color breakpoint editor"
-msgstr ""
+msgstr "색상 중단점 편집기 닫기"
 
 msgid "Close tab"
 msgstr "탭 닫기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cluster label aggregator"
-msgstr ""
+msgstr "클러스터 레이블 집계기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Clustering Radius"
-msgstr ""
+msgstr "클러스터링 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Code"
-msgstr ""
+msgstr "코드"
 
 #, fuzzy
 msgid "Code Copied!"
@@ -3386,98 +5350,175 @@ msgstr "데이터 미리보기"
 msgid "Collapse All"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Collapse all"
-msgstr ""
+msgstr "모두 접기"
 
 #, fuzzy
 msgid "Collapse data panel"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse row"
-msgstr ""
+msgstr "행 접기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Collapse tab content"
-msgstr ""
+msgstr "탭 콘텐츠 접기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color"
-msgstr ""
+msgstr "색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Color +/-"
-msgstr ""
+msgstr "색상 +/-"
 
 #, fuzzy
 msgid "Color By X-Axis"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By Y-Axis"
-msgstr ""
+msgstr "Y축으로 색상 지정"
 
 #, fuzzy
 msgid "Color Metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Color Scheme"
-msgstr ""
+msgstr "색상 구성표"
 
 #, fuzzy
 msgid "Color Scheme Type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Color Steps"
-msgstr ""
+msgstr "색상 단계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "X축으로 막대 색상 지정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Y축으로 막대 색상 지정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Color bounds"
-msgstr ""
+msgstr "색상 범위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color breakpoints"
-msgstr ""
+msgstr "색상 중단점"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color by"
-msgstr ""
+msgstr "색상 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
-msgstr ""
+msgstr "색상 필드는 hex 색상(#rrggbb) 또는 'rgb(r, g, b)' 형식이어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color for breakpoint"
-msgstr ""
+msgstr "중단점 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color metric"
-msgstr ""
+msgstr "색상 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color of the source location"
-msgstr ""
+msgstr "소스 위치의 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color of the target location"
-msgstr ""
+msgstr "대상 위치의 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color scheme"
-msgstr ""
+msgstr "색상 구성표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Color will be shaded based the normalized (0% to 100%) value of a given "
 "cell against the other cells in the selected range: "
-msgstr ""
+msgstr "색상은 선택한 범위의 다른 셀에 대한 특정 셀의 정규화된 값(0%~100%)을 기반으로 음영 처리됩니다: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Color: "
-msgstr ""
+msgstr "색상: "
 
 msgid "Column"
 msgstr "칼럼"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Column \"%(column)s\" is not numeric or does not exists in the query "
 "results."
-msgstr ""
+msgstr "열 \"%(column)s\"은(는) 숫자형이 아니거나 쿼리 결과에 존재하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Column Configuration"
-msgstr ""
+msgstr "열 구성"
 
 #, fuzzy
 msgid "Column Formatting"
@@ -3487,23 +5528,39 @@ msgstr "주석"
 msgid "Column Settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Column containing ISO 3166-2 codes of region/province/department in your "
 "table."
-msgstr ""
+msgstr "테이블에서 지역/도/부서의 ISO 3166-2 코드를 포함하는 열."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing latitude data"
-msgstr ""
+msgstr "위도 데이터를 포함하는 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Column containing longitude data"
-msgstr ""
+msgstr "경도 데이터를 포함하는 열"
 
 #, fuzzy
 msgid "Column data types"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Column header tooltip"
-msgstr ""
+msgstr "열 헤더 툴팁"
 
 #, fuzzy
 msgid "Column is required"
@@ -3513,13 +5570,19 @@ msgstr "데이터소스"
 msgid "Column name"
 msgstr "컬럼 추가"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column name [%s] is duplicated"
-msgstr ""
+msgstr "열 이름 [%s]이(가) 중복되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Column referenced by aggregate is undefined: %(column)s"
-msgstr ""
+msgstr "집계에서 참조하는 열이 정의되지 않았습니다: %(column)s"
 
 #, fuzzy
 msgid "Column select"
@@ -3529,10 +5592,13 @@ msgstr "컬럼 추가"
 msgid "Column to group by"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Column to use as the index of the dataframe. If None is given, Index "
 "label is used."
-msgstr ""
+msgstr "데이터프레임의 인덱스로 사용할 열. 값이 없으면 Index 레이블이 사용됩니다."
 
 #, fuzzy
 msgid "Column type"
@@ -3561,8 +5627,11 @@ msgstr "메트릭"
 msgid "Columns and metrics should be inside folders"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "열 폴더에는 열 항목만 포함할 수 있습니다"
 
 #, fuzzy, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3572,84 +5641,157 @@ msgstr "데이터 소스의 컬럼이 없습니다 : %(invalid_columns)s"
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "데이터 소스의 컬럼이 없습니다 : %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "열은 폴더 안에 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns subtotal position"
-msgstr ""
+msgstr "열 소계 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to be parsed as dates"
-msgstr ""
+msgstr "날짜로 파싱할 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Columns to calculate distribution across."
-msgstr ""
+msgstr "분포를 계산할 열."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Columns to display"
-msgstr ""
+msgstr "표시할 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by"
-msgstr ""
+msgstr "그룹화할 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the columns"
-msgstr ""
+msgstr "열에서 그룹화할 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Columns to group by on the rows"
-msgstr ""
+msgstr "행에서 그룹화할 열"
 
 #, fuzzy
 msgid "Columns to read"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns to show in the tooltip."
-msgstr ""
+msgstr "툴팁에 표시할 열."
 
 #, fuzzy
 msgid "Combine metrics"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated color picks for the intervals, e.g. 1,2,4. Integers "
 "denote colors from the chosen color scheme and are 1-indexed. Length must"
 " be matching that of interval bounds."
 msgstr ""
+"구간에 대한 쉼표로 구분된 색상 선택(예: 1,2,4). 정수는 선택한 색상 구성표의 색상을 나타내며 1부터 인덱싱됩니다. 길이는 "
+"구간 경계의 수와 일치해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and "
 "4-5. Last number should match the value provided for MAX."
 msgstr ""
+"쉼표로 구분된 구간 경계(예: 0-2, 2-4, 4-5 구간에 대해 2,4,5). 마지막 숫자는 MAX에 제공된 값과 일치해야 "
+"합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparator option"
-msgstr ""
+msgstr "비교 연산자 옵션"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compare multiple time series charts (as sparklines) and related metrics "
 "quickly."
-msgstr ""
+msgstr "여러 시계열 차트(스파크라인)와 관련 지표를 빠르게 비교합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Compare results with other time periods."
-msgstr ""
+msgstr "다른 기간의 결과와 비교합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Compare the same summarized metric across multiple groups."
-msgstr ""
+msgstr "여러 그룹에 걸쳐 동일한 요약 지표를 비교합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Compares how a metric changes over time between different groups. Each "
 "group is mapped to a row and change over time is visualized bar lengths "
 "and color."
 msgstr ""
+"서로 다른 그룹 간 시간에 따른 지표 변화를 비교합니다. 각 그룹은 행에 매핑되며 시간에 따른 변화는 막대 길이와 색상으로 "
+"시각화됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Compares metrics between different time periods. Displays time series "
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
-msgstr ""
+msgstr "서로 다른 기간 간 지표를 비교합니다. 여러 기간(주 또는 월 등)에 걸친 시계열 데이터를 표시하여 기간별 추세와 패턴을 보여줍니다."
 
 #, fuzzy
 msgid "Comparison"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Comparison Period Lag"
-msgstr ""
+msgstr "비교 기간 지연"
 
 #, fuzzy
 msgid "Comparison font size"
@@ -3659,11 +5801,19 @@ msgstr "컬럼 수정"
 msgid "Comparison suffix"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Compose multiple layers together to form complex visuals."
-msgstr ""
+msgstr "여러 레이어를 결합하여 복잡한 시각적 요소를 형성합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Compute the contribution to the total"
-msgstr ""
+msgstr "전체에 대한 기여도 계산"
 
 #, fuzzy
 msgid "Condition"
@@ -3681,54 +5831,109 @@ msgstr "주석"
 msgid "Confidence interval"
 msgstr "새로고침 간격"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confidence interval must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "신뢰 구간은 0과 1 사이여야 합니다(0과 1 제외)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Configuration"
-msgstr ""
+msgstr "구성"
 
 #, fuzzy, python-format
 msgid "Configure %s"
 msgstr "대시보드 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Configure Advanced Time Range "
-msgstr ""
+msgstr "고급 시간 범위 구성 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure Time Range: Current..."
-msgstr ""
+msgstr "시간 범위 구성: 현재..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Last..."
-msgstr ""
+msgstr "시간 범위 구성: 최근..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure Time Range: Previous..."
-msgstr ""
+msgstr "시간 범위 구성: 이전..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure automatic dashboard refresh"
-msgstr ""
+msgstr "대시보드 자동 새로 고침 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure caching and performance settings"
-msgstr ""
+msgstr "캐싱 및 성능 설정 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure custom time range"
-msgstr ""
+msgstr "사용자 정의 시간 범위 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure dashboard appearance, colors, and custom CSS"
-msgstr ""
+msgstr "대시보드 외관, 색상 및 사용자 정의 CSS 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure filter scopes"
-msgstr ""
+msgstr "필터 범위 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure the basics of your Annotation Layer."
-msgstr ""
+msgstr "주석 레이어의 기본 사항을 구성합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Configure the chart size for each zoom level"
-msgstr ""
+msgstr "각 줌 레벨에 대한 차트 크기 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure this dashboard to embed it into an external web application."
-msgstr ""
+msgstr "외부 웹 애플리케이션에 삽입하기 위해 이 대시보드를 구성합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Configure your how you overlay is displayed here."
-msgstr ""
+msgstr "오버레이 표시 방법을 여기에서 구성합니다."
 
 #, fuzzy
 msgid "Confirm"
@@ -3738,27 +5943,49 @@ msgstr "대시보드 보기"
 msgid "Confirm Password"
 msgstr "대시보드 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm overwrite"
-msgstr ""
+msgstr "덮어쓰기 확인"
 
 #, fuzzy
 msgid "Confirm password"
 msgstr "대시보드 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Confirm save"
-msgstr ""
+msgstr "저장 확인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Confirm the user's password"
-msgstr ""
+msgstr "사용자의 비밀번호 확인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect"
-msgstr ""
+msgstr "연결"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Connect Google Sheet"
-msgstr ""
+msgstr "Google 스프레드시트 연결"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect Google Sheets as tables to this database"
-msgstr ""
+msgstr "이 데이터베이스에 Google Sheets를 테이블로 연결"
 
 #, fuzzy
 msgid "Connect a database"
@@ -3768,18 +5995,30 @@ msgstr "데이터베이스 선택"
 msgid "Connect database"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database using the dynamic form instead"
-msgstr ""
+msgstr "대신 동적 양식을 사용하여 이 데이터베이스에 연결"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Connect this database with a SQLAlchemy URI string instead"
-msgstr ""
+msgstr "대신 SQLAlchemy URI 문자열을 사용하여 이 데이터베이스에 연결"
 
 #, fuzzy
 msgid "Connect to engine"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Connection"
-msgstr ""
+msgstr "연결"
 
 msgid "Connection failed, please check your connection settings"
 msgstr "연결하는데 실패했습니다. 커넥션 "
@@ -3792,9 +6031,11 @@ msgstr "연결하는데 실패했습니다. 커넥션 "
 msgid "Contains"
 msgstr "컬럼 추가"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "텍스트 포함 (ILIKE %x%)"
 
 #, fuzzy
 msgid "Content format"
@@ -3808,15 +6049,23 @@ msgstr "차트 유형"
 msgid "Continue"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Continuous"
-msgstr ""
+msgstr "연속"
 
 #, fuzzy
 msgid "Contours"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Contribution"
-msgstr ""
+msgstr "기여도"
 
 #, fuzzy
 msgid "Contribution Mode"
@@ -3826,33 +6075,59 @@ msgstr "주석 레이어"
 msgid "Control"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Control labeled "
-msgstr ""
+msgstr "레이블이 지정된 컨트롤 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Controls labeled "
-msgstr ""
+msgstr "레이블이 지정된 컨트롤 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copied to clipboard!"
-msgstr ""
+msgstr "클립보드에 복사되었습니다!"
 
 #, fuzzy
 msgid "Copied!"
 msgstr "복사됨!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy"
-msgstr ""
+msgstr "복사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy SELECT statement"
-msgstr ""
+msgstr "SELECT 문 복사"
 
 msgid "Copy SELECT statement to the clipboard"
 msgstr "클립보드에 복사하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy URL"
-msgstr ""
+msgstr "URL 복사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy and Paste JSON credentials"
-msgstr ""
+msgstr "JSON 자격 증명 복사 및 붙여넣기"
 
 #, fuzzy
 msgid "Copy code to clipboard"
@@ -3862,12 +6137,19 @@ msgstr "클립보드에 복사하기"
 msgid "Copy column name"
 msgstr "컬럼 추가"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Copy of %s"
-msgstr ""
+msgstr "%s의 복사본"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy partition query to clipboard"
-msgstr ""
+msgstr "파티션 쿼리를 클립보드에 복사"
 
 #, fuzzy
 msgid "Copy permalink to clipboard"
@@ -3876,48 +6158,93 @@ msgstr "클립보드에 복사하기"
 msgid "Copy query link to your clipboard"
 msgstr "클립보드에 복사하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the current data"
-msgstr ""
+msgstr "현재 데이터 복사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the identifier of the account you are trying to connect to."
-msgstr ""
+msgstr "연결하려는 계정의 식별자를 복사하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Copy the name of the HTTP Path of your cluster."
-msgstr ""
+msgstr "클러스터의 HTTP 경로 이름을 복사하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy the name of the database you are trying to connect to."
-msgstr ""
+msgstr "연결하려는 데이터베이스의 이름을 복사하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Copy to Clipboard"
-msgstr ""
+msgstr "클립보드에 복사"
 
 msgid "Copy to clipboard"
 msgstr "클립보드에 복사하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Copy with Headers"
-msgstr ""
+msgstr "헤더와 함께 복사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Corner Radius"
-msgstr ""
+msgstr "모서리 반경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Correlation"
-msgstr ""
+msgstr "상관관계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Cost estimate"
-msgstr ""
+msgstr "비용 추정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Could not connect to database: \"%(database)s\""
-msgstr ""
+msgstr "데이터베이스에 연결할 수 없습니다: \"%(database)s\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not determine datasource type"
-msgstr ""
+msgstr "데이터 소스 유형을 확인할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not fetch all saved charts"
-msgstr ""
+msgstr "저장된 모든 차트를 가져올 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Could not find viz object"
-msgstr ""
+msgstr "시각화 객체를 찾을 수 없습니다"
 
 msgid "Could not load database driver"
 msgstr "데이터베이스 드라이버를 로드할 수 없습니다"
@@ -3926,12 +6253,18 @@ msgstr "데이터베이스 드라이버를 로드할 수 없습니다"
 msgid "Could not load database driver for: %(engine)s"
 msgstr "데이터베이스 드라이버를 로드할 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Could not resolve hostname: \"%(host)s\"."
-msgstr ""
+msgstr "호스트 이름을 확인할 수 없습니다: \"%(host)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Could not validate the user in the current session."
-msgstr ""
+msgstr "현재 세션에서 사용자를 확인할 수 없습니다."
 
 #, fuzzy
 msgid "Count"
@@ -3941,34 +6274,62 @@ msgstr "컬럼 추가"
 msgid "Count Unique Values"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Columns"
-msgstr ""
+msgstr "열의 비율로 계산"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Rows"
-msgstr ""
+msgstr "행의 비율로 계산"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Count as Fraction of Total"
-msgstr ""
+msgstr "전체의 비율로 계산"
 
 #, fuzzy
 msgid "Country"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Country Color Scheme"
-msgstr ""
+msgstr "국가 색상 구성표"
 
 #, fuzzy
 msgid "Country Column"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Country Field Type"
-msgstr ""
+msgstr "국가 필드 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Country Map"
-msgstr ""
+msgstr "국가 지도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Create"
-msgstr ""
+msgstr "만들기"
 
 #, fuzzy
 msgid "Create API Key"
@@ -3982,10 +6343,16 @@ msgstr "데이터소스 선택"
 msgid "Create a dataset"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
+"데이터를 차트로 시각화하려면 데이터셋을 만들거나\n"
+"          SQL Lab으로 이동하여 데이터를 쿼리하세요."
 
 #, fuzzy
 msgid "Create a new Tag"
@@ -4013,8 +6380,12 @@ msgstr "데이터소스 선택"
 msgid "Create new chart"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Create or select schema..."
-msgstr ""
+msgstr "스키마 만들기 또는 선택..."
 
 msgid "Created"
 msgstr "생성자"
@@ -4037,8 +6408,12 @@ msgstr "생성자"
 msgid "Creating SSH Tunnel failed for an unknown reason"
 msgstr "차트 불러오기는 알 수 없는 이유로 실패했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Creating a data source and creating a new tab"
-msgstr ""
+msgstr "데이터 소스 생성 및 새 탭 생성 중"
 
 msgid "Creator"
 msgstr "생성자"
@@ -4051,14 +6426,24 @@ msgstr "활동"
 msgid "Cross-filter column"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
-msgstr ""
+msgstr "이 데이터셋을 사용하는 모든 차트에 교차 필터가 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cross-filtering is not enabled for this dashboard."
-msgstr ""
+msgstr "이 대시보드에서는 교차 필터링이 활성화되지 않았습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cross-filtering is not enabled in this dashboard"
-msgstr ""
+msgstr "이 대시보드에서는 교차 필터링이 활성화되지 않았습니다"
 
 #, fuzzy
 msgid "Cross-filtering scoping"
@@ -4068,11 +6453,19 @@ msgstr "필터"
 msgid "Cross-filters"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Cumulative"
-msgstr ""
+msgstr "누적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency"
-msgstr ""
+msgstr "통화"
 
 #, fuzzy
 msgid "Currency code column"
@@ -4082,11 +6475,19 @@ msgstr "D3 포멧"
 msgid "Currency format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency prefix or suffix"
-msgstr ""
+msgstr "통화 접두사 또는 접미사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Currency symbol"
-msgstr ""
+msgstr "통화 기호"
 
 #, fuzzy
 msgid "Current"
@@ -4116,12 +6517,19 @@ msgstr "Query 실행"
 msgid "Current year"
 msgstr "Query 실행"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Currently rendered: %s"
-msgstr ""
+msgstr "현재 렌더링됨: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom"
-msgstr ""
+msgstr "사용자 정의"
 
 msgid "Custom Plugin"
 msgstr "커스텀 플러그인"
@@ -4129,26 +6537,50 @@ msgstr "커스텀 플러그인"
 msgid "Custom Plugins"
 msgstr "커스텀 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL"
-msgstr ""
+msgstr "커스텀 SQL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
-msgstr ""
+msgstr "이 데이터셋에 대해 커스텀 SQL ad-hoc 지표가 활성화되어 있지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
-msgstr ""
+msgstr "커스텀 SQL 필드는 단일 SQL 문으로 파싱할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "커스텀 SQL 필드는 집합 연산을 포함할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Custom SQL fields cannot contain sub-queries."
-msgstr ""
+msgstr "커스텀 SQL 필드는 서브쿼리를 포함할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Custom color palettes"
-msgstr ""
+msgstr "커스텀 색상 팔레트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom column name (leave blank for default)"
-msgstr ""
+msgstr "커스텀 열 이름 (기본값으로 사용하려면 비워두세요)"
 
 #, fuzzy
 msgid "Custom conditional formatting"
@@ -4158,14 +6590,24 @@ msgstr "주석"
 msgid "Custom date"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
-msgstr ""
+msgstr "집계된 히트맵 셀에서는 커스텀 필드를 사용할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Custom time filter plugin"
-msgstr ""
+msgstr "커스텀 시간 필터 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Custom width of the screenshot in pixels"
-msgstr ""
+msgstr "스크린샷의 커스텀 너비 (픽셀 단위)"
 
 #, fuzzy
 msgid "Custom..."
@@ -4183,89 +6625,160 @@ msgstr "시각화 유형"
 msgid "Customization value is required"
 msgstr "데이터소스"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Customizations out of scope (%d)"
-msgstr ""
+msgstr "범위를 벗어난 커스터마이징 (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Customize"
-msgstr ""
+msgstr "커스터마이즈"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Customize Metrics"
-msgstr ""
+msgstr "지표 커스터마이즈"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize cell titles using Handlebars template syntax. Available "
 "variables: {{rowLabel}}, {{colLabel}}"
 msgstr ""
+"Handlebars 템플릿 구문을 사용하여 셀 제목을 커스터마이즈하세요. 사용 가능한 변수: {{rowLabel}}, "
+"{{colLabel}}"
 
 #, fuzzy
 msgid "Customize columns"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Customize data source, filters, and layout."
-msgstr ""
+msgstr "데이터 소스, 필터 및 레이아웃을 커스터마이즈하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
-msgstr ""
+msgstr "차트 툴팁과 범례에서 감소하는 값에 표시되는 라벨을 커스터마이즈하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
-msgstr ""
+msgstr "차트 툴팁과 범례에서 증가하는 값에 표시되는 라벨을 커스터마이즈하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
-msgstr ""
+msgstr "차트 툴팁, 범례 및 차트 축에서 합계 값에 표시되는 라벨을 커스터마이즈하세요."
 
 #, fuzzy
 msgid "Customize tooltips template"
 msgstr "CSS 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Cyclic dependency detected"
-msgstr ""
+msgstr "순환 의존성이 감지되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 format"
-msgstr ""
+msgstr "D3 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 format syntax: https://github.com/d3/d3-format"
-msgstr ""
+msgstr "D3 형식 구문: https://github.com/d3/d3-format"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "D3 number format for numbers between -1.0 and 1.0, useful when you want "
 "to have different significant digits for small and large numbers"
 msgstr ""
+"-1.0과 1.0 사이의 숫자에 대한 D3 숫자 형식으로, 작은 숫자와 큰 숫자에 대해 서로 다른 유효 자릿수를 사용하고자 할 때 "
+"유용합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format for datetime columns"
-msgstr ""
+msgstr "날짜/시간 열에 대한 D3 시간 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
-msgstr ""
+msgstr "D3 시간 형식 구문: https://github.com/d3/d3-time-format"
 
 #, fuzzy
 msgid "DATETIME"
 msgstr "시작 시간"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "DB column %(col_name)s has unknown type: %(value_type)s"
-msgstr ""
+msgstr "DB 열 %(col_name)s의 유형을 알 수 없습니다: %(value_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "DD/MM format dates, international and European format"
-msgstr ""
+msgstr "DD/MM 형식 날짜, 국제 및 유럽 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DEC"
-msgstr ""
+msgstr "12월"
 
 msgid "DELETE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DML"
-msgstr ""
+msgstr "DML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Daily seasonality"
-msgstr ""
+msgstr "일별 계절성"
 
 #, fuzzy
 msgid "Dark"
@@ -4275,11 +6788,19 @@ msgstr "분기"
 msgid "Dark (Carto)"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dark Cyan"
-msgstr ""
+msgstr "어두운 청록색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dark mode"
-msgstr ""
+msgstr "다크 모드"
 
 msgid "Dashboard"
 msgstr "대시보드"
@@ -4296,12 +6817,17 @@ msgstr "대시보드"
 msgid "Dashboard Id"
 msgstr "대시보드"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Dashboard [%s] just got created and chart [%s] was added to it"
-msgstr ""
+msgstr "대시보드 [%s]가 방금 생성되었으며 차트 [%s]가 추가되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard cannot be copied due to invalid parameters."
-msgstr ""
+msgstr "유효하지 않은 파라미터로 인해 대시보드를 복사할 수 없습니다."
 
 #, fuzzy
 msgid "Dashboard cannot be favorited."
@@ -4322,8 +6848,10 @@ msgstr "대시보드를 업데이트할 수 없습니다."
 msgid "Dashboard could not be deleted."
 msgstr "대시보드를 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Dashboard could not be restored."
-msgstr ""
+msgstr "대시보드를 복원할 수 없습니다."
 
 msgid "Dashboard could not be updated."
 msgstr "대시보드를 업데이트할 수 없습니다."
@@ -4331,8 +6859,11 @@ msgstr "대시보드를 업데이트할 수 없습니다."
 msgid "Dashboard does not exist"
 msgstr "대시보드가 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Dashboard exported as example successfully"
-msgstr ""
+msgstr "대시보드가 예시로 성공적으로 내보내기되었습니다"
 
 #, fuzzy
 msgid "Dashboard exported successfully"
@@ -4342,8 +6873,11 @@ msgstr "대시보드"
 msgid "Dashboard imported"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dashboard name and URL configuration"
-msgstr ""
+msgstr "대시보드 이름 및 URL 구성"
 
 #, fuzzy
 msgid "Dashboard name is required"
@@ -4367,12 +6901,19 @@ msgstr "대시보드"
 msgid "Dashboard scheme"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Dashboard time range filters apply to temporal columns defined in\n"
 "          the filter section of each chart. Add temporal columns to the "
 "chart\n"
 "          filters to have this dashboard filter impact those charts."
 msgstr ""
+"대시보드 시간 범위 필터는 각 차트의\n"
+"          필터 섹션에서 정의된 시간 열에 적용됩니다. 이 대시보드 필터가 해당\n"
+"          차트에 영향을 미치도록 차트 필터에 시간 열을 추가하세요."
 
 #, fuzzy
 msgid "Dashboard title"
@@ -4415,11 +6956,19 @@ msgstr "주석"
 msgid "Data Table"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data URI is not allowed."
-msgstr ""
+msgstr "데이터 URI는 허용되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Data Zoom"
-msgstr ""
+msgstr "데이터 확대/축소"
 
 #, fuzzy
 msgid "Data connection"
@@ -4429,24 +6978,36 @@ msgstr "연결 테스트"
 msgid "Data connections"
 msgstr "연결 테스트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
 "format might have changed, rendering the old data stake. You need to re-"
 "run the original query."
 msgstr ""
+"결과 백엔드에서 데이터를 역직렬화할 수 없습니다. 저장 형식이 변경되어 기존 데이터가 유효하지 않을 수 있습니다. 원래 쿼리를 다시"
+" 실행해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Data could not be retrieved from the results backend. You need to re-run "
 "the original query."
-msgstr ""
+msgstr "결과 백엔드에서 데이터를 가져올 수 없습니다. 원래 쿼리를 다시 실행해야 합니다."
 
 #, fuzzy
 msgid "Data error"
 msgstr "데이터베이스"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Data for %s"
-msgstr ""
+msgstr "%s의 데이터"
 
 #, fuzzy
 msgid "Data imported"
@@ -4455,17 +7016,29 @@ msgstr "데이터베이스"
 msgid "Data preview"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Data refreshed"
-msgstr ""
+msgstr "데이터가 새로고침되었습니다"
 
 msgid "Data type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "DataFrame include at least one series"
-msgstr ""
+msgstr "DataFrame은 최소 하나의 시리즈를 포함해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "DataFrame must include temporal column"
-msgstr ""
+msgstr "DataFrame은 시간 열을 포함해야 합니다"
 
 msgid "Database"
 msgstr "데이터베이스"
@@ -4491,19 +7064,30 @@ msgstr "데이터베이스를 삭제할 수 없습니다."
 msgid "Database could not be updated."
 msgstr "데이터베이스를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not allow data manipulation."
-msgstr ""
+msgstr "데이터베이스에서 데이터 조작을 허용하지 않습니다."
 
 msgid "Database does not exist"
 msgstr "데이터베이스가 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database does not support subqueries"
-msgstr ""
+msgstr "데이터베이스는 서브쿼리를 지원하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Database driver for importing maybe not installed. Visit the Superset "
 "documentation page for installation instructions: "
-msgstr ""
+msgstr "가져오기를 위한 데이터베이스 드라이버가 설치되어 있지 않을 수 있습니다. 설치 지침은 Superset 문서 페이지를 방문하세요: "
 
 msgid "Database error"
 msgstr "데이터베이스"
@@ -4512,8 +7096,12 @@ msgstr "데이터베이스"
 msgid "Database is offline."
 msgstr "데이터소스 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database is required for alerts"
-msgstr ""
+msgstr "알림에는 데이터베이스가 필요합니다"
 
 msgid "Database name"
 msgstr "데이터소스 명"
@@ -4521,8 +7109,12 @@ msgstr "데이터소스 명"
 msgid "Database not found."
 msgstr "데이터베이스를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Database parameters are invalid."
-msgstr ""
+msgstr "데이터베이스 파라미터가 유효하지 않습니다."
 
 #, fuzzy
 msgid "Database passwords"
@@ -4532,27 +7124,44 @@ msgstr "데이터베이스"
 msgid "Database port"
 msgstr "데이터베이스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Database reference is not allowed on a report"
-msgstr ""
+msgstr "보고서에서 데이터베이스 참조는 허용되지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database schema is not allowed for csv uploads."
-msgstr ""
+msgstr "데이터베이스 스키마는 CSV 업로드에 허용되지 않습니다."
 
 #, fuzzy
 msgid "Database settings updated"
 msgstr "데이터베이스를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database type does not support file uploads."
-msgstr ""
+msgstr "데이터베이스 유형이 파일 업로드를 지원하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "데이터베이스 업로드 파일이 최대 허용 크기를 초과합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Database upload file failed"
-msgstr ""
+msgstr "데이터베이스 파일 업로드에 실패했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Database upload file failed, while saving metadata"
-msgstr ""
+msgstr "메타데이터 저장 중 데이터베이스 파일 업로드에 실패했습니다"
 
 msgid "Databases"
 msgstr "데이터베이스"
@@ -4568,21 +7177,37 @@ msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 msgid "Dataset Name"
 msgstr "데이터소스 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset column delete failed."
-msgstr ""
+msgstr "데이터셋 열 삭제에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset column not found."
-msgstr ""
+msgstr "데이터셋 열을 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset could not be created."
-msgstr ""
+msgstr "데이터셋을 생성할 수 없습니다."
 
 #, fuzzy
 msgid "Dataset could not be duplicated."
 msgstr "데이터베이스를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset could not be updated."
-msgstr ""
+msgstr "데이터셋을 업데이트할 수 없습니다."
 
 msgid "Dataset does not exist"
 msgstr "데이터소스가 존재하지 않습니다"
@@ -4591,36 +7216,59 @@ msgstr "데이터소스가 존재하지 않습니다"
 msgid "Dataset is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset metric delete failed."
-msgstr ""
+msgstr "데이터셋 지표 삭제에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset metric not found."
-msgstr ""
+msgstr "데이터셋 지표를 찾을 수 없습니다."
 
 msgid "Dataset name"
 msgstr "데이터소스 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dataset parameters are invalid."
-msgstr ""
+msgstr "데이터셋 매개변수가 유효하지 않습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "데이터셋 스키마가 유효하지 않습니다. 원인: %(error)s"
 
 msgid "Datasets"
 msgstr "데이터베이스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Datasets can be created from database tables or SQL queries. Select a "
 "database table to the left or "
-msgstr ""
+msgstr "데이터셋은 데이터베이스 테이블 또는 SQL 쿼리에서 생성할 수 있습니다. 왼쪽에서 데이터베이스 테이블을 선택하거나 "
 
 #, fuzzy
 msgid "Datasets could not be deleted."
 msgstr "데이터베이스를 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasets do not contain a temporal column"
-msgstr ""
+msgstr "데이터셋에 시간 열이 포함되어 있지 않습니다"
 
 msgid "Datasource"
 msgstr "데이터소스"
@@ -4641,18 +7289,30 @@ msgstr "데이터소스"
 msgid "Datasource is required for validation"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Datasource type is invalid"
-msgstr ""
+msgstr "데이터 소스 유형이 유효하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Datasource type is required when datasource_id is given"
-msgstr ""
+msgstr "datasource_id가 지정된 경우 데이터 소스 유형이 필요합니다"
 
 #, fuzzy
 msgid "Datasources"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Date Time Format"
-msgstr ""
+msgstr "날짜 및 시간 형식"
 
 #, fuzzy
 msgid "Date format"
@@ -4665,77 +7325,142 @@ msgstr "D3 포멧"
 msgid "Date/Time"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Datetime column not provided as part table configuration and is required "
 "by this type of chart"
-msgstr ""
+msgstr "날짜/시간 열이 테이블 구성의 일부로 제공되지 않았으며 이 유형의 차트에 필요합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Datetime format"
-msgstr ""
+msgstr "날짜/시간 형식"
 
 msgid "Day"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Day (freq=D)"
-msgstr ""
+msgstr "일 (freq=D)"
 
 #, fuzzy, python-format
 msgid "Days %s"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Db engine did not return all queried columns"
-msgstr ""
+msgstr "DB 엔진이 쿼리된 모든 열을 반환하지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Deactivate"
-msgstr ""
+msgstr "비활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "December"
-msgstr ""
+msgstr "12월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Decides which column or measure to sort the base axis by."
-msgstr ""
+msgstr "기준 축을 정렬할 열 또는 측정값을 결정합니다."
 
 #, fuzzy
 msgid "Decimal character"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D Grid"
-msgstr ""
+msgstr "Deck.gl - 3D 그리드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - 3D HEX"
-msgstr ""
+msgstr "Deck.gl - 3D HEX"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Arc"
-msgstr ""
+msgstr "Deck.gl - 호 (Arc)"
 
 #, fuzzy
 msgid "Deck.gl - Contour"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - GeoJSON"
-msgstr ""
+msgstr "Deck.gl - GeoJSON"
 
 #, fuzzy
 msgid "Deck.gl - Heatmap"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Multiple Layers"
-msgstr ""
+msgstr "Deck.gl - 다중 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Paths"
-msgstr ""
+msgstr "Deck.gl - 경로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Polygon"
-msgstr ""
+msgstr "Deck.gl - 폴리곤"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Scatter plot"
-msgstr ""
+msgstr "Deck.gl - 산점도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Deck.gl - Screen Grid"
-msgstr ""
+msgstr "Deck.gl - 화면 그리드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Deck.gl Layer Visibility"
-msgstr ""
+msgstr "Deck.gl 레이어 표시 여부"
 
 #, fuzzy
 msgid "Deckgl"
@@ -4769,16 +7494,27 @@ msgstr "Query 공유"
 msgid "Default Schema"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Default URL"
-msgstr ""
+msgstr "기본 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# pt_BR, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
-msgstr ""
+msgstr "데이터셋 목록 페이지에서 접근 시 리디렉션할 기본 URL입니다. 다음과 같은 상대 URL을 허용합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Default Value"
-msgstr ""
+msgstr "기본값"
 
 #, fuzzy
 msgid "Default color"
@@ -4792,107 +7528,191 @@ msgstr "컬럼 수정"
 msgid "Default folders cannot be nested"
 msgstr "차트를 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Default latitude"
-msgstr ""
+msgstr "기본 위도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Default longitude"
-msgstr ""
+msgstr "기본 경도"
 
 #, fuzzy
 msgid "Default message"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Default minimal column width in pixels, actual width may still be larger "
 "than this if other columns don't need much space"
-msgstr ""
+msgstr "기본 최소 열 너비(픽셀). 다른 열이 많은 공간을 필요로 하지 않으면 실제 너비가 이보다 클 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Default value must be set when \"Filter has default value\" is checked"
-msgstr ""
+msgstr "\"필터에 기본값이 있음\"이 선택된 경우 기본값을 설정해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Default value must be set when \"Filter value is required\" is checked"
-msgstr ""
+msgstr "\"필터 값이 필수\"가 선택된 경우 기본값을 설정해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Default value set automatically when \"Select first filter value by "
 "default\" is checked"
-msgstr ""
+msgstr "\"기본으로 첫 번째 필터 값 선택\"이 선택된 경우 기본값이 자동으로 설정됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a function that receives the input and outputs the content for a "
 "tooltip"
-msgstr ""
+msgstr "입력을 받아 툴팁의 내용을 출력하는 함수를 정의하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Define a function that returns a URL to navigate to when user clicks"
-msgstr ""
+msgstr "사용자가 클릭할 때 이동할 URL을 반환하는 함수를 정의하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define a javascript function that receives the data array used in the "
 "visualization and is expected to return a modified version of that array."
 " This can be used to alter properties of the data, filter, or enrich the "
 "array."
 msgstr ""
+"시각화에 사용되는 데이터 배열을 수신하고 해당 배열의 수정된 버전을 반환하는 JavaScript 함수를 정의합니다. 이를 통해 "
+"데이터의 속성을 변경하거나 필터링하거나 배열을 보강할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define color breakpoints for the data"
-msgstr ""
+msgstr "데이터의 색상 구분점을 정의합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "Define contour layers. Isolines represent a collection of line segments "
 "that serparate the area above and below a given threshold. Isobands "
 "represent a collection of polygons that fill the are containing values in"
 " a given threshold range."
 msgstr ""
+"등고선 레이어를 정의합니다. 등치선은 주어진 임계값의 위와 아래 영역을 구분하는 선분의 집합입니다. 등치대는 주어진 임계값 범위 "
+"내의 값을 포함하는 영역을 채우는 다각형의 집합입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define delivery schedule, timezone, and frequency settings."
-msgstr ""
+msgstr "배송 일정, 시간대 및 빈도 설정을 정의합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Define the database, SQL query, and triggering conditions for alert."
-msgstr ""
+msgstr "알림에 대한 데이터베이스, SQL 쿼리 및 트리거 조건을 정의합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Defined through system configuration."
-msgstr ""
+msgstr "시스템 구성을 통해 정의됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines a rolling window function to apply, works along with the "
 "[Periods] text box"
-msgstr ""
+msgstr "적용할 롤링 윈도우 함수를 정의하며, [기간] 텍스트 상자와 함께 작동합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Defines the grid size in pixels"
-msgstr ""
+msgstr "그리드 크기를 픽셀 단위로 정의합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Defines the grouping of entities. Each series is represented by a "
 "specific color in the chart."
-msgstr ""
+msgstr "엔티티의 그룹화를 정의합니다. 각 계열은 차트에서 특정 색상으로 표시됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines the grouping of entities. Each series is shown as a specific "
 "color on the chart and has a legend toggle"
-msgstr ""
+msgstr "엔티티의 그룹화를 정의합니다. 각 계열은 차트에서 특정 색상으로 표시되며 범례 토글이 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines the size of the rolling window function, relative to the time "
 "granularity selected"
-msgstr ""
+msgstr "선택한 시간 세분성에 대한 롤링 윈도우 함수의 크기를 정의합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Defines the value that determines the boundary between different regions "
 "or levels in the data "
-msgstr ""
+msgstr "데이터에서 서로 다른 영역 또는 수준 사이의 경계를 결정하는 값을 정의합니다 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Defines whether the step should appear at the beginning, middle or end "
 "between two data points"
-msgstr ""
+msgstr "두 데이터 포인트 사이에서 계단이 시작, 중간, 끝 중 어디에 나타나야 하는지 정의합니다"
 
 #, fuzzy
 msgid "Definition"
 msgstr "활동"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
+msgstr[0] "지연됨 (%s번 새로 고침 누락)"
 
 msgid "Delete"
 msgstr "삭제"
@@ -4945,8 +7765,12 @@ msgstr "CSS 템플릿"
 msgid "Delete User?"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete all Really?"
-msgstr ""
+msgstr "정말 모두 삭제하시겠습니까?"
 
 msgid "Delete annotation"
 msgstr "주석"
@@ -4954,8 +7778,12 @@ msgstr "주석"
 msgid "Delete dashboard tab?"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete email report"
-msgstr ""
+msgstr "이메일 보고서 삭제"
 
 #, fuzzy
 msgid "Delete group"
@@ -4976,8 +7804,12 @@ msgstr "템플릿 불러오기"
 msgid "Delete theme"
 msgstr "템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delete this container and save to remove this message."
-msgstr ""
+msgstr "이 컨테이너를 삭제하고 저장하여 이 메시지를 제거하십시오."
 
 #, fuzzy
 msgid "Delete user"
@@ -4995,55 +7827,80 @@ msgstr "주석"
 msgid "Deleted"
 msgstr "삭제"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d annotation"
 msgid_plural "Deleted %(num)d annotations"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 주석이 삭제되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d annotation layer"
 msgid_plural "Deleted %(num)d annotation layers"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 주석 레이어가 삭제되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d chart"
 msgid_plural "Deleted %(num)d charts"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 차트가 삭제되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d css template"
 msgid_plural "Deleted %(num)d css templates"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 CSS 템플릿이 삭제되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, it, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d dashboard"
 msgid_plural "Deleted %(num)d dashboards"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 대시보드가 삭제되었습니다"
 
 #, python-format
 msgid "Deleted %(num)d dataset"
 msgid_plural "Deleted %(num)d datasets"
 msgstr[0] "데이터베이스 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d report schedule"
 msgid_plural "Deleted %(num)d report schedules"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 보고서 일정이 삭제되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, nl, ro, ru, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid "Deleted %(num)d rules"
 msgid_plural "Deleted %(num)d rules"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 규칙이 삭제되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Deleted %(num)d saved query"
 msgid_plural "Deleted %(num)d saved queries"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 저장된 쿼리가 삭제되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
 #, fuzzy, python-format
 msgid "Deleted %(num)d semantic view"
 msgid_plural "Deleted %(num)d semantic views"
-msgstr[0] ""
+msgstr[0] "%(num)d개의 시맨틱 뷰가 삭제되었습니다"
 
 #, fuzzy, python-format
 msgid "Deleted %(num)d theme"
@@ -5090,13 +7947,20 @@ msgstr "삭제"
 msgid "Deleted: %s"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Deleting a tab will remove all content within it and will deactivate any "
 "related alerts or reports. You may still reverse this action with the"
-msgstr ""
+msgstr "탭을 삭제하면 그 안의 모든 콘텐츠가 제거되고 관련 알림 또는 보고서가 비활성화됩니다. 다음을 사용하여 이 작업을 되돌릴 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Delimited long & lat single column"
-msgstr ""
+msgstr "구분된 경도 및 위도 단일 열"
 
 msgid "Delimiter"
 msgstr "구분자"
@@ -5105,24 +7969,40 @@ msgstr "구분자"
 msgid "Delivery method"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Density"
-msgstr ""
+msgstr "밀도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Dependent on"
-msgstr ""
+msgstr "종속 대상"
 
 msgid "Description"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description (this can be seen in the list)"
-msgstr ""
+msgstr "설명 (목록에서 볼 수 있습니다)"
 
 #, fuzzy
 msgid "Description Columns"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Description text that shows up below your Big Number"
-msgstr ""
+msgstr "큰 숫자 아래에 표시되는 설명 텍스트"
 
 msgid "Deselect all"
 msgstr "테이블 선택"
@@ -5131,109 +8011,201 @@ msgstr "테이블 선택"
 msgid "Design with"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Details"
-msgstr ""
+msgstr "세부 정보"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Details of the certification"
-msgstr ""
+msgstr "인증 세부 정보"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"필터가 값을 일치시키는 방법을 결정합니다. \"정확히 일치\"는 IN 연산자를 사용합니다(기본값). ILIKE 옵션은 자유 텍스트 "
+"입력으로 부분 텍스트 일치를 활성화합니다. 경고: ILIKE 쿼리는 인덱스를 효과적으로 사용할 수 없어 대용량 데이터셋에서 느릴 수"
+" 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Determines how whiskers and outliers are calculated."
-msgstr ""
+msgstr "수염과 이상값이 계산되는 방법을 결정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Determines whether or not this dashboard is visible in the list of all "
 "dashboards"
-msgstr ""
+msgstr "이 대시보드가 모든 대시보드 목록에 표시되는지 여부를 결정합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Diamond"
-msgstr ""
+msgstr "다이아몬드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Did you mean:"
-msgstr ""
+msgstr "다음을 말씀하신 건가요:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Difference"
-msgstr ""
+msgstr "차이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dim Gray"
-msgstr ""
+msgstr "어두운 회색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dimension"
-msgstr ""
+msgstr "차원"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"피처 클릭 시 교차 필터로 내보내지는 차원 열입니다. 대시보드의 다른 차트가 이 열을 기준으로 매칭됩니다. 설정되지 않은 경우 기하"
+" 열로 폴백됩니다(레거시 동작, 종종 매칭 불가)."
 
 #, fuzzy
 msgid "Dimension is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dimension members"
-msgstr ""
+msgstr "차원 멤버"
 
 #, fuzzy
 msgid "Dimension selection"
 msgstr "10초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on x-axis."
-msgstr ""
+msgstr "X축에 사용할 차원."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dimension to use on y-axis."
-msgstr ""
+msgstr "Y축에 사용할 차원."
 
 #, fuzzy
 msgid "Dimension values"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dimensions"
-msgstr ""
+msgstr "차원"
 
 #, fuzzy, python-format
 msgid "Dimensions (%s)"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Dimensions contain qualitative values such as names, dates, or "
 "geographical data. Use dimensions to categorize, segment, and reveal the "
 "details in your data. Dimensions affect the level of detail in the view."
 msgstr ""
+"차원에는 이름, 날짜 또는 지리적 데이터와 같은 질적 값이 포함됩니다. 차원을 사용하여 데이터를 분류, 세분화하고 세부 사항을 "
+"드러냅니다. 차원은 보기의 세부 수준에 영향을 줍니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Directed Force Layout"
-msgstr ""
+msgstr "방향성 힘 레이아웃"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Directional"
-msgstr ""
+msgstr "방향성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable SQL Lab data preview queries"
-msgstr ""
+msgstr "SQL Lab 데이터 미리 보기 쿼리 비활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Disable data preview when fetching table metadata in SQL Lab.  Useful to "
 "avoid browser performance issues when using  databases with very wide "
 "tables."
 msgstr ""
+"SQL Lab에서 테이블 메타데이터를 가져올 때 데이터 미리 보기를 비활성화합니다. 매우 넓은 테이블이 있는 데이터베이스를 사용할 "
+"때 브라우저 성능 문제를 방지하는 데 유용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disable drill to detail"
-msgstr ""
+msgstr "세부 정보 드릴다운 비활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Disable embedding?"
-msgstr ""
+msgstr "임베딩을 비활성화하시겠습니까?"
 
 #, fuzzy
 msgid "Disabled"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Disables the drill to detail feature for this database."
-msgstr ""
+msgstr "이 데이터베이스의 세부 정보 드릴 기능을 비활성화합니다."
 
 #, fuzzy
 msgid "Discard"
@@ -5247,27 +8219,47 @@ msgstr "필터"
 msgid "Display all"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column in the chart"
-msgstr ""
+msgstr "차트에 열 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display column level subtotal"
-msgstr ""
+msgstr "열 수준 소계 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display column level total"
-msgstr ""
+msgstr "열 수준 합계 표시"
 
 #, fuzzy
 msgid "Display column name"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display configuration"
-msgstr ""
+msgstr "표시 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display control configuration"
-msgstr ""
+msgstr "표시 컨트롤 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control has default value"
-msgstr ""
+msgstr "표시 컨트롤에 기본값이 있습니다"
 
 #, fuzzy
 msgid "Display control name"
@@ -5293,70 +8285,121 @@ msgstr "컬럼 추가"
 msgid "Display controls (%s)"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display cumulative total at end"
-msgstr ""
+msgstr "끝에 누적 합계 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
+msgstr "행렬 상단에 각 열의 헤더 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display labels for each row on the left side of the matrix"
-msgstr ""
+msgstr "행렬 왼쪽에 각 행의 레이블 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Display metrics side by side within each column, as opposed to each "
 "column being displayed side by side for each metric."
-msgstr ""
+msgstr "각 열 내에서 지표를 나란히 표시합니다. 각 지표마다 열을 나란히 표시하는 방식과 반대입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Display percents in the label and tooltip as the percent of the total "
 "value, from the first step of the funnel, or from the previous step in "
 "the funnel."
-msgstr ""
+msgstr "레이블과 툴팁에서 전체 값에 대한 백분율, 퍼널의 첫 번째 단계로부터의 백분율, 또는 퍼널의 이전 단계로부터의 백분율로 표시합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display row level subtotal"
-msgstr ""
+msgstr "행 수준 소계 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Display row level total"
-msgstr ""
+msgstr "행 수준 합계 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
-msgstr ""
+msgstr "대시보드 보기에서 차트에 마지막 쿼리 타임스탬프 표시"
 
 #, fuzzy
 msgid "Display type icon"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Displays connections between entities in a graph structure. Useful for "
 "mapping relationships and showing which nodes are important in a network."
 " Graph charts can be configured to be force-directed or circulate. If "
 "your data has a geospatial component, try the deck.gl Arc chart."
 msgstr ""
+"그래프 구조에서 엔티티 간의 연결을 표시합니다. 관계를 매핑하고 네트워크에서 중요한 노드를 보여주는 데 유용합니다. 그래프 차트는 "
+"힘 기반 또는 순환형으로 구성할 수 있습니다. 데이터에 지리공간 구성 요소가 있는 경우 deck.gl Arc 차트를 사용해 보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Distribute across"
-msgstr ""
+msgstr "분산 기준"
 
 #, fuzzy
 msgid "Distribution"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Divider"
-msgstr ""
+msgstr "구분선"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
-msgstr ""
+msgstr "차원의 값을 기반으로 각 범주를 하위 범주로 나눕니다. 교차 항목을 제외하는 데 사용할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Do you want a donut or a pie?"
-msgstr ""
+msgstr "도넛형 또는 파이형 차트를 원하시나요?"
 
 #, fuzzy
 msgid "Documentation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Domain"
-msgstr ""
+msgstr "도메인"
 
 #, fuzzy
 msgid "Don't refresh"
@@ -5374,131 +8417,248 @@ msgstr "월"
 msgid "Dotted"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Download"
-msgstr ""
+msgstr "다운로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download as Image"
-msgstr ""
+msgstr "이미지로 다운로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download as image"
-msgstr ""
+msgstr "이미지로 다운로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Download is on the way"
-msgstr ""
+msgstr "다운로드가 진행 중입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Download to CSV"
-msgstr ""
+msgstr "CSV로 다운로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Download to client"
-msgstr ""
+msgstr "클라이언트로 다운로드"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Downloading %(rows)s rows based on the LIMIT configuration. If you want "
 "the entire result set, you need to adjust the LIMIT."
-msgstr ""
+msgstr "LIMIT 설정에 따라 %(rows)s 행을 다운로드합니다. 전체 결과를 원하면 LIMIT을 조정해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draft"
-msgstr ""
+msgstr "초안"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components and charts to the dashboard"
-msgstr ""
+msgstr "컴포넌트와 차트를 대시보드로 드래그 앤 드롭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Drag and drop components to this tab"
-msgstr ""
+msgstr "이 탭으로 컴포넌트를 드래그 앤 드롭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drag columns and metrics here to customize tooltip content. Order matters"
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
+"툴팁 내용을 사용자 지정하려면 열과 지표를 여기로 드래그하세요. 순서가 중요합니다. 항목은 툴팁에서 같은 순서로 표시됩니다. 버튼을"
+" 클릭하여 열과 지표를 수동으로 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Drag to reorder"
-msgstr ""
+msgstr "드래그하여 순서 변경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw a marker on data points. Only applicable for line types."
-msgstr ""
+msgstr "데이터 포인트에 마커를 그립니다. 선 유형에만 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw area under curves. Only applicable for line types."
-msgstr ""
+msgstr "곡선 아래 영역을 그립니다. 선 유형에만 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw line from Pie to label when labels outside?"
-msgstr ""
+msgstr "레이블이 외부에 있을 때 파이에서 레이블로 선을 그리시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Draw split lines for minor axis ticks"
-msgstr ""
+msgstr "보조 축 눈금에 분할선 그리기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Draw split lines for minor y-axis ticks"
-msgstr ""
+msgstr "보조 Y축 눈금에 분할선 그리기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by"
-msgstr ""
+msgstr "드릴 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not available for this data point"
-msgstr ""
+msgstr "이 데이터 포인트에는 드릴 기능을 사용할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill by is not yet supported for this chart type"
-msgstr ""
+msgstr "이 차트 유형은 아직 드릴 기능을 지원하지 않습니다"
 
 #, fuzzy, python-format
 msgid "Drill by: %s"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail"
-msgstr ""
+msgstr "세부 정보 드릴"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by"
-msgstr ""
+msgstr "기준별 세부 정보 드릴"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drill to detail by value is not yet supported for this chart type."
-msgstr ""
+msgstr "이 차트 유형은 아직 값별 세부 정보 드릴을 지원하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled because this chart does not group data by "
 "dimension value."
-msgstr ""
+msgstr "이 차트는 차원 값으로 데이터를 그룹화하지 않기 때문에 세부 정보 드릴이 비활성화되어 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Drill to detail is disabled for this database. Change the database "
 "settings to enable it."
-msgstr ""
+msgstr "이 데이터베이스에서는 세부 정보 드릴이 비활성화되어 있습니다. 데이터베이스 설정을 변경하여 활성화하세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Drill to detail: %s"
-msgstr ""
+msgstr "세부 정보 드릴: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column here or click"
 msgid_plural "Drop columns here or click"
-msgstr[0] ""
+msgstr[0] "여기에 열을 드롭하거나 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Drop a column/metric here or click"
 msgid_plural "Drop columns/metrics here or click"
-msgstr[0] ""
+msgstr[0] "여기에 열/지표를 드롭하거나 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Drop a temporal column here or click"
-msgstr ""
+msgstr "여기에 시간 열을 놓거나 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Drop columns/metrics here or click"
-msgstr ""
+msgstr "여기에 열/지표를 놓거나 클릭하세요"
 
 #, fuzzy
 msgid "Dttm"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duplicate"
-msgstr ""
+msgstr "복제"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Duplicate column name(s): %(columns)s"
-msgstr ""
+msgstr "중복 열 이름: %(columns)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Duplicate column/metric labels: %(labels)s. Please make sure all columns "
 "and metrics have a unique label."
-msgstr ""
+msgstr "중복 열/지표 레이블: %(labels)s. 모든 열과 지표에 고유한 레이블이 있는지 확인하세요."
 
 #, fuzzy
 msgid "Duplicate dataset"
@@ -5512,86 +8672,148 @@ msgstr "차트 수정"
 msgid "Duplicate role"
 msgstr "차트 수정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Duplicate role %(name)s"
-msgstr ""
+msgstr "역할 %(name)s 복제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duplicate tab"
-msgstr ""
+msgstr "탭 복제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration"
-msgstr ""
+msgstr "기간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the caching timeout for charts of this database."
 " A timeout of 0 indicates that the cache never expires, and -1 bypasses "
 "the cache. Note this defaults to the global timeout if undefined."
 msgstr ""
+"이 데이터베이스의 차트 캐시 타임아웃 기간(초). 타임아웃 값이 0이면 캐시가 만료되지 않으며, -1이면 캐시를 우회합니다. 미정의"
+" 시 전역 타임아웃이 기본값으로 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the caching timeout for this chart. Set to -1 to"
 " bypass the cache. Note this defaults to the dataset's timeout if "
 "undefined."
-msgstr ""
+msgstr "이 차트의 캐시 타임아웃 기간(초). -1로 설정하면 캐시를 우회합니다. 미정의 시 데이터셋의 타임아웃이 기본값으로 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the metadata caching timeout for schemas of this"
 " database. If left unset, the cache never expires."
-msgstr ""
+msgstr "이 데이터베이스의 스키마 메타데이터 캐시 타임아웃 기간(초). 설정하지 않으면 캐시가 만료되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Duration (in seconds) of the metadata caching timeout for tables of this "
 "database. If left unset, the cache never expires. "
-msgstr ""
+msgstr "이 데이터베이스의 테이블 메타데이터 캐시 타임아웃 기간(초). 설정하지 않으면 캐시가 만료되지 않습니다."
 
 #, fuzzy
 msgid "Duration Ms"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (1.40008 => 1ms 400µs 80ns)"
-msgstr ""
+msgstr "밀리초 단위 기간 (1.40008 => 1ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Duration in ms (100.40008 => 100ms 400µs 80ns)"
-msgstr ""
+msgstr "밀리초 단위 기간 (100.40008 => 100ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Duration in ms (10500 => 0:00:10.5)"
-msgstr ""
+msgstr "밀리초 단위 기간 (10500 => 0:00:10.5)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Duration in ms (66000 => 1m 6s)"
-msgstr ""
+msgstr "밀리초 단위 기간 (66000 => 1m 6s)"
 
 #, fuzzy
 msgid "Duration in seconds"
 msgstr "10초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "동적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic Aggregation Function"
-msgstr ""
+msgstr "동적 집계 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Dynamic Section Label"
-msgstr ""
+msgstr "동적 섹션 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic group by"
-msgstr ""
+msgstr "동적 그룹화"
 
 #, fuzzy
 msgid "Dynamic section description"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Dynamically search all filter values"
-msgstr ""
+msgstr "모든 필터 값을 동적으로 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "데이터셋에서 그룹화 열을 동적으로 선택"
 
 #, fuzzy
 msgid "ECharts"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "ECharts 옵션 (JS 객체 리터럴)"
 
 msgid "EMAIL_REPORTS_CTA"
 msgstr ""
@@ -5600,20 +8822,40 @@ msgstr ""
 msgid "ERROR"
 msgstr "%s 에러"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length"
-msgstr ""
+msgstr "엣지 길이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge length between nodes"
-msgstr ""
+msgstr "노드 간 엣지 길이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edge symbols"
-msgstr ""
+msgstr "엣지 기호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Edge width"
-msgstr ""
+msgstr "엣지 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit"
-msgstr ""
+msgstr "편집"
 
 #, fuzzy, python-format
 msgid "Edit %s"
@@ -5675,27 +8917,47 @@ msgstr "주석 레이어"
 msgid "Edit chart"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit chart properties"
-msgstr ""
+msgstr "차트 속성 편집"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Edit dashboard"
-msgstr ""
+msgstr "대시보드 편집"
 
 msgid "Edit database"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit email report"
-msgstr ""
+msgstr "이메일 보고서 편집"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit formatter"
-msgstr ""
+msgstr "포매터 편집"
 
 #, fuzzy
 msgid "Edit group"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit properties"
-msgstr ""
+msgstr "속성 편집"
 
 #, fuzzy
 msgid "Edit report"
@@ -5712,8 +8974,12 @@ msgstr "로그 수정"
 msgid "Edit template"
 msgstr "템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit template parameters"
-msgstr ""
+msgstr "템플릿 매개변수 편집"
 
 #, fuzzy
 msgid "Edit the dashboard"
@@ -5723,8 +8989,12 @@ msgstr "대시보드 추가"
 msgid "Edit theme properties"
 msgstr "CSS 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Edit time range"
-msgstr ""
+msgstr "시간 범위 편집"
 
 #, fuzzy
 msgid "Edit user"
@@ -5733,24 +9003,42 @@ msgstr "저장된 Query 수정"
 msgid "Edited"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Editing 1 filter:"
-msgstr ""
+msgstr "1개의 필터 편집 중:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the database is spelled incorrectly or does not exist."
-msgstr ""
+msgstr "데이터베이스 이름의 철자가 잘못되었거나 존재하지 않습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Either the username \"%(username)s\" or the password is incorrect."
-msgstr ""
+msgstr "사용자 이름 \"%(username)s\" 또는 비밀번호가 올바르지 않습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Either the username \"%(username)s\", password, or database name "
 "\"%(database)s\" is incorrect."
-msgstr ""
+msgstr "사용자 이름 \"%(username)s\", 비밀번호 또는 데이터베이스 이름 \"%(database)s\"이(가) 올바르지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Either the username or the password is wrong."
-msgstr ""
+msgstr "사용자 이름 또는 비밀번호가 올바르지 않습니다."
 
 #, fuzzy
 msgid "Elapsed"
@@ -5760,27 +9048,47 @@ msgstr "생성자"
 msgid "Elevation"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email"
-msgstr ""
+msgstr "이메일"
 
 #, fuzzy
 msgid "Email is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email link"
-msgstr ""
+msgstr "이메일 링크"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Email reports active"
-msgstr ""
+msgstr "이메일 보고서 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Email subject name (optional)"
-msgstr ""
+msgstr "이메일 제목 (선택 사항)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Embed"
-msgstr ""
+msgstr "임베드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Embed code"
-msgstr ""
+msgstr "임베드 코드"
 
 #, fuzzy
 msgid "Embed dashboard"
@@ -5790,14 +9098,26 @@ msgstr "대시보드 저장"
 msgid "Embedded dashboard could not be deleted."
 msgstr "대시보드를 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Embedding deactivated."
-msgstr ""
+msgstr "임베딩이 비활성화되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Emphasis"
-msgstr ""
+msgstr "강조"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty circle"
-msgstr ""
+msgstr "빈 원"
 
 #, fuzzy
 msgid "Empty collection"
@@ -5811,82 +9131,161 @@ msgstr "컬럼 추가"
 msgid "Empty query result"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty query?"
-msgstr ""
+msgstr "쿼리가 비어 있습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Empty row"
-msgstr ""
+msgstr "빈 행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Enable 'Allow file uploads to database' in any database's settings"
-msgstr ""
+msgstr "데이터베이스 설정에서 '데이터베이스에 파일 업로드 허용'을 활성화하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable Matrixify"
-msgstr ""
+msgstr "Matrixify 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable cross-filtering"
-msgstr ""
+msgstr "교차 필터링 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable data zooming controls"
-msgstr ""
+msgstr "데이터 확대/축소 컨트롤 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Enable embedding"
-msgstr ""
+msgstr "임베딩 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecast"
-msgstr ""
+msgstr "예측 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable forecasting"
-msgstr ""
+msgstr "예측 기능 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable graph roaming"
-msgstr ""
+msgstr "그래프 로밍 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "아이콘 JavaScript 모드 활성화"
 
 #, fuzzy
 msgid "Enable icons"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "레이블 JavaScript 모드 활성화"
 
 #, fuzzy
 msgid "Enable labels"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "matrixify 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable node dragging"
-msgstr ""
+msgstr "노드 드래그 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable query cost estimation"
-msgstr ""
+msgstr "쿼리 비용 추정 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable row expansion in schemas"
-msgstr ""
+msgstr "스키마에서 행 확장 활성화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enable server side pagination of results (experimental feature)"
-msgstr ""
+msgstr "결과의 서버 측 페이지네이션 활성화 (실험적 기능)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "JavaScript를 통한 사용자 지정 아이콘 구성을 활성화합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "JavaScript를 통한 사용자 지정 레이블 구성을 활성화합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "GeoJSON 포인트에 대한 아이콘 렌더링을 활성화합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "GeoJSON 포인트에 대한 레이블 렌더링을 활성화합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Encountered invalid NULL spatial entry,"
 "                                        please consider filtering those "
 "out"
-msgstr ""
+msgstr "유효하지 않은 NULL 공간 항목이 발견되었습니다. 해당 항목을 필터링하는 것을 고려해 주세요"
 
 #, fuzzy
 msgid "Encrypted extra fields"
@@ -5895,31 +9294,52 @@ msgstr "저장된 Query"
 msgid "End"
 msgstr "끝 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (Longitude, Latitude): "
-msgstr ""
+msgstr "끝 (경도, 위도): "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End (exclusive)"
-msgstr ""
+msgstr "끝 (미포함)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "End Longitude & Latitude"
-msgstr ""
+msgstr "끝 경도 및 위도"
 
 #, fuzzy
 msgid "End Time"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "End angle"
-msgstr ""
+msgstr "끝 각도"
 
 #, fuzzy
 msgid "End date"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "End date excluded from time range"
-msgstr ""
+msgstr "시간 범위에서 제외된 종료 날짜"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "End date must be after start date"
-msgstr ""
+msgstr "종료 날짜는 시작 날짜 이후여야 합니다"
 
 #, fuzzy
 msgid "Ends With"
@@ -5929,30 +9349,53 @@ msgstr "차트 유형"
 msgid "Ends with (ILIKE %x)"
 msgstr "차트 유형"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
-msgstr ""
+msgstr "엔진 \"%(engine)s\"은(는) 매개변수를 통해 구성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Engine Parameters"
-msgstr ""
+msgstr "엔진 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Engine spec \"InvalidEngine\" does not support being configured via "
 "individual parameters."
-msgstr ""
+msgstr "엔진 사양 \"InvalidEngine\"은(는) 개별 매개변수를 통한 구성을 지원하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter CA_BUNDLE"
-msgstr ""
+msgstr "CA_BUNDLE 입력"
 
 #, fuzzy
 msgid "Enter Primary Credentials"
 msgstr "엑셀 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter a name for this sheet"
-msgstr ""
+msgstr "이 시트의 이름을 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter a new title for the tab"
-msgstr ""
+msgstr "탭의 새 제목을 입력하세요"
 
 #, fuzzy
 msgid "Enter a part of the object name"
@@ -5966,11 +9409,18 @@ msgstr "테이블 명"
 msgid "Enter duration in seconds"
 msgstr "10초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Enter fullscreen"
-msgstr ""
+msgstr "전체 화면으로 전환"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter minimum and maximum values for the range filter"
-msgstr ""
+msgstr "범위 필터의 최솟값과 최댓값을 입력하세요"
 
 #, fuzzy
 msgid "Enter report name"
@@ -5988,15 +9438,24 @@ msgstr "테이블 명"
 msgid "Enter the group's name"
 msgstr "테이블 명"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Enter the required %(dbModelName)s credentials"
-msgstr ""
+msgstr "필수 %(dbModelName)s 자격 증명을 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the unique project id for your database."
-msgstr ""
+msgstr "데이터베이스의 고유한 프로젝트 ID를 입력하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's email"
-msgstr ""
+msgstr "사용자의 이메일을 입력하세요"
 
 #, fuzzy
 msgid "Enter the user's first name"
@@ -6010,27 +9469,48 @@ msgstr "테이블 명"
 msgid "Enter the user's password"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter the user's username"
-msgstr ""
+msgstr "사용자의 사용자 이름을 입력하세요"
 
 #, fuzzy
 msgid "Enter theme name"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enter your login and password below:"
-msgstr ""
+msgstr "아래에 로그인 및 비밀번호를 입력하세요:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Entity"
-msgstr ""
+msgstr "엔티티"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal Date Sizes"
-msgstr ""
+msgstr "동일한 날짜 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Equal to (=)"
-msgstr ""
+msgstr "같음 (=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Equals"
-msgstr ""
+msgstr "같음"
 
 #, fuzzy
 msgid "Error"
@@ -6044,9 +9524,11 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "Error deleting %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "전체 화면 비활성화 오류: %s"
 
 #, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
@@ -6064,45 +9546,76 @@ msgstr "차트 수정"
 msgid "Error fetching charts"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error importing theme."
-msgstr ""
+msgstr "테마 가져오기 오류."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in RLS filters: %(msg)s"
-msgstr ""
+msgstr "RLS 필터의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in WHERE clause: %(msg)s"
-msgstr ""
+msgstr "WHERE 절의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr ""
+msgstr "임시 열의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
-msgstr ""
+msgstr "열 표현식의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in datetime column: %(msg)s"
-msgstr ""
+msgstr "날짜/시간 열의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error in jinja expression in fetch values predicate: %(msg)s"
-msgstr ""
+msgstr "값 가져오기 조건자의 jinja 표현식 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Error in jinja expression in metric expression: %(msg)s"
-msgstr ""
+msgstr "메트릭 표현식의 jinja 표현식 오류: %(msg)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Error loading chart datasources. Filters may not work correctly."
-msgstr ""
+msgstr "차트 데이터 소스를 불러오는 중 오류가 발생했습니다. 필터가 올바르게 작동하지 않을 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Error message"
-msgstr ""
+msgstr "오류 메시지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error parsing"
-msgstr ""
+msgstr "파싱 오류"
 
 #, fuzzy
 msgid "Error reading CSV file"
@@ -6140,82 +9653,146 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "Error while fetching roles"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error while rendering virtual dataset query: %(msg)s"
-msgstr ""
+msgstr "가상 데이터셋 쿼리 렌더링 중 오류: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(error)s"
-msgstr ""
+msgstr "오류: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Error: %(msg)s"
-msgstr ""
+msgstr "오류: %(msg)s"
 
 #, fuzzy, python-format
 msgid "Error: %s"
 msgstr "%s 에러"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Error: permalink state not found"
-msgstr ""
+msgstr "오류: 퍼머링크 상태를 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate cost"
-msgstr ""
+msgstr "비용 추정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate selected query cost"
-msgstr ""
+msgstr "선택한 쿼리 비용 추정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Estimate the cost before running a query"
-msgstr ""
+msgstr "쿼리 실행 전 비용 추정"
 
 #, fuzzy
 msgid "Event"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Event flow"
-msgstr ""
+msgstr "이벤트 흐름"
 
 #, fuzzy
 msgid "Event time column"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Every"
-msgstr ""
+msgstr "매"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Evolution"
-msgstr ""
+msgstr "추이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exact"
-msgstr ""
+msgstr "정확"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "정확히 일치 (IN)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Example"
-msgstr ""
+msgstr "예시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Examples"
-msgstr ""
+msgstr "예시"
 
 #, fuzzy
 msgid "Excel Export"
 msgstr "CSV 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excel XML Export"
-msgstr ""
+msgstr "Excel XML 내보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excel file format cannot be determined"
-msgstr ""
+msgstr "Excel 파일 형식을 확인할 수 없습니다"
 
 #, fuzzy
 msgid "Excel upload"
 msgstr "CSV 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Exclude selected values"
-msgstr ""
+msgstr "선택한 값 제외"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Excluded roles"
-msgstr ""
+msgstr "제외된 역할"
 
 #, fuzzy
 msgid "Executed SQL"
@@ -6224,65 +9801,117 @@ msgstr "저장된 Query 수정"
 msgid "Executed query"
 msgstr "저장된 Query 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Execution ID"
-msgstr ""
+msgstr "실행 ID"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Execution log"
-msgstr ""
+msgstr "실행 로그"
 
 #, fuzzy
 msgid "Existing dataset"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Exit fullscreen"
-msgstr ""
+msgstr "전체 화면 종료"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand"
-msgstr ""
+msgstr "확장"
 
 #, fuzzy
 msgid "Expand All"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand all"
-msgstr ""
+msgstr "모두 확장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expand data panel"
-msgstr ""
+msgstr "데이터 패널 확장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Expand row"
-msgstr ""
+msgstr "행 확장"
 
 #, fuzzy
 msgid "Expand row to edit"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
 "        in milliseconds since epoch. mathjs is used to evaluate the "
 "formulas.\n"
 "        Example: '2x+5'"
 msgstr ""
+"에포크 이후 밀리초 단위의 종속 시간 매개변수 'x'를 포함한 수식을 입력하세요.\n"
+"        수식 계산에는 mathjs가 사용됩니다.\n"
+"        예시: '2x+5'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Experimental"
-msgstr ""
+msgstr "실험적"
 
 #, fuzzy
 msgid "Expired"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Explore"
-msgstr ""
+msgstr "탐색"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Explore - %(table)s"
-msgstr ""
+msgstr "탐색 - %(table)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Explore the result set in the data exploration view"
-msgstr ""
+msgstr "데이터 탐색 보기에서 결과 집합 탐색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Export"
-msgstr ""
+msgstr "내보내기"
 
 #, fuzzy
 msgid "Export All Data"
@@ -6304,29 +9933,45 @@ msgstr "차트 유형"
 msgid "Export cancelled"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Export dashboards?"
-msgstr ""
+msgstr "대시보드를 내보내시겠습니까?"
 
 #, fuzzy
 msgid "Export failed"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export failed - please try again"
-msgstr ""
+msgstr "내보내기 실패 - 다시 시도해 주세요"
 
 #, fuzzy, python-format
 msgid "Export failed: %s"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export screenshot (jpeg)"
-msgstr ""
+msgstr "스크린샷 내보내기 (jpeg)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Export successful: %s"
-msgstr ""
+msgstr "내보내기 성공: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Export to .CSV"
-msgstr ""
+msgstr ".CSV로 내보내기"
 
 #, fuzzy
 msgid "Export to .JSON"
@@ -6336,8 +9981,12 @@ msgstr "대시보드 가져오기"
 msgid "Export to CSV"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Export to Excel"
-msgstr ""
+msgstr "Excel로 내보내기"
 
 #, fuzzy
 msgid "Export to PDF"
@@ -6351,102 +10000,201 @@ msgstr "대시보드 가져오기"
 msgid "Export to Pivoted Excel"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export to full .CSV"
-msgstr ""
+msgstr "전체 .CSV로 내보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Export to full Excel"
-msgstr ""
+msgstr "전체 Excel로 내보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Export to original .CSV"
-msgstr ""
+msgstr "원본 .CSV로 내보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Export to pivoted .CSV"
-msgstr ""
+msgstr "피벗된 .CSV로 내보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Expose database in SQL Lab"
-msgstr ""
+msgstr "SQL Lab에서 데이터베이스 공개"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Expose in SQL Lab"
-msgstr ""
+msgstr "SQL Lab에서 공개"
 
 #, fuzzy
 msgid "Expression"
 msgstr "표현식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Expression cannot be empty"
-msgstr ""
+msgstr "표현식은 비워둘 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Extensions"
-msgstr ""
+msgstr "확장 기능"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Extent"
-msgstr ""
+msgstr "범위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "외부 링크 경고"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra"
-msgstr ""
+msgstr "추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra Controls"
-msgstr ""
+msgstr "추가 컨트롤"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Extra Parameters"
-msgstr ""
+msgstr "추가 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra data for JS"
-msgstr ""
+msgstr "JS를 위한 추가 데이터"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "Extra data to specify table metadata. Currently supports metadata of the "
 "format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\","
 " \"details\": \"This table is the source of truth.\" }, "
 "\"warning_markdown\": \"This is a warning.\" }`."
 msgstr ""
+"테이블 메타데이터를 지정하기 위한 추가 데이터. 현재 다음 형식의 메타데이터를 지원합니다: `{ \"certification\": "
+"{ \"certified_by\": \"Data Platform Team\", \"details\": \"This table is "
+"the source of truth.\" }, \"warning_markdown\": \"This is a warning.\" "
+"}`."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Extra parameters for use in jinja templated queries"
-msgstr ""
+msgstr "jinja 템플릿 쿼리에서 사용하기 위한 추가 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Extra parameters that any plugins can choose to set for use in Jinja "
 "templated queries"
-msgstr ""
+msgstr "Jinja 템플릿 쿼리에서 사용하기 위해 플러그인이 설정할 수 있는 추가 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Extra url parameters for use in Jinja templated queries"
-msgstr ""
+msgstr "Jinja 템플릿 쿼리에서 사용하기 위한 추가 URL 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Extruded"
-msgstr ""
+msgstr "돌출"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FEB"
-msgstr ""
+msgstr "2월"
 
 #, fuzzy
 msgid "FIT DATA"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "데이터 맞추기"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "FRI"
-msgstr ""
+msgstr "금"
 
 #, fuzzy
 msgid "Factor"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Factor to multiply the metric by"
-msgstr ""
+msgstr "지표에 곱할 인수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fail login count"
-msgstr ""
+msgstr "로그인 실패 횟수"
 
 msgid "Failed"
 msgstr "실패"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed at retrieving results"
-msgstr ""
+msgstr "결과 검색에 실패했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to apply theme: Invalid JSON"
-msgstr ""
+msgstr "테마 적용 실패: 유효하지 않은 JSON"
 
 #, fuzzy
 msgid "Failed to copy API key to clipboard"
@@ -6460,29 +10208,49 @@ msgstr "클립보드에 복사하기"
 msgid "Failed to create API key"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to create report"
-msgstr ""
+msgstr "보고서 생성에 실패했습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Failed to execute %(query)s"
-msgstr ""
+msgstr "%(query)s 실행에 실패했습니다"
 
 #, fuzzy
 msgid "Failed to fetch API keys"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to generate chart edit URL"
-msgstr ""
+msgstr "차트 편집 URL 생성에 실패했습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "다운로드 생성에 실패했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data"
-msgstr ""
+msgstr "차트 데이터 로드에 실패했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Failed to load chart data."
-msgstr ""
+msgstr "차트 데이터를 로드하지 못했습니다."
 
 #, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
@@ -6492,19 +10260,29 @@ msgstr "차트 수정"
 msgid "Failed to load top values"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "파일을 열지 못했습니다. 다시 시도해 주세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr ""
+msgstr "시스템 다크 테마 제거에 실패했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to remove system default theme: %s"
-msgstr ""
+msgstr "시스템 기본 테마 제거에 실패했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to retrieve advanced type"
-msgstr ""
+msgstr "고급 유형 검색에 실패했습니다"
 
 #, fuzzy
 msgid "Failed to revoke API key"
@@ -6522,50 +10300,81 @@ msgstr "필터"
 msgid "Failed to save cross-filters setting"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to set local theme: Invalid JSON configuration"
-msgstr ""
+msgstr "로컬 테마 설정에 실패했습니다: 유효하지 않은 JSON 구성"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system dark theme: %s"
-msgstr ""
+msgstr "시스템 다크 테마 설정에 실패했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Failed to set system default theme: %s"
-msgstr ""
+msgstr "시스템 기본 테마 설정에 실패했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to start remote query on a worker."
-msgstr ""
+msgstr "워커에서 원격 쿼리를 시작하지 못했습니다."
 
 #, fuzzy
 msgid "Failed to stop query."
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to store query results. Please try again."
-msgstr ""
+msgstr "쿼리 결과를 저장하지 못했습니다. 다시 시도해 주세요."
 
 #, fuzzy
 msgid "Failed to tag items"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Failed to update report"
-msgstr ""
+msgstr "보고서 업데이트에 실패했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to validate expression. Please try again."
-msgstr ""
+msgstr "표현식 유효성 검사에 실패했습니다. 다시 시도해 주세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Failed to verify select options: %s"
-msgstr ""
+msgstr "선택 옵션 확인에 실패했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Falling back to CSV; Excel export library not available."
-msgstr ""
+msgstr "CSV로 대체합니다. Excel 내보내기 라이브러리를 사용할 수 없습니다."
 
 #, fuzzy
 msgid "False"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Favorite"
-msgstr ""
+msgstr "즐겨찾기"
 
 #, fuzzy
 msgid "Feature Not Enabled"
@@ -6575,48 +10384,81 @@ msgstr "엑셀 업로드"
 msgid "Featured"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Featured color palettes"
-msgstr ""
+msgstr "추천 색상 팔레트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "February"
-msgstr ""
+msgstr "2월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Fetch data preview"
-msgstr ""
+msgstr "데이터 미리보기 가져오기"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Fetched %s"
-msgstr ""
+msgstr "%s 가져옴"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fetching"
-msgstr ""
+msgstr "가져오는 중"
 
 #, fuzzy
 msgid "Fetching data..."
 msgstr "데이터베이스 선택"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(json_error)s"
-msgstr ""
+msgstr "필드를 JSON으로 디코딩할 수 없습니다. %(json_error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Field cannot be decoded by JSON. %(msg)s"
-msgstr ""
+msgstr "필드를 JSON으로 디코딩할 수 없습니다. %(msg)s"
 
 #, fuzzy
 msgid "Field cannot be empty."
 msgstr "대시보드를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Field is required"
-msgstr ""
+msgstr "필드는 필수입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "File extension is not allowed."
-msgstr ""
+msgstr "파일 확장자가 허용되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
-msgstr ""
+msgstr "이 브라우저에서는 파일 처리가 지원되지 않습니다. Chrome 또는 Edge와 같은 최신 브라우저를 사용해 주세요."
 
 #, fuzzy
 msgid "File settings"
@@ -6626,18 +10468,28 @@ msgstr "Query 공유"
 msgid "File upload"
 msgstr "CSV 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill Color"
-msgstr ""
+msgstr "채우기 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fill all required fields to enable \"Default Value\""
-msgstr ""
+msgstr "\"기본값\"을 활성화하려면 모든 필수 필드를 입력하세요"
 
 #, fuzzy
 msgid "Fill method"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fill out the registration form"
-msgstr ""
+msgstr "등록 양식을 작성하세요"
 
 #, fuzzy
 msgid "Filled"
@@ -6647,22 +10499,34 @@ msgstr "실패"
 msgid "Filter"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk]
+#, fuzzy
 msgid "Filter Configuration"
-msgstr ""
+msgstr "필터 구성"
 
 #, fuzzy
 msgid "Filter Settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter Type"
-msgstr ""
+msgstr "필터 유형"
 
 #, fuzzy
 msgid "Filter charts"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter has default value"
-msgstr ""
+msgstr "필터에 기본값이 있음"
 
 #, fuzzy
 msgid "Filter menu"
@@ -6671,8 +10535,12 @@ msgstr "필터"
 msgid "Filter name"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Filter only displays values relevant to selections made in other filters."
-msgstr ""
+msgstr "필터는 다른 필터에서 선택한 항목과 관련된 값만 표시합니다."
 
 #, fuzzy
 msgid "Filter options"
@@ -6685,18 +10553,30 @@ msgstr "검색 결과"
 msgid "Filter type"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value (case sensitive)"
-msgstr ""
+msgstr "필터 값 (대소문자 구분)"
 
 #, fuzzy
 msgid "Filter value is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter value list cannot be empty"
-msgstr ""
+msgstr "필터 값 목록은 비워둘 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Filter your charts"
-msgstr ""
+msgstr "차트 필터링"
 
 msgid "Filters"
 msgstr "필터"
@@ -6711,22 +10591,42 @@ msgstr "컬럼 목록"
 msgid "Filters by metrics"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Filters for comparison must have a value"
-msgstr ""
+msgstr "비교를 위한 필터에는 값이 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values equal to this exact value."
-msgstr ""
+msgstr "이 정확한 값과 같은 값을 위한 필터입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values greater than or equal."
-msgstr ""
+msgstr "크거나 같은 값을 위한 필터입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Filters for values less than or equal."
-msgstr ""
+msgstr "작거나 같은 값을 위한 필터입니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Filters out of scope (%d)"
-msgstr ""
+msgstr "범위 밖의 필터 (%d)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Filters with the same group key will be ORed together within the group, "
 "while different filter groups will be ANDed together. Undefined group "
@@ -6737,16 +10637,29 @@ msgid ""
 "filter (department = 'Finance' OR department = 'Marketing') AND (region ="
 " 'Europe')."
 msgstr ""
+"동일한 그룹 키를 가진 필터는 그룹 내에서 OR로 결합되고, 서로 다른 필터 그룹은 AND로 결합됩니다. 정의되지 않은 그룹 키는 "
+"고유 그룹으로 처리되며, 즉 함께 그룹화되지 않습니다. 예를 들어, 테이블에 세 개의 필터가 있고 그 중 두 개는 재무 및 마케팅 "
+"부서용(그룹 키 = 'department')이고 하나는 유럽 지역을 나타내는 경우(그룹 키 = 'region'), 필터 절은 "
+"(department = 'Finance' OR department = 'Marketing') AND (region = "
+"'Europe') 필터를 적용합니다."
 
 #, fuzzy
 msgid "Find"
 msgstr "실패"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Finish"
-msgstr ""
+msgstr "완료"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "First"
-msgstr ""
+msgstr "첫 번째"
 
 #, fuzzy
 msgid "First Name"
@@ -6760,91 +10673,180 @@ msgstr "차트 유형"
 msgid "First name is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Fit columns dynamically"
-msgstr ""
+msgstr "열 너비 동적 조정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Fix the trend line to the full time range specified in case filtered "
 "results do not include the start or end dates"
-msgstr ""
+msgstr "필터링된 결과에 시작 또는 종료 날짜가 포함되지 않는 경우 추세선을 지정된 전체 시간 범위에 고정합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fix to selected Time Range"
-msgstr ""
+msgstr "선택한 시간 범위에 고정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fixed"
-msgstr ""
+msgstr "고정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Fixed Color"
-msgstr ""
+msgstr "고정 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Fixed color"
-msgstr ""
+msgstr "고정 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Fixed point radius"
-msgstr ""
+msgstr "고정 포인트 반경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Flow"
-msgstr ""
+msgstr "흐름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Folder with content must have a name"
-msgstr ""
+msgstr "내용이 있는 폴더에는 이름이 있어야 합니다"
 
 #, fuzzy
 msgid "Folders"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size"
-msgstr ""
+msgstr "글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for axis labels, detail value and other text elements"
-msgstr ""
+msgstr "축 레이블, 세부 값 및 기타 텍스트 요소의 글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the biggest value in the list"
-msgstr ""
+msgstr "목록에서 가장 큰 값의 글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Font size for the smallest value in the list"
-msgstr ""
+msgstr "목록에서 가장 작은 값의 글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For Bigquery, Presto and Postgres, shows a button to compute cost before "
 "running a query."
-msgstr ""
+msgstr "Bigquery, Presto 및 Postgres의 경우 쿼리를 실행하기 전에 비용을 계산하는 버튼을 표시합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "For Trino, describe full schemas of nested ROW types, expanding them with"
 " dotted paths"
-msgstr ""
+msgstr "Trino의 경우 중첩된 ROW 유형의 전체 스키마를 점으로 구분된 경로로 확장하여 표시합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "For further instructions, consult the"
-msgstr ""
+msgstr "추가 지침은 다음을 참조하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For more information about objects are in context in the scope of this "
 "function, refer to the"
-msgstr ""
+msgstr "이 함수 범위 내에서 컨텍스트에 있는 객체에 대한 자세한 내용은 다음을 참조하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "For regular filters, these are the roles this filter will be applied to. "
 "For base filters, these are the roles that the filter DOES NOT apply to, "
 "e.g. Admin if admin should see all data."
 msgstr ""
+"일반 필터의 경우 이 필터가 적용될 역할입니다. 기본 필터의 경우 필터가 적용되지 않는 역할입니다. 예: 관리자가 모든 데이터를 볼"
+" 수 있어야 하는 경우 Admin."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forbidden"
-msgstr ""
+msgstr "금지됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Force"
-msgstr ""
+msgstr "강제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Force Time Grain as Max Interval"
-msgstr ""
+msgstr "시간 단위를 최대 간격으로 강제 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "강제 중단 (모든 구독자의 작업 중지)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
 "CTAS or CVAS in SQL Lab."
-msgstr ""
+msgstr "SQL Lab에서 CTAS 또는 CVAS를 클릭할 때 모든 테이블과 뷰를 이 스키마에 강제로 생성합니다."
 
 #, fuzzy
 msgid "Force categorical"
@@ -6854,70 +10856,127 @@ msgstr "데이터소스 명"
 msgid "Force date format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh"
-msgstr ""
+msgstr "강제 새로고침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Force refresh Slack channels list"
-msgstr ""
+msgstr "Slack 채널 목록 강제 새로고침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Force refresh catalog list"
-msgstr ""
+msgstr "카탈로그 목록 강제 새로고침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh schema list"
-msgstr ""
+msgstr "스키마 목록 강제 새로고침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Force refresh table list"
-msgstr ""
+msgstr "테이블 목록 강제 새로고침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
-msgstr ""
+msgstr "선택한 시간 단위를 X축 레이블의 최대 간격으로 강제 설정합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Forecast periods"
-msgstr ""
+msgstr "예측 기간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Foreign key"
-msgstr ""
+msgstr "외래 키"
 
 #, fuzzy
 msgid "Forest Green"
 msgstr "권한 부여"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to chart metadata."
-msgstr ""
+msgstr "캐시에서 양식 데이터를 찾을 수 없어 차트 메타데이터로 되돌립니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Form data not found in cache, reverting to dataset metadata."
-msgstr ""
+msgstr "캐시에서 양식 데이터를 찾을 수 없어 데이터셋 메타데이터로 되돌립니다."
 
 #, fuzzy
 msgid "Format"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Format JSON configuration"
-msgstr ""
+msgstr "JSON 구성 형식 지정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Format SQL"
-msgstr ""
+msgstr "SQL 형식 지정"
 
 #, fuzzy
 msgid "Format SQL query"
 msgstr "Query 저장"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-brace-format
 msgid ""
 "Format data labels. Use variables: {name}, {value}, {percent}. \\n "
 "represents a new line. ECharts compatibility:\n"
 "{a} (series), {b} (name), {c} (value), {d} (percentage)"
 msgstr ""
+"데이터 레이블 형식 지정. 변수 사용: {name}, {value}, {percent}. \\n은 새 줄을 나타냅니다. "
+"ECharts 호환성:\n"
+"{a} (계열), {b} (이름), {c} (값), {d} (백분율)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"측정항목 또는 열에 통화 기호를 접두사 또는 접미사로 형식을 지정합니다. 기호를 수동으로 선택하거나 '자동 감지'를 사용하여 "
+"데이터셋의 통화 코드 열을 기반으로 올바른 기호를 적용합니다. 여러 통화가 있는 경우 형식이 중립적인 숫자로 대체됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Formatted CSV attached in email"
-msgstr ""
+msgstr "이메일에 첨부된 형식화된 CSV"
 
 #, fuzzy
 msgid "Formatted date"
@@ -6939,31 +10998,54 @@ msgstr "주석"
 msgid "Formatting object"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Formula"
-msgstr ""
+msgstr "공식"
 
 #, fuzzy
 msgid "Forward values"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Found invalid orderby options"
-msgstr ""
+msgstr "유효하지 않은 정렬 옵션이 발견되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Fraction digits"
-msgstr ""
+msgstr "소수 자릿수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Frequency"
-msgstr ""
+msgstr "빈도"
 
 #, fuzzy
 msgid "Friction"
 msgstr "활동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friction between nodes"
-msgstr ""
+msgstr "노드 간 마찰"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Friday"
-msgstr ""
+msgstr "금요일"
 
 msgid "From date cannot be larger than to date"
 msgstr "시작 날짜가 끝 날짜보다 클 수 없습니다"
@@ -6972,18 +11054,29 @@ msgstr "시작 날짜가 끝 날짜보다 클 수 없습니다"
 msgid "Full name"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fullscreen is not supported in this browser."
-msgstr ""
+msgstr "이 브라우저에서는 전체 화면이 지원되지 않습니다."
 
 #, fuzzy
 msgid "Funnel Chart"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each column"
-msgstr ""
+msgstr "각 열의 표시 방법을 추가로 사용자 지정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Further customize how to display each metric"
-msgstr ""
+msgstr "각 측정항목의 표시 방법을 추가로 사용자 지정"
 
 msgid "GROUP BY"
 msgstr ""
@@ -6992,17 +11085,24 @@ msgstr ""
 msgid "Gantt Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Gantt chart visualizes important events over a time span. Every data "
 "point displayed as a separate event along a horizontal line."
-msgstr ""
+msgstr "간트 차트는 기간 내의 중요한 이벤트를 시각화합니다. 각 데이터 포인트는 수평선을 따라 별도의 이벤트로 표시됩니다."
 
 #, fuzzy
 msgid "Gauge Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "General"
-msgstr ""
+msgstr "일반"
 
 #, fuzzy
 msgid "General information"
@@ -7012,15 +11112,23 @@ msgstr "주석"
 msgid "General settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Generating link, please wait.."
-msgstr ""
+msgstr "링크를 생성하는 중입니다. 잠시 기다려 주세요.."
 
 #, fuzzy
 msgid "Generic Chart"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geo"
-msgstr ""
+msgstr "지리"
 
 #, fuzzy
 msgid "GeoJson Column"
@@ -7030,33 +11138,64 @@ msgstr "컬럼 추가"
 msgid "GeoJson Settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Geohash"
-msgstr ""
+msgstr "Geohash"
 
 #, fuzzy
 msgid "Geometry Column"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the last date by the date unit."
-msgstr ""
+msgstr "날짜 단위로 마지막 날짜를 가져옵니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Get the specify date for the holiday"
-msgstr ""
+msgstr "공휴일의 지정 날짜를 가져옵니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Give access to multiple catalogs in a single database connection."
-msgstr ""
+msgstr "단일 데이터베이스 연결에서 여러 카탈로그에 대한 액세스를 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Go to the edit mode to configure the dashboard and add charts"
-msgstr ""
+msgstr "대시보드를 구성하고 차트를 추가하려면 편집 모드로 이동하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Gold"
-msgstr ""
+msgstr "금색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Google Sheet Name and URL"
-msgstr ""
+msgstr "Google 시트 이름 및 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Grace period"
-msgstr ""
+msgstr "유예 기간"
 
 #, fuzzy
 msgid "Grain"
@@ -7066,11 +11205,19 @@ msgstr "분"
 msgid "Graph Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Graph layout"
-msgstr ""
+msgstr "그래프 레이아웃"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Gravity"
-msgstr ""
+msgstr "중력"
 
 #, fuzzy
 msgid "Greater Than"
@@ -7080,76 +11227,138 @@ msgstr "값은 0보다 커야합니다"
 msgid "Greater Than or Equal"
 msgstr "값은 0보다 커야합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Greater or equal (>=)"
-msgstr ""
+msgstr "크거나 같음 (>=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Greater than (>)"
-msgstr ""
+msgstr "초과 (>)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Green for increase, red for decrease"
-msgstr ""
+msgstr "증가는 녹색, 감소는 빨간색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Grid"
-msgstr ""
+msgstr "그리드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Grid Size"
-msgstr ""
+msgstr "그리드 크기"
 
 #, fuzzy
 msgid "Grid view"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group"
-msgstr ""
+msgstr "그룹"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Group By"
-msgstr ""
+msgstr "그룹화 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Group By, Metrics or Percentage Metrics must have a value"
-msgstr ""
+msgstr "그룹화 기준, 측정항목 또는 백분율 측정항목에는 값이 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group Key"
-msgstr ""
+msgstr "그룹 키"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Group by"
-msgstr ""
+msgstr "그룹화 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Group remaining as \"Others\""
-msgstr ""
+msgstr "나머지를 \"기타\"로 그룹화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Grouping"
-msgstr ""
+msgstr "그룹화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Groups"
-msgstr ""
+msgstr "그룹"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Groups remaining series into an \"Others\" category when series limit is "
 "reached. This prevents incomplete time series data from being displayed."
-msgstr ""
+msgstr "계열 한도에 도달하면 나머지 계열을 \"기타\" 범주로 그룹화합니다. 이를 통해 불완전한 시계열 데이터가 표시되는 것을 방지합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Guest user cannot modify chart payload"
-msgstr ""
+msgstr "게스트 사용자는 차트 페이로드를 수정할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "HTTP 경로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Handlebars"
-msgstr ""
+msgstr "Handlebars"
 
 #, fuzzy
 msgid "Handlebars Template"
 msgstr "템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hard value bounds applied for color coding."
-msgstr ""
+msgstr "색상 코딩에 엄격한 값 경계가 적용되었습니다."
 
 #, fuzzy
 msgid "Has created by"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Header"
-msgstr ""
+msgstr "헤더"
 
 #, fuzzy
 msgid "Header row"
@@ -7159,17 +11368,32 @@ msgstr "차트 이동"
 msgid "Header row is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Heatmap"
-msgstr ""
+msgstr "히트맵"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Height"
-msgstr ""
+msgstr "높이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Height of each row in pixels"
-msgstr ""
+msgstr "각 행의 높이(픽셀 단위)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Height of the sparkline"
-msgstr ""
+msgstr "스파크라인의 높이"
 
 #, fuzzy
 msgid "Hidden"
@@ -7179,55 +11403,93 @@ msgstr "CSV 파일"
 msgid "Hide Column"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hide Line"
-msgstr ""
+msgstr "선 숨기기"
 
 #, fuzzy
 msgid "Hide chart description"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hide layer"
-msgstr ""
+msgstr "레이어 숨기기"
 
 #, fuzzy
 msgid "Hide password."
 msgstr "비밀번호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Hides the Line for the time series"
-msgstr ""
+msgstr "시계열의 선을 숨깁니다"
 
 #, fuzzy
 msgid "Hierarchy"
 msgstr "검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Histogram"
-msgstr ""
+msgstr "히스토그램"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Home"
-msgstr ""
+msgstr "홈"
 
 #, fuzzy
 msgid "Horizon Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Horizon Charts"
-msgstr ""
+msgstr "호라이즌 차트"
 
 #, fuzzy
 msgid "Horizontal"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Horizontal (Top)"
-msgstr ""
+msgstr "수평 (위)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Horizontal alignment"
-msgstr ""
+msgstr "수평 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Host"
-msgstr ""
+msgstr "호스트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hostname or IP address"
-msgstr ""
+msgstr "호스트명 또는 IP 주소"
 
 msgid "Hour"
 msgstr "시"
@@ -7236,38 +11498,78 @@ msgstr "시"
 msgid "Hours %s"
 msgstr "시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Hours offset"
-msgstr ""
+msgstr "시간 오프셋"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How do you want to enter service account credentials?"
-msgstr ""
+msgstr "서비스 계정 자격 증명을 어떻게 입력하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "How many buckets should the data be grouped in."
-msgstr ""
+msgstr "데이터를 몇 개의 버킷으로 그룹화해야 합니까."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "How many periods into the future do we want to predict"
-msgstr ""
+msgstr "미래의 몇 개 기간을 예측하려고 합니까"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "How many top values to select"
-msgstr ""
+msgstr "선택할 상위 값의 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "How to display time shifts: as individual lines; as the difference "
 "between the main time series and each time shift; as the percentage "
 "change; or as the ratio between series and time shifts."
 msgstr ""
+"시간 이동 표시 방법: 개별 선으로; 기본 시계열과 각 시간 이동 간의 차이로; 퍼센트 변화로; 또는 시계열과 시간 이동 간의 "
+"비율로."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Huge"
-msgstr ""
+msgstr "매우 큰"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 3166-2 Codes"
-msgstr ""
+msgstr "ISO 3166-2 코드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ISO 8601"
-msgstr ""
+msgstr "ISO 8601"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon JavaScript config generator"
-msgstr ""
+msgstr "아이콘 JavaScript 설정 생성기"
 
 #, fuzzy
 msgid "Icon URL"
@@ -7277,15 +11579,30 @@ msgstr "컬럼 추가"
 msgid "Icon size"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon size unit"
-msgstr ""
+msgstr "아이콘 크기 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Id"
-msgstr ""
+msgstr "ID"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Id of root node of the tree."
-msgstr ""
+msgstr "트리의 루트 노드 ID."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "If Presto or Trino, all the queries in SQL Lab are going to be executed "
 "as the currently logged on user who must have permission to run them. If "
@@ -7293,47 +11610,90 @@ msgid ""
 "service account, but impersonate the currently logged on user via "
 "hive.server2.proxy.user property."
 msgstr ""
+"Presto 또는 Trino의 경우, SQL Lab의 모든 쿼리는 실행 권한이 있는 현재 로그인한 사용자로 실행됩니다. Hive와 "
+"hive.server2.enable.doAs가 활성화된 경우, 서비스 계정으로 쿼리를 실행하지만 "
+"hive.server2.proxy.user 속성을 통해 현재 로그인한 사용자를 가장합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "If a metric is specified, sorting will be done based on the metric value"
-msgstr ""
+msgstr "지표가 지정된 경우, 해당 지표 값을 기준으로 정렬됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If enabled, this control sorts the results/values descending, otherwise "
 "it sorts the results ascending."
-msgstr ""
+msgstr "활성화하면 이 컨트롤은 결과/값을 내림차순으로 정렬하고, 그렇지 않으면 결과를 오름차순으로 정렬합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
-msgstr ""
+msgstr "비어 있으면 저장되지 않고 목록에서 제거됩니다. 폴더를 제거하려면 지표와 열을 다른 폴더로 이동하십시오."
 
 #, fuzzy
 msgid "If table already exists"
 msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "If you don't save, changes will be lost."
-msgstr ""
+msgstr "저장하지 않으면 변경 사항이 손실됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ignore cache when generating report"
-msgstr ""
+msgstr "보고서 생성 시 캐시 무시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore null locations"
-msgstr ""
+msgstr "null 위치 무시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ignore time"
-msgstr ""
+msgstr "시간 무시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image (PNG) embedded in email"
-msgstr ""
+msgstr "이메일에 포함된 이미지 (PNG)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Image download failed, please refresh and try again."
-msgstr ""
+msgstr "이미지 다운로드에 실패했습니다. 페이지를 새로 고침하고 다시 시도해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)"
-msgstr ""
+msgstr "로그인한 사용자 가장 (Presto, Trino, Drill, Hive 및 Google Sheets)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Import"
-msgstr ""
+msgstr "가져오기"
 
 #, python-format
 msgid "Import %s"
@@ -7350,21 +11710,33 @@ msgstr "차트 불러오기는 알 수 없는 이유로 실패했습니다"
 msgid "Import charts"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dashboard failed for an unknown reason"
-msgstr ""
+msgstr "알 수 없는 이유로 대시보드 가져오기에 실패했습니다"
 
 msgid "Import dashboards"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import database failed for an unknown reason"
-msgstr ""
+msgstr "알 수 없는 이유로 데이터베이스 가져오기에 실패했습니다"
 
 #, fuzzy
 msgid "Import database from file"
 msgstr "차트 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Import dataset failed for an unknown reason"
-msgstr ""
+msgstr "알 수 없는 이유로 데이터셋 가져오기에 실패했습니다"
 
 #, fuzzy
 msgid "Import queries"
@@ -7390,34 +11762,54 @@ msgstr "대시보드"
 msgid "In Range"
 msgstr "관리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
 "service account or configure an OAuth2 client."
-msgstr ""
+msgstr "비공개 시트에 연결하려면 서비스 계정을 제공하거나 OAuth2 클라이언트를 구성해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "In this view you can preview the first 25 rows. "
-msgstr ""
+msgstr "이 보기에서 처음 25개 행을 미리 볼 수 있습니다. "
 
 #, fuzzy
 msgid "Inactive"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include Series"
-msgstr ""
+msgstr "시리즈 포함"
 
 #, fuzzy
 msgid "Include Template Parameters"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include a description that will be sent with your report"
-msgstr ""
+msgstr "보고서와 함께 전송될 설명을 포함하십시오"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Include description to be sent with %s"
-msgstr ""
+msgstr "%s와 함께 전송될 설명 포함"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Include series name as an axis"
-msgstr ""
+msgstr "시리즈 이름을 축으로 포함"
 
 #, fuzzy
 msgid "Include time"
@@ -7454,29 +11846,57 @@ msgstr "분"
 msgid "Info"
 msgstr "정보"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inherit range from time filter"
-msgstr ""
+msgstr "시간 필터에서 범위 상속"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Initial tree depth"
-msgstr ""
+msgstr "초기 트리 깊이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner Radius"
-msgstr ""
+msgstr "내부 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inner radius of donut hole"
-msgstr ""
+msgstr "도넛 구멍의 내부 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input custom width in pixels"
-msgstr ""
+msgstr "픽셀 단위로 사용자 정의 너비 입력"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Input field supports custom rotation. e.g. 30 for 30°"
-msgstr ""
+msgstr "입력 필드는 사용자 지정 회전을 지원합니다. 예: 30은 30°를 의미합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer URL"
-msgstr ""
+msgstr "레이어 URL 삽입"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Insert Layer title"
-msgstr ""
+msgstr "레이어 제목 삽입"
 
 #, fuzzy
 msgid "Inside"
@@ -7502,27 +11922,47 @@ msgstr "삭제"
 msgid "Inside right"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "내부 상단"
 
 #, fuzzy
 msgid "Inside top left"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Inside top right"
-msgstr ""
+msgstr "내부 오른쪽 상단"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Intensity"
-msgstr ""
+msgstr "강도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity Radius"
-msgstr ""
+msgstr "강도 반경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Intensity Radius is the radius at which the weight is distributed"
-msgstr ""
+msgstr "강도 반경은 가중치가 분산되는 반경입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Intensity is the value multiplied by the weight to obtain the final weight"
-msgstr ""
+msgstr "강도는 최종 가중치를 얻기 위해 가중치에 곱해지는 값입니다"
 
 #, fuzzy
 msgid "Interval"
@@ -7536,8 +11976,12 @@ msgstr "컬럼 목록"
 msgid "Interval bounds"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Interval colors"
-msgstr ""
+msgstr "구간 색상"
 
 #, fuzzy
 msgid "Interval start column"
@@ -7547,133 +11991,236 @@ msgstr "컬럼 목록"
 msgid "Intervals"
 msgstr "새로고침 간격"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid Connection String: Expecting String of the form "
 "'ocient://user:pass@host:port/database'."
-msgstr ""
+msgstr "잘못된 연결 문자열: 'ocient://user:pass@host:port/database' 형식의 문자열이 필요합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid JSON"
-msgstr ""
+msgstr "잘못된 JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Invalid JSON configuration"
-msgstr ""
+msgstr "잘못된 JSON 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid JSON metadata"
-msgstr ""
+msgstr "잘못된 JSON 메타데이터"
 
 #, fuzzy, python-format
 msgid "Invalid SQL: %(error)s"
 msgstr "부적절한 요청입니다 : %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid advanced data type: %(advanced_data_type)s"
-msgstr ""
+msgstr "잘못된 고급 데이터 유형: %(advanced_data_type)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid certificate"
-msgstr ""
+msgstr "잘못된 인증서"
 
 #, fuzzy
 msgid "Invalid color"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually follows: "
 "backend+driver://user:password@database-host/database-name"
 msgstr ""
+"잘못된 연결 문자열입니다. 유효한 문자열의 형식은 일반적으로 다음과 같습니다: "
+"backend+driver://user:password@database-host/database-name"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Invalid connection string, a valid string usually "
 "follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
 "NAME'<p>Example:'postgresql://user:password@your-postgres-"
 "db/database'</p>"
 msgstr ""
+"잘못된 연결 문자열입니다. 유효한 문자열의 형식은 일반적으로 다음과 같습니다:'DRIVER://USER:PASSWORD@DB-"
+"HOST/DATABASE-NAME'<p>예시:'postgresql://user:password@your-postgres-"
+"db/database'</p>"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid cron expression"
-msgstr ""
+msgstr "잘못된 cron 식"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid cumulative operator: %(operator)s"
-msgstr ""
+msgstr "잘못된 누적 연산자: %(operator)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid currency code in saved metrics"
-msgstr ""
+msgstr "저장된 측정 항목의 잘못된 통화 코드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid date/timestamp format"
-msgstr ""
+msgstr "잘못된 날짜/타임스탬프 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid executor type"
-msgstr ""
+msgstr "잘못된 실행기 유형"
 
 #, fuzzy
 msgid "Invalid expression"
 msgstr "표현식"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid filter operation type: %(op)s"
-msgstr ""
+msgstr "잘못된 필터 작업 유형: %(op)s"
 
 #, fuzzy
 msgid "Invalid formula expression"
 msgstr "표현식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geodetic string"
-msgstr ""
+msgstr "잘못된 측지 문자열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid geohash string"
-msgstr ""
+msgstr "잘못된 지오해시 문자열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid input"
-msgstr ""
+msgstr "잘못된 입력"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid lat/long configuration."
-msgstr ""
+msgstr "잘못된 위도/경도 구성입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Invalid longitude/latitude"
-msgstr ""
+msgstr "잘못된 경도/위도"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid metric object: %(metric)s"
-msgstr ""
+msgstr "잘못된 측정 항목 개체: %(metric)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid numpy function: %(operator)s"
-msgstr ""
+msgstr "잘못된 numpy 함수: %(operator)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid options for %(rolling_type)s: %(options)s"
-msgstr ""
+msgstr "%(rolling_type)s에 대한 잘못된 옵션: %(options)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Invalid permalink key"
-msgstr ""
+msgstr "잘못된 고정 링크 키"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid reference to column: \"%(column)s\""
-msgstr ""
+msgstr "열에 대한 잘못된 참조: \"%(column)s\""
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid result type: %(result_type)s"
-msgstr ""
+msgstr "잘못된 결과 유형: %(result_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Invalid rolling_type: %(type)s"
-msgstr ""
+msgstr "잘못된 rolling_type: %(type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Invalid spatial point encountered: %(latlong)s"
-msgstr ""
+msgstr "잘못된 공간 점이 발견되었습니다: %(latlong)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid state."
-msgstr ""
+msgstr "잘못된 상태입니다."
 
 #, fuzzy, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
 msgstr "부적절한 요청입니다 : %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid username or password"
-msgstr ""
+msgstr "잘못된 사용자 이름 또는 비밀번호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Inverse selection"
-msgstr ""
+msgstr "선택 반전"
 
 #, fuzzy
 msgid "Invert current page"
@@ -7691,39 +12238,73 @@ msgstr "차트 유형"
 msgid "Is certified"
 msgstr "수정됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Is custom tag"
-msgstr ""
+msgstr "사용자 지정 태그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is dimension"
-msgstr ""
+msgstr "차원"
 
 #, fuzzy
 msgid "Is false"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Is favorite"
-msgstr ""
+msgstr "즐겨찾기"
 
 msgid "Is filterable"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is not null"
-msgstr ""
+msgstr "Null 아님"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Is null"
-msgstr ""
+msgstr "Null임"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is tagged"
-msgstr ""
+msgstr "태그됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Is temporal"
-msgstr ""
+msgstr "시간 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Is true"
-msgstr ""
+msgstr "참"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Isoband"
-msgstr ""
+msgstr "등치대"
 
 #, fuzzy
 msgid "Isoline"
@@ -7733,97 +12314,194 @@ msgstr "차트 이동"
 msgid "Issue 1000 - The dataset is too large to query."
 msgstr "이슈 1000 - 데이터 소스가 쿼리하기에 너무 큽니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Issue 1001 - The database is under an unusual load."
-msgstr ""
+msgstr "문제 1001 - 데이터베이스에 비정상적인 부하가 걸려 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
-msgstr ""
+msgstr "비어 있어도 삭제되지 않습니다. 비어 있으면 차트 편집 보기에 표시되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
-msgstr ""
+msgstr "막대 차트에서 Y축을 잘라내는 것은 권장하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JAN"
-msgstr ""
+msgstr "1월"
 
 msgid "JSON"
 msgstr "JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON Configuration"
-msgstr ""
+msgstr "JSON 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "JSON Metadata"
-msgstr ""
+msgstr "JSON 메타데이터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "JSON metadata"
-msgstr ""
+msgstr "JSON 메타데이터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "JSON metadata and advanced configuration"
-msgstr ""
+msgstr "JSON 메타데이터 및 고급 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "JSON metadata is invalid!"
-msgstr ""
+msgstr "JSON 메타데이터가 유효하지 않습니다!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "JSON string containing additional connection configuration. This is used "
 "to provide connection information for systems like Hive, Presto and "
 "BigQuery which do not conform to the username:password syntax normally "
 "used by SQLAlchemy."
 msgstr ""
+"추가 연결 구성을 포함하는 JSON 문자열입니다. 이는 SQLAlchemy에서 일반적으로 사용하는 username:password "
+"구문을 따르지 않는 Hive, Presto, BigQuery와 같은 시스템의 연결 정보를 제공하는 데 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "JUL"
-msgstr ""
+msgstr "7월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JUN"
-msgstr ""
+msgstr "6월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "January"
-msgstr ""
+msgstr "1월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript data interceptor"
-msgstr ""
+msgstr "JavaScript 데이터 인터셉터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "JavaScript onClick href"
-msgstr ""
+msgstr "JavaScript onClick href"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "JavaScript tooltip generator"
-msgstr ""
+msgstr "JavaScript 툴팁 생성기"
 
 #, fuzzy
 msgid "Jinja templating"
 msgstr "템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "July"
-msgstr ""
+msgstr "7월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "June"
-msgstr ""
+msgstr "6월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "KPI"
-msgstr ""
+msgstr "KPI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Keep control settings?"
-msgstr ""
+msgstr "컨트롤 설정을 유지하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Keep editing"
-msgstr ""
+msgstr "계속 편집"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Key"
-msgstr ""
+msgstr "키"
 
 #, fuzzy
 msgid "Key Prefix"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "키보드 단축키"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
-msgstr ""
+msgstr "키는 생성 시 한 번만 표시됩니다. 안전하게 보관하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Keys for table"
-msgstr ""
+msgstr "테이블 키"
 
 #, fuzzy
 msgid "Kilometers"
@@ -7836,11 +12514,18 @@ msgstr "레이블"
 msgid "Label Contents"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label JavaScript config generator"
-msgstr ""
+msgstr "레이블 JavaScript 구성 생성기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label Line"
-msgstr ""
+msgstr "레이블 선"
 
 #, fuzzy
 msgid "Label Template"
@@ -7866,14 +12551,25 @@ msgstr "시작 시간"
 msgid "Label descending"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label for the index column. Don't use an existing column name."
-msgstr ""
+msgstr "인덱스 열의 레이블입니다. 기존 열 이름을 사용하지 마세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Label for your query"
-msgstr ""
+msgstr "쿼리 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label position"
-msgstr ""
+msgstr "레이블 위치"
 
 #, fuzzy
 msgid "Label property name"
@@ -7883,27 +12579,50 @@ msgstr "테이블 명"
 msgid "Label size"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label size unit"
-msgstr ""
+msgstr "레이블 크기 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Label threshold"
-msgstr ""
+msgstr "레이블 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labelling"
-msgstr ""
+msgstr "레이블링"
 
 #, fuzzy
 msgid "Labels"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the marker lines"
-msgstr ""
+msgstr "마커 선의 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the markers"
-msgstr ""
+msgstr "마커의 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Labels for the ranges"
-msgstr ""
+msgstr "범위의 레이블"
 
 #, fuzzy
 msgid "Languages"
@@ -7913,16 +12632,23 @@ msgstr "관리"
 msgid "Large"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Last"
-msgstr ""
+msgstr "마지막"
 
 #, fuzzy
 msgid "Last Name"
 msgstr "데이터소스 명"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last Updated %s"
-msgstr ""
+msgstr "마지막 업데이트 %s"
 
 #, fuzzy, python-format
 msgid "Last Updated %s by %s"
@@ -7932,9 +12658,12 @@ msgstr "마지막 수정"
 msgid "Last Used"
 msgstr "저장된 Query 수정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Last available value seen on %s"
-msgstr ""
+msgstr "%s에서 마지막으로 확인된 사용 가능한 값"
 
 #, fuzzy
 msgid "Last day"
@@ -7967,8 +12696,12 @@ msgstr "분기"
 msgid "Last queried at"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Last run"
-msgstr ""
+msgstr "마지막 실행"
 
 #, fuzzy, python-format
 msgid "Last updated %s ago"
@@ -7982,14 +12715,25 @@ msgstr "주"
 msgid "Last year"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lat"
-msgstr ""
+msgstr "위도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude"
-msgstr ""
+msgstr "위도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Latitude of default viewport"
-msgstr ""
+msgstr "기본 뷰포트의 위도"
 
 #, fuzzy
 msgid "Layer"
@@ -7999,11 +12743,18 @@ msgstr "년"
 msgid "Layer Name"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Layer URL"
-msgstr ""
+msgstr "레이어 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Layer configuration"
-msgstr ""
+msgstr "레이어 구성"
 
 #, fuzzy
 msgid "Layer title"
@@ -8017,43 +12768,83 @@ msgstr "필터"
 msgid "Layers"
 msgstr "경고"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout"
-msgstr ""
+msgstr "레이아웃"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout elements"
-msgstr ""
+msgstr "레이아웃 요소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of graph"
-msgstr ""
+msgstr "그래프의 레이아웃 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Layout type of tree"
-msgstr ""
+msgstr "트리의 레이아웃 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Least recently modified"
-msgstr ""
+msgstr "최근 수정 순서가 낮은"
 
 #, fuzzy
 msgid "Left"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left Margin"
-msgstr ""
+msgstr "왼쪽 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left margin, in pixels, allowing for more room for axis labels"
-msgstr ""
+msgstr "왼쪽 여백(픽셀 단위), 축 레이블을 위한 공간을 더 확보합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Left to Right"
-msgstr ""
+msgstr "왼쪽에서 오른쪽으로"
 
 #, fuzzy
 msgid "Left value"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legacy"
-msgstr ""
+msgstr "레거시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Legend"
-msgstr ""
+msgstr "범례"
 
 #, fuzzy
 msgid "Legend Format"
@@ -8063,49 +12854,94 @@ msgstr "D3 포멧"
 msgid "Legend Orientation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Legend Position"
-msgstr ""
+msgstr "범례 위치"
 
 #, fuzzy
 msgid "Legend Type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Legend type"
-msgstr ""
+msgstr "범례 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than"
-msgstr ""
+msgstr "미만"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Less Than or Equal"
-msgstr ""
+msgstr "이하"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Less or equal (<=)"
-msgstr ""
+msgstr "이하 (<=)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Less than (<)"
-msgstr ""
+msgstr "미만 (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Lift percent precision"
-msgstr ""
+msgstr "리프트 백분율 정밀도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Light"
-msgstr ""
+msgstr "라이트"
 
 #, fuzzy
 msgid "Light (Carto)"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Light mode"
-msgstr ""
+msgstr "라이트 모드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like"
-msgstr ""
+msgstr "유사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Like (case insensitive)"
-msgstr ""
+msgstr "유사 (대소문자 구분 없음)"
 
 #, fuzzy
 msgid "Limit"
@@ -8115,12 +12951,23 @@ msgstr "구분자"
 msgid "Limit type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Limits the number of cells that get retrieved."
-msgstr ""
+msgstr "검색되는 셀의 수를 제한합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Limits the number of rows that get displayed."
-msgstr ""
+msgstr "표시되는 행의 수를 제한합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of series that get displayed. A joined subquery (or an "
 "extra phase where subqueries are not supported) is applied to limit the "
@@ -8128,11 +12975,17 @@ msgid ""
 "when grouping by high cardinality column(s) though does increase the "
 "query complexity and cost."
 msgstr ""
+"표시되는 시리즈의 수를 제한합니다. 조인된 하위 쿼리(또는 하위 쿼리가 지원되지 않는 경우 추가 단계)를 적용하여 가져오고 "
+"렌더링되는 시리즈 수를 제한합니다. 이 기능은 높은 카디널리티 열로 그룹화할 때 유용하지만 쿼리 복잡성과 비용이 증가합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Limits the number of the rows that are computed in the query that is the "
 "source of the data used for this chart."
-msgstr ""
+msgstr "이 차트에 사용되는 데이터 소스인 쿼리에서 계산되는 행의 수를 제한합니다."
 
 #, fuzzy
 msgid "Line"
@@ -8142,36 +12995,72 @@ msgstr "분"
 msgid "Line Chart"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line Style"
-msgstr ""
+msgstr "선 스타일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Line chart is used to visualize measurements taken over a given category."
 " Line chart is a type of chart which displays information as a series of "
 "data points connected by straight line segments. It is a basic type of "
 "chart common in many fields."
 msgstr ""
+"선형 차트는 특정 카테고리에 걸쳐 측정된 값을 시각화하는 데 사용됩니다. 선형 차트는 정보를 직선 세그먼트로 연결된 일련의 데이터 "
+"포인트로 표시하는 차트 유형입니다. 이는 많은 분야에서 공통적으로 사용되는 기본 차트 유형입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line charts on a map"
-msgstr ""
+msgstr "지도 위의 선형 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Line interpolation as defined by d3.js"
-msgstr ""
+msgstr "d3.js에서 정의된 선 보간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Line width"
-msgstr ""
+msgstr "선 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Line width unit"
-msgstr ""
+msgstr "선 너비 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear Color Scheme"
-msgstr ""
+msgstr "선형 색상 구성표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear color scheme"
-msgstr ""
+msgstr "선형 색상 구성표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Linear interpolation"
-msgstr ""
+msgstr "선형 보간"
 
 #, fuzzy
 msgid "Linear palette"
@@ -8181,8 +13070,12 @@ msgstr "차트 이동"
 msgid "Lines column"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Lines encoding"
-msgstr ""
+msgstr "선 인코딩"
 
 #, fuzzy
 msgid "List"
@@ -8192,8 +13085,11 @@ msgstr "구분자"
 msgid "List Groups"
 msgstr "저장된 Query 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List Roles"
-msgstr ""
+msgstr "역할 목록"
 
 #, fuzzy
 msgid "List Unique Values"
@@ -8203,20 +13099,39 @@ msgstr "필터"
 msgid "List Users"
 msgstr "저장된 Query 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of extra columns made available in JavaScript functions"
-msgstr ""
+msgstr "JavaScript 함수에서 사용 가능한 추가 열 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "List of n+1 values for bucketing metric into n buckets."
-msgstr ""
+msgstr "메트릭을 n개의 버킷으로 분류하기 위한 n+1개의 값 목록."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "List of the column names that should be read"
-msgstr ""
+msgstr "읽어야 할 열 이름 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with lines"
-msgstr ""
+msgstr "선으로 표시할 값 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "List of values to mark with triangles"
-msgstr ""
+msgstr "삼각형으로 표시할 값 목록"
 
 #, fuzzy
 msgid "List updated"
@@ -8226,18 +13141,30 @@ msgstr "분기"
 msgid "List view"
 msgstr "저장된 Query 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Live render"
-msgstr ""
+msgstr "실시간 렌더링"
 
 #, fuzzy
 msgid "Load CSS template (optional)"
 msgstr "CSS 템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Loaded data cached"
-msgstr ""
+msgstr "로드된 데이터가 캐시됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Loaded from cache"
-msgstr ""
+msgstr "캐시에서 로드됨"
 
 #, fuzzy
 msgid "Loading"
@@ -8247,22 +13174,34 @@ msgstr "로그인"
 msgid "Loading filter values"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Loading timezones..."
-msgstr ""
+msgstr "시간대 불러오는 중..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Loading..."
-msgstr ""
+msgstr "불러오는 중..."
 
 #, fuzzy
 msgid "Local"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Local theme set for preview"
-msgstr ""
+msgstr "미리보기용 로컬 테마 설정됨"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Local theme set to \"%s\""
-msgstr ""
+msgstr "로컬 테마가 \"%s\"(으)로 설정됨"
 
 #, fuzzy
 msgid "Locate the chart"
@@ -8272,26 +13211,53 @@ msgstr "새 차트 생성"
 msgid "Log"
 msgstr "로그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Log Scale"
-msgstr ""
+msgstr "로그 스케일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Log retention"
-msgstr ""
+msgstr "로그 보존"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Logarithmic axis"
-msgstr ""
+msgstr "로그 축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on primary y-axis"
-msgstr ""
+msgstr "기본 Y축의 로그 스케일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic scale on secondary y-axis"
-msgstr ""
+msgstr "보조 Y축의 로그 스케일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Logarithmic x-axis"
-msgstr ""
+msgstr "로그 X축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Logarithmic y-axis"
-msgstr ""
+msgstr "로그 Y축"
 
 msgid "Login"
 msgstr "로그인"
@@ -8300,8 +13266,12 @@ msgstr "로그인"
 msgid "Login count"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Login with"
-msgstr ""
+msgstr "로 로그인"
 
 msgid "Logout"
 msgstr "로그아웃"
@@ -8309,41 +13279,87 @@ msgstr "로그아웃"
 msgid "Logs"
 msgstr "로그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lon"
-msgstr ""
+msgstr "경도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Long dashed"
-msgstr ""
+msgstr "긴 파선"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude"
-msgstr ""
+msgstr "경도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Longitude & Latitude"
-msgstr ""
+msgstr "경도 및 위도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude & Latitude columns"
-msgstr ""
+msgstr "경도 및 위도 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Longitude and Latitude"
-msgstr ""
+msgstr "경도 및 위도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Longitude of default viewport"
-msgstr ""
+msgstr "기본 뷰포트의 경도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Lower Threshold"
-msgstr ""
+msgstr "하한 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Lower threshold must be lower than upper threshold"
-msgstr ""
+msgstr "하한 임계값은 상한 임계값보다 낮아야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAR"
-msgstr ""
+msgstr "3월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MAY"
-msgstr ""
+msgstr "5월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "MON"
-msgstr ""
+msgstr "월"
 
 #, fuzzy
 msgid "Main"
@@ -8353,43 +13369,68 @@ msgstr "분"
 msgid "Main navigation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Make sure that the controls are configured properly and the datasource "
 "contains data for the selected time range"
-msgstr ""
+msgstr "컨트롤이 올바르게 구성되어 있고 데이터 소스에 선택한 시간 범위에 대한 데이터가 포함되어 있는지 확인하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Make the x-axis categorical"
-msgstr ""
+msgstr "X축을 범주형으로 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Malformed request. slice_id or table_name and db_name arguments are "
 "expected"
-msgstr ""
+msgstr "잘못된 요청입니다. slice_id 또는 table_name 및 db_name 인수가 필요합니다"
 
 msgid "Manage"
 msgstr "관리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Manage dashboard owners and access permissions"
-msgstr ""
+msgstr "대시보드 소유자 및 접근 권한 관리"
 
 #, fuzzy
 msgid "Manage email report"
 msgstr "대시보드에 차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
-msgstr ""
+msgstr "범위, 설명 및 제한을 설정하기 위해 필터와 사용자 정의를 관리하세요. 더 나은 대시보드 인사이트를 위한 새 요소를 만드세요."
 
 #, fuzzy
 msgid "Manage your databases"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mandatory"
-msgstr ""
+msgstr "필수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Manually set min/max values for the y-axis."
-msgstr ""
+msgstr "Y축의 최솟값/최댓값을 수동으로 설정합니다."
 
 #, fuzzy
 msgid "Map"
@@ -8403,191 +13444,354 @@ msgstr "주석"
 msgid "Map Renderer"
 msgstr "새로고침 간격"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Map Style"
-msgstr ""
+msgstr "지도 스타일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (오픈소스)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "MapLibre는 오픈소스이며 API 키가 필요하지 않습니다. Mapbox는 서버에서 MAPBOX_API_KEY를 구성해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Mapbox"
-msgstr ""
+msgstr "Mapbox"
 
 #, fuzzy
 msgid "Mapbox (API key required)"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox는 서버에서 MAPBOX_API_KEY를 구성해야 합니다."
 
 msgid "March"
 msgstr "검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Margin"
-msgstr ""
+msgstr "여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Mark a column as temporal in \"Edit datasource\" modal"
-msgstr ""
+msgstr "\"데이터 소스 편집\" 모달에서 열을 시간 열로 표시"
 
 #, fuzzy
 msgid "Marker"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker Size"
-msgstr ""
+msgstr "마커 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker labels"
-msgstr ""
+msgstr "마커 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker line labels"
-msgstr ""
+msgstr "마커 선 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker lines"
-msgstr ""
+msgstr "마커 선"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Marker size"
-msgstr ""
+msgstr "마커 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Markers"
-msgstr ""
+msgstr "마커"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Markup type"
-msgstr ""
+msgstr "마크업 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match system"
-msgstr ""
+msgstr "시스템 설정 따르기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Match time shift color with original series"
-msgstr ""
+msgstr "시간 이동 색상을 원본 시리즈와 일치"
 
 #, fuzzy
 msgid "Match type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Matrixify"
-msgstr ""
+msgstr "행렬화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Max"
-msgstr ""
+msgstr "최대"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Max Bubble Size"
-msgstr ""
+msgstr "최대 버블 크기"
 
 #, fuzzy
 msgid "Max value"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Max. features"
-msgstr ""
+msgstr "최대 피처 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum"
-msgstr ""
+msgstr "최대"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Font Size"
-msgstr ""
+msgstr "최대 글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum Radius"
-msgstr ""
+msgstr "최대 반지름"
 
 #, fuzzy
 msgid "Maximum Width"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "최대 폴더 중첩 깊이에 도달했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum number of features to fetch from service"
-msgstr ""
+msgstr "서비스에서 가져올 최대 피처 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this maximum radius."
-msgstr ""
+msgstr "원의 최대 반지름 크기(픽셀 단위). 줌 레벨이 변경되어도 원이 이 최대 반지름을 유지하도록 합니다."
 
 #, fuzzy
 msgid "Maximum value"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Maximum value on the gauge axis"
-msgstr ""
+msgstr "게이지 축의 최대값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "경로의 최대 너비(픽셀 또는 미터)."
 
 msgid "May"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mean of values over specified period"
-msgstr ""
+msgstr "지정된 기간의 평균값"
 
 #, fuzzy
 msgid "Mean values"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Median"
-msgstr ""
+msgstr "중앙값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median edge width, the thickest edge will be 4 times thicker than the "
 "thinnest."
-msgstr ""
+msgstr "중간값 엣지 너비, 가장 두꺼운 엣지는 가장 얇은 엣지보다 4배 두껍습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Median node size, the largest node will be 4 times larger than the "
 "smallest"
-msgstr ""
+msgstr "중간값 노드 크기, 가장 큰 노드는 가장 작은 노드보다 4배 큽니다"
 
 #, fuzzy
 msgid "Median values"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Medium"
-msgstr ""
+msgstr "중간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - binary (1024B => 1KiB)"
-msgstr ""
+msgstr "바이트 단위 메모리 - 이진수 (1024B => 1KiB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory in bytes - decimal (1024B => 1.024kB)"
-msgstr ""
+msgstr "바이트 단위 메모리 - 십진수 (1024B => 1.024kB)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - binary (1024B => 1KiB/s)"
-msgstr ""
+msgstr "바이트 단위 메모리 전송 속도 - 이진수 (1024B => 1KiB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
+msgstr "바이트 단위 메모리 전송 속도 - 십진수 (1024B => 1.024kB/s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Menu actions trigger"
-msgstr ""
+msgstr "메뉴 동작 트리거"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Message content"
-msgstr ""
+msgstr "메시지 내용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metadata"
-msgstr ""
+msgstr "메타데이터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metadata Parameters"
-msgstr ""
+msgstr "메타데이터 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metadata has been synced"
-msgstr ""
+msgstr "메타데이터가 동기화되었습니다"
 
 #, fuzzy
 msgid "Meters"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Method"
-msgstr ""
+msgstr "방법"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Method to compute the displayed value. \"Overall value\" calculates a "
 "single metric across the entire filtered time period, ideal for non-"
 "additive metrics like ratios, averages, or distinct counts. Other methods"
 " operate over the time series data points."
 msgstr ""
+"표시 값을 계산하는 방법입니다. \"전체 값\"은 필터링된 전체 기간에 걸쳐 단일 지표를 계산하며, 비율, 평균 또는 고유 수와 "
+"같은 비가산 지표에 적합합니다. 다른 방법들은 시계열 데이터 포인트에 대해 작동합니다."
 
 msgid "Metric"
 msgstr "메트릭"
@@ -8600,77 +13804,155 @@ msgstr "메트릭 '%(metric)s' 이 존재하지 않습니다."
 msgid "Metric Key"
 msgstr "메트릭"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Metric ``%(metric_name)s`` not found in %(dataset_name)s."
-msgstr ""
+msgstr "지표 ``%(metric_name)s``을(를) %(dataset_name)s에서 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric ascending"
-msgstr ""
+msgstr "지표 오름차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric assigned to the [X] axis"
-msgstr ""
+msgstr "[X] 축에 할당된 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric assigned to the [Y] axis"
-msgstr ""
+msgstr "[Y] 축에 할당된 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric change in value from `since` to `until`"
-msgstr ""
+msgstr "`since`에서 `until`까지의 지표 값 변화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric currency"
-msgstr ""
+msgstr "지표 통화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric descending"
-msgstr ""
+msgstr "지표 내림차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric factor change from `since` to `until`"
-msgstr ""
+msgstr "`since`에서 `until`까지의 지표 인수 변화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric for node values"
-msgstr ""
+msgstr "노드 값에 대한 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metric for ordering"
-msgstr ""
+msgstr "정렬에 사용할 지표"
 
 #, fuzzy
 msgid "Metric name"
 msgstr "Query 검색"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Metric name [%s] is duplicated"
-msgstr ""
+msgstr "지표 이름 [%s]이(가) 중복됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric percent change in value from `since` to `until`"
-msgstr ""
+msgstr "`since`에서 `until`까지의 지표 값 백분율 변화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric that defines the size of the bubble"
-msgstr ""
+msgstr "버블 크기를 정의하는 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Metric to display bottom title"
-msgstr ""
+msgstr "하단 제목을 표시하는 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metric to use for ordering Top N values"
-msgstr ""
+msgstr "상위 N 값 정렬에 사용할 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used as a weight for the grid's coloring"
-msgstr ""
+msgstr "그리드 색상 지정의 가중치로 사용되는 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Metric used to calculate bubble size"
-msgstr ""
+msgstr "버블 크기 계산에 사용되는 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Metric used to control height"
-msgstr ""
+msgstr "높이 제어에 사용되는 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or cell "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"계열 또는 셀 제한이 있을 때 상위 계열의 정렬 방식을 정의하는 데 사용되는 지표입니다. 정의되지 않은 경우 첫 번째 지표로 "
+"되돌아갑니다(적절한 경우)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Metric used to define how the top series are sorted if a series or row "
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
+"계열 또는 행 제한이 있을 때 상위 계열의 정렬 방식을 정의하는 데 사용되는 지표입니다. 정의되지 않은 경우 첫 번째 지표로 "
+"되돌아갑니다(적절한 경우)."
 
 msgid "Metrics"
 msgstr "메트릭"
@@ -8679,41 +13961,69 @@ msgstr "메트릭"
 msgid "Metrics (%s)"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "지표는 행과 열 모두에 동시에 사용할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "지표 폴더에는 지표 항목만 포함할 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "지표는 폴더 안에 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics to show in the tooltip."
-msgstr ""
+msgstr "툴팁에 표시할 지표입니다."
 
 #, fuzzy
 msgid "Middle"
 msgstr "CSV 파일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Midnight"
-msgstr ""
+msgstr "자정"
 
 #, fuzzy
 msgid "Miles"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Min"
-msgstr ""
+msgstr "최소"
 
 #, fuzzy
 msgid "Min Periods"
 msgstr "10초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min Width"
-msgstr ""
+msgstr "최소 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min periods"
-msgstr ""
+msgstr "최소 기간"
 
 #, fuzzy
 msgid "Min value"
@@ -8723,55 +14033,100 @@ msgstr "테이블 명"
 msgid "Min value cannot be greater than max value"
 msgstr "시작 날짜가 끝 날짜보다 클 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Min value should be smaller or equal to max value"
-msgstr ""
+msgstr "최솟값은 최댓값보다 작거나 같아야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Min/max (no outliers)"
-msgstr ""
+msgstr "최소/최대 (이상값 제외)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Mine"
-msgstr ""
+msgstr "내 것"
 
 #, fuzzy
 msgid "Minimum"
 msgstr "분"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum Font Size"
-msgstr ""
+msgstr "최소 글꼴 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Minimum Radius"
-msgstr ""
+msgstr "최소 반지름"
 
 #, fuzzy
 msgid "Minimum Width"
 msgstr "분"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Minimum must be strictly less than maximum"
-msgstr ""
+msgstr "최솟값은 최댓값보다 반드시 작아야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this minimum radius."
-msgstr ""
+msgstr "원의 최소 반지름 크기(픽셀 단위)입니다. 줌 레벨이 변경될 때 원이 이 최소 반지름을 유지하도록 보장합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum threshold in percentage points for showing labels."
-msgstr ""
+msgstr "레이블 표시를 위한 최소 임계값(백분율 포인트)입니다."
 
 #, fuzzy
 msgid "Minimum value"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value for label to be displayed on graph."
-msgstr ""
+msgstr "그래프에 표시될 레이블의 최솟값."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minimum value on the gauge axis"
-msgstr ""
+msgstr "게이지 축의 최솟값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "경로의 최소 너비 크기(픽셀 또는 미터)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Minor Split Line"
-msgstr ""
+msgstr "보조 분할선"
 
 #, fuzzy
 msgid "Minor ticks"
@@ -8788,8 +14143,11 @@ msgstr "분"
 msgid "Missing %s"
 msgstr "표현식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Missing OAuth2 token"
-msgstr ""
+msgstr "OAuth2 토큰이 없습니다"
 
 #, fuzzy
 msgid "Missing URL parameter"
@@ -8810,10 +14168,12 @@ msgstr "수정됨"
 msgid "Modified %s"
 msgstr "마지막 수정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
+msgstr[0] "가상 데이터셋에서 %s개의 열이 수정되었습니다"
 
 msgid "Modified by"
 msgstr "수정됨"
@@ -8826,8 +14186,12 @@ msgstr "마지막 수정"
 msgid "Modified from \"%s\" template"
 msgstr "CSS 템플릿 불러오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Monday"
-msgstr ""
+msgstr "월요일"
 
 msgid "Month"
 msgstr "달"
@@ -8848,64 +14212,128 @@ msgstr "주석"
 msgid "More filters"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "MotherDuck token"
-msgstr ""
+msgstr "MotherDuck 토큰"
 
 #, fuzzy
 msgid "Move icon"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Move only"
-msgstr ""
+msgstr "이동만"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Moves the given set of dates by a specified interval."
-msgstr ""
+msgstr "주어진 날짜 집합을 지정된 간격만큼 이동합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Multi-Dimensions"
-msgstr ""
+msgstr "다중 차원"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Layers"
-msgstr ""
+msgstr "다중 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Levels"
-msgstr ""
+msgstr "다중 수준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multi-Variables"
-msgstr ""
+msgstr "다중 변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Multiple"
-msgstr ""
+msgstr "다중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Multiple formats accepted, look the geopy.points Python library for more "
 "details"
-msgstr ""
+msgstr "여러 형식이 허용됩니다. 자세한 내용은 Python의 geopy.points 라이브러리를 참조하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Multiplier"
-msgstr ""
+msgstr "승수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Must be a chart owner to overwrite this chart. Save as a new chart "
 "instead."
-msgstr ""
+msgstr "이 차트를 덮어쓰려면 차트 소유자여야 합니다. 대신 새 차트로 저장하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must be unique"
-msgstr ""
+msgstr "고유해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Must choose either a chart or a dashboard"
-msgstr ""
+msgstr "차트 또는 대시보드 중 하나를 선택해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Must have a [Group By] column to have 'count' as the [Label]"
-msgstr ""
+msgstr "[레이블]로 'count'를 사용하려면 [Group By] 열이 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Must provide credentials for the SSH Tunnel"
-msgstr ""
+msgstr "SSH 터널에 대한 자격 증명을 제공해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Must specify a value for filters with comparison operators"
-msgstr ""
+msgstr "비교 연산자가 있는 필터에는 값을 지정해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "My beautiful colors"
-msgstr ""
+msgstr "내 아름다운 색상"
 
 #, fuzzy
 msgid "My column"
@@ -8914,14 +14342,22 @@ msgstr "컬럼 추가"
 msgid "My metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "N/A"
-msgstr ""
+msgstr "N/A"
 
 msgid "NOT GROUPED BY"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "NOV"
-msgstr ""
+msgstr "11월"
 
 #, fuzzy
 msgid "NUMERIC"
@@ -8930,18 +14366,30 @@ msgstr "메트릭"
 msgid "Name"
 msgstr "이름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name is required"
-msgstr ""
+msgstr "이름은 필수입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name must be unique"
-msgstr ""
+msgstr "이름은 고유해야 합니다"
 
 #, fuzzy
 msgid "Name of table to be created"
 msgstr "데이터베이스를 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the column containing the id of the parent node"
-msgstr ""
+msgstr "부모 노드의 id를 포함하는 열의 이름"
 
 #, fuzzy
 msgid "Name of the id column"
@@ -8951,11 +14399,19 @@ msgstr "컬럼 수정"
 msgid "Name of the semantic layer"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the source nodes"
-msgstr ""
+msgstr "소스 노드의 이름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Name of the target nodes"
-msgstr ""
+msgstr "대상 노드의 이름"
 
 #, fuzzy
 msgid "Name of your tag"
@@ -8965,21 +14421,35 @@ msgstr "데이터베이스 선택"
 msgid "Name your database"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
-msgstr ""
+msgstr "폴더 이름을 지정하고 나중에 편집하려면 폴더 이름을 클릭하세요"
 
 #, fuzzy
 msgid "Native filter column is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Native filter values has no values"
-msgstr ""
+msgstr "기본 필터 값에 값이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn how to connect your database"
-msgstr ""
+msgstr "도움이 필요하신가요? 데이터베이스 연결 방법을 알아보세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Need help? Learn more about"
-msgstr ""
+msgstr "도움이 필요하신가요? 자세히 알아보기"
 
 #, fuzzy
 msgid "Network Error"
@@ -8989,11 +14459,18 @@ msgstr "알 수 없는 에러"
 msgid "Network error"
 msgstr "알 수 없는 에러"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Network error while attempting to fetch resource"
-msgstr ""
+msgstr "리소스를 가져오는 중 네트워크 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, it, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Network error."
-msgstr ""
+msgstr "네트워크 오류."
 
 #, fuzzy
 msgid "New"
@@ -9021,31 +14498,58 @@ msgstr "차트 이동"
 msgid "New tab"
 msgstr "탭 닫기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + q)"
-msgstr ""
+msgstr "새 탭 (Ctrl + q)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "New tab (Ctrl + t)"
-msgstr ""
+msgstr "새 탭 (Ctrl + t)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Next"
-msgstr ""
+msgstr "다음"
 
 #, fuzzy
 msgid "Nightingale"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Nightingale Rose Chart"
-msgstr ""
+msgstr "나이팅게일 로즈 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No"
-msgstr ""
+msgstr "아니오"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "No %s yet"
-msgstr ""
+msgstr "아직 %s가 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No Data"
-msgstr ""
+msgstr "데이터 없음"
 
 #, fuzzy
 msgid "No Logs yet"
@@ -9097,20 +14601,38 @@ msgstr "컬럼 추가"
 msgid "No compatible %s found"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible catalog found"
-msgstr ""
+msgstr "호환되는 카탈로그를 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No compatible columns found"
-msgstr ""
+msgstr "호환되는 열을 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No compatible schema found"
-msgstr ""
+msgstr "호환되는 스키마를 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No data"
-msgstr ""
+msgstr "데이터 없음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No data after filtering or data is NULL for the latest time record"
-msgstr ""
+msgstr "필터링 후 데이터가 없거나 최신 시간 기록의 데이터가 NULL입니다"
 
 msgid "No data in file"
 msgstr "파일에 데이터가 없습니다"
@@ -9119,21 +14641,36 @@ msgstr "파일에 데이터가 없습니다"
 msgid "No databases available"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No databases match your search"
-msgstr ""
+msgstr "검색어와 일치하는 데이터베이스가 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No description available."
-msgstr ""
+msgstr "설명이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No entities have this tag currently assigned"
-msgstr ""
+msgstr "현재 이 태그가 할당된 항목이 없습니다"
 
 #, fuzzy
 msgid "No filter"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No filter is selected."
-msgstr ""
+msgstr "선택된 필터가 없습니다."
 
 #, fuzzy
 msgid "No filters"
@@ -9143,20 +14680,37 @@ msgstr "테이블 추가"
 msgid "No filters applied"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No filters are currently added to this dashboard."
-msgstr ""
+msgstr "현재 이 대시보드에 추가된 필터가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "아직 필터 또는 사용자 정의가 생성되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No form settings were maintained"
-msgstr ""
+msgstr "양식 설정이 유지되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "No global filters are currently added"
-msgstr ""
+msgstr "현재 추가된 전역 필터가 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No groups"
-msgstr ""
+msgstr "그룹 없음"
 
 #, fuzzy
 msgid "No groups yet"
@@ -9166,37 +14720,66 @@ msgstr "차트"
 msgid "No items"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No matching records found"
-msgstr ""
+msgstr "일치하는 레코드를 찾을 수 없습니다"
 
 #, fuzzy
 msgid "No matching results found"
 msgstr "검색 결과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
-msgstr ""
+msgstr "현재 이 대시보드에 추가된 다중 레이어 deck.gl 차트가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No records found"
-msgstr ""
+msgstr "레코드를 찾을 수 없습니다"
 
 #, fuzzy
 msgid "No results"
 msgstr "결과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "No results found"
-msgstr ""
+msgstr "결과를 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No results match your filter criteria"
-msgstr ""
+msgstr "필터 기준에 일치하는 결과가 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No results were returned for this query"
-msgstr ""
+msgstr "이 쿼리에 대한 결과가 반환되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "No results were returned for this query. If you expected results to be "
 "returned, ensure any filters are configured properly and the datasource "
 "contains data for the selected time range."
 msgstr ""
+"이 쿼리에 대한 결과가 반환되지 않았습니다. 결과가 반환될 것으로 예상했다면 필터가 올바르게 구성되어 있는지, 데이터 소스에 선택한"
+" 시간 범위에 대한 데이터가 포함되어 있는지 확인하세요."
 
 #, fuzzy
 msgid "No roles"
@@ -9206,13 +14789,17 @@ msgstr "차트"
 msgid "No roles yet"
 msgstr "차트"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No rows were returned for this %s"
-msgstr ""
+msgstr "이 %s에 대해 반환된 행이 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "No samples were returned for this %s"
-msgstr ""
+msgstr "이 %s에 대해 반환된 샘플이 없습니다"
 
 #, fuzzy
 msgid "No saved expressions found"
@@ -9222,11 +14809,19 @@ msgstr "표현식"
 msgid "No saved metrics found"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No stored results found, you need to re-run your query"
-msgstr ""
+msgstr "저장된 결과를 찾을 수 없습니다. 쿼리를 다시 실행해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No such column found. To filter on a metric, try the Custom SQL tab."
-msgstr ""
+msgstr "해당 열을 찾을 수 없습니다. 지표를 필터링하려면 사용자 정의 SQL 탭을 사용해 보세요."
 
 #, fuzzy
 msgid "No table columns"
@@ -9236,11 +14831,18 @@ msgstr "컬럼 보기"
 msgid "No tasks yet"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "No temporal columns found"
-msgstr ""
+msgstr "시간 열을 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "No time columns"
-msgstr ""
+msgstr "시간 열 없음"
 
 #, fuzzy
 msgid "No user registrations yet"
@@ -9250,48 +14852,93 @@ msgstr "차트"
 msgid "No users yet"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "No validator found (configured for the engine)"
-msgstr ""
+msgstr "유효성 검사기를 찾을 수 없습니다 (엔진에 구성됨)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "No validator named %(validator_name)s found (configured for the "
 "%(engine_spec)s engine)"
-msgstr ""
+msgstr "%(engine_spec)s 엔진에 구성된 %(validator_name)s 이름의 유효성 검사기를 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node label position"
-msgstr ""
+msgstr "노드 레이블 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node select mode"
-msgstr ""
+msgstr "노드 선택 모드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Node size"
-msgstr ""
+msgstr "노드 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None"
-msgstr ""
+msgstr "없음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> Arrow"
-msgstr ""
+msgstr "없음 -> 화살표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "None -> None"
-msgstr ""
+msgstr "없음 -> 없음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normal"
-msgstr ""
+msgstr "보통"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Normalize"
-msgstr ""
+msgstr "정규화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalize Across"
-msgstr ""
+msgstr "전체 정규화"
 
 #, fuzzy
 msgid "Normalize column names"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Normalized"
-msgstr ""
+msgstr "정규화됨"
 
 #, fuzzy
 msgid "Not Contains"
@@ -9301,8 +14948,12 @@ msgstr "대시보드 가져오기"
 msgid "Not Equal"
 msgstr "결과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not Time Series"
-msgstr ""
+msgstr "시계열 아님"
 
 #, fuzzy
 msgid "Not a valid ZIP file"
@@ -9312,18 +14963,28 @@ msgstr "테이블 추가"
 msgid "Not added to any dashboard"
 msgstr "대시보드 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not all required fields are complete. Please provide the following:"
-msgstr ""
+msgstr "모든 필수 필드가 완성되지 않았습니다. 다음을 입력해 주세요:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Not available"
-msgstr ""
+msgstr "사용 불가"
 
 #, fuzzy
 msgid "Not defined"
 msgstr "수정됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Not equal to (≠)"
-msgstr ""
+msgstr "같지 않음 (≠)"
 
 #, fuzzy
 msgid "Not found"
@@ -9333,25 +14994,41 @@ msgstr "데이터베이스를 찾을 수 없습니다."
 msgid "Not in"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not null"
-msgstr ""
+msgstr "Null이 아님"
 
 #, fuzzy
 msgid "Not set"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Not triggered"
-msgstr ""
+msgstr "트리거되지 않음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Not up to date"
-msgstr ""
+msgstr "최신 상태가 아님"
 
 #, fuzzy
 msgid "Nothing here yet"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Nothing triggered"
-msgstr ""
+msgstr "트리거된 항목 없음"
 
 #, fuzzy
 msgid "Notification Method"
@@ -9360,11 +15037,19 @@ msgstr "주석 레이어"
 msgid "Notification method"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "November"
-msgstr ""
+msgstr "11월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Now"
-msgstr ""
+msgstr "지금"
 
 #, fuzzy
 msgid "Null Values"
@@ -9374,93 +15059,180 @@ msgstr "원본 값"
 msgid "Null imputation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Null or Empty"
-msgstr ""
+msgstr "Null 또는 비어 있음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number Format"
-msgstr ""
+msgstr "숫자 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Number bounds used for color encoding from red to blue.\n"
 "               Reverse the numbers for blue to red. To get pure red or "
 "blue,\n"
 "               you can enter either only min or max."
 msgstr ""
+"빨간색에서 파란색으로의 색상 인코딩에 사용되는 숫자 범위.\n"
+"               파란색에서 빨간색으로 변경하려면 숫자를 반전하세요. 순수한 빨간색이나 파란색을 얻으려면\n"
+"               최솟값 또는 최댓값 중 하나만 입력할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number format"
-msgstr ""
+msgstr "숫자 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number format string"
-msgstr ""
+msgstr "숫자 형식 문자열"
 
 #, fuzzy
 msgid "Number formatting"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of buckets to group data"
-msgstr ""
+msgstr "데이터를 그룹화할 버킷 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts per row when not fitting dynamically"
-msgstr ""
+msgstr "동적으로 맞추지 않을 때 행당 차트 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of charts to display per row"
-msgstr ""
+msgstr "행당 표시할 차트 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal digits to round numbers to"
-msgstr ""
+msgstr "숫자를 반올림할 소수 자릿수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display lift values"
-msgstr ""
+msgstr "리프트 값을 표시할 소수 자릿수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of decimal places with which to display p-values"
-msgstr ""
+msgstr "p값을 표시할 소수 자릿수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Number of periods to compare against. You can use negative numbers to "
 "compare from the beginning of the time range."
-msgstr ""
+msgstr "비교할 기간 수. 음수를 사용하면 시간 범위의 시작부터 비교할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Number of periods to ratio against"
-msgstr ""
+msgstr "비율을 계산할 기간 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Number of rows of file to read. Leave empty (default) to read all rows"
-msgstr ""
+msgstr "읽을 파일의 행 수. 모든 행을 읽으려면 비워 두세요(기본값)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of rows to skip at start of file."
-msgstr ""
+msgstr "파일 시작 부분에서 건너뛸 행 수."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of split segments on the axis"
-msgstr ""
+msgstr "축의 분할 세그먼트 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the X scale"
-msgstr ""
+msgstr "X 축 스케일 표시 시 눈금 사이의 단계 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Number of steps to take between ticks when displaying the Y scale"
-msgstr ""
+msgstr "Y 축 스케일 표시 시 눈금 사이의 단계 수"
 
 #, fuzzy
 msgid "Number of top values"
 msgstr "테이블 명"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Numbers must be within %(min)s and %(max)s"
-msgstr ""
+msgstr "숫자는 %(min)s 이상 %(max)s 이하여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Numeric column used to calculate the histogram."
-msgstr ""
+msgstr "히스토그램 계산에 사용되는 숫자 열."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Numerical range"
-msgstr ""
+msgstr "숫자 범위"
 
 #, fuzzy
 msgid "OAuth2 client information"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OCT"
-msgstr ""
+msgstr "10월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "OK"
-msgstr ""
+msgstr "확인"
 
 #, fuzzy
 msgid "OR"
@@ -9469,35 +15241,63 @@ msgstr "시간"
 msgid "OVERWRITE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "October"
-msgstr ""
+msgstr "10월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Offline"
-msgstr ""
+msgstr "오프라인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "On Grace"
-msgstr ""
+msgstr "유예 기간 중"
 
 #, fuzzy
 msgid "On dashboards"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many columns to group by. High cardinality groupings should "
 "include a series limit to limit the number of fetched and rendered "
 "series."
-msgstr ""
+msgstr "그룹화할 하나 이상의 열. 카디널리티가 높은 그룹화의 경우 가져오고 렌더링되는 계열 수를 제한하기 위해 계열 제한을 포함해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "One or many controls to group by. If grouping, latitude and longitude "
 "columns must be present."
-msgstr ""
+msgstr "그룹화할 하나 이상의 컨트롤. 그룹화하는 경우 위도 및 경도 열이 있어야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or many controls to pivot as columns"
-msgstr ""
+msgstr "열로 피벗할 하나 이상의 컨트롤"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "One or many metrics to display"
-msgstr ""
+msgstr "표시할 하나 이상의 측정 항목"
 
 #, fuzzy
 msgid "One or more annotation layers failed loading."
@@ -9521,64 +15321,125 @@ msgstr "하나 이상의 메트릭이 중복됩니다"
 msgid "One or more metrics do not exist"
 msgstr "하나 이상의 메트릭이 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters needed to configure a database are missing."
-msgstr ""
+msgstr "데이터베이스 구성에 필요한 하나 이상의 매개변수가 누락되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "One or more parameters specified in the query are malformed."
-msgstr ""
+msgstr "쿼리에 지정된 하나 이상의 매개변수가 잘못된 형식입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "One or more parameters specified in the query are missing."
-msgstr ""
+msgstr "쿼리에 지정된 하나 이상의 매개변수가 누락되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Only Total"
-msgstr ""
+msgstr "합계만"
 
 msgid "Only `SELECT` statements are allowed"
 msgstr "오직 `SELECT` 구문만 허용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is not set to a percentage."
-msgstr ""
+msgstr "\"레이블 유형\"이 백분율로 설정되지 않은 경우에만 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only applies when \"Label Type\" is set to show values."
-msgstr ""
+msgstr "\"레이블 유형\"이 값 표시로 설정된 경우에만 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "문자열이 아닌 열에는 정확히 일치만 사용할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "대상 또는 소스를 신뢰하는 경우에만 계속하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
 "selected category"
-msgstr ""
+msgstr "누적 차트에 합계 값만 표시하고 선택한 카테고리에는 표시하지 않음"
 
 msgid "Only single queries supported"
 msgstr "오직 하나의 쿼리만 지원됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Only the default catalog is supported for this connection"
-msgstr ""
+msgstr "이 연결에서는 기본 카탈로그만 지원됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Oops! An error occurred!"
-msgstr ""
+msgstr "이런! 오류가 발생했습니다!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity"
-msgstr ""
+msgstr "불투명도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of Area Chart. Also applies to confidence band."
-msgstr ""
+msgstr "영역 차트의 불투명도. 신뢰 구간에도 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of all clusters, points, and labels. Between 0 and 1."
-msgstr ""
+msgstr "모든 클러스터, 포인트 및 레이블의 불투명도. 0에서 1 사이."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Opacity of area chart."
-msgstr ""
+msgstr "영역 차트의 불투명도."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Opacity of bubbles, 0 means completely transparent, 1 means opaque"
-msgstr ""
+msgstr "버블의 불투명도, 0은 완전 투명, 1은 불투명을 의미합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Opacity, expects values between 0 and 100"
-msgstr ""
+msgstr "불투명도, 0에서 100 사이의 값을 입력하세요"
 
 msgid "Open Datasource tab"
 msgstr "데이터소스 명"
@@ -9597,25 +15458,38 @@ msgstr "SQL Lab"
 msgid "Open query in SQL Lab"
 msgstr "새로운 탭에서 Query실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Operate the database in asynchronous mode, meaning that the queries are "
 "executed on remote workers as opposed to on the web server itself. This "
 "assumes that you have a Celery worker setup as well as a results backend."
 " Refer to the installation docs for more information."
 msgstr ""
+"데이터베이스를 비동기 모드로 운영합니다. 이는 쿼리가 웹 서버 자체가 아닌 원격 워커에서 실행됨을 의미합니다. 이 기능을 사용하려면"
+" Celery 워커 설정과 결과 백엔드가 필요합니다. 자세한 내용은 설치 문서를 참조하세요."
 
 #, fuzzy
 msgid "Operator"
 msgstr "생성자"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Operator undefined for aggregator: %(name)s"
-msgstr ""
+msgstr "집계기 %(name)s에 대한 연산자가 정의되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Optional CA_BUNDLE contents to validate HTTPS requests. Only available on"
 " certain database engines."
-msgstr ""
+msgstr "HTTPS 요청 검증을 위한 선택적 CA_BUNDLE 내용. 특정 데이터베이스 엔진에서만 사용 가능합니다."
 
 #, fuzzy
 msgid "Optional d3 date format string"
@@ -9625,89 +15499,167 @@ msgstr "주석"
 msgid "Optional d3 number format string"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional name of the data column."
-msgstr ""
+msgstr "데이터 열의 선택적 이름."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Optional warning about use of this metric"
-msgstr ""
+msgstr "이 측정 항목 사용에 대한 선택적 경고"
 
 #, fuzzy
 msgid "Options"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Or choose from a list of other databases we support:"
-msgstr ""
+msgstr "또는 지원하는 다른 데이터베이스 목록에서 선택하세요:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Order results by selected columns"
-msgstr ""
+msgstr "선택한 열을 기준으로 결과 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ordering"
-msgstr ""
+msgstr "정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Orders the query result that generates the source data for this chart. If"
 " a series or row limit is reached, this determines what data are "
 "truncated. If undefined, defaults to the first metric (where "
 "appropriate)."
 msgstr ""
+"이 차트의 소스 데이터를 생성하는 쿼리 결과를 정렬합니다. 계열 또는 행 제한에 도달하면 어떤 데이터가 잘릴지 결정합니다. 정의되지"
+" 않은 경우 첫 번째 측정 항목이 기본값으로 사용됩니다(해당하는 경우)."
 
 #, fuzzy
 msgid "Orientation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Orientation of bar chart"
-msgstr ""
+msgstr "막대 차트의 방향"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Orientation of filter bar"
-msgstr ""
+msgstr "필터 바 방향"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Orientation of tree"
-msgstr ""
+msgstr "트리 방향"
 
 #, fuzzy
 msgid "Original"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Original table column order"
-msgstr ""
+msgstr "원본 테이블 열 순서"
 
 msgid "Original value"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Orthogonal"
-msgstr ""
+msgstr "직교형"
 
 #, fuzzy
 msgid "Other"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Other color palettes"
-msgstr ""
+msgstr "다른 색상 팔레트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outdoors"
-msgstr ""
+msgstr "야외"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outer Radius"
-msgstr ""
+msgstr "외부 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Outer edge of Pie chart"
-msgstr ""
+msgstr "파이 차트의 외부 가장자리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Overlap"
-msgstr ""
+msgstr "겹침"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Overlay one or more timeseries from a relative time period. Expects "
 "relative time deltas in natural language (example:  24 hours, 7 days, 52 "
 "weeks, 365 days). Free text is supported."
 msgstr ""
+"상대적인 기간에서 하나 이상의 시계열을 오버레이합니다. 자연어로 상대적인 시간 차이를 입력하세요(예:  24 hours, 7 "
+"days, 52 weeks, 365 days). 자유 텍스트를 지원합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Overlay one or more timeseries from a relative time period. Expects "
 "relative time deltas in natural language (example: 24 hours, 7 days, 52 "
 "weeks, 365 days). Free text is supported."
 msgstr ""
+"상대적인 기간에서 하나 이상의 시계열을 오버레이합니다. 자연어로 상대적인 시간 차이를 입력하세요(예: 24 hours, 7 "
+"days, 52 weeks, 365 days). 자유 텍스트를 지원합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Overlay results from a relative time period. Expects relative time deltas"
 " in natural language (example:  24 hours, 7 days, 52 weeks, 365 days). "
@@ -9715,56 +15667,110 @@ msgid ""
 "the comparison time range by the same length as your time range and use "
 "\"Custom\" to set a custom comparison range."
 msgstr ""
+"상대적인 기간의 결과를 오버레이합니다. 자연어로 상대적인 시간 차이를 입력하세요(예:  24 hours, 7 days, 52 "
+"weeks, 365 days). 자유 텍스트를 지원합니다. \"시간 필터에서 범위 상속\"을 사용하면 현재 시간 범위와 동일한 "
+"길이만큼 비교 기간을 이동할 수 있으며, \"사용자 정의\"를 사용하면 사용자 정의 비교 범위를 설정할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Overlays a hexagonal grid on a map, and aggregates data within the "
 "boundary of each cell."
-msgstr ""
+msgstr "지도 위에 육각형 격자를 오버레이하고, 각 셀의 경계 내 데이터를 집계합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Override time grain"
-msgstr ""
+msgstr "시간 단위 재정의"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Override time range"
-msgstr ""
+msgstr "시간 범위 재정의"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Overwrite"
-msgstr ""
+msgstr "덮어쓰기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Overwrite & Explore"
-msgstr ""
+msgstr "덮어쓰기 및 탐색"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Overwrite Dashboard [%s]"
-msgstr ""
+msgstr "대시보드 덮어쓰기 [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Overwrite existing"
-msgstr ""
+msgstr "기존 항목 덮어쓰기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Overwrite text in the editor with a query on this table"
-msgstr ""
+msgstr "이 테이블의 쿼리로 에디터의 텍스트 덮어쓰기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Owned Created or Favored"
-msgstr ""
+msgstr "소유, 생성 또는 즐겨찾기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Owner"
-msgstr ""
+msgstr "소유자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Owners"
-msgstr ""
+msgstr "소유자"
 
 msgid "Owners are invalid"
 msgstr "소유자가 부적절합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Owners is a list of users who can alter the dashboard."
-msgstr ""
+msgstr "소유자는 대시보드를 수정할 수 있는 사용자 목록입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Owners is a list of users who can alter the dashboard. Searchable by name"
 " or username."
-msgstr ""
+msgstr "소유자는 대시보드를 수정할 수 있는 사용자 목록입니다. 이름 또는 사용자 이름으로 검색할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "PDF download failed, please refresh and try again."
-msgstr ""
+msgstr "PDF 다운로드에 실패했습니다. 새로 고침 후 다시 시도해 주세요."
 
 #, fuzzy
 msgid "Page"
@@ -9774,64 +15780,124 @@ msgstr "관리"
 msgid "Page Size:"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Page length"
-msgstr ""
+msgstr "페이지 길이"
 
 #, fuzzy
 msgid "Page navigation"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paired t-test Table"
-msgstr ""
+msgstr "대응표본 t-검정 표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pandas resample method"
-msgstr ""
+msgstr "Pandas 리샘플 방법"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pandas resample rule"
-msgstr ""
+msgstr "Pandas 리샘플 규칙"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Parallel Coordinates"
-msgstr ""
+msgstr "평행 좌표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Parameter error"
-msgstr ""
+msgstr "매개변수 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Parameters"
-msgstr ""
+msgstr "매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Parameters "
-msgstr ""
+msgstr "매개변수 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Parameters related to the view and perspective on the map"
-msgstr ""
+msgstr "지도의 뷰 및 원근감과 관련된 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Parent"
-msgstr ""
+msgstr "상위"
 
 #, fuzzy, python-format
 msgid "Parsing error: %(error)s"
 msgstr "부적절한 요청입니다 : %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Part of a Whole"
-msgstr ""
+msgstr "전체의 일부"
 
 #, fuzzy
 msgid "Partition Chart"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Partition Diagram"
-msgstr ""
+msgstr "파티션 다이어그램"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Partition Limit"
-msgstr ""
+msgstr "파티션 제한"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Partition Threshold"
-msgstr ""
+msgstr "파티션 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Partitions whose height to parent height proportions are below this value"
 " are pruned"
-msgstr ""
+msgstr "부모 높이 대비 높이 비율이 이 값 미만인 파티션은 제거됩니다"
 
 #, fuzzy
 msgid "Password"
@@ -9853,17 +15919,31 @@ msgstr "대시보드가 존재하지 않습니다"
 msgid "Paste"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Paste Private Key here"
-msgstr ""
+msgstr "여기에 개인 키를 붙여넣으세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Paste content of service credentials JSON file here"
-msgstr ""
+msgstr "여기에 서비스 자격 증명 JSON 파일의 내용을 붙여넣으세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Paste the shareable Google Sheet URL here"
-msgstr ""
+msgstr "공유 가능한 Google 스프레드시트 URL을 여기에 붙여넣으세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Paste your access token here"
-msgstr ""
+msgstr "여기에 액세스 토큰을 붙여넣으세요"
 
 #, fuzzy
 msgid "Path Color"
@@ -9873,11 +15953,18 @@ msgstr "삭제"
 msgid "Path Size"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pattern"
-msgstr ""
+msgstr "패턴"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "탭이 비활성 상태인 경우 자동 새로 고침 일시 중지"
 
 #, fuzzy
 msgid "Pause auto-refresh"
@@ -9899,8 +15986,11 @@ msgstr "Superset 튜토리얼"
 msgid "Percent Difference format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percent of total"
-msgstr ""
+msgstr "전체 대비 백분율"
 
 #, fuzzy
 msgid "Percentage"
@@ -9910,8 +16000,11 @@ msgstr "Superset 튜토리얼"
 msgid "Percentage change"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Percentage difference between the time periods"
-msgstr ""
+msgstr "기간 간 백분율 차이"
 
 #, fuzzy
 msgid "Percentage metric calculation"
@@ -9921,94 +16014,187 @@ msgstr "메트릭"
 msgid "Percentage metrics"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Percentage threshold"
-msgstr ""
+msgstr "백분율 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Percentages"
-msgstr ""
+msgstr "백분율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Performance"
-msgstr ""
+msgstr "성능"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Period average"
-msgstr ""
+msgstr "기간 평균"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Periods"
-msgstr ""
+msgstr "기간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Periods must be a whole number"
-msgstr ""
+msgstr "기간은 정수여야 합니다"
 
 #, fuzzy
 msgid "Permissions"
 msgstr "표현식"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Permissions successfully synced for %s"
-msgstr ""
+msgstr "%s에 대한 권한이 성공적으로 동기화되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this chart."
-msgstr ""
+msgstr "이 차트를 인증한 개인 또는 그룹."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this dashboard."
-msgstr ""
+msgstr "이 대시보드를 인증한 개인 또는 그룹."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Person or group that has certified this metric"
-msgstr ""
+msgstr "이 지표를 인증한 개인 또는 그룹"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "개인 정보"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical"
-msgstr ""
+msgstr "물리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Physical (table or view)"
-msgstr ""
+msgstr "물리 (테이블 또는 뷰)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Pick a dimension from which categorical colors are defined"
-msgstr ""
+msgstr "범주형 색상이 정의되는 차원 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a metric for x, y and size"
-msgstr ""
+msgstr "x, y 및 크기에 대한 지표 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a metric to display"
-msgstr ""
+msgstr "표시할 지표 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a name to help you identify this database."
-msgstr ""
+msgstr "이 데이터베이스를 식별하는 데 도움이 되는 이름을 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pick a nickname for how the database will display in Superset."
-msgstr ""
+msgstr "Superset에서 데이터베이스가 표시될 별명을 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick a title for you annotation."
-msgstr ""
+msgstr "주석의 제목을 선택하세요."
 
 msgid "Pick at least one metric"
 msgstr "적어도 하나의 메트릭을 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Pick one or more columns that should be shown in the annotation. If you "
 "don't select a column all of them will be shown."
-msgstr ""
+msgstr "주석에 표시할 하나 이상의 열을 선택하세요. 열을 선택하지 않으면 모든 열이 표시됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Pick your favorite markup language"
-msgstr ""
+msgstr "선호하는 마크업 언어를 선택하세요"
 
 #, fuzzy
 msgid "Pie Chart"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pie charts on a map"
-msgstr ""
+msgstr "지도의 파이 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Pie shape"
-msgstr ""
+msgstr "파이 형태"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Piecewise"
-msgstr ""
+msgstr "구간별"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pin"
-msgstr ""
+msgstr "고정"
 
 #, fuzzy
 msgid "Pin Column"
@@ -10018,14 +16204,23 @@ msgstr "컬럼 수정"
 msgid "Pin Left"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Pin Right"
-msgstr ""
+msgstr "오른쪽에 고정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "결과 패널에 고정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pin to top"
-msgstr ""
+msgstr "상단에 고정"
 
 #, fuzzy
 msgid "Pivot Mode"
@@ -10034,11 +16229,19 @@ msgstr "Query 검색"
 msgid "Pivot Table"
 msgstr "피봇 테이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation must include at least one aggregate"
-msgstr ""
+msgstr "피벗 작업에는 최소 하나의 집계가 포함되어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pivot operation requires at least one index"
-msgstr ""
+msgstr "피벗 작업에는 최소 하나의 인덱스가 필요합니다"
 
 #, fuzzy
 msgid "Pivoted"
@@ -10048,69 +16251,128 @@ msgstr "테이블 수정"
 msgid "Pivots"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixel height of each series"
-msgstr ""
+msgstr "각 시리즈의 픽셀 높이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pixels"
-msgstr ""
+msgstr "픽셀"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Plain"
-msgstr ""
+msgstr "일반"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Please check your query and confirm that all template parameters are "
 "surround by double braces, for example, \"{{ ds }}\". Then, try running "
 "your query again."
 msgstr ""
+"쿼리를 확인하고 모든 템플릿 파라미터가 이중 중괄호로 둘러싸여 있는지 확인하세요(예: \"{{ ds }}\"). 그런 다음 쿼리를 "
+"다시 실행해 보세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors at or near "
 "\"%(syntax_error)s\". Then, try running your query again."
-msgstr ""
+msgstr "\"%(syntax_error)s\" 근처의 쿼리에서 구문 오류를 확인하세요. 그런 다음 쿼리를 다시 실행해 보세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Please check your query for syntax errors near \"%(server_error)s\". "
 "Then, try running your query again."
-msgstr ""
+msgstr "\"%(server_error)s\" 근처의 쿼리에서 구문 오류를 확인하세요. 그런 다음 쿼리를 다시 실행해 보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Please check your template parameters for syntax errors and make sure "
 "they match across your SQL query and Set Parameters. Then, try running "
 "your query again."
 msgstr ""
+"템플릿 파라미터에서 구문 오류를 확인하고 SQL 쿼리 및 설정 파라미터와 일치하는지 확인하세요. 그런 다음 쿼리를 다시 실행해 "
+"보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please choose a valid value"
-msgstr ""
+msgstr "유효한 값을 선택하세요"
 
 #, fuzzy
 msgid "Please choose at least one groupby"
 msgstr "적어도 하나의 'Group by'필드를 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please confirm"
-msgstr ""
+msgstr "확인해 주세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please confirm the overwrite values."
-msgstr ""
+msgstr "덮어쓰기 값을 확인해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please confirm your password"
-msgstr ""
+msgstr "비밀번호를 확인해 주세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Please enter a SQLAlchemy URI to test"
-msgstr ""
+msgstr "테스트할 SQLAlchemy URI를 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email"
-msgstr ""
+msgstr "유효한 이메일을 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "유효한 이메일 주소를 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter valid text. Spaces alone are not permitted."
-msgstr ""
+msgstr "유효한 텍스트를 입력하세요. 공백만은 허용되지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please enter your email"
-msgstr ""
+msgstr "이메일을 입력하세요"
 
 #, fuzzy
 msgid "Please enter your first name"
@@ -10128,156 +16390,298 @@ msgstr "비밀번호"
 msgid "Please enter your username"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please fix the following errors"
-msgstr ""
+msgstr "다음 오류를 수정하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Please provide a valid min or max value"
-msgstr ""
+msgstr "유효한 최솟값 또는 최댓값을 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please re-enter the password."
-msgstr ""
+msgstr "비밀번호를 다시 입력하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Please re-export your file and try importing again"
-msgstr ""
+msgstr "파일을 다시 내보내고 가져오기를 다시 시도해 주세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# ja, lv, mi, pl, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "Please reach out to the Chart Owner for assistance."
 msgid_plural "Please reach out to the Chart Owners for assistance."
-msgstr[0] ""
+msgstr[0] "도움이 필요하시면 차트 소유자에게 문의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your chart first, then try creating a new email report."
-msgstr ""
+msgstr "먼저 차트를 저장한 다음, 새 이메일 보고서를 작성해 보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Please save your dashboard first, then try creating a new email report."
-msgstr ""
+msgstr "먼저 대시보드를 저장한 다음, 새 이메일 보고서를 작성해 보세요."
 
 #, fuzzy
 msgid "Please select at least one role or group"
 msgstr "적어도 하나의 'Group by'필드를 선택하세요"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Please select both a %s and a Chart type to proceed"
-msgstr ""
+msgstr "진행하려면 %s와 차트 유형을 모두 선택하세요"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja "
 "macro."
-msgstr ""
+msgstr "Jinja 매크로에서 ``%(name)s`` 지표에 대한 데이터셋 ID를 지정해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Please use 3 different metric labels"
-msgstr ""
+msgstr "3개의 서로 다른 지표 레이블을 사용해 주세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Plot the distance (like flight paths) between origin and destination."
-msgstr ""
+msgstr "출발지와 목적지 사이의 거리(항공 경로 등)를 표시합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Plots the individual metrics for each row in the data vertically and "
 "links them together as a line. This chart is useful for comparing "
 "multiple metrics across all of the samples or rows in the data."
 msgstr ""
+"데이터의 각 행에 대한 개별 지표를 수직으로 표시하고 선으로 연결합니다. 이 차트는 데이터의 모든 샘플 또는 행에 걸쳐 여러 지표를"
+" 비교하는 데 유용합니다."
 
 msgid "Plugins"
 msgstr "플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Point Cluster Map"
-msgstr ""
+msgstr "포인트 클러스터 맵"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Color"
-msgstr ""
+msgstr "포인트 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius"
-msgstr ""
+msgstr "포인트 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Radius Scale"
-msgstr ""
+msgstr "포인트 반지름 배율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point Radius Unit"
-msgstr ""
+msgstr "포인트 반지름 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Point Size"
-msgstr ""
+msgstr "포인트 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Point Unit"
-msgstr ""
+msgstr "포인트 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Point to your spatial columns"
-msgstr ""
+msgstr "공간 열을 지정하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Points"
-msgstr ""
+msgstr "포인트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Points and clusters will update as the viewport is being changed"
-msgstr ""
+msgstr "뷰포트가 변경됨에 따라 포인트와 클러스터가 업데이트됩니다"
 
 #, fuzzy
 msgid "Polygon Column"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Polygon Encoding"
-msgstr ""
+msgstr "폴리곤 인코딩"
 
 #, fuzzy
 msgid "Polygon Settings"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Polyline"
-msgstr ""
+msgstr "폴리라인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Populate \"Default value\" to enable this control"
-msgstr ""
+msgstr "이 컨트롤을 활성화하려면 \"기본값\"을 입력하세요"
 
 #, fuzzy
 msgid "Port"
 msgstr "생성자"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Port %(port)s on hostname \"%(hostname)s\" refused the connection."
-msgstr ""
+msgstr "호스트 이름 \"%(hostname)s\"의 %(port)s 포트가 연결을 거부했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Port out of range 0-65535"
-msgstr ""
+msgstr "포트가 0-65535 범위를 벗어났습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Position JSON"
-msgstr ""
+msgstr "위치 JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of child node label on tree"
-msgstr ""
+msgstr "트리에서 자식 노드 레이블의 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of column level subtotal"
-msgstr ""
+msgstr "열 수준 소계의 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Position of intermediate node label on tree"
-msgstr ""
+msgstr "트리에서 중간 노드 레이블의 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Position of row level subtotal"
-msgstr ""
+msgstr "행 수준 소계의 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Powered by Apache Superset"
-msgstr ""
+msgstr "Apache Superset 기반"
 
 #, fuzzy
 msgid "Pre-filter"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Pre-filter available values"
-msgstr ""
+msgstr "사용 가능한 값 사전 필터링"
 
 #, fuzzy
 msgid "Pre-filter is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Predictive"
-msgstr ""
+msgstr "예측"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Predictive Analytics"
-msgstr ""
+msgstr "예측 분석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix"
-msgstr ""
+msgstr "접두사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Prefix or suffix"
-msgstr ""
+msgstr "접두사 또는 접미사"
 
 msgid "Preview"
 msgstr "데이터 미리보기"
@@ -10286,14 +16690,25 @@ msgstr "데이터 미리보기"
 msgid "Preview uploaded file"
 msgstr "엑셀 업로드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Previous"
-msgstr ""
+msgstr "이전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Previous Line"
-msgstr ""
+msgstr "이전 행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Primary"
-msgstr ""
+msgstr "기본"
 
 #, fuzzy
 msgid "Primary Metric"
@@ -10303,27 +16718,49 @@ msgstr "메트릭"
 msgid "Primary key"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary or secondary y-axis"
-msgstr ""
+msgstr "기본 또는 보조 Y축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Primary y-axis Bounds"
-msgstr ""
+msgstr "기본 Y축 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Primary y-axis format"
-msgstr ""
+msgstr "기본 Y축 형식"
 
 #, fuzzy
 msgid "Private"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Private Channels (Bot in channel)"
-msgstr ""
+msgstr "비공개 채널 (채널 내 봇)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Private Key"
-msgstr ""
+msgstr "개인 키"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Private Key & Password"
-msgstr ""
+msgstr "개인 키 및 비밀번호"
 
 #, fuzzy
 msgid "Private Key Password"
@@ -10333,49 +16770,95 @@ msgstr "비밀번호"
 msgid "Proceed"
 msgstr "생성자"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Processing export for %s"
-msgstr ""
+msgstr "%s 내보내기 처리 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Processing export..."
-msgstr ""
+msgstr "내보내기 처리 중..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progress"
-msgstr ""
+msgstr "진행률"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Progressive"
-msgstr ""
+msgstr "점진적"
 
 #, fuzzy
 msgid "Project Id"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Proportional"
-msgstr ""
+msgstr "비례"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "공개 및 비공개 공유 시트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "공개 공유 시트만"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Published"
-msgstr ""
+msgstr "게시됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Purple"
-msgstr ""
+msgstr "보라색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put labels outside"
-msgstr ""
+msgstr "레이블을 바깥에 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Put the labels outside of the pie?"
-msgstr ""
+msgstr "파이 차트 외부에 레이블을 표시하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Put your code here"
-msgstr ""
+msgstr "여기에 코드를 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Python datetime string pattern"
-msgstr ""
+msgstr "Python 날짜/시간 문자열 패턴"
 
 msgid "Quarter"
 msgstr "분기"
@@ -10388,12 +16871,19 @@ msgstr "분기"
 msgid "Queries"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query"
-msgstr ""
+msgstr "쿼리"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Query %s: %s"
-msgstr ""
+msgstr "쿼리 %s: %s"
 
 #, fuzzy
 msgid "Query A"
@@ -10429,11 +16919,19 @@ msgstr "Query 실행 이력"
 msgid "Query imported"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query in a new tab"
-msgstr ""
+msgstr "새 탭에서 쿼리 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Query is too complex and takes too long to run."
-msgstr ""
+msgstr "쿼리가 너무 복잡하여 실행하는 데 시간이 너무 오래 걸립니다."
 
 #, fuzzy
 msgid "Query mode"
@@ -10445,18 +16943,30 @@ msgstr "Query 검색"
 msgid "Query preview"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Query was stopped"
-msgstr ""
+msgstr "쿼리가 중지되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Query was stopped."
-msgstr ""
+msgstr "쿼리가 중지되었습니다."
 
 #, fuzzy
 msgid "Queued"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "RGB Color"
-msgstr ""
+msgstr "RGB 색상"
 
 #, fuzzy
 msgid "RLS Rule not found."
@@ -10466,15 +16976,23 @@ msgstr "CSS 템플릿을 찾을수 없습니다."
 msgid "RLS rules could not be deleted."
 msgstr "차트를 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar"
-msgstr ""
+msgstr "레이더"
 
 #, fuzzy
 msgid "Radar Chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radar render type, whether to display 'circle' shape."
-msgstr ""
+msgstr "레이더 렌더링 유형, '원형' 모양 표시 여부."
 
 #, fuzzy
 msgid "Radial"
@@ -10484,14 +17002,25 @@ msgstr "실패"
 msgid "Radius"
 msgstr "실패"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Radius in kilometers"
-msgstr ""
+msgstr "반경(킬로미터)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Radius in meters"
-msgstr ""
+msgstr "반경(미터)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Radius in miles"
-msgstr ""
+msgstr "반경(마일)"
 
 #, fuzzy
 msgid "Range"
@@ -10509,11 +17038,19 @@ msgstr "차트 유형"
 msgid "Range filter"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range filter plugin using AntD"
-msgstr ""
+msgstr "AntD를 사용한 범위 필터 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Range labels"
-msgstr ""
+msgstr "범위 레이블"
 
 #, fuzzy
 msgid "Range type"
@@ -10523,60 +17060,112 @@ msgstr "차트 유형"
 msgid "Ranges"
 msgstr "관리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Ranges to highlight with shading"
-msgstr ""
+msgstr "음영으로 강조할 범위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Ranking"
-msgstr ""
+msgstr "순위"
 
 #, fuzzy
 msgid "Ratio"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Raw records"
-msgstr ""
+msgstr "원시 레코드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Recently modified"
-msgstr ""
+msgstr "최근 수정됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Recents"
-msgstr ""
+msgstr "최근"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Recipients are separated by \",\" or \";\""
-msgstr ""
+msgstr "수신자는 \",\" 또는 \";\"로 구분됩니다"
 
 #, fuzzy
 msgid "Records"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Rectangle"
-msgstr ""
+msgstr "직사각형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Recurring (every)"
-msgstr ""
+msgstr "반복 (매)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Red for increase, green for decrease"
-msgstr ""
+msgstr "증가는 빨간색, 감소는 녹색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Redo the action"
-msgstr ""
+msgstr "작업 다시 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Reduce X ticks"
-msgstr ""
+msgstr "X축 눈금 줄이기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Reduces the number of X-axis ticks to be rendered. If true, the x-axis "
 "will not overflow and labels may be missing. If false, a minimum width "
 "will be applied to columns and the width may overflow into an horizontal "
 "scroll."
 msgstr ""
+"렌더링할 X축 눈금 수를 줄입니다. true이면 X축이 넘치지 않지만 레이블이 누락될 수 있습니다. false이면 열에 최소 너비가"
+" 적용되며 너비가 가로 스크롤로 넘칠 수 있습니다."
 
 #, fuzzy
 msgid "Refer to the"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Referenced columns not available in DataFrame."
-msgstr ""
+msgstr "참조된 열이 DataFrame에서 사용할 수 없습니다."
 
 #, fuzzy
 msgid "Referrer"
@@ -10592,12 +17181,18 @@ msgstr "대시보드 가져오기"
 msgid "Refresh delayed"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh frequency"
-msgstr ""
+msgstr "새로 고침 빈도"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Refresh frequency must be at least %s seconds"
-msgstr ""
+msgstr "새로 고침 빈도는 최소 %s초 이상이어야 합니다"
 
 msgid "Refresh interval"
 msgstr "새로고침 간격"
@@ -10618,8 +17213,12 @@ msgstr "Query 공유"
 msgid "Refresh table schema"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Refresh the default values"
-msgstr ""
+msgstr "기본값 새로 고침"
 
 #, fuzzy
 msgid "Refreshing charts"
@@ -10637,47 +17236,85 @@ msgstr "필터"
 msgid "Registration date"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "등록이 완료되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Regular"
-msgstr ""
+msgstr "일반"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Regular filters add where clauses to queries if a user belongs to a role "
 "referenced in the filter, base filters apply filters to all queries "
 "except the roles defined in the filter, and can be used to define what "
 "users can see if no RLS filters within a filter group apply to them."
 msgstr ""
+"일반 필터는 사용자가 필터에 참조된 역할에 속하는 경우 쿼리에 WHERE 절을 추가하고, 기본 필터는 필터에 정의된 역할을 제외한 "
+"모든 쿼리에 필터를 적용하며, 필터 그룹 내의 RLS 필터가 적용되지 않는 경우 사용자가 볼 수 있는 내용을 정의하는 데 사용할 수"
+" 있습니다."
 
 #, fuzzy
 msgid "Relational"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relationships between community channels"
-msgstr ""
+msgstr "커뮤니티 채널 간의 관계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative Date/Time"
-msgstr ""
+msgstr "상대 날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative period"
-msgstr ""
+msgstr "상대 기간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Relative quantity"
-msgstr ""
+msgstr "상대적 수량"
 
 #, fuzzy
 msgid "Reload"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove"
-msgstr ""
+msgstr "제거"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Dark Theme"
-msgstr ""
+msgstr "시스템 다크 테마 제거"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Remove System Default Theme"
-msgstr ""
+msgstr "시스템 기본 테마 제거"
 
 #, fuzzy
 msgid "Remove cross-filter"
@@ -10691,33 +17328,56 @@ msgstr "시각화 유형"
 msgid "Remove filter"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove item"
-msgstr ""
+msgstr "항목 제거"
 
 msgid "Remove query from log"
 msgstr "Query 로그 삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Remove table preview"
-msgstr ""
+msgstr "테이블 미리보기 제거"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Removed 1 column from the virtual dataset"
 msgid_plural "Removed %s columns from the virtual dataset"
-msgstr[0] ""
+msgstr[0] "가상 데이터셋에서 %s개의 열을 제거했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Rename tab"
-msgstr ""
+msgstr "탭 이름 바꾸기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render HTML"
-msgstr ""
+msgstr "HTML 렌더링"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Render columns in HTML format"
-msgstr ""
+msgstr "HTML 형식으로 열 렌더링"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Renders table cells as HTML when applicable. For example, HTML <a> tags "
 "will be rendered as hyperlinks."
-msgstr ""
+msgstr "해당되는 경우 테이블 셀을 HTML로 렌더링합니다. 예를 들어, HTML <a> 태그는 하이퍼링크로 표시됩니다."
 
 msgid "Replace"
 msgstr "바꾸기"
@@ -10730,47 +17390,102 @@ msgstr "생성자"
 msgid "Report Name"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule could not be created."
-msgstr ""
+msgstr "보고서 일정을 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule could not be updated."
-msgstr ""
+msgstr "보고서 일정을 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule delete failed."
-msgstr ""
+msgstr "보고서 일정 삭제에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a csv."
-msgstr ""
+msgstr "CSV 생성 중 보고서 일정 실행에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a dataframe."
-msgstr ""
+msgstr "데이터프레임 생성 중 보고서 일정 실행에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a pdf."
-msgstr ""
+msgstr "PDF 생성 중 보고서 일정 실행에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution failed when generating a screenshot."
-msgstr ""
+msgstr "스크린샷 생성 중 보고서 일정 실행에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule execution got an unexpected error."
-msgstr ""
+msgstr "보고서 일정 실행 중 예기치 않은 오류가 발생했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule is still working, refusing to re-compute."
-msgstr ""
+msgstr "보고서 일정이 아직 실행 중이므로 재계산을 거부합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule log prune failed."
-msgstr ""
+msgstr "보고서 일정 로그 정리에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule not found."
-msgstr ""
+msgstr "보고서 일정을 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule parameters are invalid."
-msgstr ""
+msgstr "보고서 일정 매개변수가 유효하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule reached a working timeout."
-msgstr ""
+msgstr "보고서 일정이 작업 시간 초과에 도달했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report Schedule state not found"
-msgstr ""
+msgstr "보고서 일정 상태를 찾을 수 없음"
 
 #, fuzzy
 msgid "Report a bug"
@@ -10780,8 +17495,12 @@ msgstr "차트 유형"
 msgid "Report contents"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Report failed"
-msgstr ""
+msgstr "보고서 실패"
 
 #, fuzzy
 msgid "Report is active"
@@ -10790,17 +17509,31 @@ msgstr "차트 유형"
 msgid "Report name"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report schedule client error"
-msgstr ""
+msgstr "보고서 일정 클라이언트 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Report schedule system error"
-msgstr ""
+msgstr "보고서 일정 시스템 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Report schedule unexpected error"
-msgstr ""
+msgstr "보고서 일정 예기치 않은 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Report sending"
-msgstr ""
+msgstr "보고서 전송 중"
 
 msgid "Report sent"
 msgstr "대시보드 가져오기"
@@ -10809,56 +17542,102 @@ msgstr "대시보드 가져오기"
 msgid "Report updated"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Reports"
-msgstr ""
+msgstr "보고서"
 
 #, fuzzy
 msgid "Repulsion"
 msgstr "표현식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Repulsion strength between nodes"
-msgstr ""
+msgstr "노드 간 반발력 강도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request Access"
-msgstr ""
+msgstr "액세스 요청"
 
 #, python-format
 msgid "Request is incorrect: %(error)s"
 msgstr "부적절한 요청입니다 : %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Request is not JSON"
-msgstr ""
+msgstr "요청이 JSON이 아닙니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Request missing data field."
-msgstr ""
+msgstr "요청에 데이터 필드가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Request timed out"
-msgstr ""
+msgstr "요청 시간이 초과되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required"
-msgstr ""
+msgstr "필수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Required control values have been removed"
-msgstr ""
+msgstr "필수 제어 값이 제거되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Resample"
-msgstr ""
+msgstr "리샘플링"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Resample method should be in "
-msgstr ""
+msgstr "리샘플링 방법은 다음 중 하나여야 합니다 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Resample operation requires DatetimeIndex"
-msgstr ""
+msgstr "리샘플링 작업에는 DatetimeIndex가 필요합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset"
-msgstr ""
+msgstr "재설정"
 
 #, fuzzy
 msgid "Reset Columns"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "모든 폴더를 기본값으로 재설정"
 
 #, fuzzy
 msgid "Reset columns"
@@ -10872,28 +17651,46 @@ msgstr "비밀번호"
 msgid "Reset password"
 msgstr "비밀번호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Reset state"
-msgstr ""
+msgstr "상태 재설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, lv, ru,
+# sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset to default folders?"
-msgstr ""
+msgstr "기본 폴더로 재설정하시겠습니까?"
 
 #, fuzzy
 msgid "Resize"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Resource already has an attached report."
-msgstr ""
+msgstr "이 리소스에는 이미 첨부된 보고서가 있습니다."
 
 #, fuzzy
 msgid "Resource was not found."
 msgstr "데이터베이스를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Resource was removed before ownership could be verified"
-msgstr ""
+msgstr "소유권을 확인하기 전에 리소스가 제거되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Restore filter"
-msgstr ""
+msgstr "필터 복원"
 
 msgid "Results"
 msgstr "결과"
@@ -10902,11 +17699,19 @@ msgstr "결과"
 msgid "Results %s"
 msgstr "결과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend is not configured."
-msgstr ""
+msgstr "결과 백엔드가 구성되지 않았습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Results backend needed for asynchronous queries is not configured."
-msgstr ""
+msgstr "비동기 쿼리에 필요한 결과 백엔드가 구성되지 않았습니다."
 
 #, fuzzy
 msgid "Resume auto-refresh"
@@ -10924,40 +17729,73 @@ msgstr "검색 결과"
 msgid "Return to Superset"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Return to specific datetime."
-msgstr ""
+msgstr "특정 날짜/시간으로 돌아갑니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reverse Lat & Long"
-msgstr ""
+msgstr "위도 및 경도 반전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Reverse lat/long "
-msgstr ""
+msgstr "위도/경도 반전 "
 
 #, fuzzy
 msgid "Revoke"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke API Key"
-msgstr ""
+msgstr "API 키 취소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "이 API 키 취소"
 
 #, fuzzy
 msgid "Revoked"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich Tooltip"
-msgstr ""
+msgstr "상세 툴팁"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rich tooltip"
-msgstr ""
+msgstr "상세 툴팁"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Right"
-msgstr ""
+msgstr "오른쪽"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Right Axis Format"
-msgstr ""
+msgstr "오른쪽 축 형식"
 
 #, fuzzy
 msgid "Right Axis Metric"
@@ -10967,18 +17805,30 @@ msgstr "메트릭"
 msgid "Right Panel"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Right axis metric"
-msgstr ""
+msgstr "오른쪽 축 지표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Right to Left"
-msgstr ""
+msgstr "오른쪽에서 왼쪽으로"
 
 #, fuzzy
 msgid "Right value"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Right-click on a dimension value to drill to detail by that value."
-msgstr ""
+msgstr "치수 값을 마우스 오른쪽 버튼으로 클릭하면 해당 값으로 세부 정보를 드릴다운합니다."
 
 msgid "Role"
 msgstr "역할"
@@ -10994,111 +17844,210 @@ msgstr "데이터소스"
 msgid "Roles"
 msgstr "역할"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks. If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"역할은 대시보드 접근을 정의하는 목록입니다. 역할에 대시보드 접근 권한을 부여하면 데이터셋 수준의 검사가 우회됩니다. 역할이 "
+"정의되지 않은 경우 일반 접근 권한이 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Roles is a list which defines access to the dashboard. Granting a role "
 "access to a dashboard will bypass dataset level checks.If no roles are "
 "defined, regular access permissions apply."
 msgstr ""
+"역할은 대시보드 접근을 정의하는 목록입니다. 역할에 대시보드 접근 권한을 부여하면 데이터셋 수준의 검사가 우회됩니다.역할이 정의되지"
+" 않은 경우 일반 접근 권한이 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Rolling Function"
-msgstr ""
+msgstr "롤링 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Rolling Window"
-msgstr ""
+msgstr "롤링 윈도우"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Rolling function"
-msgstr ""
+msgstr "롤링 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rolling window"
-msgstr ""
+msgstr "롤링 윈도우"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root certificate"
-msgstr ""
+msgstr "루트 인증서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Root node id"
-msgstr ""
+msgstr "루트 노드 ID"
 
 #, fuzzy
 msgid "Rose Type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotate x axis label"
-msgstr ""
+msgstr "X축 레이블 회전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Rotate y axis label"
-msgstr ""
+msgstr "Y축 레이블 회전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rotation to apply to words in the cloud"
-msgstr ""
+msgstr "워드 클라우드의 단어에 적용할 회전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Round cap"
-msgstr ""
+msgstr "둥근 끝점"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Row"
-msgstr ""
+msgstr "행"
 
 #, fuzzy
 msgid "Row Level Security"
 msgstr "저수준 보안"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
 msgstr ""
+"행 제한: 백분율은 행 제한을 고려하여 검색된 데이터의 부분 집합을 기반으로 계산됩니다. 전체 레코드: 백분율은 행 제한을 무시하고"
+" 전체 데이터셋을 기반으로 계산됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Row containing the headers to use as column names (0 is first line of "
 "data)."
-msgstr ""
+msgstr "열 이름으로 사용할 헤더가 포함된 행 (0은 데이터의 첫 번째 줄)."
 
 #, fuzzy
 msgid "Row height"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Row limit"
-msgstr ""
+msgstr "행 제한"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Rows (vertical layout)"
-msgstr ""
+msgstr "행 (세로 레이아웃)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows per page, 0 means no pagination"
-msgstr ""
+msgstr "페이지당 행 수, 0은 페이지 매김 없음을 의미"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rows subtotal position"
-msgstr ""
+msgstr "행 소계 위치"
 
 #, fuzzy
 msgid "Rows to read"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Rule"
-msgstr ""
+msgstr "규칙"
 
 #, fuzzy
 msgid "Rule Name"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Rule added"
-msgstr ""
+msgstr "규칙이 추가되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run"
-msgstr ""
+msgstr "실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Run a query to display query history"
-msgstr ""
+msgstr "쿼리 기록을 표시하려면 쿼리를 실행하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Run a query to display results"
-msgstr ""
+msgstr "결과를 표시하려면 쿼리를 실행하세요"
 
 #, fuzzy
 msgid "Run current query"
@@ -11110,45 +18059,79 @@ msgstr "SQL Lab"
 msgid "Run query"
 msgstr "Query 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Run query (Ctrl + Return)"
-msgstr ""
+msgstr "쿼리 실행 (Ctrl + Return)"
 
 msgid "Run query in a new tab"
 msgstr "새로운 탭에서 Query실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Run selection"
-msgstr ""
+msgstr "선택 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Running"
-msgstr ""
+msgstr "실행 중"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr ""
+msgstr "%(block_count)s 중 %(block_num)s 블록 실행 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SAT"
-msgstr ""
+msgstr "토"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SEP"
-msgstr ""
+msgstr "9월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 msgid "SQL Lab"
 msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab은 완전히 파싱되지 않은 구문을 승인할 수 없습니다. 테이블을 명시적으로 지정하고 저장 프로시저 또는 공급업체별 호출 "
+"내에서 동적 SQL을 피하세요."
 
 #, fuzzy
 msgid "SQL Lab queries"
 msgstr "저장된 Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "SQL Lab uses your browser's local storage to store queries and results.\n"
 "Currently, you are using %(currentUsage)s KB out of %(maxStorage)d KB "
@@ -11158,12 +18141,21 @@ msgid ""
 "delete the tab.\n"
 "Note that you will need to close other SQL Lab windows before you do this."
 msgstr ""
+"SQL Lab은 쿼리와 결과를 저장하기 위해 브라우저의 로컬 스토리지를 사용합니다.\n"
+"현재 %(maxStorage)d KB 중 %(currentUsage)s KB를 사용하고 있습니다.\n"
+"SQL Lab의 충돌을 방지하려면 일부 쿼리 탭을 삭제하세요.\n"
+"탭을 삭제하기 전에 저장 기능을 사용하여 이 쿼리에 다시 접근할 수 있습니다.\n"
+"이 작업을 수행하기 전에 다른 SQL Lab 창을 닫아야 합니다."
 
 msgid "SQL Query"
 msgstr "Query 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQL expression"
-msgstr ""
+msgstr "SQL 표현식"
 
 msgid "SQL query"
 msgstr "Query 저장"
@@ -11172,24 +18164,44 @@ msgstr "Query 저장"
 msgid "SQL was formatted"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "SQLAlchemy URI"
-msgstr ""
+msgstr "SQLAlchemy URI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Host"
-msgstr ""
+msgstr "SSH 호스트"
 
 #, fuzzy
 msgid "SSH Password"
 msgstr "비밀번호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Port"
-msgstr ""
+msgstr "SSH 포트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel"
-msgstr ""
+msgstr "SSH 터널"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunnel configuration parameters"
-msgstr ""
+msgstr "SSH 터널 구성 매개변수"
 
 #, fuzzy
 msgid "SSH Tunnel could not be deleted."
@@ -11207,30 +18219,59 @@ msgstr "CSS 템플릿을 찾을수 없습니다."
 msgid "SSH Tunnel parameters are invalid."
 msgstr "차트의 파라미터가 부적절합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSH Tunneling is not enabled"
-msgstr ""
+msgstr "SSH 터널링이 활성화되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "SSL"
-msgstr ""
+msgstr "SSL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SSL Mode \"require\" will be used."
-msgstr ""
+msgstr "SSL 모드 \"require\"가 사용됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "STEP %(stepCurr)s OF %(stepLast)s"
-msgstr ""
+msgstr "단계 %(stepCurr)s / %(stepLast)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "STRING"
-msgstr ""
+msgstr "문자열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "SUN"
-msgstr ""
+msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sample Standard Deviation"
-msgstr ""
+msgstr "표본 표준편차"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sample Variance"
-msgstr ""
+msgstr "표본 분산"
 
 #, fuzzy
 msgid "Samples"
@@ -11252,26 +18293,46 @@ msgstr "차트 보기"
 msgid "Satellite"
 msgstr "테이블 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Satellite Streets"
-msgstr ""
+msgstr "위성 거리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Saturday"
-msgstr ""
+msgstr "토요일"
 
 msgid "Save"
 msgstr "저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Save & Explore"
-msgstr ""
+msgstr "저장 및 탐색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Save & go to dashboard"
-msgstr ""
+msgstr "저장 및 대시보드로 이동"
 
 msgid "Save (Overwrite)"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Save as"
-msgstr ""
+msgstr "다른 이름으로 저장"
 
 #, fuzzy, python-format
 msgid "Save as %s"
@@ -11306,8 +18367,11 @@ msgstr "대시보드 추가"
 msgid "Save chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Save color breakpoint values"
-msgstr ""
+msgstr "색상 중단점 값 저장"
 
 msgid "Save dashboard"
 msgstr "대시보드 저장"
@@ -11316,20 +18380,35 @@ msgstr "대시보드 저장"
 msgid "Save dataset"
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save for this session"
-msgstr ""
+msgstr "이 세션에 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save or Overwrite Dataset"
-msgstr ""
+msgstr "데이터셋 저장 또는 덮어쓰기"
 
 msgid "Save query"
 msgstr "Query 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "이 API 키를 안전하게 저장하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Save this query as a virtual dataset to continue exploring"
-msgstr ""
+msgstr "탐색을 계속하려면 이 쿼리를 가상 데이터셋으로 저장하세요"
 
 msgid "Saved"
 msgstr "저장"
@@ -11347,8 +18426,12 @@ msgstr "저장된 Query"
 msgid "Saved queries"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Saved queries could not be deleted."
-msgstr ""
+msgstr "저장된 쿼리를 삭제할 수 없습니다."
 
 msgid "Saved query not found."
 msgstr "저장된 쿼리를 찾을 수 없습니다."
@@ -11357,32 +18440,62 @@ msgstr "저장된 쿼리를 찾을 수 없습니다."
 msgid "Saved query parameters are invalid."
 msgstr "차트의 파라미터가 부적절합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Saving..."
-msgstr ""
+msgstr "저장 중..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale and Move"
-msgstr ""
+msgstr "크기 조정 및 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "지표 기반 선 너비에 적용된 배율 인수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scale only"
-msgstr ""
+msgstr "크기 조정만"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scatter"
-msgstr ""
+msgstr "산포"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Scatter Plot"
-msgstr ""
+msgstr "산점도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Scatter Plot has the horizontal axis in linear units, and the points are "
 "connected in order. It shows a statistical relationship between two "
 "variables."
-msgstr ""
+msgstr "산점도는 수평 축이 선형 단위로 되어 있으며 점들이 순서대로 연결됩니다. 두 변수 간의 통계적 관계를 보여줍니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule"
-msgstr ""
+msgstr "일정"
 
 #, fuzzy
 msgid "Schedule a new email report"
@@ -11391,18 +18504,30 @@ msgstr "대시보드에 차트 추가"
 msgid "Schedule query"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Schedule the query periodically"
-msgstr ""
+msgstr "쿼리를 주기적으로 예약하세요"
 
 #, fuzzy
 msgid "Schedule type"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled"
-msgstr ""
+msgstr "예약됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scheduled at (UTC)"
-msgstr ""
+msgstr "예약 시간 (UTC)"
 
 #, fuzzy
 msgid "Scheduled task executor not found"
@@ -11415,40 +18540,75 @@ msgstr "스키마"
 msgid "Schema cache timeout"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Schemas allowed for File upload"
-msgstr ""
+msgstr "파일 업로드가 허용된 스키마"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Scope"
-msgstr ""
+msgstr "범위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scoping"
-msgstr ""
+msgstr "범위 지정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Screenshot width"
-msgstr ""
+msgstr "스크린샷 너비"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Screenshot width must be between %(min)spx and %(max)spx"
-msgstr ""
+msgstr "스크린샷 너비는 %(min)spx에서 %(max)spx 사이여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Scroll"
-msgstr ""
+msgstr "스크롤"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Scroll down to the bottom to enable overwriting changes. "
-msgstr ""
+msgstr "변경 사항 덮어쓰기를 활성화하려면 맨 아래로 스크롤하세요. "
 
 msgid "Search"
 msgstr "검색"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Search %s records"
-msgstr ""
+msgstr "%s 레코드 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Search / Filter"
-msgstr ""
+msgstr "검색 / 필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Search Metrics & Columns"
-msgstr ""
+msgstr "지표 및 열 검색"
 
 #, fuzzy
 msgid "Search all charts"
@@ -11466,8 +18626,12 @@ msgstr "검색"
 msgid "Search by"
 msgstr "검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Search by query text"
-msgstr ""
+msgstr "쿼리 텍스트로 검색"
 
 #, fuzzy
 msgid "Search calculated columns by name"
@@ -11523,17 +18687,31 @@ msgstr "초"
 msgid "Secondary Metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary currency format"
-msgstr ""
+msgstr "보조 통화 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Secondary y-axis Bounds"
-msgstr ""
+msgstr "보조 Y축 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis format"
-msgstr ""
+msgstr "보조 Y축 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Secondary y-axis title"
-msgstr ""
+msgstr "보조 Y축 제목"
 
 #, fuzzy, python-format
 msgid "Seconds %s"
@@ -11549,15 +18727,26 @@ msgstr "보안"
 msgid "See "
 msgstr "저장된 Query"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "See all %(tableName)s"
-msgstr ""
+msgstr "모든 %(tableName)s 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "See less"
-msgstr ""
+msgstr "간략히 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "See more"
-msgstr ""
+msgstr "더 보기"
 
 #, fuzzy
 msgid "See query details"
@@ -11571,8 +18760,12 @@ msgstr "삭제"
 msgid "Select %s or type to search %s"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Select ..."
-msgstr ""
+msgstr "선택..."
 
 #, fuzzy
 msgid "Select All"
@@ -11582,8 +18775,12 @@ msgstr "테이블 선택"
 msgid "Select Database and Schema"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select Delivery Method"
-msgstr ""
+msgstr "전송 방법 선택"
 
 #, fuzzy
 msgid "Select Filter"
@@ -11617,8 +18814,11 @@ msgstr "대시보드 저장"
 msgid "Select a database"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a database table and create dataset"
-msgstr ""
+msgstr "데이터베이스 테이블을 선택하고 데이터셋 만들기"
 
 #, fuzzy
 msgid "Select a database table."
@@ -11628,14 +18828,25 @@ msgstr "데이터베이스 선택"
 msgid "Select a database to connect"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Select a database to upload the file to"
-msgstr ""
+msgstr "파일을 업로드할 데이터베이스를 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select a database to write a query"
-msgstr ""
+msgstr "쿼리를 작성할 데이터베이스를 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a delimiter for this data"
-msgstr ""
+msgstr "이 데이터의 구분자를 선택하세요"
 
 #, fuzzy
 msgid "Select a dimension"
@@ -11645,23 +18856,36 @@ msgstr "대시보드 저장"
 msgid "Select a linear color scheme"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a metric to display on the right axis"
-msgstr ""
+msgstr "오른쪽 축에 표시할 지표를 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select a metric to display. You can use an aggregation function on a "
 "column or write custom SQL to create a metric."
-msgstr ""
+msgstr "표시할 지표를 선택하세요. 열에 집계 함수를 사용하거나 사용자 지정 SQL을 작성하여 지표를 만들 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr ""
+msgstr "대시보드에 적용할 미리 정의된 CSS 템플릿을 선택하세요"
 
 #, fuzzy
 msgid "Select a schema"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a schema if the database supports this"
-msgstr ""
+msgstr "데이터베이스가 지원하는 경우 스키마를 선택하세요"
 
 #, fuzzy
 msgid "Select a semantic layer"
@@ -11671,8 +18895,11 @@ msgstr "테이블 선택"
 msgid "Select a semantic layer type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select a sheet name from the uploaded file"
-msgstr ""
+msgstr "업로드된 파일에서 시트 이름을 선택하세요"
 
 #, fuzzy
 msgid "Select a tab"
@@ -11682,16 +18909,27 @@ msgstr "데이터베이스 선택"
 msgid "Select a theme"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select a time grain for the visualization. The grain is the time interval"
 " represented by a single point on the chart."
-msgstr ""
+msgstr "시각화를 위한 시간 단위를 선택하세요. 단위는 차트의 단일 포인트로 표현되는 시간 간격입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Select a visualization type"
-msgstr ""
+msgstr "시각화 유형을 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Select aggregate options"
-msgstr ""
+msgstr "집계 옵션을 선택하세요"
 
 #, fuzzy
 msgid "Select all"
@@ -11705,8 +18943,11 @@ msgstr "테이블 선택"
 msgid "Select all items"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select catalog or type to search catalogs"
-msgstr ""
+msgstr "카탈로그를 선택하거나 검색하려면 입력하세요"
 
 #, fuzzy
 msgid "Select channels"
@@ -11728,8 +18969,12 @@ msgstr "시각화 유형"
 msgid "Select charts"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select color scheme"
-msgstr ""
+msgstr "색상 구성표 선택"
 
 #, fuzzy
 msgid "Select column"
@@ -11739,10 +18984,13 @@ msgstr "컬럼 목록"
 msgid "Select column name"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
 "columns."
-msgstr ""
+msgstr "테이블에 표시될 열을 선택하세요. 여러 열을 선택할 수 있습니다."
 
 #, fuzzy
 msgid "Select content type"
@@ -11772,11 +19020,17 @@ msgstr "대시보드 저장"
 msgid "Select database"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Select databases require additional fields to be completed in the "
 "Advanced tab to successfully connect the database. Learn what "
 "requirements your databases has "
 msgstr ""
+"선택한 데이터베이스는 데이터베이스에 성공적으로 연결하기 위해 고급 탭에서 추가 필드를 입력해야 합니다. 데이터베이스의 요구 사항을 "
+"알아보세요 "
 
 #, fuzzy
 msgid "Select dataset source"
@@ -11810,11 +19064,19 @@ msgstr "필터"
 msgid "Select filter"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select filter plugin using AntD"
-msgstr ""
+msgstr "AntD를 사용하여 필터 플러그인 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select first filter value by default"
-msgstr ""
+msgstr "기본적으로 첫 번째 필터 값 선택"
 
 #, fuzzy
 msgid "Select format"
@@ -11824,6 +19086,9 @@ msgstr "D3 포멧"
 msgid "Select groups"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -11831,6 +19096,9 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"레이어를 쌓을 순서대로 선택하세요. 먼저 선택한 항목이 맨 아래에 표시됩니다. 레이어를 사용하면 하나의 지도에 여러 시각화를 결합할"
+" 수 있습니다. 각 레이어는 다양한 데이터나 인사이트를 표시하는 저장된 deck.gl 차트(산점도, 폴리곤, 호 등)입니다. "
+"레이어를 쌓아 데이터 전반의 패턴과 관계를 파악하세요."
 
 #, fuzzy
 msgid "Select layers to hide"
@@ -11840,32 +19108,59 @@ msgstr "차트 추가"
 msgid "Select object name"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
 "percentages of total. Percentage metrics will be calculated only from "
 "data within the row limit. You can use an aggregation function on a "
 "column or write custom SQL to create a percentage metric."
 msgstr ""
+"표시할 지표를 하나 이상 선택하세요. 이 지표는 전체의 백분율로 표시됩니다. 백분율 지표는 행 제한 내의 데이터에서만 계산됩니다. "
+"열에 집계 함수를 사용하거나 사용자 지정 SQL을 작성하여 백분율 지표를 만들 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select one or many metrics to display. You can use an aggregation "
 "function on a column or write custom SQL to create a metric."
-msgstr ""
+msgstr "표시할 지표를 하나 이상 선택하세요. 열에 집계 함수를 사용하거나 사용자 지정 SQL을 작성하여 지표를 만들 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select operator"
-msgstr ""
+msgstr "연산자 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select or type a custom value..."
-msgstr ""
+msgstr "사용자 지정 값을 선택하거나 입력하세요..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select or type currency symbol"
-msgstr ""
+msgstr "통화 기호를 선택하거나 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select or type dataset name"
-msgstr ""
+msgstr "데이터셋 이름을 선택하거나 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select owners"
-msgstr ""
+msgstr "소유자 선택"
 
 #, fuzzy
 msgid "Select page size"
@@ -11899,26 +19194,42 @@ msgstr "테이블 선택"
 msgid "Select semantic views"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
 "same size. \"LINEAR\" increases sizes linearly based on specified slope. "
 "\"EXP\" increases sizes exponentially based on specified exponent"
 msgstr ""
+"값 계산을 위한 형태를 선택하세요. \"FIXED\"는 모든 확대/축소 수준을 동일한 크기로 설정합니다. \"LINEAR\"는 "
+"지정된 기울기에 따라 크기를 선형으로 증가시킵니다. \"EXP\"는 지정된 지수에 따라 크기를 지수적으로 증가시킵니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Select subject"
-msgstr ""
+msgstr "제목 선택"
 
 #, fuzzy
 msgid "Select tab"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select table or type to search tables"
-msgstr ""
+msgstr "테이블을 선택하거나 검색하려면 입력하세요"
 
 #, fuzzy
 msgid "Select the Annotation Layer you would like to use."
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters in this "
 "dashboard. Deselecting a chart will exclude it from being filtered when "
@@ -11926,29 +19237,52 @@ msgid ""
 "\"All charts\" to apply cross-filters to all charts that use the same "
 "dataset or contain the same column name in the dashboard."
 msgstr ""
+"이 대시보드에서 교차 필터를 적용할 차트를 선택하세요. 차트를 선택 해제하면 대시보드의 다른 차트에서 교차 필터를 적용할 때 해당 "
+"차트가 필터링에서 제외됩니다. \"모든 차트\"를 선택하면 동일한 데이터셋을 사용하거나 대시보드에서 동일한 열 이름을 포함하는 모든"
+" 차트에 교차 필터를 적용할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Select the charts to which you want to apply cross-filters when "
 "interacting with this chart. You can select \"All charts\" to apply "
 "filters to all charts that use the same dataset or contain the same "
 "column name in the dashboard."
 msgstr ""
+"이 차트와 상호 작용할 때 교차 필터를 적용할 차트를 선택하세요. \"모든 차트\"를 선택하면 동일한 데이터셋을 사용하거나 "
+"대시보드에서 동일한 열 이름을 포함하는 모든 차트에 필터를 적용할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that indicate an increase in the chart"
-msgstr ""
+msgstr "차트에서 증가를 나타내는 값에 사용할 색상을 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values that represent total bars in the chart"
-msgstr ""
+msgstr "차트에서 합계 막대를 나타내는 값에 사용할 색상을 선택하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
-msgstr ""
+msgstr "차트에서 감소를 나타내는 값에 사용할 색상을 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"USD, EUR, GBP 등의 통화 코드가 포함된 열을 선택하세요. '자동 감지' 통화 형식이 활성화된 경우 차트를 작성할 때 "
+"사용됩니다. 이 열이 설정되지 않았거나 차트 지표에 여러 통화가 포함된 경우 차트는 중립적인 숫자 형식으로 대체됩니다."
 
 #, fuzzy
 msgid "Select the fixed color"
@@ -11958,18 +19292,29 @@ msgstr "테이블 선택"
 msgid "Select the geojson column"
 msgstr "테이블 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"지도 타일 제공업체를 선택하세요. MapLibre는 오픈 소스이며 API 키가 필요 없습니다. Mapbox는 Superset에서 "
+"MAPBOX_API_KEY를 구성해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
-msgstr ""
+msgstr "각 경로가 속하는 색상 분기점 범위를 결정하는 데 사용할 지표를 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select the type of color scheme to use."
-msgstr ""
+msgstr "사용할 색상 구성표 유형을 선택하세요."
 
 #, fuzzy
 msgid "Select users"
@@ -11979,17 +19324,23 @@ msgstr "삭제"
 msgid "Select values"
 msgstr "필터"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Select values in highlighted field(s) in the control panel. Then run the "
 "query by clicking on the %s button."
-msgstr ""
+msgstr "제어판에서 강조 표시된 필드의 값을 선택하세요. 그런 다음 %s 버튼을 클릭하여 쿼리를 실행하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
-msgstr ""
+msgstr "필터 컨트롤에서 사용 가능한 시간 단위를 선택하세요. 이것은 UI 허용 목록일 뿐이며 기본 쿼리에 추가 조건을 추가하지 않습니다."
 
 #, fuzzy
 msgid "Selected"
@@ -12003,18 +19354,27 @@ msgstr "데이터소스"
 msgid "Selection method"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic"
-msgstr ""
+msgstr "시맨틱"
 
 #, fuzzy
 msgid "Semantic Layer"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "시맨틱 뷰"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "시맨틱 뷰"
 
 #, fuzzy
 msgid "Semantic layer"
@@ -12072,35 +19432,72 @@ msgstr "데이터소스가 존재하지 않습니다"
 msgid "Semantic view parameters are invalid."
 msgstr "차트의 파라미터가 부적절합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "시맨틱 뷰가 업데이트되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "시맨틱 뷰"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as CSV"
-msgstr ""
+msgstr "CSV로 보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Send as PDF"
-msgstr ""
+msgstr "PDF로 보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as PNG"
-msgstr ""
+msgstr "PNG로 보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Send as text"
-msgstr ""
+msgstr "텍스트로 보내기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "September"
-msgstr ""
+msgstr "9월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sequential"
-msgstr ""
+msgstr "순차적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Series"
-msgstr ""
+msgstr "시리즈"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Series Height"
-msgstr ""
+msgstr "시리즈 높이"
 
 #, fuzzy
 msgid "Series Order"
@@ -12110,17 +19507,31 @@ msgstr "저장된 Query"
 msgid "Series Style"
 msgstr "시계열 테이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Series chart type (line, bar etc)"
-msgstr ""
+msgstr "시리즈 차트 유형 (선형, 막대 등)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series decrease setting"
-msgstr ""
+msgstr "시리즈 감소 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Series increase setting"
-msgstr ""
+msgstr "시리즈 증가 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Series limit"
-msgstr ""
+msgstr "시리즈 제한"
 
 #, fuzzy
 msgid "Series settings"
@@ -12134,82 +19545,152 @@ msgstr "주석"
 msgid "Series type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server Page Length"
-msgstr ""
+msgstr "서버 페이지 길이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Server pagination"
-msgstr ""
+msgstr "서버 페이지네이션"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Server pagination needs to be enabled for values over %s"
-msgstr ""
+msgstr "%s 이상의 값에 대해 서버 페이지네이션을 활성화해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Service Account"
-msgstr ""
+msgstr "서비스 계정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Service version"
-msgstr ""
+msgstr "서비스 버전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Dark Theme"
-msgstr ""
+msgstr "시스템 다크 테마 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set System Default Theme"
-msgstr ""
+msgstr "시스템 기본 테마 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default dark theme"
-msgstr ""
+msgstr "기본 다크 테마로 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default light theme"
-msgstr ""
+msgstr "기본 라이트 테마로 설정"
 
 #, fuzzy
 msgid "Set auto-refresh"
 msgstr "새로고침 간격"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Set filter mapping"
-msgstr ""
+msgstr "필터 매핑 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing"
-msgstr ""
+msgstr "테스트용 로컬 테마 설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing (preview only)"
-msgstr ""
+msgstr "테스트용 로컬 테마 설정 (미리보기 전용)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set refresh frequency for current session only."
-msgstr ""
+msgstr "현재 세션에 대해서만 새로고침 빈도를 설정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set the automatic refresh frequency for this dashboard."
-msgstr ""
+msgstr "이 대시보드의 자동 새로고침 빈도를 설정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Set the automatic refresh frequency for this dashboard. The dashboard "
 "will reload its data at the specified interval."
-msgstr ""
+msgstr "이 대시보드의 자동 새로고침 빈도를 설정합니다. 대시보드는 지정된 간격으로 데이터를 다시 로드합니다."
 
 #, fuzzy
 msgid "Set up an email report"
 msgstr "대시보드에 차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set up basic details, such as name and description."
-msgstr ""
+msgstr "이름 및 설명과 같은 기본 정보를 설정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"이 데이터셋의 기본 시간 열을 설정합니다. 시간 차원이 필요한 차트를 만들 때 자동으로 시간 열로 선택되며 대시보드 수준의 시간 "
+"필터에서도 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
 "        represented by one ring with the innermost circle as the top of "
 "the hierarchy."
 msgstr ""
+"차트의 계층 수준을 설정합니다. 각 수준은\n"
+"        하나의 링으로 표시되며 가장 안쪽의 원이 계층의 최상위입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings"
-msgstr ""
+msgstr "설정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Settings for time series"
-msgstr ""
+msgstr "시계열 설정"
 
 #, fuzzy
 msgid "Shape"
@@ -12218,11 +19699,19 @@ msgstr "관리"
 msgid "Share"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Share chart by email"
-msgstr ""
+msgstr "이메일로 차트 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Share permalink by email"
-msgstr ""
+msgstr "이메일로 고정 링크 공유"
 
 #, fuzzy
 msgid "Shared"
@@ -12239,33 +19728,57 @@ msgstr "저장된 Query"
 msgid "Sheet name"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Shift + Click to sort by multiple columns"
-msgstr ""
+msgstr "Shift + 클릭으로 여러 열 기준 정렬"
 
 #, fuzzy
 msgid "Shift start date"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Short description must be unique for this layer"
-msgstr ""
+msgstr "이 레이어의 간단한 설명은 고유해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should daily seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
-msgstr ""
+msgstr "일별 계절성을 적용해야 합니다. 정수 값은 계절성의 푸리에 차수를 지정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should weekly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
-msgstr ""
+msgstr "주별 계절성을 적용해야 합니다. 정수 값은 계절성의 푸리에 차수를 지정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Should yearly seasonality be applied. An integer value will specify "
 "Fourier order of seasonality."
-msgstr ""
+msgstr "연간 계절성을 적용해야 합니다. 정수 값은 계절성의 푸리에 차수를 지정합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show"
-msgstr ""
+msgstr "표시"
 
 #, fuzzy, python-format
 msgid "Show %s entries"
@@ -12275,8 +19788,12 @@ msgstr "메트릭 보기"
 msgid "Show Bubbles"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show CREATE VIEW statement"
-msgstr ""
+msgstr "CREATE VIEW 문 표시"
 
 msgid "Show Dashboard"
 msgstr "대시보드 보기"
@@ -12288,8 +19805,12 @@ msgstr "테이블 보기"
 msgid "Show Log"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Markers"
-msgstr ""
+msgstr "마커 표시"
 
 #, fuzzy
 msgid "Show Metric Name"
@@ -12307,8 +19828,12 @@ msgstr "테이블 추가"
 msgid "Show SQL"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show Timestamp"
-msgstr ""
+msgstr "타임스탬프 표시"
 
 #, fuzzy
 msgid "Show Tooltip Labels"
@@ -12318,11 +19843,19 @@ msgstr "테이블 보기"
 msgid "Show Total"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Trend Line"
-msgstr ""
+msgstr "추세선 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Upper Labels"
-msgstr ""
+msgstr "상단 레이블 표시"
 
 #, fuzzy
 msgid "Show Values"
@@ -12332,20 +19865,32 @@ msgstr "테이블 보기"
 msgid "Show X-axis"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show Y-axis"
-msgstr ""
+msgstr "Y축 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show Y-axis on the sparkline. Will display the manually set min/max if "
 "set or min/max values in the data otherwise."
-msgstr ""
+msgstr "스파크라인에 Y축을 표시합니다. 수동으로 설정된 최솟값/최댓값이 있으면 표시하고, 그렇지 않으면 데이터의 최솟값/최댓값을 표시합니다."
 
 #, fuzzy
 msgid "Show all columns"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show axis line ticks"
-msgstr ""
+msgstr "축 선 눈금 표시"
 
 #, fuzzy
 msgid "Show cell bars"
@@ -12375,8 +19920,12 @@ msgstr "컬럼 보기"
 msgid "Show columns total"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show data points as circle markers on the lines"
-msgstr ""
+msgstr "선 위에 데이터 포인트를 원형 마커로 표시"
 
 #, fuzzy
 msgid "Show empty columns"
@@ -12386,23 +19935,39 @@ msgstr "컬럼 수정"
 msgid "Show entries per page"
 msgstr "메트릭 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Show hierarchical relationships of data, with the value represented by "
 "area, showing proportion and contribution to the whole."
-msgstr ""
+msgstr "데이터의 계층적 관계를 표시하며, 값은 면적으로 표현되어 전체에 대한 비율과 기여도를 보여줍니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show info tooltip"
-msgstr ""
+msgstr "정보 툴팁 표시"
 
 #, fuzzy
 msgid "Show label"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show labels when the node has children."
-msgstr ""
+msgstr "노드에 하위 항목이 있을 때 레이블을 표시합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show legend"
-msgstr ""
+msgstr "범례 표시"
 
 #, fuzzy
 msgid "Show less columns"
@@ -12412,21 +19977,36 @@ msgstr "컬럼 수정"
 msgid "Show min/max axis labels"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Show minor ticks on axes."
-msgstr ""
+msgstr "축에 보조 눈금을 표시합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show only my charts"
-msgstr ""
+msgstr "내 차트만 표시"
 
 #, fuzzy
 msgid "Show password."
 msgstr "대시보드 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Show percentage"
-msgstr ""
+msgstr "백분율 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show pointer"
-msgstr ""
+msgstr "포인터 표시"
 
 #, fuzzy
 msgid "Show progress"
@@ -12444,88 +20024,157 @@ msgstr "테이블 보기"
 msgid "Show rows subtotal"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show rows total"
-msgstr ""
+msgstr "행 합계 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show series values on the chart"
-msgstr ""
+msgstr "차트에 계열 값 표시"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show split lines"
-msgstr ""
+msgstr "분할선 표시"
 
 #, fuzzy
 msgid "Show summary"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Show the value on top of the bar"
-msgstr ""
+msgstr "막대 위에 값 표시"
 
 #, fuzzy
 msgid "Show total"
 msgstr "컬럼 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Show total aggregations of selected metrics. Note that row limit does not"
 " apply to the result."
-msgstr ""
+msgstr "선택한 지표의 전체 집계를 표시합니다. 행 제한은 결과에 적용되지 않습니다."
 
 #, fuzzy
 msgid "Show value"
 msgstr "테이블 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single metric front-and-center. Big number is best used to "
 "call attention to a KPI or the one thing you want your audience to focus "
 "on."
 msgstr ""
+"단일 지표를 전면 중앙에 표시합니다. 빅 넘버는 KPI나 청중이 집중하길 원하는 한 가지 항목에 주의를 끌기 위해 사용하는 것이 "
+"가장 좋습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases a single number accompanied by a simple line chart, to call "
 "attention to an important metric along with its change over time or other"
 " dimension."
-msgstr ""
+msgstr "단일 숫자와 간단한 꺾은선 차트를 함께 표시하여 중요한 지표와 시간 또는 다른 차원에 따른 변화에 주의를 끕니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases how a metric changes as the funnel progresses. This classic "
 "chart is useful for visualizing drop-off between stages in a pipeline or "
 "lifecycle."
 msgstr ""
+"퍼널이 진행됨에 따라 지표가 어떻게 변하는지 보여줍니다. 이 클래식 차트는 파이프라인이나 라이프사이클의 단계 간 이탈을 시각화하는 "
+"데 유용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the flow or link between categories using thickness of chords. "
 "The value and corresponding thickness can be different for each side."
-msgstr ""
+msgstr "코드의 두께를 사용하여 카테고리 간의 흐름 또는 연결을 보여줍니다. 값과 해당 두께는 각 면마다 다를 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Showcases the progress of a single metric against a given target. The "
 "higher the fill, the closer the metric is to the target."
-msgstr ""
+msgstr "주어진 목표에 대한 단일 지표의 진행 상황을 보여줍니다. 채워진 정도가 높을수록 지표가 목표에 가까워집니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Showing %s of %s items"
-msgstr ""
+msgstr "%s / %s 항목 표시 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows a list of all series available at that point in time"
-msgstr ""
+msgstr "해당 시점에 사용 가능한 모든 계열 목록을 표시합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Shows or hides markers for the time series"
-msgstr ""
+msgstr "시계열의 마커를 표시하거나 숨깁니다"
 
 #, fuzzy
 msgid "Sign in"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sign in with"
-msgstr ""
+msgstr "다음으로 로그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Significance Level"
-msgstr ""
+msgstr "유의 수준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple"
-msgstr ""
+msgstr "단순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Simple ad-hoc metrics are not enabled for this dataset"
-msgstr ""
+msgstr "이 데이터셋에는 간단한 임시 지표가 활성화되어 있지 않습니다"
 
 #, fuzzy
 msgid "Single"
@@ -12543,20 +20192,38 @@ msgstr "원본 값"
 msgid "Single value"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Single value type"
-msgstr ""
+msgstr "단일 값 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Size in pixels"
-msgstr ""
+msgstr "픽셀 단위 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of edge symbols"
-msgstr ""
+msgstr "엣지 기호 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Size of marker. Also applies to forecast observations."
-msgstr ""
+msgstr "마커 크기. 예측 관측값에도 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip blank lines rather than interpreting them as Not A Number values"
-msgstr ""
+msgstr "빈 줄을 숫자가 아닌 값(NaN)으로 해석하지 않고 건너뜁니다"
 
 #, fuzzy
 msgid "Skip rows"
@@ -12566,117 +20233,221 @@ msgstr "%s 에러"
 msgid "Skip rows is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Skip spaces after delimiter"
-msgstr ""
+msgstr "구분자 뒤의 공백 건너뛰기"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Skipped %d system themes that cannot be deleted"
-msgstr ""
+msgstr "삭제할 수 없는 시스템 테마 %d개를 건너뛰었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slice Id"
-msgstr ""
+msgstr "차트 ID"
 
 #, fuzzy
 msgid "Slider"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Slider and range input"
-msgstr ""
+msgstr "슬라이더 및 범위 입력"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Slug"
-msgstr ""
+msgstr "슬러그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small"
-msgstr ""
+msgstr "작음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Small number format"
-msgstr ""
+msgstr "작은 숫자 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Smooth Line"
-msgstr ""
+msgstr "부드러운 선"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Smooth-line is a variation of the line chart. Without angles and hard "
 "edges, Smooth-line sometimes looks smarter and more professional."
-msgstr ""
+msgstr "부드러운 선은 꺾은선 차트의 변형입니다. 각도와 날카로운 모서리 없이 부드러운 선은 때때로 더 세련되고 전문적으로 보입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Solid"
-msgstr ""
+msgstr "실선"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "일부 그룹을 확인할 수 없어 ID로 표시됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "일부 권한을 확인할 수 없어 ID로 표시됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
-msgstr ""
+msgstr "다른 탭의 일부 필수 필터에 값이 있으며 지워지지 않습니다"
 
 msgid "Some roles do not exist"
 msgstr "몇몇 역할이 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong while saving the user info"
-msgstr ""
+msgstr "사용자 정보를 저장하는 중 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Something went wrong with embedded authentication. Check the dev console "
 "for details."
-msgstr ""
+msgstr "임베디드 인증에 문제가 발생했습니다. 자세한 내용은 개발자 콘솔을 확인하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Something went wrong."
-msgstr ""
+msgstr "오류가 발생했습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Sorry there was an error fetching database information: %s"
-msgstr ""
+msgstr "데이터베이스 정보를 가져오는 중 오류가 발생했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Sorry there was an error fetching saved charts: "
-msgstr ""
+msgstr "저장된 차트를 가져오는 중 오류가 발생했습니다: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, An error occurred"
-msgstr ""
+msgstr "죄송합니다, 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an error occurred"
-msgstr ""
+msgstr "죄송합니다, 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred"
-msgstr ""
+msgstr "죄송합니다, 알 수 없는 오류가 발생했습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, an unknown error occurred."
-msgstr ""
+msgstr "죄송합니다, 알 수 없는 오류가 발생했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Embedding could not be deactivated."
-msgstr ""
+msgstr "죄송합니다, 오류가 발생했습니다. 임베딩을 비활성화할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sorry, something went wrong. Please try again."
-msgstr ""
+msgstr "죄송합니다, 오류가 발생했습니다. 다시 시도해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, something went wrong. Try again later."
-msgstr ""
+msgstr "죄송합니다, 오류가 발생했습니다. 나중에 다시 시도하세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Sorry, there was an error saving this %s: %s"
-msgstr ""
+msgstr "죄송합니다, 이 %s을(를) 저장하는 중 오류가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "Sorry, there was an error saving this dashboard: %s"
-msgstr ""
+msgstr "죄송합니다, 이 대시보드를 저장하는 중 오류가 발생했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, your browser does not support copying."
-msgstr ""
+msgstr "죄송합니다, 귀하의 브라우저는 복사를 지원하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sorry, your browser does not support copying. Use Ctrl / Cmd + C!"
-msgstr ""
+msgstr "죄송합니다, 귀하의 브라우저는 복사를 지원하지 않습니다. Ctrl / Cmd + C를 사용하세요!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort"
-msgstr ""
+msgstr "정렬"
 
 #, fuzzy
 msgid "Sort Ascending"
 msgstr "클릭하여 제목 수정하기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort Descending"
-msgstr ""
+msgstr "내림차순 정렬"
 
 #, fuzzy
 msgid "Sort Metric"
@@ -12690,17 +20461,33 @@ msgstr "클릭하여 제목 수정하기"
 msgid "Sort Series By"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort X Axis"
-msgstr ""
+msgstr "X축 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort Y Axis"
-msgstr ""
+msgstr "Y축 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort ascending"
-msgstr ""
+msgstr "오름차순 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort by"
-msgstr ""
+msgstr "정렬 기준"
 
 #, fuzzy, python-format
 msgid "Sort by %s"
@@ -12714,21 +20501,36 @@ msgstr "대시보드 가져오기"
 msgid "Sort by metric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Sort by original table order"
-msgstr ""
+msgstr "원래 테이블 순서로 정렬"
 
 #, fuzzy
 msgid "Sort by series"
 msgstr "대시보드 가져오기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort columns alphabetically"
-msgstr ""
+msgstr "열을 알파벳 순으로 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Sort columns by"
-msgstr ""
+msgstr "열 정렬 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sort descending"
-msgstr ""
+msgstr "내림차순 정렬"
 
 #, fuzzy
 msgid "Sort display control values"
@@ -12749,31 +20551,52 @@ msgstr "메트릭"
 msgid "Sort query by"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"시리즈 이름을 기준으로 결과를 오름차순으로 정렬합니다. \"메트릭 기준 정렬\"과 함께 사용하면 동일한 메트릭 값에 대한 동점 처리"
+" 기준으로 작동합니다. 이 정렬을 추가하면 일부 데이터베이스에서 쿼리 성능이 저하될 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Sort rows by"
-msgstr ""
+msgstr "행 정렬 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sort series in ascending order"
-msgstr ""
+msgstr "시리즈를 오름차순으로 정렬"
 
 #, fuzzy
 msgid "Sort type"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Source"
-msgstr ""
+msgstr "소스"
 
 #, fuzzy
 msgid "Source Color"
 msgstr "포트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Source SQL"
-msgstr ""
+msgstr "소스 SQL"
 
 #, fuzzy
 msgid "Source category"
@@ -12783,31 +20606,61 @@ msgstr "데이터소스 명"
 msgid "Source location"
 msgstr "데이터소스 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Sparkline"
-msgstr ""
+msgstr "스파크라인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Spatial"
-msgstr ""
+msgstr "공간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Specific Date/Time"
-msgstr ""
+msgstr "특정 날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE TABLE AS schema in: public"
-msgstr ""
+msgstr "CREATE TABLE AS 스키마 이름을 지정합니다: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Specify name to CREATE VIEW AS schema in: public"
-msgstr ""
+msgstr "CREATE VIEW AS 스키마 이름을 지정합니다: public"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Specify the database version. This is used with Presto for query cost "
 "estimation, and Dremio for syntax changes, among others."
-msgstr ""
+msgstr "데이터베이스 버전을 지정합니다. Presto의 쿼리 비용 추정과 Dremio의 구문 변경 등에 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Split number"
-msgstr ""
+msgstr "분할 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Split stack by"
-msgstr ""
+msgstr "스택 분할 기준"
 
 #, fuzzy
 msgid "Square kilometers"
@@ -12821,42 +20674,78 @@ msgstr "분기"
 msgid "Square miles"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack"
-msgstr ""
+msgstr "스택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stack in groups, where each group corresponds to a dimension"
-msgstr ""
+msgstr "각 그룹이 하나의 차원에 해당하는 그룹으로 스택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series"
-msgstr ""
+msgstr "시리즈 스택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stack series on top of each other"
-msgstr ""
+msgstr "시리즈를 서로 위에 스택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Stacked"
-msgstr ""
+msgstr "누적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Bars"
-msgstr ""
+msgstr "누적 막대"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stacked Style"
-msgstr ""
+msgstr "누적 스타일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Standard time series"
-msgstr ""
+msgstr "표준 시계열"
 
 msgid "Start"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start (Longitude, Latitude): "
-msgstr ""
+msgstr "시작 (경도, 위도): "
 
 #, fuzzy
 msgid "Start (inclusive)"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Start Longitude & Latitude"
-msgstr ""
+msgstr "시작 경도 및 위도"
 
 #, fuzzy
 msgid "Start Time"
@@ -12874,16 +20763,28 @@ msgstr "시작 시간"
 msgid "Start date"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start date included in time range"
-msgstr ""
+msgstr "시간 범위에 포함된 시작 날짜"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Start y-axis at 0"
-msgstr ""
+msgstr "y축을 0에서 시작"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Start y-axis at zero. Uncheck to start y-axis at minimum value in the "
 "data."
-msgstr ""
+msgstr "y축을 0에서 시작합니다. 체크 해제 시 데이터의 최솟값에서 y축이 시작됩니다."
 
 #, fuzzy
 msgid "Started"
@@ -12900,20 +20801,36 @@ msgstr "차트 유형"
 msgid "State"
 msgstr "상태"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Statistical"
-msgstr ""
+msgstr "통계"
 
 msgid "Status"
 msgstr "상태"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - end"
-msgstr ""
+msgstr "단계 - 끝"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - middle"
-msgstr ""
+msgstr "단계 - 중간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Step - start"
-msgstr ""
+msgstr "단계 - 시작"
 
 #, fuzzy
 msgid "Step type"
@@ -12923,12 +20840,18 @@ msgstr "차트 유형"
 msgid "Stepped Line"
 msgstr "시계열 테이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Stepped-line graph (also called step chart) is a variation of line chart "
 "but with the line forming a series of steps between data points. A step "
 "chart can be useful when you want to show the changes that occur at "
 "irregular intervals."
 msgstr ""
+"계단형 꺾은선 그래프(단계 차트라고도 함)는 꺾은선 그래프의 변형으로, 데이터 포인트 사이에 일련의 계단 형태로 선이 이어집니다. "
+"단계 차트는 불규칙한 간격으로 발생하는 변화를 표시할 때 유용합니다."
 
 msgid "Stop"
 msgstr "중지"
@@ -12936,50 +20859,89 @@ msgstr "중지"
 msgid "Stop query"
 msgstr "Query 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stop running (Ctrl + e)"
-msgstr ""
+msgstr "실행 중지 (Ctrl + e)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Stop running (Ctrl + x)"
-msgstr ""
+msgstr "실행 중지 (Ctrl + x)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Stopped an unsafe database connection"
-msgstr ""
+msgstr "안전하지 않은 데이터베이스 연결이 중지되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stream"
-msgstr ""
+msgstr "스트림"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Streets"
-msgstr ""
+msgstr "거리"
 
 #, fuzzy
 msgid "Streets (Carto)"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Strength to pull the graph toward center"
-msgstr ""
+msgstr "그래프를 중심으로 당기는 힘"
 
 #, fuzzy
 msgid "Stroke Color"
 msgstr "포트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Stroke Width"
-msgstr ""
+msgstr "선 굵기"
 
 #, fuzzy
 msgid "Stroked"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Structural"
-msgstr ""
+msgstr "구조적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
-msgstr ""
+msgstr "구조는 상위 시맨틱 레이어에서 관리되며 읽기 전용입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Style"
-msgstr ""
+msgstr "스타일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Style the ends of the progress bar with a round cap"
-msgstr ""
+msgstr "진행 막대의 끝을 둥근 캡으로 스타일 지정"
 
 #, fuzzy
 msgid "Styling"
@@ -12989,11 +20951,19 @@ msgstr "CSV 파일"
 msgid "Subcategories"
 msgstr "데이터소스 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Subdomain"
-msgstr ""
+msgstr "서브도메인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Submit"
-msgstr ""
+msgstr "제출"
 
 #, fuzzy
 msgid "Subscribers"
@@ -13003,36 +20973,72 @@ msgstr "데이터소스 명"
 msgid "Subtitle"
 msgstr "제목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Subtotal"
-msgstr ""
+msgstr "소계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Success"
-msgstr ""
+msgstr "성공"
 
 #, fuzzy, python-format
 msgid "Successfully changed %s!"
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix"
-msgstr ""
+msgstr "접미사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Suffix to apply after the percentage display"
-msgstr ""
+msgstr "백분율 표시 후에 적용할 접미사"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum"
-msgstr ""
+msgstr "합계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Columns"
-msgstr ""
+msgstr "열 합계의 분수 비율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Rows"
-msgstr ""
+msgstr "행 합계의 분수 비율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum as Fraction of Total"
-msgstr ""
+msgstr "전체 합계의 분수 비율"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sum of values over specified period"
-msgstr ""
+msgstr "지정된 기간 동안의 값 합계"
 
 #, fuzzy
 msgid "Sum values"
@@ -13046,14 +21052,26 @@ msgstr "분기"
 msgid "Sunburst Chart"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sunday"
-msgstr ""
+msgstr "일요일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Superset Chart"
-msgstr ""
+msgstr "Superset 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset Embedded SDK documentation."
-msgstr ""
+msgstr "Superset 임베디드 SDK 문서."
 
 msgid "Superset chart"
 msgstr "Superset 튜토리얼"
@@ -13062,8 +21080,12 @@ msgstr "Superset 튜토리얼"
 msgid "Superset docs link"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Superset encountered an error while running a command."
-msgstr ""
+msgstr "명령 실행 중 Superset에서 오류가 발생했습니다."
 
 #, fuzzy
 msgid "Superset encountered an unexpected error."
@@ -13077,91 +21099,169 @@ msgstr "데이터베이스 선택"
 msgid "Swap %s"
 msgstr "데이터소스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Swap rows and columns"
-msgstr ""
+msgstr "행과 열 바꾸기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Swiss army knife for visualizing data. Choose between step, line, "
 "scatter, and bar charts. This viz type has many customization options as "
 "well."
 msgstr ""
+"데이터 시각화를 위한 만능 도구입니다. 계단형, 선형, 산점도, 막대 차트 중에서 선택할 수 있으며, 다양한 사용자 정의 옵션도 "
+"제공합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the next tab"
-msgstr ""
+msgstr "다음 탭으로 전환"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Switch to the previous tab"
-msgstr ""
+msgstr "이전 탭으로 전환"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Symbol"
-msgstr ""
+msgstr "기호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Symbol of two ends of edge line"
-msgstr ""
+msgstr "엣지 선 양 끝의 기호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Symbol size"
-msgstr ""
+msgstr "기호 크기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sync Permissions"
-msgstr ""
+msgstr "권한 동기화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Sync columns from source"
-msgstr ""
+msgstr "소스에서 열 동기화"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s"
-msgstr ""
+msgstr "%s의 권한을 동기화하는 중"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syncing permissions for %s in the background"
-msgstr ""
+msgstr "백그라운드에서 %s의 권한을 동기화하는 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Syntax"
-msgstr ""
+msgstr "구문"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
-msgstr ""
+msgstr "구문 오류: %(qualifier)s 입력 \"%(input)s\"에서 \"%(expected)s\"이(가) 필요합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System"
-msgstr ""
+msgstr "시스템"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System Theme - Read Only"
-msgstr ""
+msgstr "시스템 테마 - 읽기 전용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System dark theme removed"
-msgstr ""
+msgstr "시스템 어두운 테마가 제거되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "System default theme removed"
-msgstr ""
+msgstr "시스템 기본 테마가 제거되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TABLES"
-msgstr ""
+msgstr "테이블"
 
 msgid "TEMPORAL_RANGE"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "THU"
-msgstr ""
+msgstr "목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "TUE"
-msgstr ""
+msgstr "화"
 
 msgid "Tab name"
 msgstr "테이블 명"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Tab schema is invalid, caused by: %(error)s"
-msgstr ""
+msgstr "탭 스키마가 유효하지 않습니다. 원인: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tab title"
-msgstr ""
+msgstr "탭 제목"
 
 msgid "Table"
 msgstr "테이블"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Table %(table)s wasn't found in the database %(db)s"
-msgstr ""
+msgstr "데이터베이스 %(db)s에서 테이블 %(table)s을(를) 찾을 수 없습니다"
 
 msgid "Table Name"
 msgstr "테이블 명"
@@ -13170,16 +21270,23 @@ msgstr "테이블 명"
 msgid "Table V2"
 msgstr "테이블"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "Table [%(table)s] could not be found, please double check your database "
 "connection, schema, and table name"
-msgstr ""
+msgstr "테이블 [%(table)s]을(를) 찾을 수 없습니다. 데이터베이스 연결, 스키마 및 테이블 이름을 다시 확인하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Table already exists. You can change your 'if table already exists' "
 "strategy to append or replace or provide a different Table Name to use."
 msgstr ""
+"테이블이 이미 존재합니다. '테이블이 이미 존재하는 경우' 전략을 추가 또는 교체로 변경하거나 사용할 다른 테이블 이름을 제공할 수"
+" 있습니다."
 
 #, fuzzy
 msgid "Table cache timeout"
@@ -13204,22 +21311,38 @@ msgstr "테이블 명이 정해지지 않았습니다"
 msgid "Table or View \"%(table)s\" does not exist."
 msgstr "메트릭 '%(metric)s' 이 존재하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Table that visualizes paired t-tests, which are used to understand "
 "statistical differences between groups."
-msgstr ""
+msgstr "그룹 간의 통계적 차이를 이해하는 데 사용되는 대응 표본 t-검정을 시각화하는 테이블입니다."
 
 msgid "Tables"
 msgstr "테이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabs"
-msgstr ""
+msgstr "탭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tabular"
-msgstr ""
+msgstr "표 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Tag"
-msgstr ""
+msgstr "태그"
 
 #, fuzzy
 msgid "Tag could not be created."
@@ -13245,8 +21368,12 @@ msgstr "생성자"
 msgid "Tag name"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tag name is invalid (cannot contain ':')"
-msgstr ""
+msgstr "태그 이름이 유효하지 않습니다 (':'를 포함할 수 없습니다)"
 
 #, fuzzy
 msgid "Tag parameters are invalid."
@@ -13256,9 +21383,12 @@ msgstr "차트의 파라미터가 부적절합니다."
 msgid "Tag updated"
 msgstr "분기"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Tagged %s %ss"
-msgstr ""
+msgstr "%s개의 %s에 태그가 지정됨"
 
 #, fuzzy
 msgid "Tagged Object could not be deleted."
@@ -13304,10 +21434,13 @@ msgstr "차트를 생성할 수 없습니다."
 msgid "Task could not be updated."
 msgstr "차트를 업데이트할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
-msgstr ""
+msgstr "작업을 중단할 수 없습니다. 작업이 진행 중이지만 중단 핸들러가 등록되지 않았습니다."
 
 #, fuzzy
 msgid "Task parameters are invalid."
@@ -13317,99 +21450,181 @@ msgstr "차트의 파라미터가 부적절합니다."
 msgid "Tasks"
 msgstr "상태"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
-msgstr ""
+msgstr "백그라운드 작업이 실행되면 여기에 작업이 표시됩니다."
 
 #, fuzzy
 msgid "Template"
 msgstr "CSS 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Template for cell titles. Use Handlebars templating syntax (a popular "
 "templating library that uses double curly brackets for variable "
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
+"셀 제목용 템플릿입니다. Handlebars 템플릿 구문(변수 대체를 위해 이중 중괄호를 사용하는 인기 있는 템플릿 라이브러리)을 "
+"사용하세요: {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Template parameters"
-msgstr ""
+msgstr "템플릿 매개변수"
 
 #, fuzzy, python-format
 msgid "Template processing error: %(error)s"
 msgstr "부적절한 요청입니다 : %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "템플릿 처리에 실패했습니다: %(ex)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
 "coming from the controls."
-msgstr ""
+msgstr "템플릿 링크입니다. {{ metric }} 또는 컨트롤에서 오는 다른 값을 포함할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Temporal X-Axis"
-msgstr ""
+msgstr "시간 X축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Terminate running queries when browser window closed or navigated to "
 "another page. Available for Presto, Hive, MySQL, Postgres and Snowflake "
 "databases."
 msgstr ""
+"브라우저 창이 닫히거나 다른 페이지로 이동할 때 실행 중인 쿼리를 종료합니다. Presto, Hive, MySQL, Postgres"
+" 및 Snowflake 데이터베이스에서 사용할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Test connection"
-msgstr ""
+msgstr "연결 테스트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text"
-msgstr ""
+msgstr "텍스트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Text / Markdown"
-msgstr ""
+msgstr "텍스트 / 마크다운"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text align"
-msgstr ""
+msgstr "텍스트 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Text embedded in email"
-msgstr ""
+msgstr "이메일에 포함된 텍스트"
 
 #, fuzzy, python-format
 msgid "The %s"
 msgstr "Query 공유"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "The %s linked to this chart may have been deleted."
-msgstr ""
+msgstr "이 차트에 연결된 %s이(가) 삭제되었을 수 있습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
-msgstr ""
+msgstr "%s의 API 응답이 IDatabaseTable 인터페이스와 일치하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The CSS for individual dashboards can be altered here, or in the "
 "dashboard view where changes are immediately visible"
-msgstr ""
+msgstr "개별 대시보드의 CSS는 여기에서 또는 변경 사항이 즉시 표시되는 대시보드 보기에서 변경할 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The CTAS (create table as select) doesn't have a SELECT statement at the "
 "end. Please make sure your query has a SELECT as its last statement. "
 "Then, try running your query again."
 msgstr ""
+"CTAS(create table as select)의 끝에 SELECT 문이 없습니다. 쿼리의 마지막 문이 SELECT인지 "
+"확인하십시오. 그런 다음 쿼리를 다시 실행해 보십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The GeoJsonLayer takes in GeoJSON formatted data and renders it as "
 "interactive polygons, lines and points (circles, icons and/or texts)."
 msgstr ""
+"GeoJsonLayer는 GeoJSON 형식의 데이터를 받아 대화형 폴리곤, 선 및 점(원, 아이콘 및/또는 텍스트)으로 "
+"렌더링합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Global Task Framework가 활성화되어 있지 않습니다. 관리자에게 GLOBAL_TASK_FRAMEWORK 기능 플래그를"
+" 활성화하도록 요청하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Global Task Framework가 활성화되어 있지 않습니다. @task를 사용하려면 기능 플래그에서 "
+"GLOBAL_TASK_FRAMEWORK=True로 설정하십시오. 구성 세부 정보는 "
+"https://superset.apache.org/docs/configuration/async-queries-celery를 "
+"참조하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
 "values across\n"
@@ -13419,18 +21634,32 @@ msgid ""
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
+"생키 차트는 시스템 단계 전반에 걸친 값의 이동과 변환을 시각적으로 추적합니다. 노드는 단계를 나타내며 값 흐름을 묘사하는 링크로 "
+"연결됩니다. 노드\n"
+"          높이는 시각화된 지표에 해당하여 값의 분포와 변환을 명확하게 표현합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The URL is missing the dataset_id or slice_id parameters."
-msgstr ""
+msgstr "URL에 dataset_id 또는 slice_id 매개변수가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The X-axis is not on the filters list"
-msgstr ""
+msgstr "X축이 필터 목록에 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The X-axis is not on the filters list which will prevent it from being "
 "used in time range filters in dashboards. Would you like to add it to the"
 " filters list?"
-msgstr ""
+msgstr "X축이 필터 목록에 없어 대시보드의 시간 범위 필터에서 사용할 수 없습니다. 필터 목록에 추가하시겠습니까?"
 
 #, fuzzy
 msgid "The annotation has been saved"
@@ -13444,14 +21673,25 @@ msgstr "주석 레이어"
 msgid "The background color of the charts."
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The category of source nodes used to assign colors. If a node is "
 "associated with more than one category, only the first will be used."
-msgstr ""
+msgstr "색상을 지정하는 데 사용되는 소스 노드의 카테고리입니다. 노드가 둘 이상의 카테고리와 연결된 경우 첫 번째 카테고리만 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
-msgstr ""
+msgstr "차트가 아직 로딩 중입니다. 잠시 기다린 후 다시 시도하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
 "what demographics follow your blog, or what portion of the budget goes to"
@@ -13461,86 +21701,168 @@ msgid ""
 " relative proportion is important, consider using a bar or other chart "
 "type instead."
 msgstr ""
+"클래식. 각 투자자가 회사의 얼마를 차지하는지, 블로그를 팔로우하는 인구 통계, 또는 예산의 어느 부분이 군산복합체에 할당되는지 "
+"보여주기에 훌륭합니다.\n"
+"\n"
+"        원형 차트는 정확하게 해석하기 어려울 수 있습니다. 상대적 비율의 명확성이 중요한 경우 대신 막대형 또는 다른 차트 "
+"유형을 사용하는 것을 고려하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The color for points and clusters in RGB"
-msgstr ""
+msgstr "RGB 형식의 점과 클러스터 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the elements border"
-msgstr ""
+msgstr "요소 테두리 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the isoband"
-msgstr ""
+msgstr "등치대의 색상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color of the isoline"
-msgstr ""
+msgstr "등치선의 색상"
 
 #, fuzzy
 msgid "The color of the point labels"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The color scheme for rendering chart"
-msgstr ""
+msgstr "차트 렌더링을 위한 색상 구성표"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The color scheme is determined by the related dashboard.\n"
 "        Edit the color scheme in the dashboard properties."
 msgstr ""
+"색상 구성표는 관련 대시보드에 의해 결정됩니다.\n"
+"        대시보드 속성에서 색상 구성표를 편집하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The color used when a value doesn't match any defined breakpoints."
-msgstr ""
+msgstr "값이 정의된 중단점과 일치하지 않을 때 사용되는 색상입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The colors of this chart might be overridden by custom label colors of "
 "the related dashboard.\n"
 "    Check the JSON metadata in the Advanced settings."
 msgstr ""
+"이 차트의 색상은 관련 대시보드의 사용자 정의 레이블 색상으로 재정의될 수 있습니다.\n"
+"    고급 설정에서 JSON 메타데이터를 확인하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column header label"
-msgstr ""
+msgstr "열 헤더 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the source of the edge."
-msgstr ""
+msgstr "에지의 소스로 사용할 열입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The column to be used as the target of the edge."
-msgstr ""
+msgstr "에지의 대상으로 사용할 열입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The column was deleted or renamed in the database."
-msgstr ""
+msgstr "데이터베이스에서 열이 삭제되거나 이름이 변경되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The configuration for the map layers"
-msgstr ""
+msgstr "맵 레이어 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The corner radius of the chart background"
-msgstr ""
+msgstr "차트 배경의 모서리 반경"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The country code standard that Superset should expect to find in the "
 "[country] column"
-msgstr ""
+msgstr "Superset이 [country] 열에서 찾을 것으로 예상하는 국가 코드 표준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The dashboard has been saved"
-msgstr ""
+msgstr "대시보드가 저장되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The data source seems to have been deleted"
-msgstr ""
+msgstr "데이터 소스가 삭제된 것 같습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The database columns that contains lines information"
-msgstr ""
+msgstr "선 정보가 포함된 데이터베이스 열"
 
 #, fuzzy
 msgid "The database could not be found"
 msgstr "데이터베이스를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is currently running too many queries."
-msgstr ""
+msgstr "데이터베이스에서 현재 너무 많은 쿼리를 실행하고 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The database is under an unusual load."
-msgstr ""
+msgstr "데이터베이스에 비정상적인 부하가 걸려 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The database referenced in this query was not found. Please contact an "
 "administrator for further assistance or try again."
-msgstr ""
+msgstr "이 쿼리에서 참조된 데이터베이스를 찾을 수 없습니다. 추가 지원을 받으려면 관리자에게 문의하거나 다시 시도하십시오."
 
 #, fuzzy
 msgid "The database returned an unexpected error."
@@ -13558,15 +21880,30 @@ msgstr "데이터베이스를 삭제할 수 없습니다."
 msgid "The database was not found."
 msgstr "데이터베이스를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The dataset associated with this chart no longer exists"
-msgstr ""
+msgstr "이 차트와 연결된 데이터셋이 더 이상 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
-msgstr ""
+msgstr "차트의 x축 값을 반환하는 데이터셋 열/지표입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The dataset column/metric that returns the values on your chart's y-axis."
-msgstr ""
+msgstr "차트의 y축 값을 반환하는 데이터셋 열/지표입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
 "              based on the changes in your SQL query. If your changes "
@@ -13574,7 +21911,13 @@ msgid ""
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
+"데이터셋 열은 SQL 쿼리의 변경 사항에 따라 자동으로 동기화됩니다.\n"
+"              변경 사항이 열 정의에 영향을 미치지 않는 경우 이 단계를 건너뛸 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The dataset configuration exposed here\n"
 "                affects all the charts using this dataset.\n"
@@ -13582,100 +21925,172 @@ msgid ""
 "                here may affect other charts\n"
 "                in undesirable ways."
 msgstr ""
+"여기에 표시된 데이터셋 구성은\n"
+"                이 데이터셋을 사용하는 모든 차트에 영향을 미칩니다.\n"
+"                여기서 설정을 변경하면\n"
+"                다른 차트에 원하지 않는 방식으로\n"
+"                영향을 줄 수 있으므로 주의하십시오."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The dataset has been saved"
-msgstr ""
+msgstr "데이터셋이 저장되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The datasource couldn't be loaded"
-msgstr ""
+msgstr "데이터 소스를 불러올 수 없습니다"
 
 #, fuzzy
 msgid "The datasource is too large to query."
 msgstr "이슈 1000 - 데이터 소스가 쿼리하기에 너무 큽니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default catalog that should be used for the connection."
-msgstr ""
+msgstr "연결에 사용해야 하는 기본 카탈로그입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The default schema that should be used for the connection."
-msgstr ""
+msgstr "연결에 사용할 기본 스키마입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The description can be displayed as widget headers in the dashboard view."
 " Supports markdown."
-msgstr ""
+msgstr "설명은 대시보드 뷰에서 위젯 헤더로 표시될 수 있습니다. 마크다운을 지원합니다."
 
 #, fuzzy
 msgid "The display name of your dashboard"
 msgstr "대시보드 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The distance between cells, in pixels"
-msgstr ""
+msgstr "셀 간의 거리(픽셀)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The duration of time in seconds before the cache is invalidated. Set to "
 "-1 to bypass the cache."
-msgstr ""
+msgstr "캐시가 무효화되기 전의 시간(초)입니다. 캐시를 우회하려면 -1로 설정하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The encoding format of the lines"
-msgstr ""
+msgstr "라인의 인코딩 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The engine_params object gets unpacked into the sqlalchemy.create_engine "
 "call."
-msgstr ""
+msgstr "engine_params 객체는 sqlalchemy.create_engine 호출로 언패킹됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The exponent to compute all sizes from. \"EXP\" only"
-msgstr ""
+msgstr "모든 크기를 계산하는 데 사용할 지수입니다. \"EXP\"에만 해당"
 
 #, fuzzy, python-format
 msgid "The extension %(id)s could not be loaded."
 msgstr "데이터베이스를 찾을 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
 "the extent so that all data points are included in the viewport. CUSTOM "
 "allows users to define the extent manually."
 msgstr ""
+"애플리케이션 시작 시 지도의 범위입니다. FIT DATA는 모든 데이터 포인트가 뷰포트에 포함되도록 범위를 자동으로 설정합니다. "
+"CUSTOM은 사용자가 범위를 수동으로 정의할 수 있도록 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "포인트 레이블에 사용할 피처 속성"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The following entries in `series_columns` are missing in `columns`: "
 "%(columns)s. "
-msgstr ""
+msgstr "`series_columns`의 다음 항목이 `columns`에 없습니다: %(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
-msgstr ""
+msgstr "다음 필드에는 내보내기 중에 마스킹된 민감한 정보가 포함되어 있습니다. 이 데이터베이스를 가져오려면 값을 입력해 주세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The following filters have the 'Select first filter value by default'\n"
 "                    option checked and could not be loaded, which is "
 "preventing the dashboard\n"
 "                    from rendering: %s"
 msgstr ""
+"다음 필터는 '기본으로 첫 번째 필터 값 선택'\n"
+"                    옵션이 체크되어 있으며 로드할 수 없어, 대시보드가\n"
+"                    렌더링되지 않습니다: %s"
 
 #, fuzzy
 msgid "The font size of the point labels"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The function to use when aggregating points into groups"
-msgstr ""
+msgstr "포인트를 그룹으로 집계할 때 사용할 함수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The group has been created successfully."
-msgstr ""
+msgstr "그룹이 성공적으로 생성되었습니다."
 
 #, fuzzy
 msgid "The group has been updated successfully."
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
-msgstr ""
+msgstr "모든 높이를 계산하는 데 사용할 현재 줌 레벨의 높이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
 "          representing the frequency or count of values within different "
@@ -13684,72 +22099,134 @@ msgid ""
 " and provides\n"
 "          insights into its shape, central tendency, and spread."
 msgstr ""
+"히스토그램 차트는 다양한 범위 또는 구간 내 값의 빈도 또는 개수를 표현하여\n"
+"          데이터셋의 분포를 표시합니다.\n"
+"          데이터의 패턴, 클러스터 및 이상값을 시각화하는 데 도움이 되며\n"
+"          데이터의 형태, 중심 경향 및 분산에 대한 인사이트를 제공합니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The host \"%(hostname)s\" might be down and can't be reached."
-msgstr ""
+msgstr "호스트 \"%(hostname)s\"가 다운되어 연결할 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The host \"%(hostname)s\" might be down, and can't be reached on port "
 "%(port)s."
-msgstr ""
+msgstr "호스트 \"%(hostname)s\"가 다운되어 포트 %(port)s로 연결할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The host might be down, and can't be reached on the provided port."
-msgstr ""
+msgstr "호스트가 다운되어 제공된 포트로 연결할 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "The hostname \"%(hostname)s\" cannot be resolved."
-msgstr ""
+msgstr "호스트명 \"%(hostname)s\"을(를) 확인할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The hostname provided can't be resolved."
-msgstr ""
+msgstr "제공된 호스트명을 확인할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The id of the active chart"
-msgstr ""
+msgstr "활성 차트의 ID"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"GeoJSON 포인트에 표시할 아이콘의 이미지 URL입니다. 이미지 URL이 올바르게 로드되려면 콘텐츠 보안 정책(CSP)을 "
+"준수해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
-msgstr ""
+msgstr "트리의 초기 레벨(깊이)입니다. -1로 설정하면 모든 노드가 펼쳐집니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The layer attribution"
-msgstr ""
+msgstr "레이어 출처"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The lower limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "아이소밴드 임계값 범위의 하한"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The maximum number of subdivisions of each group; lower values are pruned"
 " first"
-msgstr ""
+msgstr "각 그룹의 최대 세분화 수; 낮은 값이 먼저 제거됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The maximum value of metrics. It is an optional configuration"
-msgstr ""
+msgstr "메트릭의 최대값입니다. 선택적 구성입니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%(key)s is invalid."
-msgstr ""
+msgstr "Extra 필드의 metadata_params가 올바르게 구성되지 않았습니다. 키 %(key)s가 유효하지 않습니다."
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-brace-format
 msgid ""
 "The metadata_params in Extra field is not configured correctly. The key "
 "%{key}s is invalid."
-msgstr ""
+msgstr "Extra 필드의 metadata_params가 올바르게 구성되지 않았습니다. 키 %{key}s가 유효하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The metadata_params object gets unpacked into the sqlalchemy.MetaData "
 "call."
-msgstr ""
+msgstr "metadata_params 객체는 sqlalchemy.MetaData 호출로 언패킹됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The minimum number of rolling periods required to show a value. For "
 "instance if you do a cumulative sum on 7 days you may want your \"Min "
@@ -13757,77 +22234,134 @@ msgid ""
 "periods. This will hide the \"ramp up\" taking place over the first 7 "
 "periods"
 msgstr ""
+"값을 표시하는 데 필요한 최소 롤링 기간 수입니다. 예를 들어 7일 누적 합계를 계산하는 경우 \"최소 기간\"을 7로 설정하면 "
+"표시되는 모든 데이터 포인트가 7개 기간의 합계가 됩니다. 이렇게 하면 처음 7개 기간 동안 발생하는 \"점진적 증가\"가 "
+"숨겨집니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The minimum value of metrics. It is an optional configuration. If not "
 "set, it will be the minimum value of the data"
-msgstr ""
+msgstr "메트릭의 최소값입니다. 선택적 구성입니다. 설정하지 않으면 데이터의 최소값이 사용됩니다."
 
 #, fuzzy
 msgid "The name of the geometry column"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The name of the layer as described in GetCapabilities"
-msgstr ""
+msgstr "GetCapabilities에 설명된 레이어 이름"
 
 #, fuzzy
 msgid "The name of the rule must be unique"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The number color \"steps\""
-msgstr ""
+msgstr "색상 \"단계\" 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The number of bins for the histogram"
-msgstr ""
+msgstr "히스토그램의 구간(bin) 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The number of hours, negative or positive, to shift the time column. This"
 " can be used to move UTC time to local time."
-msgstr ""
+msgstr "시간 열을 이동할 시간 수(음수 또는 양수)입니다. UTC 시간을 현지 시간으로 변환하는 데 사용할 수 있습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of results displayed is limited to %(rows)d."
-msgstr ""
+msgstr "표시되는 결과 수는 %(rows)d개로 제한됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
-msgstr ""
+msgstr "표시되는 행 수는 드롭다운에 의해 %(rows)d개로 제한됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the limit dropdown."
-msgstr ""
+msgstr "표시되는 행 수는 제한 드롭다운에 의해 %(rows)d개로 제한됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the query"
-msgstr ""
+msgstr "표시되는 행 수는 쿼리에 의해 %(rows)d개로 제한됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The number of rows displayed is limited to %(rows)d by the query and "
 "limit dropdown."
-msgstr ""
+msgstr "표시되는 행 수는 쿼리 및 제한 드롭다운에 의해 %(rows)d개로 제한됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The number of seconds before expiring the cache"
-msgstr ""
+msgstr "캐시가 만료되기 전의 초 수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The object does not exist in the given database."
-msgstr ""
+msgstr "해당 데이터베이스에 객체가 존재하지 않습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The parameter %(parameters)s in your query is undefined."
 msgid_plural "The following parameters in your query are undefined: %(parameters)s."
-msgstr[0] ""
+msgstr[0] "쿼리에서 다음 매개변수가 정의되지 않았습니다: %(parameters)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "The password provided for username \"%(username)s\" is incorrect."
-msgstr ""
+msgstr "사용자 이름 \"%(username)s\"에 대한 비밀번호가 올바르지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The password provided when connecting to a database is not valid."
-msgstr ""
+msgstr "데이터베이스 연결 시 제공한 비밀번호가 유효하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The password reset was successful"
-msgstr ""
+msgstr "비밀번호 재설정이 완료되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the charts. Please note that the \"Secure Extra\" and "
@@ -13835,7 +22369,13 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"아래 데이터베이스를 차트와 함께 가져오려면 비밀번호가 필요합니다. 데이터베이스 구성의 \"Secure Extra\" 및 "
+"\"Certificate\" 섹션은 내보내기 파일에 포함되지 않으며, 필요한 경우 가져오기 후 수동으로 추가해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the dashboards. Please note that the \"Secure Extra\" and "
@@ -13843,7 +22383,13 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"아래 데이터베이스를 대시보드와 함께 가져오려면 비밀번호가 필요합니다. 데이터베이스 구성의 \"Secure Extra\" 및 "
+"\"Certificate\" 섹션은 내보내기 파일에 포함되지 않으며, 필요한 경우 가져오기 후 수동으로 추가해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the datasets. Please note that the \"Secure Extra\" and "
@@ -13851,7 +22397,13 @@ msgid ""
 " export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
+"아래 데이터베이스의 비밀번호는 데이터셋과 함께 가져오기 위해 필요합니다. 데이터베이스 설정의 \"Secure Extra\" 및 "
+"\"Certificate\" 섹션은 내보내기 파일에 포함되지 않으므로, 필요한 경우 가져오기 후 수동으로 추가해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the saved queries. Please note that the \"Secure Extra\" "
@@ -13859,218 +22411,416 @@ msgid ""
 "present in export files, and should be added manually after the import if"
 " they are needed."
 msgstr ""
+"아래 데이터베이스의 비밀번호는 저장된 쿼리와 함께 가져오기 위해 필요합니다. 데이터베이스 설정의 \"Secure Extra\" 및 "
+"\"Certificate\" 섹션은 내보내기 파일에 포함되지 않으므로, 필요한 경우 가져오기 후 수동으로 추가해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
-msgstr ""
+msgstr "아래 데이터베이스를 가져오려면 비밀번호가 필요합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "The pattern of timestamp format. For strings use "
-msgstr ""
+msgstr "타임스탬프 형식의 패턴입니다. 문자열의 경우 다음을 사용하세요 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The periodicity over which to pivot time. Users can provide\n"
 "            \"Pandas\" offset alias.\n"
 "            Click on the info bubble for more details on accepted "
 "\"freq\" expressions."
 msgstr ""
+"시간을 피벗하는 주기입니다. 사용자는\n"
+"            \"Pandas\" 오프셋 별칭을 제공할 수 있습니다.\n"
+"            허용되는 \"freq\" 표현식에 대한 자세한 내용은 정보 말풍선을 클릭하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The pixel radius"
-msgstr ""
+msgstr "픽셀 반지름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The pointer to a physical table (or view). Keep in mind that the chart is"
 " associated to this Superset logical table, and this logical table points"
 " the physical table referenced here."
 msgstr ""
+"물리 테이블(또는 뷰)에 대한 포인터입니다. 차트는 이 Superset 논리 테이블과 연결되어 있으며, 이 논리 테이블은 여기서 "
+"참조된 물리 테이블을 가리킵니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The port is closed."
-msgstr ""
+msgstr "포트가 닫혀 있습니다."
 
 #, fuzzy
 msgid "The port number is invalid."
 msgstr "차트의 파라미터가 부적절합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The primary metric is used to define the arc segment sizes"
-msgstr ""
+msgstr "기본 지표는 호 세그먼트의 크기를 정의하는 데 사용됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The provided table was not found in the provided database"
-msgstr ""
+msgstr "제공된 데이터베이스에서 제공된 테이블을 찾을 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query associated with the results was deleted."
-msgstr ""
+msgstr "결과와 관련된 쿼리가 삭제되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The query associated with these results could not be found. You need to "
 "re-run the original query."
-msgstr ""
+msgstr "이 결과와 관련된 쿼리를 찾을 수 없습니다. 원래 쿼리를 다시 실행해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query contains one or more malformed template parameters."
-msgstr ""
+msgstr "쿼리에 하나 이상의 잘못된 형식의 템플릿 매개변수가 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The query couldn't be loaded"
-msgstr ""
+msgstr "쿼리를 불러올 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "The query estimation was killed after %(sqllab_timeout)s seconds. It "
 "might be too complex, or the database might be under heavy load."
 msgstr ""
+"%(sqllab_timeout)s초 후에 쿼리 추정이 종료되었습니다. 쿼리가 너무 복잡하거나 데이터베이스에 부하가 많이 걸릴 수 "
+"있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query has a syntax error."
-msgstr ""
+msgstr "쿼리에 구문 오류가 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The query returned no data"
-msgstr ""
+msgstr "쿼리가 데이터를 반환하지 않았습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The query was killed after %(sqllab_timeout)s seconds. It might be too "
 "complex, or the database might be under heavy load."
-msgstr ""
+msgstr "%(sqllab_timeout)s초 후에 쿼리가 종료되었습니다. 쿼리가 너무 복잡하거나 데이터베이스에 부하가 많이 걸릴 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius (in pixels) the algorithm uses to define a cluster. Choose 0 "
 "to turn off clustering, but beware that a large number of points (>1000) "
 "will cause lag."
 msgstr ""
+"알고리즘이 클러스터를 정의하는 데 사용하는 반지름(픽셀 단위)입니다. 클러스터링을 끄려면 0을 선택하세요. 단, 점의 수가 "
+"많으면(>1000) 처리가 느려질 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The radius of individual points (ones that are not in a cluster). Either "
 "a numerical column or `Auto`, which scales the point based on the largest"
 " cluster"
 msgstr ""
+"개별 점(클러스터에 속하지 않는 점)의 반지름입니다. 숫자 열이나 `Auto`를 사용할 수 있으며, `Auto`는 가장 큰 "
+"클러스터를 기준으로 점의 크기를 조정합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The report has been created"
-msgstr ""
+msgstr "보고서가 생성되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The report will be sent to your email at"
-msgstr ""
+msgstr "보고서가 이메일로 발송됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The result of this query must be a value capable of numeric "
 "interpretation e.g. 1, 1.0, or \"1\" (compatible with Python's float() "
 "function)."
 msgstr ""
+"이 쿼리의 결과는 숫자로 해석 가능한 값이어야 합니다. 예: 1, 1.0, 또는 \"1\" (Python의 float() 함수와 "
+"호환)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The result size exceeds the allowed limit."
-msgstr ""
+msgstr "결과 크기가 허용 한도를 초과합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The results backend no longer has the data from the query."
-msgstr ""
+msgstr "결과 백엔드에 더 이상 쿼리의 데이터가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The results stored in the backend were stored in a different format, and "
 "no longer can be deserialized."
-msgstr ""
+msgstr "백엔드에 저장된 결과는 다른 형식으로 저장되어 더 이상 역직렬화할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The rich tooltip shows a list of all series for that point in time"
-msgstr ""
+msgstr "상세 툴팁은 해당 시점의 모든 시리즈 목록을 표시합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The role has been created successfully."
-msgstr ""
+msgstr "역할이 성공적으로 생성되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The role has been duplicated successfully."
-msgstr ""
+msgstr "역할이 성공적으로 복제되었습니다."
 
 #, fuzzy
 msgid "The role has been updated successfully."
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The row limit set for the chart was reached. The chart may show partial "
 "data."
-msgstr ""
+msgstr "차트에 설정된 행 제한에 도달했습니다. 차트에 일부 데이터만 표시될 수 있습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema)s\" does not exist. A valid schema must be used to "
 "run this query."
-msgstr ""
+msgstr "스키마 \"%(schema)s\"가 존재하지 않습니다. 이 쿼리를 실행하려면 유효한 스키마를 사용해야 합니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The schema \"%(schema_name)s\" does not exist. A valid schema must be "
 "used to run this query."
-msgstr ""
+msgstr "스키마 \"%(schema_name)s\"가 존재하지 않습니다. 이 쿼리를 실행하려면 유효한 스키마를 사용해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The schema of the submitted payload is invalid."
-msgstr ""
+msgstr "제출된 페이로드의 스키마가 유효하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The schema was deleted or renamed in the database."
-msgstr ""
+msgstr "스키마가 데이터베이스에서 삭제되었거나 이름이 변경되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot could not be downloaded. Please, try again later."
-msgstr ""
+msgstr "스크린샷을 다운로드할 수 없습니다. 나중에 다시 시도해 주세요."
 
 #, fuzzy
 msgid "The screenshot has been downloaded."
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The screenshot is being generated. Please, do not leave the page."
-msgstr ""
+msgstr "스크린샷을 생성 중입니다. 페이지를 벗어나지 마세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The service url of the layer"
-msgstr ""
+msgstr "레이어의 서비스 URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The size of each cell in meters"
-msgstr ""
+msgstr "각 셀의 크기(미터 단위)"
 
 #, fuzzy
 msgid "The size of the point icons"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The size of the square cell, in pixels"
-msgstr ""
+msgstr "정사각형 셀의 크기(픽셀 단위)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The slope to compute all sizes from. \"LINEAR\" only"
-msgstr ""
+msgstr "모든 크기를 계산하는 기준 기울기입니다. \"LINEAR\" 전용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The submitted payload failed validation."
-msgstr ""
+msgstr "제출된 페이로드가 유효성 검사에 실패했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect format."
-msgstr ""
+msgstr "제출된 페이로드의 형식이 잘못되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The submitted payload has the incorrect schema."
-msgstr ""
+msgstr "제출된 페이로드의 스키마가 잘못되었습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table)s\" does not exist. A valid table must be used to run"
 " this query."
-msgstr ""
+msgstr "테이블 \"%(table)s\"가 존재하지 않습니다. 이 쿼리를 실행하려면 유효한 테이블을 사용해야 합니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "The table \"%(table_name)s\" does not exist. A valid table must be used "
 "to run this query."
-msgstr ""
+msgstr "테이블 \"%(table_name)s\"가 존재하지 않습니다. 이 쿼리를 실행하려면 유효한 테이블을 사용해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The table was deleted or renamed in the database."
-msgstr ""
+msgstr "테이블이 데이터베이스에서 삭제되었거나 이름이 변경되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time column for the visualization. Note that you can define arbitrary"
 " expression that return a DATETIME column in the table. Also note that "
 "the filter below is applied against this column or expression"
 msgstr ""
+"시각화를 위한 시간 열입니다. 테이블에서 DATETIME 열을 반환하는 임의의 표현식을 정의할 수 있습니다. 아래 필터는 이 열 "
+"또는 표현식에 적용됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. Note that you can type and "
 "use simple natural language as in `10 seconds`, `1 day` or `56 weeks`"
 msgstr ""
+"시각화의 시간 세분성입니다. `10 seconds`, `1 day` 또는 `56 weeks`와 같은 간단한 자연어를 입력하여 사용할"
+" 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. Note that you can type and "
 "use simple natural language as in `10 seconds`,`1 day` or `56 weeks`"
 msgstr ""
+"시각화의 시간 세분성입니다. `10 seconds`,`1 day` 또는 `56 weeks`와 같은 간단한 자연어를 입력하여 사용할 "
+"수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time granularity for the visualization. This applies a date "
 "transformation to alter your time column and defines a new time "
 "granularity. The options here are defined on a per database engine basis "
 "in the Superset source code."
 msgstr ""
+"시각화의 시간 세분성입니다. 날짜 변환을 적용하여 시간 열을 변경하고 새로운 시간 세분성을 정의합니다. 여기의 옵션은 "
+"Superset 소스 코드에서 데이터베이스 엔진별로 정의됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time range for the visualization. All relative times, e.g. \"Last "
 "month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using"
@@ -14080,14 +22830,28 @@ msgid ""
 " explicitly set the timezone per the ISO 8601 format if specifying either"
 " the start and/or end time."
 msgstr ""
+"시각화를 위한 시간 범위입니다. \"지난 달\", \"최근 7일\", \"지금\" 등의 모든 상대적 시간은 서버의 현지 시간(시간대"
+" 없음)을 사용하여 서버에서 계산됩니다. 모든 툴팁과 자리 표시자 시간은 UTC(시간대 없음)로 표시됩니다. 그런 다음 타임스탬프는"
+" 엔진의 로컬 시간대를 사용하여 데이터베이스에서 계산됩니다. 시작 시간 및/또는 종료 시간을 지정하는 경우 ISO 8601 형식에 "
+"따라 시간대를 명시적으로 설정할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
+"각 블록의 시간 단위입니다. domain_granularity보다 작은 단위여야 합니다. Time Grain보다 크거나 같아야 "
+"합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The time unit used for the grouping of blocks"
-msgstr ""
+msgstr "블록 그룹화에 사용되는 시간 단위"
 
 #, fuzzy
 msgid "The two passwords that you entered do not match!"
@@ -14097,20 +22861,38 @@ msgstr "대시보드가 존재하지 않습니다"
 msgid "The type of the layer"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The type of visualization to display"
-msgstr ""
+msgstr "표시할 시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for icon size"
-msgstr ""
+msgstr "아이콘 크기의 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "레이블 크기의 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The unit of measure for the specified point radius"
-msgstr ""
+msgstr "지정된 포인트 반경의 측정 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The upper limit of the threshold range of the Isoband"
-msgstr ""
+msgstr "Isoband의 임계값 범위 상한"
 
 #, fuzzy
 msgid "The user has been created successfully."
@@ -14120,50 +22902,93 @@ msgstr "주석 레이어"
 msgid "The user has been updated successfully."
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "The user seems to have been deleted"
-msgstr ""
+msgstr "사용자가 삭제된 것 같습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The user was updated successfully"
-msgstr ""
+msgstr "사용자가 성공적으로 업데이트되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "The user/password combination is not valid (Incorrect password for user)."
-msgstr ""
+msgstr "사용자/비밀번호 조합이 유효하지 않습니다(사용자의 비밀번호가 올바르지 않습니다)."
 
 #, fuzzy, python-format
 msgid "The username \"%(username)s\" does not exist."
 msgstr "메트릭 '%(metric)s' 이 존재하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The username provided when connecting to a database is not valid."
-msgstr ""
+msgstr "데이터베이스에 연결할 때 제공된 사용자 이름이 유효하지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The values overlap other breakpoint values"
-msgstr ""
+msgstr "값이 다른 중단점 값과 겹칩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The version of the service"
-msgstr ""
+msgstr "서비스 버전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The visible title of the layer"
-msgstr ""
+msgstr "레이어의 표시 제목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "The way the ticks are laid out on the X-axis"
-msgstr ""
+msgstr "X축에서 눈금이 배치되는 방식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the Isoline in pixels"
-msgstr ""
+msgstr "Isoline의 너비(픽셀)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the current zoom level to compute all widths from"
-msgstr ""
+msgstr "모든 너비를 계산하는 데 기준이 되는 현재 줌 레벨의 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the elements border"
-msgstr ""
+msgstr "요소 테두리의 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The width of the lines"
-msgstr ""
+msgstr "선의 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
-msgstr ""
+msgstr "고정 값 또는 지표에 따른 가변 너비로서의 선 너비"
 
 #, fuzzy
 msgid "Theme"
@@ -14192,17 +23017,33 @@ msgstr "관련된 알람이나 리포트가 있습니다"
 msgid "There are associated alerts or reports: %(report_names)s"
 msgstr "관련된 알람이나 리포트가 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "There are no charts added to this dashboard"
-msgstr ""
+msgstr "이 대시보드에 추가된 차트가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "There are no components added to this tab"
-msgstr ""
+msgstr "이 탭에 추가된 구성 요소가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There are no filters in this dashboard."
-msgstr ""
+msgstr "이 대시보드에는 필터가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There are unsaved changes."
-msgstr ""
+msgstr "저장되지 않은 변경 사항이 있습니다."
 
 #, fuzzy
 msgid ""
@@ -14210,24 +23051,37 @@ msgid ""
 " or a typo."
 msgstr "이슈 1003 - SQL 쿼리에 문법 오류가 있습니다. 오탈자가 있는지 확인하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "There is currently no information to display."
-msgstr ""
+msgstr "현재 표시할 정보가 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is no chart definition associated with this component, could it "
 "have been deleted?"
-msgstr ""
+msgstr "이 구성 요소와 연결된 차트 정의가 없습니다. 삭제되었을 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "There is not enough space for this component. Try decreasing its width, "
 "or increasing the destination width."
-msgstr ""
+msgstr "이 구성 요소를 위한 공간이 부족합니다. 너비를 줄이거나 대상 너비를 늘려보십시오."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
-msgstr ""
+msgstr "대시보드를 새로 고치는 중에 문제가 발생했습니다. %s 후에 예정대로 다시 시도합니다."
 
 #, fuzzy
 msgid "There was an error creating the group. Please, try again."
@@ -14253,9 +23107,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an error fetching dataset's related objects"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "There was an error fetching the favorite status: %s"
-msgstr ""
+msgstr "즐겨찾기 상태를 가져오는 중에 오류가 발생했습니다: %s"
 
 #, fuzzy
 msgid "There was an error fetching the filtered charts and dashboards:"
@@ -14277,11 +23134,19 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an error loading the chart data"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error loading the schemas"
-msgstr ""
+msgstr "스키마를 로드하는 중에 오류가 발생했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error loading the tables"
-msgstr ""
+msgstr "테이블을 로드하는 중에 오류가 발생했습니다."
 
 #, fuzzy
 msgid "There was an error loading users."
@@ -14291,9 +23156,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an error retrieving dashboard tabs."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy, python-format
 msgid "There was an error saving the favorite status: %s"
-msgstr ""
+msgstr "즐겨찾기 상태를 저장하는 중에 오류가 발생했습니다: %s"
 
 #, fuzzy
 msgid "There was an error updating the group. Please, try again."
@@ -14319,8 +23187,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an error while fetching users"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an error with your request"
-msgstr ""
+msgstr "요청에 오류가 발생했습니다."
 
 #, fuzzy, python-format
 msgid "There was an issue cancelling the task: %s"
@@ -14330,9 +23202,12 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an issue deleting %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting %s: %s"
-msgstr ""
+msgstr "%s 삭제 중에 문제가 발생했습니다: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting registration for user: %s"
@@ -14346,36 +23221,58 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an issue deleting the selected %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected %s: %s"
-msgstr ""
+msgstr "선택한 %s 삭제 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected annotations: %s"
-msgstr ""
+msgstr "선택한 주석 삭제 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected charts: %s"
-msgstr ""
+msgstr "선택한 차트 삭제 중에 문제가 발생했습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "There was an issue deleting the selected dashboards: "
-msgstr ""
+msgstr "선택한 대시보드 삭제 중에 문제가 발생했습니다: "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected layers: %s"
-msgstr ""
+msgstr "선택한 레이어 삭제 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected templates: %s"
-msgstr ""
+msgstr "선택한 템플릿 삭제 중에 문제가 발생했습니다: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue deleting the selected themes: %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue deleting: %s"
-msgstr ""
+msgstr "삭제 중에 문제가 발생했습니다: %s"
 
 #, fuzzy, python-format
 msgid "There was an issue duplicating the %s."
@@ -14405,114 +23302,213 @@ msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였
 msgid "There was an issue exporting the selected themes"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an issue favoriting this dashboard."
-msgstr ""
+msgstr "이 대시보드를 즐겨찾기에 추가하는 중에 문제가 발생했습니다."
 
 #, fuzzy
 msgid "There was an issue fetching reports."
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "There was an issue fetching the favorite status of this dashboard."
-msgstr ""
+msgstr "이 대시보드의 즐겨찾기 상태를 가져오는 중에 문제가 발생했습니다."
 
 #, fuzzy, python-format
 msgid "There was an issue fetching your chart: %s"
 msgstr "데이터 베이스 목록을 가져오는 도중 에러가 발생하였습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There was an issue fetching your dashboards: %s"
-msgstr ""
+msgstr "대시보드를 가져오는 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue fetching your recent activity: %s"
-msgstr ""
+msgstr "최근 활동을 가져오는 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "There was an issue fetching your saved queries: %s"
-msgstr ""
+msgstr "저장된 쿼리를 가져오는 중에 문제가 발생했습니다: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query %s"
-msgstr ""
+msgstr "선택한 쿼리 %s를 미리 보는 중에 문제가 발생했습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "There was an issue previewing the selected query. %s"
-msgstr ""
+msgstr "선택한 쿼리를 미리 보는 중에 문제가 발생했습니다. %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "These are the datasets this filter will be applied to."
-msgstr ""
+msgstr "이 필터가 적용될 데이터셋입니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This JSON object is generated dynamically when clicking the save or "
 "overwrite button in the dashboard view. It is exposed here for reference "
 "and for power users who may want to alter specific parameters."
 msgstr ""
+"이 JSON 객체는 대시보드 보기에서 저장 또는 덮어쓰기 버튼을 클릭할 때 동적으로 생성됩니다. 특정 파라미터를 변경하려는 파워 "
+"유저와 참조용으로 여기에 표시됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "This action will permanently delete %s."
-msgstr ""
+msgstr "이 작업으로 %s이(가) 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the group."
-msgstr ""
+msgstr "이 작업으로 그룹이 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the layer."
-msgstr ""
+msgstr "이 작업으로 레이어가 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the role."
-msgstr ""
+msgstr "이 작업으로 역할이 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the saved query."
-msgstr ""
+msgstr "이 작업으로 저장된 쿼리가 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This action will permanently delete the template."
-msgstr ""
+msgstr "이 작업으로 템플릿이 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the theme."
-msgstr ""
+msgstr "이 작업으로 테마가 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user registration."
-msgstr ""
+msgstr "이 작업으로 사용자 등록 정보가 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This action will permanently delete the user."
-msgstr ""
+msgstr "이 작업으로 사용자가 영구적으로 삭제됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This can be either an IP address (e.g. 127.0.0.1) or a domain name (e.g. "
 "mydatabase.com)."
-msgstr ""
+msgstr "IP 주소(예: 127.0.0.1) 또는 도메인 이름(예: mydatabase.com)을 입력할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This chart applies cross-filters to charts whose datasets contain columns"
 " with the same name."
-msgstr ""
+msgstr "이 차트는 동일한 이름의 열을 포함하는 데이터셋을 가진 차트에 교차 필터를 적용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart has been moved to a different filter scope."
-msgstr ""
+msgstr "이 차트가 다른 필터 범위로 이동되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr ""
+msgstr "이 차트는 외부에서 관리되며 Superset에서 덮어쓸 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This chart is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "이 차트는 외부에서 관리되며 Superset에서 편집할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This chart might be incompatible with the filter (datasets don't match)"
-msgstr ""
+msgstr "이 차트는 필터와 호환되지 않을 수 있습니다 (데이터셋이 일치하지 않음)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This chart type is not supported when using an unsaved query as a chart "
 "source. "
-msgstr ""
+msgstr "저장되지 않은 쿼리를 차트 소스로 사용할 경우 이 차트 유형은 지원되지 않습니다. "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
-msgstr ""
+msgstr "이 열은 현재 %s과(와) 호환되지 않을 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This column might be incompatible with current dataset"
-msgstr ""
+msgstr "이 열은 현재 데이터셋과 호환되지 않을 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This column must contain date/time information."
-msgstr ""
+msgstr "이 열은 날짜/시간 정보를 포함해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This control filters the whole chart based on the selected time range. "
 "All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. "
@@ -14522,130 +23518,248 @@ msgid ""
 "engine's local timezone. Note one can explicitly set the timezone per the"
 " ISO 8601 format if specifying either the start and/or end time."
 msgstr ""
+"이 컨트롤은 선택된 시간 범위를 기준으로 전체 차트를 필터링합니다. \"지난달\", \"최근 7일\", \"지금\" 등 모든 상대적"
+" 시간은 서버의 로컬 시간(시간대 제외)을 사용하여 서버에서 평가됩니다. 모든 툴팁 및 자리 표시자 시간은 UTC(시간대 제외)로 "
+"표현됩니다. 타임스탬프는 이후 엔진의 로컬 시간대를 사용하여 데이터베이스에서 평가됩니다. 시작 및/또는 종료 시간을 지정하는 경우 "
+"ISO 8601 형식에 따라 시간대를 명시적으로 설정할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the \"time_range\" field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"현재 보기의 \"time_range\" 필드를\n"
+"                  주석 데이터가 포함된 차트에 전달할지 여부를 제어합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This controls whether the time grain field from the current\n"
 "                  view should be passed down to the chart containing the "
 "annotation data."
 msgstr ""
+"현재 보기의 시간 단위 필드를\n"
+"                  주석 데이터가 포함된 차트에 전달할지 여부를 제어합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dashboard is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "이 대시보드는 외부에서 관리되며 Superset에서 편집할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published which means it will not show up in the "
 "list of dashboards. Favorite it to see it there or access it by using the"
 " URL directly."
 msgstr ""
+"이 대시보드는 게시되지 않아 대시보드 목록에 표시되지 않습니다. 즐겨찾기에 추가하여 거기서 확인하거나 URL을 직접 사용하여 "
+"액세스하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is not published, it will not show up in the list of "
 "dashboards. Click here to publish this dashboard."
-msgstr ""
+msgstr "이 대시보드는 게시되지 않아 대시보드 목록에 표시되지 않습니다. 여기를 클릭하여 이 대시보드를 게시하세요."
 
 #, fuzzy
 msgid "This dashboard is now hidden"
 msgstr "이 차트를 변경하는 것은 불가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is now published"
-msgstr ""
+msgstr "이 대시보드가 게시되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This dashboard is published. Click to make it a draft."
-msgstr ""
+msgstr "이 대시보드가 게시되었습니다. 클릭하여 초안으로 전환하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This dashboard is ready to embed. In your application, pass the following"
 " id to the SDK:"
-msgstr ""
+msgstr "이 대시보드를 임베드할 준비가 되었습니다. 애플리케이션에서 다음 ID를 SDK에 전달하세요:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "This dashboard was saved successfully."
-msgstr ""
+msgstr "이 대시보드가 성공적으로 저장되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This database does not allow for DDL/DML, but the query mutates data. "
 "Please contact your administrator for more assistance."
-msgstr ""
+msgstr "이 데이터베이스는 DDL/DML을 허용하지 않지만 쿼리가 데이터를 변경합니다. 추가 지원을 받으려면 관리자에게 문의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This database is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "이 데이터베이스는 외부에서 관리되며 Superset에서 편집할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This database table does not contain any data. Please select a different "
 "table."
-msgstr ""
+msgstr "이 데이터베이스 테이블에는 데이터가 없습니다. 다른 테이블을 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"이 데이터베이스는 인증에 OAuth2를 사용합니다. 위의 링크를 클릭하여 Apache Superset이 데이터에 액세스할 수 있도록"
+" 권한을 부여하세요. 개인 액세스 토큰은 암호화되어 저장되며 귀하가 실행하는 쿼리에만 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "This dataset is managed externally, and can't be edited in Superset"
-msgstr ""
+msgstr "이 데이터셋은 외부에서 관리되며 Superset에서 편집할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "This defines the element to be plotted on the chart"
-msgstr ""
+msgstr "이는 차트에 표시될 요소를 정의합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This email is already associated with an account. Please choose another "
 "one."
-msgstr ""
+msgstr "이 이메일은 이미 계정과 연결되어 있습니다. 다른 이메일을 선택하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This feature is experimental and may change or have limitations"
-msgstr ""
+msgstr "이 기능은 실험적이며 변경되거나 제한이 있을 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the calculated "
 "dimension to charts. It is also used as the alias in the SQL query."
-msgstr ""
+msgstr "이 필드는 계산된 차원을 차트에 연결하는 고유 식별자로 사용됩니다. SQL 쿼리에서 별칭으로도 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This field is used as a unique identifier to attach the metric to charts."
 " It is also used as the alias in the SQL query."
-msgstr ""
+msgstr "이 필드는 지표를 차트에 연결하는 고유 식별자로 사용됩니다. SQL 쿼리에서 별칭으로도 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "This filter already exist on the report"
-msgstr ""
+msgstr "이 필터는 이미 보고서에 있습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This filter might be incompatible with current %s"
-msgstr ""
+msgstr "이 필터는 현재 %s과(와) 호환되지 않을 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "이 폴더는 현재 비어 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "이 폴더는 열만 지원합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "이 폴더는 지표만 지원합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This functionality is disabled in your environment for security reasons."
-msgstr ""
+msgstr "이 기능은 보안상의 이유로 귀하의 환경에서 비활성화되어 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
-msgstr ""
+msgstr "이것은 기본 열 폴더입니다. 이름을 변경하거나 제거할 수 없습니다. 비워 둘 수 있지만 열 항목만 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
-msgstr ""
+msgstr "이것은 기본 지표 폴더입니다. 이름을 변경하거나 제거할 수 없습니다. 비워 둘 수 있지만 지표 항목만 허용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for a"
-msgstr ""
+msgstr "이것은 a에 대한 사용자 정의 오류 메시지입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is custom error message for b"
-msgstr ""
+msgstr "이것은 b에 대한 사용자 정의 오류 메시지입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
 "example, to only return rows for a particular client, you might define a "
@@ -14653,103 +23767,199 @@ msgid ""
 " a user belongs to a RLS filter role, a base filter can be created with "
 "the clause `1 = 0` (always false)."
 msgstr ""
+"이것은 WHERE 절에 추가될 조건입니다. 예를 들어, 특정 클라이언트의 행만 반환하려면 `client_id = 9` 절이 있는 "
+"일반 필터를 정의할 수 있습니다. 사용자가 RLS 필터 역할에 속하지 않는 한 어떤 행도 표시하지 않으려면 `1 = 0` (항상 "
+"false) 절이 있는 기본 필터를 만들 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default dark theme"
-msgstr ""
+msgstr "이것은 기본 다크 테마입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default folder"
-msgstr ""
+msgstr "이것은 기본 폴더입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "이것은 기본 라이트 테마입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
-msgstr ""
+msgstr "이 키는 이번에만 볼 수 있습니다. 안전하게 보관하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This json object describes the positioning of the widgets in the "
 "dashboard. It is dynamically generated when adjusting the widgets size "
 "and positions by using drag & drop in the dashboard view"
 msgstr ""
+"이 JSON 객체는 대시보드에서 위젯의 위치를 설명합니다. 대시보드 보기에서 드래그 앤 드롭을 사용하여 위젯의 크기와 위치를 조정할"
+" 때 동적으로 생성됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
+msgstr "이 링크는 주소가 안전하지 않아 따라갈 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
-msgstr ""
+msgstr "이 링크를 클릭하면 외부 웹사이트로 이동합니다. 외부 목적지의 안전을 보장할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error."
-msgstr ""
+msgstr "이 마크다운 컴포넌트에 오류가 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This markdown component has an error. Please revert your recent changes."
-msgstr ""
+msgstr "이 마크다운 컴포넌트에 오류가 있습니다. 최근 변경 사항을 되돌려 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This may be due to the extension not being activated or the content not "
 "being available."
-msgstr ""
+msgstr "이는 확장 기능이 활성화되지 않았거나 콘텐츠를 사용할 수 없기 때문일 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This may be triggered by:"
-msgstr ""
+msgstr "이는 다음에 의해 트리거될 수 있습니다:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This metric might be incompatible with current %s"
-msgstr ""
+msgstr "이 지표는 현재 %s와(과) 호환되지 않을 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This name is already taken. Please choose another one."
-msgstr ""
+msgstr "이 이름은 이미 사용 중입니다. 다른 이름을 선택해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This option has been disabled by the administrator."
-msgstr ""
+msgstr "이 옵션은 관리자에 의해 비활성화되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This page is intended to be embedded in an iframe, but it looks like that"
 " is not the case."
-msgstr ""
+msgstr "이 페이지는 iframe에 임베드되도록 설계되었지만, 현재 그렇지 않은 것 같습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This section allows you to configure how to use the slice\n"
 "              to generate annotations."
 msgstr ""
+"이 섹션에서는 슬라이스를\n"
+"              사용하여 어노테이션을 생성하는 방법을 구성할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "This section contains options that allow for advanced analytical post "
 "processing of query results"
-msgstr ""
+msgstr "이 섹션에는 쿼리 결과의 고급 분석 후처리를 허용하는 옵션이 포함되어 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This section contains validation errors"
-msgstr ""
+msgstr "이 섹션에 유효성 검사 오류가 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "This session has encountered an interruption, and some controls may not "
 "work as intended. If you are the developer of this app, please check that"
 " the guest token is being generated correctly."
 msgstr ""
+"이 세션에 중단이 발생했으며, 일부 컨트롤이 의도한 대로 작동하지 않을 수 있습니다. 이 앱의 개발자라면 게스트 토큰이 올바르게 "
+"생성되고 있는지 확인해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This table already has a dataset"
-msgstr ""
+msgstr "이 테이블에는 이미 데이터셋이 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "This table already has a dataset associated with it. You can only "
 "associate one dataset with a table.\n"
-msgstr ""
+msgstr "이 테이블에는 이미 연결된 데이터셋이 있습니다. 테이블에는 하나의 데이터셋만 연결할 수 있습니다.\n"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally"
-msgstr ""
+msgstr "이 테마는 로컬에서 설정되어 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This theme is set locally for your session"
-msgstr ""
+msgstr "이 테마는 현재 세션에 로컬로 설정되어 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This username is already taken. Please choose another one."
-msgstr ""
+msgstr "이 사용자 이름은 이미 사용 중입니다. 다른 이름을 선택해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be greater than the left target value"
-msgstr ""
+msgstr "이 값은 왼쪽 목표 값보다 커야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This value should be smaller than the right target value"
-msgstr ""
+msgstr "이 값은 오른쪽 목표 값보다 작아야 합니다"
 
 #, fuzzy
 msgid "This visualization type does not support cross-filtering."
@@ -14758,52 +23968,96 @@ msgstr "시각화 유형 선택"
 msgid "This visualization type is not supported."
 msgstr "시각화 유형 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, es,
+# fa, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy
 msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
-msgstr[0] ""
+msgstr[0] "이것은 다음에 의해 트리거되었습니다:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "이것은 모든 %s 구독자의 작업을 중단(정지)시킵니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
 "to main columns for increase and decrease. Basic conditional formatting "
 "can be overwritten by conditional formatting below."
 msgstr ""
+"이것은 전체 테이블에 적용됩니다. 증가와 감소를 위해 기본 열에 화살표(↑ 및 ↓)가 추가됩니다. 기본 조건부 서식은 아래의 조건부"
+" 서식으로 덮어쓸 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "이것은 작업을 취소합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "This will remove your current embed configuration."
-msgstr ""
+msgstr "현재 임베드 구성이 제거됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
-msgstr ""
+msgstr "모든 지표와 열을 기본 폴더로 재구성합니다. 사용자 지정 폴더는 모두 제거됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold"
-msgstr ""
+msgstr "임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Threshold alpha level for determining significance"
-msgstr ""
+msgstr "유의성 결정을 위한 임계 알파 수준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold for Other"
-msgstr ""
+msgstr "기타 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Threshold: "
-msgstr ""
+msgstr "임계값: "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thumbnails"
-msgstr ""
+msgstr "썸네일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Thursday"
-msgstr ""
+msgstr "목요일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time"
-msgstr ""
+msgstr "시간"
 
 #, fuzzy
 msgid "Time Column"
@@ -14817,20 +24071,38 @@ msgstr "컬럼 수정"
 msgid "Time Format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time Grain"
-msgstr ""
+msgstr "시간 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time Grain must be specified when using Time Shift."
-msgstr ""
+msgstr "시간 이동 사용 시 시간 단위를 지정해야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time Granularity"
-msgstr ""
+msgstr "시간 세분성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time Lag"
-msgstr ""
+msgstr "시간 지연"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Time Range"
-msgstr ""
+msgstr "시간 범위"
 
 #, fuzzy
 msgid "Time Ratio"
@@ -14840,27 +24112,51 @@ msgstr "D3 포멧"
 msgid "Time Series"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Line Chart"
-msgstr ""
+msgstr "시계열 - 꺾은선 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Nightingale Rose Chart"
-msgstr ""
+msgstr "시계열 - 나이팅게일 로즈 차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Paired t-test"
-msgstr ""
+msgstr "시계열 - 대응 표본 t-검정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Percent Change"
-msgstr ""
+msgstr "시계열 - 퍼센트 변화"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Series - Period Pivot"
-msgstr ""
+msgstr "시계열 - 기간 피벗"
 
 #, fuzzy
 msgid "Time Series Options"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time Shift"
-msgstr ""
+msgstr "시간 이동"
 
 msgid "Time Table View"
 msgstr "시간 테이블 뷰"
@@ -14869,35 +24165,62 @@ msgstr "시간 테이블 뷰"
 msgid "Time column"
 msgstr "컬럼 수정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Time column \"%(col)s\" does not exist in dataset"
-msgstr ""
+msgstr "시간 열 \"%(col)s\"이(가) 데이터셋에 존재하지 않습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time column chart customization plugin"
-msgstr ""
+msgstr "시간 열 차트 사용자 지정 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column filter plugin"
-msgstr ""
+msgstr "시간 열 필터 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply dependent temporal filter to"
-msgstr ""
+msgstr "종속 시간 필터를 적용할 시간 열"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time column to apply time range to"
-msgstr ""
+msgstr "시간 범위를 적용할 시간 열"
 
 msgid "Time comparison"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Time delta in natural language\n"
 "                  (example:  24 hours, 7 days, 56 weeks, 365 days)"
 msgstr ""
+"자연어로 표현된 시간 차이\n"
+"                  (예시:  24 hours, 7 days, 56 weeks, 365 days)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time delta is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
-msgstr ""
+msgstr "시간 차이가 모호합니다. [%(human_readable)s 전] 또는 [%(human_readable)s 후]로 지정하세요."
 
 #, fuzzy
 msgid "Time filter"
@@ -14907,40 +24230,70 @@ msgstr "테이블 추가"
 msgid "Time format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time grain"
-msgstr ""
+msgstr "시간 단위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time grain chart customization plugin"
-msgstr ""
+msgstr "시간 단위 차트 사용자 지정 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time grain filter plugin"
-msgstr ""
+msgstr "시간 단위 필터 플러그인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time grain missing"
-msgstr ""
+msgstr "시간 단위 누락"
 
 #, fuzzy
 msgid "Time grain options"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Time granularity"
-msgstr ""
+msgstr "시간 세분성"
 
 msgid "Time in seconds"
 msgstr "10초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time lag"
-msgstr ""
+msgstr "시간 지연"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time range"
-msgstr ""
+msgstr "시간 범위"
 
 #, fuzzy
 msgid "Time ratio"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time related form attributes"
-msgstr ""
+msgstr "시간 관련 폼 속성"
 
 #, fuzzy
 msgid "Time series"
@@ -14949,21 +24302,32 @@ msgstr "컬럼 수정"
 msgid "Time series columns"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Time shift"
-msgstr ""
+msgstr "시간 이동"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Time string is ambiguous. Please specify [%(human_readable)s ago] or "
 "[%(human_readable)s later]."
-msgstr ""
+msgstr "시간 문자열이 모호합니다. [%(human_readable)s 전] 또는 [%(human_readable)s 후]로 지정하세요."
 
 #, fuzzy
 msgid "Time-series Percent Change"
 msgstr "시계열 테이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Time-series Period Pivot"
-msgstr ""
+msgstr "시계열 기간 피벗"
 
 msgid "Time-series Table"
 msgstr "시계열 테이블"
@@ -14976,23 +24340,41 @@ msgstr "D3 포멧"
 msgid "Timeline"
 msgstr "분"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
-msgstr ""
+msgstr "타임아웃이 구성되었지만(%s초) 중단 핸들러가 정의되지 않았습니다. 작업은 타임아웃 이후에도 계속 실행됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timeout error"
-msgstr ""
+msgstr "시간 초과 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Timestamp format"
-msgstr ""
+msgstr "타임스탬프 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timezone"
-msgstr ""
+msgstr "시간대"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Timezone selector"
-msgstr ""
+msgstr "시간대 선택기"
 
 #, fuzzy
 msgid "Tiny"
@@ -15009,35 +24391,65 @@ msgstr "컬럼 수정"
 msgid "Title is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Title or Slug"
-msgstr ""
+msgstr "제목 또는 슬러그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Google Sheets 사용을 시작하려면 먼저 데이터베이스를 만들어야 합니다. 데이터베이스는 데이터를 쿼리하고 시각화할 수 있도록"
+" 식별하는 방법으로 사용됩니다. 이 데이터베이스는 여기서 연결하기로 선택한 모든 개별 Google Sheets를 보관합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
 "clicking the column header."
-msgstr ""
+msgstr "여러 열 정렬을 활성화하려면 열 헤더를 클릭하는 동안 ⇧ Shift 키를 누르고 있으세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "To filter on a metric, use Custom SQL tab."
-msgstr ""
+msgstr "지표를 기준으로 필터링하려면 사용자 정의 SQL 탭을 사용하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "To get a readable URL for your dashboard"
-msgstr ""
+msgstr "대시보드의 읽기 쉬운 URL을 얻으려면"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "토큰 요청 URI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Tool Panel"
-msgstr ""
+msgstr "도구 패널"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tooltip"
-msgstr ""
+msgstr "툴팁"
 
 #, fuzzy
 msgid "Tooltip (columns)"
@@ -15047,8 +24459,11 @@ msgstr "컬럼 수정"
 msgid "Tooltip (metrics)"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Tooltip Contents"
-msgstr ""
+msgstr "툴팁 내용"
 
 #, fuzzy
 msgid "Tooltip contents"
@@ -15058,8 +24473,12 @@ msgstr "새 차트 생성"
 msgid "Tooltip sort by metric"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Tooltip time format"
-msgstr ""
+msgstr "툴팁 시간 형식"
 
 #, fuzzy
 msgid "Top"
@@ -15073,22 +24492,38 @@ msgstr "삭제"
 msgid "Top n"
 msgstr "중지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Top right"
-msgstr ""
+msgstr "오른쪽 상단"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Top to Bottom"
-msgstr ""
+msgstr "위에서 아래로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Total"
-msgstr ""
+msgstr "합계"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggfunc)s)"
-msgstr ""
+msgstr "합계 (%(aggfunc)s)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Total (%(aggregatorName)s)"
-msgstr ""
+msgstr "합계 (%(aggregatorName)s)"
 
 #, fuzzy
 msgid "Total color"
@@ -15102,31 +24537,57 @@ msgstr "원본 값"
 msgid "Total value"
 msgstr "원본 값"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Total: %s"
-msgstr ""
+msgstr "합계: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Track job"
-msgstr ""
+msgstr "작업 추적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transformable"
-msgstr ""
+msgstr "변환 가능"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transparent"
-msgstr ""
+msgstr "투명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Transpose pivot"
-msgstr ""
+msgstr "피벗 전치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Treat values as categorical."
-msgstr ""
+msgstr "값을 범주형으로 처리합니다."
 
 #, fuzzy
 msgid "Tree Chart"
 msgstr "차트 이동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tree layout"
-msgstr ""
+msgstr "트리 레이아웃"
 
 #, fuzzy
 msgid "Tree orientation"
@@ -15135,21 +24596,37 @@ msgstr "주석"
 msgid "Treemap"
 msgstr "트리맵"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trend"
-msgstr ""
+msgstr "추세"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Triangle"
-msgstr ""
+msgstr "삼각형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Trigger Alert If..."
-msgstr ""
+msgstr "다음 조건에서 알림 발생..."
 
 #, fuzzy
 msgid "True"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate Cells"
-msgstr ""
+msgstr "셀 잘라내기"
 
 #, fuzzy
 msgid "Truncate Metric"
@@ -15159,34 +24636,67 @@ msgstr "메트릭"
 msgid "Truncate X Axis"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
 " applicable for numerical X axis."
-msgstr ""
+msgstr "X축 자르기. 최솟값 또는 최댓값 범위를 지정하여 재정의할 수 있습니다. 숫자형 X축에만 적용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis"
-msgstr ""
+msgstr "Y축 자르기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
-msgstr ""
+msgstr "Y축 자르기. 최솟값 또는 최댓값 범위를 지정하여 재정의할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Truncate long cells to the \"min width\" set above"
-msgstr ""
+msgstr "긴 셀을 위에 설정된 \"최소 너비\"로 자르기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Truncates the specified date to the accuracy specified by the date unit."
-msgstr ""
+msgstr "지정된 날짜를 날짜 단위에 지정된 정확도로 자릅니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "이 URL을 신뢰하고 다시 묻지 않기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Try applying different filters or ensuring your datasource has data"
-msgstr ""
+msgstr "다른 필터를 적용하거나 데이터 소스에 데이터가 있는지 확인해 보세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Try different criteria to display results."
-msgstr ""
+msgstr "결과를 표시하려면 다른 기준을 사용해 보세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Tuesday"
-msgstr ""
+msgstr "화요일"
 
 #, fuzzy
 msgid "Tukey"
@@ -15195,217 +24705,404 @@ msgstr "Query 공유"
 msgid "Type"
 msgstr "타입"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Type \"%s\" to confirm"
-msgstr ""
+msgstr "\"%s\"을(를) 입력하여 확인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value"
-msgstr ""
+msgstr "값을 입력하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type a value here"
-msgstr ""
+msgstr "여기에 값을 입력하세요"
 
 #, fuzzy
 msgid "Type a value..."
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type is required"
-msgstr ""
+msgstr "유형은 필수입니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "허용된 Google 스프레드시트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Type of chart to display in sparkline"
-msgstr ""
+msgstr "스파크라인에 표시할 차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Type of comparison, value difference or percentage"
-msgstr ""
+msgstr "비교 유형, 값 차이 또는 백분율"
 
 #, fuzzy
 msgid "Type to search (contains)..."
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "검색어 입력 (끝나는 문자)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "검색어 입력 (시작하는 문자)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "UI Configuration"
-msgstr ""
+msgstr "UI 구성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "UI theme administration is not enabled."
-msgstr ""
+msgstr "UI 테마 관리가 활성화되어 있지 않습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #, fuzzy
 msgid "URL Filters"
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "URL Parameters"
-msgstr ""
+msgstr "URL 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "URL Slug"
-msgstr ""
+msgstr "URL 슬러그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "URL parameters"
-msgstr ""
+msgstr "URL 매개변수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to calculate such a date delta"
-msgstr ""
+msgstr "이러한 날짜 차이를 계산할 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to catalog named \"%(catalog_name)s\"."
-msgstr ""
+msgstr "\"%(catalog_name)s\"이라는 카탈로그에 연결할 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to connect to database \"%(database)s\"."
-msgstr ""
+msgstr "데이터베이스 \"%(database)s\"에 연결할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", "
 "\"BigQuery Job User\" and the following permissions are set "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
+"연결할 수 없습니다. 서비스 계정에 다음 역할이 설정되어 있는지 확인하세요: \"BigQuery Data Viewer\", "
+"\"BigQuery Metadata Viewer\", \"BigQuery Job User\" 그리고 다음 권한이 설정되어 있는지 "
+"확인하세요: \"bigquery.readsessions.create\", "
+"\"bigquery.readsessions.getData\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"연결할 수 없습니다. 서비스 계정에 다음 역할이 설정되어 있는지 확인하세요: \"Cloud Datastore Viewer\", "
+"\"Cloud Datastore User\", \"Cloud Datastore Creator\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to create chart without a query id."
-msgstr ""
+msgstr "쿼리 ID 없이 차트를 생성할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"보고서를 생성할 수 없습니다: 사용자 이메일 주소가 필요하지만 찾을 수 없습니다. 사용자 프로필에 유효한 이메일 주소가 있는지 "
+"확인해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to decode value"
-msgstr ""
+msgstr "값을 디코딩할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to encode value"
-msgstr ""
+msgstr "값을 인코딩할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
-msgstr ""
+msgstr "시맨틱 뷰를 가져올 수 없습니다. 레이어 구성을 확인해 주세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
-msgstr ""
+msgstr "이러한 공휴일을 찾을 수 없습니다: [%(holiday)s]"
 
 #, fuzzy
 msgid "Unable to generate download payload"
 msgstr "대시보드 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
 "ensure your dataset has a properly configured time column."
-msgstr ""
+msgstr "날짜 범위 시간 비교를 위한 시간 열을 식별할 수 없습니다. 데이터셋에 올바르게 구성된 시간 열이 있는지 확인해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
-msgstr ""
+msgstr "선택한 테이블의 열을 불러올 수 없습니다. 다른 테이블을 선택해 주세요."
 
 #, fuzzy
 msgid "Unable to load dashboard"
 msgstr "대시보드 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query editor state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"쿼리 편집기 상태를 백엔드로 마이그레이션할 수 없습니다. Superset이 나중에 재시도합니다. 이 문제가 지속되면 관리자에게 "
+"문의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
-msgstr ""
+msgstr "쿼리 상태를 백엔드로 마이그레이션할 수 없습니다. Superset이 나중에 재시도합니다. 이 문제가 지속되면 관리자에게 문의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Unable to migrate table schema state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
+"테이블 스키마 상태를 백엔드로 마이그레이션할 수 없습니다. Superset이 나중에 재시도합니다. 이 문제가 지속되면 관리자에게 "
+"문의하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to parse SQL"
-msgstr ""
+msgstr "SQL을 파싱할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to read the file, please refresh and try again."
-msgstr ""
+msgstr "파일을 읽을 수 없습니다. 새로 고침 후 다시 시도해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Unable to retrieve dashboard colors"
-msgstr ""
+msgstr "대시보드 색상을 가져올 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unable to sync permissions for this database connection."
-msgstr ""
+msgstr "이 데이터베이스 연결에 대한 권한을 동기화할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Undefined"
-msgstr ""
+msgstr "정의되지 않음"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undefined window for rolling operation"
-msgstr ""
+msgstr "롤링 작업에 대한 창이 정의되지 않았습니다"
 
 #, fuzzy
 msgid "Undo the action"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Undo?"
-msgstr ""
+msgstr "실행 취소?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr ""
+msgstr "예기치 않은 HTTP 401 응답입니다. 자격 증명을 확인하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error"
-msgstr ""
+msgstr "예기치 않은 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error occurred, please check your logs for details"
-msgstr ""
+msgstr "예기치 않은 오류가 발생했습니다. 자세한 내용은 로그를 확인해 주세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Unexpected error: "
-msgstr ""
+msgstr "예기치 않은 오류: "
 
 #, fuzzy
 msgid "Unexpected no file extension found"
 msgstr "표현식"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unexpected time range: %(error)s"
-msgstr ""
+msgstr "예기치 않은 시간 범위: %(error)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Ungroup By"
-msgstr ""
+msgstr "그룹 해제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Unhide"
-msgstr ""
+msgstr "숨기기 해제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown"
-msgstr ""
+msgstr "알 수 없음"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown Doris server host \"%(hostname)s\"."
-msgstr ""
+msgstr "알 수 없는 Doris 서버 호스트 \"%(hostname)s\"."
 
 #, fuzzy
 msgid "Unknown Error"
 msgstr "알 수 없는 에러"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unknown MySQL server host \"%(hostname)s\"."
-msgstr ""
+msgstr "알 수 없는 MySQL 서버 호스트 \"%(hostname)s\"."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Unknown OceanBase server host \"%(hostname)s\"."
-msgstr ""
+msgstr "알 수 없는 OceanBase 서버 호스트 \"%(hostname)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Presto Error"
-msgstr ""
+msgstr "알 수 없는 Presto 오류"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown Status"
-msgstr ""
+msgstr "알 수 없는 상태"
 
 #, fuzzy, python-format
 msgid "Unknown column used in orderby: %(col)s"
@@ -15414,11 +25111,18 @@ msgstr "알 수 없는 칼럼이 orderby에 사용되었습니다: %(col)"
 msgid "Unknown error"
 msgstr "알 수 없는 에러"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Unknown input format"
-msgstr ""
+msgstr "알 수 없는 입력 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "알 수 없는 토큰은 경고로 강조 표시됩니다."
 
 #, fuzzy
 msgid "Unknown type"
@@ -15428,48 +25132,83 @@ msgstr "알 수 없는 에러"
 msgid "Unknown value"
 msgstr "알 수 없는 에러"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Unpin"
-msgstr ""
+msgstr "고정 해제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "결과 패널에서 고정 해제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "상단에서 고정 해제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy
 msgid "Unsafe link blocked"
-msgstr ""
+msgstr "안전하지 않은 링크가 차단되었습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
-msgstr ""
+msgstr "함수 %(func)s의 안전하지 않은 반환 유형: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsafe template value for key %(key)s: %(value_type)s"
-msgstr ""
+msgstr "키 %(key)s의 안전하지 않은 템플릿 값: %(value_type)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported clause type: %(clause)s"
-msgstr ""
+msgstr "지원되지 않는 절 유형: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
-msgstr ""
+msgstr "지원되지 않는 파일 형식입니다. CSV, Excel 또는 열 형식 파일을 사용하세요."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported post processing operation: %(operation)s"
-msgstr ""
+msgstr "지원되지 않는 후처리 작업: %(operation)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported return value for method %(name)s"
-msgstr ""
+msgstr "메서드 %(name)s에 대해 지원되지 않는 반환 값"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported template value for key %(key)s"
-msgstr ""
+msgstr "키 %(key)s에 대해 지원되지 않는 템플릿 값"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Unsupported time grain: %(time_grain)s"
-msgstr ""
+msgstr "지원되지 않는 시간 단위: %(time_grain)s"
 
 #, fuzzy
 msgid "Untitled Dataset"
@@ -15486,8 +25225,12 @@ msgstr "Query 공유"
 msgid "Unverified"
 msgstr "수정됨"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Update"
-msgstr ""
+msgstr "업데이트"
 
 #, fuzzy
 msgid "Update auto-refresh"
@@ -15497,8 +25240,12 @@ msgstr "새로고침 간격"
 msgid "Update chart"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Updating chart was stopped"
-msgstr ""
+msgstr "차트 업데이트가 중지되었습니다"
 
 msgid "Upload"
 msgstr "CSV 업로드"
@@ -15531,12 +25278,18 @@ msgstr "엑셀 업로드"
 msgid "Upload Excel to database"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Upload JSON file"
-msgstr ""
+msgstr "JSON 파일 업로드"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Upload a file with a valid extension. Valid: [%s]"
-msgstr ""
+msgstr "유효한 확장자를 가진 파일을 업로드하세요. 유효한 확장자: [%s]"
 
 #, fuzzy
 msgid "Upload credentials"
@@ -15554,11 +25307,17 @@ msgstr "차트 수정"
 msgid "Uploading a file is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper Threshold"
-msgstr ""
+msgstr "상한 임계값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Upper threshold must be greater than lower threshold"
-msgstr ""
+msgstr "상한 임계값은 하한 임계값보다 커야 합니다"
 
 #, fuzzy
 msgid "Usage"
@@ -15572,74 +25331,145 @@ msgstr "새로운 탭에서 Query실행"
 msgid "Use Area Proportions"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
-msgstr ""
+msgstr "Handlebars 구문을 사용하여 사용자 정의 툴팁을 만드세요. 사용 가능한 변수는 위에서 선택한 툴팁 내용을 기반으로 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale"
-msgstr ""
+msgstr "로그 척도 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the X-axis"
-msgstr ""
+msgstr "X축에 로그 척도 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use a log scale for the Y-axis"
-msgstr ""
+msgstr "Y축에 로그 척도 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use an encrypted connection to the database"
-msgstr ""
+msgstr "데이터베이스에 암호화된 연결 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use an ssh tunnel connection to the database"
-msgstr ""
+msgstr "데이터베이스에 SSH 터널 연결 사용"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "Use another existing chart as a source for annotations and overlays.\n"
 "          Your chart must be one of these visualization types: [%s]"
 msgstr ""
+"다른 기존 차트를 주석 및 오버레이의 소스로 사용하세요.\n"
+"          차트는 다음 시각화 유형 중 하나여야 합니다: [%s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use automatic color"
-msgstr ""
+msgstr "자동 색상 사용"
 
 #, fuzzy
 msgid "Use current extent"
 msgstr "Query 실행"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use date formatting even when metric value is not a timestamp"
-msgstr ""
+msgstr "측정값이 타임스탬프가 아닌 경우에도 날짜 형식 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Use gradient"
-msgstr ""
+msgstr "그라데이션 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use metrics as a top level group for columns or for rows"
-msgstr ""
+msgstr "열 또는 행의 최상위 그룹으로 지표 사용"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use only a single value."
-msgstr ""
+msgstr "단일 값만 사용하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use the Advanced Analytics options below"
-msgstr ""
+msgstr "아래 고급 분석 옵션을 사용하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want a query that aggregates"
-msgstr ""
+msgstr "집계 쿼리를 원하는 경우 이 섹션을 사용하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Use this section if you want to query atomic rows"
-msgstr ""
+msgstr "원자 행을 쿼리하려는 경우 이 섹션을 사용하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Use this to define a static color for all circles"
-msgstr ""
+msgstr "모든 원에 정적 색상을 정의하려면 이것을 사용하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used internally to identify the plugin. Should be set to the package name"
 " from the pluginʼs package.json"
-msgstr ""
+msgstr "플러그인을 식별하기 위해 내부적으로 사용됩니다. 플러그인의 package.json에 있는 패키지 이름으로 설정해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Used to summarize a set of data by grouping together multiple statistics "
 "along two axes. Examples: Sales numbers by region and month, tasks by "
 "status and assignee, active users by age and location. Not the most "
 "visually stunning visualization, but highly informative and versatile."
 msgstr ""
+"두 개의 축을 따라 여러 통계를 그룹화하여 데이터 집합을 요약하는 데 사용됩니다. 예시: 지역 및 월별 판매 수치, 상태 및 "
+"담당자별 작업, 연령 및 위치별 활성 사용자. 시각적으로 가장 화려한 시각화는 아니지만 정보량이 많고 다양하게 활용할 수 있습니다."
 
 msgid "User"
 msgstr "사용자"
@@ -15652,21 +25482,35 @@ msgstr "Query 검색"
 msgid "User Registrations"
 msgstr "대시보드"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "User doesn't have the proper permissions."
-msgstr ""
+msgstr "사용자에게 적절한 권한이 없습니다."
 
 #, fuzzy
 msgid "User info"
 msgstr "사용자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the chart customization"
-msgstr ""
+msgstr "차트 사용자 정의를 적용하기 전에 사용자가 값을 선택해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the customization"
-msgstr ""
+msgstr "사용자 지정을 적용하기 전에 사용자가 값을 선택해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "User must select a value before applying the filter"
-msgstr ""
+msgstr "필터를 적용하기 전에 사용자가 값을 선택해야 합니다"
 
 msgid "User query"
 msgstr "Query 공유"
@@ -15691,29 +25535,51 @@ msgstr "Query 검색"
 msgid "Users"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Users are not allowed to set a search path for security reasons."
-msgstr ""
+msgstr "보안상의 이유로 사용자는 검색 경로를 설정할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "Uses Gaussian Kernel Density Estimation to visualize spatial distribution"
 " of data"
-msgstr ""
+msgstr "가우시안 커널 밀도 추정을 사용하여 데이터의 공간적 분포를 시각화합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses a gauge to showcase progress of a metric towards a target. The "
 "position of the dial represents the progress and the terminal value in "
 "the gauge represents the target value."
 msgstr ""
+"게이지를 사용하여 목표를 향한 지표의 진행 상황을 표시합니다. 다이얼의 위치는 진행 상황을 나타내며, 게이지의 끝 값은 목표 값을 "
+"나타냅니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Uses circles to visualize the flow of data through different stages of a "
 "system. Hover over individual paths in the visualization to understand "
 "the stages a value took. Useful for multi-stage, multi-group visualizing "
 "funnels and pipelines."
 msgstr ""
+"원을 사용하여 시스템의 다양한 단계를 통한 데이터 흐름을 시각화합니다. 시각화의 개별 경로 위에 마우스를 올리면 값이 거친 단계를 "
+"이해할 수 있습니다. 다단계, 다중 그룹의 퍼널 및 파이프라인 시각화에 유용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "차원에 더 많은 값이 있으면 처음 25개 값을 사용합니다."
 
 #, fuzzy
 msgid "Valid SQL expression"
@@ -15727,15 +25593,24 @@ msgstr "Query 공유"
 msgid "Validate your expression"
 msgstr "표현식"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Validating connectivity for %s"
-msgstr ""
+msgstr "%s에 대한 연결을 확인 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Validating..."
-msgstr ""
+msgstr "확인 중..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Value"
-msgstr ""
+msgstr "값"
 
 #, fuzzy
 msgid "Value Aggregation"
@@ -15745,28 +25620,50 @@ msgstr "생성자"
 msgid "Value Columns"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value Domain"
-msgstr ""
+msgstr "값 도메인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Value Format"
-msgstr ""
+msgstr "값 형식"
 
 #, fuzzy
 msgid "Value and Percentage"
 msgstr "Superset 튜토리얼"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Value bounds"
-msgstr ""
+msgstr "값 범위"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "Value cannot exceed %s"
-msgstr ""
+msgstr "값은 %s를 초과할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value difference between the time periods"
-msgstr ""
+msgstr "기간 간의 값 차이"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Value format"
-msgstr ""
+msgstr "값 형식"
 
 #, fuzzy
 msgid "Value greater than"
@@ -15776,8 +25673,11 @@ msgstr "값은 0보다 커야합니다"
 msgid "Value is required"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Value less than"
-msgstr ""
+msgstr "값이 다음보다 작음"
 
 #, fuzzy
 msgid "Value must be 0 or greater"
@@ -15790,38 +25690,72 @@ msgstr "값은 0보다 커야합니다"
 msgid "Values"
 msgstr "테이블 명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Values are dependent on other filters"
-msgstr ""
+msgstr "값은 다른 필터에 종속됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Values dependent on"
-msgstr ""
+msgstr "다음에 종속된 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Values less than this percentage will be grouped into the Other category."
-msgstr ""
+msgstr "이 백분율보다 작은 값은 기타 카테고리로 분류됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Values selected in other filters will affect the filter options to only "
 "show relevant values"
-msgstr ""
+msgstr "다른 필터에서 선택된 값은 관련 값만 표시하도록 필터 옵션에 영향을 줍니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version"
-msgstr ""
+msgstr "버전"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Version number"
-msgstr ""
+msgstr "버전 번호"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Vertical"
-msgstr ""
+msgstr "수직"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Vertical (Left)"
-msgstr ""
+msgstr "수직 (왼쪽)"
 
 #, fuzzy
 msgid "View"
 msgstr "데이터 미리보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "View All »"
-msgstr ""
+msgstr "모두 보기 »"
 
 #, fuzzy
 msgid "View Dataset"
@@ -15838,9 +25772,12 @@ msgstr "탭 닫기"
 msgid "View in SQL Lab"
 msgstr "SQL Lab"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "View keys & indexes (%s)"
-msgstr ""
+msgstr "키 및 인덱스 보기 (%s)"
 
 msgid "View query"
 msgstr "Query 공유"
@@ -15849,33 +25786,60 @@ msgstr "Query 공유"
 msgid "View theme properties"
 msgstr "CSS 템플릿"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Viewed"
-msgstr ""
+msgstr "조회됨"
 
 #, fuzzy, python-format
 msgid "Viewed %s"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Viewport"
-msgstr ""
+msgstr "뷰포트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Virtual"
-msgstr ""
+msgstr "가상"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual (SQL)"
-msgstr ""
+msgstr "가상 (SQL)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot be empty"
-msgstr ""
+msgstr "가상 데이터셋 쿼리는 비워 둘 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Virtual dataset query cannot consist of multiple statements"
-msgstr ""
+msgstr "가상 데이터셋 쿼리는 여러 구문으로 구성될 수 없습니다"
 
 msgid "Virtual dataset query must be read-only"
 msgstr "가상 데이터셋 쿼리는 읽기 전용이어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Visual Tweaks"
-msgstr ""
+msgstr "시각적 조정"
 
 #, fuzzy
 msgid "Visual formatting"
@@ -15884,80 +25848,148 @@ msgstr "주석"
 msgid "Visualization Type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a parallel set of metrics across multiple groups. Each group is"
 " visualized using its own line of points and each metric is represented "
 "as an edge in the chart."
 msgstr ""
+"여러 그룹에 걸쳐 병렬 지표 세트를 시각화합니다. 각 그룹은 자체 점 라인을 사용하여 시각화되며, 각 지표는 차트에서 엣지로 "
+"표현됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize a related metric across pairs of groups. Heatmaps excel at "
 "showcasing the correlation or strength between two groups. Color is used "
 "to emphasize the strength of the link between each pair of groups."
 msgstr ""
+"그룹 쌍 간의 관련 지표를 시각화합니다. 히트맵은 두 그룹 간의 상관 관계 또는 강도를 보여주는 데 탁월합니다. 색상은 각 그룹 쌍"
+" 간의 연결 강도를 강조하는 데 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize geospatial data like 3D buildings, landscapes, or objects in "
 "grid view."
-msgstr ""
+msgstr "그리드 보기에서 3D 건물, 지형, 오브젝트 등의 지리공간 데이터를 시각화합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
 "structure."
-msgstr ""
+msgstr "친숙한 트리 구조를 사용하여 여러 수준의 계층을 시각화합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualize two different series using the same x-axis. Note that both "
 "series can be visualized with a different chart type (e.g. 1 using bars "
 "and 1 using a line)."
 msgstr ""
+"동일한 X축을 사용하여 두 개의 다른 시리즈를 시각화합니다. 두 시리즈 모두 다른 차트 유형으로 시각화할 수 있습니다(예: 하나는 "
+"막대, 하나는 선 사용)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes a metric across three dimensions of data in a single chart (X "
 "axis, Y axis, and bubble size). Bubbles from the same group can be "
 "showcased using bubble color."
 msgstr ""
+"단일 차트에서 데이터의 세 가지 차원(X축, Y축, 버블 크기)에 걸쳐 지표를 시각화합니다. 같은 그룹의 버블은 버블 색상을 "
+"사용하여 표시할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Visualizes connected points, which form a path, on a map."
-msgstr ""
+msgstr "지도에서 경로를 형성하는 연결된 점들을 시각화합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes geographic areas from your data as polygons on a Mapbox "
 "rendered map. Polygons can be colored using a metric."
-msgstr ""
+msgstr "Mapbox 렌더링 지도에서 데이터의 지리적 영역을 폴리곤으로 시각화합니다. 폴리곤은 지표를 사용하여 색상을 지정할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes how a metric has changed over a time using a color scale and a"
 " calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
+"색상 척도와 달력 보기를 사용하여 지표가 시간에 따라 어떻게 변화했는지 시각화합니다. 회색 값은 누락된 값을 나타내며, 선형 색상 "
+"체계는 각 날의 값의 크기를 나타내는 데 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "Visualizes how a single metric varies across a country's principal "
 "subdivisions (states, provinces, etc) on a choropleth map. Each "
 "subdivision's value is elevated when you hover over the corresponding "
 "geographic boundary."
 msgstr ""
+"단계 구분도에서 국가의 주요 행정 구역(주, 도 등)에 걸쳐 단일 지표가 어떻게 달라지는지 시각화합니다. 해당 지리적 경계 위에 "
+"마우스를 올리면 각 구역의 값이 강조됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes many different time-series objects in a single chart. This "
 "chart is being deprecated and we recommend using the Time-series Chart "
 "instead."
-msgstr ""
+msgstr "단일 차트에서 다양한 시계열 객체를 시각화합니다. 이 차트는 더 이상 사용되지 않으며, 대신 시계열 차트를 사용하는 것을 권장합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Visualizes the words in a column that appear the most often. Bigger font "
 "corresponds to higher frequency."
-msgstr ""
+msgstr "열에서 가장 자주 나타나는 단어를 시각화합니다. 폰트가 클수록 빈도가 높음을 나타냅니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Viz is missing a datasource"
-msgstr ""
+msgstr "Viz에 데이터 소스가 없습니다"
 
 msgid "Viz type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "WED"
-msgstr ""
+msgstr "수"
 
 msgid "WFS"
 msgstr ""
@@ -15965,122 +25997,218 @@ msgstr ""
 msgid "WMS"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "첫 번째 새로 고침 대기 중"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Waiting on %s"
-msgstr ""
+msgstr "%s 대기 중"
 
 #, fuzzy
 msgid "Waiting on database..."
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Want to add a new database?"
-msgstr ""
+msgstr "새 데이터베이스를 추가하시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "웨어하우스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Warning"
-msgstr ""
+msgstr "경고"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Warning!"
-msgstr ""
+msgstr "경고!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Warning! Changing the dataset may break the chart if the metadata does "
 "not exist."
-msgstr ""
+msgstr "경고! 메타데이터가 없는 경우 데이터셋을 변경하면 차트가 손상될 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
-msgstr ""
+msgstr "경고: ILIKE 쿼리는 인덱스를 효과적으로 사용할 수 없어 대용량 데이터셋에서 느릴 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Was unable to check your query"
-msgstr ""
+msgstr "쿼리를 확인할 수 없었습니다"
 
 #, fuzzy
 msgid "Waterfall Chart"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We are unable to connect to your database."
-msgstr ""
+msgstr "데이터베이스에 연결할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We are working on your query"
-msgstr ""
+msgstr "쿼리를 처리하고 있습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve column \"%(column)s\" at line %(location)s."
-msgstr ""
+msgstr "%(location)s행의 \"%(column)s\" 열을 찾을 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "We can't seem to resolve the column \"%(column_name)s\""
-msgstr ""
+msgstr "\"%(column_name)s\" 열을 찾을 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We can't seem to resolve the column \"%(column_name)s\" at line "
 "%(location)s."
-msgstr ""
+msgstr "%(location)s행의 \"%(column_name)s\" 열을 찾을 수 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "We have the following keys: %s"
-msgstr ""
+msgstr "다음 키가 있습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We were unable to activate or deactivate this report."
-msgstr ""
+msgstr "이 보고서를 활성화하거나 비활성화할 수 없었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "We were unable to carry over any controls when switching to this new "
 "dataset."
-msgstr ""
+msgstr "이 새 데이터셋으로 전환할 때 컨트롤을 가져올 수 없었습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid ""
 "We were unable to connect to your database named \"%(database)s\". Please"
 " verify your database name and try again."
-msgstr ""
+msgstr "\"%(database)s\"라는 데이터베이스에 연결할 수 없었습니다. 데이터베이스 이름을 확인하고 다시 시도해 주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Web"
-msgstr ""
+msgstr "웹"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Wednesday"
-msgstr ""
+msgstr "수요일"
 
 msgid "Week"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week ending Saturday"
-msgstr ""
+msgstr "토요일로 끝나는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Week ending Sunday"
-msgstr ""
+msgstr "일요일로 끝나는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Monday"
-msgstr ""
+msgstr "월요일로 시작하는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Week starting Sunday"
-msgstr ""
+msgstr "일요일로 시작하는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Weekly Report"
-msgstr ""
+msgstr "주간 보고서"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid "Weekly Report for %s"
-msgstr ""
+msgstr "%s 주간 보고서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Weekly seasonality"
-msgstr ""
+msgstr "주간 계절성"
 
 #, fuzzy, python-format
 msgid "Weeks %s"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Weight"
-msgstr ""
+msgstr "가중치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading these results. Queries are set to timeout "
@@ -16088,8 +26216,10 @@ msgid ""
 msgid_plural ""
 "We’re having trouble loading these results. Queries are set to timeout "
 "after %s seconds."
-msgstr[0] ""
+msgstr[0] "이 결과를 불러오는 데 문제가 있습니다. 쿼리는 %s초 후에 시간 초과되도록 설정되어 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fa,
+# fr, ja, lv, mi, ro, ru, sl, sr, sr_Latn, uk]
 #, fuzzy, python-format
 msgid ""
 "We’re having trouble loading this visualization. Queries are set to "
@@ -16097,60 +26227,109 @@ msgid ""
 msgid_plural ""
 "We’re having trouble loading this visualization. Queries are set to "
 "timeout after %s seconds."
-msgstr[0] ""
+msgstr[0] "이 시각화를 불러오는 데 문제가 있습니다. 쿼리는 %s초 후에 시간 초과되도록 설정되어 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the label"
-msgstr ""
+msgstr "레이블로 표시할 항목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "What should be shown as the tooltip label"
-msgstr ""
+msgstr "툴팁 레이블로 표시할 항목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "What should be shown on the label?"
-msgstr ""
+msgstr "레이블에 무엇을 표시해야 합니까?"
 
 #, fuzzy
 msgid "What should happen if the table already exists"
 msgstr "같은 이름의 데이터베이스가 이미 존재합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "When `Calculation type` is set to \"Percentage change\", the Y Axis "
 "Format is forced to `.1%`"
-msgstr ""
+msgstr "`계산 유형`이 \"백분율 변화\"로 설정되면 Y축 형식이 `.1%`로 강제 설정됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When a secondary metric is provided, a linear color scale is used."
-msgstr ""
+msgstr "보조 지표가 제공되면 선형 색상 스케일이 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When checked, the map will zoom to your data after each query"
-msgstr ""
+msgstr "선택하면 각 쿼리 후 지도가 데이터로 확대됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When enabled, the axis will display labels for the minimum and maximum "
 "values of your data"
-msgstr ""
+msgstr "활성화하면 축에 데이터의 최솟값과 최댓값 레이블이 표시됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When enabled, users are able to visualize SQL Lab results in Explore."
-msgstr ""
+msgstr "활성화하면 사용자가 Explore에서 SQL Lab 결과를 시각화할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "When only a primary metric is provided, a categorical color scale is used."
-msgstr ""
+msgstr "기본 지표만 제공되면 범주형 색상 스케일이 사용됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When specifying SQL, the datasource acts as a view. Superset will use "
 "this statement as a subquery while grouping and filtering on the "
 "generated parent queries.If changes are made to your SQL query, columns "
 "in your dataset will be synced when saving the dataset."
 msgstr ""
+"SQL을 지정하면 데이터 소스가 뷰 역할을 합니다. Superset은 생성된 상위 쿼리를 그룹화하고 필터링하는 동안 이 구문을 하위"
+" 쿼리로 사용합니다. SQL 쿼리를 변경하면 데이터셋 저장 시 데이터셋의 열이 동기화됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When the secondary temporal columns are filtered, apply the same filter "
 "to the main datetime column."
-msgstr ""
+msgstr "보조 시간 열이 필터링되면 동일한 필터를 기본 날짜/시간 열에 적용합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "When unchecked, colors from the selected color scheme will be used for "
 "time shifted series"
-msgstr ""
+msgstr "선택 해제 시 선택한 색상 구성표의 색상이 시간 이동 시계열에 사용됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid ""
 "When using \"Autocomplete filters\", this can be used to improve "
 "performance of the query fetching the values. Use this option to apply a "
@@ -16158,245 +26337,520 @@ msgid ""
 "the table. Typically the intent would be to limit the scan by applying a "
 "relative time filter on a partitioned or indexed time-related field."
 msgstr ""
+"\"자동 완성 필터\"를 사용할 때 값을 가져오는 쿼리의 성능을 향상시키는 데 사용할 수 있습니다. 이 옵션을 사용하여 테이블에서 "
+"고유한 값을 선택하는 쿼리에 조건(WHERE 절)을 적용합니다. 일반적으로 파티션 또는 인덱스가 지정된 시간 관련 필드에 상대적 "
+"시간 필터를 적용하여 스캔을 제한하는 것을 목적으로 합니다."
 
 msgid "When using 'Group By' you are limited to use a single metric"
 msgstr "'Group By'를 사용 할 때 오직 하나의 메트릭만 사용 가능합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "When using other than adaptive formatting, labels may overlap"
-msgstr ""
+msgstr "적응형 이외의 형식을 사용할 때 레이블이 겹칠 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ro, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "When using this option, default value can't be set. Using this option may"
 " impact the load times for your dashboard."
-msgstr ""
+msgstr "이 옵션을 사용하면 기본값을 설정할 수 없습니다. 이 옵션을 사용하면 대시보드 로딩 시간에 영향을 줄 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
-msgstr ""
+msgstr "여러 데이터 그룹이 있을 때 진행 표시줄이 겹치는지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Whether to align background charts with both positive and negative values"
 " at 0"
-msgstr ""
+msgstr "양수 및 음수 값을 모두 포함한 배경 차트를 0에서 정렬할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to align positive and negative values in cell bar chart at 0"
-msgstr ""
+msgstr "셀 막대형 차트에서 양수 및 음수 값을 0에서 정렬할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to always show the annotation label"
-msgstr ""
+msgstr "주석 레이블을 항상 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to animate the progress and the value or just display them"
-msgstr ""
+msgstr "진행 상황과 값을 애니메이션으로 표시할지 아니면 그냥 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to apply a normal distribution based on rank on the color scale"
-msgstr ""
+msgstr "색상 스케일에서 순위 기반 정규 분포를 적용할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to colorize numeric values by if they are positive or negative"
-msgstr ""
+msgstr "숫자 값이 양수인지 음수인지에 따라 색상을 지정할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to colorize numeric values by whether they are positive or "
 "negative"
-msgstr ""
+msgstr "숫자 값이 양수인지 음수인지에 따라 색상을 지정할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a bar chart background in table columns"
-msgstr ""
+msgstr "테이블 열에 막대 차트 배경을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display a legend for the chart"
-msgstr ""
+msgstr "차트의 범례를 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display bubbles on top of countries"
-msgstr ""
+msgstr "국가 위에 버블을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display in the chart"
-msgstr ""
+msgstr "차트에 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the X Axis"
-msgstr ""
+msgstr "X축을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the Y Axis"
-msgstr ""
+msgstr "Y축을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to display the aggregate count"
-msgstr ""
+msgstr "집계 수를 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the interactive data table"
-msgstr ""
+msgstr "대화형 데이터 테이블을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the labels."
-msgstr ""
+msgstr "레이블을 표시할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the legend (toggles)"
-msgstr ""
+msgstr "범례를 표시할지 여부 (토글)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the metric name"
-msgstr ""
+msgstr "지표 이름을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the metric name as a title"
-msgstr ""
+msgstr "지표 이름을 제목으로 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the X-axis"
-msgstr ""
+msgstr "X축의 최솟값과 최댓값을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the min and max values of the Y-axis"
-msgstr ""
+msgstr "Y축의 최솟값과 최댓값을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Whether to display the numbered column"
-msgstr ""
+msgstr "번호가 매겨진 열을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the numerical values within the cells"
-msgstr ""
+msgstr "셀 내의 숫자 값을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the percentage value in the tooltip"
-msgstr ""
+msgstr "툴팁에 백분율 값을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the stroke"
-msgstr ""
+msgstr "윤곽선을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the time range interactive selector"
-msgstr ""
+msgstr "시간 범위 대화형 선택기를 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the timestamp"
-msgstr ""
+msgstr "타임스탬프를 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the tooltip labels."
-msgstr ""
+msgstr "툴팁 레이블을 표시할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the total value in the tooltip"
-msgstr ""
+msgstr "툴팁에 합계 값을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to display the trend line"
-msgstr ""
+msgstr "추세선을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to display the type icon (#, Δ, %)"
-msgstr ""
+msgstr "유형 아이콘 (#, Δ, %)을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable changing graph position and scaling."
-msgstr ""
+msgstr "그래프 위치 변경 및 확대/축소를 활성화할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to enable node dragging in force layout mode."
-msgstr ""
+msgstr "강제 레이아웃 모드에서 노드 드래그를 활성화할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to fill the objects"
-msgstr ""
+msgstr "객체를 채울지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to ignore locations that are null"
-msgstr ""
+msgstr "null인 위치를 무시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include a client-side search box"
-msgstr ""
+msgstr "클라이언트 측 검색 상자를 포함할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include the percentage in the tooltip"
-msgstr ""
+msgstr "툴팁에 백분율을 포함할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to include the time granularity as defined in the time section"
-msgstr ""
+msgstr "시간 섹션에 정의된 시간 세분성을 포함할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to make the grid 3D"
-msgstr ""
+msgstr "그리드를 3D로 만들지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to populate autocomplete filters options"
-msgstr ""
+msgstr "자동 완성 필터 옵션을 채울지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to show as Nightingale chart."
-msgstr ""
+msgstr "나이팅게일 차트로 표시할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Whether to show extra controls or not. Extra controls include things like"
 " making multiBar charts stacked or side by side."
-msgstr ""
+msgstr "추가 컨트롤을 표시할지 여부. 추가 컨트롤에는 다중 막대 차트를 누적 또는 나란히 표시하는 것과 같은 기능이 포함됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show minor ticks on the axis"
-msgstr ""
+msgstr "축에 보조 눈금을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the pointer"
-msgstr ""
+msgstr "포인터를 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the progress of gauge chart"
-msgstr ""
+msgstr "게이지 차트의 진행률을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to show the split lines on the axis"
-msgstr ""
+msgstr "축에 분할선을 표시할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Whether to sort ascending or descending on the base Axis."
-msgstr ""
+msgstr "기본 축에서 오름차순 또는 내림차순으로 정렬할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort descending or ascending"
-msgstr ""
+msgstr "내림차순 또는 오름차순으로 정렬할지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort results by the selected metric in descending order."
-msgstr ""
+msgstr "선택한 지표를 기준으로 결과를 내림차순으로 정렬할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whether to sort tooltip by the selected metric in descending order."
-msgstr ""
+msgstr "선택한 지표를 기준으로 툴팁을 내림차순으로 정렬할지 여부."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Whether to truncate metrics"
-msgstr ""
+msgstr "지표를 잘라낼지 여부"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which country to plot the map for?"
-msgstr ""
+msgstr "지도를 그릴 국가는 어디입니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Which relatives to highlight on hover"
-msgstr ""
+msgstr "마우스 오버 시 강조 표시할 관련 항목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Whisker/outlier options"
-msgstr ""
+msgstr "수염/이상값 옵션"
 
 #, fuzzy
 msgid "Why do I need to create a database?"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Width"
-msgstr ""
+msgstr "너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Width of the confidence interval. Should be between 0 and 1"
-msgstr ""
+msgstr "신뢰 구간의 너비. 0과 1 사이여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Width of the sparkline"
-msgstr ""
+msgstr "스파크라인의 너비"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Width scale multiplier"
-msgstr ""
+msgstr "너비 배율 승수"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Window must be > 0"
-msgstr ""
+msgstr "창 크기는 0보다 커야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "With a subheader"
-msgstr ""
+msgstr "서브헤더 포함"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Word Cloud"
-msgstr ""
+msgstr "워드 클라우드"
 
 #, fuzzy
 msgid "Word Rotation"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working"
-msgstr ""
+msgstr "처리 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Working timeout"
-msgstr ""
+msgstr "처리 시간 초과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "World Map"
-msgstr ""
+msgstr "세계 지도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Write a description for your query"
-msgstr ""
+msgstr "쿼리에 대한 설명을 작성하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Write a handlebars template to render the data"
-msgstr ""
+msgstr "데이터를 렌더링하기 위한 Handlebars 템플릿을 작성하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "X Axis"
-msgstr ""
+msgstr "X 축"
 
 #, fuzzy
 msgid "X Axis Bounds"
 msgstr "컬럼 목록"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X Axis Format"
-msgstr ""
+msgstr "X 축 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Axis Label"
-msgstr ""
+msgstr "X 축 레이블"
 
 #, fuzzy
 msgid "X Axis Label Interval"
@@ -16406,32 +26860,65 @@ msgstr "새로고침 간격"
 msgid "X Axis Number Format"
 msgstr "D3 포멧"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "X Axis Title"
-msgstr ""
+msgstr "X 축 제목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X Axis Title Margin"
-msgstr ""
+msgstr "X 축 제목 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Log Scale"
-msgstr ""
+msgstr "X 로그 스케일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X Tick Layout"
-msgstr ""
+msgstr "X 눈금 레이아웃"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "X axis title margin"
-msgstr ""
+msgstr "X 축 제목 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X bounds"
-msgstr ""
+msgstr "X 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X-Axis Sort Ascending"
-msgstr ""
+msgstr "X축 오름차순 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "X-Axis Sort By"
-msgstr ""
+msgstr "X축 정렬 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "X-axis"
-msgstr ""
+msgstr "X축"
 
 #, fuzzy
 msgid "X-scale interval"
@@ -16440,56 +26927,120 @@ msgstr "새로고침 간격"
 msgid "XYZ"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y 2 bounds"
-msgstr ""
+msgstr "Y 2 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis"
-msgstr ""
+msgstr "Y 축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis 2 Bounds"
-msgstr ""
+msgstr "Y 축 2 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Bounds"
-msgstr ""
+msgstr "Y 축 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Format"
-msgstr ""
+msgstr "Y 축 형식"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Label"
-msgstr ""
+msgstr "Y 축 레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title"
-msgstr ""
+msgstr "Y 축 제목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Axis Title Margin"
-msgstr ""
+msgstr "Y 축 제목 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y Axis Title Position"
-msgstr ""
+msgstr "Y 축 제목 위치"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y Log Scale"
-msgstr ""
+msgstr "Y 로그 스케일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "Y axis title margin"
-msgstr ""
+msgstr "Y 축 제목 여백"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y bounds"
-msgstr ""
+msgstr "Y 경계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-Axis"
-msgstr ""
+msgstr "Y축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-Axis Sort Ascending"
-msgstr ""
+msgstr "Y축 오름차순 정렬"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Y-Axis Sort By"
-msgstr ""
+msgstr "Y축 정렬 기준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Y-axis"
-msgstr ""
+msgstr "Y축"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Y-axis bounds"
-msgstr ""
+msgstr "Y축 경계"
 
 #, fuzzy
 msgid "Y-scale interval"
@@ -16498,293 +27049,554 @@ msgstr "새로고침 간격"
 msgid "Year"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Year (freq=AS)"
-msgstr ""
+msgstr "연도 (freq=AS)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yearly seasonality"
-msgstr ""
+msgstr "연간 계절성"
 
 #, fuzzy, python-format
 msgid "Years %s"
 msgstr "년"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes"
-msgstr ""
+msgstr "예"
 
 #, fuzzy
 msgid "Yes, Cancel"
 msgstr "취소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Yes, cancel"
-msgstr ""
+msgstr "예, 취소합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Yes, overwrite changes"
-msgstr ""
+msgstr "예, 변경 사항을 덮어씁니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
 msgid "You are adding tags to %s %ss"
-msgstr ""
+msgstr "%s %ss에 태그를 추가하고 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "가상 데이터셋의 쿼리를 편집하고 있습니다 "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
-msgstr ""
+msgstr "이미 존재하는 차트를 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업 내용이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more dashboards that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
-msgstr ""
+msgstr "이미 존재하는 대시보드를 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업 내용이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more databases that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
-msgstr ""
+msgstr "이미 존재하는 데이터베이스를 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업 내용이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more datasets that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
-msgstr ""
+msgstr "이미 존재하는 데이터셋을 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업 내용이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid ""
 "You are importing one or more saved queries that already exist. "
 "Overwriting might cause you to lose some of your work. Are you sure you "
 "want to overwrite?"
-msgstr ""
+msgstr "이미 존재하는 저장된 쿼리를 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are importing one or more themes that already exist. Overwriting "
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
-msgstr ""
+msgstr "이미 존재하는 테마를 하나 이상 가져오고 있습니다. 덮어쓰면 일부 작업이 손실될 수 있습니다. 정말로 덮어쓰시겠습니까?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in a dashboard context with labels shared "
 "across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
+"여러 차트에서 레이블을 공유하는 대시보드 컨텍스트에서 이 차트를 보고 있습니다.\n"
+"        색상 구성표 선택이 비활성화되어 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "You are viewing this chart in the context of a dashboard that is directly"
 " affecting its colors.\n"
 "        To edit the color scheme, open this chart outside of the "
 "dashboard."
 msgstr ""
+"이 차트는 색상에 직접 영향을 미치는 대시보드의 컨텍스트에서 보고 있습니다.\n"
+"        색상 구성표를 편집하려면 대시보드 외부에서 이 차트를 여세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can"
-msgstr ""
+msgstr "할 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can add the components in the"
-msgstr ""
+msgstr "다음에서 컴포넌트를 추가할 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You can add the components in the edit mode."
-msgstr ""
+msgstr "편집 모드에서 컴포넌트를 추가할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "You can also just click on the chart to apply cross-filter."
-msgstr ""
+msgstr "차트를 클릭하여 교차 필터를 적용할 수도 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can choose to display all charts that you have access to or only the "
 "ones you own.\n"
 "              Your filter selection will be saved and remain active until"
 " you choose to change it."
 msgstr ""
+"접근 권한이 있는 모든 차트를 표시하거나 본인 소유의 차트만 표시하도록 선택할 수 있습니다.\n"
+"              필터 선택이 저장되며 변경하기로 선택할 때까지 활성 상태를 유지합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You can create a new chart or use existing ones from the panel on the "
 "right"
-msgstr ""
+msgstr "오른쪽 패널에서 새 차트를 만들거나 기존 차트를 사용할 수 있습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can preview the list of dashboards in the chart settings dropdown."
-msgstr ""
+msgstr "차트 설정 드롭다운에서 대시보드 목록을 미리 볼 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You can't apply cross-filter on this data point."
-msgstr ""
+msgstr "이 데이터 포인트에는 교차 필터를 적용할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You cannot delete the last temporal filter as it's used for time range "
 "filters in dashboards."
-msgstr ""
+msgstr "마지막 시간 필터는 대시보드의 시간 범위 필터에 사용되므로 삭제할 수 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You cannot use 45° tick layout along with the time range filter"
-msgstr ""
+msgstr "시간 범위 필터와 함께 45° 눈금 레이아웃을 사용할 수 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "You do not have permission to edit this %s"
-msgstr ""
+msgstr "이 %s을(를) 편집할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You do not have permission to edit this chart"
-msgstr ""
+msgstr "이 차트를 편집할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You do not have permission to edit this dashboard"
-msgstr ""
+msgstr "이 대시보드를 편집할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You do not have permission to perform this operation"
-msgstr ""
+msgstr "이 작업을 수행할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You do not have permission to read tags"
-msgstr ""
+msgstr "태그를 읽을 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You do not have permissions to edit this dashboard."
-msgstr ""
+msgstr "이 대시보드를 편집할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You do not have sufficient permissions to edit the chart"
-msgstr ""
+msgstr "차트를 편집할 충분한 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have access to this chart."
-msgstr ""
+msgstr "이 차트에 접근할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You don't have access to this dashboard."
-msgstr ""
+msgstr "이 대시보드에 접근할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have access to this dataset."
-msgstr ""
+msgstr "이 데이터셋에 접근할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have access to this embedded dashboard config."
-msgstr ""
+msgstr "이 임베드된 대시보드 설정에 접근할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have access to this semantic view."
-msgstr ""
+msgstr "이 시맨틱 뷰에 접근할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to copy to clipboard"
-msgstr ""
+msgstr "클립보드에 복사할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export data"
-msgstr ""
+msgstr "데이터를 내보낼 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export images"
-msgstr ""
+msgstr "이미지를 내보낼 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "You don't have permission to modify the value."
-msgstr ""
+msgstr "값을 수정할 권한이 없습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "You don't have the rights to alter %(resource)s"
-msgstr ""
+msgstr "%(resource)s을(를) 변경할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have the rights to alter this chart"
-msgstr ""
+msgstr "이 차트를 변경할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have the rights to alter this dashboard"
-msgstr ""
+msgstr "이 대시보드를 변경할 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You don't have the rights to alter this title."
-msgstr ""
+msgstr "이 제목을 변경할 권한이 없습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have the rights to create a chart"
-msgstr ""
+msgstr "차트를 만들 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "You don't have the rights to create a dashboard"
-msgstr ""
+msgstr "대시보드를 만들 권한이 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You don't have the rights to export data"
-msgstr ""
+msgstr "데이터를 내보낼 권한이 없습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "You have been removed from task: %s"
-msgstr ""
+msgstr "작업에서 제거되었습니다: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You have removed this filter."
-msgstr ""
+msgstr "이 필터를 제거했습니다."
 
 #, fuzzy
 msgid "You have unsaved changes"
 msgstr "차트 보기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You have unsaved changes."
-msgstr ""
+msgstr "저장되지 않은 변경 사항이 있습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-format
 msgid ""
 "You have used all %(historyLength)s undo slots and will not be able to "
 "fully undo subsequent actions. You may save your current state to reset "
 "the history."
 msgstr ""
+"%(historyLength)s개의 실행 취소 슬롯을 모두 사용했으며 이후 작업을 완전히 취소할 수 없습니다. 현재 상태를 저장하여"
+" 기록을 재설정할 수 있습니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You must be a %s owner in order to edit. Please reach out to a %s owner "
 "to request modifications or edit access."
-msgstr ""
+msgstr "편집하려면 %s 소유자여야 합니다. %s 소유자에게 연락하여 수정 또는 편집 접근 권한을 요청하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You must be a dataset owner in order to edit. Please reach out to a "
 "dataset owner to request modifications or edit access."
-msgstr ""
+msgstr "편집하려면 데이터셋 소유자여야 합니다. 데이터셋 소유자에게 연락하여 수정 또는 편집 접근 권한을 요청하세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "You must pick a name for the new dashboard"
-msgstr ""
+msgstr "새 대시보드의 이름을 선택해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "You must run the query successfully first"
-msgstr ""
+msgstr "먼저 쿼리를 성공적으로 실행해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "You updated the values in the control panel, but the chart was not "
 "updated automatically. Run the query by clicking on the \"Update chart\" "
 "button or"
-msgstr ""
+msgstr "컨트롤 패널의 값을 업데이트했지만 차트가 자동으로 업데이트되지 않았습니다. \"차트 업데이트\" 버튼을 클릭하여 쿼리를 실행하거나"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
-msgstr ""
+msgstr "이 작업에서 제거됩니다. 다른 %s명의 구독자를 위해 계속 실행됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
-msgstr ""
+msgstr "데이터셋을 변경했습니다. 이 새 데이터셋과 일치하는 데이터(열, 메트릭)가 있는 모든 컨트롤이 유지되었습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "계정이 활성화되었습니다. 자격 증명으로 로그인할 수 있습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your changes will be lost if you leave without saving."
-msgstr ""
+msgstr "저장하지 않고 나가면 변경 사항이 손실됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "Your chart is not up to date"
-msgstr ""
+msgstr "차트가 최신 상태가 아닙니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your chart is ready to go!"
-msgstr ""
+msgstr "차트가 준비되었습니다!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your dashboard is near the size limit."
-msgstr ""
+msgstr "대시보드가 크기 제한에 근접했습니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Your dashboard is too large. Please reduce its size before saving it."
-msgstr ""
+msgstr "대시보드가 너무 큽니다. 저장하기 전에 크기를 줄여주세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Your query could not be saved"
-msgstr ""
+msgstr "쿼리를 저장할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Your query could not be scheduled"
-msgstr ""
+msgstr "쿼리를 예약할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Your query could not be updated"
-msgstr ""
+msgstr "쿼리를 업데이트할 수 없습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "Your query has been scheduled. To see details of your query, navigate to "
 "Saved queries"
-msgstr ""
+msgstr "쿼리가 예약되었습니다. 쿼리의 세부 정보를 보려면 저장된 쿼리로 이동하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your query was not properly saved"
-msgstr ""
+msgstr "쿼리가 올바르게 저장되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Your query was saved"
-msgstr ""
+msgstr "쿼리가 저장되었습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Your query was updated"
-msgstr ""
+msgstr "쿼리가 업데이트되었습니다"
 
 #, fuzzy
 msgid "Your report could not be deleted"
@@ -16794,123 +27606,242 @@ msgstr "차트를 삭제할 수 없습니다."
 msgid "Your user information"
 msgstr "주석"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Z-A"
-msgstr ""
+msgstr "Z-A"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ZIP file contains multiple file types"
-msgstr ""
+msgstr "ZIP 파일에 여러 파일 형식이 포함되어 있습니다"
 
 #, fuzzy
 msgid "Zero imputation"
 msgstr "설명"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom"
-msgstr ""
+msgstr "확대/축소"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Zoom level"
-msgstr ""
+msgstr "확대/축소 수준"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "Zoom level of the map"
-msgstr ""
+msgstr "지도의 확대/축소 수준"
 
 #, fuzzy
 msgid "[ untitled dashboard ]"
 msgstr "대시보드 저장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[Longitude] and [Latitude] columns must be present in [Group By]"
-msgstr ""
+msgstr "[경도] 및 [위도] 열이 [그룹화 기준]에 있어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[Longitude] and [Latitude] must be set"
-msgstr ""
+msgstr "[경도] 및 [위도]를 설정해야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "[Missing Dataset]"
-msgstr ""
+msgstr "[데이터셋 없음]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "[Untitled]"
-msgstr ""
+msgstr "[제목 없음]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[asc]"
-msgstr ""
+msgstr "[오름차순]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "[dashboard name]"
-msgstr ""
+msgstr "[대시보드 이름]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "[desc]"
-msgstr ""
+msgstr "[내림차순]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "[optional] this secondary metric is used to define the color as a ratio "
 "against the primary metric. When omitted, the color is categorical and "
 "based on labels"
 msgstr ""
+"[선택 사항] 이 보조 지표는 기본 지표에 대한 비율로 색상을 정의하는 데 사용됩니다. 생략하면 색상은 범주형이며 레이블을 기반으로"
+" 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[제목 없는 사용자 지정]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_columns` must have the same length as `source_columns`."
-msgstr ""
+msgstr "`compare_columns`는 `source_columns`와 동일한 길이여야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`compare_type` must be `difference`, `percentage` or `ratio`"
-msgstr ""
+msgstr "`compare_type`은 `difference`, `percentage` 또는 `ratio`여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`confidence_interval` must be between 0 and 1 (exclusive)"
-msgstr ""
+msgstr "`confidence_interval`은 0과 1 사이여야 합니다 (양 끝 제외)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "`count` is COUNT(*) if a group by is used. Numerical columns will be "
 "aggregated with the aggregator. Non-numerical columns will be used to "
 "label points. Leave empty to get a count of points in each cluster."
 msgstr ""
+"그룹화를 사용하는 경우 `count`는 COUNT(*)입니다. 수치 열은 집계 함수로 집계됩니다. 비수치 열은 포인트 레이블 지정에"
+" 사용됩니다. 각 클러스터의 포인트 수를 얻으려면 비워 두세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`operation` property of post processing object undefined"
-msgstr ""
+msgstr "후처리 객체의 `operation` 속성이 정의되지 않았습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods`는 1과 %(max)s 사이여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`prophet` package not installed"
-msgstr ""
+msgstr "`prophet` 패키지가 설치되지 않았습니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "`rename_columns` must have the same length as `columns` + "
 "`time_shift_columns`."
-msgstr ""
+msgstr "`rename_columns`는 `columns` + `time_shift_columns`와 동일한 길이여야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_limit` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_limit`은 0 이상이어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`row_offset` must be greater than or equal to 0"
-msgstr ""
+msgstr "`row_offset`은 0 이상이어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "`width` must be greater or equal to 0"
-msgstr ""
+msgstr "`width`는 0 이상이어야 합니다"
 
 #, fuzzy
 msgid "a few seconds"
 msgstr "30초"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "aggregate"
-msgstr ""
+msgstr "집계"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alert"
-msgstr ""
+msgstr "알림"
 
 #, fuzzy
 msgid "alert condition"
 msgstr "활동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "alerts"
-msgstr ""
+msgstr "알림"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "all"
-msgstr ""
+msgstr "모두"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "also copy (duplicate) charts"
-msgstr ""
+msgstr "차트도 복사 (복제)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "ancestor"
-msgstr ""
+msgstr "상위 항목"
 
 msgid "annotation"
 msgstr "주석"
@@ -16918,42 +27849,71 @@ msgstr "주석"
 msgid "annotation_layer"
 msgstr "주석 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "asfreq"
-msgstr ""
+msgstr "asfreq"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "at"
-msgstr ""
+msgstr "에"
 
 #, fuzzy
 msgid "auto"
 msgstr "생성자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "background"
-msgstr ""
+msgstr "배경"
 
 #, fuzzy
 msgid "background color"
 msgstr "컬럼 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "basis"
-msgstr ""
+msgstr "기준"
 
 #, fuzzy
 msgid "begins with"
 msgstr "차트 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "below (example:"
-msgstr ""
+msgstr "아래 (예:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "beta"
-msgstr ""
+msgstr "베타"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "between {down} and {up} {name}"
-msgstr ""
+msgstr "{down}과 {up} 사이의 {name}"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "bfill"
-msgstr ""
+msgstr "bfill"
 
 msgid "bolt"
 msgstr ""
@@ -16962,21 +27922,37 @@ msgstr ""
 msgid "boolean"
 msgstr "활동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "boolean type icon"
-msgstr ""
+msgstr "불리언 유형 아이콘"
 
 #, fuzzy
 msgid "bottom"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "button (cmd + z) until you save your changes."
-msgstr ""
+msgstr "버튼(cmd + z)을 변경 사항을 저장할 때까지 누르세요."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "by using"
-msgstr ""
+msgstr "을(를) 사용하여"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "cannot be empty"
-msgstr ""
+msgstr "비울 수 없습니다"
 
 #, fuzzy
 msgid "cardinal"
@@ -16990,30 +27966,57 @@ msgstr "차트 추가"
 msgid "change"
 msgstr "관리"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "chart"
-msgstr ""
+msgstr "차트"
 
 #, fuzzy
 msgid "charts"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "choose WHERE or HAVING..."
-msgstr ""
+msgstr "WHERE 또는 HAVING 선택..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "click here"
-msgstr ""
+msgstr "여기를 클릭하세요"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "close"
-msgstr ""
+msgstr "닫기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-2 (cca2)"
-msgstr ""
+msgstr "ISO 3166-1 alpha-2 코드 (cca2)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code ISO 3166-1 alpha-3 (cca3)"
-msgstr ""
+msgstr "ISO 3166-1 alpha-3 코드 (cca3)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "code International Olympic Committee (cioc)"
-msgstr ""
+msgstr "국제 올림픽 위원회 코드 (cioc)"
 
 #, fuzzy
 msgid "color scheme for comparison"
@@ -17026,9 +28029,11 @@ msgstr "차트 유형"
 msgid "column"
 msgstr "컬럼 추가"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "connecting to %(dbModelName)s"
-msgstr ""
+msgstr "%(dbModelName)s에 연결 중"
 
 #, fuzzy
 msgid "containing"
@@ -17050,21 +28055,37 @@ msgstr "생성자"
 msgid "create a new chart"
 msgstr "새 차트 생성"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "create dataset from SQL query"
-msgstr ""
+msgstr "SQL 쿼리에서 데이터셋 만들기"
 
 #, fuzzy
 msgid "crontab"
 msgstr "컬럼 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css"
-msgstr ""
+msgstr "css"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "css_template"
-msgstr ""
+msgstr "css_template"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "cumsum"
-msgstr ""
+msgstr "누적 합계"
 
 msgid "dashboard"
 msgstr "대시보드"
@@ -17088,8 +28109,12 @@ msgstr "데이터베이스"
 msgid "databases"
 msgstr "데이터베이스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "dataset"
-msgstr ""
+msgstr "데이터셋"
 
 #, fuzzy
 msgid "dataset name"
@@ -17107,23 +28132,42 @@ msgstr "데이터소스"
 msgid "datasources"
 msgstr "데이터소스"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "date"
-msgstr ""
+msgstr "날짜"
 
 msgid "day"
 msgstr "일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the month"
-msgstr ""
+msgstr "월의 날짜"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "day of the week"
-msgstr ""
+msgstr "요일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl 3D Hexagon"
-msgstr ""
+msgstr "deck.gl 3D 육각형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "deck.gl Arc"
-msgstr ""
+msgstr "deck.gl 호"
 
 #, fuzzy
 msgid "deck.gl Contour"
@@ -17132,51 +28176,85 @@ msgstr "차트 추가"
 msgid "deck.gl Geojson"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Grid"
-msgstr ""
+msgstr "deck.gl 격자"
 
 #, fuzzy
 msgid "deck.gl Heatmap"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Multiple Layers"
-msgstr ""
+msgstr "deck.gl 다중 레이어"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Path"
-msgstr ""
+msgstr "deck.gl 경로"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Polygon"
-msgstr ""
+msgstr "deck.gl 다각형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Scatterplot"
-msgstr ""
+msgstr "deck.gl 산점도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl Screen Grid"
-msgstr ""
+msgstr "deck.gl 화면 격자"
 
 #, fuzzy
 msgid "deck.gl layers (charts)"
 msgstr "차트 추가"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "deckGL"
-msgstr ""
+msgstr "deckGL"
 
 #, fuzzy
 msgid "default"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "descendant"
-msgstr ""
+msgstr "하위 항목"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "description"
-msgstr ""
+msgstr "설명"
 
 #, fuzzy
 msgid "deviation"
 msgstr "활동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "dialect+driver://username:password@host:port/database"
-msgstr ""
+msgstr "dialect+driver://사용자명:비밀번호@호스트:포트/데이터베이스"
 
 #, fuzzy
 msgid "documentation"
@@ -17185,52 +28263,101 @@ msgstr "주석"
 msgid "dttm"
 msgstr "날짜/시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. ********"
-msgstr ""
+msgstr "예: ********"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 127.0.0.1"
-msgstr ""
+msgstr "예: 127.0.0.1"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. 5432"
-msgstr ""
+msgstr "예: 5432"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. AccountAdmin"
-msgstr ""
+msgstr "예: AccountAdmin"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "e.g. Analytics"
-msgstr ""
+msgstr "예: Analytics"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. compute_wh"
-msgstr ""
+msgstr "예: compute_wh"
 
 #, fuzzy
 msgid "e.g. default"
 msgstr "삭제"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "e.g. hive_metastore"
-msgstr ""
+msgstr "예: hive_metastore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "e.g. param1=value1&param2=value2"
-msgstr ""
+msgstr "예: param1=value1&param2=value2"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. sql/protocolv1/o/12345"
-msgstr ""
+msgstr "예: sql/protocolv1/o/12345"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. world_population"
-msgstr ""
+msgstr "예: world_population"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "e.g. xy12345.us-east-2.aws"
-msgstr ""
+msgstr "예: xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "예: CI/CD 파이프라인, 분석 스크립트"
 
 #, fuzzy
 msgid "edit mode"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "email subject"
-msgstr ""
+msgstr "이메일 제목"
 
 #, fuzzy
 msgid "ends with"
@@ -17256,14 +28383,26 @@ msgstr "%s 에러"
 msgid "error_message"
 msgstr "에러 메시지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every"
-msgstr ""
+msgstr "매"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "every day of the month"
-msgstr ""
+msgstr "매월 매일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "every day of the week"
-msgstr ""
+msgstr "매주 매일"
 
 msgid "every hour"
 msgstr "1시간"
@@ -17275,44 +28414,75 @@ msgstr "월"
 msgid "every month"
 msgstr "월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "expand"
-msgstr ""
+msgstr "확장"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard는 객체여야 합니다"
 
 #, fuzzy
 msgid "failed"
 msgstr "실패"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "작별"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "fetching"
-msgstr ""
+msgstr "가져오는 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "ffill"
-msgstr ""
+msgstr "ffill"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "flat"
-msgstr ""
+msgstr "플랫"
 
 #, fuzzy
 msgid "for a list of available helpers."
 msgstr "필터"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "for more information on how to structure your URI."
-msgstr ""
+msgstr "URI를 구성하는 방법에 대한 자세한 내용은 다음을 참조하세요."
 
 #, fuzzy
 msgid "formatted"
 msgstr "데이터베이스 선택"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "function type icon"
-msgstr ""
+msgstr "함수 유형 아이콘"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "geohash (square)"
-msgstr ""
+msgstr "지오해시 (정사각형)"
 
 #, fuzzy
 msgid "greeting"
@@ -17322,11 +28492,18 @@ msgstr "생성자"
 msgid "heatmap"
 msgstr "스키마"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "heatmap: values are normalized across the entire heatmap"
-msgstr ""
+msgstr "히트맵: 값이 전체 히트맵에 걸쳐 정규화됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "안녕하세요"
 
 #, fuzzy
 msgid "here"
@@ -17335,80 +28512,133 @@ msgstr "Query 공유"
 msgid "hour"
 msgstr "시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "in"
-msgstr ""
+msgstr "포함"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "이 작업을 실행하기 위해."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "invalid email"
-msgstr ""
+msgstr "유효하지 않은 이메일"
 
 #, fuzzy
 msgid "is"
 msgstr "활동"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
 msgstr ""
+"Mapbox/OSM URL(예: mapbox://styles/...) 또는 타일 서버 URL(예: tile://http...)이어야"
+" 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be a number"
-msgstr ""
+msgstr "숫자여야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "is expected to be an integer"
-msgstr ""
+msgstr "정수여야 합니다"
 
 #, fuzzy
 msgid "is false"
 msgstr "테이블 수정"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards and users have %s SQL"
 " Lab tabs using this database open. Are you sure you want to continue? "
 "Deleting the database will break those objects."
 msgstr ""
+"%s개의 대시보드에 표시되는 %s개의 차트와 연결되어 있으며, 사용자들이 이 데이터베이스를 사용하는 %s개의 SQL Lab 탭을 "
+"열고 있습니다. 계속하시겠습니까? 데이터베이스를 삭제하면 해당 객체들이 손상됩니다."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
-msgstr ""
+msgstr "%s개의 대시보드에 표시되는 %s개의 차트와 연결되어 있습니다. 계속하시겠습니까? 데이터셋을 삭제하면 해당 객체들이 손상됩니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not"
-msgstr ""
+msgstr "이(가) 아님"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is not null"
-msgstr ""
+msgstr "null이 아님"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ro, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "is null"
-msgstr ""
+msgstr "null임"
 
 #, fuzzy
 msgid "is true"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key a-z"
-msgstr ""
+msgstr "키 a-z"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "key z-a"
-msgstr ""
+msgstr "키 z-a"
 
 #, fuzzy
 msgid "label"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "latest partition:"
-msgstr ""
+msgstr "최신 파티션:"
 
 #, fuzzy
 msgid "left"
 msgstr "삭제"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "less than {min} {name}"
-msgstr ""
+msgstr "{min} {name} 미만"
 
 #, fuzzy
 msgid "linear"
@@ -17418,22 +28648,40 @@ msgstr "차트 이동"
 msgid "locale_key"
 msgstr "레이블"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "log"
-msgstr ""
+msgstr "로그"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "lower percentile must be greater than 0 and less than 100. Must be lower "
 "than upper percentile."
-msgstr ""
+msgstr "하위 백분위수는 0보다 크고 100보다 작아야 합니다. 상위 백분위수보다 낮아야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "max"
-msgstr ""
+msgstr "최대"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "mean"
-msgstr ""
+msgstr "평균"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "median"
-msgstr ""
+msgstr "중앙값"
 
 #, fuzzy
 msgid "meters"
@@ -17465,48 +28713,73 @@ msgstr "월"
 msgid "month"
 msgstr "월"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy, python-brace-format
 msgid "more than {max} {name}"
-msgstr ""
+msgstr "{max} {name} 초과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "must have a value"
-msgstr ""
+msgstr "값이 있어야 합니다"
 
 #, fuzzy
 msgid "name"
 msgstr "이름"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters는 목록이어야 합니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s]에 필수 키가 누락되었습니다: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s]는 객체여야 합니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues는 목록이어야 합니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s'가 대시보드에 존재하지 않습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].nativeFilterId는 비어 있지 않은 문자열이어야 합니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "no SQL validator is configured"
-msgstr ""
+msgstr "SQL 유효성 검사기가 구성되어 있지 않습니다"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "no SQL validator is configured for %(engine_spec)s"
-msgstr ""
+msgstr "%(engine_spec)s에 대한 SQL 유효성 검사기가 구성되어 있지 않습니다"
 
 #, fuzzy
 msgid "not containing"
@@ -17516,27 +28789,49 @@ msgstr "주석"
 msgid "numeric"
 msgstr "메트릭"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "numeric type icon"
-msgstr ""
+msgstr "숫자 유형 아이콘"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "nvd3"
-msgstr ""
+msgstr "nvd3"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "of"
-msgstr ""
+msgstr "중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "offline"
-msgstr ""
+msgstr "오프라인"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "on"
-msgstr ""
+msgstr "에서"
 
 #, fuzzy
 msgid "or"
 msgstr "시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "or use existing ones from the panel on the right"
-msgstr ""
+msgstr "또는 오른쪽 패널에서 기존 항목을 사용하세요"
 
 #, fuzzy
 msgid "orderby column must be populated"
@@ -17546,15 +28841,22 @@ msgstr "하나 이상의 칼럼이 중복됩니다"
 msgid "original"
 msgstr "원본 값"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "overall"
-msgstr ""
+msgstr "전체"
 
 #, fuzzy
 msgid "owners"
 msgstr "차트"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "p-value precision"
-msgstr ""
+msgstr "p값 정밀도"
 
 msgid "p1"
 msgstr ""
@@ -17568,13 +28870,20 @@ msgstr ""
 msgid "p99"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "pending"
-msgstr ""
+msgstr "보류 중"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "percentiles must be a list or tuple with two numeric values, of which the"
 " first is lower than the second value"
-msgstr ""
+msgstr "백분위수는 두 개의 숫자 값으로 구성된 목록 또는 튜플이어야 하며, 첫 번째 값이 두 번째 값보다 작아야 합니다"
 
 #, fuzzy
 msgid "permalink state not found"
@@ -17584,23 +28893,45 @@ msgstr "CSS 템플릿을 찾을수 없습니다."
 msgid "pivoted_xlsx"
 msgstr "테이블 수정"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "pixels"
-msgstr ""
+msgstr "픽셀"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar month"
-msgstr ""
+msgstr "이전 달력 월"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "previous calendar quarter"
-msgstr ""
+msgstr "이전 달력 분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar week"
-msgstr ""
+msgstr "이전 달력 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "previous calendar year"
-msgstr ""
+msgstr "이전 달력 연도"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "권한 부여"
 
 #, fuzzy
 msgid "quarter"
@@ -17609,36 +28940,68 @@ msgstr "분기"
 msgid "query"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "random"
-msgstr ""
+msgstr "무작위"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "reboot"
-msgstr ""
+msgstr "재시작"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "recent"
-msgstr ""
+msgstr "최근"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, uk]
+#, fuzzy
 msgid "recipients"
-msgstr ""
+msgstr "수신자"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "report"
-msgstr ""
+msgstr "보고서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "reports"
-msgstr ""
+msgstr "보고서"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "restore zoom"
-msgstr ""
+msgstr "줌 복원"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "right"
-msgstr ""
+msgstr "오른쪽"
 
 #, fuzzy
 msgid "rowlevelsecurity"
 msgstr "저수준 보안"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "running"
-msgstr ""
+msgstr "실행 중"
 
 #, fuzzy
 msgid "save"
@@ -17655,11 +29018,17 @@ msgstr "30초"
 msgid "series"
 msgstr "저장된 Query"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "series: Treat each series independently; overall: All series use the same"
 " scale; change: Show changes compared to the first data point in each "
 "series"
 msgstr ""
+"시리즈: 각 시리즈를 독립적으로 처리합니다. 전체: 모든 시리즈가 동일한 척도를 사용합니다. 변화: 각 시리즈의 첫 번째 데이터 "
+"포인트와 비교한 변화를 표시합니다."
 
 msgid "sql"
 msgstr ""
@@ -17668,14 +29037,24 @@ msgstr ""
 msgid "square"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stack"
-msgstr ""
+msgstr "누적"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "staggered"
-msgstr ""
+msgstr "엇갈린"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "std"
-msgstr ""
+msgstr "표준편차"
 
 #, fuzzy
 msgid "step-after"
@@ -17688,54 +29067,89 @@ msgstr ""
 msgid "stopped"
 msgstr "중지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "stream"
-msgstr ""
+msgstr "스트림"
 
 #, fuzzy
 msgid "string"
 msgstr "CSV 파일"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "string type icon"
-msgstr ""
+msgstr "문자열 유형 아이콘"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "success"
-msgstr ""
+msgstr "성공"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "sum"
-msgstr ""
+msgstr "합계"
 
 msgid "superset.example.com"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "syntax."
-msgstr ""
+msgstr "구문."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "tag"
-msgstr ""
+msgstr "태그"
 
 #, fuzzy
 msgid "task"
 msgstr "상태"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid "temporal type icon"
-msgstr ""
+msgstr "시간 유형 아이콘"
 
 #, fuzzy
 msgid "text color"
 msgstr "시작 시간"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "textarea"
-msgstr ""
+msgstr "텍스트 영역"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "Handlebars 차트 문서"
 
 #, fuzzy
 msgid "theme"
 msgstr "Query 공유"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "timestamp"
-msgstr ""
+msgstr "타임스탬프"
 
 #, fuzzy
 msgid "to"
@@ -17745,8 +29159,11 @@ msgstr "중지"
 msgid "top"
 msgstr "중지"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "undo"
-msgstr ""
+msgstr "실행 취소"
 
 #, fuzzy
 msgid "unknown type icon"
@@ -17760,29 +29177,50 @@ msgstr "컬럼 추가"
 msgid "updated"
 msgstr "분기"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
 msgid ""
 "upper percentile must be greater than 0 and less than 100. Must be higher"
 " than lower percentile."
-msgstr ""
+msgstr "상위 백분위수는 0보다 크고 100보다 작아야 합니다. 하위 백분위수보다 높아야 합니다."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "use latest_partition template"
-msgstr ""
+msgstr "latest_partition 템플릿 사용"
 
 #, fuzzy
 msgid "username"
 msgstr "Query 검색"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "value ascending"
-msgstr ""
+msgstr "값 오름차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
+# zh_TW]
+#, fuzzy
 msgid "value descending"
-msgstr ""
+msgstr "값 내림차순"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "var"
-msgstr ""
+msgstr "분산"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "variance"
-msgstr ""
+msgstr "분산"
 
 #, fuzzy
 msgid "view instructions"
@@ -17792,32 +29230,61 @@ msgstr "10초"
 msgid "viz type"
 msgstr "시각화 유형"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
+# sr_Latn, tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "was created"
-msgstr ""
+msgstr "생성되었습니다"
 
 msgid "week"
 msgstr "주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week ending Saturday"
-msgstr ""
+msgstr "토요일로 끝나는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "week starting Sunday"
-msgstr ""
+msgstr "일요일로 시작하는 주"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "working timeout"
-msgstr ""
+msgstr "작업 시간 초과"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x"
-msgstr ""
+msgstr "x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "x: values are normalized within each column"
-msgstr ""
+msgstr "x: 각 열 내에서 값이 정규화됩니다"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y"
-msgstr ""
+msgstr "y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk]
+#, fuzzy
 msgid "y: values are normalized within each row"
-msgstr ""
+msgstr "y: 각 행 내에서 값이 정규화됩니다"
 
 msgid "year"
 msgstr "년"
@@ -17825,11 +29292,21 @@ msgstr "년"
 msgid "your-project-1234-a1"
 msgstr ""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
+# zh, zh_TW]
+#, fuzzy
 msgid "zoom area"
-msgstr ""
+msgstr "줌 영역"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "© Layer attribution"
-msgstr ""
+msgstr "© 레이어 출처"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"


### PR DESCRIPTION
### SUMMARY

Backfills the remaining untranslated entries in the Korean (`ko`) catalog using `scripts/translations/backfill_po.py`, which drafts translations with Claude using every other language's existing translation of the same string as cross-language disambiguation context (per `docs/developer_docs/contributing/howtos.md`). Do-not-translate tokens (icon names, enum values, SQL keywords, API field names, placeholders) are skipped.

All generated strings are marked `#, fuzzy` with a `Machine-translated via backfill_po.py` attribution comment. The `#, fuzzy` flag marks each entry as machine-generated and needing native-speaker review. **Note on serving:** both the frontend (`po2json --fuzzy`) and backend builds include fuzzy entries, so these translations render in the UI once built; reviewers should verify each and remove the `#, fuzzy` flag to confirm. Format placeholders are preserved (verified programmatically).

Tracked by `check_translation_regression.py` as `untranslated → fuzzy`, which is explicitly **not** a regression. Part of a per-language sweep.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Translation catalog only, no layout or behavior change. Strings render once the frontend/backend are rebuilt.

### TESTING INSTRUCTIONS

- `pybabel compile --use-fuzzy -d superset/translations -l ko` succeeds.
- Korean native speakers: review the `#, fuzzy` entries and de-fuzz once confirmed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API