### PR TITLE
feat(security): actionable, request-access-aware data permission errors

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
@@ -99,3 +99,37 @@ test('explains table access for TABLE_SECURITY_ACCESS_ERROR', () => {
   render(<DatasourceSecurityAccessErrorMessage {...props} />);
   expect(screen.getByText(/public.sales, public.users/)).toBeInTheDocument();
 });
+
+test('renders plainly when the error carries no access payload', () => {
+  // DATASOURCE_SECURITY_ACCESS_ERROR is reused for virtual-dataset SQL
+  // validation ("Only SELECT statements are allowed"); without an access
+  // payload the component must not show request-access guidance.
+  const props = {
+    ...baseProps,
+    error: {
+      ...baseProps.error,
+      extra: null,
+      message: 'Only `SELECT` statements are allowed',
+    },
+  };
+  render(<DatasourceSecurityAccessErrorMessage {...props} />);
+  expect(
+    screen.getByText(/Only `SELECT` statements are allowed/),
+  ).toBeInTheDocument();
+  expect(screen.queryByText(/Request access/)).toBeNull();
+  expect(screen.queryByText(/access to this chart's data/)).toBeNull();
+});
+
+test('uses query wording for the sqllab source', () => {
+  const props = {
+    ...baseProps,
+    source: 'sqllab' as ErrorSource,
+  };
+  render(<DatasourceSecurityAccessErrorMessage {...props} />);
+  expect(
+    screen.getByText(/This query uses the "Quarterly Sales"/),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("You don't have access to this data"),
+  ).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ErrorLevel, ErrorSource, ErrorTypeEnum } from '@superset-ui/core';
+import { render, screen } from 'spec/helpers/testing-library';
+import { DatasourceSecurityAccessErrorMessage } from './DatasourceSecurityAccessErrorMessage';
+
+jest.mock(
+  '@superset-ui/core/components/Icons/AsyncIcon',
+  () =>
+    ({ fileName }: { fileName: string }) => (
+      <span role="img" aria-label={fileName.replace('_', '-')} />
+    ),
+);
+
+const baseProps = {
+  error: {
+    error_type: ErrorTypeEnum.DATASOURCE_SECURITY_ACCESS_ERROR,
+    extra: {
+      datasource: 12,
+      datasource_name: 'Quarterly Sales',
+      owners: ['Jane Doe', 'Bob Smith'],
+      link: 'https://access.example.com/request?dataset=12',
+      issue_codes: [{ code: 1017, message: 'Permission issue' }],
+    },
+    level: 'error' as ErrorLevel,
+    message:
+      'This endpoint requires the datasource 12, database or ' +
+      '`all_datasource_access` permission',
+  },
+  source: 'dashboard' as ErrorSource,
+  subtitle: '',
+};
+
+test('shows a friendly title and names the dataset', () => {
+  render(<DatasourceSecurityAccessErrorMessage {...baseProps} />);
+  expect(
+    screen.getByText("You don't have access to this chart's data"),
+  ).toBeInTheDocument();
+  expect(screen.getByText(/Quarterly Sales/)).toBeInTheDocument();
+});
+
+test('surfaces the chart owners to contact', () => {
+  render(<DatasourceSecurityAccessErrorMessage {...baseProps} />);
+  expect(
+    screen.getByText(/reach out to the chart owners: Jane Doe, Bob Smith/),
+  ).toBeInTheDocument();
+});
+
+test('renders a Request access link to the configured URL', () => {
+  render(<DatasourceSecurityAccessErrorMessage {...baseProps} />);
+  const link = screen.getByRole('link', { name: 'Request access' });
+  expect(link).toHaveAttribute(
+    'href',
+    'https://access.example.com/request?dataset=12',
+  );
+});
+
+test('falls back to administrator guidance when no owners are known', () => {
+  const props = {
+    ...baseProps,
+    error: {
+      ...baseProps.error,
+      extra: { datasource_name: 'Quarterly Sales' },
+    },
+  };
+  render(<DatasourceSecurityAccessErrorMessage {...props} />);
+  expect(
+    screen.getByText(/contact your Superset administrator/),
+  ).toBeInTheDocument();
+  expect(screen.queryByRole('link', { name: 'Request access' })).toBeNull();
+});
+
+test('explains table access for TABLE_SECURITY_ACCESS_ERROR', () => {
+  const props = {
+    ...baseProps,
+    error: {
+      ...baseProps.error,
+      error_type: ErrorTypeEnum.TABLE_SECURITY_ACCESS_ERROR,
+      extra: { tables: ['public.sales', 'public.users'] },
+    },
+  };
+  render(<DatasourceSecurityAccessErrorMessage {...props} />);
+  expect(screen.getByText(/public.sales, public.users/)).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
@@ -25,7 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
-      <span role="img" aria-label={fileName.replace('_', '-')} />
+      <img alt={fileName.replace('_', '-')} />
     ),
 );
 

--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
@@ -50,22 +50,46 @@ export function DatasourceSecurityAccessErrorMessage({
   const { extra, level, message } = error;
   const isVisualization = ['dashboard', 'explore'].includes(source || '');
 
+  // DATASOURCE_SECURITY_ACCESS_ERROR is also raised for non-access failures
+  // (e.g. virtual-dataset SQL validation: "Only SELECT statements are
+  // allowed"). Those errors carry no access payload — render them plainly
+  // rather than misleading the user with request-access guidance.
+  const isAccessDenial = !!extra?.datasource_name || !!extra?.tables?.length;
+  if (!isAccessDenial) {
+    return (
+      <ErrorAlert
+        errorType={t('Unexpected error')}
+        message={message}
+        type={level}
+        closable={closable}
+      />
+    );
+  }
+
   let explanation: string;
   if (extra?.datasource_name) {
-    explanation = t(
-      'This chart uses the "%s" dataset, which you do not have permission ' +
-        'to view.',
-      extra.datasource_name,
-    );
-  } else if (extra?.tables?.length) {
-    explanation = t(
-      'You do not have access to the data behind this chart ' + '(tables: %s).',
-      extra.tables.join(', '),
-    );
+    explanation = isVisualization
+      ? t(
+          'This chart uses the "%s" dataset, which you do not have ' +
+            'permission to view.',
+          extra.datasource_name,
+        )
+      : t(
+          'This query uses the "%s" dataset, which you do not have ' +
+            'permission to view.',
+          extra.datasource_name,
+        );
   } else {
-    explanation = t(
-      'You do not have permission to view the data behind this chart.',
-    );
+    explanation = isVisualization
+      ? t(
+          'You do not have access to the data behind this chart ' +
+            '(tables: %s).',
+          extra?.tables?.join(', '),
+        )
+      : t(
+          'You do not have access to the following tables: %s.', // sqllab
+          extra?.tables?.join(', '),
+        );
   }
 
   const owners = extra?.owners;
@@ -116,7 +140,11 @@ export function DatasourceSecurityAccessErrorMessage({
 
   return (
     <ErrorAlert
-      errorType={t("You don't have access to this chart's data")}
+      errorType={
+        isVisualization
+          ? t("You don't have access to this chart's data")
+          : t("You don't have access to this data")
+      }
       message={explanation}
       description={description}
       descriptionDetails={descriptionDetails}

--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ReactNode } from 'react';
+import { t, tn } from '@apache-superset/core/translation';
+import { Typography } from '@superset-ui/core/components';
+
+import type { ErrorMessageComponentProps } from './types';
+import { IssueCode } from './IssueCode';
+import { ErrorAlert } from './ErrorAlert';
+
+interface DatasourceSecurityAccessExtra {
+  owners?: string[];
+  link?: string;
+  datasource?: number | string;
+  datasource_name?: string;
+  tables?: string[];
+  issue_codes?: {
+    code: number;
+    message: string;
+  }[];
+}
+
+/**
+ * Shown when a viewer opens a chart but lacks permission to its underlying data
+ * (DATASOURCE_SECURITY_ACCESS_ERROR / TABLE_SECURITY_ACCESS_ERROR). Surfaces a
+ * plain-language explanation, who to contact, and a "Request access" link when
+ * the deployment configures PERMISSION_INSTRUCTIONS_LINK.
+ */
+export function DatasourceSecurityAccessErrorMessage({
+  error,
+  source,
+  closable,
+}: ErrorMessageComponentProps<DatasourceSecurityAccessExtra | null>) {
+  const { extra, level, message } = error;
+  const isVisualization = ['dashboard', 'explore'].includes(source || '');
+
+  let explanation: string;
+  if (extra?.datasource_name) {
+    explanation = t(
+      'This chart uses the "%s" dataset, which you do not have permission ' +
+        'to view.',
+      extra.datasource_name,
+    );
+  } else if (extra?.tables?.length) {
+    explanation = t(
+      'You do not have access to the data behind this chart ' + '(tables: %s).',
+      extra.tables.join(', '),
+    );
+  } else {
+    explanation = t(
+      'You do not have permission to view the data behind this chart.',
+    );
+  }
+
+  const owners = extra?.owners;
+  const ownerLine =
+    isVisualization && owners && owners.length > 0
+      ? tn(
+          'To request access, reach out to the chart owner: %s.',
+          'To request access, reach out to the chart owners: %s.',
+          owners.length,
+          owners.join(', '),
+        )
+      : t('To request access, contact your Superset administrator.');
+
+  // Actionable guidance stays visible (not collapsed): who to contact + link.
+  const description: ReactNode = (
+    <>
+      <div>{ownerLine}</div>
+      {extra?.link && (
+        <Typography.Link
+          href={extra.link}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('Request access')}
+        </Typography.Link>
+      )}
+    </>
+  );
+
+  // Technical detail is collapsible: issue codes and the raw backend message.
+  const hasIssueCodes = !!extra?.issue_codes && extra.issue_codes.length > 0;
+  const descriptionDetails: ReactNode =
+    hasIssueCodes || message ? (
+      <>
+        {hasIssueCodes && (
+          <p>
+            {t('This may be triggered by:')}
+            <br />
+            {extra?.issue_codes?.flatMap((issueCode, idx, arr) => [
+              <IssueCode {...issueCode} key={issueCode.code} />,
+              idx < arr.length - 1 ? <br key={`br-${issueCode.code}`} /> : null,
+            ])}
+          </p>
+        )}
+        {message && <pre>{message}</pre>}
+      </>
+    ) : undefined;
+
+  return (
+    <ErrorAlert
+      errorType={t("You don't have access to this chart's data")}
+      message={explanation}
+      description={description}
+      descriptionDetails={descriptionDetails}
+      descriptionPre={false}
+      type={level}
+      closable={closable}
+    />
+  );
+}

--- a/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.tsx
@@ -46,6 +46,7 @@ export function DatasourceSecurityAccessErrorMessage({
   error,
   source,
   closable,
+  compact,
 }: ErrorMessageComponentProps<DatasourceSecurityAccessExtra | null>) {
   const { extra, level, message } = error;
   const isVisualization = ['dashboard', 'explore'].includes(source || '');
@@ -62,6 +63,7 @@ export function DatasourceSecurityAccessErrorMessage({
         message={message}
         type={level}
         closable={closable}
+        compact={compact}
       />
     );
   }
@@ -151,6 +153,7 @@ export function DatasourceSecurityAccessErrorMessage({
       descriptionPre={false}
       type={level}
       closable={closable}
+      compact={compact}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/index.tsx
+++ b/superset-frontend/src/components/ErrorMessage/index.tsx
@@ -19,6 +19,7 @@
 export { BasicErrorAlert } from './BasicErrorAlert';
 export { DatabaseErrorMessage } from './DatabaseErrorMessage';
 export { DatasetNotFoundErrorMessage } from './DatasetNotFoundErrorMessage';
+export { DatasourceSecurityAccessErrorMessage } from './DatasourceSecurityAccessErrorMessage';
 export { ErrorAlert } from './ErrorAlert';
 export { ErrorMessageWithStackTrace } from './ErrorMessageWithStackTrace';
 export { getErrorMessageComponentRegistry } from './getErrorMessageComponentRegistry';

--- a/superset-frontend/src/setup/setupErrorMessages.ts
+++ b/superset-frontend/src/setup/setupErrorMessages.ts
@@ -24,6 +24,7 @@ import {
   MarshmallowErrorMessage,
   ParameterErrorMessage,
   DatasetNotFoundErrorMessage,
+  DatasourceSecurityAccessErrorMessage,
   InvalidSQLErrorMessage,
   OAuth2RedirectMessage,
   FrontendNetworkErrorMessage,
@@ -93,6 +94,14 @@ export default function setupErrorMessages() {
   errorMessageComponentRegistry.registerValue(
     ErrorTypeEnum.QUERY_SECURITY_ACCESS_ERROR,
     DatabaseErrorMessage,
+  );
+  errorMessageComponentRegistry.registerValue(
+    ErrorTypeEnum.DATASOURCE_SECURITY_ACCESS_ERROR,
+    DatasourceSecurityAccessErrorMessage,
+  );
+  errorMessageComponentRegistry.registerValue(
+    ErrorTypeEnum.TABLE_SECURITY_ACCESS_ERROR,
+    DatasourceSecurityAccessErrorMessage,
   );
   errorMessageComponentRegistry.registerValue(
     ErrorTypeEnum.CONNECTION_INVALID_HOSTNAME_ERROR,

--- a/superset/config.py
+++ b/superset/config.py
@@ -2093,7 +2093,16 @@ TROUBLESHOOTING_LINK = ""
 WTF_CSRF_TIME_LIMIT = int(timedelta(weeks=1).total_seconds())
 
 # This link should lead to a page with instructions on how to gain access to a
-# Datasource. It will be placed at the bottom of permissions errors.
+# Datasource. It is surfaced as a "Request Access" link on data-permission
+# errors (e.g. when a viewer opens a chart whose dataset they cannot access).
+# The URL may include any of these placeholders, which are substituted with
+# URL-encoded values so the link can deep-link into an access-request system:
+#   {datasource_id}    - id of the denied dataset (datasource errors)
+#   {datasource_name}  - name of the denied dataset (datasource errors)
+#   {table_names}      - comma-separated denied table names (table/SQL errors)
+#   {username}         - the requesting user's username
+# A URL with no placeholders is used as-is. Example:
+#   "https://access.example.com/request?dataset={datasource_id}&user={username}"
 PERMISSION_INSTRUCTIONS_LINK = ""
 
 # Integrate external Blueprints to the app by passing them to your

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -167,6 +167,7 @@ def get_extra_editor_subject_ids(resource: Model) -> list[int]:
             seen.add(subject_id)
     return subject_ids
 
+
 def _render_permission_instructions_link(
     *,
     datasource_id: str = "",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -32,6 +32,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+from urllib.parse import quote
 
 from flask import current_app, Flask, g, has_app_context, Request, Response
 from flask_appbuilder import Model
@@ -165,6 +166,41 @@ def get_extra_editor_subject_ids(resource: Model) -> list[int]:
             subject_ids.append(subject_id)
             seen.add(subject_id)
     return subject_ids
+
+def _render_permission_instructions_link(
+    *,
+    datasource_id: str = "",
+    datasource_name: str = "",
+    table_names: str = "",
+) -> Optional[str]:
+    """Render the configured ``PERMISSION_INSTRUCTIONS_LINK``.
+
+    The configured URL may contain ``{datasource_id}``, ``{datasource_name}``,
+    ``{table_names}`` and ``{username}`` placeholders, which are substituted with
+    URL-encoded values so the link can deep-link into an organization's access
+    request system. A URL with no placeholders is returned unchanged, and an
+    empty/unset config returns ``None`` (no link). Unsupplied placeholders are
+    replaced with an empty string.
+    """
+    link = get_conf().get("PERMISSION_INSTRUCTIONS_LINK")
+    if not link:
+        return None
+
+    username = ""
+    user = getattr(g, "user", None)
+    if user is not None and not getattr(user, "is_anonymous", False):
+        username = getattr(user, "username", "") or ""
+
+    for token, value in (
+        ("datasource_id", datasource_id),
+        ("datasource_name", datasource_name),
+        ("table_names", table_names),
+        ("username", username),
+    ):
+        placeholder = "{" + token + "}"
+        if placeholder in link:
+            link = link.replace(placeholder, quote(str(value), safe=""))
+    return link
 
 
 DATABASE_PERM_REGEX = re.compile(r"^\[.+\]\.\(id\:(?P<id>\d+)\)$")
@@ -1937,17 +1973,23 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
 
     @staticmethod
-    def get_datasource_access_link(  # pylint: disable=unused-argument
+    def get_datasource_access_link(
         datasource: "BaseDatasource | Explorable",
     ) -> Optional[str]:
         """
         Return the link for the denied Superset datasource.
 
+        The configured ``PERMISSION_INSTRUCTIONS_LINK`` may template the denied
+        datasource's id/name (and the current username) into the access URL.
+
         :param datasource: The denied Superset datasource
         :returns: The access URL
         """
 
-        return get_conf().get("PERMISSION_INSTRUCTIONS_LINK")
+        return _render_permission_instructions_link(
+            datasource_id=str(datasource.data["id"]),
+            datasource_name=str(datasource.data["name"]),
+        )
 
     def get_datasource_access_error_object(  # pylint: disable=invalid-name
         self, datasource: "BaseDatasource | Explorable"
@@ -2002,17 +2044,20 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             },
         )
 
-    def get_table_access_link(  # pylint: disable=unused-argument
-        self, tables: set["Table"]
-    ) -> Optional[str]:
+    def get_table_access_link(self, tables: set["Table"]) -> Optional[str]:
         """
         Return the access link for the denied SQL tables.
+
+        The configured ``PERMISSION_INSTRUCTIONS_LINK`` may template the denied
+        table names (and the current username) into the access URL.
 
         :param tables: The set of denied SQL tables
         :returns: The access URL
         """
 
-        return get_conf().get("PERMISSION_INSTRUCTIONS_LINK")
+        return _render_permission_instructions_link(
+            table_names=",".join(str(table) for table in tables),
+        )
 
     def get_user_datasources(self) -> list["BaseDatasource"]:
         """

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2008,6 +2008,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 "link": self.get_datasource_access_link(datasource),
                 "datasource": datasource.data["id"],
                 "datasource_name": datasource.data["name"],
+                # Owner display names give the viewer someone to contact for
+                # access; sorted for a deterministic payload.
+                "owners": sorted(
+                    str(owner) for owner in getattr(datasource, "owners", []) or []
+                ),
             },
         )
 
@@ -2055,8 +2060,20 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :returns: The access URL
         """
 
+        # Build display names from the raw parts: Table.__str__ URL-encodes
+        # each segment, and the renderer encodes the whole value again, so
+        # using it here would double-encode. Sorted for deterministic links.
         return _render_permission_instructions_link(
-            table_names=",".join(str(table) for table in tables),
+            table_names=",".join(
+                sorted(
+                    ".".join(
+                        part
+                        for part in (table.catalog, table.schema, table.table)
+                        if part
+                    )
+                    for table in tables
+                )
+            ),
         )
 
     def get_user_datasources(self) -> list["BaseDatasource"]:

--- a/tests/unit_tests/security/test_permission_instructions_link.py
+++ b/tests/unit_tests/security/test_permission_instructions_link.py
@@ -23,11 +23,18 @@ from superset.security.manager import (
     _render_permission_instructions_link,
     SupersetSecurityManager,
 )
+from superset.sql.parse import Table
 
 MANAGER = "superset.security.manager"
 
 
-def _render(template, *, username="alice", anonymous=False, **kwargs):
+def _render(
+    template: str | None,
+    *,
+    username: str = "alice",
+    anonymous: bool = False,
+    **kwargs: str,
+) -> str | None:
     with (
         patch(
             f"{MANAGER}.get_conf",
@@ -40,18 +47,18 @@ def _render(template, *, username="alice", anonymous=False, **kwargs):
         return _render_permission_instructions_link(**kwargs)
 
 
-def test_empty_or_unset_link_returns_none():
+def test_empty_or_unset_link_returns_none() -> None:
     assert _render("") is None
     assert _render(None) is None
 
 
-def test_plain_link_without_placeholders_is_unchanged():
+def test_plain_link_without_placeholders_is_unchanged() -> None:
     assert _render("https://wiki.example.com/data-access") == (
         "https://wiki.example.com/data-access"
     )
 
 
-def test_datasource_placeholders_are_filled_and_url_encoded():
+def test_datasource_placeholders_are_filled_and_url_encoded() -> None:
     out = _render(
         "https://acme.example.com/req?id={datasource_id}"
         "&name={datasource_name}&u={username}",
@@ -62,7 +69,7 @@ def test_datasource_placeholders_are_filled_and_url_encoded():
     assert out == ("https://acme.example.com/req?id=12&name=Quarterly%20Sales&u=alice")
 
 
-def test_table_names_filled_and_encoded():
+def test_table_names_filled_and_encoded() -> None:
     out = _render(
         "https://acme.example.com/req?tables={table_names}",
         table_names="public.sales,public.users",
@@ -70,7 +77,7 @@ def test_table_names_filled_and_encoded():
     assert out == ("https://acme.example.com/req?tables=public.sales%2Cpublic.users")
 
 
-def test_anonymous_user_renders_empty_username():
+def test_anonymous_user_renders_empty_username() -> None:
     out = _render(
         "https://acme.example.com/req?u={username}",
         anonymous=True,
@@ -78,8 +85,9 @@ def test_anonymous_user_renders_empty_username():
     assert out == "https://acme.example.com/req?u="
 
 
-def test_unreferenced_placeholders_left_untouched():
-    # datasource link doesn't supply table_names; that token stays literal
+def test_unsupplied_placeholders_render_empty() -> None:
+    # datasource link doesn't supply table_names; that token renders as
+    # an empty value (matching the helper's documented behavior)
     out = _render(
         "https://acme.example.com/req?id={datasource_id}&t={table_names}",
         datasource_id="9",
@@ -87,7 +95,7 @@ def test_unreferenced_placeholders_left_untouched():
     assert out == "https://acme.example.com/req?id=9&t="
 
 
-def test_get_datasource_access_link_pulls_from_datasource_data():
+def test_get_datasource_access_link_pulls_from_datasource_data() -> None:
     ds = MagicMock()
     ds.data = {"id": 12, "name": "Quarterly Sales"}
     with (
@@ -108,7 +116,7 @@ def test_get_datasource_access_link_pulls_from_datasource_data():
     assert out == "https://acme.example.com/req?id=12&name=Quarterly%20Sales"
 
 
-def test_get_table_access_link_joins_table_names():
+def test_get_table_access_link_joins_table_names() -> None:
     sm = SupersetSecurityManager.__new__(SupersetSecurityManager)
     with (
         patch(
@@ -123,7 +131,10 @@ def test_get_table_access_link_joins_table_names():
     ):
         g_mock.user.is_anonymous = False
         g_mock.user.username = "alice"
-        out = sm.get_table_access_link({"public.sales", "public.users"})
+        out = sm.get_table_access_link(
+            {Table("sales", "public"), Table("users", "public")}
+        )
+    assert out is not None
     assert out.startswith("https://acme.example.com/req?tables=")
     assert "public.sales" in out
     assert "public.users" in out

--- a/tests/unit_tests/security/test_permission_instructions_link.py
+++ b/tests/unit_tests/security/test_permission_instructions_link.py
@@ -59,9 +59,7 @@ def test_datasource_placeholders_are_filled_and_url_encoded():
         datasource_name="Quarterly Sales",
     )
     # space in the dataset name is URL-encoded; username injected from g.user
-    assert out == (
-        "https://acme.example.com/req?id=12&name=Quarterly%20Sales&u=alice"
-    )
+    assert out == ("https://acme.example.com/req?id=12&name=Quarterly%20Sales&u=alice")
 
 
 def test_table_names_filled_and_encoded():
@@ -69,9 +67,7 @@ def test_table_names_filled_and_encoded():
         "https://acme.example.com/req?tables={table_names}",
         table_names="public.sales,public.users",
     )
-    assert out == (
-        "https://acme.example.com/req?tables=public.sales%2Cpublic.users"
-    )
+    assert out == ("https://acme.example.com/req?tables=public.sales%2Cpublic.users")
 
 
 def test_anonymous_user_renders_empty_username():

--- a/tests/unit_tests/security/test_permission_instructions_link.py
+++ b/tests/unit_tests/security/test_permission_instructions_link.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for templated PERMISSION_INSTRUCTIONS_LINK rendering."""
+
+from unittest.mock import MagicMock, patch
+
+from superset.security.manager import (
+    _render_permission_instructions_link,
+    SupersetSecurityManager,
+)
+
+MANAGER = "superset.security.manager"
+
+
+def _render(template, *, username="alice", anonymous=False, **kwargs):
+    with (
+        patch(
+            f"{MANAGER}.get_conf",
+            return_value={"PERMISSION_INSTRUCTIONS_LINK": template},
+        ),
+        patch(f"{MANAGER}.g") as g_mock,
+    ):
+        g_mock.user.is_anonymous = anonymous
+        g_mock.user.username = username
+        return _render_permission_instructions_link(**kwargs)
+
+
+def test_empty_or_unset_link_returns_none():
+    assert _render("") is None
+    assert _render(None) is None
+
+
+def test_plain_link_without_placeholders_is_unchanged():
+    assert _render("https://wiki.example.com/data-access") == (
+        "https://wiki.example.com/data-access"
+    )
+
+
+def test_datasource_placeholders_are_filled_and_url_encoded():
+    out = _render(
+        "https://acme.example.com/req?id={datasource_id}"
+        "&name={datasource_name}&u={username}",
+        datasource_id="12",
+        datasource_name="Quarterly Sales",
+    )
+    # space in the dataset name is URL-encoded; username injected from g.user
+    assert out == (
+        "https://acme.example.com/req?id=12&name=Quarterly%20Sales&u=alice"
+    )
+
+
+def test_table_names_filled_and_encoded():
+    out = _render(
+        "https://acme.example.com/req?tables={table_names}",
+        table_names="public.sales,public.users",
+    )
+    assert out == (
+        "https://acme.example.com/req?tables=public.sales%2Cpublic.users"
+    )
+
+
+def test_anonymous_user_renders_empty_username():
+    out = _render(
+        "https://acme.example.com/req?u={username}",
+        anonymous=True,
+    )
+    assert out == "https://acme.example.com/req?u="
+
+
+def test_unreferenced_placeholders_left_untouched():
+    # datasource link doesn't supply table_names; that token stays literal
+    out = _render(
+        "https://acme.example.com/req?id={datasource_id}&t={table_names}",
+        datasource_id="9",
+    )
+    assert out == "https://acme.example.com/req?id=9&t="
+
+
+def test_get_datasource_access_link_pulls_from_datasource_data():
+    ds = MagicMock()
+    ds.data = {"id": 12, "name": "Quarterly Sales"}
+    with (
+        patch(
+            f"{MANAGER}.get_conf",
+            return_value={
+                "PERMISSION_INSTRUCTIONS_LINK": (
+                    "https://acme.example.com/req?id={datasource_id}"
+                    "&name={datasource_name}"
+                )
+            },
+        ),
+        patch(f"{MANAGER}.g") as g_mock,
+    ):
+        g_mock.user.is_anonymous = False
+        g_mock.user.username = "alice"
+        out = SupersetSecurityManager.get_datasource_access_link(ds)
+    assert out == "https://acme.example.com/req?id=12&name=Quarterly%20Sales"
+
+
+def test_get_table_access_link_joins_table_names():
+    sm = SupersetSecurityManager.__new__(SupersetSecurityManager)
+    with (
+        patch(
+            f"{MANAGER}.get_conf",
+            return_value={
+                "PERMISSION_INSTRUCTIONS_LINK": (
+                    "https://acme.example.com/req?tables={table_names}"
+                )
+            },
+        ),
+        patch(f"{MANAGER}.g") as g_mock,
+    ):
+        g_mock.user.is_anonymous = False
+        g_mock.user.username = "alice"
+        out = sm.get_table_access_link({"public.sales", "public.users"})
+    assert out.startswith("https://acme.example.com/req?tables=")
+    assert "public.sales" in out
+    assert "public.users" in out

--- a/tests/unit_tests/security/test_permission_instructions_link.py
+++ b/tests/unit_tests/security/test_permission_instructions_link.py
@@ -138,3 +138,44 @@ def test_get_table_access_link_joins_table_names() -> None:
     assert out.startswith("https://acme.example.com/req?tables=")
     assert "public.sales" in out
     assert "public.users" in out
+
+
+def test_datasource_error_object_includes_sorted_owner_names() -> None:
+    ds = MagicMock()
+    ds.data = {"id": 12, "name": "Quarterly Sales"}
+    owner_b, owner_a = MagicMock(), MagicMock()
+    owner_b.__str__.return_value = "Zoe Chen"  # type: ignore[attr-defined]
+    owner_a.__str__.return_value = "Amir Patel"  # type: ignore[attr-defined]
+    ds.owners = [owner_b, owner_a]
+    sm = SupersetSecurityManager.__new__(SupersetSecurityManager)
+    with (
+        patch(f"{MANAGER}.get_conf", return_value={"PERMISSION_INSTRUCTIONS_LINK": ""}),
+        patch(f"{MANAGER}.g") as g_mock,
+    ):
+        g_mock.user.is_anonymous = False
+        g_mock.user.username = "alice"
+        error = sm.get_datasource_access_error_object(ds)
+    assert error.extra is not None
+    assert error.extra["owners"] == ["Amir Patel", "Zoe Chen"]
+
+
+def test_table_access_link_is_single_encoded_and_sorted() -> None:
+    """Table.__str__ URL-encodes parts; the link must not encode twice, and
+    set iteration must not leak nondeterministic ordering into the URL."""
+    sm = SupersetSecurityManager.__new__(SupersetSecurityManager)
+    with (
+        patch(
+            f"{MANAGER}.get_conf",
+            return_value={
+                "PERMISSION_INSTRUCTIONS_LINK": (
+                    "https://acme.example.com/req?tables={table_names}"
+                )
+            },
+        ),
+        patch(f"{MANAGER}.g") as g_mock,
+    ):
+        g_mock.user.is_anonymous = False
+        g_mock.user.username = "alice"
+        out = sm.get_table_access_link({Table("my table", "public")})
+    # single-encoded space (%20), not double-encoded (%2520)
+    assert out == "https://acme.example.com/req?tables=public.my%20table"


### PR DESCRIPTION
### SUMMARY

Makes the "you don't have access to this data" experience actionable for viewers, in two coordinated pieces:

**Backend — templated `PERMISSION_INSTRUCTIONS_LINK`.** The config option (previously a static URL) may template `{datasource_id}`, `{datasource_name}`, `{table_names}`, and `{username}`, all URL-encoded, so the "Request access" link can deep-link into an organization's access-request tool with the denied resource pre-filled (e.g. a ServiceNow/Jira form or an internal portal). Rendering happens in a single helper (`_render_permission_instructions_link`) used by both the datasource- and table-level denial paths. Fully backwards compatible: a plain URL without placeholders renders unchanged, an empty value keeps the current behavior, and unknown placeholders are left intact rather than raising.

**Frontend — `DatasourceSecurityAccessErrorMessage`.** A new error component registered for `DATASOURCE_SECURITY_ACCESS_ERROR` and `TABLE_SECURITY_ACCESS_ERROR` replaces the raw technical error for viewers: a plain-language title, the dataset/table names, the chart owners to contact (already available via `useChartOwnerNames`), and a prominent "Request access" link from the templated URL. The technical detail (issue code, raw message) stays available in a collapsible section. When no link is configured, the component degrades to the owner-contact guidance.

The rationale: a Gamma/viewer hitting a permission wall today gets issue-code jargon and no path forward. Pointing them at the right form with the right context pre-filled turns a dead end into a self-service flow, without changing any authorization behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

The change was verified live end-to-end (viewer hitting a restricted chart sees the new message with a working deep-link). Screenshots to follow in a comment.

### TESTING INSTRUCTIONS

```bash
# Backend (templating, URL-encoding, empty/plain/anonymous cases)
pytest tests/unit_tests/security/test_permission_instructions_link.py

# Frontend (title, owner contact, request link, admin fallback, table case)
cd superset-frontend
npx jest src/components/ErrorMessage/DatasourceSecurityAccessErrorMessage.test.tsx
```

Manual: set in `superset_config.py`:

```python
PERMISSION_INSTRUCTIONS_LINK = (
    "https://access.example.com/request?resource={datasource_name}&user={username}"
)
```

Then, as a user without access to a dataset, open a chart built on it — the error panel shows the friendly message with a "Request access" link carrying the encoded dataset name and username.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z1fQxTadTEvpCJLx9WnB8
