### PR TITLE
test(preset-chart-deckgl): prove ctrl+click on deck.gl legend toggles the layer without opening a new tab

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@testing-library/jest-dom';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
@@ -68,4 +68,34 @@ test('leaves labels untouched when no format is provided', () => {
   );
 
   expect(screen.getByText('[1, 81)')).toBeInTheDocument();
+});
+
+test('ctrl+clicking a legend item toggles the category without opening a new tab', () => {
+  // Regression proof for #34157: legend items are href="#" anchors, so a
+  // ctrl+click whose default action is not prevented would ask the browser
+  // to open the "#" href in a new tab instead of just toggling the layer.
+  const toggleCategory = jest.fn();
+  renderWithTheme(
+    <Legend
+      format={null}
+      categories={{
+        cat1: { enabled: true, color: [255, 0, 0] },
+        cat2: { enabled: false, color: [0, 0, 255] },
+      }}
+      toggleCategory={toggleCategory}
+    />,
+  );
+
+  const legendItem = screen.getByRole('button', { name: 'cat1' });
+  const ctrlClickEvent = createEvent.click(legendItem, {
+    ctrlKey: true,
+  }) as MouseEvent;
+  fireEvent(legendItem, ctrlClickEvent);
+
+  // preventDefault() in the onClick handler is what stops the browser's
+  // native ctrl+click "open link in new tab" behavior on the anchor.
+  expect(ctrlClickEvent.defaultPrevented).toBe(true);
+  expect(ctrlClickEvent.ctrlKey).toBe(true);
+  expect(toggleCategory).toHaveBeenCalledTimes(1);
+  expect(toggleCategory).toHaveBeenCalledWith('cat1');
 });


### PR DESCRIPTION
### SUMMARY
Test-only PR — no production code changes.

Issue #34157 reported that ctrl+clicking a legend item on a DeckGL Scatter chart (reported on Superset 4.1.2) opened a new browser tab instead of just toggling the layer's visibility. The legend items are rendered as `href="#"` anchors, so a ctrl+click whose default action is not suppressed asks the browser to open the href in a new tab.

On current `master` this is already fixed: `Legend.tsx` (`superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx`) calls `e.preventDefault()` in both the `onClick` and `onDoubleClick` handlers of the legend anchors, which suppresses the browser's native ctrl+click "open link in new tab" behavior while still invoking `toggleCategory`.

This PR adds a regression test to the existing colocated `Legend.test.tsx` that encodes the expected behavior: firing a click with `ctrlKey: true` on a legend item asserts that the `toggleCategory` callback fires exactly once for that category and that the click event's `defaultPrevented` is `true`. The test passes against master, proving the issue is resolved, and pins the behavior so it can't silently regress.

closes #34157

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — test-only change.

### TESTING INSTRUCTIONS
```bash
cd superset-frontend
npm run test -- plugins/preset-chart-deckgl/src/components/Legend.test.tsx --maxWorkers=2
```
All 4 tests in the file pass, including the new `ctrl+clicking a legend item toggles the category without opening a new tab` test.

### ADDITIONAL INFORMATION
- [x] Has associated issue: closes #34157
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
