### PR TITLE
test(preset-chart-deckgl): prove legend clicks no longer scroll to top

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -70,6 +70,31 @@ test('leaves labels untouched when no format is provided', () => {
   expect(screen.getByText('[1, 81)')).toBeInTheDocument();
 });
 
+test('clicking a legend item toggles the category without triggering anchor navigation', () => {
+  // Regression proof for #33576: the legend items are href="#" anchors, so a
+  // click whose default action is not prevented would navigate to "#" and
+  // scroll the browser window to the top of the page.
+  const toggleCategory = jest.fn();
+  renderWithTheme(
+    <Legend
+      format={null}
+      categories={{
+        Positive: { enabled: true, color: [0, 255, 0] },
+        Negative: { enabled: true, color: [255, 0, 0] },
+      }}
+      toggleCategory={toggleCategory}
+    />,
+  );
+
+  const legendItem = screen.getByRole('button', { name: 'Positive' });
+  const clickEvent = createEvent.click(legendItem);
+  fireEvent(legendItem, clickEvent);
+
+  expect(clickEvent.defaultPrevented).toBe(true);
+  expect(toggleCategory).toHaveBeenCalledTimes(1);
+  expect(toggleCategory).toHaveBeenCalledWith('Positive');
+});
+
 test('ctrl+clicking a legend item toggles the category without opening a new tab', () => {
   // Regression proof for #34157: legend items are href="#" anchors, so a
   // ctrl+click whose default action is not prevented would ask the browser


### PR DESCRIPTION
### SUMMARY

closes #33576

This is a test-only PR. The bug reported in #33576 — clicking a legend item on a Deck.gl scatter plot navigates the `href="#"` anchor and scrolls the browser window to the top of the page — is already fixed on master. The deck.gl legend was rewritten as part of the deck.gl modernization work (#38035), and the rewritten `Legend.tsx` calls `e.preventDefault()` in the anchor's `onClick` handler before invoking `toggleCategory`, so the `#` navigation (and the scroll-to-top it causes) never happens.

This PR adds a regression test to `Legend.test.tsx` that encodes the behavior the issue asked for: a plain click on a legend item must have its default action prevented (`event.defaultPrevented === true`) and must fire the `toggleCategory` callback with the clicked category. The test passes against current master, proving the fix, and will catch any future regression of the anchor navigation behavior (this same bug previously regressed once already — see #13092 / #13335).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change, no runtime behavior modified.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/preset-chart-deckgl/src/components/Legend.test.tsx --maxWorkers=2
```

All tests in the suite pass, including the new `clicking a legend item toggles the category without triggering anchor navigation` test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #33576
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)