### PR TITLE
fix(trino): support inline SQL UDFs (WITH FUNCTION ... BEGIN ... END)

### DIFF
--- a/superset/sql/dialects/__init__.py
+++ b/superset/sql/dialects/__init__.py
@@ -21,6 +21,7 @@ from .firebolt import Firebolt, FireboltOld
 from .hana import Hana
 from .opensearch import OpenSearch
 from .pinot import Pinot
+from .trino import Trino
 from .vertica import Vertica
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "Hana",
     "OpenSearch",
     "Pinot",
+    "Trino",
     "Vertica",
 ]

--- a/superset/sql/dialects/__init__.py
+++ b/superset/sql/dialects/__init__.py
@@ -22,6 +22,7 @@ from .hana import Hana
 from .opensearch import OpenSearch
 from .pinot import Pinot
 from .starrocks import StarRocks
+from .trino import Trino
 from .vertica import Vertica
 
 __all__ = [
@@ -33,5 +34,6 @@ __all__ = [
     "OpenSearch",
     "Pinot",
     "StarRocks",
+    "Trino",
     "Vertica",
 ]

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -1,0 +1,273 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import typing as t
+
+from sqlglot import exp
+from sqlglot.dialects.trino import Trino as SqlglotTrino
+from sqlglot.tokens import Token, TokenType
+
+# Keywords that open a block terminated by ``END`` in Trino SQL routines
+# (https://trino.io/docs/current/udf/sql.html). ``CASE`` is included because
+# both the ``CASE`` statement and the ``CASE`` expression are terminated by
+# ``END``, so counting them keeps the depth balanced either way.
+BLOCK_OPENERS = {"BEGIN", "CASE", "IF", "LOOP", "REPEAT", "WHILE"}
+
+# Keywords that are also scalar functions in Trino (e.g. ``IF(a, b, c)`` and
+# ``REPEAT('a', 3)``). When immediately followed by ``(`` they are function
+# calls, not block openers.
+AMBIGUOUS_OPENERS = {"IF", "REPEAT"}
+
+BODY_KEYWORDS = ("RETURN", "BEGIN")
+
+
+class InlineUDF(exp.CTE):
+    """
+    An inline SQL user-defined function declared in a ``WITH`` clause.
+
+    Trino supports declaring UDFs inline as part of a query::
+
+        WITH FUNCTION meaning_of_life()
+          RETURNS tinyint
+          BEGIN
+            DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+            DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+            RETURN a * b;
+          END
+        SELECT meaning_of_life()
+
+    The function definition is stored verbatim as an opaque string (wrapped
+    in an ``exp.Var`` so that AST traversal helpers see an expression), since
+    sqlglot has no representation for SQL routine bodies. Trino does not
+    allow queries inside SQL UDF bodies, so no table references are hidden
+    by the opaque representation.
+
+    This subclasses ``exp.CTE`` because ``sqlglot.parser.Parser._parse_with``
+    only collects ``exp.CTE`` instances into the ``WITH`` clause.
+    """
+
+    arg_types = {"this": True}
+
+
+class Trino(SqlglotTrino):
+    """
+    Custom Trino dialect with support for inline SQL UDFs.
+
+    sqlglot cannot parse Trino SQL routine syntax; see
+    https://github.com/tobymao/sqlglot/issues/5178. There are two separate
+    problems:
+
+    1. The parser splits statements on every semicolon, including the ones
+       inside a ``BEGIN ... END`` routine body.
+    2. The ``FUNCTION`` specification in a ``WITH`` clause is not valid CTE
+       syntax.
+
+    This dialect keeps routine bodies intact when splitting statements, and
+    parses inline function specifications into opaque `InlineUDF` nodes that
+    regenerate verbatim.
+
+    Note that sqlglot's ``Dialect`` metaclass registers subclasses by class
+    name, so once this module is imported this class also replaces the
+    built-in dialect for string-based lookups (``dialect="trino"``). This is
+    intentional, and consistent with how other Superset dialects (e.g.
+    ``Dremio``) shadow their sqlglot counterparts: the extensions are purely
+    additive, only activating on syntax that fails to parse upstream.
+    """
+
+    class Parser(SqlglotTrino.Parser):
+        @staticmethod
+        def _block_depth_delta(
+            text: str,
+            prev_text: str,
+            next_token: Token | None,
+        ) -> int:
+            """
+            Compute the block nesting change contributed by a routine token.
+            """
+            if text in BLOCK_OPENERS:
+                if prev_text == "END":
+                    return 0  # block terminator, e.g. `END IF`, `END CASE`
+                if (
+                    text in AMBIGUOUS_OPENERS
+                    and next_token
+                    and next_token.token_type == TokenType.L_PAREN
+                ):
+                    return 0  # scalar function call, e.g. `IF(a, b, c)`
+                return 1
+            if text == "END":
+                return -1
+            return 0
+
+        def _parse(
+            self,
+            parse_method: t.Callable[..., exp.Expression | None],
+            raw_tokens: list[Token],
+            sql: str | None = None,
+        ) -> list[exp.Expression | None]:
+            """
+            Split tokens into statements, keeping routine bodies intact.
+
+            This is a copy of ``sqlglot.parser.Parser._parse`` with one
+            change: when a statement starts with ``WITH FUNCTION``, ``CREATE
+            FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons inside
+            ``BEGIN ... END`` blocks do not split the statement.
+            """
+            self.reset()
+            self.sql = sql or ""
+
+            total = len(raw_tokens)
+            chunks: list[list[Token]] = [[]]
+            routine_mode = False
+            depth = 0
+            prev_text = ""
+
+            for i, token in enumerate(raw_tokens):
+                if token.token_type == TokenType.SEMICOLON and depth <= 0:
+                    if token.comments:
+                        chunks.append([token])
+                    if i < total - 1:
+                        chunks.append([])
+                    routine_mode = False
+                    depth = 0
+                    prev_text = ""
+                    continue
+
+                chunk = chunks[-1]
+                chunk.append(token)
+
+                if token.token_type == TokenType.FUNCTION and not routine_mode:
+                    heads = [tok.token_type for tok in chunk[:-1]]
+                    routine_mode = heads in (
+                        [TokenType.WITH],
+                        [TokenType.CREATE],
+                        [TokenType.CREATE, TokenType.OR, TokenType.REPLACE],
+                    )
+                elif routine_mode:
+                    text = token.text.upper()
+                    next_token = raw_tokens[i + 1] if i < total - 1 else None
+                    depth += self._block_depth_delta(text, prev_text, next_token)
+
+                prev_text = token.text.upper()
+
+            self._chunks = chunks
+            return self._parse_batch_statements(
+                parse_method=parse_method,
+                sep_first_statement=False,
+            )
+
+        def _parse_cte(self) -> exp.CTE | None:
+            """
+            Parse a single entry in a ``WITH`` clause.
+
+            An entry starting with the ``FUNCTION`` keyword followed by an
+            identifier is an inline UDF specification; anything else
+            (including a CTE named "function") is handled by sqlglot.
+            """
+            if (
+                self._curr
+                and self._curr.token_type == TokenType.FUNCTION
+                and self._next
+                and self._next.token_type
+                not in (TokenType.ALIAS, TokenType.L_PAREN, TokenType.COMMA)
+            ):
+                return self._parse_inline_udf()
+
+            return super()._parse_cte()
+
+        def _parse_inline_udf(self) -> InlineUDF:
+            """
+            Consume an inline UDF specification and return it verbatim.
+
+            The specification is ``FUNCTION name(params) RETURNS type`` plus
+            optional routine characteristics, followed by a body that is
+            either ``RETURN expression`` or a ``BEGIN ... END`` block.
+            """
+            start = self._curr
+            self._advance()
+
+            # scan for the start of the function body, skipping over the
+            # signature, return type, and routine characteristics
+            paren_depth = 0
+            body: str | None = None
+            while self._curr:
+                token_type = self._curr.token_type
+                text = self._curr.text.upper()
+                if token_type == TokenType.L_PAREN:
+                    paren_depth += 1
+                elif token_type == TokenType.R_PAREN:
+                    paren_depth -= 1
+                elif paren_depth == 0 and text in BODY_KEYWORDS:
+                    body = text
+                    break
+                self._advance()
+
+            if body is None:
+                self.raise_error(
+                    "Expected RETURN or BEGIN in inline function specification"
+                )
+
+            if body == "RETURN":
+                self._advance()
+                if not self._parse_expression():
+                    self.raise_error("Expected expression after RETURN")
+            else:
+                self._consume_block()
+
+            raw = self.sql[start.start : self._prev.end + 1]
+            return self.expression(InlineUDF(this=exp.Var(this=raw)), token=start)
+
+        def _consume_block(self) -> None:
+            """
+            Consume a ``BEGIN ... END`` block, tracking nested blocks.
+            """
+            depth = 0
+            while self._curr:
+                text = self._curr.text.upper()
+                if text in BLOCK_OPENERS:
+                    if (
+                        text in AMBIGUOUS_OPENERS
+                        and self._next
+                        and self._next.token_type == TokenType.L_PAREN
+                    ):
+                        pass  # scalar function call, e.g. `IF(a, b, c)`
+                    else:
+                        depth += 1
+                    self._advance()
+                elif text == "END":
+                    depth -= 1
+                    self._advance()
+                    if (
+                        depth > 0
+                        and self._curr
+                        and self._curr.text.upper() in BLOCK_OPENERS
+                    ):
+                        # block terminator, e.g. `END IF`, `END CASE`
+                        self._advance()
+                    if depth == 0:
+                        return
+                else:
+                    self._advance()
+
+            self.raise_error("Unbalanced BEGIN/END in inline function specification")
+
+    class Generator(SqlglotTrino.Generator):
+        TRANSFORMS = {
+            **SqlglotTrino.Generator.TRANSFORMS,
+            InlineUDF: lambda self, e: e.this.name,
+        }

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -144,6 +144,31 @@ class Trino(SqlglotTrino):
                 return -1
             return 0
 
+        @staticmethod
+        def _starts_routine(
+            heads: list[TokenType],
+            paren_depth: int,
+        ) -> bool:
+            """
+            Determine whether a ``FUNCTION`` token at the end of ``heads``
+            (excluded from the list) begins a new routine specification:
+            ``CREATE FUNCTION``, ``CREATE OR REPLACE FUNCTION``, or an entry
+            in a ``WITH`` list, either right after ``WITH`` itself or after a
+            top-level comma separating it from a preceding CTE, e.g.
+            ``WITH cte AS (...), FUNCTION f() ...``.
+            """
+            if heads[:1] == [TokenType.CREATE]:
+                return heads in (
+                    [TokenType.CREATE],
+                    [TokenType.CREATE, TokenType.OR, TokenType.REPLACE],
+                )
+            if heads[:1] == [TokenType.WITH]:
+                return paren_depth == 0 and heads[-1] in (
+                    TokenType.WITH,
+                    TokenType.COMMA,
+                )
+            return False
+
         def _parse(
             self,
             parse_method: t.Callable[..., exp.Expression | None],
@@ -169,6 +194,7 @@ class Trino(SqlglotTrino):
             chunks: list[list[Token]] = [[]]
             routine_mode: bool = False
             depth: int = 0
+            paren_depth: int = 0
             prev_text: str = ""
 
             for i, token in enumerate(raw_tokens):
@@ -179,6 +205,7 @@ class Trino(SqlglotTrino):
                         chunks.append([])
                     routine_mode = False
                     depth = 0
+                    paren_depth = 0
                     prev_text = ""
                     continue
 
@@ -187,13 +214,14 @@ class Trino(SqlglotTrino):
 
                 if token.token_type == TokenType.FUNCTION and not routine_mode:
                     heads = [tok.token_type for tok in chunk[:-1]]
-                    routine_mode = heads in (
-                        [TokenType.WITH],
-                        [TokenType.CREATE],
-                        [TokenType.CREATE, TokenType.OR, TokenType.REPLACE],
-                    )
+                    routine_mode = self._starts_routine(heads, paren_depth)
                 elif routine_mode:
                     depth += self._block_depth_delta(raw_tokens, i, prev_text)
+
+                if token.token_type == TokenType.L_PAREN:
+                    paren_depth += 1
+                elif token.token_type == TokenType.R_PAREN:
+                    paren_depth -= 1
 
                 prev_text = token.text.upper()
 

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -27,14 +27,39 @@ from sqlglot.tokens import Token, TokenType
 # (https://trino.io/docs/current/udf/sql.html). ``CASE`` is included because
 # both the ``CASE`` statement and the ``CASE`` expression are terminated by
 # ``END``, so counting them keeps the depth balanced either way.
-BLOCK_OPENERS = {"BEGIN", "CASE", "IF", "LOOP", "REPEAT", "WHILE"}
+BLOCK_OPENERS: set[str] = {"BEGIN", "CASE", "IF", "LOOP", "REPEAT", "WHILE"}
 
 # Keywords that are also scalar functions in Trino (e.g. ``IF(a, b, c)`` and
 # ``REPEAT('a', 3)``). When immediately followed by ``(`` they are function
-# calls, not block openers.
-AMBIGUOUS_OPENERS = {"IF", "REPEAT"}
+# calls, not block openers, unless the token stream shows otherwise (see
+# ``_is_paren_condition_block``).
+AMBIGUOUS_OPENERS: set[str] = {"IF", "REPEAT"}
 
-BODY_KEYWORDS = ("RETURN", "BEGIN")
+BODY_KEYWORDS: tuple[str, str] = ("RETURN", "BEGIN")
+
+
+def _is_paren_condition_block(tokens: t.Sequence[Token], paren_index: int) -> bool:
+    """
+    Determine whether the parenthesized group starting at ``tokens[paren_index]``
+    (an ``L_PAREN``) is a procedural block condition, e.g. ``IF (a > b) THEN``,
+    as opposed to a scalar function call argument list, e.g. ``IF(a, b, c)``.
+
+    Only ``IF`` has this ambiguity: a parenthesized condition is followed by
+    ``THEN``, while a scalar function call's closing paren never is.
+    """
+    depth = 0
+    for i in range(paren_index, len(tokens)):
+        token_type = tokens[i].token_type
+        if token_type == TokenType.L_PAREN:
+            depth += 1
+        elif token_type == TokenType.R_PAREN:
+            depth -= 1
+            if depth == 0:
+                next_token = tokens[i + 1] if i + 1 < len(tokens) else None
+                return (
+                    next_token is not None and next_token.token_type == TokenType.THEN
+                )
+    return False
 
 
 class InlineUDF(exp.CTE):
@@ -93,21 +118,26 @@ class Trino(SqlglotTrino):
     class Parser(SqlglotTrino.Parser):
         @staticmethod
         def _block_depth_delta(
-            text: str,
+            tokens: list[Token],
+            index: int,
             prev_text: str,
-            next_token: Token | None,
         ) -> int:
             """
-            Compute the block nesting change contributed by a routine token.
+            Compute the block nesting change contributed by the routine token
+            at ``tokens[index]``.
             """
+            text = tokens[index].text.upper()
             if text in BLOCK_OPENERS:
                 if prev_text == "END":
                     return 0  # block terminator, e.g. `END IF`, `END CASE`
+                next_token = tokens[index + 1] if index + 1 < len(tokens) else None
                 if (
                     text in AMBIGUOUS_OPENERS
                     and next_token
                     and next_token.token_type == TokenType.L_PAREN
                 ):
+                    if text == "IF" and _is_paren_condition_block(tokens, index + 1):
+                        return 1  # procedural `IF (...) THEN`, not a call
                     return 0  # scalar function call, e.g. `IF(a, b, c)`
                 return 1
             if text == "END":
@@ -123,19 +153,23 @@ class Trino(SqlglotTrino):
             """
             Split tokens into statements, keeping routine bodies intact.
 
-            This is a copy of ``sqlglot.parser.Parser._parse`` with one
-            change: when a statement starts with ``WITH FUNCTION``, ``CREATE
-            FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons inside
-            ``BEGIN ... END`` blocks do not split the statement.
+            This is a copy of ``sqlglot.parser.Parser._parse`` (as of
+            sqlglot 30.8.0, the version pinned in ``requirements/base.txt``)
+            with one change: when a statement starts with ``WITH FUNCTION``,
+            ``CREATE FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons
+            inside ``BEGIN ... END`` blocks do not split the statement. If
+            sqlglot's own ``_parse`` changes on a future upgrade, this copy
+            will silently drift from it and should be re-diffed against the
+            new version.
             """
             self.reset()
             self.sql = sql or ""
 
             total = len(raw_tokens)
             chunks: list[list[Token]] = [[]]
-            routine_mode = False
-            depth = 0
-            prev_text = ""
+            routine_mode: bool = False
+            depth: int = 0
+            prev_text: str = ""
 
             for i, token in enumerate(raw_tokens):
                 if token.token_type == TokenType.SEMICOLON and depth <= 0:
@@ -159,9 +193,7 @@ class Trino(SqlglotTrino):
                         [TokenType.CREATE, TokenType.OR, TokenType.REPLACE],
                     )
                 elif routine_mode:
-                    text = token.text.upper()
-                    next_token = raw_tokens[i + 1] if i < total - 1 else None
-                    depth += self._block_depth_delta(text, prev_text, next_token)
+                    depth += self._block_depth_delta(raw_tokens, i, prev_text)
 
                 prev_text = token.text.upper()
 
@@ -203,7 +235,7 @@ class Trino(SqlglotTrino):
 
             # scan for the start of the function body, skipping over the
             # signature, return type, and routine characteristics
-            paren_depth = 0
+            paren_depth: int = 0
             body: str | None = None
             while self._curr:
                 token_type = self._curr.token_type
@@ -236,15 +268,20 @@ class Trino(SqlglotTrino):
             """
             Consume a ``BEGIN ... END`` block, tracking nested blocks.
             """
-            depth = 0
+            depth: int = 0
             while self._curr:
                 text = self._curr.text.upper()
                 if text in BLOCK_OPENERS:
-                    if (
+                    is_scalar_call = (
                         text in AMBIGUOUS_OPENERS
                         and self._next
                         and self._next.token_type == TokenType.L_PAREN
-                    ):
+                        and not (
+                            text == "IF"
+                            and _is_paren_condition_block(self._tokens, self._index + 1)
+                        )
+                    )
+                    if is_scalar_call:
                         pass  # scalar function call, e.g. `IF(a, b, c)`
                     else:
                         depth += 1

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -37,6 +37,32 @@ AMBIGUOUS_OPENERS: set[str] = {"IF", "REPEAT"}
 
 BODY_KEYWORDS: tuple[str, str] = ("RETURN", "BEGIN")
 
+# ``BEGIN``, ``CASE``, and ``END`` are reserved words in sqlglot's Trino
+# tokenizer, so they always carry one of these dedicated token types when
+# used as keywords, and a different one (``STRING``/``IDENTIFIER``) when
+# used as a string literal or quoted identifier, e.g. the string ``'END'``
+# or the quoted identifier ``"end"``. ``IF``, ``LOOP``, ``REPEAT``, and
+# ``WHILE`` are not reserved, so the tokenizer emits ``VAR`` for them both
+# when they're used as a keyword and when they're an unquoted identifier;
+# requiring ``VAR`` still rules out string literals and quoted identifiers,
+# which is the ambiguity ``_is_routine_keyword`` guards against.
+_RESERVED_BLOCK_TOKEN_TYPES: dict[str, TokenType] = {
+    "BEGIN": TokenType.BEGIN,
+    "CASE": TokenType.CASE,
+    "END": TokenType.END,
+}
+
+
+def _is_routine_keyword(token: Token, text: str) -> bool:
+    """
+    Determine whether ``token`` (whose upper-cased text is ``text``) is an
+    actual occurrence of a routine block keyword, as opposed to a string
+    literal or quoted identifier that happens to spell the same word.
+    """
+    if (expected := _RESERVED_BLOCK_TOKEN_TYPES.get(text)) is not None:
+        return token.token_type == expected
+    return token.token_type == TokenType.VAR
+
 
 def _is_paren_condition_block(tokens: t.Sequence[Token], paren_index: int) -> bool:
     """
@@ -126,8 +152,11 @@ class Trino(SqlglotTrino):
             Compute the block nesting change contributed by the routine token
             at ``tokens[index]``.
             """
-            text = tokens[index].text.upper()
+            token = tokens[index]
+            text = token.text.upper()
             if text in BLOCK_OPENERS:
+                if not _is_routine_keyword(token, text):
+                    return 0  # string literal or quoted identifier, not a keyword
                 if prev_text == "END":
                     return 0  # block terminator, e.g. `END IF`, `END CASE`
                 next_token = tokens[index + 1] if index + 1 < len(tokens) else None
@@ -140,7 +169,7 @@ class Trino(SqlglotTrino):
                         return 1  # procedural `IF (...) THEN`, not a call
                     return 0  # scalar function call, e.g. `IF(a, b, c)`
                 return 1
-            if text == "END":
+            if text == "END" and _is_routine_keyword(token, text):
                 return -1
             return 0
 
@@ -298,8 +327,9 @@ class Trino(SqlglotTrino):
             """
             depth: int = 0
             while self._curr:
-                text = self._curr.text.upper()
-                if text in BLOCK_OPENERS:
+                token = self._curr
+                text = token.text.upper()
+                if text in BLOCK_OPENERS and _is_routine_keyword(token, text):
                     is_scalar_call = (
                         text in AMBIGUOUS_OPENERS
                         and self._next
@@ -314,13 +344,14 @@ class Trino(SqlglotTrino):
                     else:
                         depth += 1
                     self._advance()
-                elif text == "END":
+                elif text == "END" and _is_routine_keyword(token, text):
                     depth -= 1
                     self._advance()
                     if (
                         depth > 0
                         and self._curr
                         and self._curr.text.upper() in BLOCK_OPENERS
+                        and _is_routine_keyword(self._curr, self._curr.text.upper())
                     ):
                         # block terminator, e.g. `END IF`, `END CASE`
                         self._advance()

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -45,23 +45,53 @@ BODY_KEYWORDS: tuple[str, str] = ("RETURN", "BEGIN")
 # ``WHILE`` are not reserved, so the tokenizer emits ``VAR`` for them both
 # when they're used as a keyword and when they're an unquoted identifier;
 # requiring ``VAR`` still rules out string literals and quoted identifiers,
-# which is the ambiguity ``_is_routine_keyword`` guards against.
+# which is the ambiguity ``_is_keyword_token`` guards against.
 _RESERVED_BLOCK_TOKEN_TYPES: dict[str, TokenType] = {
     "BEGIN": TokenType.BEGIN,
     "CASE": TokenType.CASE,
     "END": TokenType.END,
 }
 
+# Token text that can immediately precede a new routine statement inside a
+# ``BEGIN ... END`` body: the start of the body itself, a statement
+# separator, or a branch/loop keyword that introduces a nested statement
+# list. Used by ``_is_routine_keyword`` to tell a non-reserved block-opening
+# keyword (``IF``, ``LOOP``, ``REPEAT``, ``WHILE``) apart from an unquoted
+# routine parameter or column reference spelled the same way, since Trino
+# does not reserve these words and its tokenizer emits ``VAR`` for both.
+_STATEMENT_START_PREV_TEXTS: frozenset[str] = frozenset(
+    {"BEGIN", ";", "THEN", "ELSE", "DO", "LOOP", "REPEAT"}
+)
 
-def _is_routine_keyword(token: Token, text: str) -> bool:
+
+def _is_keyword_token(token: Token, text: str) -> bool:
     """
     Determine whether ``token`` (whose upper-cased text is ``text``) is an
-    actual occurrence of a routine block keyword, as opposed to a string
-    literal or quoted identifier that happens to spell the same word.
+    actual occurrence of a routine keyword, as opposed to a string literal
+    or quoted identifier that happens to spell the same word.
     """
     if (expected := _RESERVED_BLOCK_TOKEN_TYPES.get(text)) is not None:
         return token.token_type == expected
     return token.token_type == TokenType.VAR
+
+
+def _is_routine_keyword(token: Token, text: str, prev_text: str) -> bool:
+    """
+    Determine whether ``token`` is an actual occurrence of a routine block
+    keyword, as opposed to a string literal or quoted identifier that
+    happens to spell the same word (see ``_is_keyword_token``), or, for the
+    non-reserved keywords (``IF``, ``LOOP``, ``REPEAT``, ``WHILE``), an
+    unquoted parameter or column reference spelled the same way, e.g. a UDF
+    parameter named ``loop`` in ``RETURN loop``. A block-opening keyword only
+    ever appears where a new statement can start, so ``prev_text`` (the
+    upper-cased text of the immediately preceding token) is checked against
+    ``_STATEMENT_START_PREV_TEXTS`` for these ambiguous, non-reserved words.
+    """
+    if not _is_keyword_token(token, text):
+        return False
+    if text in _RESERVED_BLOCK_TOKEN_TYPES:
+        return True
+    return prev_text in _STATEMENT_START_PREV_TEXTS
 
 
 def _is_paren_condition_block(tokens: t.Sequence[Token], paren_index: int) -> bool:
@@ -155,8 +185,8 @@ class Trino(SqlglotTrino):
             token = tokens[index]
             text = token.text.upper()
             if text in BLOCK_OPENERS:
-                if not _is_routine_keyword(token, text):
-                    return 0  # string literal or quoted identifier, not a keyword
+                if not _is_routine_keyword(token, text, prev_text):
+                    return 0  # literal, identifier, or parameter reference
                 if prev_text == "END":
                     return 0  # block terminator, e.g. `END IF`, `END CASE`
                 next_token = tokens[index + 1] if index + 1 < len(tokens) else None
@@ -169,7 +199,7 @@ class Trino(SqlglotTrino):
                         return 1  # procedural `IF (...) THEN`, not a call
                     return 0  # scalar function call, e.g. `IF(a, b, c)`
                 return 1
-            if text == "END" and _is_routine_keyword(token, text):
+            if text == "END" and _is_routine_keyword(token, text, prev_text):
                 return -1
             return 0
 
@@ -291,7 +321,10 @@ class Trino(SqlglotTrino):
             self._advance()
 
             # scan for the start of the function body, skipping over the
-            # signature, return type, and routine characteristics
+            # signature, return type, and routine characteristics. The
+            # ``_is_keyword_token`` check rules out a routine characteristic
+            # whose string value happens to spell a body keyword, e.g.
+            # ``COMMENT 'RETURN'`` or ``COMMENT 'BEGIN'``.
             paren_depth: int = 0
             body: str | None = None
             while self._curr:
@@ -301,7 +334,11 @@ class Trino(SqlglotTrino):
                     paren_depth += 1
                 elif token_type == TokenType.R_PAREN:
                     paren_depth -= 1
-                elif paren_depth == 0 and text in BODY_KEYWORDS:
+                elif (
+                    paren_depth == 0
+                    and text in BODY_KEYWORDS
+                    and _is_keyword_token(self._curr, text)
+                ):
                     body = text
                     break
                 self._advance()
@@ -326,10 +363,13 @@ class Trino(SqlglotTrino):
             Consume a ``BEGIN ... END`` block, tracking nested blocks.
             """
             depth: int = 0
+            prev_text: str = ""
             while self._curr:
                 token = self._curr
                 text = token.text.upper()
-                if text in BLOCK_OPENERS and _is_routine_keyword(token, text):
+                if text in BLOCK_OPENERS and _is_routine_keyword(
+                    token, text, prev_text
+                ):
                     is_scalar_call = (
                         text in AMBIGUOUS_OPENERS
                         and self._next
@@ -343,21 +383,25 @@ class Trino(SqlglotTrino):
                         pass  # scalar function call, e.g. `IF(a, b, c)`
                     else:
                         depth += 1
+                    prev_text = text
                     self._advance()
-                elif text == "END" and _is_routine_keyword(token, text):
+                elif text == "END" and _is_routine_keyword(token, text, prev_text):
                     depth -= 1
+                    prev_text = text
                     self._advance()
                     if (
                         depth > 0
                         and self._curr
                         and self._curr.text.upper() in BLOCK_OPENERS
-                        and _is_routine_keyword(self._curr, self._curr.text.upper())
+                        and _is_keyword_token(self._curr, self._curr.text.upper())
                     ):
                         # block terminator, e.g. `END IF`, `END CASE`
+                        prev_text = self._curr.text.upper()
                         self._advance()
                     if depth == 0:
                         return
                 else:
+                    prev_text = text
                     self._advance()
 
             self.raise_error("Unbalanced BEGIN/END in inline function specification")

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -37,6 +37,15 @@ AMBIGUOUS_OPENERS: set[str] = {"IF", "REPEAT"}
 
 BODY_KEYWORDS: tuple[str, str] = ("RETURN", "BEGIN")
 
+# Scalar functions Trino allows calling without parentheses, e.g. plain
+# ``current_user`` rather than ``current_user()``. These are the same
+# no-paren functions sqlglot's base parser special-cases (unmodified by the
+# Trino dialect), reused here rather than duplicated so this stays in sync
+# with future sqlglot upgrades.
+_NO_PAREN_FUNCTION_TOKEN_TYPES: frozenset[TokenType] = frozenset(
+    SqlglotTrino.Parser.NO_PAREN_FUNCTIONS
+)
+
 # ``BEGIN``, ``CASE``, and ``END`` are reserved words in sqlglot's Trino
 # tokenizer, so they always carry one of these dedicated token types when
 # used as keywords, and a different one (``STRING``/``IDENTIFIER``) when
@@ -60,6 +69,16 @@ _RESERVED_BLOCK_TOKEN_TYPES: dict[str, TokenType] = {
 # keyword (``IF``, ``LOOP``, ``REPEAT``, ``WHILE``) apart from an unquoted
 # routine parameter or column reference spelled the same way, since Trino
 # does not reserve these words and its tokenizer emits ``VAR`` for both.
+#
+# Known limitation: ``THEN`` precedes a new statement in a procedural ``IF``
+# or ``CASE`` *statement*, but also precedes a scalar value in a ``CASE``
+# *expression* (e.g. ``DEFAULT CASE x WHEN 1 THEN if ELSE 0 END``), and both
+# forms share the same tokens. A bare identifier spelled exactly ``if``,
+# ``loop``, ``while``, or ``repeat`` immediately after ``THEN`` in a scalar
+# ``CASE`` expression is therefore misread as a block opener. Resolving this
+# would need to track statement-vs-expression context rather than a single
+# lookback token, which is a bigger change than this heuristic scanner is
+# meant to carry.
 _STATEMENT_START_PREV_TEXTS: frozenset[str] = frozenset(
     {"BEGIN", ";", "THEN", "ELSE", "DO", "LOOP", "REPEAT", ":"}
 )
@@ -139,12 +158,20 @@ def _extract_function_calls(tokens: t.Sequence[Token]) -> list[exp.Anonymous]:
     positives are harmless here, since this list is only used to check for
     the presence of specific denylisted function names, not to validate the
     call itself.
+
+    A few functions (e.g. ``current_user``, ``current_timestamp``) are also
+    callable with no parentheses at all, so those are matched separately by
+    token type, regardless of what follows.
     """
     return [
         exp.Anonymous(this=tokens[i - 1].text)
         for i in range(1, len(tokens))
         if tokens[i].token_type == TokenType.L_PAREN
         and tokens[i - 1].text.isidentifier()
+    ] + [
+        exp.Anonymous(this=token.text)
+        for token in tokens
+        if token.token_type in _NO_PAREN_FUNCTION_TOKEN_TYPES
     ]
 
 
@@ -284,7 +311,7 @@ class Trino(SqlglotTrino):
 
             This is a copy of ``sqlglot.parser.Parser._parse`` (verified to
             match through sqlglot 30.16.0, the version pinned in
-            ``requirements/base.txt`` as of this writing) with one change:
+            ``requirements/base.txt``) with one change:
             when a statement starts with ``WITH FUNCTION``, ``CREATE
             FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons inside
             ``BEGIN ... END`` blocks do not split the statement. Because this

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -126,19 +126,25 @@ def _extract_function_calls(tokens: t.Sequence[Token]) -> list[exp.Anonymous]:
     that ``SQLScript.check_functions_present`` still sees them even though
     the UDF body itself is kept as opaque, verbatim text.
 
-    A call is any unreserved-keyword-or-identifier token (tokenized as
-    ``VAR``, since Trino's tokenizer does not distinguish an unquoted
-    identifier from an unreserved keyword) immediately followed by ``(``.
-    This can also match a routine/parameter type name (e.g. ``varchar(10)``)
-    or the UDF's own name at its declaration site; those false positives are
-    harmless here, since this list is only used to check for the presence of
-    specific denylisted function names, not to validate the call itself.
+    A call is any word-like token immediately followed by ``(``. Most scalar
+    functions tokenize as plain ``VAR`` (Trino's tokenizer does not
+    distinguish an unquoted identifier from an unreserved keyword), but a few
+    (e.g. ``current_user``, ``localtime``) are reserved words with their own
+    dedicated ``TokenType`` and would otherwise slip past a ``VAR``-only
+    check while still being callable with parentheses, so the token text
+    itself (rather than its type) decides whether it looks like a call head.
+    This can also match a routine/parameter type name (e.g. ``varchar(10)``),
+    a keyword used with parenthesized syntax (e.g. ``CAST(...)``, ``IN
+    (...)``), or the UDF's own name at its declaration site; those false
+    positives are harmless here, since this list is only used to check for
+    the presence of specific denylisted function names, not to validate the
+    call itself.
     """
     return [
         exp.Anonymous(this=tokens[i - 1].text)
         for i in range(1, len(tokens))
         if tokens[i].token_type == TokenType.L_PAREN
-        and tokens[i - 1].token_type == TokenType.VAR
+        and tokens[i - 1].text.isidentifier()
     ]
 
 
@@ -276,14 +282,16 @@ class Trino(SqlglotTrino):
             """
             Split tokens into statements, keeping routine bodies intact.
 
-            This is a copy of ``sqlglot.parser.Parser._parse`` (as of
-            sqlglot 30.8.0, the version pinned in ``requirements/base.txt``)
-            with one change: when a statement starts with ``WITH FUNCTION``,
-            ``CREATE FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons
-            inside ``BEGIN ... END`` blocks do not split the statement. If
-            sqlglot's own ``_parse`` changes on a future upgrade, this copy
-            will silently drift from it and should be re-diffed against the
-            new version.
+            This is a copy of ``sqlglot.parser.Parser._parse`` (verified to
+            match through sqlglot 30.16.0, the version pinned in
+            ``requirements/base.txt`` as of this writing) with one change:
+            when a statement starts with ``WITH FUNCTION``, ``CREATE
+            FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons inside
+            ``BEGIN ... END`` blocks do not split the statement. Because this
+            is a hand-maintained copy rather than an extension through a
+            public hook, it will silently drift if sqlglot's own ``_parse``
+            changes on a future upgrade; re-diff this method against the new
+            version whenever ``sqlglot`` is bumped in ``requirements/base.txt``.
             """
             self.reset()
             self.sql = sql or ""

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -54,13 +54,14 @@ _RESERVED_BLOCK_TOKEN_TYPES: dict[str, TokenType] = {
 
 # Token text that can immediately precede a new routine statement inside a
 # ``BEGIN ... END`` body: the start of the body itself, a statement
-# separator, or a branch/loop keyword that introduces a nested statement
-# list. Used by ``_is_routine_keyword`` to tell a non-reserved block-opening
+# separator, a branch/loop keyword that introduces a nested statement list,
+# or ``:`` following a statement label (e.g. ``top: WHILE ... END WHILE``).
+# Used by ``_is_routine_keyword`` to tell a non-reserved block-opening
 # keyword (``IF``, ``LOOP``, ``REPEAT``, ``WHILE``) apart from an unquoted
 # routine parameter or column reference spelled the same way, since Trino
 # does not reserve these words and its tokenizer emits ``VAR`` for both.
 _STATEMENT_START_PREV_TEXTS: frozenset[str] = frozenset(
-    {"BEGIN", ";", "THEN", "ELSE", "DO", "LOOP", "REPEAT"}
+    {"BEGIN", ";", "THEN", "ELSE", "DO", "LOOP", "REPEAT", ":"}
 )
 
 
@@ -118,6 +119,29 @@ def _is_paren_condition_block(tokens: t.Sequence[Token], paren_index: int) -> bo
     return False
 
 
+def _extract_function_calls(tokens: t.Sequence[Token]) -> list[exp.Anonymous]:
+    """
+    Scan the raw tokens of an inline UDF specification for scalar function
+    calls, e.g. ``regexp_replace(...)`` in ``RETURN regexp_replace(...)``, so
+    that ``SQLScript.check_functions_present`` still sees them even though
+    the UDF body itself is kept as opaque, verbatim text.
+
+    A call is any unreserved-keyword-or-identifier token (tokenized as
+    ``VAR``, since Trino's tokenizer does not distinguish an unquoted
+    identifier from an unreserved keyword) immediately followed by ``(``.
+    This can also match a routine/parameter type name (e.g. ``varchar(10)``)
+    or the UDF's own name at its declaration site; those false positives are
+    harmless here, since this list is only used to check for the presence of
+    specific denylisted function names, not to validate the call itself.
+    """
+    return [
+        exp.Anonymous(this=tokens[i - 1].text)
+        for i in range(1, len(tokens))
+        if tokens[i].token_type == TokenType.L_PAREN
+        and tokens[i - 1].token_type == TokenType.VAR
+    ]
+
+
 class InlineUDF(exp.CTE):
     """
     An inline SQL user-defined function declared in a ``WITH`` clause.
@@ -137,13 +161,17 @@ class InlineUDF(exp.CTE):
     in an ``exp.Var`` so that AST traversal helpers see an expression), since
     sqlglot has no representation for SQL routine bodies. Trino does not
     allow queries inside SQL UDF bodies, so no table references are hidden
-    by the opaque representation.
+    by the opaque representation. Scalar function calls, however, would be
+    hidden from ``SQLScript.check_functions_present`` (used to enforce
+    ``DISALLOWED_SQL_FUNCTIONS``) since it walks the AST for ``exp.Func``
+    nodes, so those are additionally extracted into ``expressions`` as
+    ``exp.Anonymous`` nodes; they play no part in regenerating the SQL.
 
     This subclasses ``exp.CTE`` because ``sqlglot.parser.Parser._parse_with``
     only collects ``exp.CTE`` instances into the ``WITH`` clause.
     """
 
-    arg_types = {"this": True}
+    arg_types = {"this": True, "expressions": False}
 
 
 class Trino(SqlglotTrino):
@@ -206,6 +234,7 @@ class Trino(SqlglotTrino):
         @staticmethod
         def _starts_routine(
             heads: list[TokenType],
+            next_token_type: TokenType | None,
             paren_depth: int,
         ) -> bool:
             """
@@ -215,6 +244,14 @@ class Trino(SqlglotTrino):
             in a ``WITH`` list, either right after ``WITH`` itself or after a
             top-level comma separating it from a preceding CTE, e.g.
             ``WITH cte AS (...), FUNCTION f() ...``.
+
+            In the ``WITH`` case, ``FUNCTION`` may also just be an ordinary
+            CTE named "function", e.g. ``WITH function AS (...) SELECT ...``.
+            ``next_token_type`` (the token immediately after ``FUNCTION``) is
+            checked the same way ``_parse_cte`` disambiguates the two: a CTE
+            named "function" is followed by ``AS``, ``(``, or a comma (for a
+            column alias list), while a routine specification is followed by
+            the function name.
             """
             if heads[:1] == [TokenType.CREATE]:
                 return heads in (
@@ -222,9 +259,11 @@ class Trino(SqlglotTrino):
                     [TokenType.CREATE, TokenType.OR, TokenType.REPLACE],
                 )
             if heads[:1] == [TokenType.WITH]:
-                return paren_depth == 0 and heads[-1] in (
-                    TokenType.WITH,
-                    TokenType.COMMA,
+                return (
+                    paren_depth == 0
+                    and heads[-1] in (TokenType.WITH, TokenType.COMMA)
+                    and next_token_type
+                    not in (TokenType.ALIAS, TokenType.L_PAREN, TokenType.COMMA)
                 )
             return False
 
@@ -273,7 +312,12 @@ class Trino(SqlglotTrino):
 
                 if token.token_type == TokenType.FUNCTION and not routine_mode:
                     heads = [tok.token_type for tok in chunk[:-1]]
-                    routine_mode = self._starts_routine(heads, paren_depth)
+                    next_token = raw_tokens[i + 1] if i + 1 < total else None
+                    routine_mode = self._starts_routine(
+                        heads,
+                        next_token.token_type if next_token else None,
+                        paren_depth,
+                    )
                 elif routine_mode:
                     depth += self._block_depth_delta(raw_tokens, i, prev_text)
 
@@ -318,6 +362,7 @@ class Trino(SqlglotTrino):
             either ``RETURN expression`` or a ``BEGIN ... END`` block.
             """
             start = self._curr
+            start_index = self._index
             self._advance()
 
             # scan for the start of the function body, skipping over the
@@ -356,7 +401,10 @@ class Trino(SqlglotTrino):
                 self._consume_block()
 
             raw = self.sql[start.start : self._prev.end + 1]
-            return self.expression(InlineUDF(this=exp.Var(this=raw)), token=start)
+            calls = _extract_function_calls(self._tokens[start_index : self._index])
+            return self.expression(
+                InlineUDF(this=exp.Var(this=raw), expressions=calls), token=start
+            )
 
         def _consume_block(self) -> None:
             """

--- a/superset/sql/dialects/trino.py
+++ b/superset/sql/dialects/trino.py
@@ -310,7 +310,7 @@ class Trino(SqlglotTrino):
             Split tokens into statements, keeping routine bodies intact.
 
             This is a copy of ``sqlglot.parser.Parser._parse`` (verified to
-            match through sqlglot 30.16.0, the version pinned in
+            match through sqlglot 30.17.0, the version pinned in
             ``requirements/base.txt``) with one change:
             when a statement starts with ``WITH FUNCTION``, ``CREATE
             FUNCTION``, or ``CREATE OR REPLACE FUNCTION``, semicolons inside

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -55,6 +55,7 @@ from superset.sql.dialects import (
     Hana,
     OpenSearch,
     Pinot,
+    Trino,
     Vertica,
 )
 
@@ -161,7 +162,7 @@ SQLGLOT_DIALECTS = {
     "superset": Dialects.SQLITE,
     # "taosws": ???
     "teradatasql": Dialects.TERADATA,
-    "trino": Dialects.TRINO,
+    "trino": Trino,
     "vertica": Vertica,
     # "ydb" is a plugin dialect (ydb-sqlglot-plugin) auto-discovered via entry_points,
     # hence a string name rather than a class reference like the built-in dialects.

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -55,6 +55,7 @@ from superset.sql.dialects import (
     OpenSearch,
     Pinot,
     StarRocks,
+    Trino,
     Vertica,
 )
 
@@ -163,7 +164,7 @@ SQLGLOT_DIALECTS = {
     "superset": Dialects.SQLITE,
     # "taosws": ???
     "teradatasql": Dialects.TERADATA,
-    "trino": Dialects.TRINO,
+    "trino": Trino,
     "vertica": Vertica,
     # "ydb" is a plugin dialect (ydb-sqlglot-plugin) auto-discovered via entry_points,
     # hence a string name rather than a class reference like the built-in dialects.

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -165,6 +165,27 @@ def test_cte_named_function_still_works() -> None:
     assert statement.sql(dialect=Trino) == sql
 
 
+def test_inline_udf_after_regular_cte() -> None:
+    """
+    An inline UDF following a regular CTE in the same ``WITH`` clause must
+    still have its body's semicolons kept intact.
+    """
+    sql = """
+WITH cte AS (SELECT 1),
+FUNCTION meaning_of_life()
+  RETURNS tinyint
+  BEGIN
+    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+    RETURN a * b;
+  END
+SELECT meaning_of_life()
+""".strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
 def test_unbalanced_body_raises() -> None:
     """
     An unterminated routine body should raise a parse error.

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -169,6 +169,35 @@ def test_missing_body_raises() -> None:
         sqlglot.parse(sql, dialect=Trino)
 
 
+def test_missing_return_expression_raises() -> None:
+    """
+    A ``RETURN`` body without a following expression should raise a parse
+    error.
+    """
+    sql = "WITH FUNCTION f() RETURNS int RETURN"
+    with pytest.raises(sqlglot.errors.ParseError):
+        sqlglot.parse(sql, dialect=Trino)
+
+
+def test_semicolon_with_trailing_comment() -> None:
+    """
+    A statement-separating semicolon with a comment attached to it (no
+    whitespace in between) should still split statements correctly.
+    """
+    sql = "SELECT 1;-- trailing\nSELECT 2"
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 3  # SELECT 1, the comment-bearing `;`, SELECT 2
+
+
+def test_trailing_semicolon_with_no_following_statement() -> None:
+    """
+    A single statement terminated by a semicolon with nothing after it
+    should parse as one statement.
+    """
+    statements = sqlglot.parse("SELECT 1;", dialect=Trino)
+    assert len(statements) == 1
+
+
 def test_sqlscript_inline_udf() -> None:
     """
     Integration with the Superset parsing API (reproduces #26162).

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -1,0 +1,239 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import sqlglot
+
+from superset.exceptions import SupersetParseError
+from superset.sql.dialects.trino import InlineUDF, Trino
+from superset.sql.parse import SQLScript, SQLStatement, Table
+
+# example from https://trino.io/docs/current/udf/sql/begin.html, reported in
+# https://github.com/apache/superset/issues/26162
+INLINE_UDF = """
+WITH FUNCTION meaning_of_life()
+  RETURNS tinyint
+  BEGIN
+    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+    RETURN a * b;
+  END
+SELECT meaning_of_life()
+""".strip()
+
+
+def test_inline_udf_is_single_statement() -> None:
+    """
+    Semicolons inside the routine body must not split the statement.
+    """
+    statements = sqlglot.parse(INLINE_UDF, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
+def test_inline_udf_generates_verbatim() -> None:
+    """
+    The function specification should be preserved verbatim, and the
+    generated SQL should be parseable again.
+    """
+    statement = sqlglot.parse_one(INLINE_UDF, dialect=Trino)
+    generated = statement.sql(dialect=Trino)
+    assert (
+        """
+WITH FUNCTION meaning_of_life()
+  RETURNS tinyint
+  BEGIN
+    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+    RETURN a * b;
+  END
+""".strip()
+        in generated
+    )
+    assert sqlglot.parse_one(generated, dialect=Trino)
+
+
+def test_inline_udf_return_form() -> None:
+    """
+    Test functions whose body is a single ``RETURN`` expression, including
+    multiple comma-separated functions in one ``WITH`` clause.
+    """
+    sql = """
+WITH
+  FUNCTION hello(name varchar)
+    RETURNS varchar
+    RETURN format('Hello %s!', name),
+  FUNCTION bye()
+    RETURNS varchar
+    RETURN 'Bye!'
+SELECT hello('Finn') || ' and ' || bye()
+    """.strip()
+    statement = sqlglot.parse_one(sql, dialect=Trino)
+    assert len(list(statement.find_all(InlineUDF))) == 2
+
+    generated = statement.sql(dialect=Trino)
+    assert "RETURN format('Hello %s!', name)" in generated
+    assert "RETURN 'Bye!'" in generated
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        """
+WITH FUNCTION classify(a bigint)
+  RETURNS varchar
+  BEGIN
+    CASE a
+      WHEN 0 THEN RETURN 'zero';
+      WHEN 1 THEN RETURN 'one';
+      ELSE RETURN 'more than one or negative';
+    END CASE;
+    RETURN NULL;
+  END
+SELECT classify(x) FROM some_table
+        """,
+        """
+WITH FUNCTION classify(a bigint)
+  RETURNS varchar
+  BEGIN
+    IF a > 100 THEN
+      RETURN 'big';
+    ELSEIF a > 0 THEN
+      RETURN 'small';
+    END IF;
+    RETURN 'negative';
+  END
+SELECT classify(x) FROM some_table
+        """,
+        """
+WITH FUNCTION classify(a bigint)
+  RETURNS varchar
+  BEGIN
+    WHILE a < 100 DO
+      SET a = a + 1;
+    END WHILE;
+    RETURN IF(a = 100, 'hundred', 'other');
+  END
+SELECT classify(x) FROM some_table
+        """,
+    ],
+)
+def test_inline_udf_nested_blocks(sql: str) -> None:
+    """
+    Test nested blocks: ``CASE ... END CASE``, ``IF ... END IF``,
+    ``WHILE ... END WHILE``, and scalar ``IF()`` function calls.
+    """
+    statements = sqlglot.parse(sql.strip(), dialect=Trino)
+    assert len(statements) == 1
+
+
+def test_cte_named_function_still_works() -> None:
+    """
+    A CTE named "function" must still be parsed as a regular CTE.
+    """
+    sql = "WITH function AS (SELECT 1 AS x) SELECT x FROM function"
+    statement = sqlglot.parse_one(sql, dialect=Trino)
+    assert not list(statement.find_all(InlineUDF))
+    assert statement.sql(dialect=Trino) == sql
+
+
+def test_unbalanced_body_raises() -> None:
+    """
+    An unterminated routine body should raise a parse error.
+    """
+    sql = "WITH FUNCTION f() RETURNS int BEGIN RETURN 1; SELECT f()"
+    with pytest.raises(sqlglot.errors.ParseError):
+        sqlglot.parse(sql, dialect=Trino)
+
+
+def test_missing_body_raises() -> None:
+    """
+    A function specification without a body should raise a parse error.
+    """
+    sql = "WITH FUNCTION f() RETURNS int SELECT f()"
+    with pytest.raises(sqlglot.errors.ParseError):
+        sqlglot.parse(sql, dialect=Trino)
+
+
+def test_sqlscript_inline_udf() -> None:
+    """
+    Integration with the Superset parsing API (reproduces #26162).
+    """
+    script = SQLScript(INLINE_UDF, "trino")
+    assert len(script.statements) == 1
+    assert not script.has_mutation()
+
+    statement = script.statements[0]
+    assert statement.is_select()
+    assert statement.format() == statement.format()  # deterministic
+
+
+def test_sqlscript_inline_udf_multiple_statements() -> None:
+    """
+    Statements after the UDF query should still be split correctly.
+    """
+    script = SQLScript(f"{INLINE_UDF};\nSELECT 42", "trino")
+    assert len(script.statements) == 2
+
+
+def test_sqlstatement_extract_tables() -> None:
+    """
+    Tables referenced by the main query should still be extracted.
+    """
+    sql = """
+WITH FUNCTION doubleup(x integer)
+  RETURNS integer
+  BEGIN
+    RETURN x * 2;
+  END
+SELECT doubleup(some_column) FROM some_table
+    """.strip()
+    statement = SQLStatement(sql, "trino")
+    assert statement.tables == {Table("some_table")}
+
+
+def test_sqlstatement_regular_queries_unaffected() -> None:
+    """
+    Regular Trino queries should parse exactly as before.
+    """
+    script = SQLScript(
+        "WITH t AS (SELECT 1 AS x) SELECT * FROM t; SELECT 2",
+        "trino",
+    )
+    assert len(script.statements) == 2
+    assert script.statements[0].tables == set()
+
+    with pytest.raises(SupersetParseError):
+        SQLStatement("SELECT * FROM", "trino")
+
+
+def test_create_function_not_split() -> None:
+    """
+    ``CREATE FUNCTION`` bodies should not be split on semicolons either.
+    """
+    sql = """
+CREATE FUNCTION meaning_of_life()
+  RETURNS tinyint
+  BEGIN
+    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+    RETURN a * b;
+  END;
+SELECT 42
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 2

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -130,12 +130,26 @@ WITH FUNCTION classify(a bigint)
   END
 SELECT classify(x) FROM some_table
         """,
+        """
+WITH FUNCTION classify(a bigint)
+  RETURNS varchar
+  BEGIN
+    IF (a > 100) THEN
+      RETURN 'big';
+    ELSEIF a > 0 THEN
+      RETURN 'small';
+    END IF;
+    RETURN 'negative';
+  END
+SELECT classify(x) FROM some_table
+        """,
     ],
 )
 def test_inline_udf_nested_blocks(sql: str) -> None:
     """
     Test nested blocks: ``CASE ... END CASE``, ``IF ... END IF``,
-    ``WHILE ... END WHILE``, and scalar ``IF()`` function calls.
+    ``WHILE ... END WHILE``, scalar ``IF()`` function calls, and a
+    parenthesized ``IF (...) THEN`` condition.
     """
     statements = sqlglot.parse(sql.strip(), dialect=Trino)
     assert len(statements) == 1

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -285,6 +285,49 @@ def test_sqlstatement_regular_queries_unaffected() -> None:
         SQLStatement("SELECT * FROM", "trino")
 
 
+def test_inline_udf_nested_parens_in_condition() -> None:
+    """
+    A parenthesized ``IF`` condition containing its own nested parens must
+    still be recognized as a block opener, not a scalar function call.
+    """
+    sql = """
+WITH FUNCTION classify(a bigint, b bigint)
+  RETURNS varchar
+  BEGIN
+    IF ((a > 100) AND (b > 100)) THEN
+      RETURN 'big';
+    END IF;
+    RETURN 'small';
+  END
+SELECT classify(x, y) FROM some_table
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+
+
+def test_scalar_function_named_function() -> None:
+    """
+    A regular scalar function call literally named ``function`` (outside a
+    ``CREATE``/``WITH`` routine specification) must parse normally.
+    """
+    sql = "SELECT function(x) FROM t"
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+
+
+def test_unclosed_if_condition_raises() -> None:
+    """
+    An ``IF`` condition with an unbalanced opening paren should fail to
+    parse rather than being silently misread as a block.
+    """
+    sql = (
+        "WITH FUNCTION f() RETURNS int BEGIN "
+        "IF (a > 1 THEN RETURN 1; END IF; RETURN 2; END SELECT 1"
+    )
+    with pytest.raises(sqlglot.errors.ParseError):
+        sqlglot.parse(sql, dialect=Trino)
+
+
 def test_create_function_not_split() -> None:
     """
     ``CREATE FUNCTION`` bodies should not be split on semicolons either.

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -303,6 +303,7 @@ SELECT classify(x, y) FROM some_table
     """.strip()
     statements = sqlglot.parse(sql, dialect=Trino)
     assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
 
 
 def test_scalar_function_named_function() -> None:

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -345,3 +345,45 @@ SELECT 42
     """.strip()
     statements = sqlglot.parse(sql, dialect=Trino)
     assert len(statements) == 2
+
+
+def test_create_or_replace_function_not_split() -> None:
+    """
+    ``CREATE OR REPLACE FUNCTION`` bodies should not be split on semicolons
+    either, and the routine is followed by the next statement.
+    """
+    sql = """
+CREATE OR REPLACE FUNCTION meaning_of_life()
+  RETURNS tinyint
+  BEGIN
+    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
+    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
+    RETURN a * b;
+  END;
+SELECT 42
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 2
+
+
+def test_block_keywords_in_string_literals_and_identifiers_ignored() -> None:
+    """
+    Block keywords (``BEGIN``, ``CASE``, ``END``, ``IF``, ...) that appear as
+    the text of a string literal or a quoted identifier must not be mistaken
+    for actual routine keywords when tracking block depth, since they carry
+    the same text but a different token type.
+    """
+    sql = """
+WITH FUNCTION describe_status(status varchar)
+  RETURNS varchar
+  BEGIN
+    IF status = 'END' THEN
+      RETURN 'terminal';
+    END IF;
+    RETURN "case";
+  END
+SELECT describe_status('END')
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -439,3 +439,63 @@ SELECT describe_status('END')
     statements = sqlglot.parse(sql, dialect=Trino)
     assert len(statements) == 1
     assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
+def test_cte_named_function_does_not_trigger_routine_mode() -> None:
+    """
+    An ordinary CTE named "function" must not put the parser into routine
+    mode: block keywords used as ordinary identifiers/expressions elsewhere
+    in the script (here, `loop` as a column alias, and the `CASE ... END`
+    expression) must not affect statement splitting, and a later statement
+    must still be split off correctly.
+    """
+    sql = (
+        "WITH function AS (SELECT 1 AS a, 2 AS loop) "
+        "SELECT CASE WHEN a THEN loop ELSE 0 END FROM function; "
+        "SELECT 2"
+    )
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 2
+    assert not list(statements[0].find_all(InlineUDF))
+
+
+def test_labeled_loop_block_depth_tracked() -> None:
+    """
+    A labeled loop (``label: WHILE ... END WHILE``, per
+    https://trino.io/docs/current/udf/sql.html) must still be tracked for
+    block depth: the label's trailing ``:`` sits between the loop opener and
+    its preceding statement separator/branch keyword.
+    """
+    sql = """
+WITH FUNCTION count_to(n bigint)
+  RETURNS bigint
+  BEGIN
+    DECLARE r bigint DEFAULT 0;
+    top: WHILE r < n DO
+      SET r = r + 1;
+    END WHILE;
+    RETURN r;
+  END
+SELECT count_to(5)
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
+def test_udf_body_function_calls_visible_to_check_functions_present() -> None:
+    """
+    A scalar function call inside an inline UDF body must still be visible
+    to ``SQLScript.check_functions_present`` (used to enforce
+    ``DISALLOWED_SQL_FUNCTIONS``), even though the body itself is stored as
+    opaque, verbatim text.
+    """
+    sql = """
+WITH FUNCTION mask(x varchar)
+  RETURNS varchar
+  RETURN regexp_replace(x, '.', '*')
+SELECT mask(some_column) FROM some_table
+    """.strip()
+    script = SQLScript(sql, "trino")
+    assert script.statements[0].check_functions_present({"regexp_replace"})
+    assert not script.statements[0].check_functions_present({"not_present"})

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -499,3 +499,22 @@ SELECT mask(some_column) FROM some_table
     script = SQLScript(sql, "trino")
     assert script.statements[0].check_functions_present({"regexp_replace"})
     assert not script.statements[0].check_functions_present({"not_present"})
+
+
+def test_udf_body_reserved_word_function_call_visible_to_check_functions_present() -> (
+    None
+):
+    """
+    A handful of scalar functions (``current_user``, ``localtime``, etc.) are
+    reserved words with their own dedicated token type rather than the
+    generic ``VAR`` most function names get, so they must still be caught
+    when called with parentheses inside an inline UDF body.
+    """
+    sql = """
+WITH FUNCTION whoami()
+  RETURNS varchar
+  RETURN current_user()
+SELECT whoami()
+    """.strip()
+    script = SQLScript(sql, "trino")
+    assert script.statements[0].check_functions_present({"current_user"})

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -15,12 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import hashlib
+import inspect
+
 import pytest
 import sqlglot
+from sqlglot.parser import Parser as SqlglotParser
 
 from superset.exceptions import SupersetParseError
 from superset.sql.dialects.trino import InlineUDF, Trino
 from superset.sql.parse import SQLScript, SQLStatement, Table
+
+# Hash of ``sqlglot.parser.Parser._parse``'s source, verified against
+# sqlglot 30.16.0 (the version pinned in ``requirements/base.txt``) when
+# ``Trino.Parser._parse`` was copied from it. ``Trino.Parser._parse`` is a
+# hand-maintained copy rather than an extension through a public hook (see
+# its own docstring), so it silently drifts if sqlglot changes this method.
+# This test is a tripwire: a hash mismatch means sqlglot's ``_parse`` moved
+# out from under the copy, and ``Trino.Parser._parse`` needs a re-diff (and
+# this hash needs updating) before the next sqlglot bump.
+_UPSTREAM_PARSE_SOURCE_SHA256 = (
+    "674878e8b6c33a06cffe58c3565dba54e6e3c82c2ad8a5449ac790698f2bd519"
+)
 
 # example from https://trino.io/docs/current/udf/sql/begin.html, reported in
 # https://github.com/apache/superset/issues/26162
@@ -518,3 +534,75 @@ SELECT whoami()
     """.strip()
     script = SQLScript(sql, "trino")
     assert script.statements[0].check_functions_present({"current_user"})
+
+
+def test_udf_body_bare_no_paren_function_call_visible_to_check_functions_present() -> (
+    None
+):
+    """
+    Trino also permits calling a handful of scalar functions with no
+    parentheses at all, e.g. plain ``current_user`` rather than
+    ``current_user()``. That bare form must still be caught, since it
+    otherwise would not have looked like a call at all (nothing follows it).
+    """
+    sql = """
+WITH FUNCTION whoami()
+  RETURNS varchar
+  RETURN current_user
+SELECT whoami()
+    """.strip()
+    script = SQLScript(sql, "trino")
+    assert script.statements[0].check_functions_present({"current_user"})
+
+
+def test_upstream_parse_source_is_unchanged() -> None:
+    """
+    ``Trino.Parser._parse`` is a hand-maintained copy of
+    ``sqlglot.parser.Parser._parse``, not an extension through a public
+    hook (see its own docstring). If sqlglot ever changes that method, this
+    copy silently drifts out of sync instead of failing loudly, so this
+    hashes the upstream source and compares it against the version this
+    copy was last verified against.
+
+    A failure here does not mean anything is broken; it means
+    ``Trino.Parser._parse`` needs a re-diff against the new sqlglot source,
+    and this hash needs updating once that's done.
+    """
+    upstream_source = inspect.getsource(SqlglotParser._parse)
+    upstream_hash = hashlib.sha256(upstream_source.encode()).hexdigest()
+    assert upstream_hash == _UPSTREAM_PARSE_SOURCE_SHA256, (
+        "sqlglot.parser.Parser._parse has changed since Trino.Parser._parse "
+        "was copied from it. Re-diff superset/sql/dialects/trino.py's "
+        "_parse against the new sqlglot source, update its docstring, and "
+        "update _UPSTREAM_PARSE_SOURCE_SHA256 above to match."
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "known limitation: a bare `if`/`loop`/`while`/`repeat` identifier "
+        "right after THEN in a scalar CASE expression is misread as a "
+        "procedural block opener, since THEN also opens a nested statement "
+        "in a procedural IF/CASE statement and both share the same tokens; "
+        "see _STATEMENT_START_PREV_TEXTS"
+    ),
+    strict=True,
+)
+def test_udf_body_case_expression_then_bare_identifier_known_limitation() -> None:
+    """
+    Pins the known limitation documented on ``_STATEMENT_START_PREV_TEXTS``:
+    a scalar ``CASE`` expression whose ``THEN`` branch is a bare identifier
+    spelled like a block-opening keyword fails to parse inside a routine
+    body, because it is indistinguishable from a procedural statement
+    starting there without tracking statement-vs-expression context.
+    """
+    sql = """
+WITH FUNCTION f(x int)
+  RETURNS int
+  BEGIN
+    DECLARE a int DEFAULT CASE x WHEN 1 THEN if ELSE 0 END;
+    RETURN a;
+  END
+SELECT f(1)
+    """.strip()
+    SQLScript(sql, "trino")

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -366,6 +366,58 @@ SELECT 42
     assert len(statements) == 2
 
 
+def test_block_keyword_as_parameter_reference_not_counted() -> None:
+    """
+    ``LOOP``, ``REPEAT``, and ``WHILE`` are not reserved words in Trino, so
+    an unquoted routine parameter or column reference spelled the same way
+    (e.g. a parameter named ``loop``) must not be mistaken for a
+    block-opening keyword, which would otherwise leave the block depth
+    unbalanced at ``END``.
+    """
+    sql = """
+WITH FUNCTION echo(loop bigint)
+  RETURNS bigint
+  BEGIN
+    RETURN loop;
+  END
+SELECT echo(x) FROM some_table
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
+def test_body_keyword_in_routine_characteristic_ignored() -> None:
+    """
+    A routine characteristic string value that happens to spell a body
+    keyword (e.g. ``COMMENT 'RETURN'`` or ``COMMENT 'BEGIN'``) must not be
+    mistaken for the actual start of the function body.
+    """
+    sql = """
+WITH FUNCTION f()
+  RETURNS int
+  COMMENT 'RETURN'
+  BEGIN
+    RETURN 1;
+  END
+SELECT f()
+    """.strip()
+    statements = sqlglot.parse(sql, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+    sql_begin_comment = """
+WITH FUNCTION f()
+  RETURNS int
+  COMMENT 'BEGIN'
+  RETURN 1
+SELECT f()
+    """.strip()
+    statements = sqlglot.parse(sql_begin_comment, dialect=Trino)
+    assert len(statements) == 1
+    assert len(list(statements[0].find_all(InlineUDF))) == 1
+
+
 def test_block_keywords_in_string_literals_and_identifiers_ignored() -> None:
     """
     Block keywords (``BEGIN``, ``CASE``, ``END``, ``IF``, ...) that appear as

--- a/tests/unit_tests/sql/dialects/trino_tests.py
+++ b/tests/unit_tests/sql/dialects/trino_tests.py
@@ -27,7 +27,7 @@ from superset.sql.dialects.trino import InlineUDF, Trino
 from superset.sql.parse import SQLScript, SQLStatement, Table
 
 # Hash of ``sqlglot.parser.Parser._parse``'s source, verified against
-# sqlglot 30.16.0 (the version pinned in ``requirements/base.txt``) when
+# sqlglot 30.17.0 (the version pinned in ``requirements/base.txt``) when
 # ``Trino.Parser._parse`` was copied from it. ``Trino.Parser._parse`` is a
 # hand-maintained copy rather than an extension through a public hook (see
 # its own docstring), so it silently drifts if sqlglot changes this method.

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2014,6 +2014,43 @@ def test_is_mutating_postgres_command_constructs(sql: str, expected: bool) -> No
 
 
 @pytest.mark.parametrize(
+    "sql, expected",
+    [
+        # A persistent catalog function has no structured sqlglot grammar and
+        # falls back to an opaque exp.Command("CREATE"), which the generic
+        # exp.Create check does not catch. Without the Trino-specific
+        # exp.Command check, this would slip past a read-only (allow_dml=False)
+        # gate and still create a function on the Trino cluster.
+        (
+            "CREATE FUNCTION meaning_of_life() RETURNS tinyint BEGIN RETURN 42; END",
+            True,
+        ),
+        (
+            "CREATE OR REPLACE FUNCTION meaning_of_life() RETURNS tinyint "
+            "BEGIN RETURN 42; END",
+            True,
+        ),
+        # An inline `WITH FUNCTION` UDF is scoped to the query and does not
+        # persist anything server-side, so it must stay non-mutating.
+        (
+            "WITH FUNCTION meaning_of_life() RETURNS tinyint "
+            "BEGIN RETURN 42; END "
+            "SELECT meaning_of_life()",
+            False,
+        ),
+    ],
+)
+def test_is_mutating_trino_create_function(sql: str, expected: bool) -> None:
+    """
+    Trino `CREATE [OR REPLACE] FUNCTION ... BEGIN ... END` creates a
+    persistent catalog function and must be classified as mutating, even
+    though sqlglot represents it as an opaque `exp.Command` rather than a
+    structured `exp.Create` node.
+    """
+    assert SQLStatement(sql, "trino").is_mutating() == expected
+
+
+@pytest.mark.parametrize(
     "sql, engine, functions, expected",
     [
         # MySQL `@@<name>` syntax parses as exp.SessionParameter, which is

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2209,6 +2209,43 @@ def test_is_mutating_postgres_command_constructs(sql: str, expected: bool) -> No
 
 
 @pytest.mark.parametrize(
+    "sql, expected",
+    [
+        # A persistent catalog function has no structured sqlglot grammar and
+        # falls back to an opaque exp.Command("CREATE"), which the generic
+        # exp.Create check does not catch. Without the Trino-specific
+        # exp.Command check, this would slip past a read-only (allow_dml=False)
+        # gate and still create a function on the Trino cluster.
+        (
+            "CREATE FUNCTION meaning_of_life() RETURNS tinyint BEGIN RETURN 42; END",
+            True,
+        ),
+        (
+            "CREATE OR REPLACE FUNCTION meaning_of_life() RETURNS tinyint "
+            "BEGIN RETURN 42; END",
+            True,
+        ),
+        # An inline `WITH FUNCTION` UDF is scoped to the query and does not
+        # persist anything server-side, so it must stay non-mutating.
+        (
+            "WITH FUNCTION meaning_of_life() RETURNS tinyint "
+            "BEGIN RETURN 42; END "
+            "SELECT meaning_of_life()",
+            False,
+        ),
+    ],
+)
+def test_is_mutating_trino_create_function(sql: str, expected: bool) -> None:
+    """
+    Trino `CREATE [OR REPLACE] FUNCTION ... BEGIN ... END` creates a
+    persistent catalog function and must be classified as mutating, even
+    though sqlglot represents it as an opaque `exp.Command` rather than a
+    structured `exp.Create` node.
+    """
+    assert SQLStatement(sql, "trino").is_mutating() == expected
+
+
+@pytest.mark.parametrize(
     "sql, engine, functions, expected",
     [
         # MySQL `@@<name>` syntax parses as exp.SessionParameter, which is


### PR DESCRIPTION
### SUMMARY
Trino queries that declare inline SQL UDFs (`WITH FUNCTION ... RETURNS ... BEGIN ... END SELECT ...`) fail to parse in SQL Lab, even though they run fine in Trino itself. Two things go wrong: sqlglot splits statements on every semicolon (including the ones inside `BEGIN ... END` routine bodies), and it has no grammar for `FUNCTION` specifications in a `WITH` clause. The upstream issue (tobymao/sqlglot#5178) was closed as "low priority, PRs welcome", so this fixes it on our side with a custom Trino dialect in `superset/sql/dialects/trino.py`, following the same pattern as our Firebolt/Dremio/Pinot dialects.

The dialect does two things: keeps routine bodies intact when chunking statements (tracking `BEGIN`/`CASE`/`IF`/`LOOP`/`REPEAT`/`WHILE` ... `END` nesting), and parses inline function specifications into opaque `InlineUDF` nodes that regenerate verbatim. Trino doesn't allow queries inside SQL UDF bodies, so the opaque representation hides no table references from the security checks... table extraction, mutation detection, and limit handling all keep working on the main query. The new code paths only activate on syntax that fails to parse today (`WITH FUNCTION`, `CREATE [OR REPLACE] FUNCTION`), so existing queries are untouched — a CTE literally named `function` still parses as a regular CTE, and there's a test pinning that.

A procedural `IF` statement whose condition is parenthesized (`IF (a > b) THEN`) is disambiguated from the scalar `IF()` function by checking whether the matching close paren is followed by `THEN`; a `WITH` clause with a normal CTE before the inline function (`WITH cte AS (...), FUNCTION f() ...`) is also handled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (from #26162): `sql parse error: Expecting (. Line 2, Col: 29.` — after, the query from the [Trino docs](https://trino.io/docs/current/udf/sql/begin.html) parses, splits, and round-trips correctly.

### TESTING INSTRUCTIONS
Run `pytest tests/unit_tests/sql/dialects/trino_tests.py`. Or with a Trino 458+ database connected, paste the example from the issue into SQL Lab and run it:

```sql
WITH FUNCTION meaning_of_life()
  RETURNS tinyint
  BEGIN
    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
    RETURN a * b;
  END
SELECT meaning_of_life()
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #26162
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
