### PR TITLE
chore(ci): update GHA actions to Node.js 24-compatible versions (#40477)

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -26,16 +26,16 @@ runs:
 
     - name: Set up QEMU
       if: ${{ inputs.build == 'true' }}
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx
       if: ${{ inputs.build == 'true' }}
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Try to login to DockerHub
       if: ${{ inputs.login-to-dockerhub == 'true' }}
       continue-on-error: true
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-token }}

--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
 
     - name: Setup Node Env
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
 
@@ -21,7 +21,7 @@ runs:
 
     - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
       if: ${{ inputs.from-npm == 'false' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: apache-superset/supersetbot
         path: supersetbot

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,11 @@ jobs:
       # in the context of push (using multi-platform build), we need to pull the image locally
       - name: Docker pull
         if: github.event_name == 'push' && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
-        run: docker pull $IMAGE_TAG
+        run: |
+          for i in 1 2 3; do
+            docker pull $IMAGE_TAG && break
+            [ $i -lt 3 ] && sleep 30
+          done
 
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker


### PR DESCRIPTION
### SUMMARY

Backport of #40477 to the `6.1` branch to fix CI.

`6.1` pins three docker actions in `.github/actions/setup-docker/action.yml` to SHAs (v3.x) that are **not** on apache/superset's allowed-actions list. As a result, every workflow that uses the `setup-docker` composite action fails at startup with:

> Error: The actions `docker/setup-qemu-action@2910929…`, `docker/setup-buildx-action@8d2750c6…`, and `docker/login-action@c94ce9fb…` are not allowed in apache/superset because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns…

Master already resolved this in #40477 by bumping the actions to the allowed v4.x SHAs. This PR mirrors that change on `6.1`:

- `docker/setup-qemu-action` → `v4.1.0` (`06116385…`)
- `docker/setup-buildx-action` → `v4.1.0` (`d7f5e7f5…`)
- `docker/login-action` → `v4.2.0` (`650006c6…`)
- `setup-supersetbot`: pin `actions/setup-node` → `v6.4.0` and `actions/checkout` → `v6.0.2`
- `docker.yml`: wrap `docker pull` in a 3-attempt retry loop

Note: `6.1` does not carry the binfmt `image:` pin from #40235, so the QEMU step here only bumps the SHA (no `with: image:` block), which is why a straight cherry-pick conflicted.

### TESTING INSTRUCTIONS

CI on this PR should now pass the workflow validation / startup step that previously failed on `6.1` with the "actions are not allowed" error. Confirm the docker-based workflows start successfully.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
