### PR TITLE
test(sql): prove Oracle GROUP BY is no longer rewritten to ordinals (#35414)

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -439,6 +439,40 @@ WHERE
     )
 
 
+def test_format_oracle_group_by_keeps_explicit_expressions() -> None:
+    """
+    Test that formatting Oracle SQL doesn't rewrite ``GROUP BY`` to ordinals.
+
+    Oracle doesn't support positional grouping (``GROUP BY 1, 2``) and fails
+    with ``ORA-00979: not a GROUP BY expression``. sqlglot < 27.21.0 rewrote
+    ``GROUP BY`` expressions that matched aliased projections into ordinals
+    when generating Oracle SQL, breaking chart queries.
+
+    Regression test for https://github.com/apache/superset/issues/35414,
+    fixed by upgrading sqlglot.
+    """
+    sql = (
+        "SELECT TRUNC(CAST(order_date AS DATE), 'MONTH') AS __timestamp, "
+        'region AS region, SUM(sales) AS "SUM(sales)" '
+        "FROM orders "
+        "GROUP BY TRUNC(CAST(order_date AS DATE), 'MONTH'), region "
+        'ORDER BY "SUM(sales)" DESC'
+    )
+    formatted = SQLStatement(sql, engine="oracle").format()
+
+    # pretty-formatting puts each `GROUP BY` item on its own line
+    group_by_clause = formatted.split("GROUP BY")[1].split("ORDER BY")[0]
+    group_by_items = [
+        line.strip().rstrip(",") for line in group_by_clause.strip().splitlines()
+    ]
+    assert group_by_items == [
+        "TRUNC(CAST(order_date AS DATE), 'MONTH')",
+        "region",
+    ]
+    # no item should have been replaced by a positional reference
+    assert not any(item.isdigit() for item in group_by_items)
+
+
 def test_split_no_dialect() -> None:
     """
     Test the statement split when the engine has no corresponding dialect.


### PR DESCRIPTION
### SUMMARY

Test-only PR — closes #35414.

Issue #35414 reported that on 6.0.0-RC2, Oracle bar charts failed with `ORA-00979: not a GROUP BY expression` because Superset's SQL formatting/generation path rewrote explicit `GROUP BY` expressions into positional ordinals (`GROUP BY 1, 2`), which Oracle does not support.

The root cause was in sqlglot: versions < 27.21.0 rewrote `GROUP BY` expressions that matched aliased projections (e.g. `region AS region`, exactly what SQLAlchemy emits for chart queries) into ordinals when generating Oracle SQL. This is empirically reproducible with sqlglot 27.20.0:

```
-- input
... GROUP BY TRUNC(CAST(order_date AS DATE), 'MONTH'), region ...
-- sqlglot 27.20.0 Oracle output
GROUP BY
  TRUNC(CAST(order_date AS DATE), 'MONTH'),
  2
```

`master` pins `sqlglot==30.8.0` (`requirements/base.txt`), which contains the upstream fix — explicit expressions are preserved. A user on the issue thread also confirmed Superset 6.0 works once sqlglot >= 27.29 is installed.

This PR adds a unit test on `SQLStatement.format()` (the path behind the "Formatted" view-query toggle and SQL prettification) with the Oracle dialect, asserting the `GROUP BY` clause keeps explicit column expressions and contains no positional references. The test passes on current master and guards against a future sqlglot downgrade or Oracle-dialect regression reintroducing ORA-00979.

No production code changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only)

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/sql/parse_tests.py::test_format_oracle_group_by_keeps_explicit_expressions -x -q
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: closes #35414
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)