### PR TITLE
test(dashboard): prove activeTabs from permalinks selects tab content

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.test.tsx
@@ -29,6 +29,7 @@ import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButto
 import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import emptyDashboardLayout from 'src/dashboard/fixtures/emptyDashboardLayout';
 import React from 'react';
+import { RENDER_TAB_CONTENT } from '../Tab';
 import TabsComponent from './Tabs';
 
 // Cast to accept partial mock props in tests
@@ -262,6 +263,57 @@ test('Switching tabs', () => {
   userEvent.click(screen.getAllByRole('tab')[2]);
   expect(props.logEvent).toHaveBeenCalled();
   expect(props.onChangeTab).toHaveBeenCalled();
+});
+
+test('activeTabs hydrated from a permalink selects the matching tab content', () => {
+  // Regression guard for #36132: when a dashboard is opened via a
+  // permalink/anchor (including embedded dashboards), the permalink state is
+  // hydrated into dashboardState.activeTabs. The Tabs component must use that
+  // value to select the matching tab AND render that tab's content panel,
+  // not just highlight the tab header while showing the first tab's content.
+  const props = createProps();
+  props.editMode = false;
+  render(<Tabs {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState: {
+      dashboardState: {
+        activeTabs: ['TAB-YT6eNksV-'],
+      },
+    },
+  });
+
+  // The tab referenced by dashboardState.activeTabs is the selected one
+  const tabs = screen.getAllByRole('tab');
+  expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+  expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+
+  // ...and its content panel is the one mounted as visible, while the
+  // default (first) tab's content is not shown
+  const contentCalls = (DashboardComponent as unknown as jest.Mock).mock.calls
+    .map(
+      call =>
+        call[0] as {
+          id: string;
+          renderType: string;
+          isComponentVisible?: boolean;
+        },
+    )
+    .filter(componentProps => componentProps.renderType === RENDER_TAB_CONTENT);
+  expect(
+    contentCalls.some(
+      componentProps =>
+        componentProps.id === 'TAB-YT6eNksV-' &&
+        componentProps.isComponentVisible === true,
+    ),
+  ).toBe(true);
+  expect(
+    contentCalls.some(
+      componentProps =>
+        componentProps.id === 'TAB-AsMaxdYL_t' &&
+        componentProps.isComponentVisible === true,
+    ),
+  ).toBe(false);
 });
 
 test('Call "DashboardComponent.onDropOnTab"', async () => {


### PR DESCRIPTION
### SUMMARY

Test-only PR — no product code changes.

Issue #36132 reported that opening an embedded dashboard with a `permalink_key` pointing at a non-default tab would highlight the right tab header but always show the first tab's content. Investigating on current master ([comment](https://github.com/apache/superset/issues/36132#issuecomment-4725853813)), the content-switching path turns out to be wired up and not gated for embedded mode: `DashboardPage` hydrates the permalink's `activeTabs` into `dashboardState.activeTabs` identically for embedded and non-embedded dashboards, and `Tabs.tsx` uses that value as a fallback when computing the selected tab index — which is what decides which tab content panel actually mounts as visible. The `activeTabs`-from-permalink wiring landed in #35343, right around when the reporter last tested, and the reporter also suspected it had since been fixed.

This PR adds a unit test that encodes the reported expectation so we can close the issue with the behavior pinned down: rendering the dashboard `Tabs` component with `dashboardState.activeTabs` referencing a non-default tab (exactly what permalink hydration produces) must select that tab **and** mount that tab's content panel as the visible one — not just highlight the tab header while showing the first tab's content. The test passes on current master, confirming the behavior works, and it was verified to fail if the `activeTabs` fallback in `Tabs.tsx` is removed, so it guards against regressing this again.

closes #36132

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only change)

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- src/dashboard/components/gridComponents/Tabs/Tabs.test.tsx --maxWorkers=2
```

The new test is `activeTabs hydrated from a permalink selects the matching tab content`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #36132
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
