### PR TITLE
feat(deck-multi): migrate deck_multi chart to the v1 chart data API

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
@@ -43,8 +43,28 @@ jest.mock('@superset-ui/core', () => ({
   ...jest.requireActual('@superset-ui/core'),
   SupersetClient: {
     get: jest.fn(),
+    post: jest.fn(),
   },
 }));
+
+// register stub buildQuery/transformProps for the layer types the tests use
+const { getChartBuildQueryRegistry, getChartTransformPropsRegistry } =
+  jest.requireActual('@superset-ui/core');
+['deck_scatter', 'deck_polygon'].forEach(vizType => {
+  getChartBuildQueryRegistry().registerValue(
+    vizType,
+    (formData: Record<string, unknown>) => ({
+      datasource: 'test_datasource',
+      queries: [{}],
+      form_data: formData,
+    }),
+  );
+  getChartTransformPropsRegistry().registerValue(vizType, () => ({
+    payload: {
+      data: { features: [], mapboxApiKey: 'test-key', metricLabels: [] },
+    },
+  }));
+});
 
 const mockStore = configureStore({
   reducer: {
@@ -128,6 +148,11 @@ const renderWithProviders = (component: React.ReactElement) =>
 describe('DeckMulti Autozoom Functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (SupersetClient.post as jest.Mock).mockResolvedValue({
+      json: {
+        result: [{ data: [] }],
+      },
+    });
     (SupersetClient.get as jest.Mock).mockResolvedValue({
       json: {
         data: {
@@ -451,6 +476,11 @@ describe('DeckMulti Autozoom Functionality', () => {
 describe('DeckMulti Component Rendering', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (SupersetClient.post as jest.Mock).mockResolvedValue({
+      json: {
+        result: [{ data: [] }],
+      },
+    });
     (SupersetClient.get as jest.Mock).mockResolvedValue({
       json: {
         data: {
@@ -498,16 +528,13 @@ describe('DeckMulti Component Rendering', () => {
 
     // Wait for child slice requests
     await waitFor(() => {
-      expect(SupersetClient.get).toHaveBeenCalled();
+      expect(SupersetClient.post).toHaveBeenCalled();
     });
 
     // Check that all requests include the dashboardId
-    const { calls } = (SupersetClient.get as jest.Mock).mock;
+    const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
-      const url = call[0].endpoint;
-      const urlParams = new URLSearchParams(url.split('?')[1]);
-      const formDataString = urlParams.get('form_data');
-      const formData = JSON.parse(formDataString || '{}');
+      const formData = call[0].jsonPayload?.form_data || {};
       expect(formData.dashboardId).toBe(123);
     });
   });
@@ -525,16 +552,13 @@ describe('DeckMulti Component Rendering', () => {
 
     // Wait for child slice requests
     await waitFor(() => {
-      expect(SupersetClient.get).toHaveBeenCalled();
+      expect(SupersetClient.post).toHaveBeenCalled();
     });
 
     // Check that requests don't include dashboardId
-    const { calls } = (SupersetClient.get as jest.Mock).mock;
+    const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
-      const url = call[0].endpoint;
-      const formData = JSON.parse(
-        new URLSearchParams(url.split('?')[1]).get('form_data') || '{}',
-      );
+      const formData = call[0].jsonPayload?.form_data || {};
       expect(formData.dashboardId).toBeUndefined();
     });
   });
@@ -553,16 +577,13 @@ describe('DeckMulti Component Rendering', () => {
 
     // Wait for child slice requests
     await waitFor(() => {
-      expect(SupersetClient.get).toHaveBeenCalled();
+      expect(SupersetClient.post).toHaveBeenCalled();
     });
 
     // Verify dashboardId is preserved with filters
-    const { calls } = (SupersetClient.get as jest.Mock).mock;
+    const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
-      const url = call[0].endpoint;
-      const formData = JSON.parse(
-        new URLSearchParams(url.split('?')[1]).get('form_data') || '{}',
-      );
+      const formData = call[0].jsonPayload?.form_data || {};
       expect(formData.dashboardId).toBe(456);
       expect(formData.extra_filters).toBeDefined();
     });
@@ -608,20 +629,12 @@ describe('DeckMulti Component Rendering', () => {
 
 test('includes parent_slice_id in child slice requests when parent has slice_id', async () => {
   jest.clearAllMocks();
-  const mockGet = jest.fn().mockResolvedValue({
+  const mockPost = jest.fn().mockResolvedValue({
     json: {
-      result: {
-        form_data: {
-          viz_type: 'deck_scatter',
-          datasource: '1__table',
-        },
-      },
-      data: {
-        features: [],
-      },
+      result: [{ data: [] }],
     },
   });
-  (SupersetClient.get as jest.Mock) = mockGet;
+  (SupersetClient.post as jest.Mock) = mockPost;
   const parentSliceId = 99;
   const dashboardId = 5;
 
@@ -637,39 +650,28 @@ test('includes parent_slice_id in child slice requests when parent has slice_id'
   renderWithProviders(<DeckMulti {...props} />);
 
   await waitFor(() => {
-    expect(mockGet).toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalled();
   });
 
   // Check that the child slice requests include parent_slice_id
-  const { calls } = mockGet.mock;
+  const { calls } = mockPost.mock;
   calls.forEach(call => {
-    const { endpoint } = call[0];
-    if (endpoint.includes('api/v1/explore/form_data')) {
-      const body = JSON.parse(call[0].body);
-      expect(body.form_data).toMatchObject({
-        dashboardId,
-        parent_slice_id: parentSliceId,
-      });
-    }
+    const formData = call[0].jsonPayload?.form_data || {};
+    expect(formData).toMatchObject({
+      dashboardId,
+      parent_slice_id: parentSliceId,
+    });
   });
 });
 
 test('includes parent_slice_id in embedded mode', async () => {
   jest.clearAllMocks();
-  const mockGet = jest.fn().mockResolvedValue({
+  const mockPost = jest.fn().mockResolvedValue({
     json: {
-      result: {
-        form_data: {
-          viz_type: 'deck_scatter',
-          datasource: '1__table',
-        },
-      },
-      data: {
-        features: [],
-      },
+      result: [{ data: [] }],
     },
   });
-  (SupersetClient.get as jest.Mock) = mockGet;
+  (SupersetClient.post as jest.Mock) = mockPost;
   const parentSliceId = 200;
   const dashboardId = 10;
 
@@ -686,36 +688,25 @@ test('includes parent_slice_id in embedded mode', async () => {
   renderWithProviders(<DeckMulti {...props} />);
 
   await waitFor(() => {
-    expect(mockGet).toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalled();
   });
 
   // Verify parent_slice_id is included in embedded mode
-  const { calls } = mockGet.mock;
+  const { calls } = mockPost.mock;
   calls.forEach(call => {
-    const { endpoint } = call[0];
-    if (endpoint.includes('api/v1/explore/form_data')) {
-      const body = JSON.parse(call[0].body);
-      expect(body.form_data.parent_slice_id).toBe(parentSliceId);
-    }
+    const formData = call[0].jsonPayload?.form_data || {};
+    expect(formData.parent_slice_id).toBe(parentSliceId);
   });
 });
 
 test('does not include parent_slice_id when parent has no slice_id', async () => {
   jest.clearAllMocks();
-  const mockGet = jest.fn().mockResolvedValue({
+  const mockPost = jest.fn().mockResolvedValue({
     json: {
-      result: {
-        form_data: {
-          viz_type: 'deck_scatter',
-          datasource: '1__table',
-        },
-      },
-      data: {
-        features: [],
-      },
+      result: [{ data: [] }],
     },
   });
-  (SupersetClient.get as jest.Mock) = mockGet;
+  (SupersetClient.post as jest.Mock) = mockPost;
 
   const props = {
     ...baseMockProps,
@@ -729,16 +720,13 @@ test('does not include parent_slice_id when parent has no slice_id', async () =>
   renderWithProviders(<DeckMulti {...props} />);
 
   await waitFor(() => {
-    expect(mockGet).toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalled();
   });
 
   // Verify parent_slice_id is not included when parent has no slice_id
-  const { calls } = mockGet.mock;
+  const { calls } = mockPost.mock;
   calls.forEach(call => {
-    const { endpoint } = call[0];
-    if (endpoint.includes('api/v1/explore/form_data')) {
-      const body = JSON.parse(call[0].body);
-      expect(body.form_data.parent_slice_id).toBeUndefined();
-    }
+    const formData = call[0].jsonPayload?.form_data || {};
+    expect(formData.parent_slice_id).toBeUndefined();
   });
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -412,7 +412,7 @@ const DeckMulti = (props: DeckMultiProps) => {
 
   const fetchSubslices = useCallback(
     (sliceIds: number[]) =>
-      Promise.all(
+      Promise.all<({ slice_id: number } & JsonObject) | null>(
         sliceIds.map(sliceId =>
           SupersetClient.get({ endpoint: `/api/v1/chart/${sliceId}` })
             .then(({ json }) => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -25,12 +25,15 @@ import { isEqual } from 'lodash-es';
 import { createSelector } from '@reduxjs/toolkit';
 import {
   AdhocFilter,
+  ChartProps,
   ContextMenuFilters,
   DataMask,
   Datasource,
   ensureIsArray,
   ExtraFormData,
   FilterState,
+  getChartBuildQueryRegistry,
+  getChartTransformPropsRegistry,
   HandlerFunction,
   isDefined,
   JsonObject,
@@ -41,14 +44,13 @@ import {
   getMapProviderMapStyle,
   usePrevious,
 } from '@superset-ui/core';
-import { styled } from '@apache-superset/core/theme';
+import { styled, useTheme } from '@apache-superset/core/theme';
 import { Layer } from '@deck.gl/core';
 
 import {
   DeckGLContainerHandle,
   DeckGLContainerStyledWrapper,
 } from '../DeckGLContainer';
-import { getExploreLongUrl } from '../utils/explore';
 import layerGenerators from '../layers';
 import fitViewport, { Viewport } from '../utils/fitViewport';
 import { getMapboxApiKey } from '../utils/mapbox';
@@ -105,6 +107,7 @@ const selectDataMask = createSelector(
 
 const DeckMulti = (props: DeckMultiProps) => {
   const containerRef = useRef<DeckGLContainerHandle>();
+  const theme = useTheme();
 
   const dataMask = useSelector(selectDataMask);
 
@@ -119,20 +122,21 @@ const DeckMulti = (props: DeckMultiProps) => {
     let viewport = { ...props.viewport };
 
     // Default to autozoom enabled for backward compatibility (undefined treated as true)
+    // legacy container payloads carried pre-merged features; the v1 path
+    // fetches every layer client-side, so there may be none here
+    const features = props.payload?.data?.features || {};
     if (props.formData.autozoom !== false) {
       const points = [
-        ...getPointsPolygon(props.payload.data.features.deck_polygon || []),
-        ...getPointsPath(props.payload.data.features.deck_path || []),
-        ...getPointsGrid(props.payload.data.features.deck_grid || []),
-        ...getPointsScatter(props.payload.data.features.deck_scatter || []),
-        ...getPointsContour(props.payload.data.features.deck_contour || []),
-        ...getPointsHeatmap(props.payload.data.features.deck_heatmap || []),
-        ...getPointsHex(props.payload.data.features.deck_hex || []),
-        ...getPointsArc(props.payload.data.features.deck_arc || []),
-        ...getPointsGeojson(props.payload.data.features.deck_geojson || []),
-        ...getPointsScreengrid(
-          props.payload.data.features.deck_screengrid || [],
-        ),
+        ...getPointsPolygon(features.deck_polygon || []),
+        ...getPointsPath(features.deck_path || []),
+        ...getPointsGrid(features.deck_grid || []),
+        ...getPointsScatter(features.deck_scatter || []),
+        ...getPointsContour(features.deck_contour || []),
+        ...getPointsHeatmap(features.deck_heatmap || []),
+        ...getPointsHex(features.deck_hex || []),
+        ...getPointsArc(features.deck_arc || []),
+        ...getPointsGeojson(features.deck_geojson || []),
+        ...getPointsScreengrid(features.deck_screengrid || []),
       ];
 
       if (props.formData && points.length > 0) {
@@ -296,31 +300,68 @@ const DeckMulti = (props: DeckMultiProps) => {
         },
       } as any as JsonObject & { slice_id: number };
 
-      const url = getExploreLongUrl(subsliceCopy.form_data, 'json');
-
-      if (url) {
-        SupersetClient.get({ endpoint: url })
-          .then(({ json }) => {
-            const layer = createLayerFromData(subsliceCopy, json);
+      const vizType = subsliceCopy.form_data.viz_type as string;
+      Promise.all([
+        getChartBuildQueryRegistry().get(vizType),
+        getChartTransformPropsRegistry().get(vizType),
+      ])
+        .then(([layerBuildQuery, layerTransformProps]) => {
+          if (
+            typeof layerBuildQuery !== 'function' ||
+            typeof layerTransformProps !== 'function'
+          ) {
+            throw new Error(`Unknown deck.gl layer type: ${vizType}`);
+          }
+          const queryContext = layerBuildQuery(
+            subsliceCopy.form_data as QueryFormData,
+          );
+          return SupersetClient.post({
+            endpoint: '/api/v1/chart/data',
+            jsonPayload: {
+              ...queryContext,
+              result_format: 'json',
+              result_type: 'full',
+            },
+          }).then(({ json }) => {
+            const chartProps = new ChartProps({
+              width: props.width,
+              height: props.height,
+              datasource: props.datasource as unknown as JsonObject,
+              formData: subsliceCopy.form_data,
+              queriesData: (json as JsonObject).result,
+              theme,
+              hooks: {},
+              initialValues: {},
+            });
+            const layerProps = layerTransformProps(chartProps) as JsonObject;
+            const layer = createLayerFromData(subsliceCopy, layerProps.payload);
             setSubSlicesLayers(subSlicesLayers => ({
               ...subSlicesLayers,
               [subsliceCopy.slice_id]: layer,
             }));
-          })
-          .catch(error => {
-            throw new Error(
-              `Error loading layer for slice ${subsliceCopy.slice_id}: ${error}`,
-            );
           });
-      }
+        })
+        .catch(error => {
+          throw new Error(
+            `Error loading layer for slice ${subsliceCopy.slice_id}: ${error}`,
+          );
+        });
     },
-    [getLayerIndex, processLayerFilters, createLayerFromData],
+    [
+      getLayerIndex,
+      processLayerFilters,
+      createLayerFromData,
+      props.width,
+      props.height,
+      props.datasource,
+      theme,
+    ],
   );
 
   const loadLayers = useCallback(
     (
       formData: QueryFormData,
-      payload: JsonObject,
+      slices: ({ slice_id: number } & JsonObject)[],
       visibleLayers?: number[],
     ): void => {
       setViewport(getAdjustedViewport());
@@ -338,7 +379,7 @@ const DeckMulti = (props: DeckMultiProps) => {
 
       const deckSlicesOrder = formData.deck_slices || [];
 
-      payload.data.slices.forEach(
+      slices.forEach(
         (subslice: { slice_id: number } & JsonObject, payloadIndex: number) => {
           if (visibleDeckLayers && Array.isArray(visibleDeckLayers)) {
             if (!visibleDeckLayers.includes(subslice.slice_id)) {
@@ -351,7 +392,7 @@ const DeckMulti = (props: DeckMultiProps) => {
       );
 
       const orderedSliceIds = deckSlicesOrder.filter((sliceId: number) => {
-        const subslice = payload.data.slices.find(
+        const subslice = slices.find(
           (s: { slice_id: number }) => s.slice_id === sliceId,
         );
         if (!subslice) return false;
@@ -369,6 +410,39 @@ const DeckMulti = (props: DeckMultiProps) => {
   const prevDeckSlices = usePrevious(props.formData.deck_slices);
   const prevVisibleLayersRedux = usePrevious(visibleDeckLayersFromRedux);
 
+  const fetchSubslices = useCallback(
+    (sliceIds: number[]) =>
+      Promise.all(
+        sliceIds.map(sliceId =>
+          SupersetClient.get({ endpoint: `/api/v1/chart/${sliceId}` })
+            .then(({ json }) => {
+              const result = (json as JsonObject).result || {};
+              let params: JsonObject = {};
+              try {
+                params = JSON.parse(result.params || '{}');
+              } catch {
+                params = {};
+              }
+              return {
+                slice_id: sliceId,
+                form_data: {
+                  ...params,
+                  slice_id: sliceId,
+                  viz_type: result.viz_type ?? params.viz_type,
+                },
+              };
+            })
+            .catch(() => null),
+        ),
+      ).then(slices =>
+        slices.filter(
+          (slice): slice is { slice_id: number } & JsonObject =>
+            slice !== null,
+        ),
+      ),
+    [],
+  );
+
   useEffect(() => {
     const { formData, payload } = props;
 
@@ -379,10 +453,19 @@ const DeckMulti = (props: DeckMultiProps) => {
     );
 
     if (deckSlicesChanged || visibilityFilterChanged) {
-      loadLayers(formData, payload, visibleDeckLayersFromRedux);
+      // legacy explore_json payloads already carried the subslice metadata
+      const legacySlices = payload?.data?.slices;
+      if (legacySlices) {
+        loadLayers(formData, legacySlices, visibleDeckLayersFromRedux);
+      } else {
+        fetchSubslices(ensureIsArray(formData.deck_slices) as number[]).then(
+          slices => loadLayers(formData, slices, visibleDeckLayersFromRedux),
+        );
+      }
     }
   }, [
     loadLayers,
+    fetchSubslices,
     prevDeckSlices,
     prevVisibleLayersRedux,
     visibleDeckLayersFromRedux,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/buildQuery.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/buildQuery.ts
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { buildQueryContext, QueryFormData } from '@superset-ui/core';
+
+/**
+ * The multi-layer chart issues no query of its own: every layer is a
+ * saved chart fetched client-side through its own buildQuery, exactly
+ * like the legacy DeckGLMultiLayer whose query_obj was empty.
+ */
+export default function buildQuery(formData: QueryFormData) {
+  return buildQueryContext(formData, () => []);
+}

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/index.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/index.ts
@@ -33,7 +33,6 @@ const metadata = new ChartMetadata({
   name: t('deck.gl Multiple Layers'),
   thumbnail,
   thumbnailDark,
-  useLegacyApi: true,
   tags: [t('deckGL'), t('Multi-Layers')],
 });
 
@@ -41,6 +40,7 @@ export default class MultiChartPlugin extends ChartPlugin {
   constructor() {
     super({
       loadChart: () => import('./Multi'),
+      loadBuildQuery: () => import('./buildQuery'),
       controlPanel,
       metadata,
       transformProps,

--- a/tests/unit_tests/charts/data/test_empty_query_context.py
+++ b/tests/unit_tests/charts/data/test_empty_query_context.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from superset.charts.schemas import ChartDataQueryContextSchema
+
+
+def test_query_context_schema_accepts_empty_queries(app_context: Any) -> None:
+    """
+    Charts that compose other charts (deck.gl Multiple Layers) issue no
+    query of their own: their buildQuery produces an empty ``queries``
+    list and every layer is fetched client-side. The schema must accept
+    that shape so the container chart can flow through /api/v1/chart/data,
+    and the processor must return an empty result list for it.
+    """
+    with patch(
+        "superset.common.query_context_factory.DatasourceDAO.get_datasource",
+        return_value=MagicMock(),
+    ):
+        query_context = ChartDataQueryContextSchema().load(
+            {
+                "datasource": {"id": 1, "type": "table"},
+                "queries": [],
+                "result_format": "json",
+                "result_type": "full",
+            }
+        )
+    assert query_context.queries == []


### PR DESCRIPTION
### SUMMARY

Tier 4 of #41714 (targets `remove-legacy-viz-pipeline`): migrate **deck.gl Multiple Layers (`deck_multi`)** off `explore_json` — the last `useLegacyApi` chart, and the last holdout in the deck.gl preset migration.

`deck_multi` depended on `explore_json` twice: the container query (whose `viz.py` class fetched every sub-slice server-side just to hand back metadata and merged features) and each per-layer data fetch. Both move client-side:

- New `Multi/buildQuery.ts` returns an **empty `queries` list** — the legacy `DeckGLMultiLayer.query_obj` was empty too; a new backend unit test pins that `ChartDataQueryContextSchema` accepts that shape.
- `Multi.tsx` fetches sub-slice metadata via `GET /api/v1/chart/<id>` (bounded by `deck_slices`), and loads each layer through its own registered `buildQuery` → `POST /api/v1/chart/data` → registered `transformProps`, whose output payload is exactly what the layer generators consume. Legacy container payloads (cached) still short-circuit the metadata fetch.
- Layer-scoped dashboard filtering (`layer_filter_scope`/`filter_data_mapping`), `dashboardId` and `parent_slice_id` propagation are unchanged — tests updated to assert them on the v1 POST payloads.
- Known minor behavior notes: initial autozoom falls back to the saved viewport when no pre-merged container features exist (bounds previously came from the container payload), and dashboard filter badges no longer aggregate child-layer applied-filter metadata (the legacy container merged it server-side).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change in layer rendering; see autozoom note above.

### TESTING INSTRUCTIONS

- `npm run test -- plugins/preset-chart-deckgl/src/Multi` — 30 tests pass (layer loading via registries, dashboardId/parent_slice_id propagation on POST payloads, layer visibility filtering, viewport handling).
- `pytest tests/unit_tests/charts/data/test_empty_query_context.py` — empty-queries context accepted.
- Manual: open a saved deck.gl Multiple Layers chart; network tab shows one `POST /api/v1/chart/data` per layer (no `/superset/explore_json/`); layer-scoped dashboard filters behave as before.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
