### PR TITLE
feat(parallel-coordinates): migrate para chart to v1 chart data API

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/buildQuery.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  buildQueryContext,
+  ensureIsArray,
+  getMetricLabel,
+  QueryFormData,
+  QueryFormMetric,
+  QueryFormOrderBy,
+} from '@superset-ui/core';
+
+/**
+ * Mirrors the query the legacy `para` viz built server-side: one query
+ * grouped by `series` selecting all metrics (including the secondary
+ * "color" metric, aliased into `metrics` by extractQueryFields). The
+ * sort metric is added to the select list so its ordering is visible in
+ * the result, and ordering is applied when `order_desc` is set.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  const { timeseries_limit_metric, order_desc } = formData;
+  return buildQueryContext(formData, baseQueryObject => {
+    let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
+    const orderby: QueryFormOrderBy[] = [];
+    const sortByMetric = ensureIsArray(
+      timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
+    )[0];
+    if (sortByMetric) {
+      const sortByLabel = getMetricLabel(sortByMetric);
+      if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
+        metrics = [...metrics, sortByMetric];
+      }
+      if (order_desc) {
+        orderby.push([sortByMetric, !order_desc]);
+      }
+    }
+    return [
+      {
+        ...baseQueryObject,
+        metrics,
+        ...(orderby.length > 0 && { orderby }),
+      },
+    ];
+  });
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/buildQuery.ts
@@ -53,7 +53,9 @@ export default function buildQuery(formData: QueryFormData) {
       {
         ...baseQueryObject,
         metrics,
-        ...(orderby.length > 0 && { orderby }),
+        // own the ordering entirely: the legacy pipeline ignored residual
+        // orderby fields (e.g. order_by_cols left over from other viz types)
+        orderby: orderby.length > 0 ? orderby : undefined,
       },
     ];
   });

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/index.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/index.ts
@@ -38,16 +38,16 @@ const metadata = new ChartMetadata({
     { url: example2, urlDark: example2Dark },
   ],
   name: t('Parallel Coordinates'),
-  tags: [t('Directional'), t('Legacy'), t('Relational')],
+  tags: [t('Directional'), t('Relational')],
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
 });
 
 export default class ParallelCoordinatesChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('./ReactParallelCoordinates'),
+      loadBuildQuery: () => import('./buildQuery'),
       metadata,
       transformProps,
       controlPanel,

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/buildQuery.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import buildQuery from '../src/buildQuery';
+
+const basicFormData: QueryFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  time_range: 'No filter',
+  viz_type: 'para',
+  series: 'gender',
+  metrics: ['sum__num', 'avg__num'],
+};
+
+test('builds columns from series and keeps all metrics', () => {
+  const [query] = buildQuery(basicFormData).queries;
+  expect(query.columns).toEqual(['gender']);
+  expect(query.metrics).toEqual(['sum__num', 'avg__num']);
+});
+
+test('includes the secondary (color) metric in the query', () => {
+  const [query] = buildQuery({
+    ...basicFormData,
+    secondary_metric: 'count',
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'avg__num', 'count']);
+});
+
+test('maps granularity_sqla from legacy saved form data', () => {
+  const [query] = buildQuery(basicFormData).queries;
+  expect(query.granularity).toEqual('ds');
+});
+
+test('appends the sort metric to the select list when missing', () => {
+  const [query] = buildQuery({
+    ...basicFormData,
+    timeseries_limit_metric: 'count',
+    order_desc: false,
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'avg__num', 'count']);
+  expect(query.orderby).toBeUndefined();
+});
+
+test('does not duplicate the sort metric when already selected', () => {
+  const [query] = buildQuery({
+    ...basicFormData,
+    timeseries_limit_metric: 'sum__num',
+    order_desc: true,
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'avg__num']);
+  expect(query.orderby).toEqual([['sum__num', false]]);
+});
+
+test('orders by the sort metric descending only when order_desc is set', () => {
+  const [query] = buildQuery({
+    ...basicFormData,
+    timeseries_limit_metric: 'count',
+    order_desc: true,
+  }).queries;
+  expect(query.orderby).toEqual([['count', false]]);
+});
+
+test('supports adhoc sort metrics', () => {
+  const adhocMetric = {
+    expressionType: 'SIMPLE' as const,
+    aggregate: 'SUM' as const,
+    column: { column_name: 'num' },
+    label: 'SUM(num)',
+  };
+  const [query] = buildQuery({
+    ...basicFormData,
+    timeseries_limit_metric: adhocMetric,
+    order_desc: true,
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'avg__num', adhocMetric]);
+  expect(query.orderby).toEqual([[adhocMetric, false]]);
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/buildQuery.test.ts
@@ -76,6 +76,14 @@ test('orders by the sort metric descending only when order_desc is set', () => {
   expect(query.orderby).toEqual([['count', false]]);
 });
 
+test('ignores residual order_by_cols from other viz types', () => {
+  const [query] = buildQuery({
+    ...basicFormData,
+    order_by_cols: ['["count", false]'],
+  }).queries;
+  expect(query.orderby).toBeUndefined();
+});
+
 test('supports adhoc sort metrics', () => {
   const adhocMetric = {
     expressionType: 'SIMPLE' as const,

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false
+  },
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*", "../types/**/*", "../../../types/**/*"]
+}


### PR DESCRIPTION
### SUMMARY

Tier 1 of #41714 (targets `remove-legacy-viz-pipeline`): migrate **Parallel Coordinates (`para`)** off `explore_json` onto `/api/v1/chart/data`.

- New `buildQuery.ts` mirroring the legacy `ParallelCoordinatesViz.query_obj`: `series` → groupby column, secondary (color) metric included via `extractQueryFields`' `secondary_metric` alias, sort metric appended to the select list, `orderby` applied when `order_desc` is set.
- `useLegacyApi: true` removed (and the "Legacy" tag dropped from the viz gallery metadata).
- `transformProps` unchanged — the legacy `get_data()` was a plain `df.to_dict("records")` pass-through, which is exactly what the v1 endpoint returns.
- **No DB migration needed**: `viz_type` is unchanged, and legacy saved-chart form data (`granularity_sqla`, `time_range`) is handled by `extractExtras`, covered by a test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change — same renderer, same data shape, different endpoint.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/legacy-plugin-chart-parallel-coordinates` — 7 new buildQuery tests covering series/metrics extraction, secondary metric, sort-metric append/dedup, order_desc, adhoc sort metrics, and legacy granularity_sqla handling.
- Manual: open any saved Parallel Coordinates chart; the network tab should show `POST /api/v1/chart/data` instead of `/superset/explore_json/`, with identical rendering.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
