### PR TITLE
fix(test): change regex for RTL to retrieve button used for filter removal

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -45112,7 +45112,7 @@
         "@deck.gl/extensions": "~9.2.9",
         "@deck.gl/geo-layers": "~9.2.5",
         "@deck.gl/layers": "~9.2.5",
-        "@deck.gl/mapbox": "^9.3.5",
+        "@deck.gl/mapbox": "~9.3.5",
         "@deck.gl/mesh-layers": "~9.2.5",
         "@luma.gl/constants": "~9.2.5",
         "@luma.gl/core": "~9.2.5",

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -181,6 +181,7 @@ const NAME_REQUIRED_REGEX = /^name is required$/i;
 const COLUMN_REQUIRED_REGEX = /^column is required$/i;
 const PRE_FILTER_REQUIRED_REGEX = /^pre-filter is required$/i;
 const DEFAULT_VALUE_INVALID_REGEX = /choose.*valid value/i;
+const REMOVE_FILTER_BUTTON_REGEX = /Remove filter/i;
 
 const props: FiltersConfigModalProps = {
   isOpen: true,
@@ -974,13 +975,15 @@ test('restores a deleted filter via the "Restore filter" button', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
+  fireEvent.click(
+    within(firstTab).getByRole('button', { name: REMOVE_FILTER_BUTTON_REGEX }),
+  );
 
   expect(
     await screen.findByText(/you have removed this filter/i),
   ).toBeInTheDocument();
   const restoreButton = screen.getByTestId('restore-filter-button');
-  await userEvent.click(restoreButton);
+  userEvent.click(restoreButton);
 
   await waitFor(() => {
     expect(
@@ -1009,11 +1012,13 @@ test('undoes a filter deletion via the sidebar "Undo?" link', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
+  fireEvent.click(
+    within(firstTab).getByRole('button', { name: REMOVE_FILTER_BUTTON_REGEX }),
+  );
 
   const undoButton = await screen.findByTestId('undo-button');
   expect(undoButton).toHaveTextContent(/undo\?/i);
-  await userEvent.click(undoButton);
+  userEvent.click(undoButton);
 
   await waitFor(() => {
     expect(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(test): change regex for RTL to retrieve button used for filter removal

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix broken `master` CI from [failing Jest test in 5th shard](https://github.com/apache/superset/actions/runs/28694184374/job/85107960470). Originally from https://github.com/apache/superset/pull/41742

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Green CI as acceptance criterion

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
