### PR TITLE
test(async-queries): prove OAuth2RedirectError survives async chart queries

### DIFF
--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -154,6 +155,57 @@ def test_load_chart_data_into_cache_with_superset_errors_exception(
     assert errors[1]["message"] == "Table not found"
     assert errors[1]["error_type"] == SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR
     assert errors[1]["level"] == ErrorLevel.WARNING
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_preserves_oauth2_redirect_error(
+    mock_query_context_schema_cls: mock.MagicMock,
+    mock_command_cls: mock.MagicMock,
+    mock_async_query_manager: mock.MagicMock,
+    mock_security_manager: mock.MagicMock,
+) -> None:
+    """
+    OAuth2RedirectError raised by ``ChartDataCommand.run`` must reach the async
+    job's errors list as a structured SIP-40 envelope (with ``error_type`` and
+    the OAuth2 ``extra`` payload) instead of being flattened to a plain
+    message, so dashboard charts can render the OAuth2 banner when
+    GLOBAL_ASYNC_QUERIES is enabled.
+    """
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data: dict[str, Any] = {}
+
+    mock_security_manager.get_user_by_id.return_value = mock.MagicMock()
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value.load.return_value = mock.MagicMock()
+
+    mock_command_cls.return_value.run.side_effect = OAuth2RedirectError(
+        url="https://accounts.example.com/o/oauth2/v2/auth?...",
+        tab_id="tab-123",
+        redirect_uri="https://superset.example.com/oauth2/redirect",
+    )
+
+    with pytest.raises(OAuth2RedirectError):
+        load_chart_data_into_cache(job_metadata, form_data)
+
+    call_args = mock_async_query_manager.update_job.call_args
+    assert call_args[0] == (job_metadata, "error")
+    errors = call_args[1]["errors"]
+    assert len(errors) == 1
+    # A flattened error would only carry the generic permission message; the
+    # structured envelope must be preserved for the frontend OAuth2 banner.
+    assert errors[0] != {"message": "You don't have permission to access the data."}
+    assert errors[0]["error_type"] == SupersetErrorType.OAUTH2_REDIRECT
+    assert errors[0]["level"] == ErrorLevel.WARNING
+    assert errors[0]["extra"] == {
+        "url": "https://accounts.example.com/o/oauth2/v2/auth?...",
+        "tab_id": "tab-123",
+        "redirect_uri": "https://superset.example.com/oauth2/redirect",
+    }
 
 
 @mock.patch("superset.tasks.async_queries.security_manager")


### PR DESCRIPTION
### SUMMARY

Test-only PR that proves issue #39096 is already fixed on master, and closes it.

closes #39096

The issue reported that with `GLOBAL_ASYNC_QUERIES` enabled, an `OAuth2RedirectError` raised while loading chart data (e.g. Trino + Keycloak OAuth2) was caught by the generic `Exception` handler in `load_chart_data_into_cache` and flattened to a plain `{"message": "You don't have permission to access the data."}`, losing the structured payload (`url`, `tab_id`, `redirect_uri`) the frontend needs to render the OAuth2 banner.

That code path has since been fixed:

- #36596 added SIP-40 structured-error extraction to `load_chart_data_into_cache` (the exact handler quoted in the issue), so any `SupersetErrorException` — including `OAuth2RedirectError`, which subclasses it — is serialized via `dataclasses.asdict(ex.error)` with its full `error_type`/`level`/`extra` payload.
- #39897 extended the same treatment to the legacy `load_explore_json_into_cache` path and added an OAuth2-specific test there.

What was still missing is a regression test for the issue's exact scenario: `OAuth2RedirectError` raised by `ChartDataCommand.run` inside `load_chart_data_into_cache`. The existing chart-path tests only cover a generic `SupersetErrorException`, and the OAuth2-specific test from #39897 only covers the explore-json path. This PR adds that complementary unit test, which asserts the async job is updated with the structured `OAUTH2_REDIRECT` envelope (including the `url`/`tab_id`/`redirect_uri` extras) rather than the flattened permission message. The test passes on current master, confirming the reported behavior is resolved and guarding against regression.

No production code is changed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only change)

### TESTING INSTRUCTIONS

```bash
python -m pytest tests/unit_tests/tasks/test_async_queries.py -x -q
```

All tests in the module pass, including the new `test_load_chart_data_into_cache_preserves_oauth2_redirect_error`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #39096
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
