### PR TITLE
fix(dashboard): apply auto-refresh interval in standalone mode

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -105,6 +105,15 @@ jest.mock('src/dashboard/containers/DashboardGrid', () => {
   MockDashboardGrid.displayName = 'MockDashboardGrid';
   return MockDashboardGrid;
 });
+// The real component renders null, so mock it with a visible marker to let
+// tests assert whether DashboardBuilder mounts it.
+jest.mock('src/dashboard/components/Header/HeadlessAutoRefresh', () => {
+  const MockHeadlessAutoRefresh = () => (
+    <div data-test="mock-headless-auto-refresh" />
+  );
+  MockHeadlessAutoRefresh.displayName = 'MockHeadlessAutoRefresh';
+  return MockHeadlessAutoRefresh;
+});
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardBuilder', () => {
@@ -177,6 +186,49 @@ describe('DashboardBuilder', () => {
       const { queryByTestId } = setup();
       expect(
         queryByTestId('dashboard-header-container'),
+      ).not.toBeInTheDocument();
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
+  test('should mount HeadlessAutoRefresh when the header is hidden (?standalone=2)', () => {
+    // Regression test for #25970: the auto-refresh timer lives in the header,
+    // so hiding the header must swap in the headless driver — reverting the
+    // conditional in DashboardBuilder would strand standalone dashboards with
+    // no refresh timer at all.
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=2');
+    try {
+      const { queryByTestId } = setup();
+      expect(queryByTestId('mock-headless-auto-refresh')).toBeInTheDocument();
+      expect(
+        queryByTestId('dashboard-header-container'),
+      ).not.toBeInTheDocument();
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
+  test('should not mount HeadlessAutoRefresh when the header is visible', () => {
+    const { queryByTestId } = setup();
+    expect(queryByTestId('dashboard-header-container')).toBeInTheDocument();
+    expect(queryByTestId('mock-headless-auto-refresh')).not.toBeInTheDocument();
+  });
+
+  test('should not start any auto-refresh in report mode (?standalone=3)', () => {
+    // Report mode drives one-shot screenshot renders (email reports,
+    // thumbnails); a live refresh timer there could re-fetch charts
+    // mid-capture, so neither the header nor the headless driver may mount.
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=3');
+    try {
+      const { queryByTestId } = setup();
+      expect(
+        queryByTestId('dashboard-header-container'),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByTestId('mock-headless-auto-refresh'),
       ).not.toBeInTheDocument();
     } finally {
       window.history.replaceState({}, '', originalHref);

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -516,7 +516,11 @@ const DashboardBuilder = () => {
   const headerContent = useMemo(
     () => (
       <>
-        {hideDashboardHeader ? <HeadlessAutoRefresh /> : <DashboardHeader />}
+        {!hideDashboardHeader && <DashboardHeader />}
+        {/* Report mode is a one-shot screenshot render (reports, thumbnails),
+            so it must never start a refresh timer that could re-fetch charts
+            mid-capture. */}
+        {hideDashboardHeader && !isReport && <HeadlessAutoRefresh />}
         {showFilterBar &&
           filterBarOrientation === FilterBarOrientation.Horizontal && (
             <FilterBar

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -27,6 +27,7 @@ import { EmptyState, Loading } from '@superset-ui/core/components';
 import { ErrorBoundary, BasicErrorAlert } from 'src/components';
 import BuilderComponentPane from 'src/dashboard/components/BuilderComponentPane';
 import DashboardHeader from 'src/dashboard/components/Header';
+import HeadlessAutoRefresh from 'src/dashboard/components/Header/HeadlessAutoRefresh';
 import { Icons } from '@superset-ui/core/components/Icons';
 import IconButton from 'src/dashboard/components/IconButton';
 import { Droppable } from 'src/dashboard/components/dnd/DragDroppable';
@@ -515,7 +516,7 @@ const DashboardBuilder = () => {
   const headerContent = useMemo(
     () => (
       <>
-        {!hideDashboardHeader && <DashboardHeader />}
+        {hideDashboardHeader ? <HeadlessAutoRefresh /> : <DashboardHeader />}
         {showFilterBar &&
           filterBarOrientation === FilterBarOrientation.Horizontal && (
             <FilterBar

--- a/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from 'spec/helpers/testing-library';
+import { AutoRefreshProvider } from 'src/dashboard/contexts/AutoRefreshContext';
+import HeadlessAutoRefresh from './HeadlessAutoRefresh';
+
+const mockUseHeaderAutoRefresh = jest.fn();
+
+jest.mock('./useHeaderAutoRefresh', () => ({
+  useHeaderAutoRefresh: (props: unknown) => {
+    mockUseHeaderAutoRefresh(props);
+    return {
+      forceRefresh: jest.fn(),
+      handlePauseToggle: jest.fn(),
+      autoRefreshPauseOnInactiveTab: false,
+      setPauseOnInactiveTab: jest.fn(),
+    };
+  },
+}));
+
+const initialState = {
+  dashboardInfo: {
+    id: 42,
+    metadata: { timed_refresh_immune_slices: [7] },
+    common: { conf: { DASHBOARD_AUTO_REFRESH_MODE: 'fetch' } },
+  },
+  dashboardState: {
+    refreshFrequency: 30,
+    sliceIds: [1, 2, 3],
+  },
+  charts: {
+    1: { id: 1, chartUpdateStartTime: 0, chartUpdateEndTime: 0 },
+    2: { id: 2, chartUpdateStartTime: 0, chartUpdateEndTime: 0 },
+  },
+};
+
+beforeEach(() => {
+  mockUseHeaderAutoRefresh.mockClear();
+});
+
+test('drives the auto-refresh hook from redux state without a header', () => {
+  const { container } = render(
+    <AutoRefreshProvider>
+      <HeadlessAutoRefresh />
+    </AutoRefreshProvider>,
+    { useRedux: true, initialState },
+  );
+
+  // The component renders nothing but must still start the refresh timer.
+  expect(container).toBeEmptyDOMElement();
+  expect(mockUseHeaderAutoRefresh).toHaveBeenCalledTimes(1);
+  expect(mockUseHeaderAutoRefresh).toHaveBeenCalledWith(
+    expect.objectContaining({
+      chartIds: [1, 2, 3],
+      dashboardId: 42,
+      refreshFrequency: 30,
+      timedRefreshImmuneSlices: [7],
+      autoRefreshMode: 'fetch',
+      isLoading: false,
+    }),
+  );
+});
+
+test('passes the redux refresh frequency through to the hook', () => {
+  render(
+    <AutoRefreshProvider>
+      <HeadlessAutoRefresh />
+    </AutoRefreshProvider>,
+    {
+      useRedux: true,
+      initialState: {
+        ...initialState,
+        dashboardState: { ...initialState.dashboardState, refreshFrequency: 0 },
+      },
+    },
+  );
+
+  expect(mockUseHeaderAutoRefresh).toHaveBeenCalledWith(
+    expect.objectContaining({ refreshFrequency: 0 }),
+  );
+});

--- a/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.test.tsx
@@ -73,6 +73,9 @@ test('drives the auto-refresh hook from redux state without a header', () => {
       timedRefreshImmuneSlices: [7],
       autoRefreshMode: 'fetch',
       isLoading: false,
+      onRefresh: expect.any(Function),
+      setRefreshFrequency: expect.any(Function),
+      logEvent: expect.any(Function),
     }),
   );
 });

--- a/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.tsx
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useMemo } from 'react';
+import { bindActionCreators } from 'redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'src/dashboard/types';
+import { useChartIds } from 'src/dashboard/util/charts/useChartIds';
+import { onRefresh, setRefreshFrequency } from '../../actions/dashboardState';
+import { logEvent } from '../../../logger/actions';
+import { useHeaderAutoRefresh } from './useHeaderAutoRefresh';
+
+/**
+ * Headless component that drives the dashboard auto-refresh timer when the
+ * dashboard header is not rendered (e.g. standalone mode or `hideTitle: true`
+ * in embedded dashboards). The auto-refresh logic lives in the header, so
+ * hiding the header would otherwise stop the refresh interval from ever
+ * starting. Rendering this component keeps the timer running independently of
+ * header visibility. It renders nothing.
+ */
+const HeadlessAutoRefresh = (): null => {
+  const dispatch = useDispatch();
+  const chartIds = useChartIds();
+  const dashboardId = useSelector((state: RootState) => state.dashboardInfo.id);
+  const refreshFrequency = useSelector(
+    (state: RootState) => state.dashboardState.refreshFrequency ?? 0,
+  );
+  const timedRefreshImmuneSlices = useSelector(
+    (state: RootState) =>
+      state.dashboardInfo.metadata?.timed_refresh_immune_slices || [],
+  );
+  const autoRefreshMode = useSelector(
+    (state: RootState) =>
+      state.dashboardInfo.common?.conf?.DASHBOARD_AUTO_REFRESH_MODE,
+  );
+  const isLoading = useSelector((state: RootState) =>
+    Object.values(state.charts).some(chart => {
+      const start = chart.chartUpdateStartTime ?? 0;
+      const end = chart.chartUpdateEndTime ?? 0;
+      return start > end;
+    }),
+  );
+
+  const boundActionCreators = useMemo(
+    () =>
+      bindActionCreators(
+        {
+          onRefresh,
+          setRefreshFrequency,
+          logEvent,
+        },
+        dispatch,
+      ),
+    [dispatch],
+  );
+
+  useHeaderAutoRefresh({
+    chartIds,
+    dashboardId,
+    refreshFrequency,
+    timedRefreshImmuneSlices,
+    autoRefreshMode,
+    isLoading,
+    onRefresh: boundActionCreators.onRefresh,
+    setRefreshFrequency: boundActionCreators.setRefreshFrequency,
+    logEvent: boundActionCreators.logEvent,
+  });
+
+  return null;
+};
+
+export default HeadlessAutoRefresh;

--- a/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeadlessAutoRefresh.tsx
@@ -40,9 +40,13 @@ const HeadlessAutoRefresh = (): null => {
   const refreshFrequency = useSelector(
     (state: RootState) => state.dashboardState.refreshFrequency ?? 0,
   );
-  const timedRefreshImmuneSlices = useSelector(
+  const immuneSlices = useSelector(
     (state: RootState) =>
-      state.dashboardInfo.metadata?.timed_refresh_immune_slices || [],
+      state.dashboardInfo.metadata?.timed_refresh_immune_slices,
+  );
+  const timedRefreshImmuneSlices = useMemo(
+    () => immuneSlices || [],
+    [immuneSlices],
   );
   const autoRefreshMode = useSelector(
     (state: RootState) =>


### PR DESCRIPTION
### SUMMARY

The dashboard auto-refresh timer is driven by the `useHeaderAutoRefresh` hook, and that hook only mounts inside the `DashboardHeader` component. When the header isn't rendered — standalone `HideNavAndTitle` mode, `?standalone=1` report rendering, or `hideTitle: true` in embedded dashboards — the hook never runs, so the configured refresh interval never starts and charts stop auto-refreshing.

This is the long-standing behavior reported in #25970: several folks noticed auto-refresh works with `standalone=1` but breaks with `standalone=2`/`HideNavAndTitle` or when `hideTitle` hides the header in the embedded SDK.

The fix decouples the refresh timer from header visibility. I added a small headless `HeadlessAutoRefresh` component that reads the same redux state the header uses (chart ids, refresh frequency, immune slices, auto-refresh mode, loading state) and runs the existing `useHeaderAutoRefresh` hook. In `DashboardBuilder`, when the header is hidden we render `HeadlessAutoRefresh` instead of `DashboardHeader`. Exactly one instance of the timer is ever live: the header when it's visible, the headless component when it isn't — so there's no risk of double-firing.

I intentionally reused the existing hook rather than duplicating the refresh logic, so pause/tab-visibility/immune-slice handling all keep working identically in both paths.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual change. The behavior change is that charts now keep refreshing on the configured interval even when the header is hidden.

### TESTING INSTRUCTIONS

1. Open a dashboard and set a refresh interval (e.g. "Set auto-refresh interval" → 10 seconds).
2. View it with the header hidden, using any of:
   - `?standalone=2` (hides nav and title)
   - the embedded SDK with `dashboardUiConfig: { hideTitle: true }`
3. Confirm the charts continue to auto-refresh on the interval. Previously they would never refresh.
4. Sanity check the normal (header-visible) case still auto-refreshes and the pause toggle still works.

Unit tests: `HeadlessAutoRefresh.test.tsx` verifies the component drives the auto-refresh hook from redux state (and renders nothing) when the header is absent.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #25970
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API