### PR TITLE
test(superset-ui-core): prove angle-bracketed non-HTML values render as text (#34082)

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -95,6 +95,17 @@ describe('isProbablyHTML', () => {
     expect(isProbablyHTML('price < $100')).toBe(false);
   });
 
+  test('should return false for angle-bracketed data values (issue #34082)', () => {
+    // MySQL column values wrapped in angle brackets must not be treated as
+    // HTML, otherwise they get swallowed and appear truncated in SQL Lab
+    // and Table chart results
+    expect(isProbablyHTML('<Buddhist Blue Duck-No Giblets>')).toBe(false);
+    expect(isProbablyHTML('<Roasted Chicken-Whole>')).toBe(false);
+    expect(
+      isProbablyHTML('prefix <Buddhist Blue Duck-No Giblets> suffix'),
+    ).toBe(false);
+  });
+
   test('should return true for all known HTML tags', () => {
     expect(isProbablyHTML('<section>Content</section>')).toBe(true);
     expect(isProbablyHTML('<article>Content</article>')).toBe(true);
@@ -145,6 +156,12 @@ describe('safeHtmlSpan', () => {
     const plainText = 'Just a plain text';
     const result = safeHtmlSpan(plainText);
     expect(result).toEqual(plainText);
+  });
+
+  test('should return angle-bracketed data values untouched (issue #34082)', () => {
+    const dataValue = '<Buddhist Blue Duck-No Giblets>';
+    expect(safeHtmlSpan(dataValue)).toBe(dataValue);
+    expect(sanitizeHtmlIfNeeded(dataValue)).toBe(dataValue);
   });
 });
 


### PR DESCRIPTION
### SUMMARY

Test-only PR that proves issue #34082 (MySQL data values wrapped in angle brackets, e.g. `<Buddhist Blue Duck-No Giblets>`, appearing truncated in SQL Lab and Table chart results) is already fixed on master.

The truncation happened because such values were misdetected as HTML and sanitized away. On master, `isProbablyHTML` in `superset-frontend/packages/superset-ui-core/src/utils/html.tsx` only treats a string as HTML when it matches a known HTML tag-name allowlist (`KNOWN_HTML_TAGS` / `HTML_TAG_PATTERN`), so angle-bracketed data values like the one from the issue fall through as plain text. This PR encodes that behavior in the existing `html.test.tsx` suite:

- `isProbablyHTML('<Buddhist Blue Duck-No Giblets>')`, `isProbablyHTML('<Roasted Chicken-Whole>')`, and the same value embedded in surrounding text all return `false`
- `safeHtmlSpan` and `sanitizeHtmlIfNeeded` return the raw string untouched for such values, so nothing is swallowed when rendering results

These tests pass on current master, so the regression guard is green from day one; a future change that loosens the HTML detection back to swallowing arbitrary `<...>` values will fail them.

closes #34082

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only change)

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- packages/superset-ui-core/src/utils/html.test.tsx --maxWorkers=2
```

All 42 tests in the suite pass, including the two new cases.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: closes #34082
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)