### PR TITLE
fix(ui): standardize card kebab menu behavior

### DIFF
--- a/superset-frontend/src/components/KebabMenuButton/KebabMenuButton.test.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/KebabMenuButton.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import type { MenuItem } from '@superset-ui/core/components/Menu';
+import { KebabMenuButton } from '.';
+
+const menuItems: MenuItem[] = [
+  {
+    key: 'edit',
+    label: 'Edit',
+  },
+  {
+    key: 'delete',
+    label: 'Delete',
+  },
+];
+
+test('opens the menu on click', async () => {
+  render(<KebabMenuButton menuItems={menuItems} />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'More Options' }));
+
+  expect(await screen.findByText('Edit')).toBeInTheDocument();
+  expect(screen.getByText('Delete')).toBeInTheDocument();
+});
+
+test('does not open the menu on hover', async () => {
+  render(<KebabMenuButton menuItems={menuItems} />);
+
+  await userEvent.hover(screen.getByRole('button', { name: 'More Options' }));
+
+  await waitFor(() => {
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+  });
+});
+
+test('sets accessibility and test attributes on the trigger button', () => {
+  render(
+    <KebabMenuButton
+      menuItems={menuItems}
+      ariaLabel="Open actions"
+      buttonId="actions-menu"
+      dataTest="actions-menu-trigger"
+    />,
+  );
+
+  const button = screen.getByRole('button', { name: 'Open actions' });
+  expect(button).toHaveAttribute('id', 'actions-menu');
+  expect(button).toHaveAttribute('aria-haspopup', 'true');
+  expect(button).toHaveAttribute('data-test', 'actions-menu-trigger');
+});
+
+test('renders a custom icon', () => {
+  render(
+    <KebabMenuButton
+      menuItems={menuItems}
+      icon={<span data-test="custom-menu-icon">Actions</span>}
+    />,
+  );
+
+  expect(screen.getByTestId('custom-menu-icon')).toBeInTheDocument();
+});
+
+test('renders a rotated vertical icon when requested', () => {
+  render(<KebabMenuButton menuItems={menuItems} iconOrientation="vertical" />);
+
+  const button = screen.getByRole('button', { name: 'More Options' });
+  expect(button.querySelector('[style*="rotate(90deg)"]')).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/KebabMenuButton/index.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ReactNode } from 'react';
+import {
+  Button,
+  Dropdown,
+  Icons,
+  type ButtonProps,
+  type DropdownProps,
+} from '@superset-ui/core/components';
+import type { MenuItem } from '@superset-ui/core/components/Menu';
+
+export interface KebabMenuButtonProps {
+  menuItems: MenuItem[];
+  icon?: ReactNode;
+  iconOrientation?: 'horizontal' | 'vertical';
+  ariaLabel?: string;
+  dataTest?: string;
+  buttonId?: string;
+  buttonSize?: ButtonProps['buttonSize'];
+  buttonStyle?: ButtonProps['buttonStyle'];
+  placement?: DropdownProps['placement'];
+  overlayStyle?: DropdownProps['overlayStyle'];
+}
+
+export function KebabMenuButton({
+  menuItems,
+  icon,
+  iconOrientation = 'horizontal',
+  ariaLabel = 'More Options',
+  dataTest,
+  buttonId,
+  buttonSize = 'xsmall',
+  buttonStyle = 'link',
+  placement,
+  overlayStyle,
+}: KebabMenuButtonProps) {
+  const defaultIcon =
+    iconOrientation === 'vertical' ? (
+      <Icons.EllipsisOutlined
+        iconSize="xl"
+        style={{ transform: 'rotate(90deg)' }}
+      />
+    ) : (
+      <Icons.MoreOutlined iconSize="xl" />
+    );
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems }}
+      trigger={['click']}
+      placement={placement}
+      overlayStyle={overlayStyle}
+    >
+      <Button
+        id={buttonId}
+        buttonSize={buttonSize}
+        buttonStyle={buttonStyle}
+        aria-label={ariaLabel}
+        aria-haspopup="true"
+        data-test={dataTest}
+      >
+        {icon || defaultIcon}
+      </Button>
+    </Dropdown>
+  );
+}

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -49,3 +49,4 @@ export {
   type PluginContextType,
 } from './DynamicPlugins';
 export * from './FacePile';
+export { KebabMenuButton, type KebabMenuButtonProps } from './KebabMenuButton';

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -82,22 +82,18 @@ const RefreshTooltip = styled.div`
 const getScreenshotNodeSelector = (chartId: string | number) =>
   `.dashboard-chart-id-${chartId}`;
 
-const VerticalDotsTrigger = () => {
-  const theme = useTheme();
-  return (
-    <Icons.EllipsisOutlined
-      css={css`
-        transform: rotate(90deg);
-        &:hover {
-          cursor: pointer;
-        }
-      `}
-      iconSize="xl"
-      iconColor={theme.colorTextLabel}
-      className="dot"
-    />
-  );
-};
+const VerticalDotsTrigger = () => (
+  <Icons.EllipsisOutlined
+    css={css`
+      transform: rotate(90deg);
+      &:hover {
+        cursor: pointer;
+      }
+    `}
+    iconSize="xl"
+    className="dot"
+  />
+);
 
 export interface SliceHeaderControlsProps {
   chartHolderRef?: RefObject<HTMLDivElement>;

--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -22,16 +22,14 @@ import { css } from '@apache-superset/core/theme';
 import { Link, useHistory } from 'react-router-dom';
 import {
   ConfirmStatusChange,
-  Button,
-  Dropdown,
   FaveStar,
+  Icons,
   Label,
   ListViewCard,
-  Icons,
   MenuItem,
 } from '@superset-ui/core/components';
 import Chart from 'src/types/Chart';
-import { FacePile } from 'src/components';
+import { FacePile, KebabMenuButton } from 'src/components';
 import { handleChartDelete, CardStyles } from 'src/views/CRUD/utils';
 import { assetUrl } from 'src/utils/assetUrl';
 import type { ListViewFetchDataConfig as FetchDataConfig } from 'src/components';
@@ -207,11 +205,7 @@ export default function ChartCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown menu={{ items: menuItems }} trigger={['click', 'hover']}>
-              <Button buttonSize="xsmall" type="link" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
+            <KebabMenuButton menuItems={menuItems} dataTest="chart-card-menu" />
           </ListViewCard.Actions>
         }
       />

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -21,17 +21,15 @@ import { t } from '@apache-superset/core/translation';
 import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { CardStyles } from 'src/views/CRUD/utils';
 import {
-  Dropdown,
-  Button,
   FaveStar,
+  Icons,
   PublishedLabel,
   ListViewCard,
 } from '@superset-ui/core/components';
 import { MenuItem } from '@superset-ui/core/components/Menu';
-import { Icons } from '@superset-ui/core/components/Icons';
 import { Dashboard } from 'src/views/CRUD/types';
 import { assetUrl } from 'src/utils/assetUrl';
-import { FacePile } from 'src/components';
+import { FacePile, KebabMenuButton } from 'src/components';
 
 interface DashboardCardProps {
   isChart?: boolean;
@@ -164,11 +162,10 @@ function DashboardCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown menu={{ items: menuItems }} trigger={['hover', 'click']}>
-              <Button buttonSize="xsmall" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
+            <KebabMenuButton
+              menuItems={menuItems}
+              dataTest="dashboard-card-menu"
+            />
           </ListViewCard.Actions>
         }
       />

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -27,16 +27,11 @@ import CodeSyntaxHighlighter, {
 import { LoadingCards } from 'src/pages/Home';
 import { TableTab } from 'src/views/CRUD/types';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import {
-  Dropdown,
-  DeleteModal,
-  Button,
-  ListViewCard,
-} from '@superset-ui/core/components';
+import { DeleteModal, Icons, ListViewCard } from '@superset-ui/core/components';
 import { MenuItem } from '@superset-ui/core/components/Menu';
 import { copyQueryLink, useListViewResource } from 'src/views/CRUD/hooks';
-import { Icons } from '@superset-ui/core/components/Icons';
 import { User } from 'src/types/bootstrapTypes';
+import { KebabMenuButton } from 'src/components';
 import {
   CardContainer,
   createErrorHandler,
@@ -344,14 +339,10 @@ export const SavedQueries = ({
                       e.preventDefault();
                     }}
                   >
-                    <Dropdown
-                      menu={{ items: menuItems(q) }}
-                      trigger={['click', 'hover']}
-                    >
-                      <Button buttonSize="xsmall" buttonStyle="link">
-                        <Icons.MoreOutlined iconSize="xl" />
-                      </Button>
-                    </Dropdown>
+                    <KebabMenuButton
+                      menuItems={menuItems(q)}
+                      dataTest="saved-query-card-menu"
+                    />
                   </ListViewCard.Actions>
                 }
               />


### PR DESCRIPTION
### SUMMARY
Fixes #36324.

Standardizes card kebab menu behavior across chart, dashboard, and saved query cards by introducing a shared `KebabMenuButton` component.

This keeps the existing link-style button appearance while making card menus open on click only. The icon color is not hardcoded, so hover, active, and disabled states continue to inherit from the underlying Button styles.

This also removes the hardcoded `colorTextLabel` icon color from dashboard chart header controls so the chart kebab trigger follows the same inheritance pattern.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: card kebab menus used inconsistent interaction patterns, with some opening on hover and click.
<img width="1917" height="503" alt="before-welcome page" src="https://github.com/user-attachments/assets/da0920ae-1119-4375-b802-00afb5858131" />

<img width="1914" height="561" alt="before-dashboard page" src="https://github.com/user-attachments/assets/5329ac1c-2d15-4c76-ae2b-c365c92ccfa7" />

After: chart, dashboard, saved query, and dashboard chart kebab triggers use click-based interaction, while icon color is inherited from the Button state.
<img width="1919" height="506" alt="{87E12643-21B2-4789-B8B9-A08CBB143589}" src="https://github.com/user-attachments/assets/e15e9d2a-be29-4a17-b4f9-bea5a516cfd0" />

<img width="1901" height="549" alt="{63CFB0F1-0222-4CFC-84E0-CF67C8A34688}" src="https://github.com/user-attachments/assets/662911c9-c846-4c1d-a4c2-c09164efaf16" />



### TESTING INSTRUCTIONS
1. Open the Welcome page.
2. Hover over chart, dashboard, and saved query card kebab buttons.
3. Verify the menu does not open on hover.
4. Click each kebab button.
5. Verify the menu opens on click.
6. Open a dashboard with chart cards.
7. Verify the chart header kebab menu still opens on click and preserves Button-driven hover/active styling.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36324
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
