### PR TITLE
fix(views): add new_target to deprecated explore_json_data endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -246,7 +246,7 @@ class Superset(BaseSupersetView):
     @permission_name("explore_json")
     @expose("/explore_json/data/<cache_key>", methods=("GET",))
     @check_resource_permissions(check_explore_cache_perms)
-    @deprecated(eol_version="5.0.0")
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
     def explore_json_data(self, cache_key: str) -> FlaskResponse:
         """Serves cached result data for async explore_json calls
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -246,7 +246,7 @@ class Superset(BaseSupersetView):
     @permission_name("explore_json")
     @expose("/explore_json/data/<cache_key>", methods=("GET",))
     @check_resource_permissions(check_explore_cache_perms)
-    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data/<cache_key>")
     def explore_json_data(self, cache_key: str) -> FlaskResponse:
         """Serves cached result data for async explore_json calls
 


### PR DESCRIPTION
### The warning

Production logs (Datadog) show a WARNING fired by the `@deprecated()` decorator on `Superset.explore_json_data`:

```
Superset.explore_json_data This API endpoint is deprecated and will be removed in version 5.0.0
```

Its sibling endpoint, `explore_json`, already got a `new_target="/api/v1/chart/data"` hint added to its `@deprecated()` decorator in #41159 ("add new_target to deprecated explore_json endpoints") — but that PR's diff only touched `explore_json`, missing `explore_json_data` despite the plural title.

`explore_json_data` serves cached async-query results by `cache_key` (populated by `load_explore_json_into_cache` in `superset/tasks/async_queries.py`). The direct modern equivalent is `/api/v1/chart/data/<cache_key>` (`ChartDataRestApi.data_from_cache`), populated by the sibling `load_chart_data_into_cache` task in the same file — both use the same cache backend (`cache_manager.cache`) and the same `generate_cache_key` / `set_and_log_cache` utilities, just for the v1 pipeline instead of the legacy one.

### What changed

One line: added `new_target="/api/v1/chart/data/<cache_key>"` to the `@deprecated()` decorator on `explore_json_data`, matching the existing convention for deprecated endpoints with path params (see `fetch_datasource_metadata`'s `new_target` a few hundred lines down in the same file).

### No behavior change

This only affects the deprecation warning's log message (adds a "use this instead" hint). It does not change the endpoint's routing, permissions, or response behavior. Confirmed via `ruff check` and by tracing the `deprecated()` decorator's closure scoping (`superset/views/base.py`) — each `@deprecated(...)` call site gets its own independent `_warned` flag, so this doesn't interact with `explore_json`'s decorator instance.

### Test plan

- `uvx ruff check superset/views/core.py` — passes
- Confirmed `tests/unit_tests/views/test_base.py::test_deprecated_logs_warning_exactly_once` (the only test exercising `deprecated()`'s warning behavior) is synthetic/generic and unaffected
- Confirmed `test_explore_json_data_invalid_cache_key` (the only test referencing `explore_json_data`) only asserts a 404 on invalid cache keys, unaffected by the decorator change
- Confirmed no conflict with #41714 (open, unrelated legacy-viz removal PR) — it doesn't touch `superset/views/core.py`