### PR TITLE
feat(i18n): expose the six newly backfilled locales

### DIFF
--- a/superset-frontend/packages/superset-core/src/translation/types/index.ts
+++ b/superset-frontend/packages/superset-core/src/translation/types/index.ts
@@ -25,18 +25,35 @@ export { default as __hack_reexport_jed } from './jed';
  * Superset supported languages.
  */
 export type Locale =
+  | 'ar'
+  | 'ca'
+  | 'cs'
   | 'de'
   | 'en'
   | 'es'
+  | 'fa'
+  | 'fi'
   | 'fr'
   | 'it'
   | 'ja'
   | 'ko'
+  | 'lv'
+  | 'mi'
+  | 'nl'
+  | 'pl'
   | 'pt'
   | 'pt_BR'
+  | 'ro'
   | 'ru'
+  | 'sk'
+  | 'sl'
+  | 'sr'
+  | 'sr_Latn'
+  | 'th'
+  | 'tr'
+  | 'uk'
   | 'zh'
-  | 'zh_TW'; // supported locales in Superset
+  | 'zh_TW'; // every locale with a catalog in superset/translations
 
 /**
  * Language pack provided to `jed`.

--- a/superset/config.py
+++ b/superset/config.py
@@ -523,6 +523,12 @@ LANGUAGES = {
     "uk": {"flag": "ua", "name": "Ukrainian"},
     "mi": {"flag": "nz", "name": "Māori"},
     "ro": {"flag": "ro", "name": "Romanian"},
+    "ar": {"flag": "sa", "name": "Arabic"},
+    "ca": {"flag": "es", "name": "Catalan"},
+    "fa": {"flag": "ir", "name": "Persian"},
+    "fi": {"flag": "fi", "name": "Finnish"},
+    "th": {"flag": "th", "name": "Thai"},
+    "tr": {"flag": "tr", "name": "Turkish"},
 }
 # Turning off i18n by default as translation in most languages are
 # incomplete and not well maintained.


### PR DESCRIPTION
### SUMMARY

The i18n backfill campaign left every catalog in `superset/translations/` with zero untranslated entries, but six of them — **Arabic, Catalan, Persian, Finnish, Thai, Turkish** — were never added to the `LANGUAGES` reference dict in `config.py`, so operators who enable i18n still can't select them. This adds the six entries with their flag codes.

Also completes the frontend `Locale` type union in `@superset-core` to the full set of catalog locales: it had drifted to 12 of 29 (missing not just these six but also mi/uk/sk/sl/lv/nl/pl/cs/ro/sr/sr_Latn). Type-level only; no runtime change.

Note `LANGUAGES` remains `{}` by default (i18n stays opt-in) — this only extends the reference dict operators copy from.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — config reference + type union.

### TESTING INSTRUCTIONS

Enable the six locales in `superset_config.py`, switch languages in the UI, observe translated content (catalogs are fully backfilled; AI-generated entries are fuzzy-served pending human review, per the backfill convention).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)