### PR TITLE
feat(bullet): migrate bullet chart to v1 chart data API

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/buildQuery.ts
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { buildQueryContext, QueryFormData } from '@superset-ui/core';
+
+/**
+ * Mirrors the legacy BulletViz.query_obj: a single ungrouped metric.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  const { metric } = formData;
+  return buildQueryContext(formData, baseQueryObject => [
+    {
+      ...baseQueryObject,
+      columns: [],
+      metrics: metric ? [metric] : [],
+    },
+  ]);
+}

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/index.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bullet/index.ts
@@ -33,16 +33,16 @@ const metadata = new ChartMetadata({
   ),
   exampleGallery: [{ url: example, urlDark: exampleDark }],
   name: t('Bullet Chart'),
-  tags: [t('Business'), t('Legacy'), t('Report'), t('nvd3')],
+  tags: [t('Business'), t('Report'), t('nvd3')],
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
 });
 
 export default class BulletChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('../ReactNVD3'),
+      loadBuildQuery: () => import('./buildQuery'),
       metadata,
       transformProps,
       controlPanel,

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 // @ts-nocheck -- legacy transformProps with loosely-typed formData from ChartProps
-import { ChartProps, VizType } from '@superset-ui/core';
+import { ChartProps, getMetricLabel, VizType } from '@superset-ui/core';
 import isTruthy from './utils/isTruthy';
 import {
   tokenizeToNumericArray,
@@ -122,15 +122,24 @@ export default function transformProps(chartProps: ChartProps) {
   } = formData;
 
   const rawData = queriesData[0].data || [];
-  const data = Array.isArray(rawData)
-    ? rawData.map(row => ({
-        ...row,
-        values: Array.isArray(row.values)
-          ? row.values.map(value => ({ ...value }))
-          : row.values,
-        key: formatLabel(row.key, datasource.verboseMap),
-      }))
-    : rawData;
+  let data;
+  if (vizType === VizType.Bullet && Array.isArray(rawData)) {
+    // The legacy explore_json endpoint reshaped the single-metric result
+    // into `{ measures: [...] }` server-side; the v1 chart data endpoint
+    // returns plain records, so the reshape happens here.
+    const metricLabel = getMetricLabel(metric);
+    data = { measures: rawData.map(row => row[metricLabel]) };
+  } else {
+    data = Array.isArray(rawData)
+      ? rawData.map(row => ({
+          ...row,
+          values: Array.isArray(row.values)
+            ? row.values.map(value => ({ ...value }))
+            : row.values,
+          key: formatLabel(row.key, datasource.verboseMap),
+        }))
+      : rawData;
+  }
 
   if (vizType === VizType.Pie) {
     numberFormat = numberFormat || grabD3Format(datasource, metric);

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/Bullet.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/Bullet.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { supersetTheme } from '@apache-superset/core/theme';
+import { ChartProps, QueryFormData, VizType } from '@superset-ui/core';
+import buildQuery from '../src/Bullet/buildQuery';
+import transformProps from '../src/transformProps';
+
+const formData: QueryFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  time_range: 'No filter',
+  viz_type: VizType.Bullet,
+  metric: 'sum__num',
+};
+
+describe('Bullet buildQuery', () => {
+  test('selects the single ungrouped metric', () => {
+    const [query] = buildQuery(formData).queries;
+    expect(query.metrics).toEqual(['sum__num']);
+    expect(query.columns).toEqual([]);
+  });
+
+  test('maps legacy granularity_sqla saved form data', () => {
+    const [query] = buildQuery(formData).queries;
+    expect(query.granularity).toEqual('ds');
+  });
+});
+
+describe('Bullet transformProps', () => {
+  const baseChartProps = {
+    width: 800,
+    height: 600,
+    datasource: { verboseMap: {} },
+    theme: supersetTheme,
+    hooks: {},
+    initialValues: {},
+  };
+
+  test('reshapes v1 records into the measures shape', () => {
+    const chartProps = new ChartProps({
+      ...baseChartProps,
+      formData: { vizType: VizType.Bullet, metric: 'sum__num' },
+      queriesData: [{ data: [{ sum__num: 42 }] }],
+    });
+    const { data } = transformProps(chartProps) as {
+      data: { measures: number[] };
+    };
+    expect(data).toEqual({ measures: [42] });
+  });
+
+  test('passes through legacy-shaped measures payloads', () => {
+    const chartProps = new ChartProps({
+      ...baseChartProps,
+      formData: { vizType: VizType.Bullet, metric: 'sum__num' },
+      queriesData: [{ data: { measures: [42] } }],
+    });
+    const { data } = transformProps(chartProps) as {
+      data: { measures: number[] };
+    };
+    expect(data).toEqual({ measures: [42] });
+  });
+
+  test('reshapes using adhoc metric labels', () => {
+    const chartProps = new ChartProps({
+      ...baseChartProps,
+      formData: {
+        vizType: VizType.Bullet,
+        metric: {
+          expressionType: 'SIMPLE',
+          aggregate: 'SUM',
+          column: { column_name: 'num' },
+          label: 'SUM(num)',
+        },
+      },
+      queriesData: [{ data: [{ 'SUM(num)': 7 }] }],
+    });
+    const { data } = transformProps(chartProps) as {
+      data: { measures: number[] };
+    };
+    expect(data).toEqual({ measures: [7] });
+  });
+});


### PR DESCRIPTION
### SUMMARY

Tier 1 of #41714 (targets `remove-legacy-viz-pipeline`): migrate the nvd3 **Bullet Chart (`bullet`)** off `explore_json` onto `/api/v1/chart/data`.

- New `Bullet/buildQuery.ts` mirroring the legacy `BulletViz.query_obj`: a single ungrouped metric.
- The `{measures: [...]}` reshape `viz.py` did server-side now happens in the Bullet branch of the shared nvd3 `transformProps` (legacy-shaped payloads pass through untouched; other nvd3 charts unaffected).
- `useLegacyApi: true` removed (and the "Legacy" tag dropped).
- **No DB migration**: `viz_type` unchanged; legacy `granularity_sqla`/`time_range` handled by `extractExtras` (covered by test).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change — same renderer, same data shape, different endpoint.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/legacy-preset-chart-nvd3` — 5 new Jest tests (buildQuery shape, granularity_sqla mapping, v1 records→measures reshape incl. adhoc metric labels, legacy payload pass-through); 37 total pass.
- Manual: open a saved Bullet chart; network tab shows `POST /api/v1/chart/data`; rendering identical.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
