### PR TITLE
fix(semantic-cache): forced queries store their fresh result

### DIFF
--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -219,10 +219,13 @@ def _make_cached_dispatch(
     """
     Wrap the semantic view dispatcher with a containment-aware cache.
 
-    Row-count queries bypass the cache. Cache failures are logged and the
-    dispatcher is called as if the cache were absent.
+    Row-count queries bypass the cache entirely. Forced queries skip the
+    cache READ but still STORE their fresh result — a forced refresh must
+    replace the stale entry that other requests' containment lookups keep
+    reading, not leave it in place until TTL. Cache failures are logged and
+    the dispatcher is called as if the cache were absent.
     """
-    if query_object.is_rowcount or query_object.force_query:
+    if query_object.is_rowcount:
         return dispatcher
 
     view = query_object.datasource
@@ -232,9 +235,13 @@ def _make_cached_dispatch(
         changed_on_iso=changed_on.isoformat() if changed_on else "",
         cache_timeout=getattr(view, "cache_timeout", None),
     )
+    skip_read = query_object.force_query
 
     def cached_dispatch(query: SemanticQuery) -> SemanticResult:
-        if (hit := try_serve_from_cache(view_meta, query)) is not None:
+        if (
+            not skip_read
+            and (hit := try_serve_from_cache(view_meta, query)) is not None
+        ):
             return hit
         result = dispatcher(query)
         store_result(view_meta, query, result)

--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -220,10 +220,14 @@ def _make_cached_dispatch(
     Wrap the semantic view dispatcher with a containment-aware cache.
 
     Row-count queries bypass the cache entirely. Forced queries skip the
-    cache READ but still STORE their fresh result — a forced refresh must
-    replace the stale entry that other requests' containment lookups keep
-    reading, not leave it in place until TTL. Cache failures are logged and
-    the dispatcher is called as if the cache were absent.
+    cache READ but still STORE their fresh result, replacing the cached
+    entry for the SAME query (identical canonical shape) so identical and
+    contained-by-it requests see the fresh result. Broader stale entries in
+    the bucket are untouched — a narrower forced result cannot rebuild them
+    — and age out by TTL or ``changed_on`` rotation; freshest-first
+    candidate ranking ensures the refreshed entry wins for the identical
+    query. Cache failures are logged and the dispatcher is called as if the
+    cache were absent.
     """
     if query_object.is_rowcount:
         return dispatcher

--- a/tests/unit_tests/semantic_layers/cache_integration_test.py
+++ b/tests/unit_tests/semantic_layers/cache_integration_test.py
@@ -222,13 +222,16 @@ def test_force_query_bypasses_semantic_cache_read_but_stores_fresh_result(
     datasource: MagicMock,
 ) -> None:
     """A forced query must skip the cache READ (fresh execution) but still
-    STORE its result — otherwise the stale entry survives the refresh and
-    other requests' containment lookups keep serving it until TTL."""
+    STORE its result — otherwise the same query's stale entry survives the
+    refresh and keeps being served until TTL. (Broader stale entries are
+    out of a forced store's reach by design; see _make_cached_dispatch.)"""
     view_implementation.get_table = MagicMock(return_value=_result([(2, 1.0)]))
 
     get_results(_qo(datasource, ">", 1))
     assert view_implementation.get_table.call_count == 1
 
+    # Fresh mock: the counter resets with the swap, and 99.0 doubles as the
+    # freshness sentinel for the final assertion.
     view_implementation.get_table = MagicMock(return_value=_result([(2, 99.0)]))
     get_results(_qo(datasource, ">", 1, force_query=True))
     assert view_implementation.get_table.call_count == 1  # forced: re-executed

--- a/tests/unit_tests/semantic_layers/cache_integration_test.py
+++ b/tests/unit_tests/semantic_layers/cache_integration_test.py
@@ -216,18 +216,29 @@ def test_changed_on_invalidates_cache(
     assert view_implementation.get_table.call_count == 2
 
 
-def test_force_query_bypasses_semantic_cache(
+def test_force_query_bypasses_semantic_cache_read_but_stores_fresh_result(
     fake_cache: _InMemoryCache,
     view_implementation: Any,
     datasource: MagicMock,
 ) -> None:
+    """A forced query must skip the cache READ (fresh execution) but still
+    STORE its result — otherwise the stale entry survives the refresh and
+    other requests' containment lookups keep serving it until TTL."""
     view_implementation.get_table = MagicMock(return_value=_result([(2, 1.0)]))
 
     get_results(_qo(datasource, ">", 1))
     assert view_implementation.get_table.call_count == 1
 
+    view_implementation.get_table = MagicMock(return_value=_result([(2, 99.0)]))
     get_results(_qo(datasource, ">", 1, force_query=True))
-    assert view_implementation.get_table.call_count == 2
+    assert view_implementation.get_table.call_count == 1  # forced: re-executed
+
+    # The forced refresh must have REPLACED the cached entry: a subsequent
+    # ordinary request is served from cache (no new execution) and sees the
+    # refreshed value, not the stale one.
+    result = get_results(_qo(datasource, ">", 1))
+    assert view_implementation.get_table.call_count == 1
+    assert result.df["x"].tolist() == [99.0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### SUMMARY

Third contribution **into #40221's branch** (`sl-cache`) — the remaining half of the force-refresh bug shape fixed in #41825:

`_make_cached_dispatch` returned the raw dispatcher when `force_query` was set, bypassing both the cache read **and `store_result`**. Consequence: a forced refresh executed fresh but **never replaced the stale containment-cache entry** — other requests whose queries were contained by that stale entry kept being served from it until TTL or a view-definition change. (#41825 fixed the same shape at the DATA-cache layer; this fixes it at the semantic layer.)

**The fix**: forced queries skip only the cache *read* and still store their fresh result; row-count queries continue to bypass entirely.

### TESTING INSTRUCTIONS

The existing force test is rewritten to pin the full contract: the forced query re-executes, **and** a subsequent ordinary request is served from cache with the *refreshed* value rather than the stale one — validated to **fail against the pre-fix mapper**.

```bash
pytest tests/unit_tests/semantic_layers/cache_integration_test.py -q   # 15 passed
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)