### PR TITLE
fix(a11y): use aria-label instead of non-functional alt prop on filter icons

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/DraggableFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/DraggableFilter.tsx
@@ -96,7 +96,7 @@ export const DraggableFilter: FC<FilterTabTitleProps> = ({
       <Container isDragging={isDragging} {...attributes} {...listeners}>
         <DragIcon
           isDragging={isDragging}
-          alt={t('Move icon')}
+          aria-label={t('Move icon')}
           viewBox="4 4 16 16"
         />
         <div css={{ flex: 1 }}>{children}</div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/DraggableFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/DraggableFilter.tsx
@@ -96,7 +96,7 @@ export const DraggableFilter: FC<FilterTabTitleProps> = ({
       <Container isDragging={isDragging} {...attributes} {...listeners}>
         <DragIcon
           isDragging={isDragging}
-          aria-label={t('Move icon')}
+          alt={t('Move icon')}
           viewBox="4 4 16 16"
         />
         <div css={{ flex: 1 }}>{children}</div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigPane.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigPane.test.tsx
@@ -82,7 +82,9 @@ test('drag and drop', () => {
 test('remove filter', async () => {
   defaultRender();
   // First trash icon
-  const removeFilterIcon = document.querySelector("[alt='Remove filter']")!;
+  const removeFilterIcon = document.querySelector(
+    "[aria-label='Remove filter']",
+  )!;
   userEvent.click(removeFilterIcon);
   expect(defaultProps.onRemove).toHaveBeenCalledWith('NATIVE_FILTER-1');
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -211,7 +211,7 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
                   event.stopPropagation();
                   onRemove(id);
                 }}
-                alt={t('Remove filter')}
+                aria-label={t('Remove filter')}
                 data-test="filter-remove-button"
               />
             )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
@@ -179,7 +179,7 @@ const ItemTitleContainer = forwardRef<HTMLDivElement, Props>(
                   event.stopPropagation();
                   onRemove(id);
                 }}
-                alt={deleteAltText}
+                aria-label={deleteAltText}
               />
             )}
           </div>


### PR DESCRIPTION
### WCAG rule
WCAG 2.1 SC 4.1.2 — Level A (Name, Role, Value).

### What changed
Two icon-only controls in the native filters config modal (`FilterTitleContainer.tsx`'s "remove filter" icon and `ItemTitleContainer.tsx`'s "remove item" icon, both `Icons.DeleteOutlined`) were passing an `alt` prop to try to give them a contextual accessible name. `alt` isn't a recognized prop on these `Icons.*` components (built on the shared `BaseIcon`) — it's just spread onto the DOM as an inert attribute — so screen readers fell back to `BaseIcon`'s generic auto-generated label ("delete") instead of the intended "Remove filter" / "Remove item" text. Swapped `alt=` for `aria-label=` at both call sites, which does take effect (confirmed via `BaseIcon.tsx`'s prop-spread order for this icon type).

A third call site (`DraggableFilter.tsx`, `Icons.Drag`) had the same `alt` bug, but that icon renders through `BaseIcon`'s `customIcons` branch, which has a *different*, pre-existing issue: caller props are spread onto the inner SVG rather than the outer `role`-bearing `<span>`, so an `aria-label` override there doesn't reach the accessible element either way. Left that one alone rather than papering over it — it needs a fix in `BaseIcon.tsx` itself, which affects many more call sites and is out of scope for this small fix.

Also updated `FilterConfigPane.test.tsx`'s "remove filter" test, which queried the DOM by the old `[alt=...]` attribute selector, to query by `[aria-label=...]` instead.

### Behavior
No visual or functional change — same click handlers, same icons, same test coverage. Only the accessible name computation changes.

### Test plan
- [x] `npx jest src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigPane.test.tsx` — 5/5 passing
- [ ] Manual: open a dashboard's native filters config modal, tab to a filter's "remove" (trash) icon with a screen reader running, verify it announces "Remove filter" (not "delete")