### PR TITLE
fix(semantic-cache): serialise index bucket writers under a cache-level lock

### DIFF
--- a/superset/semantic_layers/cache.py
+++ b/superset/semantic_layers/cache.py
@@ -262,10 +262,13 @@ def _update_index(
     SKIPPED (losing at most this write's cache benefit) rather than performed
     unlocked, which could clobber a concurrent writer. The release is fenced
     by an owner token, and locks abandoned without a TTL are broken after
-    ``_INDEX_LOCK_STALE_FACTOR`` x the TTL. Two best-effort windows remain,
-    both bounded to the benign lost-entry: the non-atomic get-compare-delete
-    in the release and break fences, and cross-worker clock skew beyond the
-    stale threshold. Backends whose ``add`` is not
+    ``_INDEX_LOCK_STALE_FACTOR`` x the TTL. Three best-effort windows
+    remain, all bounded to the benign lost-entry: the non-atomic
+    get-compare-delete in the release and break fences; cross-worker clock
+    skew beyond the stale threshold; and plain TTL expiry if the locked
+    get + set itself stalls past the TTL (the critical section makes no
+    per-entry backend calls, so its normal duration is milliseconds
+    against a 2 s budget). Backends whose ``add`` is not
     atomic (``SimpleCache``'s check-then-act, ``NullCache``'s always-True
     no-op) degrade to best-effort locking — at worst the pre-fix benign
     clobber. Duck-typed caches without ``add`` at all (test doubles; every
@@ -320,11 +323,11 @@ def try_serve_from_cache(
         candidates.sort(key=lambda c: c[0])
 
         served: SemanticResult | None = None
-        dead_value_keys: set[str] = set()
+        dead_entries: set[CachedEntry] = set()
         for _, entry, leftovers, mode in candidates:
             payload = cache.get(entry.value_key)
             if payload is None:
-                dead_value_keys.add(entry.value_key)
+                dead_entries.add(entry)
                 continue
             if mode == ReuseMode.ROLLUP and not _projection_input_complete(
                 entry, payload
@@ -335,8 +338,8 @@ def try_serve_from_cache(
 
         # Gated on having actually observed an evicted value above, so the
         # common clean-hit read stays lock-free.
-        if dead_value_keys:
-            _prune_evicted(cache, view_meta, idx_key, dead_value_keys)
+        if dead_entries:
+            _prune_evicted(cache, view_meta, idx_key, dead_entries)
         return served
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache lookup failed", exc_info=True)
@@ -347,16 +350,20 @@ def _prune_evicted(
     cache: Cache,
     view_meta: ViewMeta,
     idx_key: str,
-    dead_value_keys: set[str],
+    dead_entries: set[CachedEntry],
 ) -> None:
-    """Drop index entries whose values the caller observed evicted.
+    """Drop the exact index entries whose values the caller observed evicted.
 
-    Only the value keys the candidate loop actually saw missing are pruned —
-    the evidence was gathered OUTSIDE the lock, so the critical section is a
-    constant get + membership filter + set with zero per-entry backend
-    calls, keeping it far under the lock TTL regardless of bucket size.
-    Dead entries that never matched a query linger until the bucket's TTL
-    or the MAX_ENTRIES trim — an accepted trade for lock-free clean hits.
+    Pruning is by ENTRY IDENTITY (the frozen dataclass, timestamp included),
+    not by value key: a concurrent ``store_result`` re-executing the same
+    query re-registers the SAME canonical value key with a fresh timestamp —
+    a key-based prune would drop that fresh registration even though its
+    value now exists. The evidence was gathered OUTSIDE the lock, so the
+    critical section is a constant get + membership filter + set with zero
+    per-entry backend calls, keeping it far under the lock TTL regardless
+    of bucket size. Dead entries that never matched a query linger until
+    the bucket's TTL or the MAX_ENTRIES trim — an accepted trade for
+    lock-free clean hits.
 
     A single non-blocking lock attempt: the prune is purely opportunistic
     (a missed prune is retried by a future read that observes the same
@@ -368,7 +375,7 @@ def _prune_evicted(
     try:
 
         def prune(current: list[CachedEntry]) -> list[CachedEntry] | None:
-            pruned = [e for e in current if e.value_key not in dead_value_keys]
+            pruned = [e for e in current if e not in dead_entries]
             return pruned if len(pruned) != len(current) else None
 
         _update_index(cache, idx_key, _timeout(view_meta), prune, attempts=1)

--- a/superset/semantic_layers/cache.py
+++ b/superset/semantic_layers/cache.py
@@ -44,7 +44,7 @@ import time as _time
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import pandas as pd
 import pyarrow as pa
@@ -128,6 +128,62 @@ class CachedEntry:
 # ---------------------------------------------------------------------------
 
 
+_INDEX_LOCK_TIMEOUT = 2  # seconds; bounds a dead holder's exclusion window
+_INDEX_LOCK_ATTEMPTS = 50
+_INDEX_LOCK_WAIT = 0.01  # seconds between attempts (max ~500 ms total)
+
+
+def _update_index(
+    cache: Any,
+    idx_key: str,
+    timeout: int | None,
+    mutate: Callable[[list[CachedEntry]], list[CachedEntry] | None],
+) -> None:
+    """Read-modify-write the index bucket under a short cache-level lock.
+
+    A bare ``get``/``set`` on the index is not atomic: two concurrent writers
+    for one view can clobber each other's entries, and the eviction prune can
+    drop an entry added between its read and write. The losses are benign by
+    design (a dropped index entry is a future cache miss, never wrong data),
+    but under concurrent dashboard load they silently discard cache benefit.
+
+    A Redis ``WATCH``/Lua transaction can't be used here: the index value is
+    a pickled Python list managed through the Flask-Caching abstraction, and
+    the data cache is not guaranteed to be Redis-backed. ``cache.add`` is the
+    portable set-if-absent primitive (``SET NX`` on Redis, ``add`` on
+    memcached), so a short-lived lock key serialises index writers per bucket.
+
+    Invariant: when the backend supports ``add``, the index is only ever
+    written while holding the lock. On lock-acquisition timeout the update is
+    SKIPPED (losing at most this write's cache benefit) rather than performed
+    unlocked, which could clobber a concurrent writer's entry. Backends
+    without ``add`` degrade to the unlocked read-modify-write.
+
+    ``mutate`` receives the freshly read entry list and returns the new list,
+    or ``None`` to skip the write.
+    """
+    lock_key = f"{idx_key}:lock"
+    add = getattr(cache, "add", None)
+    acquired = add is None  # no lock support: proceed unlocked (degraded)
+    if add is not None:
+        for _ in range(_INDEX_LOCK_ATTEMPTS):
+            if add(lock_key, "1", timeout=_INDEX_LOCK_TIMEOUT):
+                acquired = True
+                break
+            _time.sleep(_INDEX_LOCK_WAIT)
+        if not acquired:
+            logger.debug("Semantic view cache index lock busy; skipping index update")
+            return
+    try:
+        entries: list[CachedEntry] = list(cache.get(idx_key) or [])
+        new_entries = mutate(entries)
+        if new_entries is not None:
+            cache.set(idx_key, new_entries, timeout=timeout)
+    finally:
+        if add is not None and acquired:
+            cache.delete(lock_key)
+
+
 def try_serve_from_cache(
     view_meta: ViewMeta,
     query: SemanticQuery,
@@ -162,10 +218,14 @@ def try_serve_from_cache(
             served = _apply_post_processing(payload, query, leftovers, mode)
             break
 
-        # Drop index entries whose values have been evicted.
-        pruned = [e for e in entries if cache.get(e.value_key) is not None]
-        if len(pruned) != len(entries):
-            cache.set(idx_key, pruned, timeout=_timeout(view_meta))
+        # Drop index entries whose values have been evicted. Re-read under
+        # the index lock so the prune cannot clobber an entry added by a
+        # concurrent ``store_result`` between our read above and this write.
+        def prune(current: list[CachedEntry]) -> list[CachedEntry] | None:
+            pruned = [e for e in current if cache.get(e.value_key) is not None]
+            return pruned if len(pruned) != len(current) else None
+
+        _update_index(cache, idx_key, _timeout(view_meta), prune)
         return served
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache lookup failed", exc_info=True)
@@ -185,7 +245,6 @@ def store_result(
         cache.set(vkey, result, timeout=timeout)
 
         idx_key = shape_key(view_meta, query)
-        entries: list[CachedEntry] = list(cache.get(idx_key) or [])
         entry = CachedEntry(
             filters=frozenset(query.filters or set()),
             dimension_keys=frozenset(_dimension_key(d) for d in query.dimensions),
@@ -196,11 +255,17 @@ def store_result(
             group_limit_key=_group_limit_key(query.group_limit),
             value_key=vkey,
         )
-        entries = [e for e in entries if e.value_key != vkey]
-        entries.append(entry)
-        if len(entries) > MAX_ENTRIES_PER_VIEW:
-            entries = sorted(entries, key=lambda e: e.timestamp)[-MAX_ENTRIES_PER_VIEW:]
-        cache.set(idx_key, entries, timeout=timeout)
+
+        def register(entries: list[CachedEntry]) -> list[CachedEntry]:
+            entries = [e for e in entries if e.value_key != vkey]
+            entries.append(entry)
+            if len(entries) > MAX_ENTRIES_PER_VIEW:
+                entries = sorted(entries, key=lambda e: e.timestamp)[
+                    -MAX_ENTRIES_PER_VIEW:
+                ]
+            return entries
+
+        _update_index(cache, idx_key, timeout, register)
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache store failed", exc_info=True)
 

--- a/superset/semantic_layers/cache.py
+++ b/superset/semantic_layers/cache.py
@@ -39,6 +39,7 @@ See ``docs/`` and the plan file for the design rationale; the rules summary:
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time as _time
 import uuid
@@ -140,22 +141,12 @@ _INDEX_LOCK_WAIT = 0.01
 # SETNX-then-EXPIRE (cachelib RedisCache): a holder killed between the two
 # calls leaves a lock with no TTL, which would otherwise freeze the bucket's
 # index updates until the view's ``changed_on`` rotates the key.
-_INDEX_LOCK_STALE_FACTOR = 2
-
-
-def _value_exists(cache: Cache, key: str) -> bool:
-    """Existence check that avoids transferring the payload where possible.
-
-    ``cache.has`` maps to ``EXISTS`` on Redis; ``cachelib.BaseCache.has``
-    raises ``NotImplementedError`` on backends without a cheap check, where
-    we fall back to a full ``get``.
-    """
-    try:
-        return bool(cache.has(key))
-    except (AttributeError, NotImplementedError):
-        # No ``has`` (duck-typed cache) or no efficient implementation
-        # (``cachelib.BaseCache.has`` raises): fall back to a full get.
-        return cache.get(key) is not None
+# The threshold doubles as the tolerated wall-clock skew BETWEEN WORKERS
+# (the timestamp is written with the holder's clock and aged with the
+# waiter's): a waiter whose clock runs ahead by more than TTL x FACTOR
+# would break live locks. 30 s tolerates realistic NTP drift while only
+# modestly delaying recovery of a genuinely orphaned lock — the rarer event.
+_INDEX_LOCK_STALE_FACTOR = 15
 
 
 def _lock_is_stale(raw: Any) -> bool:
@@ -170,31 +161,58 @@ def _lock_is_stale(raw: Any) -> bool:
         return True
     _, _, timestamp = raw.rpartition(":")
     try:
-        age = _time.time() - float(timestamp)
+        parsed = float(timestamp)
     except ValueError:
         return True
-    return age > _INDEX_LOCK_TIMEOUT * _INDEX_LOCK_STALE_FACTOR
+    if not math.isfinite(parsed):
+        # float() accepts "nan"/"inf"; nan compares False against any
+        # threshold, which would make the lock fresh forever — an
+        # unbreakable wedge, the exact outcome this rule exists to prevent.
+        return True
+    return _time.time() - parsed > _INDEX_LOCK_TIMEOUT * _INDEX_LOCK_STALE_FACTOR
+
+
+def _mint_token() -> str:
+    """A fresh lock value: random owner component plus the current time."""
+    return f"{uuid.uuid4().hex}:{_time.time()}"
 
 
 def _acquire_index_lock(cache: Cache, lock_key: str, attempts: int) -> str | None:
     """Try to acquire the per-bucket index lock; return the owner token.
 
     The token embeds a random component (fencing the release: only the owner
-    deletes) and the acquisition timestamp (letting waiters break a lock
-    abandoned by a holder that died before its TTL was applied).
+    deletes) and a timestamp (letting waiters break a lock abandoned by a
+    holder that died before its TTL was applied). The token is minted fresh
+    on every attempt so the timestamp reflects acquisition time — a token
+    minted once before a slow retry loop could be stale at birth, making the
+    just-acquired lock immediately breakable.
+
+    The break path is best-effort fenced: the lock value is re-read and
+    compared immediately before the delete, so a waiter that lost the break
+    race does not delete the winner's fresh lock. Like the release fence,
+    get-compare-delete is not atomic through the cache abstraction, so a
+    narrow double-acquire window remains when several waiters break one
+    abandoned lock together; the consequence degrades to the benign
+    lost-index-entry, never wrong data.
     """
-    token = f"{uuid.uuid4().hex}:{_time.time()}"
     for attempt in range(attempts):
+        token = _mint_token()
         if cache.add(lock_key, token, timeout=_INDEX_LOCK_TIMEOUT):
             return token
         current = cache.get(lock_key)
         if current is not None and _lock_is_stale(current):
-            logger.warning(
+            logger.info(
                 "Semantic view cache index lock %s appears abandoned; breaking it",
                 lock_key,
             )
-            cache.delete(lock_key)
-            continue  # retry the add immediately
+            if cache.get(lock_key) == current:
+                cache.delete(lock_key)
+            # Retry immediately (also on the final/only attempt, so a
+            # single-attempt caller that breaks an orphan still gets its
+            # own acquisition rather than donating the break).
+            token = _mint_token()
+            if cache.add(lock_key, token, timeout=_INDEX_LOCK_TIMEOUT):
+                return token
         if attempt + 1 < attempts:
             _time.sleep(_INDEX_LOCK_WAIT)
     return None
@@ -206,8 +224,8 @@ def _release_index_lock(cache: Cache, lock_key: str, token: str) -> None:
     If the critical section outlived the lock TTL, a successor may hold the
     lock; an unconditional delete would release the successor's lock and
     cascade the race. ``get``-compare-``delete`` is not atomic, so a narrow
-    window remains, but combined with the cheap existence checks keeping the
-    critical section far under the TTL it is vanishingly small — and the
+    window remains, but the critical section is a constant get + filter +
+    set (no per-entry backend calls), keeping it far under the TTL — and the
     consequence degrades to the pre-fix benign lost-entry, never wrong data.
     """
     try:
@@ -244,7 +262,10 @@ def _update_index(
     SKIPPED (losing at most this write's cache benefit) rather than performed
     unlocked, which could clobber a concurrent writer. The release is fenced
     by an owner token, and locks abandoned without a TTL are broken after
-    ``_INDEX_LOCK_STALE_FACTOR`` x the TTL. Backends whose ``add`` is not
+    ``_INDEX_LOCK_STALE_FACTOR`` x the TTL. Two best-effort windows remain,
+    both bounded to the benign lost-entry: the non-atomic get-compare-delete
+    in the release and break fences, and cross-worker clock skew beyond the
+    stale threshold. Backends whose ``add`` is not
     atomic (``SimpleCache``'s check-then-act, ``NullCache``'s always-True
     no-op) degrade to best-effort locking — at worst the pre-fix benign
     clobber. Duck-typed caches without ``add`` at all (test doubles; every
@@ -299,11 +320,11 @@ def try_serve_from_cache(
         candidates.sort(key=lambda c: c[0])
 
         served: SemanticResult | None = None
-        observed_evicted = False
+        dead_value_keys: set[str] = set()
         for _, entry, leftovers, mode in candidates:
             payload = cache.get(entry.value_key)
             if payload is None:
-                observed_evicted = True
+                dead_value_keys.add(entry.value_key)
                 continue
             if mode == ReuseMode.ROLLUP and not _projection_input_complete(
                 entry, payload
@@ -314,16 +335,28 @@ def try_serve_from_cache(
 
         # Gated on having actually observed an evicted value above, so the
         # common clean-hit read stays lock-free.
-        if observed_evicted:
-            _prune_evicted(cache, view_meta, idx_key)
+        if dead_value_keys:
+            _prune_evicted(cache, view_meta, idx_key, dead_value_keys)
         return served
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache lookup failed", exc_info=True)
         return None
 
 
-def _prune_evicted(cache: Cache, view_meta: ViewMeta, idx_key: str) -> None:
-    """Drop index entries whose values have been evicted.
+def _prune_evicted(
+    cache: Cache,
+    view_meta: ViewMeta,
+    idx_key: str,
+    dead_value_keys: set[str],
+) -> None:
+    """Drop index entries whose values the caller observed evicted.
+
+    Only the value keys the candidate loop actually saw missing are pruned —
+    the evidence was gathered OUTSIDE the lock, so the critical section is a
+    constant get + membership filter + set with zero per-entry backend
+    calls, keeping it far under the lock TTL regardless of bucket size.
+    Dead entries that never matched a query linger until the bucket's TTL
+    or the MAX_ENTRIES trim — an accepted trade for lock-free clean hits.
 
     A single non-blocking lock attempt: the prune is purely opportunistic
     (a missed prune is retried by a future read that observes the same
@@ -335,7 +368,7 @@ def _prune_evicted(cache: Cache, view_meta: ViewMeta, idx_key: str) -> None:
     try:
 
         def prune(current: list[CachedEntry]) -> list[CachedEntry] | None:
-            pruned = [e for e in current if _value_exists(cache, e.value_key)]
+            pruned = [e for e in current if e.value_key not in dead_value_keys]
             return pruned if len(pruned) != len(current) else None
 
         _update_index(cache, idx_key, _timeout(view_meta), prune, attempts=1)
@@ -386,7 +419,7 @@ def store_result(
             # documented trade-off is losing cache benefit, never data.
             logger.warning(
                 "Semantic view cache index lock busy; skipping registration "
-                "of %s (result cached but unreachable until re-stored)",
+                "of %s (result cached; may be unreachable until re-stored)",
                 idx_key,
             )
     except Exception:  # pragma: no cover - defensive

--- a/superset/semantic_layers/cache.py
+++ b/superset/semantic_layers/cache.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import logging
 import re
 import time as _time
+import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from enum import Enum
@@ -49,6 +50,7 @@ from typing import Any, Callable, Iterable
 import pandas as pd
 import pyarrow as pa
 from flask import current_app
+from flask_caching import Cache
 from superset_core.semantic_layers.types import (
     AdhocExpression,
     AggregationType,
@@ -128,17 +130,100 @@ class CachedEntry:
 # ---------------------------------------------------------------------------
 
 
-_INDEX_LOCK_TIMEOUT = 2  # seconds; bounds a dead holder's exclusion window
+_INDEX_LOCK_TIMEOUT = 2  # seconds; bounds a live holder's exclusion window
 _INDEX_LOCK_ATTEMPTS = 50
-_INDEX_LOCK_WAIT = 0.01  # seconds between attempts (max ~500 ms total)
+# Sleep between acquisition attempts. The worst-case wait is the sleeps plus
+# up to ``_INDEX_LOCK_ATTEMPTS`` ``add``/``get`` round-trips to the backend.
+_INDEX_LOCK_WAIT = 0.01
+# A lock whose embedded timestamp is older than this multiple of the TTL is
+# considered abandoned and broken. Covers backends where ``add`` is
+# SETNX-then-EXPIRE (cachelib RedisCache): a holder killed between the two
+# calls leaves a lock with no TTL, which would otherwise freeze the bucket's
+# index updates until the view's ``changed_on`` rotates the key.
+_INDEX_LOCK_STALE_FACTOR = 2
+
+
+def _value_exists(cache: Cache, key: str) -> bool:
+    """Existence check that avoids transferring the payload where possible.
+
+    ``cache.has`` maps to ``EXISTS`` on Redis; ``cachelib.BaseCache.has``
+    raises ``NotImplementedError`` on backends without a cheap check, where
+    we fall back to a full ``get``.
+    """
+    try:
+        return bool(cache.has(key))
+    except (AttributeError, NotImplementedError):
+        # No ``has`` (duck-typed cache) or no efficient implementation
+        # (``cachelib.BaseCache.has`` raises): fall back to a full get.
+        return cache.get(key) is not None
+
+
+def _lock_is_stale(raw: Any) -> bool:
+    """True when a lock value's embedded timestamp is past breakable age.
+
+    Unparseable values (including non-strings) are treated as stale: lock
+    values are always written by ``_acquire_index_lock`` in
+    ``"<token>:<epoch>"`` form, so anything else is a leftover from a
+    different format and should not wedge the bucket forever.
+    """
+    if not isinstance(raw, str):
+        return True
+    _, _, timestamp = raw.rpartition(":")
+    try:
+        age = _time.time() - float(timestamp)
+    except ValueError:
+        return True
+    return age > _INDEX_LOCK_TIMEOUT * _INDEX_LOCK_STALE_FACTOR
+
+
+def _acquire_index_lock(cache: Cache, lock_key: str, attempts: int) -> str | None:
+    """Try to acquire the per-bucket index lock; return the owner token.
+
+    The token embeds a random component (fencing the release: only the owner
+    deletes) and the acquisition timestamp (letting waiters break a lock
+    abandoned by a holder that died before its TTL was applied).
+    """
+    token = f"{uuid.uuid4().hex}:{_time.time()}"
+    for attempt in range(attempts):
+        if cache.add(lock_key, token, timeout=_INDEX_LOCK_TIMEOUT):
+            return token
+        current = cache.get(lock_key)
+        if current is not None and _lock_is_stale(current):
+            logger.warning(
+                "Semantic view cache index lock %s appears abandoned; breaking it",
+                lock_key,
+            )
+            cache.delete(lock_key)
+            continue  # retry the add immediately
+        if attempt + 1 < attempts:
+            _time.sleep(_INDEX_LOCK_WAIT)
+    return None
+
+
+def _release_index_lock(cache: Cache, lock_key: str, token: str) -> None:
+    """Best-effort fenced release: delete the lock only if we still own it.
+
+    If the critical section outlived the lock TTL, a successor may hold the
+    lock; an unconditional delete would release the successor's lock and
+    cascade the race. ``get``-compare-``delete`` is not atomic, so a narrow
+    window remains, but combined with the cheap existence checks keeping the
+    critical section far under the TTL it is vanishingly small — and the
+    consequence degrades to the pre-fix benign lost-entry, never wrong data.
+    """
+    try:
+        if cache.get(lock_key) == token:
+            cache.delete(lock_key)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Semantic view cache lock release failed", exc_info=True)
 
 
 def _update_index(
-    cache: Any,
+    cache: Cache,
     idx_key: str,
     timeout: int | None,
     mutate: Callable[[list[CachedEntry]], list[CachedEntry] | None],
-) -> None:
+    attempts: int | None = None,
+) -> bool:
     """Read-modify-write the index bucket under a short cache-level lock.
 
     A bare ``get``/``set`` on the index is not atomic: two concurrent writers
@@ -150,38 +235,45 @@ def _update_index(
     A Redis ``WATCH``/Lua transaction can't be used here: the index value is
     a pickled Python list managed through the Flask-Caching abstraction, and
     the data cache is not guaranteed to be Redis-backed. ``cache.add`` is the
-    portable set-if-absent primitive (``SET NX`` on Redis, ``add`` on
-    memcached), so a short-lived lock key serialises index writers per bucket.
+    portable set-if-absent primitive, so a short-lived lock key serialises
+    index writers per bucket.
 
-    Invariant: when the backend supports ``add``, the index is only ever
-    written while holding the lock. On lock-acquisition timeout the update is
+    Invariant, honestly scoped: on backends where ``add`` is atomic (Redis,
+    memcached, the metastore cache's unique-key insert), the index is only
+    written while holding the lock; on acquisition failure the update is
     SKIPPED (losing at most this write's cache benefit) rather than performed
-    unlocked, which could clobber a concurrent writer's entry. Backends
-    without ``add`` degrade to the unlocked read-modify-write.
+    unlocked, which could clobber a concurrent writer. The release is fenced
+    by an owner token, and locks abandoned without a TTL are broken after
+    ``_INDEX_LOCK_STALE_FACTOR`` x the TTL. Backends whose ``add`` is not
+    atomic (``SimpleCache``'s check-then-act, ``NullCache``'s always-True
+    no-op) degrade to best-effort locking — at worst the pre-fix benign
+    clobber. Duck-typed caches without ``add`` at all (test doubles; every
+    Flask-Caching backend has it) use the unlocked read-modify-write.
 
     ``mutate`` receives the freshly read entry list and returns the new list,
-    or ``None`` to skip the write.
+    or ``None`` to skip the write. Returns True when the update ran (locked
+    or degraded), False when it was skipped because the lock stayed busy.
     """
+    if attempts is None:
+        attempts = _INDEX_LOCK_ATTEMPTS
     lock_key = f"{idx_key}:lock"
-    add = getattr(cache, "add", None)
-    acquired = add is None  # no lock support: proceed unlocked (degraded)
-    if add is not None:
-        for _ in range(_INDEX_LOCK_ATTEMPTS):
-            if add(lock_key, "1", timeout=_INDEX_LOCK_TIMEOUT):
-                acquired = True
-                break
-            _time.sleep(_INDEX_LOCK_WAIT)
-        if not acquired:
-            logger.debug("Semantic view cache index lock busy; skipping index update")
-            return
-    try:
+    if getattr(cache, "add", None) is None:
         entries: list[CachedEntry] = list(cache.get(idx_key) or [])
         new_entries = mutate(entries)
         if new_entries is not None:
             cache.set(idx_key, new_entries, timeout=timeout)
+        return True
+    token = _acquire_index_lock(cache, lock_key, attempts)
+    if token is None:
+        return False
+    try:
+        locked_entries: list[CachedEntry] = list(cache.get(idx_key) or [])
+        new_locked = mutate(locked_entries)
+        if new_locked is not None:
+            cache.set(idx_key, new_locked, timeout=timeout)
+        return True
     finally:
-        if add is not None and acquired:
-            cache.delete(lock_key)
+        _release_index_lock(cache, lock_key, token)
 
 
 def try_serve_from_cache(
@@ -207,9 +299,11 @@ def try_serve_from_cache(
         candidates.sort(key=lambda c: c[0])
 
         served: SemanticResult | None = None
+        observed_evicted = False
         for _, entry, leftovers, mode in candidates:
             payload = cache.get(entry.value_key)
             if payload is None:
+                observed_evicted = True
                 continue
             if mode == ReuseMode.ROLLUP and not _projection_input_complete(
                 entry, payload
@@ -218,18 +312,38 @@ def try_serve_from_cache(
             served = _apply_post_processing(payload, query, leftovers, mode)
             break
 
-        # Drop index entries whose values have been evicted. Re-read under
-        # the index lock so the prune cannot clobber an entry added by a
-        # concurrent ``store_result`` between our read above and this write.
-        def prune(current: list[CachedEntry]) -> list[CachedEntry] | None:
-            pruned = [e for e in current if cache.get(e.value_key) is not None]
-            return pruned if len(pruned) != len(current) else None
-
-        _update_index(cache, idx_key, _timeout(view_meta), prune)
+        # Gated on having actually observed an evicted value above, so the
+        # common clean-hit read stays lock-free.
+        if observed_evicted:
+            _prune_evicted(cache, view_meta, idx_key)
         return served
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache lookup failed", exc_info=True)
         return None
+
+
+def _prune_evicted(cache: Cache, view_meta: ViewMeta, idx_key: str) -> None:
+    """Drop index entries whose values have been evicted.
+
+    A single non-blocking lock attempt: the prune is purely opportunistic
+    (a missed prune is retried by a future read that observes the same
+    eviction). The entry list is re-read under the index lock so the prune
+    cannot clobber an entry added by a concurrent ``store_result`` between
+    the caller's read and this write. Isolated in its own try/except so
+    housekeeping can never turn an already-computed cache hit into a miss.
+    """
+    try:
+
+        def prune(current: list[CachedEntry]) -> list[CachedEntry] | None:
+            pruned = [e for e in current if _value_exists(cache, e.value_key)]
+            return pruned if len(pruned) != len(current) else None
+
+        _update_index(cache, idx_key, _timeout(view_meta), prune, attempts=1)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug(
+            "Semantic view cache prune failed; serving result anyway",
+            exc_info=True,
+        )
 
 
 def store_result(
@@ -265,7 +379,16 @@ def store_result(
                 ]
             return entries
 
-        _update_index(cache, idx_key, timeout, register)
+        if not _update_index(cache, idx_key, timeout, register):
+            # The value blob at ``vkey`` stays unindexed until its TTL
+            # expires — deliberately NOT deleted here: an earlier index
+            # entry may reference the same canonical value key, and the
+            # documented trade-off is losing cache benefit, never data.
+            logger.warning(
+                "Semantic view cache index lock busy; skipping registration "
+                "of %s (result cached but unreachable until re-stored)",
+                idx_key,
+            )
     except Exception:  # pragma: no cover - defensive
         logger.warning("Semantic view cache store failed", exc_info=True)
 

--- a/superset/semantic_layers/cache.py
+++ b/superset/semantic_layers/cache.py
@@ -320,7 +320,12 @@ def try_serve_from_cache(
             ok, leftovers, mode = can_satisfy(entry, query)
             if ok:
                 candidates.append((_MODE_RANK[mode], entry, leftovers, mode))
-        candidates.sort(key=lambda c: c[0])
+        # Tie-break same-rank candidates FRESHEST FIRST: a just-forced (or
+        # just-stored) entry must win over an older stale entry that also
+        # satisfies the query — Python's stable sort would otherwise keep
+        # insertion order and serve the older one, so a forced refresh could
+        # be shadowed by the very entry it was meant to supersede.
+        candidates.sort(key=lambda c: (c[0], -c[1].timestamp))
 
         served: SemanticResult | None = None
         dead_entries: set[CachedEntry] = set()

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -1483,3 +1483,93 @@ def test_same_rank_candidates_served_freshest_first(
     served = cache_module.try_serve_from_cache(VIEW, q)
     assert served is fresh_result, "older same-rank entry shadowed the freshest one"
     assert post.call_args[0][0] is fresh_result
+
+
+def test_acquire_lock_retries_when_lock_vanishes_between_add_and_get() -> None:
+    """A failed ``add`` followed by a ``get`` that finds no lock (the holder
+    released in between) must simply retry — not treat the gap as stale."""
+
+    class VanishingLockCache:
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {}
+            self.add_calls = 0
+
+        def get(self, key: str) -> Any:
+            return None  # the lock is gone by the time we look
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self.add_calls += 1
+            return self.add_calls > 1  # first attempt loses, second wins
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    fake = VanishingLockCache()
+    token = cache_module._acquire_index_lock(fake, "b:lock", attempts=3)
+    assert token is not None
+    assert fake.add_calls == 2
+
+
+def test_stale_break_declines_when_lock_changed_hands() -> None:
+    """The fenced break re-reads the lock before deleting; if the value
+    changed (another waiter already broke and re-acquired), the delete is
+    skipped so the new owner's fresh lock survives."""
+    stale = f"deadowner:{cache_module._time.time() - 10_000}"
+    fresh = f"newowner:{cache_module._time.time()}"
+
+    class HandoffCache:
+        def __init__(self) -> None:
+            self.get_calls = 0
+            self.deleted: list[str] = []
+
+        def get(self, key: str) -> Any:
+            self.get_calls += 1
+            # Staleness read sees the orphan; the fenced re-read sees the
+            # new owner's token.
+            return stale if self.get_calls == 1 else fresh
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            return False  # fresh owner holds it throughout
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            return True
+
+        def delete(self, key: str) -> bool:
+            self.deleted.append(key)
+            return True
+
+    fake = HandoffCache()
+    token = cache_module._acquire_index_lock(fake, "b:lock", attempts=1)
+    assert token is None
+    assert fake.deleted == [], "fenced break deleted a lock that changed hands"
+
+
+def test_degraded_no_add_cache_skips_write_when_mutate_returns_none() -> None:
+    """Duck-typed caches without ``add`` take the unlocked path; a ``None``
+    from ``mutate`` must still skip the write there."""
+
+    class NoAddCache:
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {"b": ["existing"]}
+            self.set_calls = 0
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self.set_calls += 1
+            self._store[key] = value
+            return True
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    fake = NoAddCache()
+    updated = cache_module._update_index(fake, "b", 60, lambda entries: None)
+    assert updated is True  # degraded path reports the update ran
+    assert fake.set_calls == 0, "mutate returning None must skip the write"
+    assert fake._store["b"] == ["existing"]

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -840,3 +840,149 @@ def test_project_rejected_when_order_references_dropped_metric() -> None:
     new_q = SemanticQuery(metrics=[M_X], dimensions=[COL_A], limit=10)
     ok, _, _ = can_satisfy(entry_from(cached_q), new_q)
     assert ok is False
+
+
+class _RacingCache:
+    """In-memory cache that parks a designated thread inside its index read.
+
+    Coordination harness for the concurrent-store regression test below:
+    ``parked`` is set (and the caller blocked on ``release``) the first time
+    the designated ``park_thread`` reads an index-bucket key; a failed
+    ``add`` — meaning another thread holds the index lock, i.e. the fix is
+    engaged — sets ``release``.
+    """
+
+    def __init__(self, parked: Any, release: Any) -> None:
+        import threading
+
+        self._store: dict[str, Any] = {}
+        self._mutex = threading.Lock()
+        self._parked_once = False
+        self._parked = parked
+        self._release = release
+        self.park_thread: Any = None
+
+    def _should_park(self, key: str) -> bool:
+        import threading
+
+        from superset.semantic_layers import cache as cache_module
+
+        return (
+            key.startswith(cache_module.INDEX_KEY_PREFIX)
+            and not key.endswith(":lock")
+            and not self._parked_once
+            and threading.current_thread() is self.park_thread
+        )
+
+    def get(self, key: str) -> Any:
+        with self._mutex:
+            should_park = self._should_park(key)
+            if should_park:
+                self._parked_once = True
+            value = self._store.get(key)
+        if should_park:
+            self._parked.set()
+            assert self._release.wait(timeout=10), "thread B never signalled"
+        return value
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+        with self._mutex:
+            self._store[key] = value
+        return True
+
+    def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+        with self._mutex:
+            if key in self._store:
+                taken = True
+            else:
+                self._store[key] = value
+                taken = False
+        if taken:
+            # The caller is blocked on the index lock: the fix is engaged,
+            # so it is safe to let the parked thread finish and release.
+            self._release.set()
+        return not taken
+
+    def delete(self, key: str) -> bool:
+        with self._mutex:
+            return self._store.pop(key, None) is not None
+
+
+def test_concurrent_store_results_do_not_clobber_index(
+    app: Any,
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """Deterministic regression for the index read-modify-write race.
+
+    ``store_result`` reads the index bucket, appends its entry, and writes the
+    bucket back. Unprotected, two concurrent writers for one view interleave
+    as: A reads, B reads+writes, A writes A's STALE list — silently dropping
+    B's entry (lost cache benefit on every subsequent narrower query).
+
+    This test choreographs that exact interleaving with events (no timing
+    dependence): thread A is parked inside its index read while thread B runs
+    a full ``store_result`` for the same view, then A resumes. With the index
+    lock, B blocks on the lock instead (the instrumented ``add`` releases A on
+    B's first failed acquisition), A completes and releases, B appends — and
+    BOTH entries survive. Without the lock this fails with only A's entry
+    present.
+    """
+    import threading
+    from unittest.mock import MagicMock
+
+    from superset.semantic_layers import cache as cache_module
+    from superset.semantic_layers.cache import store_result, value_key
+
+    a_parked = threading.Event()
+    release_a = threading.Event()
+    fake = _RacingCache(a_parked, release_a)
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    q_a = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    q_b = query(filters={where(COL_A, Operator.GREATER_THAN, 2)})
+    errors: list[Exception] = []
+
+    def worker_a() -> None:
+        try:
+            with app.app_context():
+                store_result(VIEW, q_a, MagicMock())
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            a_parked.set()  # never leave B waiting if A failed pre-park
+
+    def worker_b() -> None:
+        try:
+            assert a_parked.wait(timeout=10), "thread A never parked"
+            with app.app_context():
+                store_result(VIEW, q_b, MagicMock())
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            # Pre-fix path: B completes without ever touching the lock, so
+            # release A here; post-fix this is a no-op (already released).
+            release_a.set()
+
+    t_a = threading.Thread(target=worker_a)
+    t_b = threading.Thread(target=worker_b)
+    fake.park_thread = t_a
+    t_a.start()
+    t_b.start()
+    t_a.join(timeout=30)
+    t_b.join(timeout=30)
+    assert not t_a.is_alive(), "thread A deadlocked"
+    assert not t_b.is_alive(), "thread B deadlocked"
+    assert not errors, f"workers raised: {errors!r}"
+
+    idx_key = shape_key(VIEW, q_a)
+    final_entries = fake._store.get(idx_key) or []
+    stored_value_keys = {e.value_key for e in final_entries}
+    assert value_key(VIEW, q_a) in stored_value_keys, "A's entry lost"
+    assert value_key(VIEW, q_b) in stored_value_keys, (
+        "B's entry was clobbered by A's stale index write"
+    )

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -1417,3 +1417,69 @@ def test_single_attempt_caller_acquires_after_breaking_orphan(
     )
     assert updated is True, "single-attempt caller donated the break and skipped"
     assert fake._store.get("bucket") == [marker]
+
+
+def test_same_rank_candidates_served_freshest_first(
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """When two cached entries both satisfy a query at the same reuse rank,
+    the FRESHEST must be served. Insertion-order (stable-sort) selection
+    would let an older stale broader entry shadow a just-forced refresh of
+    the identical query — the refresh would never stick for readers.
+    """
+
+    class PlainCache:
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {}
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            if key in self._store:
+                return False
+            self._store[key] = value
+            return True
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    fake = PlainCache()
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    q = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    # Older, broader entry (no filters — satisfies q EXACT-with-leftovers)
+    # whose payload is STALE.
+    import dataclasses
+
+    broad_q = query(filters=None)
+    stale_entry = dataclasses.replace(
+        entry_from(broad_q, value_key_="sv:val:stale-broad"),
+        timestamp=cache_module._time.time() - 60,  # deterministically older
+    )
+    # Newer exact entry for q — the "just forced" fresh result.
+    fresh_entry = entry_from(q, value_key_="sv:val:fresh-exact")
+    assert fresh_entry.timestamp > stale_entry.timestamp
+
+    idx_key = shape_key(VIEW, q)
+    fake._store[idx_key] = [stale_entry, fresh_entry]  # older first
+    stale_result = MagicMock(name="stale")
+    fresh_result = MagicMock(name="fresh")
+    fake._store["sv:val:stale-broad"] = stale_result
+    fake._store["sv:val:fresh-exact"] = fresh_result
+
+    post = mocker.patch.object(
+        cache_module, "_apply_post_processing", side_effect=lambda p, *a: p
+    )
+    served = cache_module.try_serve_from_cache(VIEW, q)
+    assert served is fresh_result, "older same-rank entry shadowed the freshest one"
+    assert post.call_args[0][0] is fresh_result

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime
 from typing import Any
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pyarrow as pa
@@ -845,26 +847,27 @@ def test_project_rejected_when_order_references_dropped_metric() -> None:
 class _RacingCache:
     """In-memory cache that parks a designated thread inside its index read.
 
-    Coordination harness for the concurrent-store regression test below:
+    Coordination harness for the concurrency regression tests below:
     ``parked`` is set (and the caller blocked on ``release``) the first time
-    the designated ``park_thread`` reads an index-bucket key; a failed
-    ``add`` — meaning another thread holds the index lock, i.e. the fix is
-    engaged — sets ``release``.
+    the designated ``park_thread`` reads an index-bucket key. In the
+    store-vs-store test the parked thread is ALREADY HOLDING the index lock
+    when it parks — which is why the other thread's failed ``add`` (see that
+    method) is proof the fix is engaged rather than an inference from
+    timing. Harness-level failures are recorded in ``harness_errors``
+    (raising here would be swallowed by production code's defensive
+    ``except Exception``).
     """
 
-    def __init__(self, parked: Any, release: Any) -> None:
-        import threading
-
+    def __init__(self, parked: threading.Event, release: threading.Event) -> None:
         self._store: dict[str, Any] = {}
         self._mutex = threading.Lock()
         self._parked_once = False
         self._parked = parked
         self._release = release
-        self.park_thread: Any = None
+        self.park_thread: threading.Thread | None = None
+        self.harness_errors: list[str] = []
 
     def _should_park(self, key: str) -> bool:
-        import threading
-
         from superset.semantic_layers import cache as cache_module
 
         return (
@@ -882,7 +885,8 @@ class _RacingCache:
             value = self._store.get(key)
         if should_park:
             self._parked.set()
-            assert self._release.wait(timeout=10), "thread B never signalled"
+            if not self._release.wait(timeout=10):
+                self.harness_errors.append("parked thread was never released")
         return value
 
     def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
@@ -928,11 +932,12 @@ def test_concurrent_store_results_do_not_clobber_index(
     BOTH entries survive. Without the lock this fails with only A's entry
     present.
     """
-    import threading
-    from unittest.mock import MagicMock
-
     from superset.semantic_layers import cache as cache_module
     from superset.semantic_layers.cache import store_result, value_key
+
+    # Generous retry budget so a starved CI runner can't push thread B past
+    # its lock wait while A wakes up (attempts are resolved at call time).
+    mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1000)
 
     a_parked = threading.Event()
     release_a = threading.Event()
@@ -978,6 +983,7 @@ def test_concurrent_store_results_do_not_clobber_index(
     assert not t_a.is_alive(), "thread A deadlocked"
     assert not t_b.is_alive(), "thread B deadlocked"
     assert not errors, f"workers raised: {errors!r}"
+    assert not fake.harness_errors, f"harness: {fake.harness_errors!r}"
 
     idx_key = shape_key(VIEW, q_a)
     final_entries = fake._store.get(idx_key) or []
@@ -985,4 +991,199 @@ def test_concurrent_store_results_do_not_clobber_index(
     assert value_key(VIEW, q_a) in stored_value_keys, "A's entry lost"
     assert value_key(VIEW, q_b) in stored_value_keys, (
         "B's entry was clobbered by A's stale index write"
+    )
+
+
+def test_store_result_skips_index_write_when_lock_stays_busy(
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """Pin the timeout-skip half of the locking invariant.
+
+    When the lock cannot be acquired within the attempts budget, the index
+    write must be SKIPPED — falling through to an unlocked write would
+    reintroduce the clobber precisely under the contention that triggers
+    the timeout. The lock here is held by "someone else" with a fresh
+    (non-stale) token, so the stale-lock breaker must not fire either.
+    """
+    from superset.semantic_layers import cache as cache_module
+    from superset.semantic_layers.cache import store_result, value_key
+
+    mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1)
+
+    class BusyLockCache:
+        """Cache whose index lock is permanently held by another owner."""
+
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {}
+            self.foreign_token = f"someoneelse:{cache_module._time.time()}"
+
+        def get(self, key: str) -> Any:
+            if key.endswith(":lock"):
+                return self.foreign_token  # fresh: must not be broken as stale
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            return False  # lock always busy
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    fake = BusyLockCache()
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    q = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    store_result(VIEW, q, MagicMock())
+
+    idx_key = shape_key(VIEW, q)
+    assert idx_key not in fake._store, (
+        "index was written without holding the lock (timeout must skip)"
+    )
+    # The value blob itself IS written (before the index registration) —
+    # the documented orphan-until-TTL trade-off.
+    assert value_key(VIEW, q) in fake._store
+
+
+def test_abandoned_ttlless_lock_is_broken(
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """A lock left behind by a holder that died before its TTL applied
+    (cachelib RedisCache.add is SETNX + separate EXPIRE) must be broken by
+    the next writer instead of freezing the bucket's index updates forever.
+    """
+    from superset.semantic_layers import cache as cache_module
+    from superset.semantic_layers.cache import store_result
+
+    class OrphanedLockCache:
+        """The bucket's lock key pre-exists with a stale, TTL-less token."""
+
+        def __init__(self, orphan_key: str) -> None:
+            stale_age = (
+                cache_module._INDEX_LOCK_TIMEOUT * cache_module._INDEX_LOCK_STALE_FACTOR
+                + 1
+            )
+            self._store: dict[str, Any] = {
+                orphan_key: f"deadowner:{cache_module._time.time() - stale_age}"
+            }
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            if key in self._store:
+                return False
+            self._store[key] = value
+            return True
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    q = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    idx_key = shape_key(VIEW, q)
+    fake = OrphanedLockCache(f"{idx_key}:lock")
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    store_result(VIEW, q, MagicMock())
+
+    assert idx_key in fake._store, (
+        "abandoned TTL-less lock was not broken; bucket index frozen"
+    )
+
+
+def test_concurrent_prune_does_not_clobber_store(
+    app: Any,
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """Deterministic regression for the prune half of the race.
+
+    A reader that observed an evicted value prunes the index; unprotected
+    (or if the prune filtered its PRE-LOCK snapshot instead of re-reading),
+    a ``store_result`` landing between the reader's first index read and
+    its prune write would be silently dropped. Choreography: reader R parks
+    inside its FIRST (unlocked) index read; writer W then runs a full
+    ``store_result`` for the same bucket; R resumes, observes the evicted
+    entry, and prunes. The prune must re-read under the lock and keep W's
+    entry while dropping only the dead one.
+    """
+    from superset.semantic_layers import cache as cache_module
+    from superset.semantic_layers.cache import (
+        store_result,
+        try_serve_from_cache,
+        value_key,
+    )
+
+    mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1000)
+
+    r_parked = threading.Event()
+    release_r = threading.Event()
+    fake = _RacingCache(r_parked, release_r)
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    # Seed the bucket with one entry whose value is already evicted (its
+    # value key is never stored), satisfiable by the reader's query.
+    q_dead = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    dead_entry = entry_from(q_dead, value_key_="sv:val:evicted")
+    idx_key = shape_key(VIEW, q_dead)
+    fake._store[idx_key] = [dead_entry]
+
+    q_new = query(filters={where(COL_A, Operator.GREATER_THAN, 2)})
+    errors: list[Exception] = []
+
+    def reader() -> None:
+        try:
+            with app.app_context():
+                try_serve_from_cache(VIEW, q_dead)
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            r_parked.set()
+
+    def writer() -> None:
+        try:
+            assert r_parked.wait(timeout=10), "reader never parked"
+            with app.app_context():
+                store_result(VIEW, q_new, MagicMock())
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            release_r.set()
+
+    t_r = threading.Thread(target=reader)
+    t_w = threading.Thread(target=writer)
+    fake.park_thread = t_r
+    t_r.start()
+    t_w.start()
+    t_r.join(timeout=30)
+    t_w.join(timeout=30)
+    assert not t_r.is_alive(), "reader deadlocked"
+    assert not t_w.is_alive(), "writer deadlocked"
+    assert not errors, f"workers raised: {errors!r}"
+    assert not fake.harness_errors, f"harness: {fake.harness_errors!r}"
+
+    final_keys = {e.value_key for e in fake._store.get(idx_key) or []}
+    assert "sv:val:evicted" not in final_keys, "dead entry was not pruned"
+    assert value_key(VIEW, q_new) in final_keys, (
+        "prune clobbered the concurrently stored entry"
     )

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -870,20 +870,27 @@ class _RacingCache:
         self.park_thread: threading.Thread | None = None
         self.harness_errors: list[str] = []
 
-    def _should_park(self, key: str) -> bool:
-        return (
-            key.startswith(cache_module.INDEX_KEY_PREFIX)
-            and not key.endswith(":lock")
-            and not self._parked_once
-            and threading.current_thread() is self.park_thread
+    park_on_value_miss = False  # park on first MISSING value read instead
+
+    def _should_park(self, key: str, value: Any) -> bool:
+        if self._parked_once or threading.current_thread() is not self.park_thread:
+            return False
+        if self.park_on_value_miss:
+            return (
+                not key.startswith(cache_module.INDEX_KEY_PREFIX)
+                and not key.endswith(":lock")
+                and value is None
+            )
+        return key.startswith(cache_module.INDEX_KEY_PREFIX) and not key.endswith(
+            ":lock"
         )
 
     def get(self, key: str) -> Any:
         with self._mutex:
-            should_park = self._should_park(key)
+            value = self._store.get(key)
+            should_park = self._should_park(key, value)
             if should_park:
                 self._parked_once = True
-            value = self._store.get(key)
         if should_park:
             self._parked.set()
             if not self._release.wait(timeout=10):
@@ -1287,11 +1294,126 @@ def test_lock_is_stale_edges(raw: Any, stale: bool) -> None:
     assert cache_module._lock_is_stale(raw) is stale
 
 
-def test_lock_is_stale_boundary() -> None:
-    """Fresh and exactly-at-threshold locks are NOT stale (strict >); one
-    second past the threshold is."""
-    now = cache_module._time.time()
+def test_lock_is_stale_boundary(mocker: Any) -> None:
+    """Exactly-at-threshold locks are NOT stale (strict >); just past is."""
+    frozen_now = 1_000_000.0
+    mocker.patch.object(cache_module._time, "time", return_value=frozen_now)
     threshold = cache_module._INDEX_LOCK_TIMEOUT * cache_module._INDEX_LOCK_STALE_FACTOR
-    assert cache_module._lock_is_stale(f"tok:{now}") is False
-    assert cache_module._lock_is_stale(f"tok:{now - threshold + 1}") is False
-    assert cache_module._lock_is_stale(f"tok:{now - threshold - 1}") is True
+    assert cache_module._lock_is_stale(f"tok:{frozen_now}") is False
+    assert cache_module._lock_is_stale(f"tok:{frozen_now - threshold}") is False
+    assert cache_module._lock_is_stale(f"tok:{frozen_now - threshold - 0.001}") is True
+
+
+def test_prune_spares_fresh_same_key_registration(
+    app: Any,
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """The prune must drop only the exact entries observed dead, not every
+    entry sharing the value key.
+
+    A concurrent ``store_result`` re-executing the SAME query re-registers
+    the SAME canonical value key with a fresh entry (new timestamp) and a
+    live value. Choreography: reader R parks at the moment it observes the
+    value missing; writer W then re-stores the same query (same value key);
+    R resumes and prunes. A key-based prune would drop W's fresh, live
+    registration; the identity-based prune spares it.
+    """
+    mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1000)
+
+    r_parked = threading.Event()
+    release_r = threading.Event()
+    fake = _RacingCache(r_parked, release_r)
+    fake.park_on_value_miss = True
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    q = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    vkey = value_key(VIEW, q)
+    idx_key = shape_key(VIEW, q)
+    stale_entry = entry_from(q, value_key_=vkey)  # value never stored: dead
+    fake._store[idx_key] = [stale_entry]
+
+    errors: list[Exception] = []
+
+    def reader() -> None:
+        try:
+            with app.app_context():
+                try_serve_from_cache(VIEW, q)
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            r_parked.set()
+
+    def writer() -> None:
+        try:
+            assert r_parked.wait(timeout=10), "reader never parked"
+            with app.app_context():
+                store_result(VIEW, q, MagicMock())
+        except Exception as ex:  # pragma: no cover - defensive
+            errors.append(ex)
+        finally:
+            release_r.set()
+
+    t_r = threading.Thread(target=reader)
+    t_w = threading.Thread(target=writer)
+    fake.park_thread = t_r
+    t_r.start()
+    t_w.start()
+    t_r.join(timeout=30)
+    t_w.join(timeout=30)
+    assert not t_r.is_alive(), "reader deadlocked"
+    assert not t_w.is_alive(), "writer deadlocked"
+    assert not errors, f"workers raised: {errors!r}"
+    assert not fake.harness_errors, f"harness: {fake.harness_errors!r}"
+
+    final = fake._store.get(idx_key) or []
+    assert stale_entry not in final, "the observed-dead entry was not pruned"
+    assert any(e.value_key == vkey for e in final), (
+        "prune dropped the writer's fresh same-key registration"
+    )
+
+
+def test_single_attempt_caller_acquires_after_breaking_orphan(
+    mocker: Any,
+) -> None:
+    """A one-attempt caller (the prune path) that breaks a TTL-less orphaned
+    lock must complete its own update in the same attempt — not donate the
+    break and skip."""
+
+    class OrphanedLockCache:
+        def __init__(self, orphan_key: str) -> None:
+            stale_age = (
+                cache_module._INDEX_LOCK_TIMEOUT * cache_module._INDEX_LOCK_STALE_FACTOR
+                + 1
+            )
+            self._store: dict[str, Any] = {
+                orphan_key: f"deadowner:{cache_module._time.time() - stale_age}"
+            }
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            if key in self._store:
+                return False
+            self._store[key] = value
+            return True
+
+        def delete(self, key: str) -> bool:
+            return self._store.pop(key, None) is not None
+
+    fake = OrphanedLockCache("bucket:lock")
+    marker = entry_from(query(), value_key_="single-attempt-marker")
+    updated = cache_module._update_index(
+        fake, "bucket", 60, lambda entries: entries + [marker], attempts=1
+    )
+    assert updated is True, "single-attempt caller donated the break and skipped"
+    assert fake._store.get("bucket") == [marker]

--- a/tests/unit_tests/semantic_layers/cache_test.py
+++ b/tests/unit_tests/semantic_layers/cache_test.py
@@ -40,6 +40,7 @@ from superset_core.semantic_layers.types import (
     SemanticResult,
 )
 
+from superset.semantic_layers import cache as cache_module
 from superset.semantic_layers.cache import (
     _apply_post_processing,
     _implies,
@@ -48,6 +49,8 @@ from superset.semantic_layers.cache import (
     can_satisfy,
     ReuseMode,
     shape_key,
+    store_result,
+    try_serve_from_cache,
     value_key,
     ViewMeta,
 )
@@ -868,8 +871,6 @@ class _RacingCache:
         self.harness_errors: list[str] = []
 
     def _should_park(self, key: str) -> bool:
-        from superset.semantic_layers import cache as cache_module
-
         return (
             key.startswith(cache_module.INDEX_KEY_PREFIX)
             and not key.endswith(":lock")
@@ -932,9 +933,6 @@ def test_concurrent_store_results_do_not_clobber_index(
     BOTH entries survive. Without the lock this fails with only A's entry
     present.
     """
-    from superset.semantic_layers import cache as cache_module
-    from superset.semantic_layers.cache import store_result, value_key
-
     # Generous retry budget so a starved CI runner can't push thread B past
     # its lock wait while A wakes up (attempts are resolved at call time).
     mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1000)
@@ -1006,9 +1004,6 @@ def test_store_result_skips_index_write_when_lock_stays_busy(
     the timeout. The lock here is held by "someone else" with a fresh
     (non-stale) token, so the stale-lock breaker must not fire either.
     """
-    from superset.semantic_layers import cache as cache_module
-    from superset.semantic_layers.cache import store_result, value_key
-
     mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1)
 
     class BusyLockCache:
@@ -1017,6 +1012,8 @@ def test_store_result_skips_index_write_when_lock_stays_busy(
         def __init__(self) -> None:
             self._store: dict[str, Any] = {}
             self.foreign_token = f"someoneelse:{cache_module._time.time()}"
+            self.deleted_keys: list[str] = []
+            self.lock_add_timeouts: list[int | None] = []
 
         def get(self, key: str) -> Any:
             if key.endswith(":lock"):
@@ -1028,9 +1025,12 @@ def test_store_result_skips_index_write_when_lock_stays_busy(
             return True
 
         def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            if key.endswith(":lock"):
+                self.lock_add_timeouts.append(timeout)
             return False  # lock always busy
 
         def delete(self, key: str) -> bool:
+            self.deleted_keys.append(key)
             return self._store.pop(key, None) is not None
 
     fake = BusyLockCache()
@@ -1050,6 +1050,18 @@ def test_store_result_skips_index_write_when_lock_stays_busy(
     # The value blob itself IS written (before the index registration) —
     # the documented orphan-until-TTL trade-off.
     assert value_key(VIEW, q) in fake._store
+    # The foreign lock is FRESH, so the stale-lock breaker must not fire:
+    # a breaker regression here would turn contention into a clobber vector.
+    assert f"{idx_key}:lock" not in fake.deleted_keys, (
+        "stale-lock breaker fired against a fresh foreign lock"
+    )
+    # Every lock acquisition attempt must carry the TTL — an add without
+    # a timeout would make ordinary abandonment depend entirely on the
+    # stale-breaker.
+    assert fake.lock_add_timeouts, "no lock acquisition was attempted"
+    assert all(t == cache_module._INDEX_LOCK_TIMEOUT for t in fake.lock_add_timeouts), (
+        f"lock add() missing/wrong TTL: {fake.lock_add_timeouts!r}"
+    )
 
 
 def test_abandoned_ttlless_lock_is_broken(
@@ -1060,8 +1072,6 @@ def test_abandoned_ttlless_lock_is_broken(
     (cachelib RedisCache.add is SETNX + separate EXPIRE) must be broken by
     the next writer instead of freezing the bucket's index updates forever.
     """
-    from superset.semantic_layers import cache as cache_module
-    from superset.semantic_layers.cache import store_result
 
     class OrphanedLockCache:
         """The bucket's lock key pre-exists with a stale, TTL-less token."""
@@ -1123,13 +1133,6 @@ def test_concurrent_prune_does_not_clobber_store(
     entry, and prunes. The prune must re-read under the lock and keep W's
     entry while dropping only the dead one.
     """
-    from superset.semantic_layers import cache as cache_module
-    from superset.semantic_layers.cache import (
-        store_result,
-        try_serve_from_cache,
-        value_key,
-    )
-
     mocker.patch.object(cache_module, "_INDEX_LOCK_ATTEMPTS", 1000)
 
     r_parked = threading.Event()
@@ -1187,3 +1190,108 @@ def test_concurrent_prune_does_not_clobber_store(
     assert value_key(VIEW, q_new) in final_keys, (
         "prune clobbered the concurrently stored entry"
     )
+
+
+def test_release_lock_declines_foreign_token() -> None:
+    """Pin the release fence: a holder whose lock was broken and re-acquired
+    by a successor must NOT delete the successor's fresh lock — the fencing
+    is what stops a TTL-outliving holder from cascading the race."""
+
+    class RecordingCache:
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {"bucket:lock": "successor:123.0"}
+            self.deleted_keys: list[str] = []
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def delete(self, key: str) -> bool:
+            self.deleted_keys.append(key)
+            return self._store.pop(key, None) is not None
+
+    fake = RecordingCache()
+    cache_module._release_index_lock(fake, "bucket:lock", "mine:456.0")
+    assert fake.deleted_keys == [], "release deleted a lock it does not own"
+    assert fake._store["bucket:lock"] == "successor:123.0"
+
+    # Control: the owner's own release does delete.
+    cache_module._release_index_lock(fake, "bucket:lock", "successor:123.0")
+    assert fake.deleted_keys == ["bucket:lock"]
+
+
+def test_clean_hit_reads_take_no_lock(
+    app_context: None,
+    mocker: Any,
+) -> None:
+    """Pin the lock-free clean-hit property: serving a cached result whose
+    value is present must perform ZERO lock operations — the eviction gate
+    exists precisely so the hottest path pays no synchronization tax."""
+
+    class CountingCache:
+        def __init__(self) -> None:
+            self._store: dict[str, Any] = {}
+            self.lock_ops = 0
+
+        def get(self, key: str) -> Any:
+            return self._store.get(key)
+
+        def set(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self._store[key] = value
+            return True
+
+        def add(self, key: str, value: Any, timeout: int | None = None) -> bool:
+            self.lock_ops += 1
+            self._store.setdefault(key, value)
+            return True
+
+        def delete(self, key: str) -> bool:
+            self.lock_ops += 1
+            return self._store.pop(key, None) is not None
+
+    fake = CountingCache()
+    mocker.patch.object(
+        type(cache_module.cache_manager),
+        "data_cache",
+        property(lambda self: fake),
+    )
+
+    q = query(filters={where(COL_A, Operator.GREATER_THAN, 1)})
+    entry = entry_from(q, value_key_=value_key(VIEW, q))
+    fake._store[shape_key(VIEW, q)] = [entry]
+    fake._store[value_key(VIEW, q)] = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="select 1")],
+        results=pa.table({"a": [1]}),
+    )
+
+    result = try_serve_from_cache(VIEW, q)
+    assert result is not None, "expected a clean cache hit"
+    assert fake.lock_ops == 0, (
+        f"clean hit performed {fake.lock_ops} lock operations; must be 0"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,stale",
+    [
+        (f"abc123:{0.0}", True),  # ancient epoch
+        ("abc123:nan", True),  # nan compares False vs any threshold: wedge
+        ("abc123:inf", True),  # age = -inf would never exceed the threshold
+        ("abc123:-inf", True),
+        ("not-a-token", True),  # no parsable timestamp
+        (b"bytes-value", True),  # non-string round-trip
+        (None, True),
+        ("abc123:not-a-float", True),
+    ],
+)
+def test_lock_is_stale_edges(raw: Any, stale: bool) -> None:
+    assert cache_module._lock_is_stale(raw) is stale
+
+
+def test_lock_is_stale_boundary() -> None:
+    """Fresh and exactly-at-threshold locks are NOT stale (strict >); one
+    second past the threshold is."""
+    now = cache_module._time.time()
+    threshold = cache_module._INDEX_LOCK_TIMEOUT * cache_module._INDEX_LOCK_STALE_FACTOR
+    assert cache_module._lock_is_stale(f"tok:{now}") is False
+    assert cache_module._lock_is_stale(f"tok:{now - threshold + 1}") is False
+    assert cache_module._lock_is_stale(f"tok:{now - threshold - 1}") is True


### PR DESCRIPTION
### SUMMARY

Contribution **into #40221's branch** (`sl-cache`), addressing @rusackas's twice-flagged review finding: `store_result` performs a non-atomic read-modify-write on the index bucket, so two concurrent writers for one view can clobber each other's entries. The eviction prune in `try_serve_from_cache` has the same shape and can *actively drop* an entry added between its read and write.

**Why not WATCH/MULTI or Lua** (the original suggestion): the index value is a pickled Python list managed through the Flask-Caching abstraction, and `data_cache` is not guaranteed to be Redis-backed. Lua can't merge pickled payloads, and `WATCH` requires reaching into Redis-only client internals.

**The fix**: a short-lived lock key acquired via `cache.add` — the portable set-if-absent primitive (`SETNX` on Redis, `add` on memcached) — serialises index writers per bucket. The invariant, honestly scoped: *on backends where `add` is atomic, the index is only written while holding the lock*, with two narrow best-effort windows (the non-atomic get-compare-delete in the release/break fences, and cross-worker clock skew beyond the 30 s stale threshold), both bounded to the pre-fix benign lost-entry — never wrong data. On acquisition timeout (~500 ms of sleeps plus backend round-trips) the update is **skipped** — losing at most that write's future cache benefit — rather than performed unlocked, which could clobber a concurrent writer. Backends without `add()` degrade to the previous behavior. Both `store_result` and the prune path go through the same helper (`_update_index`), and the prune re-reads under the lock instead of writing back a stale list.

**Hardening from two review rounds** (both panels' findings and resolutions are in the PR comments): the lock value is an owner token minted per acquisition attempt (release and stale-break are both fenced by compare-before-delete); locks orphaned without a TTL (cachelib `RedisCache.add` is SETNX-then-EXPIRE, so a holder killed between the two leaves one) are broken after 15×TTL, with `math.isfinite` guarding against never-stale `:nan` values and the threshold sized for cross-worker clock skew; the eviction prune performs **zero backend calls inside the lock** (it prunes exactly the value keys the candidate loop observed missing) and clean cache hits take no lock at all; skipped registrations log at warning.

### TESTING INSTRUCTIONS

Nine dedicated tests, every one validated to fail under the exact mutation or pre-fix code it guards:

- **Four event-choreographed concurrency tests** (no timing dependence; independently verified 30/30 consecutive green runs, and 4/4 red against the base branch): store-vs-store clobber, timeout-skip invariant (busy lock → the index is never written unlocked), abandoned-TTL-less-lock breaking, and prune-vs-store (the locked re-read keeps a concurrently stored entry while dropping the dead one).
- **Five protocol kill-tests**: the release fence declines a foreign token; the stale-breaker does not fire on a fresh foreign lock; every lock `add` carries the TTL; clean cache hits perform zero lock operations; and the staleness parser's nan/inf/boundary edges.

```bash
pytest tests/unit_tests/semantic_layers/ -q   # 388 passed
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

