### PR TITLE
fix(legacy-viz): restore line-engine default ordering for horizon and rose

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/src/buildQuery.ts
@@ -16,18 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { buildQueryContext, QueryFormData } from '@superset-ui/core';
+import {
+  buildQueryContext,
+  ensureIsArray,
+  QueryFormData,
+} from '@superset-ui/core';
 
 /**
- * Mirrors the legacy HorizonViz query: a plain timeseries query grouped
- * by the dimensions. Series limiting (the `limit` control) and
- * order_desc are handled by buildQueryObject.
+ * Mirrors the legacy HorizonViz query (via NVD3TimeSeriesViz): a
+ * timeseries query grouped by the dimensions, ordered by the first
+ * metric ascending unless order_desc. Series limiting (the `limit`
+ * control) is handled by buildQueryObject.
  */
 export default function buildQuery(formData: QueryFormData) {
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      is_timeseries: true,
-    },
-  ]);
+  const { order_desc } = formData;
+  return buildQueryContext(formData, baseQueryObject => {
+    const firstMetric = ensureIsArray(baseQueryObject.metrics)[0];
+    return [
+      {
+        ...baseQueryObject,
+        is_timeseries: true,
+        orderby: firstMetric ? [[firstMetric, !order_desc]] : undefined,
+      },
+    ];
+  });
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/test/buildQuery.test.ts
@@ -37,4 +37,11 @@ test('builds a grouped timeseries query with a series limit', () => {
   expect(query.is_timeseries).toBe(true);
   expect(query.series_limit).toEqual(25);
   expect(query.granularity).toEqual('ds');
+  // legacy engine default: order by the first metric ascending
+  expect(query.orderby).toEqual([['sum__num', true]]);
+});
+
+test('orders descending when order_desc is set', () => {
+  const [query] = buildQuery({ ...formData, order_desc: true }).queries;
+  expect(query.orderby).toEqual([['sum__num', false]]);
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/buildQuery.ts
@@ -57,9 +57,18 @@ export default function buildQuery(rawFormData: QueryFormData) {
         : rawFormData.comparison_type,
   };
   return buildQueryContext(formData, baseQueryObject => {
+    const firstMetric = ensureIsArray(baseQueryObject.metrics)[0];
     const queryObject = {
       ...baseQueryObject,
       is_timeseries: true,
+      // the legacy engine ordered by the first metric, ascending unless
+      // order_desc
+      orderby: firstMetric
+        ? ([[firstMetric, !formData.order_desc]] as [
+            typeof firstMetric,
+            boolean,
+          ][])
+        : undefined,
       time_offsets: isTimeComparison(formData, baseQueryObject)
         ? ensureIsArray(formData.time_compare)
         : [],

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/test/buildQuery.test.ts
@@ -29,6 +29,13 @@ const formData: QueryFormData = {
   metrics: ['sum__num'],
 };
 
+test('orders by the first metric like the legacy engine', () => {
+  const [query] = buildQuery(formData).queries;
+  expect(query.orderby).toEqual([['sum__num', true]]);
+  const [descQuery] = buildQuery({ ...formData, order_desc: true }).queries;
+  expect(descQuery.orderby).toEqual([['sum__num', false]]);
+});
+
 test('builds a pivot + flatten post-processing pipeline', () => {
   const [query] = buildQuery(formData).queries;
   const operations = (query.post_processing || [])


### PR DESCRIPTION
### SUMMARY

Follow-up to #41725/#41726 (targets `remove-legacy-viz-pipeline`): a bot review on the partition PR pointed out that the legacy line engine (`NVD3TimeSeriesViz.query_obj`) always ordered by the sort metric *or the first selected metric*, ascending unless `order_desc`. The horizon and rose buildQueries had dropped that default ordering, which changes which rows survive `row_limit` truncation. Restored, with tests pinning both directions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — query ordering parity only.

### TESTING INSTRUCTIONS

`npm run test -- plugins/legacy-plugin-chart-horizon plugins/legacy-plugin-chart-rose` — 18 tests pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
