### PR TITLE
fix(mcp): user/role tools demanded a permission FAB never registers

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -106,6 +106,10 @@ class MCPNoAuthSourceError(ValueError):
 # scope. When introducing a new method permission, add it here.
 _METHOD_TO_REQUIRED_SCOPE = {
     "read": "superset:read",
+    # "get" is the read-class permission FAB registers on its security API
+    # views (User/Role) — those views have no can_read, so tools targeting
+    # them declare method_permission_name="get".
+    "get": "superset:read",
     "write": "superset:write",
     "delete": "superset:write",
     # SQL execution (execute_sql, get_chart_sql) runs arbitrary queries and is

--- a/superset/mcp_service/role/tool/get_role_info.py
+++ b/superset/mcp_service/role/tool/get_role_info.py
@@ -37,6 +37,10 @@ logger = logging.getLogger(__name__)
 @tool(
     tags=["discovery"],
     class_permission_name="Role",
+    # FAB's security API views register can_get/can_info/... — never
+    # can_read — so the default "read" method permission can never be
+    # granted on User/Role, not even to Admin.
+    method_permission_name="get",
     annotations=ToolAnnotations(
         title="Get role info",
         readOnlyHint=True,

--- a/superset/mcp_service/role/tool/list_roles.py
+++ b/superset/mcp_service/role/tool/list_roles.py
@@ -45,6 +45,10 @@ _DEFAULT_LIST_ROLES_REQUEST = ListRolesRequest()
 @tool(
     tags=["core"],
     class_permission_name="Role",
+    # FAB's security API views register can_get/can_info/... — never
+    # can_read — so the default "read" method permission can never be
+    # granted on User/Role, not even to Admin.
+    method_permission_name="get",
     annotations=ToolAnnotations(
         title="List roles",
         readOnlyHint=True,

--- a/superset/mcp_service/user/tool/get_user_info.py
+++ b/superset/mcp_service/user/tool/get_user_info.py
@@ -38,6 +38,10 @@ logger = logging.getLogger(__name__)
 @tool(
     tags=["discovery"],
     class_permission_name="User",
+    # FAB's security API views register can_get/can_info/... — never
+    # can_read — so the default "read" method permission can never be
+    # granted on User/Role, not even to Admin.
+    method_permission_name="get",
     annotations=ToolAnnotations(
         title="Get user info",
         readOnlyHint=True,

--- a/superset/mcp_service/user/tool/list_users.py
+++ b/superset/mcp_service/user/tool/list_users.py
@@ -46,6 +46,10 @@ _DEFAULT_LIST_USERS_REQUEST = ListUsersRequest()
 @tool(
     tags=["core"],
     class_permission_name="User",
+    # FAB's security API views register can_get/can_info/... — never
+    # can_read — so the default "read" method permission can never be
+    # granted on User/Role, not even to Admin.
+    method_permission_name="get",
     annotations=ToolAnnotations(
         title="List users",
         readOnlyHint=True,

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -478,3 +478,69 @@ def test_scope_execute_sql_query_requires_write_scope(app_context) -> None:
             assert check_tool_permission(func) is False
         with _patch_token_scopes(["superset:write"]):
             assert check_tool_permission(func) is True
+
+
+# ---------------------------------------------------------------------------
+# User/Role tools must request a permission FAB actually registers.
+#
+# FAB's security API views (UserApi, RoleApi) register only
+# can_get/can_info/can_post/can_put/can_delete — never can_read. Superset's
+# own ModelRestApi subclasses remap methods onto read/write, which is why
+# "can_read on Chart" exists while "can_read on User" cannot. A tool that
+# demands can_read on User/Role is therefore dead for every principal,
+# including Admin (fails closed).
+# ---------------------------------------------------------------------------
+
+# The full set of permissions FAB registers on its security API views.
+_FAB_SECURITY_VIEW_PERMISSIONS = {
+    "can_get",
+    "can_info",
+    "can_post",
+    "can_put",
+    "can_delete",
+}
+
+
+def _fab_security_view_can_access(permission_str: str, view_name: str) -> bool:
+    """Simulate can_access for a user holding every permission FAB actually
+    registers on the User/Role security views (i.e. a stock Admin)."""
+    return permission_str in _FAB_SECURITY_VIEW_PERMISSIONS
+
+
+@pytest.mark.parametrize(
+    "module_path,func_name",
+    [
+        ("superset.mcp_service.user.tool.list_users", "list_users"),
+        ("superset.mcp_service.user.tool.get_user_info", "get_user_info"),
+        ("superset.mcp_service.role.tool.list_roles", "list_roles"),
+        ("superset.mcp_service.role.tool.get_role_info", "get_role_info"),
+    ],
+)
+def test_user_role_tools_usable_by_stock_admin(
+    app_context, module_path: str, func_name: str
+) -> None:
+    """A stock Admin (holding exactly the FAB-registered permissions on the
+    User/Role views) must be able to use the user/role tools."""
+    import importlib
+
+    func = getattr(importlib.import_module(module_path), func_name)
+    g.user = MagicMock(username="admin")
+
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(side_effect=_fab_security_view_can_access)
+    with patch("superset.mcp_service.auth.security_manager", mock_sm):
+        assert check_tool_permission(func) is True, (
+            f"{func_name} requests can_"
+            f"{getattr(func, METHOD_PERMISSION_ATTR, 'read')} on "
+            f"{getattr(func, CLASS_PERMISSION_ATTR, None)}, which FAB never "
+            "registers on its security views — the tool is dead even for Admin"
+        )
+
+
+def test_get_method_permission_is_scope_mapped(app_context) -> None:
+    """The 'get' method permission must be in _METHOD_TO_REQUIRED_SCOPE:
+    unmapped method permissions are denied for scoped tokens (fail closed),
+    which would leave the user/role tools dead for scoped-JWT deployments."""
+    from superset.mcp_service.auth import _METHOD_TO_REQUIRED_SCOPE
+
+    assert _METHOD_TO_REQUIRED_SCOPE.get("get") == "superset:read"


### PR DESCRIPTION
### SUMMARY

Fixes a bug that makes four shipped MCP tools — `list_users`, `get_user_info`, `list_roles`, `get_role_info` — unusable for **every** principal, including Admin, on a stock instance.

**Root cause.** The tools declare `class_permission_name="User"/"Role"` and rely on the `@tool` decorator's default method permission, `read`, so `check_tool_permission` demands `can_read on User` / `can_read on Role`. But those permission-view pairs can never exist: FAB's security API views (`UserApi`, `RoleApi`) register only `can_get / can_info / can_post / can_put / can_delete`. Superset's own `ModelRestApi` subclasses remap their methods onto `read`/`write` — which is why `can_read on Chart` exists — but the FAB security views get no such remapping. Since Admin only holds permissions that are *registered*, even Admin is denied (probe evidence from a stock instance: `"Permission denied: can_read on Role for user admin"`; the metadata DB holds 14 Admin grants on those views, none of them `can_read`).

The failure is closed (deny), so this is not a security issue — just four dead tools.

**Fix.**
- Declare `method_permission_name="get"` on the four tools, matching the permission FAB actually registers for their views (`can_get` covers both the list and single-item GET endpoints).
- Add `"get": "superset:read"` to `_METHOD_TO_REQUIRED_SCOPE` in `superset/mcp_service/auth.py` — that map fails closed for unmapped method permissions (by design), so without this entry scoped-JWT deployments would still see the tools denied. Its own doc comment mandates the addition: "When introducing a new method permission, add it here."

`find_users` was also suspected but is **not** affected — it declares no `class_permission_name`, so it takes the documented allow-by-default path.

Found via an automated REST↔MCP capability probe run against master `1c3b070d34`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (MCP service; no UI changes)

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/test_auth_rbac.py
```

New regression tests: a simulated stock Admin holding exactly the FAB-registered permission set (`can_get/can_info/can_post/can_put/can_delete`) must pass `check_tool_permission` for each of the four tools (fails before this change with `can_read`), plus an assertion that the `get` method permission is scope-mapped.

Manual: on any instance with `MCP_RBAC_ENABLED = True` (the default), call `list_users` as Admin — before this change it returns "Permission denied: can_read on User"; after, it succeeds.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z1fQxTadTEvpCJLx9WnB8
