### PR TITLE
fix(a11y): add aria-label to notification method remove button

### DIFF
--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -465,12 +465,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               loading={methodOptionsLoading}
             />
             {index !== 0 && !!onRemove ? (
-              // eslint-disable-next-line jsx-a11y/control-has-associated-label
               <span
                 role="button"
                 tabIndex={0}
                 className="delete-button"
                 onClick={() => onRemove(index)}
+                aria-label={t('Remove notification method')}
               >
                 <Icons.DeleteOutlined iconSize="l" />
               </span>


### PR DESCRIPTION
## Summary
- `NotificationMethod.tsx`'s per-method "remove" control (`<span role="button" tabIndex={0}>` wrapping a `DeleteOutlined` icon, shown when more than one notification method is configured on an Alert/Report) had no accessible name — screen reader users tabbing to it heard nothing identifying the control's purpose. The `jsx-a11y/control-has-associated-label` lint rule was being suppressed via an `eslint-disable` comment rather than fixed.
- Adds `aria-label={t('Remove notification method')}`, matching the existing `'Remove X'` naming convention used elsewhere in the codebase (e.g. `TableCatalog.tsx`'s `'Remove sheet'`, `FilterTitleContainer.tsx`'s `'Remove filter'`), and removes the now-unneeded eslint-disable comment.
- WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A.
- Behavior is unchanged — purely an accessibility-name addition, no visual or functional change.

## Test plan
- [ ] In the Alert/Report modal, add a second notification method (so the remove control renders)
- [ ] Tab to the remove ("X") control next to the second method
- [ ] Verify a screen reader (VoiceOver/NVDA) announces "Remove notification method, button" instead of no name
- [ ] Confirm clicking still removes the row as before