### PR TITLE
fix(versioning): SAVEPOINT-isolate baseline capture so a failure can't poison the save

### DIFF
--- a/superset/versioning/baseline/insertion.py
+++ b/superset/versioning/baseline/insertion.py
@@ -55,9 +55,18 @@ def insert_baseline_and_children(
     ``_insert_baseline_row`` does not trigger a flush of Continuum's
     pending Transaction object before our direct-SQL insert claims its
     tx_id.
+
+    The direct-SQL inserts also run under a SAVEPOINT (``begin_nested``):
+    on PostgreSQL a failed statement aborts the entire transaction even
+    when the exception is caught, so without the savepoint a baseline
+    failure would poison the user's save. Rolling back to the savepoint
+    keeps the outer transaction healthy, so a baseline failure degrades
+    to "no baseline row" instead of breaking the save — the same guard the
+    change-record persist path (``changes/listener.py``) and the
+    child-baseline path (``baseline/collection.py``) already use.
     """
     try:
-        with session.no_autoflush:
+        with session.no_autoflush, session.connection().begin_nested():
             tx_id = _insert_baseline_row(session, obj, version_table)
             if tx_id is None:
                 return

--- a/tests/integration_tests/versioning/versions_api_tests.py
+++ b/tests/integration_tests/versioning/versions_api_tests.py
@@ -28,9 +28,11 @@ The suite runs with ``ENABLE_VERSIONING_CAPTURE=True`` (see
 autouse fixture clears the version tables around each test.
 """
 
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+import sqlalchemy as sa
 
 from superset import db
 from superset.connectors.sqla.models import SqlaTable
@@ -199,6 +201,49 @@ class TestChartVersionsApi(SupersetTestCase):
             # Capture is on, so the post-save fields are populated.
             assert body["new_version"] is not None
             assert body["new_version_uuid"] is not None
+        finally:
+            self.client.put(f"/api/v1/chart/{chart_id}", json={"slice_name": "Girls"})
+
+    def test_baseline_failure_does_not_break_the_save(self) -> None:
+        """A failing baseline capture must not break the user's save.
+
+        The parent-baseline direct-SQL inserts run under a SAVEPOINT
+        (``begin_nested``). On PostgreSQL a failed statement aborts the whole
+        transaction even when the surrounding ``except`` swallows the Python
+        exception, so without the savepoint a baseline failure would poison —
+        and fail — the user's commit. Inject a genuinely failing SQL statement
+        into the baseline path (a pre-SQL Python raise would never reach the
+        database, so it must be real SQL) and assert the chart edit still
+        commits. Regresses the PostgreSQL transaction-poisoning bug in
+        ``baseline/insertion.py`` (only observable with capture on).
+        """
+        chart_id = self._girls_chart().id
+        self.login(ADMIN_USERNAME)
+
+        def _fail_baseline(conn, *args: object, **kwargs: object) -> None:
+            # Real failing statement so the DB transaction is aborted on
+            # PostgreSQL, exercising the SAVEPOINT rollback rather than a
+            # Python raise that never touches the connection.
+            conn.execute(
+                sa.text("INSERT INTO __versioning_missing_shadow__ (x) VALUES (1)")
+            )
+
+        try:
+            with patch(
+                "superset.versioning.baseline.insertion.insert_baseline_shadow_row",
+                side_effect=_fail_baseline,
+            ):
+                rv = self.client.put(
+                    f"/api/v1/chart/{chart_id}",
+                    json={"slice_name": "Girls survives baseline failure"},
+                )
+            assert rv.status_code == 200, rv.data
+
+            # The edit persisted despite the baseline capture failing.
+            got = json.loads(self.client.get(f"/api/v1/chart/{chart_id}").data)[
+                "result"
+            ]
+            assert got["slice_name"] == "Girls survives baseline failure"
         finally:
             self.client.put(f"/api/v1/chart/{chart_id}", json={"slice_name": "Girls"})
 


### PR DESCRIPTION
> ⛔ **Depends on #41176 (versioning base infrastructure) — do NOT merge until that lands.** This fix touches `superset/versioning/baseline/insertion.py`, which is introduced by #41176, so this branch is **stacked on it**; the diff below includes #41176's changes until it merges, at which point this rebases to a one-line diff. Kept as a **draft** until then.

### SUMMARY

Parent baseline capture in `superset/versioning/baseline/insertion.py` runs its direct-SQL inserts under `try/except` + `no_autoflush` but **not** a SAVEPOINT. On PostgreSQL a failed statement aborts the entire transaction even when the exception is caught, so a baseline-insert failure would poison the user's save — contradicting the "versioning must never break a save" guarantee this subsystem is built around.

This wraps the inserts in `session.connection().begin_nested()`, so a failure rolls back to the savepoint and the outer transaction stays healthy — degrading to "no baseline row" instead of a broken save. It mirrors the guard the change-record persist path (`changes/listener.py`) and the child-baseline path (`baseline/collection.py:133`) already use; the parent-baseline path was the one spot missing it.

The affected path only runs with `ENABLE_VERSIONING_CAPTURE` on (the base infra ships dark/off), so this is a **pre-flag-flip correctness fix, not a deploy-time regression** — hence a follow-up rather than a change to #41176 at its merge gate.

Surfaced during a multi-model review pass on #41176.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend transaction-safety fix.

### TESTING INSTRUCTIONS

Mirrors an existing, tested pattern (`baseline/collection.py`). Includes a dedicated fault-injection regression test — `test_baseline_failure_does_not_break_the_save` in `tests/integration_tests/versioning/versions_api_tests.py` — which injects a real failing SQL statement into the parent-baseline path during a capture-on chart save and asserts the edit still commits. Without the SAVEPOINT this fails on the **PostgreSQL** CI job (the aborted transaction poisons the outer save); with it, the baseline rolls back and the save succeeds. It uses real SQL rather than a Python raise because only a failed DB statement poisons a Postgres transaction — so it passes trivially on SQLite, and the Postgres job is the real guard. The existing versioning capture tests cover the happy path.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_VERSIONING_CAPTURE` (the affected code path only runs with capture on)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
