### PR TITLE
fix(a11y): add aria-label to dependency-list remove icon

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
@@ -112,7 +112,11 @@ const Row = ({
         }
         value={value}
       />
-      <DeleteFilter iconSize="xl" onClick={() => onDelete(selection)} />
+      <DeleteFilter
+        iconSize="xl"
+        onClick={() => onDelete(selection)}
+        aria-label={t('Remove dependency')}
+      />
     </RowPanel>
   );
 };


### PR DESCRIPTION
## Summary
The per-row "remove dependency" icon in the native filter dependency list (`DependencyList.tsx`'s `Row` component) had an `onClick` handler but no accessible name. `BaseIcon`'s auto-generated fallback label ("delete") is generic and doesn't tell a screen reader user which item will be removed or from what list.

- **WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A**
- Adds `aria-label={t('Remove dependency')}` to the `DeleteFilter` icon in `superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx`
- Behavior is unchanged — purely additive `aria-label`, no visual or functional change
- Single call site of this icon in the file (confirmed via grep)

## Test plan
- [ ] Open a dashboard's native filter config modal, enable "Values are dependent on other filters" on a filter with 2+ dependency candidates
- [ ] Tab to the delete icon next to a dependency row with a screen reader running (VoiceOver/NVDA) and verify it announces "Remove dependency, button" instead of the generic "delete, button"
- [ ] Confirm clicking the icon still removes the row as before (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)