### PR TITLE
fix(swagger): resolve OpenAPI spec URL when using APPLICATION_ROOT

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -55,6 +55,23 @@ def create_app(
 ) -> Flask:
     app = SupersetApp(__name__)
 
+    # Localized compatibility patch for SwaggerView.show() to respect APPLICATION_ROOT.
+    # This workaround can be removed once the upstream Flask-AppBuilder package resolves
+    # the issue by using url_for() natively.
+    from flask import current_app, url_for
+    from flask_appbuilder.api.manager import SwaggerView
+
+    def patched_show(self: SwaggerView, version: str) -> Response:
+        openapi_uri = url_for("OpenApi.get", version=version)
+        return self.render_template(
+            current_app.config.get(
+                "FAB_API_SWAGGER_TEMPLATE", "appbuilder/swagger/swagger.html"
+            ),
+            openapi_uri=openapi_uri,
+        )
+
+    SwaggerView.show = patched_show
+
     try:
         # Allow user to override our config completely
         config_module = superset_config_module or os.environ.get(

--- a/tests/unit_tests/test_swagger_prefix.py
+++ b/tests/unit_tests/test_swagger_prefix.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask import current_app
+from flask_appbuilder.api.manager import SwaggerView
+
+
+def test_swagger_template_without_prefix(app_context: None) -> None:
+    view = SwaggerView()
+    original_app_root = current_app.config.get("APPLICATION_ROOT")
+    try:
+        current_app.config["APPLICATION_ROOT"] = "/"
+        with current_app.test_request_context("/swagger/v1"):
+            response = view.show("v1")
+            html = (
+                response
+                if isinstance(response, str)
+                else response.get_data(as_text=True)
+            )
+            assert 'url: "/api/v1/_openapi"' in html
+    finally:
+        current_app.config["APPLICATION_ROOT"] = original_app_root
+
+
+def test_swagger_template_with_prefix_script_name(app_context: None) -> None:
+    view = SwaggerView()
+    original_app_root = current_app.config.get("APPLICATION_ROOT")
+    try:
+        current_app.config["APPLICATION_ROOT"] = "/prefix"
+        with current_app.test_request_context(
+            "/swagger/v1",
+            environ_overrides={"SCRIPT_NAME": "/prefix"},
+        ):
+            response = view.show("v1")
+            html = (
+                response
+                if isinstance(response, str)
+                else response.get_data(as_text=True)
+            )
+            assert 'url: "/prefix/api/v1/_openapi"' in html
+    finally:
+        current_app.config["APPLICATION_ROOT"] = original_app_root
+
+
+def test_swagger_template_with_prefix_fallback(app_context: None) -> None:
+    view = SwaggerView()
+    original_app_root = current_app.config.get("APPLICATION_ROOT")
+    try:
+        current_app.config["APPLICATION_ROOT"] = "/prefix"
+        with current_app.test_request_context("/swagger/v1"):
+            response = view.show("v1")
+            html = (
+                response
+                if isinstance(response, str)
+                else response.get_data(as_text=True)
+            )
+            assert 'url: "/prefix/api/v1/_openapi"' in html
+    finally:
+        current_app.config["APPLICATION_ROOT"] = original_app_root


### PR DESCRIPTION
### SUMMARY

This PR addresses issue #33304, where the Swagger UI may fail to load the OpenAPI specification when Apache Superset is deployed under a custom application root (`SUPERSET_APP_ROOT` / `APPLICATION_ROOT`).

Under certain deployment configurations, the generated OpenAPI specification URL does not include the configured application prefix. As a result, the browser requests the OpenAPI specification from an incorrect path (for example, `/api/v1/_openapi` instead of `/prefix/api/v1/_openapi`), causing a `404 Not Found` response and preventing the Swagger UI from rendering correctly.

This change introduces a server-side adjustment in `superset/app.py` that ensures the correct OpenAPI URL is provided to the Swagger template when `APPLICATION_ROOT` is configured. The implementation avoids client-side URL manipulation and keeps the template unchanged.

Additionally, this PR includes regression tests covering the different deployment scenarios to ensure the correct OpenAPI URL is rendered.

---

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

- Swagger UI is accessed at:
  ```
  /prefix/swagger/v1
  ```
- Browser requests:
  ```
  /api/v1/_openapi
  ```
- Result:
  - HTTP 404 Not Found
  - Swagger UI fails to load the API specification.

#### After

- Swagger UI is accessed at:
  ```
  /prefix/swagger/v1
  ```
- Browser requests:
  ```
  /prefix/api/v1/_openapi
  ```
- Result:
  - HTTP 200 OK
  - Swagger UI successfully loads the OpenAPI specification.

---

### TESTING INSTRUCTIONS

#### Environment

```bash
export SUPERSET_APP_ROOT=/prefix
export SUPERSET_ENABLE_SWAGGER_UI=true
```

#### Initialize Superset

```bash
superset db upgrade
superset init
```

#### Start the server

```bash
flask run -p 8088
```

#### Manual Verification

1. Open:

   ```
   http://localhost:8088/prefix/swagger/v1
   ```

2. Open the browser Developer Tools → Network tab.

3. Verify that the OpenAPI specification is requested from:

   ```
   /prefix/api/v1/_openapi
   ```

4. Confirm that the request returns **HTTP 200** and the Swagger UI renders successfully.

#### Regression Tests

Run:

```bash
pytest tests/unit_tests/test_swagger_prefix.py -v
```

The regression tests verify:

- Default deployment (no application prefix)
- Deployment using `SCRIPT_NAME`
- Deployment using `APPLICATION_ROOT`

---