### PR TITLE
fix(mcp): stop masking dashboard lookup DB errors as not-found

### DIFF
--- a/superset/mcp_service/dashboard/tool/update_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/update_dashboard.py
@@ -73,10 +73,21 @@ def _find_and_authorize_dashboard(
 
     try:
         dashboard = DashboardDAO.get_by_id_or_slug(identifier)
-    except (DashboardNotFoundError, SQLAlchemyError):
+    except DashboardNotFoundError:
         return None, DashboardError(
             error=f"Dashboard not found: {identifier!r}",
             error_type="DashboardNotFound",
+        )
+    except SQLAlchemyError:
+        # ``str(exc)`` on SQLAlchemyError frequently contains table/column/
+        # constraint names that should not leak to the MCP response. The raw
+        # exception is captured here via ``logger.exception``; the response
+        # surfaces a generic message (mirrors generate_dashboard.py's
+        # rollback/error handling).
+        logger.exception("Database error looking up dashboard %r", identifier)
+        return None, DashboardError(
+            error="Failed to look up dashboard due to a database error.",
+            error_type="DatabaseError",
         )
 
     if dashboard is None:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -184,6 +184,33 @@ class TestUpdateDashboard:
         assert "not found" in (payload.get("error") or "").lower()
 
     @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
+    @pytest.mark.asyncio
+    async def test_update_lookup_database_error_is_not_masked_as_not_found(
+        self, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """A real DB/infra failure during lookup must surface as a distinct
+        ``DatabaseError``, not be collapsed into ``DashboardNotFound`` — and
+        must be logged server-side, since ``ctx.*`` calls never reach ops."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        mock_get.side_effect = SQLAlchemyError("connection to server lost")
+
+        with patch(
+            "superset.mcp_service.dashboard.tool.update_dashboard.logger"
+        ) as mock_logger:
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "update_dashboard", {"request": {"identifier": 999999}}
+                )
+
+        payload = json.loads(result.content[0].text)
+        assert payload.get("error_type") == "DatabaseError"
+        assert "not found" not in (payload.get("error") or "").lower()
+        # The raw exception text must never reach the LLM-facing response.
+        assert "connection to server lost" not in (payload.get("error") or "")
+        mock_logger.exception.assert_called_once()
+
+    @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
     async def test_update_title_and_slug_and_published(


### PR DESCRIPTION
## SUMMARY
`update_dashboard`'s `_find_and_authorize_dashboard` helper caught `DashboardNotFoundError` and `SQLAlchemyError` in the same `except` clause, returning a `DashboardNotFound` response for both. A real database/infrastructure failure during the dashboard lookup was therefore misreported to the caller as "dashboard not found," with zero server-side logging of the underlying error — invisible to operators and misleading to the MCP client.

This splits the handling:
- `DashboardNotFoundError` still returns the existing `DashboardNotFound` structured error.
- `SQLAlchemyError` is now logged server-side via `logger.exception` and returns a distinct `DatabaseError` with a generic message. The raw exception text is never included in the response, since `str(exc)` on a `SQLAlchemyError` can leak table/column/constraint names — same leak-avoidance pattern already used in `generate_dashboard.py`.

Audited the rest of the dashboard domain (`add_chart_to_existing_dashboard.py`, `remove_chart_from_dashboard.py`, `duplicate_dashboard.py`, `manage_native_filters.py`) and the wider `mcp_service` package for the same "SQLAlchemyError collapsed into not-found" pattern; no other occurrence exists.

## BEFORE/AFTER
**Before:** A transient DB error during `update_dashboard`'s lookup returned `{"error": "Dashboard not found: ...", "error_type": "DashboardNotFound"}` with no log line anywhere.

**After:** The same failure returns `{"error": "Failed to look up dashboard due to a database error.", "error_type": "DatabaseError"}` and is logged server-side via `logger.exception` (with traceback) for observability.

## TESTING INSTRUCTIONS
- `pytest tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py -q` — 15 passed, including a new test asserting the DB-error path returns `error_type="DatabaseError"`, never leaks the raw exception text, and calls `logger.exception`.
- `pytest tests/unit_tests/mcp_service/dashboard/ -q` — 265 passed (no regressions).

## ADDITIONAL INFORMATION
- [x] Has associated tests