### PR TITLE
fix(dashboard): use theme colorBorder token for chart tile borders

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -23,7 +23,7 @@ import {
   within,
   screen,
 } from 'spec/helpers/testing-library';
-import { FeatureFlag } from '@superset-ui/core';
+import { addAlpha, FeatureFlag } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/theme';
 import {
   OPEN_FILTER_BAR_WIDTH,
@@ -585,6 +585,50 @@ test('should apply min-height to the top-level tab drop target so tabs can be dr
     {
       target: '.empty-droptarget',
     },
+  );
+});
+
+test('should render chart tiles with a theme-driven border at rest, see https://github.com/apache/superset/issues/41618', () => {
+  (useStoredSidebarWidth as jest.Mock).mockImplementation(() => [
+    100,
+    jest.fn(),
+  ]);
+  (fetchFaveStar as jest.Mock).mockReturnValue({ type: 'mock-action' });
+  (setActiveTab as jest.Mock).mockReturnValue({ type: 'mock-action' });
+
+  const { container } = render(<DashboardBuilder />, {
+    useRedux: true,
+    store: storeWithState({
+      ...mockState,
+      dashboardLayout: undoableDashboardLayout,
+    }),
+    useDnd: true,
+    useTheme: true,
+    useRouter: true,
+  });
+
+  // StyledDashboardContent (className "dashboard-content") owns the nested
+  // `.dashboard-component-chart-holder` CSS, so it's the element to assert
+  // style rules against, not the individual chart holder nodes it renders.
+  const dashboardContent = container.querySelector('.dashboard-content');
+
+  expect(dashboardContent).toHaveStyleRule(
+    'border',
+    `1px solid ${supersetTheme.colorBorder}`,
+    { target: '.dashboard-component-chart-holder' },
+  );
+  expect(dashboardContent).toHaveStyleRule(
+    'border-radius',
+    `${supersetTheme.borderRadius}px`,
+    { target: '.dashboard-component-chart-holder' },
+  );
+
+  // .fade-out no longer re-declares border/border-radius (it inherits the
+  // base rule above); it should still layer its own hairline box-shadow.
+  expect(dashboardContent).toHaveStyleRule(
+    'box-shadow',
+    `0 0 0 1px ${addAlpha(supersetTheme.colorBorder, 0.5)}`,
+    { target: '.dashboard-component-chart-holder.fade-out' },
   );
 });
 

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -317,6 +317,8 @@ const StyledDashboardContent = styled.div<{
       width: 100%;
       height: 100%;
       background-color: ${theme.dashboardTileBg ?? theme.colorBgContainer};
+      border: ${theme.dashboardTileBorder ?? `1px solid ${theme.colorBorder}`};
+      border-radius: ${theme.dashboardTileBorderRadius ?? theme.borderRadius}px;
       position: relative;
       padding: ${theme.sizeUnit * 4}px;
       box-sizing: border-box;
@@ -329,16 +331,12 @@ const StyledDashboardContent = styled.div<{
         box-shadow ${theme.motionDurationMid} ease-in-out;
 
       &.fade-in {
-        border-radius: ${theme.borderRadius}px;
         box-shadow:
           inset 0 0 0 2px ${theme.colorPrimary},
           0 0 0 3px ${addAlpha(theme.colorPrimary, 0.1)};
       }
 
       &.fade-out {
-        border: ${theme.dashboardTileBorder ?? 'none'};
-        border-radius: ${theme.dashboardTileBorderRadius ??
-        theme.borderRadius}px;
         box-shadow: ${theme.dashboardTileBoxShadow ??
         `0 0 0 1px ${addAlpha(theme.colorBorder, 0.5)}`};
       }


### PR DESCRIPTION
## SUMMARY
Chart tiles (\`.dashboard-component-chart-holder\`) never rendered a border at rest in any theme -- the only border declaration lived in the transient \`.fade-out\` state and defaulted to \`none\`. This moves \`border\`/\`border-radius\` to the base rule using the existing \`theme.dashboardTileBorder ?? colorBorder\` fallback pattern, mirroring the precedent set in #35199 for the header divider.

## BEFORE/AFTER
Before: no visible boundary between chart tiles or tile-to-canvas in any theme.
After: tiles render a 1px border using \`theme.colorBorder\` (or the \`dashboardTileBorder\` override if set), switching automatically with theme changes.

## TESTING INSTRUCTIONS
- \`npm run test -- src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx\` (28/28 pass, includes new test for this fix)
- Manually: open a dashboard, toggle a custom theme with a visible \`colorBorder\`, confirm tile boundaries render and the fade-in/fade-out filter-focus and resize effects still layer correctly on top.

## ADDITIONAL INFORMATION
- Fixes #41618
- Related PRs on this issue with open gaps at time of writing: #41661 (correct approach, failing pre-commit), #41699 (merge conflict, no tests)