### PR TITLE
fix(table): hide search dropdown when search box is disabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -480,16 +480,18 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
           )}
           {includeSearch && (
             <div className="search-container">
-              {serverPagination && (
-                <div className="search-by-text-container">
-                  <span className="search-by-text"> {t('Search by')}:</span>
-                  <SearchSelectDropdown
-                    onChange={onSearchColChange}
-                    searchOptions={searchOptions}
-                    value={serverPaginationData?.searchColumn || ''}
-                  />
-                </div>
-              )}
+              {serverPagination &&
+                searchOptions &&
+                searchOptions.length > 0 && (
+                  <div className="search-by-text-container">
+                    <span className="search-by-text"> {t('Search by')}:</span>
+                    <SearchSelectDropdown
+                      onChange={onSearchColChange}
+                      searchOptions={searchOptions}
+                      value={serverPaginationData?.searchColumn || ''}
+                    />
+                  </div>
+                )}
               <div className="input-wrapper">
                 <div className="input-container">
                   <SearchOutlined />

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -481,8 +481,7 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
           {includeSearch && (
             <div className="search-container">
               {serverPagination &&
-                searchOptions &&
-                searchOptions.length > 0 && (
+                searchOptions?.length > 0 && (
                   <div className="search-by-text-container">
                     <span className="search-by-text"> {t('Search by')}:</span>
                     <SearchSelectDropdown

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -480,17 +480,16 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
           )}
           {includeSearch && (
             <div className="search-container">
-              {serverPagination &&
-                searchOptions?.length > 0 && (
-                  <div className="search-by-text-container">
-                    <span className="search-by-text"> {t('Search by')}:</span>
-                    <SearchSelectDropdown
-                      onChange={onSearchColChange}
-                      searchOptions={searchOptions}
-                      value={serverPaginationData?.searchColumn || ''}
-                    />
-                  </div>
-                )}
+              {serverPagination && searchOptions?.length > 0 && (
+                <div className="search-by-text-container">
+                  <span className="search-by-text"> {t('Search by')}:</span>
+                  <SearchSelectDropdown
+                    onChange={onSearchColChange}
+                    searchOptions={searchOptions}
+                    value={serverPaginationData?.searchColumn || ''}
+                  />
+                </div>
+              )}
               <div className="input-wrapper">
                 <div className="input-container">
                   <SearchOutlined />

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -18,7 +18,12 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { ColDef } from '@superset-ui/core/components/ThemedAgGridReact';
+import {
+  ColDef,
+  ValueFormatterParams,
+  ValueGetterParams,
+  CellClassParams,
+} from '@superset-ui/core/components/ThemedAgGridReact';
 import { useCallback, useMemo } from 'react';
 import { DataRecord, DataRecordValue, JsonObject } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
@@ -291,9 +296,9 @@ export const useColDefs = ({
         field: colId,
         headerName: getHeaderLabel(col),
         headerTooltip: col.description,
-        valueFormatter: p => valueFormatter(p, col),
-        valueGetter: p => valueGetter(p, col),
-        cellStyle: p => {
+        valueFormatter: (p: ValueFormatterParams) => valueFormatter(p, col),
+        valueGetter: (p: ValueGetterParams) => valueGetter(p, col),
+        cellStyle: (p: CellClassParams) => {
           const cellSurfaceColor =
             p.node?.rowPinned != null
               ? theme.colorBgBase
@@ -317,7 +322,7 @@ export const useColDefs = ({
 
           return getCellStyle(cellStyleParams);
         },
-        cellClass: p =>
+        cellClass: (p: CellClassParams) =>
           getCellClass({
             ...p,
             col,
@@ -479,7 +484,7 @@ export const useColDefs = ({
       headerName: t('№'),
       headerClass: 'ag-header-center',
       field: ROW_NUMBER_COL_ID,
-      valueGetter: params => {
+      valueGetter: (params: ValueGetterParams) => {
         if (params.node?.rowPinned != null) return '';
         if (serverPagination && serverPaginationData) {
           return currentPage * pageSize + (params.node?.rowIndex ?? 0) + 1;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -206,7 +206,6 @@ test('AgGridTableChart hides Search by dropdown if includeSearch is false', asyn
   });
   props.serverPagination = true;
   props.includeSearch = false;
-  props.searchOptions = [{ label: 'Name', value: 'name' }];
 
   render(
     ProviderWrapper({
@@ -239,7 +238,6 @@ test('AgGridTableChart renders Search by dropdown if includeSearch is true and t
   });
   props.serverPagination = true;
   props.includeSearch = true;
-  props.searchOptions = [{ label: 'Name', value: 'name' }];
 
   render(
     ProviderWrapper({

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -266,10 +266,7 @@ test('AgGridTableChart does not render Search by dropdown if includeSearch is tr
       {
         ...testData.basic.queriesData[0],
         colnames: ['__timestamp', 'sum__num'],
-        coltypes: [
-          GenericDataType.Temporal,
-          GenericDataType.Numeric,
-        ],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
         data: [
           {
             __timestamp: '2020-01-01T12:34:56',
@@ -310,7 +307,6 @@ test('AgGridTableChart does not render Search by dropdown if includeSearch is tr
 
   expect(screen.queryByText(/Search by/i)).not.toBeInTheDocument();
 });
-
 
 test('AgGridTableChart renders with totals', async () => {
   const props = transformProps({

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -195,6 +195,72 @@ test('AgGridTableChart renders with search enabled', async () => {
   expect(searchInput).toHaveAttribute('id', 'filter-text-box');
 });
 
+test('AgGridTableChart hides Search by dropdown if includeSearch is false', async () => {
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      server_pagination: true,
+      include_search: false,
+    },
+  });
+  props.serverPagination = true;
+  props.includeSearch = false;
+  props.searchOptions = [{ label: 'Name', value: 'name' }];
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  expect(screen.queryByText(/Search by/i)).not.toBeInTheDocument();
+});
+
+test('AgGridTableChart renders Search by dropdown if includeSearch is true and there are search options', async () => {
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      server_pagination: true,
+      include_search: true,
+    },
+  });
+  props.serverPagination = true;
+  props.includeSearch = true;
+  props.searchOptions = [{ label: 'Name', value: 'name' }];
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  expect(screen.getByText(/Search by/i)).toBeInTheDocument();
+});
+
 test('AgGridTableChart renders with totals', async () => {
   const props = transformProps({
     ...testData.basic,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -259,6 +259,59 @@ test('AgGridTableChart renders Search by dropdown if includeSearch is true and t
   expect(screen.getByText(/Search by/i)).toBeInTheDocument();
 });
 
+test('AgGridTableChart does not render Search by dropdown if includeSearch is true but searchOptions is empty', async () => {
+  const noStringColumnsData = {
+    ...testData.basic,
+    queriesData: [
+      {
+        ...testData.basic.queriesData[0],
+        colnames: ['__timestamp', 'sum__num'],
+        coltypes: [
+          GenericDataType.Temporal,
+          GenericDataType.Numeric,
+        ],
+        data: [
+          {
+            __timestamp: '2020-01-01T12:34:56',
+            sum__num: 2467063,
+          },
+        ],
+      },
+    ],
+  };
+
+  const props = transformProps({
+    ...noStringColumnsData,
+    rawFormData: {
+      ...noStringColumnsData.rawFormData,
+      server_pagination: true,
+      include_search: true,
+    },
+  });
+  props.serverPagination = true;
+  props.includeSearch = true;
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  expect(screen.queryByText(/Search by/i)).not.toBeInTheDocument();
+});
+
+
 test('AgGridTableChart renders with totals', async () => {
   const props = transformProps({
     ...testData.basic,

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -583,8 +583,7 @@ export default typedMemo(function DataTable<D extends object>({
               {searchInput && (
                 <>
                   {serverPagination &&
-                    searchOptions &&
-                    searchOptions.length > 0 && (
+                    searchOptions?.length > 0 && (
                       <Space direction="vertical" size={4}>
                         {t('Search by')}
                         <SearchSelectDropdown

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -582,16 +582,18 @@ export default typedMemo(function DataTable<D extends object>({
             <Flex wrap align="center" gap="middle">
               {searchInput && (
                 <>
-                  {serverPagination && (
-                    <Space direction="vertical" size={4}>
-                      {t('Search by')}
-                      <SearchSelectDropdown
-                        searchOptions={searchOptions}
-                        value={serverPaginationData?.searchColumn || ''}
-                        onChange={onSearchColChange}
-                      />
-                    </Space>
-                  )}
+                  {serverPagination &&
+                    searchOptions &&
+                    searchOptions.length > 0 && (
+                      <Space direction="vertical" size={4}>
+                        {t('Search by')}
+                        <SearchSelectDropdown
+                          searchOptions={searchOptions}
+                          value={serverPaginationData?.searchColumn || ''}
+                          onChange={onSearchColChange}
+                        />
+                      </Space>
+                    )}
                   <GlobalFilter<D>
                     searchInput={
                       typeof searchInput === 'boolean' ? undefined : searchInput

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -582,17 +582,16 @@ export default typedMemo(function DataTable<D extends object>({
             <Flex wrap align="center" gap="middle">
               {searchInput && (
                 <>
-                  {serverPagination &&
-                    searchOptions?.length > 0 && (
-                      <Space direction="vertical" size={4}>
-                        {t('Search by')}
-                        <SearchSelectDropdown
-                          searchOptions={searchOptions}
-                          value={serverPaginationData?.searchColumn || ''}
-                          onChange={onSearchColChange}
-                        />
-                      </Space>
-                    )}
+                  {serverPagination && searchOptions?.length > 0 && (
+                    <Space direction="vertical" size={4}>
+                      {t('Search by')}
+                      <SearchSelectDropdown
+                        searchOptions={searchOptions}
+                        value={serverPaginationData?.searchColumn || ''}
+                        onChange={onSearchColChange}
+                      />
+                    </Space>
+                  )}
                   <GlobalFilter<D>
                     searchInput={
                       typeof searchInput === 'boolean' ? undefined : searchInput

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2383,6 +2383,56 @@ describe('plugin-chart-table', () => {
       expect(filters[0].val).toEqual(['Michael']);
     });
   });
+
+  test('does not render "Search by" if there are no search options (server pagination enabled)', () => {
+    const props = transformProps({
+      ...testData.raw,
+      rawFormData: {
+        ...testData.raw.rawFormData,
+        server_pagination: true,
+        include_search: true,
+      },
+      queriesData: [
+        {
+          ...testData.raw.queriesData[0],
+          colnames: ['num'],
+          coltypes: [GenericDataType.Numeric],
+          data: [{ num: 1 }, { num: 2 }],
+        },
+      ],
+    });
+    render(
+      ProviderWrapper({
+        children: <TableChart {...props} sticky={false} />,
+      }),
+    );
+    expect(screen.queryByText('Search by')).not.toBeInTheDocument();
+  });
+
+  test('renders "Search by" if include_search is true and there are search options (server pagination enabled)', () => {
+    const props = transformProps({
+      ...testData.raw,
+      rawFormData: {
+        ...testData.raw.rawFormData,
+        server_pagination: true,
+        include_search: true,
+      },
+      queriesData: [
+        {
+          ...testData.raw.queriesData[0],
+          colnames: ['name'],
+          coltypes: [GenericDataType.String],
+          data: [{ name: 'Michael' }, { name: 'John' }],
+        },
+      ],
+    });
+    render(
+      ProviderWrapper({
+        children: <TableChart {...props} sticky={false} />,
+      }),
+    );
+    expect(screen.queryByText('Search by')).toBeInTheDocument();
+  });
 });
 
 /**


### PR DESCRIPTION
Fixes #41747

<!--

Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/

Example:

fix(dashboard): load charts correctly

-->

### SUMMARY

This PR fixes an issue where the **"Search by"** dropdown was displayed in Table charts whenever **Server Pagination** was enabled, even when the **Search Box** option was disabled in the Customize tab.

Previously, enabling server-side pagination implicitly caused search-related controls to appear, resulting in confusing behavior for users who intentionally disabled search functionality.

This change updates the rendering logic so that search-related UI elements are only displayed when search functionality is explicitly enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

- Server Pagination enabled

- Search Box disabled

- "Search by" dropdown was still visible

#### After

- Server Pagination enabled

- Search Box disabled

- "Search by" dropdown is hidden

- Search controls only appear when Search Box is enabled

### TESTING INSTRUCTIONS

1. Create a Table chart with one or more text columns.

2. Enable **Server Pagination**.

3. Leave **Search Box** disabled under the Customize tab.

4. Save and open the chart.

5. Verify that the **"Search by"** dropdown is not displayed.

Verify the following scenarios:

#### Case 1

- Server Pagination = Disabled

- Search Box = Disabled

Expected:

- No search input

- No search dropdown

#### Case 2

- Server Pagination = Disabled

- Search Box = Enabled

Expected:

- Search input visible

- Search dropdown visible

#### Case 3

- Server Pagination = Enabled

- Search Box = Disabled

Expected:

- No search input

- No search dropdown

#### Case 4

- Server Pagination = Enabled

- Search Box = Enabled

Expected:

- Search input visible

- Search dropdown visible

### ADDITIONAL INFORMATION

- Added regression coverage for search control visibility.

- Preserves existing server-side pagination functionality.

- Preserves existing search behavior when Search Box is enabled.

- No API changes.

- No database migrations required.

- Backward compatible with existing saved charts.