### PR TITLE
fix(presto): fix latest_sub_partition guard bypass + escape partition filter values

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -498,7 +498,10 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         if filters:
             l = []  # noqa: E741
             for field, value in filters.items():
-                l.append(f"{field} = '{value}'")
+                # Escape single quotes so a ``'`` in the caller-supplied value
+                # cannot break out of the SQL string literal. See #41869.
+                escaped_value = str(value).replace("'", "''")
+                l.append(f"{field} = '{escaped_value}'")
             where_clause = "WHERE " + " AND ".join(l)
 
         # Partition select syntax changed in v0.199, so check here.
@@ -671,9 +674,9 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
             )
 
         part_fields = indexes[0]["column_names"]
-        for k in kwargs.keys():  # pylint: disable=consider-iterating-dictionary
-            if k not in k in part_fields:  # pylint: disable=comparison-with-itself
-                msg = f"Field [{k}] is not part of the portioning key"
+        for k in kwargs:
+            if k not in part_fields:
+                msg = f"Field [{k}] is not part of the partitioning key"
                 raise SupersetTemplateException(msg)
         if len(kwargs.keys()) != len(part_fields) - 1:
             # pylint: disable=consider-using-f-string

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -500,7 +500,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
             for field, value in filters.items():
                 # Escape single quotes so a ``'`` in the caller-supplied value
                 # cannot break out of the SQL string literal. See #41869.
-                escaped_value = str(value).replace("'", "''")
+                escaped_value: str = str(value).replace("'", "''")
                 l.append(f"{field} = '{escaped_value}'")
             where_clause = "WHERE " + " AND ".join(l)
 
@@ -676,7 +676,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         part_fields = indexes[0]["column_names"]
         for k in kwargs:
             if k not in part_fields:
-                msg = f"Field [{k}] is not part of the partitioning key"
+                msg: str = f"Field [{k}] is not part of the partitioning key"
                 raise SupersetTemplateException(msg)
         if len(kwargs.keys()) != len(part_fields) - 1:
             # pylint: disable=consider-using-f-string

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -410,3 +410,70 @@ def test_extract_errors_maps_401_to_access_denied() -> None:
     result = PrestoEngineSpec.extract_errors(Exception(msg))
     assert len(result) == 1
     assert result[0].error_type == SupersetErrorType.CONNECTION_ACCESS_DENIED_ERROR
+
+
+def test_latest_sub_partition_rejects_unknown_field(
+    mocker: MockerFixture,
+) -> None:
+    """Regression test for #41869.
+
+    ``PrestoBaseEngineSpec.latest_sub_partition`` previously used a chained
+    comparison (``k not in k in part_fields``) that Python evaluates as
+    ``(k not in k) and (k in part_fields)``. Since ``k not in k`` is always
+    ``False`` for strings, the guard was unreachable and unknown kwarg names
+    were silently accepted, flowing into ``_partition_query`` and enabling
+    SQL injection via the ``latest_sub_partition`` Jinja macro. This test
+    locks in that unknown fields are now rejected before reaching the query
+    builder.
+    """
+    from superset.db_engine_specs.presto import PrestoBaseEngineSpec
+    from superset.exceptions import SupersetTemplateException
+
+    database = mocker.MagicMock()
+    database.get_indexes.return_value = [{"column_names": ["ds", "event_type"]}]
+    table = mocker.MagicMock()
+
+    with pytest.raises(SupersetTemplateException) as exc_info:
+        PrestoBaseEngineSpec.latest_sub_partition(
+            database,
+            table,
+            unknown_field="anything",
+        )
+
+    assert "unknown_field" in str(exc_info.value)
+    assert "not part of the partitioning key" in str(exc_info.value)
+
+
+def test_partition_query_escapes_single_quote_in_filter_value(
+    mocker: MockerFixture,
+) -> None:
+    """Regression test for #41869.
+
+    ``_partition_query`` previously interpolated filter values directly into
+    the SQL ``WHERE`` clause with an f-string, allowing SQL injection via any
+    caller that let user input reach ``filters``. Values must be escaped
+    (single-quote doubling per SQL standard) so a ``'`` in the value cannot
+    break out of the string literal.
+    """
+    from superset.db_engine_specs.presto import PrestoBaseEngineSpec
+
+    database = mocker.MagicMock()
+    database.get_extra.return_value = {}
+    table = Table("my_table", "my_schema")
+
+    injected = "2024-01-01' UNION SELECT secret FROM other_table--"
+    sql = PrestoBaseEngineSpec._partition_query(
+        table,
+        indexes=[{"column_names": ["ds", "event_type"]}],
+        database=database,
+        filters={"ds": injected},
+    )
+
+    # The single quote in the value must be doubled so the injection stays
+    # inside the SQL string literal — this is the whole payload wrapped in
+    # ONE literal, escape sequence and all.
+    assert "'2024-01-01'' UNION SELECT secret FROM other_table--'" in sql
+    # The pre-escape form (single quote closing the literal early followed
+    # by injected SQL) must NOT appear anywhere in the output — that would
+    # mean the payload broke out of the literal.
+    assert "'2024-01-01' UNION SELECT" not in sql

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -429,9 +429,9 @@ def test_latest_sub_partition_rejects_unknown_field(
     from superset.db_engine_specs.presto import PrestoBaseEngineSpec
     from superset.exceptions import SupersetTemplateException
 
-    database = mocker.MagicMock()
+    database: mock.MagicMock = mocker.MagicMock()
     database.get_indexes.return_value = [{"column_names": ["ds", "event_type"]}]
-    table = mocker.MagicMock()
+    table: mock.MagicMock = mocker.MagicMock()
 
     with pytest.raises(SupersetTemplateException) as exc_info:
         PrestoBaseEngineSpec.latest_sub_partition(
@@ -457,12 +457,12 @@ def test_partition_query_escapes_single_quote_in_filter_value(
     """
     from superset.db_engine_specs.presto import PrestoBaseEngineSpec
 
-    database = mocker.MagicMock()
+    database: mock.MagicMock = mocker.MagicMock()
     database.get_extra.return_value = {}
-    table = Table("my_table", "my_schema")
+    table: Table = Table("my_table", "my_schema")
 
-    injected = "2024-01-01' UNION SELECT secret FROM other_table--"
-    sql = PrestoBaseEngineSpec._partition_query(
+    injected: str = "2024-01-01' UNION SELECT secret FROM other_table--"
+    sql: str = PrestoBaseEngineSpec._partition_query(
         table,
         indexes=[{"column_names": ["ds", "event_type"]}],
         database=database,

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -432,7 +432,6 @@ def test_latest_sub_partition_rejects_unknown_field(
     database: mock.MagicMock = mocker.MagicMock()
     database.get_indexes.return_value = [{"column_names": ["ds", "event_type"]}]
     table: mock.MagicMock = mocker.MagicMock()
-
     with pytest.raises(SupersetTemplateException) as exc_info:
         PrestoBaseEngineSpec.latest_sub_partition(
             database,


### PR DESCRIPTION
### SUMMARY

Fixes #41869.

Two related bugs in `PrestoBaseEngineSpec` allowed authenticated SQL Lab users on Presto/Trino databases with template processing enabled to inject arbitrary SQL via the `{{ presto.latest_sub_partition(...) }}` Jinja macro:

1. **Broken kwarg guard** in `latest_sub_partition` (line 675) — the check `if k not in k in part_fields:` is a chained comparison that Python evaluates as `(k not in k) and (k in part_fields)`. Since `k not in k` is always `False` for any string, the guard was unreachable and any caller-supplied kwarg name flowed through. The `pylint: disable=comparison-with-itself` comment shows the linter had flagged this — the warning was suppressed rather than fixed.

2. **Raw f-string interpolation** in `_partition_query` (line 501) — filter values were interpolated into the WHERE clause without escaping, so a `'` in the value broke out of the SQL string literal and let injected SQL execute against the database connection's service account.

Both bugs are fixed and covered by regression tests. `TrinoEngineSpec` is also fixed because its `latest_sub_partition` delegates to `super().latest_sub_partition(...)` and it inherits `_partition_query` unchanged. `HiveEngineSpec` is unaffected — its `latest_sub_partition` is a no-op and its `_partition_query` does not interpolate filter values.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/db_engine_specs/test_presto.py -x
pytest tests/unit_tests/db_engine_specs/test_trino.py -x
```

Two new regression tests were added to `test_presto.py`:

- `test_latest_sub_partition_rejects_unknown_field` — asserts `SupersetTemplateException` is now raised when a kwarg name is not in the partitioning key. Would have failed against the broken chained-comparison guard.
- `test_partition_query_escapes_single_quote_in_filter_value` — asserts that a `'` in a filter value is doubled (`''`) so injected SQL stays inside the string literal.

Local verification: 44/44 `test_presto.py` tests pass, 96/96 `test_trino.py` tests pass.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #41869
- [x] Required feature flags: none
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Includes CLI or Node.js commands: no
- [x] Breaking change: no