### PR TITLE
fix(a11y): add aria-label to CRON schedule input

### DIFF
--- a/superset-frontend/src/features/alerts/components/AlertReportCronScheduler.tsx
+++ b/superset-frontend/src/features/alerts/components/AlertReportCronScheduler.tsx
@@ -108,6 +108,7 @@ export const AlertReportCronScheduler: FC<AlertReportCronSchedulerProps> = ({
           <Input
             type="text"
             name="crontab"
+            aria-label={t('Schedule')}
             style={error ? { borderColor: theme.colorError } : {}}
             placeholder={t('CRON expression')}
             value={value}


### PR DESCRIPTION
### WCAG rule
2.1 SC 1.3.1 (Info and Relationships) / 3.3.2 (Labels or Instructions) — Level A.

### What changed
The CRON expression text input in `AlertReportCronScheduler` (shown when a user picks "CRON Schedule" for an alert/report) had no `aria-label`, `aria-labelledby`, or associated `<label>`. Its only hint was a placeholder (`t('CRON expression')`) plus a visually adjacent but unassociated `<div className="control-label">` reading "Schedule". Screen reader users tabbing into the field heard no accessible name at all.

Added `aria-label={t('Schedule')}` to the `<Input>`, matching the naming convention already used by the sibling `Select` above it (`ariaLabel={t('Schedule type')}`, mirroring its own adjacent visible label).

### Behavior
No visual or functional change — this only adds an accessible name for assistive technology.

### Test plan
1. Open Alerts & Reports → create/edit an alert → in the "Schedule" section, switch schedule type to "CRON Schedule".
2. Tab to the CRON expression input with a screen reader running (e.g. VoiceOver/NVDA).
3. Verify the announced label is "Schedule" (previously: no accessible name announced, or generic "edit text").