### PR TITLE
test(dashboard): fix filter-delete queries broken by aria-label rename

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -974,7 +974,7 @@ test('restores a deleted filter via the "Restore filter" button', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
+  fireEvent.click(within(firstTab).getByRole('button', { name: /remove filter/i }));
 
   expect(
     await screen.findByText(/you have removed this filter/i),
@@ -1009,7 +1009,7 @@ test('undoes a filter deletion via the sidebar "Undo?" link', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
+  fireEvent.click(within(firstTab).getByRole('button', { name: /remove filter/i }));
 
   const undoButton = await screen.findByTestId('undo-button');
   expect(undoButton).toHaveTextContent(/undo\?/i);


### PR DESCRIPTION
### SUMMARY

#41742 (merged 2026-07-03) fixed the filter icons to use a real `aria-label` instead of the non-functional `alt` prop, which changed the delete icon's accessible name from `delete` to **"Remove filter"** — but didn't update the two `FiltersConfigModal` tests that query the button by its accessible name. Since then, `sharded-jest-tests (5)` fails deterministically on any PR whose CI runs it (observed on #41780 and others):

```
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name /delete/i
  Name "Remove filter": <span aria-label="Remove filter" data-test="delete" ... />
```

Two-line fix: update the `getByRole('button', { name: ... })` queries in `restores a deleted filter via the "Restore filter" button` and `undoes a filter deletion via the sidebar "Undo?" link` to `/remove filter/i`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend && npx jest src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
```

26 passed, 1 skipped (pre-existing skip) locally.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)