### PR TITLE
test(dashboard): prove BigInt column values no longer break native filter config

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -93,6 +93,9 @@ const bigIntChartDataState = () => {
             data: [
               { name: 'Abigail', count: 228 },
               { name: 'Aaron', count: 123012930123123n },
+              // Exceeds Number.MAX_SAFE_INTEGER, mirroring the BigInt values
+              // that parseResponse produces for large integer columns
+              { name: 'Adah', count: 9007199254740993n },
               { name: 'Adam', count: 454 },
             ],
             applied_filters: [{ column: 'name' }],
@@ -772,6 +775,18 @@ test('renders a filter with a chart containing BigInt values', async () => {
   });
 
   expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
+});
+
+test('creates a new filter when a chart contains BigInt values', () => {
+  // Repro for #35087: opening "Add or edit filters" on a dashboard where a
+  // chart queried a BigInt column must not throw
+  // "TypeError: Do not know how to serialize a BigInt"
+  defaultRender(bigIntChartDataState(), props);
+
+  expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
+  expect(screen.getByText(FILTER_NAME_REGEX)).toBeInTheDocument();
+  expect(screen.getByText(DATASET_REGEX)).toBeInTheDocument();
+  expect(screen.getByText(COLUMN_REGEX)).toBeInTheDocument();
 });
 
 test('displays empty state when modal opens with no filters and createNewOnOpen is false', () => {


### PR DESCRIPTION
### SUMMARY

Test-only PR that proves #35087 is fixed on master, and closes it.

The issue reported `Unexpected error: TypeError: Do not know how to serialize a BigInt` when clicking "Add or edit filters" on a dashboard where a chart had queried a BigInt column. The crash came from `JSON.stringify(charts)` in a `useMemo` dependency array in `FiltersConfigForm`, evaluated on every render of the filters config modal — chart data responses containing integers beyond `Number.MAX_SAFE_INTEGER` are parsed into native `BigInt` values by `parseResponse` (`parseMethod: 'json-bigint'`), and `JSON.stringify` throws on any `BigInt`.

That stringify call was fixed by #34539 (merged Aug 2025), which serializes only the chart ids. However, #34539's regression test only covered opening the modal onto an existing filter configuration (`createNewOnOpen: false`), while the issue's repro is the fresh "Add or edit filters" flow that auto-creates a new filter. This PR adds a test for that exact path and strengthens the shared fixture with a value above `Number.MAX_SAFE_INTEGER` (`9007199254740993n`), mirroring what `parseResponse` actually produces for large integer columns.

The new test passes on master, confirming the reported path no longer throws. No production code changes.

closes #35087

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only change)

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx --maxWorkers=2
```

The new test is `creates a new filter when a chart contains BigInt values`. To see it fail as it would have before the fix, revert the #34539 change in `FiltersConfigForm.tsx` (restore `JSON.stringify(charts)` in the `initiallyExcludedCharts` dependency array) and re-run — the render throws `TypeError: Do not know how to serialize a BigInt`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: closes #35087
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
