### PR TITLE
test(datasets): prove column metadata persists for zero-row queries

### DIFF
--- a/tests/unit_tests/connectors/sqla/utils_test.py
+++ b/tests/unit_tests/connectors/sqla/utils_test.py
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -23,6 +27,7 @@ from superset.connectors.sqla.utils import (
     get_virtual_table_metadata,
 )
 from superset.exceptions import SupersetSecurityException
+from superset.models.core import Database
 
 
 # Returns column descriptions when given valid database, catalog, schema, and query
@@ -95,6 +100,75 @@ def test_returns_column_descriptions(mocker: MockerFixture) -> None:
             "is_dttm": False,
         },
     ]
+
+
+def _create_zero_row_database(tmp_path: Path) -> tuple[Database, str]:
+    """
+    Create a real SQLite-backed ``Database`` and a query that matches zero rows.
+
+    The table itself contains data, but the ``WHERE`` clause filters everything
+    out — mirroring the repro steps in issue #37609 (a virtual dataset whose
+    date filter matches no rows).
+    """
+    db_path = tmp_path / "zero_rows.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("CREATE TABLE events (id INTEGER, name TEXT, event_date TEXT)")
+        conn.execute("INSERT INTO events VALUES (1, 'a', '2026-01-01')")
+        conn.commit()
+
+    database = Database(
+        id=1,
+        database_name="zero_rows_db",
+        sqlalchemy_uri=f"sqlite:///{db_path}",
+    )
+    query = "SELECT id, name, event_date FROM events WHERE event_date = '2026-02-01'"
+    return database, query
+
+
+def test_get_columns_description_zero_row_query(tmp_path: Path) -> None:
+    """
+    Column metadata must be derived from the cursor description even when the
+    query returns zero rows.
+
+    Executes a real query against a real (SQLite) database instead of mocking
+    the cursor, so this covers the full path used when a virtual dataset's
+    columns are synced: ``get_columns_description`` -> raw connection ->
+    ``SupersetResultSet.columns``.
+
+    Regression test for https://github.com/apache/superset/issues/37609
+    """
+    database, query = _create_zero_row_database(tmp_path)
+
+    columns = get_columns_description(database, None, None, query)
+
+    assert [col["column_name"] for col in columns] == ["id", "name", "event_date"]
+    assert all(col["name"] for col in columns)
+
+
+def test_get_virtual_table_metadata_zero_row_query(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """
+    ``get_virtual_table_metadata`` (the entry point used by "Sync columns from
+    source" / dataset metadata refresh) must return the column metadata for a
+    virtual dataset whose query returns zero rows.
+
+    Regression test for https://github.com/apache/superset/issues/37609
+    """
+    database, query = _create_zero_row_database(tmp_path)
+
+    dataset = mocker.MagicMock(
+        sql=query,
+        catalog=None,
+        schema=None,
+        database=database,
+        template_params_dict={},
+    )
+    dataset.get_template_processor().process_template.return_value = query
+
+    columns = get_virtual_table_metadata(dataset=dataset)
+
+    assert [col["column_name"] for col in columns] == ["id", "name", "event_date"]
 
 
 def test_get_virtual_table_metadata(mocker: MockerFixture) -> None:


### PR DESCRIPTION
### SUMMARY

closes #37609

Test-only PR — no production code changes.

Issue #37609 reported that a virtual dataset's column metadata is not persisted when its query returns zero rows (e.g. a date filter that matches nothing). @hainenber could not reproduce this on a recent `master` build and suspected it had already been fixed, and the reporter never re-tested despite a nudge.

This PR adds regression tests that encode the issue's repro at the unit level, proving the behavior works correctly on `master`:

- `test_get_columns_description_zero_row_query` — executes a real query against a real (SQLite) database where the `WHERE` clause matches zero rows, and asserts that `get_columns_description` still derives the column metadata (`id`, `name`, `event_date`) from the cursor description. No mocked cursors — this exercises the raw connection → `SupersetResultSet.columns` path end to end.
- `test_get_virtual_table_metadata_zero_row_query` — same zero-row query through `get_virtual_table_metadata`, the entry point used by dataset metadata refresh / "Sync columns from source".

Both tests pass against current `master`, confirming the issue is resolved. If a regression ever reintroduces the zero-row metadata loss, these tests will catch it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/connectors/sqla/utils_test.py -x -q
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: closes #37609
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)