### PR TITLE
chore(deps): bump lodash-es to ^4.18.1 across all frontend workspaces

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -26238,21 +26238,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/jsdom/node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -42464,21 +42449,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/whatwg-url/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -109,7 +109,7 @@
         "json-bigint": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "mapbox-gl": "^3.25.0",
         "markdown-to-jsx": "^9.8.2",
         "match-sorter": "^8.3.0",
@@ -26402,6 +26402,21 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/jsdom/node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -43111,6 +43126,21 @@
         }
       }
     },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -44270,7 +44300,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.29.7",
@@ -44314,7 +44344,7 @@
         "@apache-superset/core": "*",
         "@types/react": "*",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "tinycolor2": "*"
       },
       "peerDependencies": {
@@ -44819,7 +44849,7 @@
         "dompurify": "^3.4.11",
         "fast-safe-stringify": "^2.1.1",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "nvd3-fork": "^2.0.5",
         "prop-types": "^15.8.1",
         "urijs": "^1.19.11"
@@ -44842,7 +44872,7 @@
         "classnames": "^2.5.1",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "memoize-one": "^6.0.0",
         "react-table": "^7.8.0",
         "regenerator-runtime": "^0.14.1",
@@ -44882,7 +44912,7 @@
         "@types/geojson": "^7946.0.16",
         "geojson": "^0.5.0",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "peerDependencies": {
         "@ant-design/icons": "^5.6.1",
@@ -44912,7 +44942,7 @@
         "acorn": "^8.17.0",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
@@ -44957,7 +44987,7 @@
         "currencyformatter.js": "^1.0.5",
         "handlebars-group-by": "^1.0.1",
         "just-handlebars-helpers": "^1.0.19",
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -45038,7 +45068,7 @@
         "classnames": "^2.5.1",
         "d3-array": "^3.2.4",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "memoize-one": "^6.0.0",
         "react-table": "^7.8.0",
         "regenerator-runtime": "^0.14.1",
@@ -45079,7 +45109,7 @@
         "@types/d3-scale": "^4.0.9",
         "d3-cloud": "^1.2.9",
         "d3-scale": "^4.0.2",
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "devDependencies": {
         "@types/d3-cloud": "^1.2.9"
@@ -45128,7 +45158,7 @@
         "d3-scale": "^4.0.2",
         "handlebars": "^4.7.9",
         "lodash": "^4.18.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "maplibre-gl": "^5.24.0",
         "mousetrap": "^1.6.5",
         "ngeohash": "^0.6.3",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -240,7 +240,7 @@
     "uuid": "^14.0.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs": "^18.0.0",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.29.7",

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -122,6 +122,6 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   }
 }

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -28,7 +28,7 @@
     "@types/react": "*",
     "lodash": "^4.18.1",
     "tinycolor2": "*",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
@@ -37,7 +37,7 @@
     "dompurify": "^3.4.11",
     "prop-types": "^15.8.1",
     "urijs": "^1.19.11",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
@@ -33,7 +33,7 @@
     "react-table": "^7.8.0",
     "regenerator-runtime": "^0.14.1",
     "xss": "^1.0.15",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
@@ -32,7 +32,7 @@
     "@types/geojson": "^7946.0.16",
     "geojson": "^0.5.0",
     "lodash": "^4.18.1",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "d3-array": "^3.2.4",
     "lodash": "^4.18.1",
     "zod": "^4.4.3",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -30,7 +30,7 @@
     "currencyformatter.js": "^1.0.5",
     "handlebars-group-by": "^1.0.1",
     "just-handlebars-helpers": "^1.0.19",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -33,7 +33,7 @@
     "react-table": "^7.8.0",
     "regenerator-runtime": "^0.14.1",
     "xss": "^1.0.15",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/superset-frontend/plugins/plugin-chart-word-cloud/package.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/package.json
@@ -32,7 +32,7 @@
     "@types/d3-scale": "^4.0.9",
     "d3-cloud": "^1.2.9",
     "d3-scale": "^4.0.2",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
     "@apache-superset/core": "*",

--- a/superset-frontend/plugins/preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/preset-chart-deckgl/package.json
@@ -54,7 +54,7 @@
     "underscore": "^1.13.7",
     "urijs": "^1.19.11",
     "xss": "^1.0.15",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.18.1"
   },
   "devDependencies": {
     "@types/mapbox__geojson-extent": "^1.0.3",


### PR DESCRIPTION
### SUMMARY

`superset-frontend` is an npm-workspaces monorepo with a single shared `package-lock.json`. Dependabot opened eight separate PRs (#41559, #41560, #41561, #41562, #41563, #41564, #41568, #41569) each bumping `lodash-es` from `^4.17.21` to `^4.18.1` in one workspace at a time. Every one of them fails CI because bumping the dep in some workspaces while others stay at `^4.17.21` leaves the shared lockfile inconsistent.

This PR does it in one clean pass: it bumps every remaining `lodash-es: ^4.17.21` declaration to `^4.18.1` across all 11 workspaces and regenerates the single lockfile so it's internally consistent. It also covers the root `superset-frontend` package, `superset-core`, and `preset-chart-deckgl`, which dependabot didn't open PRs for. `superset-ui-core`, `generator-superset`, and `docs` were already on 4.18.1 and are left untouched.

Supersedes and will close:
- #41559
- #41560
- #41561
- #41562
- #41563
- #41564
- #41568
- #41569

### TESTING INSTRUCTIONS

Lockfile regenerated with `npm install`; frontend CI validates install/build.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API