### PR TITLE
fix(clickhouse): use equality for boolean filters instead of IS

### DIFF
--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -56,6 +56,9 @@ class ClickHouseBaseEngineSpec(BaseEngineSpec):
     time_groupby_inline = True
     supports_multivalues_insert = True
 
+    # ClickHouse doesn't support IS true/false syntax, use = true/false instead
+    use_equality_for_boolean_filters = True
+
     # ClickHouse enforces max_rows_to_read against a pre-execution estimate
     # that ignores LIMIT, so bounded sampling queries on large tables are
     # rejected with TOO_MANY_ROWS before reading begins. Break mode keeps the

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -594,6 +594,20 @@ def test_handle_boolean_filter() -> None:
         == "test_col = false"
     )
 
+    # Regression: the original bug also affects computed boolean columns like
+    # `(is_cancelled = 1)`. Verify the equality operator also compiles
+    # correctly when the "column" is a computed expression.
+    from sqlalchemy import literal_column
+
+    computed_col = literal_column("(is_cancelled = 1)")
+    result_computed = ClickHouseBaseEngineSpec.handle_boolean_filter(
+        computed_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_computed.compile(compile_kwargs={"literal_binds": True}))
+        == "(is_cancelled = 1) = true"
+    )
+
 
 def test_use_equality_for_boolean_filters_property() -> None:
     """

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -562,3 +562,43 @@ def test_run_with_sampling_read_limit_retry_honors_opt_out() -> None:
     with pytest.raises(Exception, match="TOO_MANY_ROWS"):
         database.run_with_sampling_read_limit_retry("SELECT 1", run)
     assert executed == ["SELECT 1"]
+
+
+def test_handle_boolean_filter() -> None:
+    """
+    Test that ClickHouse uses equality operators for boolean filters instead of IS.
+
+    ClickHouse rejects the ``column IS true/false`` form, so boolean filters must
+    render as ``column = true/false``.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.clickhouse import ClickHouseBaseEngineSpec
+    from superset.utils.core import FilterOperator
+
+    bool_col = Column("test_col", Boolean)
+
+    result_true = ClickHouseBaseEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_true.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = true"
+    )
+
+    result_false = ClickHouseBaseEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_FALSE, False
+    )
+    assert (
+        str(result_false.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = false"
+    )
+
+
+def test_use_equality_for_boolean_filters_property() -> None:
+    """
+    Test that ClickHouse has the use_equality_for_boolean_filters property set.
+    """
+    from superset.db_engine_specs.clickhouse import ClickHouseBaseEngineSpec
+
+    assert ClickHouseBaseEngineSpec.use_equality_for_boolean_filters is True


### PR DESCRIPTION
### SUMMARY

ClickHouse rejects the `column IS true/false` syntax that Superset generates for boolean filters, producing queries like `WHERE is_cancelled IS false` that fail to execute against ClickHouse.

This reuses the engine-spec toggle introduced for Snowflake in #34199 (also used by Athena and Presto): setting `use_equality_for_boolean_filters = True` on `ClickHouseBaseEngineSpec` makes boolean filters render as `= true`/`= false` instead of `IS true`/`IS false`.

The Snowflake half of #33235 was fixed by #34199; this PR covers the remaining ClickHouse case reported on the same issue.

### BEFORE/AFTER

Before (invalid on ClickHouse):
```sql
SELECT * FROM table WHERE is_cancelled IS false
```

After:
```sql
SELECT * FROM table WHERE is_cancelled = false
```

Other engines continue to use `IS true/false` as before.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/db_engine_specs/test_clickhouse.py -k boolean`
- Added `test_handle_boolean_filter` and `test_use_equality_for_boolean_filters_property` mirroring the existing Snowflake tests, asserting the generated predicate is `test_col = true` / `test_col = false`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Fixes #33235
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)