### PR TITLE
fix(explore): resolve adhoc Custom SQL dimension in Bubble chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -23,6 +23,7 @@ import {
   CategoricalColorNamespace,
   getNumberFormatter,
   AxisType,
+  getColumnLabel,
   getMetricLabel,
   NumberFormatter,
   tooltipHtml,
@@ -140,13 +141,17 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
   const xAxisLabel: string = getMetricLabel(x);
   const yAxisLabel: string = getMetricLabel(y);
   const sizeLabel: string = getMetricLabel(size);
+  const entityLabel: string = getColumnLabel(entity);
+  const seriesLabel: string | undefined = bubbleSeries
+    ? getColumnLabel(bubbleSeries)
+    : undefined;
 
   const refs: Refs = {};
 
   data.forEach(datum => {
-    const dataName = bubbleSeries ? datum[bubbleSeries] : datum[entity];
+    const dataName = seriesLabel ? datum[seriesLabel] : datum[entityLabel];
     const name = dataName ? String(dataName) : NULL_STRING;
-    const bubbleSeriesValue = bubbleSeries ? datum[bubbleSeries] : null;
+    const bubbleSeriesValue = seriesLabel ? datum[seriesLabel] : null;
 
     series.push({
       name,
@@ -155,7 +160,7 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
           datum[xAxisLabel],
           datum[yAxisLabel],
           datum[sizeLabel],
-          datum[entity],
+          datum[entityLabel],
           bubbleSeriesValue as any,
         ],
       ],

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/transformProps.test.ts
@@ -153,6 +153,78 @@ describe('Bubble transformProps', () => {
   });
 });
 
+describe('adhoc Custom SQL dimension', () => {
+  const adhocColumn = {
+    expressionType: 'SQL',
+    sqlExpression: 'EXTRACT(YEAR FROM ds)',
+    label: 'year',
+  };
+  const adhocQueriesData = [
+    {
+      data: [
+        {
+          year: 1992,
+          customer_name: 'AV Stores, Co.',
+          count: 10,
+          'SUM(price_each)': 20,
+          'SUM(sales)': 30,
+        },
+        {
+          year: 1993,
+          customer_name: 'Alpha Cognac',
+          count: 40,
+          'SUM(price_each)': 50,
+          'SUM(sales)': 60,
+        },
+      ],
+    },
+  ];
+
+  test('resolves the entity label so an adhoc dimension is not rendered as NULL', () => {
+    const formData: SqlaFormData = { ...defaultFormData, entity: adhocColumn };
+    const chartProps = new ChartProps({
+      ...chartConfig,
+      queriesData: adhocQueriesData,
+      formData,
+    });
+    const result = transformProps(chartProps as EchartsBubbleChartProps);
+
+    expect((result.echartOptions.legend as any).data).toEqual(['1992', '1993']);
+    expect(result.echartOptions.series).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: '1992',
+          data: [[10, 20, 30, 1992, null]],
+        }),
+      ]),
+    );
+  });
+
+  test('resolves the series label so an adhoc bubble series is not rendered as NULL', () => {
+    const formData: SqlaFormData = {
+      ...defaultFormData,
+      entity: 'customer_name',
+      series: adhocColumn,
+    };
+    const chartProps = new ChartProps({
+      ...chartConfig,
+      queriesData: adhocQueriesData,
+      formData,
+    });
+    const result = transformProps(chartProps as EchartsBubbleChartProps);
+
+    expect((result.echartOptions.legend as any).data).toEqual(['1992', '1993']);
+    expect(result.echartOptions.series).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: '1992',
+          data: [[10, 20, 30, 'AV Stores, Co.', 1992]],
+        }),
+      ]),
+    );
+  });
+});
+
 describe('Bubble formatTooltip', () => {
   const dollerFormatter = getNumberFormatter('$,.2f');
   const percentFormatter = getNumberFormatter(',.1%');


### PR DESCRIPTION
### SUMMARY

A Bubble chart shows `<NULL>` in the legend when the dimension or bubble series is a Custom SQL column instead of a physical column. Every row collapses into a single `<NULL>` series.

The transform indexed each data row with the raw form-data value for `entity` and `series`. For a physical column that value is the column name string, so the lookup works. For an adhoc (Custom SQL) column it is an object, so the key becomes `"[object Object]"`, never matches a returned column, and falls back to `<NULL>`. The x/y/size metrics already avoid this by resolving through `getMetricLabel`; the dimension columns were never resolved.

The fix resolves `entity` and `series` through `getColumnLabel` before indexing the row, the same way Pie and other charts do it. Physical and dataset-calculated columns keep working unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** — the legend collapses to a single `<NULL>` and every row merges into one series.

![before](https://files.catbox.moe/grb49x.png)

**After** — each Custom SQL year renders as its own series in the legend.

![after](https://files.catbox.moe/oml3ov.png)

### TESTING INSTRUCTIONS

1. Create a Bubble chart on a dataset with a date column (for example `birth_names`).
2. Set the dimension (Entity) to a Custom SQL column such as `EXTRACT(YEAR FROM ds)`.
3. Add metrics for the X axis, Y axis, and bubble size, then run the chart.
4. Before this change the legend shows a single `<NULL>`. After, it shows the actual values (the years).

Unit tests in `Bubble/transformProps.test.ts` cover an adhoc entity and an adhoc series.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API