### PR TITLE
feat(chord): migrate chord chart to v1 chart data API

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/buildQuery.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  buildQueryContext,
+  ensureIsArray,
+  QueryFormColumn,
+  QueryFormData,
+} from '@superset-ui/core';
+
+/**
+ * Mirrors the legacy ChordViz.query_obj: one query grouped by the source
+ * (groupby) and target (columns) dimensions, selecting the single metric,
+ * ordered by that metric when sort_by_metric is on.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  const { groupby, columns, metric, sort_by_metric } = formData;
+  const source = ensureIsArray(groupby as QueryFormColumn | QueryFormColumn[])[0];
+  const target = ensureIsArray(columns as QueryFormColumn | QueryFormColumn[])[0];
+  return buildQueryContext(formData, baseQueryObject => [
+    {
+      ...baseQueryObject,
+      columns: [source, target].filter(column => column != null),
+      metrics: metric ? [metric] : [],
+      orderby: sort_by_metric && metric ? [[metric, false]] : undefined,
+    },
+  ]);
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/index.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/index.ts
@@ -39,16 +39,16 @@ const metadata = new ChartMetadata({
     },
   ],
   name: t('Chord Diagram'),
-  tags: [t('Circular'), t('Legacy'), t('Proportional'), t('Relational')],
+  tags: [t('Circular'), t('Proportional'), t('Relational')],
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
 });
 
 export default class ChordChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('./ReactChord'),
+      loadBuildQuery: () => import('./buildQuery'),
       metadata,
       transformProps,
       controlPanel,

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/transformProps.ts
@@ -29,10 +29,10 @@ interface ChordData {
 }
 
 /**
- * Builds the symmetrical adjacency matrix that d3.chord expects, the way
- * the legacy explore_json endpoint used to server-side: nodes are the
- * union of source and target values, matrix[target][source] holds the
- * metric value.
+ * Builds the square adjacency matrix that d3.chord expects, the way the
+ * legacy explore_json endpoint used to server-side: nodes are the union
+ * of source and target values, matrix[target][source] holds the
+ * (directional) metric value.
  */
 function buildChordData(
   records: Record<string, unknown>[],
@@ -67,15 +67,16 @@ export default function transformProps(chartProps: ChartProps) {
     formData;
 
   const rawData = queriesData[0].data;
-  const data = Array.isArray(rawData)
-    ? buildChordData(
-        rawData,
-        getColumnLabel(ensureIsArray(groupby)[0]),
-        getColumnLabel(ensureIsArray(columns)[0]),
-        getMetricLabel(metric),
-      )
-    : // legacy explore_json payloads arrive pre-shaped
-      rawData;
+  const data =
+    Array.isArray(rawData) && metric
+      ? buildChordData(
+          rawData,
+          getColumnLabel(ensureIsArray(groupby)[0]),
+          getColumnLabel(ensureIsArray(columns)[0]),
+          getMetricLabel(metric),
+        )
+      : // legacy explore_json payloads arrive pre-shaped
+        rawData;
 
   return {
     colorScheme,

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/transformProps.ts
@@ -16,15 +16,70 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps } from '@superset-ui/core';
+import {
+  ChartProps,
+  ensureIsArray,
+  getColumnLabel,
+  getMetricLabel,
+} from '@superset-ui/core';
+
+interface ChordData {
+  nodes: unknown[];
+  matrix: unknown[][];
+}
+
+/**
+ * Builds the symmetrical adjacency matrix that d3.chord expects, the way
+ * the legacy explore_json endpoint used to server-side: nodes are the
+ * union of source and target values, matrix[target][source] holds the
+ * metric value.
+ */
+function buildChordData(
+  records: Record<string, unknown>[],
+  sourceLabel: string,
+  targetLabel: string,
+  metricLabel: string,
+): ChordData {
+  const nodes = Array.from(
+    new Set(
+      records.flatMap(record => [record[sourceLabel], record[targetLabel]]),
+    ),
+  );
+  const values = new Map<unknown, Map<unknown, unknown>>();
+  records.forEach(record => {
+    const source = record[sourceLabel];
+    if (!values.has(source)) {
+      values.set(source, new Map());
+    }
+    values.get(source)!.set(record[targetLabel], record[metricLabel]);
+  });
+  return {
+    nodes,
+    matrix: nodes.map(target =>
+      nodes.map(source => values.get(source)?.get(target) ?? 0),
+    ),
+  };
+}
 
 export default function transformProps(chartProps: ChartProps) {
   const { width, height, formData, queriesData } = chartProps;
-  const { yAxisFormat, colorScheme, sliceId } = formData;
+  const { yAxisFormat, colorScheme, sliceId, groupby, columns, metric } =
+    formData;
+
+  const rawData = queriesData[0].data;
+  const data = Array.isArray(rawData)
+    ? buildChordData(
+        rawData,
+        getColumnLabel(ensureIsArray(groupby)[0]),
+        getColumnLabel(ensureIsArray(columns)[0]),
+        getMetricLabel(metric),
+      )
+    : // legacy explore_json payloads arrive pre-shaped
+      rawData;
 
   return {
     colorScheme,
-    data: queriesData[0].data,
+    data,
     height,
     numberFormat: yAxisFormat,
     width,

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/test/buildQuery.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import buildQuery from '../src/buildQuery';
+
+const formData: QueryFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  time_range: 'No filter',
+  viz_type: 'chord',
+  groupby: ['source_col'],
+  columns: ['target_col'],
+  metric: 'sum__value',
+};
+
+test('groups by source then target and selects the single metric', () => {
+  const [query] = buildQuery(formData).queries;
+  expect(query.columns).toEqual(['source_col', 'target_col']);
+  expect(query.metrics).toEqual(['sum__value']);
+  expect(query.orderby).toBeUndefined();
+});
+
+test('orders by the metric descending when sort_by_metric is on', () => {
+  const [query] = buildQuery({ ...formData, sort_by_metric: true }).queries;
+  expect(query.orderby).toEqual([['sum__value', false]]);
+});
+
+test('handles bare-string source/target as stored by the single-value controls', () => {
+  const [query] = buildQuery({
+    ...formData,
+    groupby: 'source_col',
+    columns: 'target_col',
+  } as unknown as QueryFormData).queries;
+  expect(query.columns).toEqual(['source_col', 'target_col']);
+});
+
+test('maps legacy granularity_sqla saved form data', () => {
+  const [query] = buildQuery(formData).queries;
+  expect(query.granularity).toEqual('ds');
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/test/transformProps.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/test/transformProps.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { supersetTheme } from '@apache-superset/core/theme';
+import { ChartProps } from '@superset-ui/core';
+import transformProps from '../src/transformProps';
+
+const baseChartProps = {
+  width: 800,
+  height: 600,
+  datasource: {},
+  theme: supersetTheme,
+  hooks: {},
+};
+
+const formData = {
+  groupby: 'source_col',
+  columns: 'target_col',
+  metric: 'sum__value',
+  yAxisFormat: '.2f',
+  colorScheme: 'd3Category10',
+  sliceId: 1,
+};
+
+test('builds the chord node list and matrix from v1 records', () => {
+  const chartProps = new ChartProps({
+    ...baseChartProps,
+    formData,
+    queriesData: [
+      {
+        data: [
+          { source_col: 'a', target_col: 'b', sum__value: 10 },
+          { source_col: 'b', target_col: 'a', sum__value: 5 },
+          { source_col: 'a', target_col: 'c', sum__value: 2 },
+        ],
+      },
+    ],
+  });
+  const { data } = transformProps(chartProps) as {
+    data: { nodes: string[]; matrix: number[][] };
+  };
+  expect(data.nodes).toEqual(['a', 'b', 'c']);
+  // matrix[targetIndex][sourceIndex], matching the legacy backend layout
+  expect(data.matrix).toEqual([
+    [0, 5, 0], // into a: from a, b, c
+    [10, 0, 0], // into b
+    [2, 0, 0], // into c
+  ]);
+});
+
+test('keeps the last value for duplicate source/target pairs', () => {
+  const chartProps = new ChartProps({
+    ...baseChartProps,
+    formData,
+    queriesData: [
+      {
+        data: [
+          { source_col: 'a', target_col: 'b', sum__value: 1 },
+          { source_col: 'a', target_col: 'b', sum__value: 9 },
+        ],
+      },
+    ],
+  });
+  const { data } = transformProps(chartProps) as {
+    data: { nodes: string[]; matrix: number[][] };
+  };
+  expect(data.matrix[1][0]).toEqual(9);
+});
+
+test('passes through legacy pre-shaped payloads', () => {
+  const legacyPayload = { nodes: ['a'], matrix: [[0]] };
+  const chartProps = new ChartProps({
+    ...baseChartProps,
+    formData,
+    queriesData: [{ data: legacyPayload }],
+  });
+  const { data } = transformProps(chartProps) as { data: unknown };
+  expect(data).toEqual(legacyPayload);
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/test/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false
+  },
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*", "../types/**/*", "../../../types/**/*"]
+}


### PR DESCRIPTION
### SUMMARY

Tier 1 of #41714 (targets `remove-legacy-viz-pipeline`): migrate the **Chord Diagram (`chord`)** off `explore_json` onto `/api/v1/chart/data`.

- New `buildQuery.ts` mirroring the legacy `ChordViz.query_obj`: source (`groupby`) and target (`columns`) dimensions → query columns, single metric, metric-descending `orderby` when `sort_by_metric` is on.
- The d3.chord node list + symmetric adjacency matrix that `viz.py` built server-side is now built in `transformProps`, preserving the legacy `matrix[target][source]` orientation and last-write-wins duplicate handling. Legacy pre-shaped payloads pass through.
- `useLegacyApi: true` removed (and the "Legacy" tag dropped).
- **No DB migration**: `viz_type` unchanged; legacy `granularity_sqla`/`time_range` handled by `extractExtras` (covered by test).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change — same renderer, same data shape, different endpoint.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/legacy-plugin-chart-chord` — 7 Jest tests pinning query shape, matrix orientation, duplicate pair handling, bare-string vs array source/target form data, and legacy payload pass-through.
- Manual: open a saved Chord Diagram; network tab shows `POST /api/v1/chart/data`; rendering identical.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
