### PR TITLE
fix(nvd3): invoke shiftMetric() in TimePivot formDataOverrides

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
+import { QueryFormData } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   D3_FORMAT_OPTIONS,
@@ -124,9 +125,9 @@ const config: ControlPanelConfig = {
       clearable: false,
     },
   },
-  formDataOverrides: formData => ({
+  formDataOverrides: (formData: QueryFormData) => ({
     ...formData,
-    metric: getStandardizedControls().shiftMetric,
+    metric: getStandardizedControls().shiftMetric(),
   }),
 };
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/TimePivot/controlPanel.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/TimePivot/controlPanel.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SqlaFormData } from '@superset-ui/core';
+import * as ChartControls from '@superset-ui/chart-controls';
+import controlPanel from '../../src/TimePivot/controlPanel';
+
+const { __mockShiftMetric } = ChartControls as any;
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  t: (str: string) => str,
+}));
+
+jest.mock('@superset-ui/chart-controls', () => {
+  const original = jest.requireActual('@superset-ui/chart-controls');
+  const mockShiftMetric = jest.fn(() => 'shiftedMetric');
+  return {
+    ...original,
+    getStandardizedControls: () => ({
+      shiftMetric: mockShiftMetric,
+    }),
+    __mockShiftMetric: mockShiftMetric,
+  };
+});
+
+describe('TimePivot Control Panel Config', () => {
+  test('should override formData metric using getStandardizedControls', () => {
+    const dummyFormData = { someProp: 'test' } as unknown as SqlaFormData;
+    const newFormData = controlPanel.formDataOverrides!(dummyFormData);
+
+    // The original properties are spread correctly.
+    expect(newFormData.someProp).toBe('test');
+    // The metric property should be replaced by the output of shiftMetric.
+    expect(newFormData.metric).toBe('shiftedMetric');
+
+    // Ensure that the mockShiftMetric function was called.
+    expect(__mockShiftMetric).toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/TimePivot/controlPanel.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/TimePivot/controlPanel.test.ts
@@ -20,7 +20,9 @@ import { SqlaFormData } from '@superset-ui/core';
 import * as ChartControls from '@superset-ui/chart-controls';
 import controlPanel from '../../src/TimePivot/controlPanel';
 
-const { __mockShiftMetric } = ChartControls as any;
+const { __mockShiftMetric } = ChartControls as typeof ChartControls & {
+  __mockShiftMetric: jest.Mock;
+};
 
 jest.mock('@superset-ui/core', () => ({
   ...jest.requireActual('@superset-ui/core'),


### PR DESCRIPTION
### SUMMARY

This PR fixes the **Time-series Period Pivot** chart configuration issue where the required **Metric** control was rendered in a non-interactive state, preventing users from selecting a metric and causing chart execution to fail with the error:

> Metric 'None' does not exist

### Root Cause

The `formDataOverrides` configuration in the TimePivot control panel assigned the `shiftMetric` function itself instead of invoking it.

Before:

```ts
metric: getStandardizedControls().shiftMetric,
```

This stored a function reference as the metric value instead of the transformed metric object expected by the control and query pipeline.

After:

```ts
metric: getStandardizedControls().shiftMetric(),
```

Invoking `shiftMetric()` correctly initializes the metric value, allowing the Metric control to function as expected and ensuring a valid metric is included in the generated query.

### Changes

- Invoke `shiftMetric()` in `TimePivot/controlPanel.ts` instead of assigning the function reference.
- Add a regression test to verify:
  - `shiftMetric()` is invoked.
  - The returned metric is assigned to `formData`.
  - Future regressions are detected during CI.

Fixes #41884

---

### BEFORE

- Metric field appears as required.
- Metric selector is disabled and cannot be interacted with.
- Users cannot add or select a metric.
- Running the query results in:
  ```
  Metric 'None' does not exist
  ```

### AFTER

- Metric selector is interactive.
- Users can select a metric normally.
- A valid metric is included in the generated query.
- The Time-series Period Pivot chart renders successfully.

---

### TESTING INSTRUCTIONS

1. Start Superset locally.
2. Open **Explore**.
3. Select any dataset.
4. Choose the **Time-series Period Pivot** visualization.
5. Verify that the **Metric** control is enabled.
6. Select a metric.
7. Click **Run**.
8. Confirm that the chart renders successfully without the `Metric 'None' does not exist` error.
9. Run the frontend test suite and verify that the new regression test passes.

---

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #41884
- [ ] Required feature flags
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API