### PR TITLE
fix(event-log): add event logging for embedded Superset

### DIFF
--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -143,17 +143,21 @@ describe('logger middleware', () => {
   });
 
   const getSourceForPath = (href: string): string | undefined => {
-    const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
-      ...window.location,
-      href,
-    } as Location);
+    const originalHref = window.location.href;
+    Object.defineProperty(window, 'location', {
+      value: { href },
+      writable: true,
+    });
     try {
       (logger as Function)(mockStore)(next)(action);
       jest.advanceTimersByTime(2000);
       const { events } = postStub.mock.calls[0][0].postPayload;
       return events[0].source;
     } finally {
-      locationSpy.mockRestore();
+      Object.defineProperty(window, 'location', {
+        value: { href: originalHref },
+        writable: true,
+      });
     }
   };
 

--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -164,6 +164,9 @@ describe('logger middleware', () => {
   test.each([
     ['/dashboard/123/embedded/', 'embedded_dashboard'],
     ['/embedded/abc-def-uuid/', 'embedded_dashboard'],
+    // React Router also matches these routes without a trailing slash
+    ['/dashboard/123/embedded', 'embedded_dashboard'],
+    ['/embedded/abc-def-uuid', 'embedded_dashboard'],
     ['/dashboard/123/', 'dashboard'],
     // slug is literally "embedded" - must not be treated as embedded
     ['/dashboard/embedded/', 'dashboard'],

--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -142,6 +142,31 @@ describe('logger middleware', () => {
     }
   });
 
+  const getSourceForPath = (href: string): string | undefined => {
+    const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
+      ...window.location,
+      href,
+    } as Location);
+    try {
+      (logger as Function)(mockStore)(next)(action);
+      jest.advanceTimersByTime(2000);
+      const { events } = postStub.mock.calls[0][0].postPayload;
+      return events[0].source;
+    } finally {
+      locationSpy.mockRestore();
+    }
+  };
+
+  test.each([
+    ['/dashboard/123/embedded/', 'embedded_dashboard'],
+    ['/embedded/abc-def-uuid/', 'embedded_dashboard'],
+    ['/dashboard/123/', 'dashboard'],
+    // slug is literally "embedded" - must not be treated as embedded
+    ['/dashboard/embedded/', 'dashboard'],
+  ])('classifies %s as source "%s"', (path, expectedSource) => {
+    expect(getSourceForPath(`http://localhost${path}`)).toBe(expectedSource);
+  });
+
   test('should debounce a few log requests to one', () => {
     (logger as Function)(mockStore)(next)(action);
     (logger as Function)(mockStore)(next)(action);

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -34,7 +34,11 @@ import type { DashboardInfo, DashboardLayoutState } from '../dashboard/types';
 import type { QueryEditor } from '../SqlLab/types';
 
 type LogEventSource =
-  'dashboard' | 'embedded_dashboard' | 'explore' | 'sqlLab' | 'slice';
+  | 'dashboard'
+  | 'embedded_dashboard'
+  | 'explore'
+  | 'sqlLab'
+  | 'slice';
 
 interface LogEventData {
   source?: LogEventSource;

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -136,6 +136,12 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
   delayThreshold: 1000,
 });
 
+// Embedded dashboards are served from `/dashboard/:idOrSlug/embedded/` and
+// `/embedded/:uuid/`. Matching these specific shapes avoids false positives
+// for regular dashboards (e.g. a dashboard whose slug is "embedded").
+const EMBEDDED_ROUTE_REGEX =
+  /\/dashboard\/[^/]+\/embedded\/|\/embedded\/[^/]+\//;
+
 let lastEventId: string | number = 0;
 
 const loggerMiddleware: Middleware<
@@ -167,7 +173,10 @@ const loggerMiddleware: Middleware<
     }
     const path = navPath || window?.location?.href;
 
-    const isEmbedded = path?.includes('/embedded/');
+    // Match the actual embedded route patterns (`/dashboard/:idOrSlug/embedded/`
+    // and `/embedded/:uuid/`) rather than any URL containing "/embedded/", which
+    // would misclassify a regular dashboard whose slug is "embedded".
+    const isEmbedded = EMBEDDED_ROUTE_REGEX.test(path ?? '');
     if (dashboardInfo?.id && (path?.includes('/dashboard/') || isEmbedded)) {
       logMetadata = {
         source: isEmbedded ? 'embedded_dashboard' : 'dashboard',

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -34,11 +34,7 @@ import type { DashboardInfo, DashboardLayoutState } from '../dashboard/types';
 import type { QueryEditor } from '../SqlLab/types';
 
 type LogEventSource =
-  | 'dashboard'
-  | 'embedded_dashboard'
-  | 'explore'
-  | 'sqlLab'
-  | 'slice';
+  'dashboard' | 'embedded_dashboard' | 'explore' | 'sqlLab' | 'slice';
 
 interface LogEventData {
   source?: LogEventSource;

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -33,7 +33,12 @@ import { ensureAppRoot } from '../utils/pathUtils';
 import type { DashboardInfo, DashboardLayoutState } from '../dashboard/types';
 import type { QueryEditor } from '../SqlLab/types';
 
-type LogEventSource = 'dashboard' | 'explore' | 'sqlLab' | 'slice';
+type LogEventSource =
+  | 'dashboard'
+  | 'embedded_dashboard'
+  | 'explore'
+  | 'sqlLab'
+  | 'slice';
 
 interface LogEventData {
   source?: LogEventSource;
@@ -99,7 +104,7 @@ const sendBeacon = (events: LogEventData[]): void => {
   const [firstEvent] = events;
   const { source, source_id } = firstEvent;
   // backend logs treat these request params as first-class citizens
-  if (source === 'dashboard') {
+  if (source === 'dashboard' || source === 'embedded_dashboard') {
     endpoint += `&dashboard_id=${source_id}`;
   } else if (source === 'slice') {
     endpoint += `&slice_id=${source_id}`;
@@ -162,9 +167,10 @@ const loggerMiddleware: Middleware<
     }
     const path = navPath || window?.location?.href;
 
-    if (dashboardInfo?.id && path?.includes('/dashboard/')) {
+    const isEmbedded = path?.includes('/embedded/');
+    if (dashboardInfo?.id && (path?.includes('/dashboard/') || isEmbedded)) {
       logMetadata = {
-        source: 'dashboard',
+        source: isEmbedded ? 'embedded_dashboard' : 'dashboard',
         source_id: dashboardInfo.id,
         dashboard_id: dashboardInfo.id,
         ...logMetadata,

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -140,7 +140,7 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
 // `/embedded/:uuid/`. Matching these specific shapes avoids false positives
 // for regular dashboards (e.g. a dashboard whose slug is "embedded").
 const EMBEDDED_ROUTE_REGEX =
-  /\/dashboard\/[^/]+\/embedded\/|\/embedded\/[^/]+\//;
+  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
 
 let lastEventId: string | number = 0;
 


### PR DESCRIPTION
### SUMMARY

Cherry-picks #40083 (add event logging for embedded Superset) into the 6.1 branch.

This also includes the follow-up fix from #41942, which refines the embedded-dashboard detection in `loggerMiddleware`. The original check classified events by testing whether the URL contained the substring `/embedded/`, which was too broad: a regular dashboard whose slug is literally `embedded` (URL `/dashboard/embedded/`) also contains `/embedded/`, so its events were incorrectly tagged with `source: 'embedded_dashboard'` instead of `source: 'dashboard'`.

The substring check is replaced with a regular expression that matches only the actual embedded route shapes:

- `/dashboard/:idOrSlug/embedded/`
- `/embedded/:uuid/`

As a result, regular dashboard events are no longer misclassified as embedded, while genuine embedded routes continue to be detected correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal event-logging metadata change only.

### TESTING INSTRUCTIONS

Unit tests in `superset-frontend/src/middleware/logger.test.ts` cover source classification across paths:

- `/dashboard/123/embedded/` -> `embedded_dashboard`
- `/embedded/abc-def-uuid/` -> `embedded_dashboard`
- `/dashboard/123/` -> `dashboard`
- `/dashboard/embedded/` (slug is literally `embedded`) -> `dashboard`

Run:

```bash
cd superset-frontend
npm run test -- src/middleware/logger.test.ts
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
