### PR TITLE
feat(partition): migrate partition chart to v1 chart data API

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/buildQuery.ts
@@ -26,26 +26,27 @@ import {
 } from '@superset-ui/core';
 
 /**
- * Mirrors the legacy PartitionViz.query_obj: a query grouped by all the
- * hierarchy levels, timeseries only when the time-series option needs
- * per-timestamp data, with the legacy sort-metric handling.
+ * Mirrors the legacy PartitionViz.query_obj (via NVD3TimeSeriesViz): a
+ * query grouped by all the hierarchy levels, timeseries only when the
+ * time-series option needs per-timestamp data, ordered by the sort
+ * metric (falling back to the first selected metric) ascending unless
+ * order_desc.
  */
 export default function buildQuery(formData: QueryFormData) {
   const { time_series_option, timeseries_limit_metric, order_desc } = formData;
   return buildQueryContext(formData, baseQueryObject => {
     let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
     const orderby: QueryFormOrderBy[] = [];
-    const sortByMetric = ensureIsArray(
-      timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
-    )[0];
+    const sortByMetric =
+      ensureIsArray(
+        timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
+      )[0] ?? metrics[0];
     if (sortByMetric) {
       const sortByLabel = getMetricLabel(sortByMetric);
       if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
         metrics = [...metrics, sortByMetric];
       }
-      if (order_desc) {
-        orderby.push([sortByMetric, !order_desc]);
-      }
+      orderby.push([sortByMetric, !order_desc]);
     }
     return [
       {

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/buildQuery.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  buildQueryContext,
+  ensureIsArray,
+  getMetricLabel,
+  QueryFormData,
+  QueryFormMetric,
+  QueryFormOrderBy,
+} from '@superset-ui/core';
+
+/**
+ * Mirrors the legacy PartitionViz.query_obj: a query grouped by all the
+ * hierarchy levels, timeseries only when the time-series option needs
+ * per-timestamp data, with the legacy sort-metric handling.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  const { time_series_option, timeseries_limit_metric, order_desc } = formData;
+  return buildQueryContext(formData, baseQueryObject => {
+    let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
+    const orderby: QueryFormOrderBy[] = [];
+    const sortByMetric = ensureIsArray(
+      timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
+    )[0];
+    if (sortByMetric) {
+      const sortByLabel = getMetricLabel(sortByMetric);
+      if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
+        metrics = [...metrics, sortByMetric];
+      }
+      if (order_desc) {
+        orderby.push([sortByMetric, !order_desc]);
+      }
+    }
+    return [
+      {
+        ...baseQueryObject,
+        metrics,
+        is_timeseries: (time_series_option ?? 'not_time') !== 'not_time',
+        orderby: orderby.length > 0 ? orderby : undefined,
+      },
+    ];
+  });
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/index.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/index.ts
@@ -30,16 +30,16 @@ const metadata = new ChartMetadata({
   description: t('Compare the same summarized metric across multiple groups.'),
   exampleGallery: [{ url: example, urlDark: exampleDark }],
   name: t('Partition Chart'),
-  tags: [t('Categorical'), t('Comparison'), t('Legacy'), t('Proportional')],
+  tags: [t('Categorical'), t('Comparison'), t('Proportional')],
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
 });
 
 export default class PartitionChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('./ReactPartition'),
+      loadBuildQuery: () => import('./buildQuery'),
       metadata,
       transformProps,
       controlPanel,

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformData.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformData.ts
@@ -280,7 +280,12 @@ function nestProcs(
             metric,
             ...groups.slice(0, level).map(label => row[label]),
           ]);
-          tuples.set(key, [...(tuples.get(key) ?? []), row]);
+          const bucket = tuples.get(key);
+          if (bucket) {
+            bucket.push(row);
+          } else {
+            tuples.set(key, [row]);
+          }
         });
         tuples.forEach((rows, key) => columns.set(key, rows));
       }
@@ -362,6 +367,9 @@ export default function transformData(
   } = options;
   if (groupbyLabels.length === 0) {
     throw new Error('Please choose at least one groupby');
+  }
+  if (records.length === 0) {
+    return []; // the legacy endpoint returned no data for an empty frame
   }
   if (timeSeriesOption === 'not_time' || timeSeriesOption === 'agg_sum') {
     return nestAggregates(records, groupbyLabels, metricLabels, 'sum');

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformData.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformData.ts
@@ -1,0 +1,394 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { DTTM_ALIAS } from '@superset-ui/core';
+
+export interface PartitionNode {
+  name: unknown;
+  val?: number | null;
+  children: PartitionNode[];
+}
+
+type Row = Record<string, unknown>;
+
+interface Options {
+  groupbyLabels: string[];
+  metricLabels: string[];
+  timeSeriesOption?: string;
+  rollingType?: string;
+  rollingPeriods?: number;
+  minPeriods?: number;
+  contribution?: boolean;
+}
+
+const numeric = (value: unknown): number | null =>
+  typeof value === 'number' && !Number.isNaN(value) ? value : null;
+
+const sortedUnique = (values: unknown[]): unknown[] =>
+  Array.from(new Set(values)).sort((a, b) => {
+    if (a === b) return 0;
+    if (typeof a === 'number' && typeof b === 'number') return a - b;
+    return String(a) < String(b) ? -1 : 1;
+  });
+
+/** pandas-style aggregate: sum skips nulls, mean of nothing is null */
+const aggregate = (rows: Row[], metric: string, op: 'sum' | 'mean') => {
+  let total = 0;
+  let count = 0;
+  rows.forEach(row => {
+    const value = numeric(row[metric]);
+    if (value != null) {
+      total += value;
+      count += 1;
+    }
+  });
+  if (op === 'mean') {
+    return count === 0 ? null : total / count;
+  }
+  return total;
+};
+
+/**
+ * Ports PartitionViz.levels_for + nest_values: aggregate each metric at
+ * every prefix of the group hierarchy and nest the values top-down. The
+ * `groups` list may include the timestamp column for the plain
+ * time-series option, exactly like the backend prepended DTTM_ALIAS.
+ */
+function nestAggregates(
+  records: Row[],
+  groups: string[],
+  metricLabels: string[],
+  op: 'sum' | 'mean',
+): PartitionNode[] {
+  const nest = (
+    metric: string,
+    rows: Row[],
+    level: number,
+    dims: unknown[],
+  ): PartitionNode[] => {
+    if (level > groups.length - 1) {
+      return [];
+    }
+    const column = groups[level];
+    return sortedUnique(rows.map(row => row[column])).map(value => {
+      const subset = rows.filter(row => row[column] === value);
+      return {
+        // deeper levels carry the dim path in the name, like the backend
+        name: level === 0 ? value : [...dims, value],
+        val: aggregate(subset, metric, op),
+        children: nest(metric, subset, level + 1, [...dims, value]),
+      };
+    });
+  };
+  return metricLabels.map(metric => ({
+    name: metric,
+    val: aggregate(records, metric, op),
+    children: nest(metric, records, 0, []),
+  }));
+}
+
+/**
+ * Ports PartitionViz.levels_for_diff + nest_values: compare the last
+ * time grain against the first one at every hierarchy prefix.
+ */
+function nestPointComparison(
+  records: Row[],
+  groups: string[],
+  metricLabels: string[],
+  timeOp: 'point_diff' | 'point_factor' | 'point_percent',
+): PartitionNode[] {
+  const times = sortedUnique(records.map(row => row[DTTM_ALIAS])) as number[];
+  const since = times[0];
+  const until = times[times.length - 1];
+
+  // top-level comparison has no fill: a plain a-b / a/b / a/b-1
+  const topCompare = (a: number, b: number) => {
+    if (timeOp === 'point_diff') return a - b;
+    if (timeOp === 'point_factor') return a / b;
+    return a / b - 1;
+  };
+  // grouped comparisons treat missing sides as 0 (pandas fill_value=0)
+  const groupedCompare = (a: number | null, b: number | null) => {
+    const u = a ?? 0;
+    const s = b ?? 0;
+    if (timeOp === 'point_diff') return u - s;
+    if (timeOp === 'point_factor') return u / s;
+    return u / s - 1;
+  };
+
+  const nest = (
+    metric: string,
+    rows: Row[],
+    level: number,
+    dims: unknown[],
+  ): PartitionNode[] => {
+    if (level > groups.length - 1) {
+      return [];
+    }
+    const column = groups[level];
+    return sortedUnique(rows.map(row => row[column])).map(value => {
+      const subset = rows.filter(row => row[column] === value);
+      const untilRows = subset.filter(row => row[DTTM_ALIAS] === until);
+      const sinceRows = subset.filter(row => row[DTTM_ALIAS] === since);
+      const untilValue = untilRows.length
+        ? aggregate(untilRows, metric, 'sum')
+        : null;
+      const sinceValue = sinceRows.length
+        ? aggregate(sinceRows, metric, 'sum')
+        : null;
+      return {
+        name: level === 0 ? value : [...dims, value],
+        val: groupedCompare(untilValue, sinceValue),
+        children: nest(metric, subset, level + 1, [...dims, value]),
+      };
+    });
+  };
+
+  return metricLabels.map(metric => {
+    const untilTotal = aggregate(
+      records.filter(row => row[DTTM_ALIAS] === until),
+      metric,
+      'sum',
+    ) as number;
+    const sinceTotal = aggregate(
+      records.filter(row => row[DTTM_ALIAS] === since),
+      metric,
+      'sum',
+    ) as number;
+    return {
+      name: metric,
+      val: topCompare(untilTotal, sinceTotal),
+      children: nest(metric, records, 0, []),
+    };
+  });
+}
+
+/** apply_rolling equivalent over a time-indexed value list */
+function applyRolling(
+  values: (number | null)[],
+  rollingType: string | undefined,
+  rollingPeriods: number,
+  minPeriods: number,
+): (number | null)[] {
+  let result = values;
+  if (
+    rollingType &&
+    ['mean', 'sum', 'std'].includes(rollingType) &&
+    rollingPeriods
+  ) {
+    result = values.map((_, index) => {
+      const start = Math.max(0, index - rollingPeriods + 1);
+      const window = values
+        .slice(start, index + 1)
+        .filter((v): v is number => v != null);
+      if (window.length < Math.max(minPeriods, 1)) {
+        return null;
+      }
+      const sum = window.reduce((acc, v) => acc + v, 0);
+      if (rollingType === 'sum') return sum;
+      const mean = sum / window.length;
+      if (rollingType === 'mean') return mean;
+      if (window.length < 2) return null;
+      const variance =
+        window.reduce((acc, v) => acc + (v - mean) ** 2, 0) /
+        (window.length - 1);
+      return Math.sqrt(variance);
+    });
+  } else if (rollingType === 'cumsum') {
+    let running = 0;
+    result = values.map(value => {
+      running += value ?? 0;
+      return running;
+    });
+  }
+  return result;
+}
+
+/**
+ * Ports PartitionViz.levels_for_time + nest_procs for the "period
+ * analysis" option: pivot each hierarchy prefix per timestamp (sum,
+ * missing filled with 0), apply the rolling window and contribution the
+ * way process_data did, and nest as metric -> time -> group levels.
+ */
+function nestProcs(
+  records: Row[],
+  groups: string[],
+  options: Options,
+): PartitionNode[] {
+  const {
+    metricLabels,
+    rollingType,
+    rollingPeriods = 0,
+    minPeriods = 0,
+    contribution,
+  } = options;
+  const allTimes = sortedUnique(records.map(row => row[DTTM_ALIAS]));
+  // rolling windows may trim the leading periods
+  const times = minPeriods ? allTimes.slice(minPeriods) : allTimes;
+
+  // value series per (level, metric, group tuple)
+  const seriesFor = (
+    metric: string,
+    rows: Row[],
+  ): Map<unknown, number | null> => {
+    const perTime = new Map<unknown, number | null>();
+    allTimes.forEach(time => {
+      const timeRows = rows.filter(row => row[DTTM_ALIAS] === time);
+      // pivot fill_value=0: missing combinations become 0
+      perTime.set(
+        time,
+        timeRows.length ? aggregate(timeRows, metric, 'sum') : 0,
+      );
+    });
+    let values: (number | null)[] = allTimes.map(
+      time => perTime.get(time) ?? 0,
+    );
+    values = applyRolling(values, rollingType, rollingPeriods, minPeriods);
+    const result = new Map<unknown, number | null>();
+    allTimes.forEach((time, index) => result.set(time, values[index]));
+    return result;
+  };
+
+  // contribution normalizes each timestamp across every column of the
+  // same level (all metric x group-tuple combinations)
+  const buildLevel = (
+    level: number,
+  ): Map<string, Map<unknown, number | null>> => {
+    const columns = new Map<string, Row[]>();
+    metricLabels.forEach(metric => {
+      if (level === 0) {
+        columns.set(JSON.stringify([metric]), records);
+      } else {
+        const tuples = new Map<string, Row[]>();
+        records.forEach(row => {
+          const key = JSON.stringify([
+            metric,
+            ...groups.slice(0, level).map(label => row[label]),
+          ]);
+          tuples.set(key, [...(tuples.get(key) ?? []), row]);
+        });
+        tuples.forEach((rows, key) => columns.set(key, rows));
+      }
+    });
+    const built = new Map<string, Map<unknown, number | null>>();
+    columns.forEach((rows, key) => {
+      built.set(key, seriesFor(JSON.parse(key)[0], rows));
+    });
+    if (contribution) {
+      allTimes.forEach(time => {
+        let total = 0;
+        built.forEach(series => {
+          total += series.get(time) ?? 0;
+        });
+        built.forEach(series => {
+          const value = series.get(time);
+          series.set(time, total === 0 ? null : (value ?? 0) / total);
+        });
+      });
+    }
+    return built;
+  };
+
+  const levels = groups.map((_, index) => buildLevel(index + 1));
+  const level0 = buildLevel(0);
+
+  const nest = (
+    metric: string,
+    level: number,
+    dims: unknown[],
+    time: unknown,
+  ): PartitionNode[] => {
+    if (level > groups.length) {
+      return [];
+    }
+    const built = levels[level - 1];
+    const wanted = [metric, ...dims];
+    const children: PartitionNode[] = [];
+    built.forEach((series, key) => {
+      const parts = JSON.parse(key) as unknown[];
+      if (
+        parts.length !== wanted.length + 1 ||
+        !wanted.every((part, index) => parts[index] === part)
+      ) {
+        return;
+      }
+      const name = parts[parts.length - 1];
+      children.push({
+        name,
+        val: series.get(time) ?? null,
+        children: nest(metric, level + 1, [...dims, name], time),
+      });
+    });
+    return children;
+  };
+
+  return metricLabels.map(metric => ({
+    name: metric,
+    children: times.map(time => ({
+      name: time,
+      val: level0.get(JSON.stringify([metric]))?.get(time) ?? null,
+      children: nest(metric, 1, [], time),
+    })),
+  }));
+}
+
+/**
+ * Ports the legacy PartitionViz.get_data dispatch across the
+ * time-series options.
+ */
+export default function transformData(
+  records: Row[],
+  options: Options,
+): PartitionNode[] {
+  const {
+    groupbyLabels,
+    metricLabels,
+    timeSeriesOption = 'not_time',
+  } = options;
+  if (groupbyLabels.length === 0) {
+    throw new Error('Please choose at least one groupby');
+  }
+  if (timeSeriesOption === 'not_time' || timeSeriesOption === 'agg_sum') {
+    return nestAggregates(records, groupbyLabels, metricLabels, 'sum');
+  }
+  if (timeSeriesOption === 'agg_mean') {
+    return nestAggregates(records, groupbyLabels, metricLabels, 'mean');
+  }
+  if (
+    timeSeriesOption === 'point_diff' ||
+    timeSeriesOption === 'point_factor' ||
+    timeSeriesOption === 'point_percent'
+  ) {
+    return nestPointComparison(
+      records,
+      groupbyLabels,
+      metricLabels,
+      timeSeriesOption,
+    );
+  }
+  if (timeSeriesOption === 'adv_anal') {
+    return nestProcs(records, groupbyLabels, options);
+  }
+  // 'time_series': aggregate with the timestamp as the first level
+  return nestAggregates(
+    records,
+    [DTTM_ALIAS, ...groupbyLabels],
+    metricLabels,
+    'sum',
+  );
+}

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/transformProps.ts
@@ -16,7 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps } from '@superset-ui/core';
+import {
+  ChartProps,
+  ensureIsArray,
+  getColumnLabel,
+  getMetricLabel,
+  QueryFormMetric,
+} from '@superset-ui/core';
+import transformData from './transformData';
 
 export default function transformProps(chartProps: ChartProps) {
   const { width, height, datasource, formData, queriesData } = chartProps;
@@ -33,13 +40,34 @@ export default function transformProps(chartProps: ChartProps) {
     richTooltip,
     timeSeriesOption,
     sliceId,
+    rollingType,
+    rollingPeriods,
+    minPeriods,
+    contribution,
   } = formData;
   const { verboseMap = {} } = datasource;
+
+  // v1 responses arrive as flat records; the legacy explore_json endpoint
+  // delivered the nested hierarchy directly.
+  const rawData = queriesData[0].data;
+  const data = Array.isArray(rawData)
+    ? transformData(rawData, {
+        groupbyLabels: ensureIsArray(groupby).map(getColumnLabel),
+        metricLabels: ensureIsArray(metrics as QueryFormMetric[]).map(
+          getMetricLabel,
+        ),
+        timeSeriesOption,
+        rollingType,
+        rollingPeriods: Number(rollingPeriods) || 0,
+        minPeriods: Number(minPeriods) || 0,
+        contribution: Boolean(contribution),
+      })
+    : rawData;
 
   return {
     width,
     height,
-    data: queriesData[0].data,
+    data,
     colorScheme,
     dateTimeFormat,
     equalDateSize,

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/buildQuery.test.ts
@@ -35,6 +35,15 @@ test('is not a timeseries query for the not-time option', () => {
   }).queries;
   expect(query.is_timeseries).toBe(false);
   expect(query.columns).toEqual(['gender', 'state']);
+  // defaults to ordering by the first metric ascending, like the legacy engine
+  expect(query.orderby).toEqual([['sum__num', true]]);
+});
+
+test('returns an empty hierarchy for empty results', () => {
+  // covered in transformData tests; ordering falls back even when
+  // order_desc flips the direction
+  const [query] = buildQuery({ ...formData, order_desc: true }).queries;
+  expect(query.orderby).toEqual([['sum__num', false]]);
 });
 
 test('is a timeseries query for time-based options', () => {

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/buildQuery.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormData } from '@superset-ui/core';
+import buildQuery from '../src/buildQuery';
+
+const formData: QueryFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  time_range: 'No filter',
+  viz_type: 'partition',
+  groupby: ['gender', 'state'],
+  metrics: ['sum__num'],
+};
+
+test('is not a timeseries query for the not-time option', () => {
+  const [query] = buildQuery({
+    ...formData,
+    time_series_option: 'not_time',
+  }).queries;
+  expect(query.is_timeseries).toBe(false);
+  expect(query.columns).toEqual(['gender', 'state']);
+});
+
+test('is a timeseries query for time-based options', () => {
+  const [query] = buildQuery({
+    ...formData,
+    time_series_option: 'point_diff',
+  }).queries;
+  expect(query.is_timeseries).toBe(true);
+});
+
+test('appends the sort metric like the legacy engine', () => {
+  const [query] = buildQuery({
+    ...formData,
+    timeseries_limit_metric: 'count',
+    order_desc: true,
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'count']);
+  expect(query.orderby).toEqual([['count', false]]);
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/transformData.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/transformData.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import transformData from '../src/transformData';
+
+const t1 = 1704067200000;
+const t2 = 1704153600000;
+
+const base = {
+  groupbyLabels: ['gender', 'state'],
+  metricLabels: ['sum__num'],
+};
+
+const records = [
+  { __timestamp: t1, gender: 'boy', state: 'CA', sum__num: 10 },
+  { __timestamp: t1, gender: 'boy', state: 'NY', sum__num: 20 },
+  { __timestamp: t1, gender: 'girl', state: 'CA', sum__num: 30 },
+  { __timestamp: t2, gender: 'boy', state: 'CA', sum__num: 40 },
+];
+
+test('builds the summed hierarchy for the not-time option', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'not_time',
+  });
+  expect(data).toHaveLength(1);
+  const root = data[0];
+  expect(root.name).toEqual('sum__num');
+  expect(root.val).toEqual(100);
+  expect(root.children.map(child => [child.name, child.val])).toEqual([
+    ['boy', 70],
+    ['girl', 30],
+  ]);
+  // deeper levels carry the dim path in the name
+  expect(
+    root.children[0].children.map(child => [child.name, child.val]),
+  ).toEqual([
+    [['boy', 'CA'], 50],
+    [['boy', 'NY'], 20],
+  ]);
+});
+
+test('averages instead of sums for agg_mean', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'agg_mean',
+  });
+  expect(data[0].val).toEqual(25);
+  expect(data[0].children[0].val).toBeCloseTo(70 / 3);
+});
+
+test('compares the last period against the first for point_diff', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'point_diff',
+  });
+  // until = t2 (40), since = t1 (60)
+  expect(data[0].val).toEqual(40 - 60);
+  const boy = data[0].children.find(child => child.name === 'boy')!;
+  expect(boy.val).toEqual(40 - 30);
+  // girl has no rows at t2 -> treated as 0
+  const girl = data[0].children.find(child => child.name === 'girl')!;
+  expect(girl.val).toEqual(0 - 30);
+});
+
+test('uses the timestamp as the first level for time_series', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'time_series',
+  });
+  expect(data[0].children.map(child => child.name)).toEqual([t1, t2]);
+  expect(data[0].children[0].val).toEqual(60);
+  expect(
+    data[0].children[0].children.map(child => [child.name, child.val]),
+  ).toEqual([
+    [[t1, 'boy'], 30],
+    [[t1, 'girl'], 30],
+  ]);
+});
+
+test('nests metric -> time -> groups for period analysis', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'adv_anal',
+  });
+  expect(data[0].name).toEqual('sum__num');
+  expect(data[0].val).toBeUndefined();
+  expect(data[0].children.map(child => [child.name, child.val])).toEqual([
+    [t1, 60],
+    [t2, 40],
+  ]);
+  const firstTime = data[0].children[0];
+  expect(firstTime.children.map(child => [child.name, child.val])).toEqual([
+    ['boy', 30],
+    ['girl', 30],
+  ]);
+  // missing combinations are pivot-filled with 0
+  const secondTime = data[0].children[1];
+  expect(secondTime.children.map(child => [child.name, child.val])).toEqual([
+    ['boy', 40],
+    ['girl', 0],
+  ]);
+});
+
+test('applies cumulative sums in period analysis', () => {
+  const data = transformData(records, {
+    ...base,
+    timeSeriesOption: 'adv_anal',
+    rollingType: 'cumsum',
+  });
+  expect(data[0].children.map(child => child.val)).toEqual([60, 100]);
+});
+
+test('normalizes each period when contribution is on', () => {
+  const data = transformData(records, {
+    ...base,
+    groupbyLabels: ['gender'],
+    timeSeriesOption: 'adv_anal',
+    contribution: true,
+  });
+  const firstTime = data[0].children[0];
+  expect(firstTime.children.map(child => child.val)).toEqual([0.5, 0.5]);
+});
+
+test('requires at least one groupby', () => {
+  expect(() => transformData(records, { ...base, groupbyLabels: [] })).toThrow(
+    'groupby',
+  );
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/transformData.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/transformData.test.ts
@@ -137,6 +137,12 @@ test('normalizes each period when contribution is on', () => {
   expect(firstTime.children.map(child => child.val)).toEqual([0.5, 0.5]);
 });
 
+test('returns an empty hierarchy for empty results', () => {
+  expect(
+    transformData([], { ...base, timeSeriesOption: 'point_diff' }),
+  ).toEqual([]);
+});
+
 test('requires at least one groupby', () => {
   expect(() => transformData(records, { ...base, groupbyLabels: [] })).toThrow(
     'groupby',


### PR DESCRIPTION
### SUMMARY

Tier 4 of #41714 (targets `remove-legacy-viz-pipeline`): migrate the **Partition Chart (`partition`)** off `explore_json` onto `/api/v1/chart/data`. This was the largest `viz.py` transform left.

- New `buildQuery.ts` mirroring `PartitionViz.query_obj`: grouped query, `is_timeseries` only for time-based options, legacy sort-metric append/orderby.
- `transformData` ports the full `get_data` dispatch:
  - `not_time`/`agg_sum`/`agg_mean` → `levels_for` + `nest_values` (summed/averaged hierarchy, dim-path names at deeper levels, sorted group indexes);
  - `time_series` → same nesting with the timestamp prepended as the first level;
  - `point_diff`/`point_factor`/`point_percent` → `levels_for_diff` (last vs first time grain, pandas `fill_value=0` semantics for grouped rows, plain arithmetic at the top level);
  - `adv_anal` → `levels_for_time` + `nest_procs` (per-timestamp pivot summed with missing combos filled as 0, rolling mean/sum/std/cumsum with `min_periods` trimming, contribution row-normalization per level).
- `useLegacyApi: true` removed (and the "Legacy" tag dropped).
- **No DB migration**: `viz_type` unchanged; legacy `granularity_sqla`/`time_range` handled by `extractExtras`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change — same renderer, same data shape, different endpoint.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/legacy-plugin-chart-partition` — 13 Jest tests covering every time-series option (hierarchy shape and values, mean vs sum, point comparisons incl. missing-side fill, timestamp-first nesting, period analysis with cumsum and contribution, groupby validation, query shapes).
- Manual: open a saved Partition Chart in each time-series mode; network tab shows `POST /api/v1/chart/data`; rendering identical.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
