### PR TITLE
fix(explore): render DragOverlay so dragged metric/column is visible

### DIFF
--- a/superset-frontend/src/explore/components/ExploreContainer/ExploreDndContext.tsx
+++ b/superset-frontend/src/explore/components/ExploreContainer/ExploreDndContext.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react';
 import {
   DndContext,
+  DragOverlay,
   useSensor,
   useSensors,
   PointerSensor,
@@ -36,6 +37,18 @@ import {
   UniqueIdentifier,
 } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { css, styled } from '@apache-superset/core/theme';
+import {
+  ColumnOptionProps,
+  MetricOptionProps,
+} from '@superset-ui/chart-controls';
+import { Flex } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { DndItemType } from 'src/explore/components/DndItemType';
+import {
+  StyledColumnOption,
+  StyledMetricOption,
+} from 'src/explore/components/optionRenderers';
 import { DatasourcePanelDndItem } from '../DatasourcePanel/types';
 
 /**
@@ -50,6 +63,30 @@ export interface ActiveDragData {
   onMoveLabel?: (dragIndex: number, hoverIndex: number) => void;
   onDropLabel?: () => void;
 }
+
+/**
+ * Container for the <DragOverlay> preview. Mirrors DatasourceItemContainer
+ * (the lifted row from DatasourcePanelDragOption) so the item following the
+ * cursor reads as the raised source row. Fully opaque on purpose — the faded
+ * source row is what signals "in flight", not the overlay.
+ */
+const DragOverlayContainer = styled(Flex)`
+  ${({ theme }) => css`
+    width: 100%;
+    height: ${theme.sizeUnit * 6}px;
+    padding: 0 ${theme.sizeUnit}px;
+    color: ${theme.colorText};
+    background-color: ${theme.colorBgElevated};
+    border-radius: 4px;
+    box-shadow: 0 2px 8px ${theme.colorSplit};
+    cursor: grabbing;
+
+    > div {
+      min-width: 0;
+      margin-right: ${theme.sizeUnit * 2}px;
+    }
+  `}
+`;
 
 /**
  * Context to track if something is being dragged (for visual feedback)
@@ -229,6 +266,30 @@ export const ExploreDndContextProvider: FC<ExploreDndContextProps> = ({
           </ActiveDragContext.Provider>
         </DraggingContext.Provider>
       </DropzoneContext.Provider>
+      {/*
+        @dnd-kit has no native drag image (unlike react-dnd's HTML5 backend),
+        so the item following the cursor must be rendered explicitly here.
+        Reorder drags leave activeData null on purpose, so only external
+        DatasourcePanel drags (which carry a value) get a preview.
+      */}
+      <DragOverlay dropAnimation={null}>
+        {activeData?.value ? (
+          <DragOverlayContainer align="center" justify="space-between">
+            {activeData.type === DndItemType.Column ? (
+              <StyledColumnOption
+                column={activeData.value as ColumnOptionProps['column']}
+                showType
+              />
+            ) : (
+              <StyledMetricOption
+                metric={activeData.value as MetricOptionProps['metric']}
+                showType
+              />
+            )}
+            <Icons.Drag iconSize="xl" />
+          </DragOverlayContainer>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 };


### PR DESCRIPTION
### SUMMARY

This PR completes the `react-dnd` → `@dnd-kit` migration for the Explore chart builder by restoring the drag preview when dragging metrics or columns from the **Datasource** panel into Explore controls.

Unlike `react-dnd`, `@dnd-kit` does not provide a native drag preview. Although `ExploreDndContext` already tracked the active drag item, it never rendered a `DragOverlay`, resulting in no visible item following the cursor during external drags.

This PR adds a `DragOverlay` that displays the dragged item while dragging from the Datasource panel:

* Columns render using `StyledColumnOption`.
* Metrics render using `StyledMetricOption`.

The overlay is styled to match the lifted datasource row (background, border radius, drag handle, and subtle elevation). The source row remains faded during the drag, while the overlay stays fully opaque.

Reordering items within Explore controls is intentionally unchanged—those drags do not create an overlay, so the existing behavior is preserved.

This was likely introduced by https://github.com/apache/superset/pull/37880 during the `react-dnd` → `@dnd-kit` migration.

### BEFORE / AFTER

**Before**

* Dragging a metric or column showed no visual preview.
* The source row faded, but nothing followed the cursor.

https://github.com/user-attachments/assets/ffe20d25-2d5b-40a1-bcd1-f95c2838e4bf


**After**

* A drag preview displaying the item name and type follows the cursor throughout the drag operation.

https://github.com/user-attachments/assets/af313788-b112-43de-a7d4-eb84e230ffe8

### TESTING

1. Open any chart in Explore.
2. Drag a metric or column from the Datasource panel into a control (Metrics, Dimensions, Filters, etc.).
3. Verify the drag preview follows the cursor.
4. Drop the item and verify the existing drop behavior is unchanged.
5. Verify reordering items already inside a control still works as before.

**Automated tests**

```bash
npm run test -- src/explore/components/ExploreContainer/ExploreDndContext.test.tsx
```

All tests pass (**9/9**).

### ADDITIONAL INFORMATION

* [ ] Has associated issue
* [ ] Required feature flags
* [x] Changes UI
* [ ] Includes DB migration
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API