### PR TITLE
fix(frontend): jest testRegex matches Windows path separators

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -19,8 +19,10 @@
 // timezone for unit tests
 process.env.TZ = 'America/New_York';
 module.exports = {
+  // [/\\] matches both path separators so the suite also collects on
+  // native Windows, where jest hands the regex backslash-separated paths.
   testRegex:
-    '\\/superset-frontend\\/(spec|src|plugins|packages|tools)\\/.*(_spec|\\.test)\\.[jt]sx?$',
+    '[/\\\\]superset-frontend[/\\\\](spec|src|plugins|packages|tools)[/\\\\].*(_spec|\\.test)\\.[jt]sx?$',
   moduleNameMapper: {
     '\\.(css|less|geojson)$': '<rootDir>/spec/__mocks__/mockExportObject.js',
     '\\.(gif|ttf|eot|png|jpg)$': '<rootDir>/spec/__mocks__/mockExportString.js',


### PR DESCRIPTION
### SUMMARY

On native Windows, the frontend test suite silently collects zero tests:

```
> npx jest src/utils/findPermission.test.ts
No tests found, exiting with code 1
  3770 files checked.
  testRegex: ... - 0 matches
```

The `testRegex` in `superset-frontend/jest.config.js` only recognises forward slashes (`\/superset-frontend\/...`), but on Windows jest matches the pattern against backslash-separated absolute paths, so no file can ever match. Every Windows contributor either believes there are no tests or works around it with a CLI `--testRegex` override.

The fix replaces each literal separator with the two-character class `[/\]`, which matches either separator. On POSIX the regex accepts exactly the same set of paths as before (the class still matches `/`, anchors and the rest of the pattern are untouched), so CI behavior is unchanged.

Verified on Windows 11: test collection goes from 0 of 3770 files to 1118 test files with the default config, and suites execute (`npx jest findPermission`: 3 passed).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (build tooling).

### TESTING INSTRUCTIONS

On any OS: `npx jest --listTests` from `superset-frontend/` should list the suite (1118 files currently). On Linux/macOS the list is identical before and after this change; on Windows it was previously empty.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
