### PR TITLE
chore(frontend): remove orphaned eslint-plugin-cypress devDependency

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -231,7 +231,6 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^4.4.5",
-        "eslint-plugin-cypress": "^6.4.2",
         "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
         "eslint-plugin-icons": "file:eslint-rules/eslint-plugin-icons",
         "eslint-plugin-import": "^2.32.0",
@@ -18967,25 +18966,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-cypress": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-6.4.2.tgz",
-      "integrity": "sha512-OIGJP5y6/cyMxBtMASP/iBM7Pv4ZHccE9uI8MhtAZDrdNDYDwHgKa/3Khrr+FGRr9hSIfNYstGRhSmbcLURWYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globals": "^17.7.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": ">=8",
-        "eslint": ">=9"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/parser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-i18n-strings": {
       "resolved": "eslint-rules/eslint-plugin-i18n-strings",
       "link": true
@@ -21717,19 +21697,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -314,7 +314,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^4.4.5",
-    "eslint-plugin-cypress": "^6.4.2",
     "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
     "eslint-plugin-icons": "file:eslint-rules/eslint-plugin-icons",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
### SUMMARY

`eslint-plugin-cypress` in `superset-frontend/package.json` is dead weight — no active linter loads it:

- The frontend lints with **oxlint** (`npm run lint` → `npx oxlint --config oxlint.json`), which doesn't use ESLint plugins at all.
- Both `oxlint.json` and the flat `eslint.config.minimal.js` explicitly **ignore `cypress-base/**`** — the only directory the plugin would ever apply to.
- The one place that actually references `plugin:cypress/recommended` (`cypress-base/.eslintrc`) resolves against **cypress-base's own** `eslint-plugin-cypress@^3.5.0`, a separate declaration this PR doesn't touch. (`cypress-base` is a standalone project — not in the parent's workspaces and absent from the parent lockfile.)

The dependency has been unused since the ESLint→oxlint migration; it traces back to SIP-32 (#9098) in 2020. This removes it and the transitive `globals@17.7.0` it pulled in (nothing else imports `globals` directly).

This also makes the recently-merged #41849 (bumping this same dep 3.6.0 → 6.4.2) moot — the version no longer matters because the package is gone.

### TESTING INSTRUCTIONS

- `npm run lint` (oxlint) is unaffected — it never referenced this plugin.
- `npm ci` resolves cleanly; the diff is a pure removal of the plugin + its transitive `globals` (no other tree changes).
- Cypress e2e linting/behavior is unchanged (cypress-base keeps its own copy).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

Removes an unused build-time devDependency only; no runtime or user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)