### PR TITLE
fix(mcp): patch list_metrics DAOs via module object to avoid Python 3.10 mock resolution bug

### DIFF
--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py
@@ -118,12 +118,8 @@ async def test_list_metrics_builtin_happy_path(mcp_server: FastMCP) -> None:
     mock_ds = _make_dataset(42)
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
     ):
         mock_dao.find_by_id.return_value = mock_ds
         mock_view_dao.find_accessible.return_value = []
@@ -179,13 +175,9 @@ async def test_list_metrics_search_filter(mcp_server: FastMCP) -> None:
     mock_ds: MagicMock = _make_dataset(1)
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
-        patch("superset.mcp_service.semantic_layer.tool.list_metrics.db") as mock_db,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
+        patch.object(list_metrics_module, "db") as mock_db,
     ):
         mock_view_dao.find_accessible.return_value = []
         mock_query: MagicMock = MagicMock()
@@ -215,9 +207,7 @@ async def test_list_metrics_external_includes_verbose_name(
     mock_view = _make_view(5)
     mock_view.metrics[0].verbose_name = "Bookings Count"
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -237,9 +227,7 @@ async def test_list_metrics_external_access_denied(mcp_server: FastMCP) -> None:
     mock_view = _make_view(5)
     mock_view.raise_for_access.side_effect = _access_denied_exc()
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -267,9 +255,7 @@ async def test_list_metrics_external_per_metric_compatible_dimensions(
 
     mock_view.get_compatible_dimensions.side_effect = _compatible_dimensions
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -301,13 +287,9 @@ async def test_list_metrics_pagination_is_stable(mcp_server: FastMCP) -> None:
     mock_ds.columns = []
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
-        patch("superset.mcp_service.semantic_layer.tool.list_metrics.db") as mock_db,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
+        patch.object(list_metrics_module, "db") as mock_db,
     ):
         mock_view_dao.find_accessible.return_value = []
         mock_query = MagicMock()


### PR DESCRIPTION
### SUMMARY
`Python-Unit` has been intermittently failing on master's `unit-tests (previous)` job (Python 3.10) since ~2026-07-07T16:51, with:

```
AttributeError: <function list_metrics at 0x...> does not have the attribute 'DatasetDAO'
```

Root cause: `superset/mcp_service/semantic_layer/tool/__init__.py` re-exports the `list_metrics` function under the same name as its defining submodule:

```python
from superset.mcp_service.semantic_layer.tool.list_metrics import (
    list_metrics,
)
```

This overwrites the `tool.list_metrics` package attribute (originally set to the submodule by Python's import machinery) with the function object. `tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py` patches `DatasetDAO`/`SemanticViewDAO`/`db` via the dotted string `"superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"`. On Python 3.10, `unittest.mock`'s target resolution (`_importer`) walks the dotted path via plain `getattr`, so it resolves `tool.list_metrics` to the shadowed function instead of the submodule, then fails looking up `DatasetDAO` on it. This was fixed in a later CPython version (mock's resolution now prefers importing the submodule directly), so the bug only reproduces on 3.10 — hence the flip-flopping pass/fail pattern across the Python version matrix.

Confirmed with a minimal repro locally: fails identically on Python 3.10.14, passes on 3.13.0a5.

The fix switches the affected patches to `patch.object(list_metrics_module, "X")` against the module reference this file already imports at the top (`importlib.import_module(...)`) — the same pattern this file already uses for `user_can_view_data_model_metadata`. This sidesteps the ambiguous string resolution entirely rather than depending on Python-version-specific mock internals.

Checked sibling test files in the same package (`test_get_table.py`, `test_get_compatible_metrics.py`, `test_get_compatible_dimensions.py`) for the same footgun — they patch DAOs at their defining module (e.g. `superset.daos.dataset.DatasetDAO`) rather than through the re-exporting package, so they're unaffected.

### TESTING INSTRUCTIONS
On Python 3.10:
```
pytest tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py -v
```
Previously failed 6 tests with the `AttributeError` above; should now pass. `pre-commit run --files tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py` passes clean (ruff, mypy).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API