### PR TITLE
fix(sqla): cast native UUID columns to string for LIKE/ILIKE filters

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3886,7 +3886,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     }:
                         # Native UUID columns report GenericDataType.STRING but
                         # reject LIKE/ILIKE without a cast (see issue #41795)
-                        needs_string_cast_for_like = (
+                        needs_string_cast_for_like: bool = (
                             target_generic_type != GenericDataType.STRING
                             or is_uuid_native_type(col_type)
                         )

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -250,7 +250,7 @@ def json_to_dict(json_str: str) -> dict[Any, Any]:
     return {}
 
 
-UUID_NATIVE_TYPE_RE = re.compile(r"\buuid\b", re.IGNORECASE)
+UUID_NATIVE_TYPE_RE: re.Pattern[str] = re.compile(r"\buuid\b", re.IGNORECASE)
 
 
 def is_uuid_native_type(native_type: Optional[str]) -> bool:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -250,6 +250,18 @@ def json_to_dict(json_str: str) -> dict[Any, Any]:
     return {}
 
 
+def is_uuid_native_type(native_type: Optional[str]) -> bool:
+    """
+    Return True if a native column type represents a UUID.
+
+    Engines such as PostgreSQL and ClickHouse expose native UUID column types
+    (e.g. ``UUID``, ``Nullable(UUID)``) that map to ``GenericDataType.STRING``
+    yet reject LIKE/ILIKE against the raw column, so these columns need an
+    explicit cast to string before pattern matching.
+    """
+    return native_type is not None and "uuid" in native_type.lower()
+
+
 def convert_uuids(obj: Any) -> Any:
     """
     Convert UUID objects to str so we can use yaml.safe_dump
@@ -3863,7 +3875,11 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         utils.FilterOperator.ILIKE,
                         utils.FilterOperator.LIKE,
                     }:
-                        if target_generic_type != GenericDataType.STRING:
+                        # Native UUID columns report GenericDataType.STRING but
+                        # reject LIKE/ILIKE without a cast (see issue #41795)
+                        if target_generic_type != GenericDataType.STRING or (
+                            is_uuid_native_type(col_type)
+                        ):
                             sqla_col = sa.cast(sqla_col, sa.String)
 
                         if op == utils.FilterOperator.LIKE:
@@ -3874,7 +3890,11 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         utils.FilterOperator.NOT_LIKE,
                         utils.FilterOperator.NOT_ILIKE,
                     }:
-                        if target_generic_type != GenericDataType.STRING:
+                        # Native UUID columns report GenericDataType.STRING but
+                        # reject LIKE/ILIKE without a cast (see issue #41795)
+                        if target_generic_type != GenericDataType.STRING or (
+                            is_uuid_native_type(col_type)
+                        ):
                             sqla_col = sa.cast(sqla_col, sa.String)
 
                         if op == utils.FilterOperator.NOT_LIKE:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -250,6 +250,9 @@ def json_to_dict(json_str: str) -> dict[Any, Any]:
     return {}
 
 
+UUID_NATIVE_TYPE_RE = re.compile(r"\buuid\b", re.IGNORECASE)
+
+
 def is_uuid_native_type(native_type: Optional[str]) -> bool:
     """
     Return True if a native column type represents a UUID.
@@ -257,9 +260,13 @@ def is_uuid_native_type(native_type: Optional[str]) -> bool:
     Engines such as PostgreSQL and ClickHouse expose native UUID column types
     (e.g. ``UUID``, ``Nullable(UUID)``) that map to ``GenericDataType.STRING``
     yet reject LIKE/ILIKE against the raw column, so these columns need an
-    explicit cast to string before pattern matching.
+    explicit cast to string before pattern matching. The match is on the
+    whole word ``uuid`` so unrelated types that merely contain the substring
+    (e.g. a hypothetical ``uuidish`` type) aren't misclassified.
     """
-    return native_type is not None and "uuid" in native_type.lower()
+    return native_type is not None and bool(
+        UUID_NATIVE_TYPE_RE.search(native_type.strip())
+    )
 
 
 def convert_uuids(obj: Any) -> Any:
@@ -3874,30 +3881,23 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     elif op in {
                         utils.FilterOperator.ILIKE,
                         utils.FilterOperator.LIKE,
-                    }:
-                        # Native UUID columns report GenericDataType.STRING but
-                        # reject LIKE/ILIKE without a cast (see issue #41795)
-                        if target_generic_type != GenericDataType.STRING or (
-                            is_uuid_native_type(col_type)
-                        ):
-                            sqla_col = sa.cast(sqla_col, sa.String)
-
-                        if op == utils.FilterOperator.LIKE:
-                            target_clause_list.append(sqla_col.like(eq))
-                        else:
-                            target_clause_list.append(sqla_col.ilike(eq))
-                    elif op in {
                         utils.FilterOperator.NOT_LIKE,
                         utils.FilterOperator.NOT_ILIKE,
                     }:
                         # Native UUID columns report GenericDataType.STRING but
                         # reject LIKE/ILIKE without a cast (see issue #41795)
-                        if target_generic_type != GenericDataType.STRING or (
-                            is_uuid_native_type(col_type)
-                        ):
+                        needs_string_cast_for_like = (
+                            target_generic_type != GenericDataType.STRING
+                            or is_uuid_native_type(col_type)
+                        )
+                        if needs_string_cast_for_like:
                             sqla_col = sa.cast(sqla_col, sa.String)
 
-                        if op == utils.FilterOperator.NOT_LIKE:
+                        if op == utils.FilterOperator.LIKE:
+                            target_clause_list.append(sqla_col.like(eq))
+                        elif op == utils.FilterOperator.ILIKE:
+                            target_clause_list.append(sqla_col.ilike(eq))
+                        elif op == utils.FilterOperator.NOT_LIKE:
                             target_clause_list.append(sqla_col.not_like(eq))
                         else:
                             target_clause_list.append(sqla_col.not_ilike(eq))

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -250,7 +250,9 @@ def json_to_dict(json_str: str) -> dict[Any, Any]:
     return {}
 
 
-UUID_NATIVE_TYPE_RE: re.Pattern[str] = re.compile(r"\buuid\b", re.IGNORECASE)
+UUID_NATIVE_TYPE_RE: re.Pattern[str] = re.compile(
+    r"\b(uuid|uniqueidentifier)\b", re.IGNORECASE
+)
 
 
 def is_uuid_native_type(native_type: Optional[str]) -> bool:
@@ -260,9 +262,10 @@ def is_uuid_native_type(native_type: Optional[str]) -> bool:
     Engines such as PostgreSQL and ClickHouse expose native UUID column types
     (e.g. ``UUID``, ``Nullable(UUID)``) that map to ``GenericDataType.STRING``
     yet reject LIKE/ILIKE against the raw column, so these columns need an
-    explicit cast to string before pattern matching. The match is on the
-    whole word ``uuid`` so unrelated types that merely contain the substring
-    (e.g. a hypothetical ``uuidish`` type) aren't misclassified.
+    explicit cast to string before pattern matching. SQL Server's equivalent
+    native type is ``uniqueidentifier``, which is matched too. The match is
+    on whole words so unrelated types that merely contain one of these as a
+    substring (e.g. a hypothetical ``uuidish`` type) aren't misclassified.
     """
     return native_type is not None and bool(
         UUID_NATIVE_TYPE_RE.search(native_type.strip())

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3789,7 +3789,7 @@ def test_like_filter_on_string_column_does_not_cast(database: Database) -> None:
         is_timeseries=False,
         orderby=[],
     )
-    whereclause = result.sqla_query.whereclause
+    whereclause: ColumnElement = result.sqla_query.whereclause
     assert not any(isinstance(node, Cast) for node in iterate(whereclause)), (
         f"Unexpected Cast node in the filter expression: {whereclause}"
     )

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3725,7 +3725,14 @@ def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> No
 
 @pytest.mark.parametrize(
     "native_type",
-    ["UUID", "uuid", "Nullable(UUID)", "uniqueidentifier"],
+    [
+        "UUID",
+        "uuid",
+        "Nullable(UUID)",
+        "uniqueidentifier",
+        "LowCardinality(UUID)",
+        "LowCardinality(Nullable(UUID))",
+    ],
 )
 @pytest.mark.parametrize(
     "op",

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3761,7 +3761,7 @@ def test_like_filter_on_uuid_column_casts_to_string(
         is_timeseries=False,
         orderby=[],
     )
-    whereclause = result.sqla_query.whereclause
+    whereclause: ColumnElement = result.sqla_query.whereclause
     assert any(isinstance(node, Cast) for node in iterate(whereclause)), (
         f"Expected a Cast node in the filter expression: {whereclause}"
     )

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3720,3 +3720,71 @@ def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> No
     assert f"SUM({column_name})" not in rendered, (
         f"Column requiring quoting was emitted unquoted: {rendered}"
     )
+
+
+@pytest.mark.parametrize(
+    "native_type",
+    ["UUID", "uuid", "Nullable(UUID)"],
+)
+@pytest.mark.parametrize(
+    "op",
+    ["LIKE", "ILIKE", "NOT LIKE", "NOT ILIKE"],
+)
+def test_like_filter_on_uuid_column_casts_to_string(
+    database: Database, native_type: str, op: str
+) -> None:
+    """
+    LIKE-family filters on native UUID columns must cast the column to string.
+
+    UUID columns map to ``GenericDataType.STRING``, so the generic-type guard
+    alone skips the string cast — but engines such as PostgreSQL and ClickHouse
+    reject LIKE/ILIKE against a raw UUID column (issue #41795: table chart
+    server-pagination search fails with e.g. "Illegal type UUID of argument of
+    function ilike"). The native column type must force the cast.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="event_id", type=native_type)],
+    )
+
+    result = table.get_sqla_query(
+        columns=["event_id"],
+        metrics=[],
+        extras={},
+        filter=[{"col": "event_id", "op": op, "val": "abc%"}],
+        granularity=None,
+        is_timeseries=False,
+        orderby=[],
+    )
+    sql = str(result.sqla_query)
+    assert "CAST" in sql.upper(), f"Expected string cast in SQL: {sql}"
+
+
+def test_like_filter_on_string_column_does_not_cast(database: Database) -> None:
+    """
+    LIKE-family filters on plain string columns must not add a redundant cast.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="b", type="TEXT")],
+    )
+
+    result = table.get_sqla_query(
+        columns=["b"],
+        metrics=[],
+        extras={},
+        filter=[{"col": "b", "op": "ILIKE", "val": "abc%"}],
+        granularity=None,
+        is_timeseries=False,
+        orderby=[],
+    )
+    sql = str(result.sqla_query)
+    assert "CAST" not in sql.upper(), f"Unexpected cast in SQL: {sql}"

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3725,7 +3725,7 @@ def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> No
 
 @pytest.mark.parametrize(
     "native_type",
-    ["UUID", "uuid", "Nullable(UUID)"],
+    ["UUID", "uuid", "Nullable(UUID)", "uniqueidentifier"],
 )
 @pytest.mark.parametrize(
     "op",

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -29,7 +29,8 @@ from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import StaticPool
-from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.elements import Cast, ColumnElement
+from sqlalchemy.sql.visitors import iterate
 
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
@@ -3760,8 +3761,10 @@ def test_like_filter_on_uuid_column_casts_to_string(
         is_timeseries=False,
         orderby=[],
     )
-    sql = str(result.sqla_query)
-    assert "CAST" in sql.upper(), f"Expected string cast in SQL: {sql}"
+    whereclause = result.sqla_query.whereclause
+    assert any(isinstance(node, Cast) for node in iterate(whereclause)), (
+        f"Expected a Cast node in the filter expression: {whereclause}"
+    )
 
 
 def test_like_filter_on_string_column_does_not_cast(database: Database) -> None:
@@ -3786,5 +3789,7 @@ def test_like_filter_on_string_column_does_not_cast(database: Database) -> None:
         is_timeseries=False,
         orderby=[],
     )
-    sql = str(result.sqla_query)
-    assert "CAST" not in sql.upper(), f"Unexpected cast in SQL: {sql}"
+    whereclause = result.sqla_query.whereclause
+    assert not any(isinstance(node, Cast) for node in iterate(whereclause)), (
+        f"Unexpected Cast node in the filter expression: {whereclause}"
+    )


### PR DESCRIPTION
### SUMMARY

Table charts with server pagination let you search by any string-typed column, but native UUID columns (Postgres, ClickHouse) blow up when you do — they map to `GenericDataType.STRING`, so the LIKE/ILIKE handler in `models/helpers.py` skips the cast-to-string it applies to non-string columns, and the raw `ILIKE` hits the UUID column type. ClickHouse rejects it with `Illegal type UUID of argument of function ilike`, Postgres similarly.

This adds a `is_uuid_native_type()` check so the LIKE-family handlers force the string cast when the native column type is a UUID (including wrapped forms like `Nullable(UUID)`). Searching UUID columns works instead of erroring, which seems friendlier than hiding them from the search dropdown. Same family of fix as #41653, just on the analytics-query side.

Test-first: the new parametrized unit tests in `tests/unit_tests/models/helpers_test.py` fail on master and pass with the fix, plus a negative test asserting plain string columns don't pick up a redundant cast.

Fixes #41795

Closes #41851 (alternative approach to the same issue — see discussion there)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (query generation fix; before = query error toast shown in the issue, after = search returns rows)

### TESTING INSTRUCTIONS

1. Create a dataset with a native UUID column on Postgres or ClickHouse
2. Build a Table chart with server pagination enabled
3. Use the search box to search by the UUID column
4. Before: query fails with an illegal-type/ILIKE error; after: rows filter as expected

Or just run `pytest tests/unit_tests/models/helpers_test.py -k uuid_column_casts`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #41795
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

