### PR TITLE
test(plugin-chart-echarts): prove user-selected plain legend type is honored (#39540)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -938,6 +938,46 @@ describe('legend sorting', () => {
   });
 });
 
+test('honors user-selected plain legend type for top orientation when space allows (#39540)', () => {
+  // Regression test for issue #39540: switching the legend type control from
+  // scroll to plain must reach the rendered ECharts config. Horizontal legends
+  // were once unconditionally forced to scroll; scroll should be a fallback
+  // reserved for legends that do not fit the available space.
+  const chartProps = createTestChartProps({
+    formData: {
+      ...formData,
+      legendType: LegendType.Plain,
+      legendOrientation: LegendOrientation.Top,
+      showLegend: true,
+    },
+  });
+
+  const { legend } = transformProps(chartProps).echartOptions as {
+    legend: { show?: boolean; type?: LegendType };
+  };
+
+  expect(legend.show).toBe(true);
+  expect(legend.type).toBe(LegendType.Plain);
+});
+
+test('honors user-selected plain legend type for bottom orientation when space allows (#39540)', () => {
+  const chartProps = createTestChartProps({
+    formData: {
+      ...formData,
+      legendType: LegendType.Plain,
+      legendOrientation: LegendOrientation.Bottom,
+      showLegend: true,
+    },
+  });
+
+  const { legend } = transformProps(chartProps).echartOptions as {
+    legend: { show?: boolean; type?: LegendType };
+  };
+
+  expect(legend.show).toBe(true);
+  expect(legend.type).toBe(LegendType.Plain);
+});
+
 const timeCompareFormData: SqlaFormData = {
   colorScheme: 'bnbColors',
   datasource: '3__table',

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -993,6 +993,62 @@ test('getLegendLayoutResult keeps plain horizontal legends when they fit within 
   });
 });
 
+test('getLegendLayoutResult honors user-selected plain type for many horizontal legend items given ample width (#39540)', () => {
+  // Regression contract for issue #39540: a legend with enough items to be
+  // scrollable must still honor a user-selected plain type when the chart is
+  // wide enough, instead of being unconditionally forced to scroll.
+  const layout = getLegendLayoutResult({
+    chartHeight: 600,
+    chartWidth: 1600,
+    legendItems: Array.from({ length: 10 }, (_, i) => `Series ${i + 1}`),
+    legendMargin: null,
+    orientation: LegendOrientation.Top,
+    show: true,
+    theme,
+    type: LegendType.Plain,
+  });
+
+  expect(layout.effectiveType).toBe(LegendType.Plain);
+  expect(layout.effectiveMargin).toBeGreaterThanOrEqual(
+    defaultLegendPadding[LegendOrientation.Top],
+  );
+});
+
+test('getLegendLayoutResult keeps user-selected plain type for bottom-oriented legends when space allows', () => {
+  expect(
+    getLegendLayoutResult({
+      chartHeight: 400,
+      chartWidth: 800,
+      legendItems: ['Alpha', 'Beta', 'Gamma', 'Delta'],
+      legendMargin: null,
+      orientation: LegendOrientation.Bottom,
+      show: true,
+      theme,
+      type: LegendType.Plain,
+    }),
+  ).toEqual({
+    effectiveMargin: defaultLegendPadding[LegendOrientation.Bottom],
+    effectiveType: LegendType.Plain,
+  });
+});
+
+test('getLegendLayoutResult passes a user-selected scroll type through untouched', () => {
+  expect(
+    getLegendLayoutResult({
+      chartHeight: 400,
+      chartWidth: 800,
+      legendItems: ['Alpha', 'Beta'],
+      legendMargin: null,
+      orientation: LegendOrientation.Top,
+      show: true,
+      theme,
+      type: LegendType.Scroll,
+    }),
+  ).toEqual({
+    effectiveType: LegendType.Scroll,
+  });
+});
+
 test('getLegendLayoutResult adds extra margin for wrapped plain horizontal legends', () => {
   const layout = getLegendLayoutResult({
     chartHeight: 400,


### PR DESCRIPTION
### SUMMARY

Test-only PR that proves issue #39540 ("Legend type setting has no effect on charts of version 6.1.0rc2") is fixed on master, and guards against it regressing.

The regression was introduced by #36306 (December 2025), which unconditionally forced `scroll` legends for horizontal (Top/Bottom) orientations to prevent overlap — so switching the legend type control from `scroll` to `plain` (list) had no visible effect. #38675 (March 2026) restored the user's choice by adding plain-legend layout estimation with an `effectiveType` fallback: a user-selected `plain` legend is honored whenever it fits the available space, and `scroll` is only used as a fallback when it does not.

This PR adds no production code. It pins the fixed contract at two levels:

- `getLegendLayoutResult` (`superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts`):
  - a user-selected plain type is honored for a horizontal legend with many items on a wide chart (the exact issue scenario: "enough dimensions to be scrolled");
  - a user-selected plain type is kept for bottom-oriented legends when space allows;
  - a user-selected scroll type passes through untouched.
- Timeseries `transformProps` (`superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts`): the `legendType: plain` form-data selection survives end-to-end into `echartOptions.legend.type` for both Top and Bottom orientations when space allows — the layer where #36306 had forced `scroll`.

Faithfulness check: temporarily re-instating the forced-scroll behavior for horizontal legends in `getLegendLayoutResult` makes 3 of these tests fail with `Expected: "plain" / Received: "scroll"`, confirming they would have caught the original regression.

closes #39540

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only change)

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/utils/series.test.ts plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts --maxWorkers=2
```

All 146 tests in the two suites pass on master.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #39540
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)