### PR TITLE
fix(explore): admin creating new chart crashes on save

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -229,6 +229,7 @@ const SaveModal = ({
 
   const canOverwriteSlice = useCallback(
     (): boolean =>
+      !!slice &&
       (can_overwrite ||
         isUserAdmin(user) ||
         slice?.owners?.includes(user.userId)) &&


### PR DESCRIPTION
### SUMMARY

#37175 added `isUserAdmin()` to `canOverwriteSlice()` but didn't check if `slice` exists. For admins creating a new chart, this defaults the save action to "overwrite" on a null slice, crashing with `Cannot destructure property 'slice_id' of 'slice' as it is null`. Fixed by adding a `!!slice &&` guard

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
