### PR TITLE
fix(home): restore navigation for saved query cards

### DIFF
--- a/superset-frontend/src/features/home/SavedQueries.test.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.test.tsx
@@ -18,6 +18,7 @@
  */
 import { act, ComponentProps } from 'react';
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -81,6 +82,32 @@ test('navigates to SQL Lab when a saved query card is clicked', async () => {
     expect(window.location.pathname).toBe('/sqllab');
     expect(window.location.search).toContain('savedQueryId=0');
   });
+});
+
+test('navigates to SQL Lab when a saved query card is activated by keyboard', async () => {
+  await renderSavedQueries(mockedProps);
+
+  const card = await screen.findByRole('button', { name: 'cool query 0' });
+  card.focus();
+  expect(card).toHaveFocus();
+
+  fireEvent.keyDown(card, { key: 'Enter' });
+
+  await waitFor(() => {
+    expect(window.location.pathname).toBe('/sqllab');
+    expect(window.location.search).toContain('savedQueryId=0');
+  });
+});
+
+test('does not navigate when a control inside the card is activated by keyboard', async () => {
+  await renderSavedQueries(mockedProps);
+
+  const [menuButton] = await screen.findAllByRole('button', {
+    name: 'More Options',
+  });
+  fireEvent.keyDown(menuButton, { key: 'Enter' });
+
+  expect(window.location.pathname).toBe('/');
 });
 
 test('navigates only via the card wrapper, without a competing link', async () => {

--- a/superset-frontend/src/features/home/SavedQueries.test.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, ComponentProps } from 'react';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import fetchMock from 'fetch-mock';
+import SavedQueries from './SavedQueries';
+
+const savedQueriesEndpoint = 'glob:*/api/v1/saved_query/?*';
+const savedQueriesInfoEndpoint = 'glob:*/api/v1/saved_query/_info*';
+
+const mockQueries = Array.from({ length: 3 }).map((_, i) => ({
+  id: i,
+  label: `cool query ${i}`,
+  sql: 'SELECT 1',
+  changed_on_delta_humanized: '1 day ago',
+}));
+
+const mockedProps: ComponentProps<typeof SavedQueries> = {
+  addDangerToast: jest.fn(),
+  addSuccessToast: jest.fn(),
+  user: {
+    userId: 2,
+    firstName: 'Test',
+    lastName: 'User',
+    username: 'test',
+    isActive: true,
+    isAnonymous: false,
+  },
+  queryFilter: 'Mine',
+  mine: mockQueries,
+  showThumbnails: false,
+  featureFlag: false,
+};
+
+const renderSavedQueries = (props: ComponentProps<typeof SavedQueries>) =>
+  act(async () => {
+    render(<SavedQueries {...props} />, { useRedux: true, useRouter: true });
+  });
+
+beforeEach(() => {
+  window.history.pushState({}, '', '/');
+  fetchMock.get(
+    savedQueriesEndpoint,
+    { result: mockQueries },
+    { name: savedQueriesEndpoint },
+  );
+  fetchMock.get(savedQueriesInfoEndpoint, {
+    permissions: ['can_read', 'can_write'],
+  });
+});
+
+afterEach(() => fetchMock.clearHistory().removeRoutes());
+
+test('navigates to SQL Lab when a saved query card is clicked', async () => {
+  await renderSavedQueries(mockedProps);
+
+  await userEvent.click(await screen.findByText('cool query 0'));
+
+  await waitFor(() => {
+    expect(window.location.pathname).toBe('/sqllab');
+    expect(window.location.search).toContain('savedQueryId=0');
+  });
+});
+
+test('navigates only via the card wrapper, without a competing link', async () => {
+  // With thumbnails on and a query that has no SQL, ListViewCard would render
+  // its fallback cover. Navigation must come solely from the card wrapper, so
+  // the card must not also render an anchor to the saved query (which would
+  // double-navigate and break modified-click behavior).
+  const emptySqlQuery = {
+    id: 5,
+    label: 'no sql query',
+    changed_on_delta_humanized: '1 day ago',
+  };
+  fetchMock.removeRoutes();
+  fetchMock.get(
+    savedQueriesEndpoint,
+    { result: [emptySqlQuery] },
+    { name: savedQueriesEndpoint },
+  );
+  fetchMock.get(savedQueriesInfoEndpoint, {
+    permissions: ['can_read', 'can_write'],
+  });
+
+  await renderSavedQueries({
+    ...mockedProps,
+    showThumbnails: true,
+    mine: [emptySqlQuery],
+  });
+
+  await screen.findByText('no sql query');
+  expect(document.querySelectorAll('a[href*="savedQueryId"]')).toHaveLength(0);
+});

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
-import { SupersetClient } from '@superset-ui/core';
+import { SupersetClient, handleKeyboardActivation } from '@superset-ui/core';
 import { styled, useTheme, css } from '@apache-superset/core/theme';
 import CodeSyntaxHighlighter, {
   preloadLanguages,
@@ -140,6 +140,10 @@ export const SavedQueries = ({
   const canDelete = hasPerm('can_delete');
 
   const history = useHistory();
+  const openQuery = useCallback(
+    (query: Query) => history.push(`/sqllab?savedQueryId=${query.id}`),
+    [history],
+  );
   const theme = useTheme();
 
   // Preload SQL language since we'll likely show SQL snippets
@@ -299,7 +303,15 @@ export const SavedQueries = ({
           {queries.map(q => (
             <CardStyles
               key={q.id}
-              onClick={() => history.push(`/sqllab?savedQueryId=${q.id}`)}
+              role="button"
+              tabIndex={0}
+              aria-label={q.label}
+              onClick={() => openQuery(q)}
+              onKeyDown={event => {
+                // Let controls inside the card handle their own keys.
+                if (event.target !== event.currentTarget) return;
+                handleKeyboardActivation(() => openQuery(q))(event);
+              }}
             >
               <ListViewCard
                 imgURL=""

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
 import { SupersetClient } from '@superset-ui/core';
 import { styled, useTheme, css } from '@apache-superset/core/theme';
@@ -139,6 +139,7 @@ export const SavedQueries = ({
   const canEdit = hasPerm('can_edit');
   const canDelete = hasPerm('can_delete');
 
+  const history = useHistory();
   const theme = useTheme();
 
   // Preload SQL language since we'll likely show SQL snippets
@@ -296,11 +297,12 @@ export const SavedQueries = ({
       {queries.length > 0 ? (
         <CardContainer showThumbnails={showThumbnails}>
           {queries.map(q => (
-            <CardStyles key={q.id}>
+            <CardStyles
+              key={q.id}
+              onClick={() => history.push(`/sqllab?savedQueryId=${q.id}`)}
+            >
               <ListViewCard
                 imgURL=""
-                url={`/sqllab?savedQueryId=${q.id}`}
-                linkComponent={Link}
                 title={q.label}
                 imgFallbackURL={assetUrl(
                   '/static/assets/images/empty-query.svg',


### PR DESCRIPTION
### SUMMARY

Clicking a saved query card on the home page did nothing. No navigation, no feedback.

The SqlLab SPA migration (#25151) removed the `onClick` handler on the card wrapper that used to open the query in SQL Lab, leaving only a `url` prop on `ListViewCard`. That `url` only turns into a link when the card renders its fallback cover, which `SavedQueries` never does because it always passes a custom `cover`. So the card ended up with no navigation at all, while `cursor: pointer` still made it look clickable.

This restores navigation the same way `ChartCard` and `DashboardCard` already do it: an `onClick` on the card wrapper that pushes to `/sqllab?savedQueryId=<id>`. `history.push` goes through the router `basename`, so it also works under a prefixed (subdirectory) deployment.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before, clicking the card stayed on the home page:

![before](https://files.catbox.moe/o2v7ov.png)

After, clicking the card opens the query in SQL Lab:

![after](https://files.catbox.moe/0bp01z.png)

### TESTING INSTRUCTIONS

1. Create a saved query (SQL Lab, write a query, Save).
2. Go to the home page and expand the "Saved queries" section.
3. Click the saved query card.
4. It should open the query in SQL Lab.

A unit test was added in `SavedQueries.test.tsx` that asserts the card navigates to `/sqllab?savedQueryId=<id>`.

### ADDITIONAL INFORMATION
- [x] Changes UI
