### PR TITLE
fix(sqla): render Jinja templates in calculated columns used via orderby adhoc metrics

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3331,9 +3331,16 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     )
                 if utils.is_adhoc_metric(col):
                     # add adhoc sort by column to columns_by_name if not exists
+                    # Pass the template processor so a SIMPLE adhoc metric that
+                    # references a calculated column has that column's Jinja
+                    # expression rendered, matching SELECT/WHERE/GROUP BY. This
+                    # is a no-op for the SQL expression type, whose
+                    # `sqlExpression` was already rendered above; `processed`
+                    # only guards that branch.
                     col = self.adhoc_metric_to_sqla(
                         col,
                         columns_by_name,
+                        template_processor=template_processor,
                         processed=True,
                     )
                     # use the existing instance, if possible

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -202,6 +202,51 @@ class SupersetTestCases(SupersetTestCase):
             in sql
         )
 
+    @mock.patch("superset.models.core.Database.db_engine_spec", BaseEngineSpec)
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_jinja_calculated_column_in_order_by(self):
+        """
+        A calculated column referenced by a SIMPLE adhoc metric in `orderby`
+        should have its Jinja template rendered, the same way it is for
+        SELECT/WHERE/GROUP BY.
+        """
+        table = self.get_table(name="birth_names")
+        TableColumn(
+            column_name="gender_cc_jinja",
+            type="VARCHAR(255)",
+            table=table,
+            expression="""
+            case
+              when gender='boy' then {{ "'male'" }}
+              else {{ "'female'" }}
+            end
+            """,
+        )
+
+        table.database.sqlalchemy_uri = "sqlite://"
+        query_obj = {
+            "groupby": ["gender_cc_jinja"],
+            "is_timeseries": False,
+            "filter": [],
+            "orderby": [
+                [
+                    {
+                        "expressionType": "SIMPLE",
+                        "column": {"column_name": "gender_cc_jinja"},
+                        "aggregate": "MAX",
+                        "label": "max_gender_cc_jinja",
+                    },
+                    True,
+                ]
+            ],
+        }
+        sql = table.get_query_str(query_obj)
+        orderby_clause = sql.split("ORDER BY")[1]
+        assert "{%" not in orderby_clause
+        assert "{{" not in orderby_clause
+        assert "'male'" in orderby_clause
+        assert "'female'" in orderby_clause
+
 
 def test_time_grain_denylist():
     config = app.config.copy()

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import datetime
-from typing import cast
 from unittest import mock
 
 import pytest
@@ -226,12 +225,12 @@ class SupersetTestCases(SupersetTestCase):
         )
 
         table.database.sqlalchemy_uri = "sqlite://"
-        query_obj = {
+        query_obj: QueryObjectDict = {
             "groupby": ["gender_cc_jinja"],
             "is_timeseries": False,
             "filter": [],
             "orderby": [
-                [
+                (
                     {
                         "expressionType": "SIMPLE",
                         "column": {"column_name": "gender_cc_jinja"},
@@ -239,10 +238,10 @@ class SupersetTestCases(SupersetTestCase):
                         "label": "max_gender_cc_jinja",
                     },
                     True,
-                ]
+                )
             ],
         }
-        sql = table.get_query_str(cast(QueryObjectDict, query_obj))
+        sql = table.get_query_str(query_obj)
         orderby_clause = sql.split("ORDER BY")[1]
         assert "{%" not in orderby_clause
         assert "{{" not in orderby_clause

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import datetime
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -31,6 +32,7 @@ from superset.db_engine_specs.odps import OdpsBaseEngineSpec, OdpsEngineSpec
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql.parse import Table
+from superset.superset_typing import QueryObjectDict
 from superset.utils.database import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.test_app import app
@@ -204,7 +206,7 @@ class SupersetTestCases(SupersetTestCase):
 
     @mock.patch("superset.models.core.Database.db_engine_spec", BaseEngineSpec)
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_jinja_calculated_column_in_order_by(self):
+    def test_jinja_calculated_column_in_order_by(self) -> None:
         """
         A calculated column referenced by a SIMPLE adhoc metric in `orderby`
         should have its Jinja template rendered, the same way it is for
@@ -240,7 +242,7 @@ class SupersetTestCases(SupersetTestCase):
                 ]
             ],
         }
-        sql = table.get_query_str(query_obj)
+        sql = table.get_query_str(cast(QueryObjectDict, query_obj))
         orderby_clause = sql.split("ORDER BY")[1]
         assert "{%" not in orderby_clause
         assert "{{" not in orderby_clause


### PR DESCRIPTION
### SUMMARY
Calculated column expressions with Jinja templates render correctly in SELECT/WHERE/GROUP BY, but not when the calculated column is referenced by a SIMPLE adhoc metric (e.g. `MAX(calc_col)`) used in `ORDER BY`. `get_sqla_query` builds the `ORDER BY` expression via `adhoc_metric_to_sqla`, but that particular call site wasn't passed the `template_processor`, so the underlying `TableColumn`'s Jinja never got rendered and the raw `{% ... %}` / `{{ ... }}` leaked into the generated SQL.

This adds a failing-first integration test that pins the bug (a SIMPLE adhoc metric aggregating a Jinja-templated calculated column, used in `orderby`), then fixes it by threading `template_processor` through at that call site. This is a no-op for the SQL-expression adhoc metric type, since that branch's `sqlExpression` is already rendered earlier in `get_sqla_query`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (backend SQL generation change)

### TESTING INSTRUCTIONS
- `pytest tests/integration_tests/db_engine_specs/base_engine_spec_tests.py -k calculated_column_in_order_by`
- The new `test_jinja_calculated_column_in_order_by` test fails on `master` (raw `{{ ... }}` shows up in the rendered `ORDER BY` clause) and passes with this fix.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #29378
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes #29378