### PR TITLE
fix(a11y): add aria-label to remove-sheet icon button in Google Sheets catalog

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/TableCatalog.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/TableCatalog.tsx
@@ -71,6 +71,7 @@ export const TableCatalog = ({
               />
               {tableCatalog?.length > 1 && (
                 <Icons.CloseOutlined
+                  aria-label={t('Remove sheet')}
                   css={(theme: SupersetTheme) => css`
                     align-self: center;
                     background: ${theme.colorFillSecondary};


### PR DESCRIPTION
### WCAG rule
2.1 SC 4.1.2 (Name, Role, Value) — Level A.

### What changed
The "remove sheet" `Icons.CloseOutlined` button in the Google Sheets catalog section of the database connection form (`TableCatalog.tsx`) — shown next to each sheet entry when there's more than one — had an `onClick` handler but no accessible name. Screen reader users tabbing to it heard only a generic "close" announcement (from the icon's auto-generated fallback label), with no indication of what it removes or which entry it belongs to.

Added `aria-label={t('Remove sheet')}`, matching the existing "Remove {noun}" convention already used by the sibling `Remove filter` button in `FilterTitleContainer.tsx`.

### Behavior
Unchanged — purely additive, no visual or functional change.

### Test plan
- Open a database connection modal for a Google Sheets connection with 2+ sheets configured.
- Tab to the "X" icon next to a sheet entry.
- Verify a screen reader announces "Remove sheet, button" (previously announced a generic unlabeled "close"/button).
- Confirm clicking still removes the correct sheet entry (no behavior change).