### PR TITLE
fix(db_engine_specs): map var_string to STRING for MySQL/StarRocks

### DIFF
--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -238,6 +238,11 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
             LONGTEXT(),
             GenericDataType.STRING,
         ),
+        (
+            re.compile(r"^var_string", re.IGNORECASE),
+            types.VARCHAR(),
+            GenericDataType.STRING,
+        ),
     )
     column_type_mutators: dict[types.TypeEngine, Callable[[Any], Any]] = {
         DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val

--- a/superset/db_engine_specs/starrocks.py
+++ b/superset/db_engine_specs/starrocks.py
@@ -238,6 +238,11 @@ class StarRocksEngineSpec(MySQLEngineSpec):
         (re.compile(r"^array.*", re.IGNORECASE), ARRAY(), GenericDataType.STRING),
         (re.compile(r"^map.*", re.IGNORECASE), MAP(), GenericDataType.STRING),
         (re.compile(r"^struct.*", re.IGNORECASE), STRUCT(), GenericDataType.STRING),
+        (
+            re.compile(r"^var_string", re.IGNORECASE),
+            types.VARCHAR(),
+            GenericDataType.STRING,
+        ),
     )
 
     custom_errors: dict[Pattern[str], tuple[str, SupersetErrorType, dict[str, Any]]] = {

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -65,6 +65,7 @@ from tests.unit_tests.fixtures.common import dttm  # noqa: F401
         ("TINYTEXT", TINYTEXT, None, GenericDataType.STRING, False),
         ("MEDIUMTEXT", MEDIUMTEXT, None, GenericDataType.STRING, False),
         ("LONGTEXT", LONGTEXT, None, GenericDataType.STRING, False),
+        ("var_string", types.VARCHAR, None, GenericDataType.STRING, False),
         # Temporal
         ("DATE", types.Date, None, GenericDataType.TEMPORAL, True),
         ("DATETIME", types.DateTime, None, GenericDataType.TEMPORAL, True),

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -50,6 +50,7 @@ from tests.unit_tests.db_engine_specs.utils import assert_column_spec
         ("char(10)", types.CHAR, None, GenericDataType.STRING, False),
         ("varchar(65533)", types.VARCHAR, None, GenericDataType.STRING, False),
         ("binary", types.String, None, GenericDataType.STRING, False),
+        ("var_string", types.VARCHAR, None, GenericDataType.STRING, False),
         # Complex type
         ("array<varchar(65533)>", ARRAY, None, GenericDataType.STRING, False),
         ("map<string,int>", MAP, None, GenericDataType.STRING, False),


### PR DESCRIPTION
### SUMMARY

MySQL and StarRocks return `var_string` as the native type for varchar-backed columns (e.g. StarRocks `VARCHAR`). Neither engine spec's `column_type_mappings` matched `var_string` (the existing `^varchar` pattern doesn't match `var_string`), so such columns fell through unmatched and were not classified as `GenericDataType.STRING`.

Because several Explore controls gate on column type, this caused the "Force categorical" / y-axis sort control to be incorrectly hidden for these columns — the user had to cast the axis to a numeric type just to make the control appear, which doesn't make sense for a categorical axis.

This adds a `^var_string` regex mapping resolving to `GenericDataType.STRING` in both `mysql.py` and `starrocks.py` (StarRocks defines its own full override tuple). This matches the workaround confirmed by the issue reporter in the thread.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend type-classification change.

### TESTING INSTRUCTIONS

- Automated: `pytest tests/unit_tests/db_engine_specs/test_mysql.py::test_get_column_spec tests/unit_tests/db_engine_specs/test_starrocks.py::test_get_column_spec` — new parameterized cases assert `var_string` resolves to `GenericDataType.STRING`.
- Manual: On a MySQL/StarRocks dataset with a varchar-backed column, create a bar chart using that column as the categorical (x) axis and a numeric measure. The "Force categorical" / y-axis sort control should now be visible without casting the column.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30282
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API