### PR TITLE
chore(mcp): drop legacy /superset prefix from dashboard URLs

### DIFF
--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -706,8 +706,8 @@ class GenerateDashboardRequest(BaseModel):
         max_length=255,
         description=(
             "Optional URL slug for the dashboard. When set, the dashboard "
-            "is reachable at /superset/dashboard/<slug>/ instead of "
-            "/superset/dashboard/<id>/. Must be unique across the instance."
+            "is reachable at /dashboard/<slug>/ instead of "
+            "/dashboard/<id>/. Must be unique across the instance."
         ),
     )
     position_json: Dict[str, Any] | None = Field(

--- a/superset/mcp_service/dashboard/tool/duplicate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/duplicate_dashboard.py
@@ -116,7 +116,7 @@ def _serialize_new_dashboard(dashboard: Any) -> tuple[DashboardInfo, str]:
     """Build the response ``DashboardInfo`` and URL for the new dashboard."""
     from superset.mcp_service.dashboard.schemas import serialize_tag_object
 
-    dashboard_url = f"{get_superset_base_url()}/superset/dashboard/{dashboard.id}/"
+    dashboard_url = f"{get_superset_base_url()}/dashboard/{dashboard.id}/"
     include_data_model_metadata = user_can_view_data_model_metadata()
     info = DashboardInfo(
         id=dashboard.id,
@@ -202,9 +202,7 @@ def _refetch_and_serialize(
             exc_info=True,
         )
         _safe_rollback("dashboard re-fetch")
-        dashboard_url = (
-            f"{get_superset_base_url()}/superset/dashboard/{new_dashboard.id}/"
-        )
+        dashboard_url = f"{get_superset_base_url()}/dashboard/{new_dashboard.id}/"
         info = _sanitize_dashboard_info_for_llm_context(
             DashboardInfo(
                 id=new_dashboard.id,

--- a/superset/mcp_service/dashboard/tool/manage_native_filters.py
+++ b/superset/mcp_service/dashboard/tool/manage_native_filters.py
@@ -452,9 +452,7 @@ def manage_native_filters(
                 request.dashboard_id, payload
             ).run()
 
-        dashboard_url = (
-            f"{get_superset_base_url()}/superset/dashboard/{request.dashboard_id}/"
-        )
+        dashboard_url = f"{get_superset_base_url()}/dashboard/{request.dashboard_id}/"
         logger.info(
             "Managed native filters on dashboard %s (added=%d updated=%d removed=%d)",
             request.dashboard_id,

--- a/superset/mcp_service/dashboard/tool/remove_chart_from_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/remove_chart_from_dashboard.py
@@ -391,7 +391,7 @@ def remove_chart_from_dashboard(  # noqa: C901 — complexity is structural (lay
                     exc_info=True,
                 )
             dashboard_url = (
-                f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/"
+                f"{get_superset_base_url()}/dashboard/{updated_dashboard.id}/"
             )
             return RemoveChartFromDashboardResponse(
                 dashboard=DashboardInfo(
@@ -466,7 +466,7 @@ def remove_chart_from_dashboard(  # noqa: C901 — complexity is structural (lay
             created_on=updated_dashboard.created_on,
             changed_on=updated_dashboard.changed_on,
             uuid=str(updated_dashboard.uuid) if updated_dashboard.uuid else None,
-            url=f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/",
+            url=f"{get_superset_base_url()}/dashboard/{updated_dashboard.id}/",
             chart_count=len(updated_dashboard.slices),
             tags=[
                 serialize_tag_object(tag)
@@ -486,9 +486,7 @@ def remove_chart_from_dashboard(  # noqa: C901 — complexity is structural (lay
             ],
         )
 
-        dashboard_url = (
-            f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/"
-        )
+        dashboard_url = f"{get_superset_base_url()}/dashboard/{updated_dashboard.id}/"
 
         logger.info(
             "Removed chart %s from dashboard %s",

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_duplicate_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_duplicate_dashboard.py
@@ -187,7 +187,7 @@ async def test_duplicate_referencing_same_charts(
     # Response text is wrapped in LLM-context delimiters (prompt-injection
     # defense), matching the standard dashboard serializers.
     assert content["dashboard"]["dashboard_title"] == _wrapped("Staging Copy")
-    assert "/superset/dashboard/2/" in content["dashboard_url"]
+    assert "/dashboard/2/" in content["dashboard_url"]
 
     # The copy data contract must mirror what the frontend "Save as" sends:
     # required json_metadata containing the source's metadata + positions.
@@ -237,7 +237,7 @@ async def test_duplicate_with_duplicate_slices(
     assert content["error"] is None
     assert content["duplicated_slices"] is True
     assert content["dashboard"]["id"] == 3
-    assert "/superset/dashboard/3/" in content["dashboard_url"]
+    assert "/dashboard/3/" in content["dashboard_url"]
 
     _, cmd_data = mock_copy_cmd_cls.call_args.args
     assert cmd_data["duplicate_slices"] is True
@@ -449,7 +449,7 @@ async def test_refetch_failure_rolls_back_and_returns_minimal_response(
     assert content["error"] is None
     assert content["dashboard"]["id"] == 7
     assert content["dashboard"]["dashboard_title"] == _wrapped("Copy")
-    assert "/superset/dashboard/7/" in content["dashboard_url"]
+    assert "/dashboard/7/" in content["dashboard_url"]
 
 
 @patch("superset.commands.dashboard.copy.CopyDashboardCommand")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_remove_chart_from_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_remove_chart_from_dashboard.py
@@ -371,7 +371,7 @@ async def test_simple_grid_removal_prunes_empty_row(
     assert content["error"] is None
     assert content["permission_denied"] is False
     assert content["dashboard_url"] is not None
-    assert "/superset/dashboard/1/" in content["dashboard_url"]
+    assert "/dashboard/1/" in content["dashboard_url"]
     assert set(content["removed_layout_keys"]) == {"CHART-aaa", "ROW-1"}
 
     dashboard_id, update_data = mock_update_cmd_cls.call_args.args


### PR DESCRIPTION
### SUMMARY

The historical `/superset` URL prefix was removed from every view when `Superset.route_base` was set to `""` — dashboards are now canonically served at `/dashboard/<id>/`. A temporary closed-set redirect shim (`superset/middleware/legacy_prefix_redirect.py`, removed at EOL 5.0.0) keeps the old `/superset/dashboard/<id>/` paths working for one release cycle.

The MCP dashboard tools still hand-build `/superset/dashboard/<id>/` URLs in their responses, so the URLs they return only resolve today by bouncing through that temporary shim. This updates them to emit the canonical `/dashboard/<id>/` form directly, so the returned URLs are correct on their own and keep working after the shim is retired.

This matches `add_chart_to_existing_dashboard`, which already returns the new `/dashboard/<id>/` form.

Files touched (all pure string changes, no behavioral logic):
- `mcp_service/dashboard/tool/duplicate_dashboard.py`
- `mcp_service/dashboard/tool/manage_native_filters.py`
- `mcp_service/dashboard/tool/remove_chart_from_dashboard.py`
- `mcp_service/dashboard/schemas.py` (field help text)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — response URL string change only.

### TESTING INSTRUCTIONS

Existing unit tests updated to assert the `/dashboard/<id>/` form:

```
pytest tests/unit_tests/mcp_service/dashboard/tool/test_duplicate_dashboard.py \
       tests/unit_tests/mcp_service/dashboard/tool/test_remove_chart_from_dashboard.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API