### PR TITLE
fix(sqllab): redirect legacy /superset/sql/<db_id>/ deep links

### DIFF
--- a/superset/middleware/legacy_prefix_redirect.py
+++ b/superset/middleware/legacy_prefix_redirect.py
@@ -46,14 +46,18 @@ Disposition rules
 * POST against a GET-only canonical → 410 Gone (308 would 405 on retry).
 * Anything not in :data:`LEGACY_REDIRECT_MAP` → pass through unchanged.
 
-``/superset/sql/<database_id>/`` is intentionally **not** redirected:
-``Database.sql_url`` changed shape to ``/sqllab/?dbid=<id>`` (query
-string, not a path) so no 1:1 mapping exists. ``UPDATING.md`` documents
-the hard re-bookmark break.
+``/superset/sql/<database_id>/`` has no 1:1 path mapping — ``Database.sql_url``
+changed shape to ``/sqllab/?dbid=<id>`` (query string, not a path). It is
+therefore handled by a dedicated special case (:data:`_LEGACY_SQL_RE`) rather
+than the closed-set map: a numeric ``<database_id>`` 308-redirects to
+``/sqllab/?dbid=<id>`` (merging any inbound query string with ``&``); a
+non-numeric tail falls through to the closed-set map (→ 404), preserving
+closed-set discipline.
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from typing import Iterable, Optional
 from urllib.parse import quote
@@ -71,6 +75,14 @@ else:
 #: The legacy URL token the shim recognises. Hard-coded — not configurable.
 _LEGACY_PREFIX: str = "/superset"
 
+#: Special case for the legacy SQL Lab deep link. Matches the ``/superset``-
+#: stripped tail ``/sql/<database_id>/`` where ``<database_id>`` is numeric
+#: (the historical ``@expose("/sql/<int:database_id>/")`` GET route). Redirected
+#: to the migrated query-string shape ``/sqllab/?dbid=<id>`` rather than via the
+#: closed-set map, since it is a path→query-string transform, not a 1:1 path map.
+#: A non-numeric tail does not match and falls through to the map (→ 404).
+_LEGACY_SQL_RE: re.Pattern[str] = re.compile(r"^/sql/(\d+)/?$")
+
 #: Closed table mapping legacy canonical paths (the part *after*
 #: ``_LEGACY_PREFIX``) to ``(allowed_methods, canonical_path)``.
 #:
@@ -82,7 +94,7 @@ _LEGACY_PREFIX: str = "/superset"
 #: ``@expose`` decorator at HEAD ``1bc20f2206``; any change to a canonical
 #: endpoint's allowed methods MUST update the corresponding row (and the
 #: closed-set regression test in
-#: ``tests/integration_tests/middleware/test_legacy_prefix_redirect.py``).
+#: ``tests/unit_tests/middleware/test_legacy_prefix_redirect.py``).
 LEGACY_REDIRECT_MAP: dict[str, tuple[frozenset[str], str]] = {
     # views/core.py — Superset (route_base = "")
     "/welcome/": (frozenset({"GET"}), "/welcome/"),
@@ -98,6 +110,10 @@ LEGACY_REDIRECT_MAP: dict[str, tuple[frozenset[str], str]] = {
     "/file-handler": (frozenset({"GET"}), "/file-handler"),
     "/log/": (frozenset({"POST"}), "/log/"),
     "/sqllab/history/": (frozenset({"GET"}), "/sqllab/history/"),
+    # NOTE: the /explore_json[/data] canonicals below (Superset.explore_json /
+    # explore_json_data) are themselves @deprecated. When those endpoints are
+    # deleted these rows become redirects-to-404 — prune them (and their
+    # closed-set snapshot entries) in the same PR that removes the endpoints.
     "/explore_json/": (frozenset({"GET", "POST"}), "/explore_json/"),
     "/explore_json/data/": (frozenset({"GET"}), "/explore_json/data/"),
     # views/explore.py — ExploreView (route_base = "/explore") owns the
@@ -211,6 +227,22 @@ class LegacyPrefixRedirectMiddleware:
             return self.wsgi_app(environ, start_response)
 
         canonical_after_strip = candidate[len(_LEGACY_PREFIX) :] or "/"
+
+        # Special case: /superset/sql/<database_id>/ has no 1:1 path mapping —
+        # Database.sql_url migrated to the query-string shape /sqllab/?dbid=<id>.
+        # Redirect it explicitly (numeric id only) so legacy SQL Lab deep links
+        # survive one release cycle instead of hard-404ing.
+        if sql_match := _LEGACY_SQL_RE.match(canonical_after_strip):
+            if method != "GET":
+                # The old /superset/sql/<id>/ route was GET-only; a 308 would
+                # have the client retry-POST against /sqllab/ → 405. Emit 410.
+                return _response_with_location(410, None)(environ, start_response)
+            location = f"{self.app_root_prefix}/sqllab/?dbid={sql_match.group(1)}"
+            if query_string := environ.get("QUERY_STRING", ""):
+                # location already carries ?dbid=<id>; merge with & not ?.
+                location = f"{location}&{query_string}"
+            return _response_with_location(308, location)(environ, start_response)
+
         match = _match(canonical_after_strip)
         if match is None:
             # Unenumerated /superset path — closed-set discipline: pass

--- a/tests/unit_tests/middleware/test_legacy_prefix_redirect.py
+++ b/tests/unit_tests/middleware/test_legacy_prefix_redirect.py
@@ -285,17 +285,78 @@ def test_canonical_path_without_legacy_prefix_passes_through() -> None:
         assert resp.data == _SENTINEL_BODY, canonical
 
 
-def test_legacy_sql_route_passes_through_not_308() -> None:
-    """`/superset/sql/<id>/` has **no** row in `LEGACY_REDIRECT_MAP` —
-    `Database.sql_url` reshaped to `/sqllab/?dbid=<id>` so no 1:1 path
-    mapping exists. UPDATING.md documents the hard re-bookmark break."""
+def test_legacy_sql_deep_link_redirects_to_sqllab_dbid() -> None:
+    """`/superset/sql/<id>/` has **no** 1:1 path row — `Database.sql_url`
+    reshaped to `/sqllab/?dbid=<id>`. The shim special-cases the numeric
+    deep link (via `_LEGACY_SQL_RE`) and 308s to the migrated query-string
+    shape so legacy SQL Lab bookmarks survive one release cycle instead of
+    hard-404ing."""
     client = _build_client(app_root="/")
     resp = client.get("/superset/sql/5/")
-    # Pass-through: inner app reached, not a 308 from the shim.
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/sqllab/?dbid=5"
+    # Handled by the special case, NOT the closed-set map.
+    assert "/sql/" not in LEGACY_REDIRECT_MAP
+
+
+def test_legacy_sql_deep_link_without_trailing_slash() -> None:
+    """The historical route was `@expose("/sql/<int:database_id>/")`; the
+    trailing slash is optional on the inbound bookmark. Both forms 308 to the
+    same target."""
+    client = _build_client(app_root="/")
+    resp = client.get("/superset/sql/5")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/sqllab/?dbid=5"
+
+
+def test_legacy_sql_deep_link_under_subdir() -> None:
+    """Under a subdir deployment the dbid target carries the single app-root
+    prefix — `/myapp/sqllab/?dbid=<id>`, never `/myapp/superset/...`."""
+    client = _build_client(app_root="/myapp")
+    resp = client.get("/myapp/superset/sql/12/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/myapp/sqllab/?dbid=12"
+
+
+def test_legacy_sql_deep_link_merges_query_string_with_ampersand() -> None:
+    """An inbound query string is merged onto the already-present `?dbid=<id>`
+    with `&` — never a second `?`. Guards against re-introducing the
+    `SqlaTable.sql_url` double-`?` bug shape (`/sqllab/?dbid=5?table_name=…`)."""
+    client = _build_client(app_root="/")
+    resp = client.get("/superset/sql/5/?table_name=foo&schema=bar")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/sqllab/?dbid=5&table_name=foo&schema=bar"
+    # Exactly one `?` in the Location.
+    assert resp.headers["Location"].count("?") == 1
+
+
+def test_legacy_sql_post_returns_410() -> None:
+    """The old `/superset/sql/<id>/` route was GET-only; a POST 308 would
+    re-POST against `/sqllab/` (a GET view) → 405. Emit 410 instead, matching
+    the disposition of every other GET-only canonical."""
+    client = _build_client(app_root="/")
+    resp = client.post("/superset/sql/5/", data={"k": "v"})
+    assert resp.status_code == 410
+    assert "Location" not in resp.headers
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/superset/sql/",  # no id
+        "/superset/sql/abc/",  # non-numeric id
+        "/superset/sql/5/extra/",  # trailing extra segment
+    ],
+)
+def test_legacy_sql_non_numeric_passes_through(path: str) -> None:
+    """Closed-set discipline: only a bare numeric `<database_id>` is
+    special-cased. Anything else is not a real legacy SQL Lab deep link and
+    falls through to the inner app (→ 404 in production) rather than being
+    coerced into a `?dbid=<garbage>` redirect."""
+    client = _build_client(app_root="/")
+    resp = client.get(path)
     assert resp.status_code == 200
     assert resp.data == _SENTINEL_BODY
-    # Belt-and-braces: the path is not in the map either.
-    assert "/sql/" not in LEGACY_REDIRECT_MAP
 
 
 def test_degenerate_app_root_equals_superset_disables_shim() -> None:


### PR DESCRIPTION
### SUMMARY

When the `/superset` URL prefix was removed (`Superset.route_base = ""`), a closed-set 308 redirect shim (`superset/middleware/legacy_prefix_redirect.py`) was added to keep the enumerated bookmarkable `/superset/*` routes working for one release cycle. One route was **intentionally excluded**: `/superset/sql/<database_id>/`, because `Database.sql_url` changed shape from a path to a query string (`/sqllab/?dbid=<id>`), so there is no 1:1 path→path mapping for the closed-set map.

The side effect is that existing **SQL Lab bookmarks / deep links** of the form `/superset/sql/5/` hard-404 instead of degrading gracefully like every other legacy `/superset/*` route. This PR closes that gap without weakening the closed-set discipline that protects the rest of the map.

**Approach** — a dedicated special case (`_LEGACY_SQL_RE = ^/sql/(\d+)/?$`) handled ahead of the closed-set lookup:

- A **numeric** `<database_id>` → **308** to `/sqllab/?dbid=<id>`.
- Any inbound query string is merged with `&` (so `location` never ends up with `?…?…`).
- The redirect respects the deployment **app-root prefix** (subdirectory deploys).
- **Non-GET** methods → **410 Gone** (the old route was GET-only; a 308 would make the client retry-POST against `/sqllab/` → 405).
- A **non-numeric** tail does *not* match `_LEGACY_SQL_RE` and falls through to the closed-set map (→ 404), so closed-set discipline is preserved for everything that isn't this specific, well-defined transform.

This is a deliberate, documented departure from the original "leave it to hard-404" decision: the module docstring is updated to explain why this one route is handled by a special case rather than the map.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: `GET /superset/sql/5/` → 404.
After: `GET /superset/sql/5/` → `308` → `/sqllab/?dbid=5`.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/middleware/test_legacy_prefix_redirect.py
```

Added regression cases cover: numeric id → 308 to `/sqllab/?dbid=<id>`; query-string `&`-merge; app-root prefix; non-GET → 410; non-numeric tail falling through to the closed-set map (404).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API