### PR TITLE
test(databases): stabilize flaky SQLAlchemy-form visibility assertion

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -1804,8 +1804,14 @@ describe('DatabaseModal', () => {
 
     userEvent.click(screen.getByTestId('sqla-connect-btn'));
 
-    expect(await screen.findByTestId('database-name-input')).toBeVisible();
-    expect(screen.getByTestId('sqlalchemy-uri-input')).toBeVisible();
+    // assert on presence rather than visibility: the SQLAlchemy form mounts
+    // inside an animated tab pane, and rc-motion's animation state in jsdom
+    // is nondeterministic, so toBeVisible flakes while the form is in fact
+    // rendered (see the animated={{ tabPane: true }} Tabs in DatabaseModal)
+    expect(
+      await screen.findByTestId('database-name-input'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('sqlalchemy-uri-input')).toBeInTheDocument();
   });
 
   test.each([


### PR DESCRIPTION
### SUMMARY

Stabilizes a flaky assertion in the DatabaseModal RTL suite that has been intermittently failing jest shard 1 on unrelated PRs (bit #41776 today; passed on plain rerun of the same commit).

`switches to the SQLAlchemy URI form via the connect link` (from the Cypress→RTL migration, #41436) asserts `toBeVisible()` on inputs that mount inside the modal's `animated={{ tabPane: true }}` Tabs. rc-motion's animation state in jsdom is nondeterministic — in the bad mode the pane never reports visible and the test burns its full timeout, so `waitFor`-ing visibility wouldn't help. Reproduced locally as bimodal: same tree passes or fails 3/3 depending on the run.

The tab-switch regression the test guards is "the SQLAlchemy form is rendered after clicking connect," so this asserts document presence instead of animation-dependent visibility.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only.

### TESTING INSTRUCTIONS

`npx jest src/features/databases/DatabaseModal/index.test.tsx` — 82/82 pass; the previously flaky test passes 4/4 consecutive runs (previously failing 3/3 in the bad mode).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
