### PR TITLE
test(sql): prove ClickHouse parametric aggregates parse cleanly (#37285)

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1308,6 +1308,33 @@ def test_with_clause_containing_union_all_is_not_mutating_oracle() -> None:
     assert not SQLScript(sql, "oracle").has_mutation()
 
 
+@pytest.mark.parametrize("engine", ["clickhouse", "clickhousedb"])
+def test_clickhouse_parametric_aggregate_parses_and_is_read_only(engine: str) -> None:
+    """
+    Regression for #37285: ClickHouse parametric aggregate functions use a
+    double pair of parentheses — ``groupConcat(', ')(part_name)`` — where the
+    first list holds the aggregate's parameters and the second its arguments.
+
+    Older sqlglot versions choked on the second parenthesized list, so SQL
+    Lab either mangled the query sent to the database or, with DDL/DML
+    disallowed, refused to run it because it "could not be parsed to confirm
+    it is a read-only query". The sqlglot bump to >=30 fixed the parsing;
+    pinning the reporter's verbatim query guards against a future
+    dialect-specific regression. Both ClickHouse engine specs are exercised
+    since each resolves the sqlglot dialect independently.
+    """
+    sql = """
+    select
+      groupConcat(', ')(part_name) as concatenated
+    from system.parts
+    """
+    script = SQLScript(sql, engine)  # Must not raise.
+    assert not script.has_mutation(), (
+        f"Parametric aggregate misclassified as mutating on {engine!r}; "
+        "this would block the query on connections without DDL/DML allowed."
+    )
+
+
 def test_get_settings() -> None:
     """
     Test `get_settings` in some edge cases.


### PR DESCRIPTION
### SUMMARY

Test-only PR — no production code changes.

Issue #37285 reported that ClickHouse parametric aggregate functions (a double pair of parentheses, e.g. `groupConcat(', ')(part_name)`) could not run in SQL Lab: the parser choked on the second argument list, so either a mangled query was sent to the database or, with "Allow DDL and DML" unchecked, the query was rejected because it "could not be parsed to confirm it is a read-only query".

This was fixed upstream by the sqlglot bump to >=30 (the upgrade @betodealmeida anticipated in the issue thread has since landed — the pinned sqlglot 30.8.0 parses parametric aggregates correctly). This PR adds a regression test pinning the reporter's verbatim query on both ClickHouse engine specs (`clickhouse`, `clickhousedb`), asserting that `SQLScript` parses it without raising and classifies it as read-only (`has_mutation()` is `False`). The test passes on current master, proving the issue is resolved and guarding against a future dialect-specific regression.

closes #37285

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/sql/parse_tests.py -k clickhouse_parametric -x -q
```

Both parametrized cases pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #37285
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)