### PR TITLE
fix(chart-data): return 403 for SupersetSecurityException in chart data API

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -219,6 +219,8 @@ class ChartDataRestApi(ChartRestApi):
             command.validate()
         except DatasourceNotFound:
             return self.response_404()
+        except SupersetSecurityException:
+            return self.response_403()
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:
@@ -319,6 +321,8 @@ class ChartDataRestApi(ChartRestApi):
             command.validate()
         except DatasourceNotFound:
             return self.response_404()
+        except SupersetSecurityException:
+            return self.response_403()
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:
@@ -405,6 +409,8 @@ class ChartDataRestApi(ChartRestApi):
             command.validate()
         except ChartDataCacheLoadError:
             return self.response_404()
+        except SupersetSecurityException:
+            return self.response_403()
         except ValidationError as error:
             return self.response_400(
                 message=_("Request is incorrect: %(error)s", error=error.messages)

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -302,6 +302,8 @@ class ChartDataRestApi(ChartRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             500:
               $ref: '#/components/responses/500'
         """
@@ -392,6 +394,8 @@ class ChartDataRestApi(ChartRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
             422:


### PR DESCRIPTION
### SUMMARY

This change ensures that chart data API endpoints consistently return **HTTP 403 Forbidden** when a `SupersetSecurityException` is raised during request validation.

Previously, these exceptions were not explicitly handled, allowing them to propagate as an internal server error (HTTP 500). This resulted in callers, including the Alerts & Reports CSV generation flow, receiving an unexpected 500 response instead of the appropriate authorization error.

This patch adds explicit handling for `SupersetSecurityException` in the affected chart data API endpoints by returning `response_403()`, aligning their behavior with other protected Superset endpoints.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.

### TESTING INSTRUCTIONS

1. Trigger a chart data request that raises a `SupersetSecurityException`.
2. Verify the API returns **HTTP 403 Forbidden** instead of **HTTP 500 Internal Server Error**.
3. Verify authorized requests continue to return chart data successfully.
4. Verify existing chart data endpoints continue to behave as expected.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #41862
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API