### PR TITLE
feat(mcp): register /health HTTP endpoint

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -841,6 +841,21 @@ def _build_starlette_middleware(
     ]
 
 
+def _register_health_endpoint(mcp_instance: Any) -> None:
+    """
+    Register /health for load balancers and K8s probes.
+
+    The health_check MCP tool exists but is only reachable via the MCP
+    protocol, not httpGet probes.
+    """
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    @mcp_instance.custom_route("/health", methods=["GET"])
+    async def _health(_: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+
 def run_server(
     host: str = "127.0.0.1",
     port: int = 5008,
@@ -917,6 +932,8 @@ def run_server(
             if size_guard_middleware:
                 search_name = tool_search_config.get("search_tool_name", "search_tools")
                 size_guard_middleware.excluded_tools.add(search_name)
+
+    _register_health_endpoint(mcp_instance)
 
     # Create EventStore for session management (Redis for multi-pod, None for in-memory)
     event_store = create_event_store(event_store_config)

--- a/tests/unit_tests/mcp_service/test_mcp_server.py
+++ b/tests/unit_tests/mcp_service/test_mcp_server.py
@@ -17,9 +17,16 @@
 
 """Tests for MCP server EventStore creation."""
 
+from collections.abc import Awaitable, Callable
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+# A Starlette-style ASGI endpoint, matching FastMCP's custom_route contract.
+Endpoint = Callable[[Request], Awaitable[Response]]
 
 
 def test_create_event_store_returns_none_when_no_redis_url():
@@ -160,6 +167,59 @@ def test_create_event_store_returns_none_when_redis_store_fails():
         result = create_event_store(config)
 
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_register_health_endpoint_registers_get_health() -> None:
+    """/health is registered as an HTTP GET custom route on the MCP instance."""
+    from superset.mcp_service.server import _register_health_endpoint
+
+    captured: dict[str, object] = {}
+
+    def custom_route(path: str, methods: list[str]) -> Callable[[Endpoint], Endpoint]:
+        captured["path"] = path
+        captured["methods"] = methods
+
+        def decorator(fn: Endpoint) -> Endpoint:
+            captured["fn"] = fn
+            return fn
+
+        return decorator
+
+    mcp_instance = MagicMock()
+    mcp_instance.custom_route = custom_route
+
+    _register_health_endpoint(mcp_instance)
+
+    assert captured["path"] == "/health"
+    assert captured["methods"] == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_returns_ok() -> None:
+    """The /health handler returns 200 with a JSON status body."""
+    from superset.mcp_service.server import _register_health_endpoint
+    from superset.utils import json
+
+    captured: dict[str, object] = {}
+
+    def custom_route(path: str, methods: list[str]) -> Callable[[Endpoint], Endpoint]:
+        def decorator(fn: Endpoint) -> Endpoint:
+            captured["fn"] = fn
+            return fn
+
+        return decorator
+
+    mcp_instance = MagicMock()
+    mcp_instance.custom_route = custom_route
+
+    _register_health_endpoint(mcp_instance)
+
+    handler = cast(Callable[..., Awaitable[Response]], captured["fn"])
+    response = await handler(MagicMock(spec=Request))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {"status": "ok"}
 
 
 def test_create_auth_provider_uses_default_factory_for_mcp_api_key_only() -> None:


### PR DESCRIPTION
### SUMMARY
The docs for setting up the Superset MCP service describe a non-existent
/health endpoint for health checks. See: https://github.com/apache/superset/blob/b23cef136e5fb5fc9d96f5c67dda29634afa1889/superset/mcp_service/README.md.

Register a HTTP GET /health endpoint using FastMCP custom_route based on
this reference: https://gofastmcp.com/deployment/running-server#custom-routes.

### TESTING INSTRUCTIONS
1. Run the unit tests
    ```bash
    pytest tests/unit_tests/mcp_service/test_mcp_server.py
    ```
2. Start the MCP service
    ```bash
    superset mcp run --port 5008
    ```
3. Verify the endpoint responds with HTTP 200
    ```bash
    curl -i http://localhost:5008/health
    ```

### ADDITIONAL INFORMATION
- [X] Has associated issue: #38898 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API