### PR TITLE
feat(rose): migrate rose chart to v1 chart data API

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
@@ -46,7 +46,16 @@ const legacyContributionOperator = (
  * and contribution as post-processing, flattened back into records for
  * transformProps to reshape.
  */
-export default function buildQuery(formData: QueryFormData) {
+export default function buildQuery(rawFormData: QueryFormData) {
+  // the legacy control emits 'absolute' where the v1 compare
+  // post-processing operation expects 'difference'
+  const formData: QueryFormData = {
+    ...rawFormData,
+    comparison_type:
+      rawFormData.comparison_type === 'absolute'
+        ? 'difference'
+        : rawFormData.comparison_type,
+  };
   return buildQueryContext(formData, baseQueryObject => {
     const queryObject = {
       ...baseQueryObject,

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  buildQueryContext,
+  ensureIsArray,
+  QueryFormData,
+} from '@superset-ui/core';
+import {
+  flattenOperator,
+  isTimeComparison,
+  pivotOperator,
+  resampleOperator,
+  rollingWindowOperator,
+  timeCompareOperator,
+  timeComparePivotOperator,
+} from '@superset-ui/chart-controls';
+import type { PostProcessingContribution } from '@superset-ui/core';
+
+/** The legacy `contribution` checkbox row-normalized the pivoted frame. */
+const legacyContributionOperator = (
+  formData: QueryFormData,
+): PostProcessingContribution | undefined =>
+  formData.contribution
+    ? { operation: 'contribution', options: { orientation: 'row' } }
+    : undefined;
+
+/**
+ * Mirrors the legacy NVD3TimeSeriesViz pipeline the rose chart rode on:
+ * pivot on the timestamp, then resample, rolling window, time compare
+ * and contribution as post-processing, flattened back into records for
+ * transformProps to reshape.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  return buildQueryContext(formData, baseQueryObject => {
+    const queryObject = {
+      ...baseQueryObject,
+      is_timeseries: true,
+      time_offsets: isTimeComparison(formData, baseQueryObject)
+        ? ensureIsArray(formData.time_compare)
+        : [],
+    };
+    return [
+      {
+        ...queryObject,
+        post_processing: [
+          isTimeComparison(formData, queryObject)
+            ? timeComparePivotOperator(formData, queryObject)
+            : pivotOperator(formData, queryObject),
+          resampleOperator(formData, queryObject),
+          rollingWindowOperator(formData, queryObject),
+          timeCompareOperator(formData, queryObject),
+          legacyContributionOperator(formData),
+          flattenOperator(formData, queryObject),
+        ],
+      },
+    ];
+  });
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/index.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/index.ts
@@ -38,7 +38,6 @@ const metadata = new ChartMetadata({
   ],
   name: t('Nightingale Rose Chart'),
   tags: [
-    t('Legacy'),
     t('Advanced-Analytics'),
     t('Circular'),
     t('Multi-Layers'),
@@ -48,13 +47,13 @@ const metadata = new ChartMetadata({
   ],
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
 });
 
 export default class RoseChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('./ReactRose'),
+      loadBuildQuery: () => import('./buildQuery'),
       metadata,
       transformProps,
       controlPanel,

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformData.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformData.ts
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { DTTM_ALIAS } from '@superset-ui/core';
+
+export interface RoseEntry {
+  key: string | string[];
+  value: number;
+  name: string | string[];
+  time: unknown;
+}
+
+export type RoseData = Record<string, RoseEntry[]>;
+
+/** Splits a flattened pivot column label on ", " honoring "\," escapes. */
+export const splitFlatLabel = (label: string): string[] =>
+  label.split(/(?<!\\), /).map(part => part.replace(/\\,/g, ','));
+
+interface SeriesKeyOptions {
+  metricLabels: string[];
+  timeCompare: string[];
+  comparisonType?: string;
+}
+
+/**
+ * Recovers the legacy to_series key for a flattened pivot column:
+ * the metric is dropped from grouped single-metric keys, time-shifted
+ * columns get the legacy "<offset> offset" suffix, and comparison
+ * columns (difference__m__m__offset) collapse to the same suffix form.
+ */
+export const seriesKeyOf = (
+  parts: string[],
+  { metricLabels, timeCompare, comparisonType }: SeriesKeyOptions,
+): string | string[] | null => {
+  const [head, ...groups] = parts;
+  const hasGroup = groups.length > 0;
+  const singleMetric = metricLabels.length === 1;
+
+  const baseKey = (metric: string): string | string[] => {
+    if (!hasGroup) {
+      return metric;
+    }
+    return singleMetric ? groups : [metric, ...groups];
+  };
+
+  if (comparisonType && comparisonType !== 'values') {
+    // head looks like `${comparisonType}__${metric}__${metric}__${offset}`
+    const prefix = `${comparisonType}__`;
+    if (!head.startsWith(prefix)) {
+      return null; // originals are dropped in comparison mode
+    }
+    const rest = head.slice(prefix.length);
+    const metric = metricLabels.find(label =>
+      rest.startsWith(`${label}__${label}__`),
+    );
+    if (!metric) {
+      return null;
+    }
+    const offset = rest.slice(metric.length * 2 + 4);
+    const base = baseKey(metric);
+    const suffix = `${offset} offset`;
+    return Array.isArray(base) ? [...base, suffix] : [base, suffix];
+  }
+
+  // values mode: time-shifted columns are named `${metric}__${offset}`
+  for (const metric of metricLabels) {
+    for (const offset of timeCompare) {
+      if (head === `${metric}__${offset}`) {
+        const base = baseKey(metric);
+        const suffix = `${offset} offset`;
+        return Array.isArray(base) ? [...base, suffix] : [base, suffix];
+      }
+    }
+  }
+  return baseKey(head);
+};
+
+/**
+ * Ports the legacy RoseViz.get_data reshape: the pivoted series are
+ * re-keyed by timestamp, one entry per series with NaN collapsed to 0.
+ */
+export default function transformData(
+  records: Record<string, unknown>[],
+  options: SeriesKeyOptions,
+): RoseData {
+  const columns = new Set<string>();
+  records.forEach(record => {
+    Object.keys(record).forEach(column => {
+      if (column !== DTTM_ALIAS) {
+        columns.add(column);
+      }
+    });
+  });
+
+  const series: { key: string | string[]; column: string }[] = [];
+  columns.forEach(column => {
+    const key = seriesKeyOf(splitFlatLabel(column), options);
+    if (key != null) {
+      series.push({ key, column });
+    }
+  });
+  // legacy sort_series=False sorts the series by key
+  series.sort((a, b) => {
+    const aKey = Array.isArray(a.key) ? a.key.join(' ') : a.key;
+    const bKey = Array.isArray(b.key) ? b.key.join(' ') : b.key;
+    if (aKey === bKey) return 0;
+    return aKey < bKey ? -1 : 1;
+  });
+
+  const sorted = [...records].sort((a, b) => {
+    const aTime = a[DTTM_ALIAS] as number;
+    const bTime = b[DTTM_ALIAS] as number;
+    return aTime === bTime ? 0 : aTime < bTime ? -1 : 1;
+  });
+
+  const result: RoseData = {};
+  sorted.forEach(record => {
+    const timestamp = record[DTTM_ALIAS] as number;
+    const entries: RoseEntry[] = series.map(({ key, column }) => {
+      const raw = record[column];
+      const value = typeof raw === 'number' && !Number.isNaN(raw) ? raw : 0;
+      return { key, value, name: key, time: timestamp };
+    });
+    result[String(timestamp)] = entries;
+  });
+  return result;
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformProps.ts
@@ -47,7 +47,8 @@ export default function transformProps(chartProps: ChartProps) {
           getMetricLabel,
         ),
         timeCompare: ensureIsArray(timeCompare),
-        comparisonType,
+        comparisonType:
+          comparisonType === 'absolute' ? 'difference' : comparisonType,
       })
     : rawData;
 

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/transformProps.ts
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps } from '@superset-ui/core';
+import {
+  ChartProps,
+  ensureIsArray,
+  getMetricLabel,
+  QueryFormMetric,
+} from '@superset-ui/core';
+import transformData from './transformData';
 
 export default function transformProps(chartProps: ChartProps) {
   const { width, height, formData, queriesData } = chartProps;
@@ -27,12 +33,28 @@ export default function transformProps(chartProps: ChartProps) {
     richTooltip,
     roseAreaProportion,
     sliceId,
+    metrics,
+    timeCompare,
+    comparisonType,
   } = formData;
+
+  // v1 responses arrive as flattened pivot records; the legacy
+  // explore_json endpoint delivered the timestamp-keyed shape directly.
+  const rawData = queriesData[0].data;
+  const data = Array.isArray(rawData)
+    ? transformData(rawData, {
+        metricLabels: ensureIsArray(metrics as QueryFormMetric[]).map(
+          getMetricLabel,
+        ),
+        timeCompare: ensureIsArray(timeCompare),
+        comparisonType,
+      })
+    : rawData;
 
   return {
     width,
     height,
-    data: queriesData[0].data,
+    data,
     colorScheme,
     dateTimeFormat,
     numberFormat,

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import buildQuery from '../src/buildQuery';
+
+const formData: QueryFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  time_grain_sqla: 'P1D',
+  time_range: '2023 : 2024',
+  viz_type: 'rose',
+  groupby: ['gender'],
+  metrics: ['sum__num'],
+};
+
+test('builds a pivot + flatten post-processing pipeline', () => {
+  const [query] = buildQuery(formData).queries;
+  const operations = (query.post_processing || [])
+    .filter(Boolean)
+    .map(op => op!.operation);
+  expect(operations).toEqual(['pivot', 'flatten']);
+  expect(query.is_timeseries).toBe(true);
+  expect(query.time_offsets).toEqual([]);
+});
+
+test('adds rolling, resample and contribution operators when configured', () => {
+  const [query] = buildQuery({
+    ...formData,
+    rolling_type: 'mean',
+    rolling_periods: 7,
+    resample_rule: '1D',
+    resample_method: 'ffill',
+    contribution: true,
+  }).queries;
+  const operations = (query.post_processing || [])
+    .filter(Boolean)
+    .map(op => op!.operation);
+  expect(operations).toEqual([
+    'pivot',
+    'resample',
+    'rolling',
+    'contribution',
+    'flatten',
+  ]);
+});
+
+test('requests time offsets and compares when time_compare is set', () => {
+  const [query] = buildQuery({
+    ...formData,
+    time_compare: ['1 week ago'],
+    comparison_type: 'difference',
+  }).queries;
+  expect(query.time_offsets).toEqual(['1 week ago']);
+  const operations = (query.post_processing || [])
+    .filter(Boolean)
+    .map(op => op!.operation);
+  expect(operations).toContain('compare');
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
@@ -60,6 +60,20 @@ test('adds rolling, resample and contribution operators when configured', () => 
   ]);
 });
 
+test('normalizes the legacy absolute comparison type to difference', () => {
+  const [query] = buildQuery({
+    ...formData,
+    time_compare: ['1 week ago'],
+    comparison_type: 'absolute',
+  }).queries;
+  const compare = (query.post_processing || [])
+    .filter(Boolean)
+    .find(op => op!.operation === 'compare');
+  expect((compare?.options as { compare_type?: string })?.compare_type).toEqual(
+    'difference',
+  );
+});
+
 test('requests time offsets and compares when time_compare is set', () => {
   const [query] = buildQuery({
     ...formData,

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/test/transformData.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/test/transformData.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import transformData, {
+  seriesKeyOf,
+  splitFlatLabel,
+} from '../src/transformData';
+
+const t1 = 1704067200000;
+const t2 = 1704153600000;
+
+test('re-keys flattened pivot records by timestamp with NaN as 0', () => {
+  const data = transformData(
+    [
+      { __timestamp: t1, 'sum__num, boy': 10, 'sum__num, girl': 20 },
+      { __timestamp: t2, 'sum__num, boy': 30, 'sum__num, girl': null },
+    ],
+    { metricLabels: ['sum__num'], timeCompare: [] },
+  );
+  expect(data[String(t1)]).toEqual([
+    { key: ['boy'], value: 10, name: ['boy'], time: t1 },
+    { key: ['girl'], value: 20, name: ['girl'], time: t1 },
+  ]);
+  expect(data[String(t2)][1]).toEqual({
+    key: ['girl'],
+    value: 0,
+    name: ['girl'],
+    time: t2,
+  });
+});
+
+test('keys ungrouped series by the metric name', () => {
+  const data = transformData([{ __timestamp: t1, sum__num: 5 }], {
+    metricLabels: ['sum__num'],
+    timeCompare: [],
+  });
+  expect(data[String(t1)]).toEqual([
+    { key: 'sum__num', value: 5, name: 'sum__num', time: t1 },
+  ]);
+});
+
+test('splits flattened labels honoring escaped commas', () => {
+  expect(splitFlatLabel('sum__num, CA\\, USA')).toEqual([
+    'sum__num',
+    'CA, USA',
+  ]);
+});
+
+test('labels time-shifted columns with the legacy offset suffix', () => {
+  expect(
+    seriesKeyOf(['sum__num__1 week ago', 'boy'], {
+      metricLabels: ['sum__num'],
+      timeCompare: ['1 week ago'],
+    }),
+  ).toEqual(['boy', '1 week ago offset']);
+  expect(
+    seriesKeyOf(['sum__num__1 week ago'], {
+      metricLabels: ['sum__num'],
+      timeCompare: ['1 week ago'],
+    }),
+  ).toEqual(['sum__num', '1 week ago offset']);
+});
+
+test('maps comparison columns and drops originals', () => {
+  const options = {
+    metricLabels: ['sum__num'],
+    timeCompare: ['1 week ago'],
+    comparisonType: 'difference',
+  };
+  expect(
+    seriesKeyOf(['difference__sum__num__sum__num__1 week ago', 'boy'], options),
+  ).toEqual(['boy', '1 week ago offset']);
+  expect(seriesKeyOf(['sum__num', 'boy'], options)).toBeNull();
+});
+
+test('keeps the metric in multi-metric grouped keys', () => {
+  expect(
+    seriesKeyOf(['count', 'boy'], {
+      metricLabels: ['count', 'sum__num'],
+      timeCompare: [],
+    }),
+  ).toEqual(['count', 'boy']);
+});


### PR DESCRIPTION
### SUMMARY

Tier 2 of #41714 (targets `remove-legacy-viz-pipeline`): migrate the **Nightingale Rose Chart (`rose`)** off `explore_json` onto `/api/v1/chart/data`.

Rose exposed the *full* legacy nvd3 line engine (resample, rolling windows, time comparison, contribution), so this migration leans on server-side `post_processing` for exact pandas semantics rather than re-implementing them in JS:

- `buildQuery.ts` attaches the pipeline `pivot → resample → rolling → compare → contribution → flatten` using the shared `@superset-ui/chart-controls` operators (plus a small local contribution factory, since the legacy boolean `contribution` control predates `contributionMode`), and requests `time_offsets` for time comparisons — the same approach the nvd3→ECharts migrations used.
- `transformProps` re-keys the flattened pivot records into the legacy `{timestamp: [{key, value, name, time}]}` shape: metric dropped from grouped single-metric keys, time-shifted (`m__1 week ago`) and comparison (`difference__m__m__1 week ago`) columns mapped to the legacy `"<offset> offset"` suffix, NaN collapsed to 0, series sorted by key.
- `useLegacyApi: true` removed.
- **No DB migration**: `viz_type` unchanged; legacy `granularity_sqla`/`time_range` handled by `extractExtras`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change — same renderer, same data shape, different endpoint.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/legacy-plugin-chart-rose` — 9 Jest tests (post-processing pipeline composition incl. rolling/resample/contribution/compare, flattened-label parsing with escaped commas, offset/comparison key mapping, NaN→0, timestamp re-keying).
- Manual: open a saved Nightingale Rose chart (incl. one with time shift / rolling window); network tab shows `POST /api/v1/chart/data`; rendering identical.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
