### PR TITLE
feat(dashboard): respect GranularExportControls for download permission

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.ts
+++ b/superset-frontend/src/dashboard/actions/hydrate.ts
@@ -27,7 +27,7 @@ import { initSliceEntities } from 'src/dashboard/reducers/sliceEntities';
 import { getInitialState as getInitialNativeFilterState } from 'src/dashboard/reducers/nativeFilters';
 import { applyDefaultFormData } from 'src/explore/store';
 import { buildActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
-import { findPermission } from 'src/utils/findPermission';
+import { canDownloadData, findPermission } from 'src/utils/findPermission';
 import {
   canUserEditDashboard,
   canUserSaveAsDashboard,
@@ -355,7 +355,7 @@ export const hydrateDashboard =
             'Superset',
             roles,
           ),
-          superset_can_download: findPermission('can_csv', 'Superset', roles),
+          superset_can_download: canDownloadData(roles),
           common: {
             // legacy, please use state.common instead
             conf: common?.conf,

--- a/superset-frontend/src/utils/findPermission.test.ts
+++ b/superset-frontend/src/utils/findPermission.test.ts
@@ -94,10 +94,12 @@ describe('canDownloadData', () => {
     expect(canDownloadData(neither)).toEqual(false);
   });
 
-  test('checks can_export_data when GranularExportControls is on, keeping can_csv as a fallback', () => {
+  test('checks can_export_data only when GranularExportControls is on, matching the backend', () => {
     mockIsFeatureEnabled.mockReturnValue(true);
     expect(canDownloadData(exportOnly)).toEqual(true);
-    expect(canDownloadData(csvOnly)).toEqual(true);
+    // no can_csv fallback: a can_csv-only user would 403 at the backend, so
+    // the button must not show
+    expect(canDownloadData(csvOnly)).toEqual(false);
     expect(canDownloadData(both)).toEqual(true);
     expect(canDownloadData(neither)).toEqual(false);
   });

--- a/superset-frontend/src/utils/findPermission.test.ts
+++ b/superset-frontend/src/utils/findPermission.test.ts
@@ -16,7 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { findPermission } from './findPermission';
+import { isFeatureEnabled } from '@superset-ui/core';
+import { UserRoles } from 'src/types/bootstrapTypes';
+import { canDownloadData, findPermission } from './findPermission';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 test('findPermission for single role', () => {
   expect(findPermission('abc', 'def', { role: [['abc', 'def']] })).toEqual(
@@ -60,4 +69,43 @@ test('findPermission for multiple roles', () => {
 
 test('handles nonexistent roles', () => {
   expect(findPermission('abc', 'def', null)).toEqual(false);
+});
+
+describe('canDownloadData', () => {
+  const csvOnly: UserRoles = { role: [['can_csv', 'Superset']] };
+  const exportOnly: UserRoles = { role: [['can_export_data', 'Superset']] };
+  const both: UserRoles = {
+    role: [
+      ['can_csv', 'Superset'],
+      ['can_export_data', 'Superset'],
+    ],
+  };
+  const neither: UserRoles = { role: [['can_write', 'Chart']] };
+
+  afterEach(() => {
+    mockIsFeatureEnabled.mockReset();
+  });
+
+  test('checks can_csv when GranularExportControls is off', () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+    expect(canDownloadData(csvOnly)).toEqual(true);
+    expect(canDownloadData(exportOnly)).toEqual(false);
+    expect(canDownloadData(both)).toEqual(true);
+    expect(canDownloadData(neither)).toEqual(false);
+  });
+
+  test('checks can_export_data when GranularExportControls is on, keeping can_csv as a fallback', () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    expect(canDownloadData(exportOnly)).toEqual(true);
+    expect(canDownloadData(csvOnly)).toEqual(true);
+    expect(canDownloadData(both)).toEqual(true);
+    expect(canDownloadData(neither)).toEqual(false);
+  });
+
+  test('handles nonexistent roles', () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    expect(canDownloadData(null)).toEqual(false);
+    mockIsFeatureEnabled.mockReturnValue(false);
+    expect(canDownloadData(undefined)).toEqual(false);
+  });
 });

--- a/superset-frontend/src/utils/findPermission.ts
+++ b/superset-frontend/src/utils/findPermission.ts
@@ -29,13 +29,13 @@ export const findPermission = memoizeOne(
 );
 
 /**
- * Whether the user may download chart data (CSV, Excel). With
- * GranularExportControls enabled this checks the granular can_export_data
- * permission but keeps can_csv as a fallback, so turning the flag on never
- * silently removes access a user already had.
+ * Whether the user may download chart data (CSV, Excel). Mirrors what the
+ * backend enforces: with GranularExportControls enabled it checks the granular
+ * can_export_data permission, otherwise can_csv. The same shape as
+ * hydrateExplore and usePermissions, so the download button never shows for a
+ * user the backend would 403.
  */
 export const canDownloadData = (roles?: UserRoles | null): boolean =>
   isFeatureEnabled(FeatureFlag.GranularExportControls)
-    ? findPermission('can_export_data', 'Superset', roles) ||
-      findPermission('can_csv', 'Superset', roles)
+    ? findPermission('can_export_data', 'Superset', roles)
     : findPermission('can_csv', 'Superset', roles);

--- a/superset-frontend/src/utils/findPermission.ts
+++ b/superset-frontend/src/utils/findPermission.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import memoizeOne from 'memoize-one';
+import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import { UserRoles } from 'src/types/bootstrapTypes';
 
 export const findPermission = memoizeOne(
@@ -26,3 +27,15 @@ export const findPermission = memoizeOne(
       permissions.some(([perm_, view_]) => perm_ === perm && view_ === view),
     ),
 );
+
+/**
+ * Whether the user may download chart data (CSV, Excel). With
+ * GranularExportControls enabled this checks the granular can_export_data
+ * permission but keeps can_csv as a fallback, so turning the flag on never
+ * silently removes access a user already had.
+ */
+export const canDownloadData = (roles?: UserRoles | null) =>
+  isFeatureEnabled(FeatureFlag.GranularExportControls)
+    ? findPermission('can_export_data', 'Superset', roles) ||
+      findPermission('can_csv', 'Superset', roles)
+    : findPermission('can_csv', 'Superset', roles);

--- a/superset-frontend/src/utils/findPermission.ts
+++ b/superset-frontend/src/utils/findPermission.ts
@@ -34,7 +34,7 @@ export const findPermission = memoizeOne(
  * permission but keeps can_csv as a fallback, so turning the flag on never
  * silently removes access a user already had.
  */
-export const canDownloadData = (roles?: UserRoles | null) =>
+export const canDownloadData = (roles?: UserRoles | null): boolean =>
   isFeatureEnabled(FeatureFlag.GranularExportControls)
     ? findPermission('can_export_data', 'Superset', roles) ||
       findPermission('can_csv', 'Superset', roles)


### PR DESCRIPTION
### SUMMARY

Follow-up promised in #39118: the `can_export_data` switch for dashboard downloads, split out so the permission change can be discussed on its own.

`superset_can_download` in dashboard hydration now respects `GranularExportControls`:

| Flag | can_csv only | can_export_data only | both     | neither     |
|------|--------------|----------------------|----------|-------------|
| off  | download     | no download          | download | no download |
| on   | no download  | download             | download | no download |

Flag off is byte-for-byte today's behavior. Flag on is a hard switch on can_export_data — no can_csv fallback. An earlier draft kept the fallback so enabling the flag could never remove an existing download button, but per review that diverged from what the backend actually enforces and from the other two call sites (hydrateExplore.ts, usePermissions), which already hard-switch. The backend wouldn't serve a can_csv-only user with the flag on, so the fallback only preserved a button that led to a 403.

The logic lives in a small canDownloadData helper next to findPermission rather than inline in hydrate.ts, so all three call sites can share it in a follow-up.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change. The download menu item's visibility follows the table above.

### TESTING INSTRUCTIONS

Unit tests cover the permission matrix in `superset-frontend/src/utils/findPermission.test.ts` (six cases across flag on/off).

Manual: enable `GranularExportControls`, then on a dashboard chart's context menu:
1. Role with can_csv only: Download is hidden (backend would refuse the export anyway).
...rest unchanged.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GranularExportControls` (behavior only changes when it is enabled)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
