### PR TITLE
fix(docs): correct broken In the Wild logo for Région Hauts-de-France

### DIFF
--- a/RESOURCES/INTHEWILD.yaml
+++ b/RESOURCES/INTHEWILD.yaml
@@ -641,7 +641,7 @@ categories:
 
     - name: Région Hauts-de-France (France)
       url: https://www.geo2france.fr/
-      logo: geo2france.svg
+      logo: geo2france.png
 
     - name: Rennes Métropole (France)
       url: https://metropole.rennes.fr/


### PR DESCRIPTION
### SUMMARY

The "In the Wild" page renders a broken image for **Région Hauts-de-France (France)**. The `INTHEWILD.yaml` entry points its `logo` at `geo2france.svg`, but the asset committed alongside it in #41801 is `geo2france.png` — there is no `.svg`, so `/img/logos/geo2france.svg` 404s.

Fix: point the entry at the existing `geo2france.png`. Verified the other eight logos added in #41801 all resolve correctly; this was the only mismatch.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** broken-image icon next to "Région Hauts-de-France (France)".
**After:** the `geo2france.png` logo renders.

### TESTING INSTRUCTIONS

Build the docs site and open the In the Wild page; the Région Hauts-de-France card shows its logo instead of a broken image.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)