### PR TITLE
fix(query-object): exclude force_query from the chart cache key

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -442,11 +442,6 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         #  cached results will be invalidated.
         if not self.apply_fetch_values_predicate:
             del cache_dict["apply_fetch_values_predicate"]
-        # ``force_query`` is an execution-control flag (bypass the cache for
-        # THIS request), not part of the query's identity: hashing it would
-        # send a forced refresh to a different cache key, so the fresh result
-        # never replaces the stale entry that ordinary requests keep reading.
-        del cache_dict["force_query"]
         if self.datasource:
             cache_dict["datasource"] = self.datasource.uid
         if self.result_type:
@@ -469,7 +464,12 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         if self.time_offsets:
             cache_dict["time_offsets"] = self.time_offsets
 
-        for k in ["from_dttm", "to_dttm"]:
+        # PERMANENT exclusions — not part of the TODO migration above. These
+        # are execution-control values, never query identity. ``force_query``
+        # (bypass the cache for THIS request) in the hash would send a forced
+        # refresh to a different cache key, so the fresh result never replaces
+        # the stale entry that ordinary requests keep reading.
+        for k in ["from_dttm", "to_dttm", "force_query"]:
             del cache_dict[k]
 
         annotation_fields = [

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -442,6 +442,11 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         #  cached results will be invalidated.
         if not self.apply_fetch_values_predicate:
             del cache_dict["apply_fetch_values_predicate"]
+        # ``force_query`` is an execution-control flag (bypass the cache for
+        # THIS request), not part of the query's identity: hashing it would
+        # send a forced refresh to a different cache key, so the fresh result
+        # never replaces the stale entry that ordinary requests keep reading.
+        del cache_dict["force_query"]
         if self.datasource:
             cache_dict["datasource"] = self.datasource.uid
         if self.result_type:

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -373,13 +373,12 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
 
 
 def test_cache_key_ignores_force_query():
-    """``force_query`` is an execution-control flag, not query identity.
-
-    If it were hashed into the cache key, a forced refresh would write its
-    fresh result under a different key while ordinary requests keep reading
-    the stale entry under the old one — making force-refresh ineffective
-    for every subsequent viewer and doubling cache storage per chart.
-    """
+    """Forced and unforced requests must share a cache key, so a forced
+    refresh overwrites the stale entry ordinary requests read (rationale in
+    ``cache_key``'s permanent-exclusions comment)."""
     normal = QueryObject(row_limit=1, force_query=False)
     forced = QueryObject(row_limit=1, force_query=True)
     assert normal.cache_key() == forced.cache_key()
+    # Guard against an over-broad exclusion: real identity fields must still
+    # discriminate.
+    assert normal.cache_key() != QueryObject(row_limit=2).cache_key()

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -370,3 +370,16 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
         ],
         any_order=True,
     )
+
+
+def test_cache_key_ignores_force_query():
+    """``force_query`` is an execution-control flag, not query identity.
+
+    If it were hashed into the cache key, a forced refresh would write its
+    fresh result under a different key while ordinary requests keep reading
+    the stale entry under the old one — making force-refresh ineffective
+    for every subsequent viewer and doubling cache storage per chart.
+    """
+    normal = QueryObject(row_limit=1, force_query=False)
+    forced = QueryObject(row_limit=1, force_query=True)
+    assert normal.cache_key() == forced.cache_key()


### PR DESCRIPTION
### SUMMARY

Second contribution **into #40221's branch** (`sl-cache`), fixing the unaddressed codeant architect finding on `query_object.py` (2026-05-19) — **verified real**:

`force_query` was added to `QueryObject` for the semantic cache's bypass check (legitimate), but it also landed in `to_dict()`, which `cache_key()` hashes. An execution-control flag inside the identity hash means:

1. A user's **force refresh** writes its fresh result under a *different* cache key (`force_query=True` hashed in).
2. Every subsequent ordinary request hashes `force_query=False` → **keeps serving the stale entry** under the old key. Force-refresh silently stops refreshing what other viewers see, and cache storage doubles per chart.

This affects **every chart on the legacy path**, not just semantic layers.

**The fix**: strip `force_query` in `cache_key()`, exactly like the existing execution-control exclusions two lines above (`from_dttm`/`to_dttm`, conditional `apply_fetch_values_predicate`).

### TESTING INSTRUCTIONS

`test_cache_key_ignores_force_query` pins that forced and unforced requests share a cache key — validated to **fail without the fix**.

The flag's *bypass* behaviour (as opposed to key identity) is separately pinned upstream in the stack: the semantic path reads the attribute directly (`mapper.py`) and is covered by `test_force_query_bypasses_semantic_cache` in `cache_integration_test.py`; the classic chart-cache bypass is likewise attribute-driven via `QueryCacheManager`.

```bash
pytest tests/unit_tests/queries/query_object_test.py -q   # 13 passed
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
