### PR TITLE
ci: enforce SQLAlchemy 2.0 deprecation warnings in unit-test CI

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -53,6 +53,12 @@ jobs:
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["previous", "current", "next"]') }}
     env:
       PYTHONPATH: ${{ github.workspace }}
+      # Promotes the SQLAlchemy 2.0 deprecation warnings already locked in as
+      # errors via pytest.ini's `filterwarnings` to actually run in CI, so a
+      # regression on those fails the build instead of relying on a
+      # contributor remembering to set this locally. See the migration
+      # battleplan: https://github.com/apache/superset/discussions/40273
+      SQLALCHEMY_WARN_20: "1"
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
### SUMMARY

Part of the SQLAlchemy 2.0 migration battleplan: #40273

`pytest.ini`'s `filterwarnings` already promotes several SQLAlchemy 2.0 deprecation-warning categories from a bare warning to a hard error, as each gets fixed and locked in (see #41914 for 3 more). But `SQLALCHEMY_WARN_20` was never actually set anywhere in CI — grepped the whole repo, it only appears in a comment in `pytest.ini`. That means those `RemovedIn20Warning` categories never actually fire during a normal CI run, so the "enforcement" was a no-op: a regression on any already-"fixed" category would pass CI silently, and a contributor would only catch it if they remembered to set the env var locally.

This sets `SQLALCHEMY_WARN_20: "1"` on the `unit-tests` job so the categories already promoted to `error:` in `pytest.ini` are actually exercised on every PR and push.

### TESTING INSTRUCTIONS

Ran the exact CI command locally against master's current `pytest.ini` (3 promoted categories):
```bash
SQLALCHEMY_WARN_20=1 SUPERSET_TESTENV=true SUPERSET_SECRET_KEY=not-a-secret \
  pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50
```
Only 2 pre-existing, unrelated flaky tests fail (`test_get_time_filter` ×6, `test_previous_calendar_quarter`), and both reproduce identically with no env vars set at all — confirmed unrelated to this change (date-boundary-sensitive).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API