### PR TITLE
fix(a11y): add aria-label to RightMenu documentation and bug-report icon links

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -755,6 +755,7 @@ const RightMenu = ({
             target="_blank"
             rel="noreferrer"
             title={navbarRight.documentation_text || t('Documentation')}
+            aria-label={navbarRight.documentation_text || t('Documentation')}
           >
             {navbarRight.documentation_icon ? (
               <Icons.BookOutlined />
@@ -772,6 +773,7 @@ const RightMenu = ({
             target="_blank"
             rel="noreferrer"
             title={navbarRight.bug_report_text || t('Report a bug')}
+            aria-label={navbarRight.bug_report_text || t('Report a bug')}
           >
             {navbarRight.bug_report_icon ? (
               <i className={navbarRight.bug_report_icon} />


### PR DESCRIPTION
## Summary
The documentation and bug-report links in the top-right navbar menu (`RightMenu.tsx`) render icon-only anchors with only a `title` attribute. `title` is not a reliable accessible name for assistive technology (not consistently exposed, especially on touch devices), so screen reader users hear an unlabeled link.

**WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A.**

## Change
Added `aria-label` to both `<StyledAnchor>` elements, reusing the exact same expression already used for `title` (`navbarRight.documentation_text || t('Documentation')` and `navbarRight.bug_report_text || t('Report a bug')`), so any admin-configured custom text is respected.

Behavior is unchanged — this only adds an accessible name, it doesn't affect layout, styling, or the existing `title` tooltip.

## Test plan
- [ ] Tab to the documentation icon link in the top-right navbar; confirm a screen reader (VoiceOver/NVDA) announces "Documentation, link" (or the configured `documentation_text`) instead of just "link".
- [ ] Tab to the bug-report icon link; confirm a screen reader announces "Report a bug, link" (or the configured `bug_report_text`).
- [ ] Confirm the on-hover `title` tooltip still displays as before (unchanged).