### PR TITLE
fix(ci): repair stale mock target breaking Python-Unit on master

### DIFF
--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py
@@ -118,12 +118,8 @@ async def test_list_metrics_builtin_happy_path(mcp_server: FastMCP) -> None:
     mock_ds = _make_dataset(42)
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
     ):
         mock_dao.find_by_id.return_value = mock_ds
         mock_view_dao.find_accessible.return_value = []
@@ -179,13 +175,9 @@ async def test_list_metrics_search_filter(mcp_server: FastMCP) -> None:
     mock_ds: MagicMock = _make_dataset(1)
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
-        patch("superset.mcp_service.semantic_layer.tool.list_metrics.db") as mock_db,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
+        patch.object(list_metrics_module, "db") as mock_db,
     ):
         mock_view_dao.find_accessible.return_value = []
         mock_query: MagicMock = MagicMock()
@@ -215,9 +207,7 @@ async def test_list_metrics_external_includes_verbose_name(
     mock_view = _make_view(5)
     mock_view.metrics[0].verbose_name = "Bookings Count"
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -237,9 +227,7 @@ async def test_list_metrics_external_access_denied(mcp_server: FastMCP) -> None:
     mock_view = _make_view(5)
     mock_view.raise_for_access.side_effect = _access_denied_exc()
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -267,9 +255,7 @@ async def test_list_metrics_external_per_metric_compatible_dimensions(
 
     mock_view.get_compatible_dimensions.side_effect = _compatible_dimensions
 
-    with patch(
-        "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-    ) as mock_view_dao:
+    with patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao:
         mock_view_dao.find_by_id.return_value = mock_view
 
         async with Client(mcp_server) as client:
@@ -301,13 +287,9 @@ async def test_list_metrics_pagination_is_stable(mcp_server: FastMCP) -> None:
     mock_ds.columns = []
 
     with (
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"
-        ) as mock_dao,
-        patch(
-            "superset.mcp_service.semantic_layer.tool.list_metrics.SemanticViewDAO"
-        ) as mock_view_dao,
-        patch("superset.mcp_service.semantic_layer.tool.list_metrics.db") as mock_db,
+        patch.object(list_metrics_module, "DatasetDAO") as mock_dao,
+        patch.object(list_metrics_module, "SemanticViewDAO") as mock_view_dao,
+        patch.object(list_metrics_module, "db") as mock_db,
     ):
         mock_view_dao.find_accessible.return_value = []
         mock_query = MagicMock()


### PR DESCRIPTION
### SUMMARY

`Python-Unit` is red on `master`. Six tests in `tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py` fail with:

```
AttributeError: <function list_metrics at 0x...> does not have the attribute 'DatasetDAO'
AttributeError: <function list_metrics at 0x...> does not have the attribute 'SemanticViewDAO'
```

**Root cause:** the tests patch the DAOs via the string path `"superset.mcp_service.semantic_layer.tool.list_metrics.DatasetDAO"` (and `SemanticViewDAO` / `db`). But `superset/mcp_service/semantic_layer/tool/__init__.py` re-exports the `list_metrics` **function** (`from .list_metrics import list_metrics`), so the `tool.list_metrics` *attribute* points at that function, shadowing the submodule of the same name. `mock.patch` resolves its target by walking attributes, lands on the function, and can't find `DatasetDAO` on it — hence the error. (It's the classic module/function name-collision trap.)

**Fix:** patch through the already-imported module object with `patch.object(list_metrics_module, "DatasetDAO")`. The file already imports that module via `importlib` at the top (`list_metrics_module`) and its autouse fixture already patches through it — so this just makes the DAO/`db` patches consistent with the working pattern, resolving to the real submodule unambiguously. No production code changes.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/semantic_layer/tool/test_list_metrics.py
```
Before: 6 failed / 8. After: **8 passed** (verified locally). `ruff format --check` and `ruff check` both clean.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Test-only change to unbreak `master` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)