### PR TITLE
fix(dashboard): prevent dashboard crash when applying grain filters (#41700)

### DIFF
--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.ts
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.ts
@@ -100,7 +100,7 @@ export function getAppliedFilterValues(
   // use cached data if possible
   if (!(chartId in appliedFilterValuesByChart)) {
     const applicableFilters = Object.entries(filters || activeFilters).filter(
-      ([, { scope: chartIds }]) => chartIds.includes(chartId),
+      ([, activeFilter]) => activeFilter?.scope?.includes(chartId),
     );
     appliedFilterValuesByChart[chartId] = flow(
       keyBy(

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -459,7 +459,7 @@ export default function getFormDataWithExtraFilters({
 
   let extraData: JsonObject = {};
   const filterIdsAppliedOnChart = Object.entries(activeFilters)
-    .filter(([, activeFilter]) => activeFilter.scope.includes(chart.id))
+    .filter(([, activeFilter]) => activeFilter?.scope?.includes(chart.id))
     .map(([filterId]) => filterId);
 
   if (filterIdsAppliedOnChart.length) {
@@ -474,7 +474,7 @@ export default function getFormDataWithExtraFilters({
     const isDeckMultiChart = chart.form_data?.viz_type === 'deck_multi';
     const hasLayerScopeInActiveFilters =
       passedActiveFilters &&
-      Object.values(passedActiveFilters).some(filter => filter.layerScope);
+      Object.values(passedActiveFilters).some(filter => filter?.layerScope);
 
     if (isDeckMultiChart || hasLayerScopeInActiveFilters) {
       const filterDataMapping = createFilterDataMapping(


### PR DESCRIPTION
### SUMMARY

This PR fixes a dashboard crash that occurs when applying native grain filters to dashboards containing Time Series Table visualizations.

The issue was caused by dashboard filtering utilities assuming that every active filter contains a valid `scope` array. In certain scenarios involving grain display controls, filters can exist without an initialized scope, resulting in the following frontend exception:

```text
TypeError: Cannot read properties of undefined (reading 'scope')
```

This change introduces defensive handling for missing filter scopes in dashboard filter processing utilities while preserving the existing behavior for properly configured filters.

The changes include:
- Safely handling missing `scope` values when determining applicable filters for a chart.
- Preventing runtime exceptions during extra filter generation.
- Adding defensive checks for optional layer scope handling.
- Preserving existing dashboard filtering behavior for valid filter configurations.

Fixes #41700

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Applying a grain filter such as `Second` caused the dashboard to fail with:

```text
TypeError: Cannot read properties of undefined (reading 'scope')
```

#### After

- Dashboard remains functional when grain filters are applied.
- Charts continue rendering normally.
- No frontend exceptions are thrown.
- Filters with valid scopes continue to behave as expected.

### TESTING INSTRUCTIONS

1. Create a dashboard containing a Time Series Table visualization.
2. Add a native grain filter (`time_interval_grain`).
3. Apply various grain values:
   - Second
   - Minute
   - Hour
   - Day
   - Week
   - Month
4. Verify that:
   - The dashboard remains stable.
   - Charts refresh correctly after filter updates.
   - No frontend exceptions appear in the browser console.

Additionally verify:
- Existing native filters continue to work correctly.
- Cross-filtering behavior remains unchanged.
- Embedded dashboards continue functioning normally.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #41700
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API