### PR TITLE
fix(versioning): preserve complete multi-flush history

### DIFF
--- a/superset/versioning/changes/listener.py
+++ b/superset/versioning/changes/listener.py
@@ -16,30 +16,11 @@
 # under the License.
 """Session-level listeners that drive ``version_changes`` writes.
 
-Two flush events cooperate, plus two post-commit / post-rollback
-cleanups:
-
-- ``before_flush``: for each versioned entity in ``session.dirty``,
-  reads the pre-save scalar state from the DB via raw SQL inside
-  ``session.no_autoflush`` (same idiom as the baseline listener, not
-  Continuum's internal ``units_of_work`` which is a private API), reads
-  the post-save state from the in-memory ORM object, calls the diff
-  engine, and buffers the resulting :class:`ChangeRecord` list on
-  ``session.info``. This must run before the flush because after the
-  flush the DB already reflects the post-state; we can't recover the
-  pre-state from it.
-
-- ``after_flush``: drains the buffer, resolves the current Continuum
-  transaction id via ``versioning_manager.units_of_work``, and bulk-
-  inserts one ``version_changes`` row per record with a monotonic
-  ``sequence`` number. Records accumulated across multiple before_flush
-  calls within one transaction share the same ``transaction_id`` and
-  contiguous sequence numbers.
-
-- ``after_commit`` / ``after_rollback``: clean up session-scoped
-  state (processed-tx set, ``action_kind`` / ``action_meta`` keys, and
-  the pending-records buffer) so a long-lived session doesn't carry any
-  of it into the next transaction.
+The listeners retain each entity's first pre-flush state, force the final
+flush from ``before_commit``, and write one net initial-to-final semantic
+projection for the Continuum transaction. Completion of the outer transaction
+clears all session-scoped state so long-lived sessions cannot leak versioning
+intent.
 
 Scope:
   - Slice, Dashboard, SqlaTable **scalar fields** (via the cached
@@ -51,8 +32,8 @@ Scope:
 Child-collection diffs (dataset ``TableColumn`` / ``SqlMetric``,
 dashboard ``dashboard_slices``) read the pre- and post-state from
 Continuum shadow tables via the helpers in
-:mod:`superset.versioning.changes.shadow_queries`, executed in
-``after_flush`` once Continuum has written its tx-N rows.
+:mod:`superset.versioning.changes.shadow_queries`, executed during commit
+finalization after the explicit final flush has written Continuum's tx-N rows.
 
 ``session.new`` entities are not processed in this listener:
 operation_type=0 transactions (baseline capture and first-save INSERTs)
@@ -67,7 +48,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy import event
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, SessionTransaction
 
 from superset.versioning.changes.shadow_queries import (
     _dashboard_child_records_for_tx_from_shadows,
@@ -75,7 +56,8 @@ from superset.versioning.changes.shadow_queries import (
 )
 from superset.versioning.changes.state import (
     bulk_insert_records,
-    compute_records_for_entity,
+    capture_initial_state,
+    compute_records_from_state,
 )
 from superset.versioning.changes.table import ENTITY_KIND_BY_CLASS_NAME
 from superset.versioning.diff import (
@@ -86,20 +68,9 @@ from superset.versioning.diff import (
 logger = logging.getLogger(__name__)
 
 
-# Key under which the pending-records buffer is stored on ``session.info``.
-# Using ``session.info`` (SQLAlchemy's user-data dict) avoids the need
-# for a module-level WeakKeyDictionary and keeps buffers naturally scoped
-# to the session's lifetime.
-_BUFFER_KEY = "_version_changes_pending"
-
-# Key for the set of Continuum transaction ids whose change records
-# have already been written in this session. ``after_flush`` can fire
-# more than once for a single transaction (e.g. autoflush triggered by
-# a mid-commit query), and our child-diff path reads snapshot tables
-# that don't care about the buffer state — without this marker we'd
-# re-insert the same child records on the second flush and hit the
-# UNIQUE(transaction_id, entity_kind, entity_id, sequence) constraint.
-_PROCESSED_TXS_KEY = "_version_changes_processed_txs"
+# Keys for transaction-scoped state stored on ``session.info``.
+_INITIAL_STATES_KEY = "_version_changes_initial_states"
+_FINALIZING_KEY = "_version_changes_finalizing"
 
 # Key on ``session.info`` that commands set to declare the high-level
 # action that produced the current transaction. Read once per flush by
@@ -112,8 +83,8 @@ _PROCESSED_TXS_KEY = "_version_changes_processed_txs"
 #     db.session.info[ACTION_KIND_KEY] = ACTION_KIND_RESTORE
 #     db.session.commit()
 #
-# The listener pops the key after stamping, and ``after_commit`` /
-# ``after_rollback`` cleanup pop it again as a safety net, so a
+# The listener pops the key after stamping, and outer-transaction cleanup pops
+# it again as a safety net, so a
 # long-lived session can't accidentally carry the value into the next
 # transaction.
 ACTION_KIND_KEY = "_versioning_action_kind"
@@ -199,29 +170,59 @@ def build_action_headline(
 _REGISTERED_SENTINEL = "_versioning_change_listener_registered"
 
 
-def _process_dirty_entity_into_buffer(
+def _capture_dirty_entity_initial_state(
     session: Session,
     obj: Any,
-    buffer: dict[tuple[str, int], list[ChangeRecord]],
+    initial_states: dict[tuple[str, int], tuple[Any, dict[str, Any]]],
 ) -> None:
-    """Compute scalar change records for one dirty entity + append to buffer."""
+    """Retain one dirty entity's first database state for this transaction."""
     entity_kind = ENTITY_KIND_BY_CLASS_NAME.get(type(obj).__name__)
     if entity_kind is None:
         return
     entity_id = getattr(obj, "id", None)
     if entity_id is None:
         return
-    try:
-        records = compute_records_for_entity(session, obj)
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "version_changes: diff failed for %s id=%s",
-            type(obj).__name__,
-            entity_id,
-        )
+    key = (entity_kind, entity_id)
+    if key in initial_states:
         return
-    if records:
-        buffer.setdefault((entity_kind, entity_id), []).extend(records)
+    if (pre_state := capture_initial_state(session, obj)) is not None:
+        initial_states[key] = (obj, pre_state)
+
+
+def _build_scalar_buffer(
+    initial_states: dict[tuple[str, int], tuple[Any, dict[str, Any]]],
+) -> dict[tuple[str, int], list[ChangeRecord]]:
+    """Build net scalar records from retained initial and final entity states."""
+    buffer: dict[tuple[str, int], list[ChangeRecord]] = {}
+    for key, (obj, pre_state) in initial_states.items():
+        try:
+            records = compute_records_from_state(obj, pre_state)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "version_changes: final diff failed for %s id=%s",
+                type(obj).__name__,
+                key[1],
+            )
+            continue
+        if records:
+            buffer[key] = records
+    return buffer
+
+
+def _reset_transaction_state(session: Session) -> None:
+    """Discard versioning intent and retained state after a terminal event."""
+    session.info.pop(ACTION_KIND_KEY, None)
+    session.info.pop(ACTION_META_KEY, None)
+    session.info.pop(_INITIAL_STATES_KEY, None)
+    session.info.pop(_FINALIZING_KEY, None)
+
+
+def _reset_after_outer_transaction(
+    session: Session, transaction: SessionTransaction
+) -> None:
+    """Clear retained state only when the outer transaction has ended."""
+    if transaction.parent is None:
+        _reset_transaction_state(session)
 
 
 def _append_child_records_to_buffer(
@@ -231,8 +232,8 @@ def _append_child_records_to_buffer(
 ) -> None:
     """Compute dataset + dashboard child-collection records + append to buffer.
 
-    Runs in ``after_flush`` so the shadow tables already have the
-    current-tx rows. Reads from Continuum shadow tables
+    Runs during commit finalization after the explicit final flush, so the
+    shadow tables already have the current-tx rows. Reads from Continuum shadow tables
     (``table_columns_version`` / ``sql_metrics_version`` /
     ``dashboard_slices_version`` / ``slices_version``).
     """
@@ -280,17 +281,10 @@ def _inject_action_meta_record(
     """Pop ``ACTION_META_KEY`` and prepend its synthetic headline record
     to the owning entity's buffer (the ``__meta__`` record convention).
 
-    No-op when no command set the key — and, critically, no-op WITHOUT
-    popping when the buffer is empty: the buffer-empty short-circuit in
-    ``flush_change_records`` exists so a multi-flush transaction can
-    deliver its records on a later firing, and a headline-only buffer
-    would defeat it (the first firing would persist just the headline,
-    mark the tx processed, and the later flush's real records would be
-    silently dropped). Leaving the key in place parks the headline until
-    the record-bearing firing. Prepended (not appended) so the headline
-    gets ``sequence`` 0 and renders first. Malformed payloads are logged
-    and dropped — a headline is descriptive enrichment, never worth
-    failing the user's save over.
+    No-op when no command set the key and, critically, does not pop when the
+    final buffer is empty. Prepended rather than appended so the headline gets
+    ``sequence`` 0 and renders first. Malformed payloads are logged and dropped:
+    a headline is descriptive enrichment, never worth failing the user's save.
     """
     if not buffer:
         return
@@ -379,7 +373,7 @@ def _persist_buffered_records(
 
 
 def register_change_record_listener() -> None:  # noqa: C901
-    """Attach the before_flush + after_flush listeners.
+    """Attach transaction-scoped version-change listeners.
 
     Registered from :class:`superset.initialization.SupersetAppInitializer`
     (``init_versioning``) alongside the baseline, dataset-snapshot,
@@ -398,110 +392,42 @@ def register_change_record_listener() -> None:  # noqa: C901
 
     versioned_classes: tuple[type, ...] = (Dashboard, Slice, SqlaTable)
 
-    def compute_change_records(
+    def capture_initial_states(
         session: Session, _flush_context: Any, _instances: Any
     ) -> None:
-        # session.info persists across before_flush/after_flush within
-        # a single transaction. The buffer is keyed on
-        # ``(entity_kind, entity_id)`` so scalar records captured here
-        # and child records captured in after_flush merge
-        # under the same entity without duplication.
-        buffer: dict[tuple[str, int], list[ChangeRecord]] = session.info.setdefault(
-            _BUFFER_KEY, {}
+        initial_states: dict[tuple[str, int], tuple[Any, dict[str, Any]]] = (
+            session.info.setdefault(_INITIAL_STATES_KEY, {})
         )
         for obj in list(session.dirty):
             if isinstance(obj, versioned_classes):
-                _process_dirty_entity_into_buffer(session, obj, buffer)
+                _capture_dirty_entity_initial_state(session, obj, initial_states)
 
-    def flush_change_records(session: Session, _flush_context: Any) -> None:
-        buffer: dict[tuple[str, int], list[ChangeRecord]] = session.info.setdefault(
-            _BUFFER_KEY, {}
-        )
-
-        tx_id = _current_transaction_id(session)
-        if tx_id is None:
-            session.info[_BUFFER_KEY] = {}
+    def finalize_change_records(session: Session) -> None:
+        if session.in_nested_transaction() or session.info.get(_FINALIZING_KEY):
             return
 
-        # Skip if we've already written records for this tx (after_flush
-        # can fire more than once per commit — e.g. autoflush from a
-        # mid-commit query). Without this guard the child-diff path would
-        # re-read the same shadow rows and re-emit the same records,
-        # tripping the UNIQUE(transaction_id, entity_kind, entity_id,
-        # sequence) constraint on insert.
-        processed: set[int] = session.info.setdefault(_PROCESSED_TXS_KEY, set())
-        if tx_id in processed:
-            # Drop anything buffered after the tx was persisted: records
-            # left here would otherwise survive on the long-lived scoped
-            # session and be inserted under the NEXT transaction's id.
-            session.info[_BUFFER_KEY] = {}
-            return
-
-        # Stamp action_kind eagerly, before the buffer-empty short-
-        # circuit. Restores / imports / clones may flush across multiple
-        # cycles; the FIRST firing for this tx is the one with the
-        # value still on ``session.info``. The helper pops on success
-        # so subsequent firings see ``None`` and short-circuit cleanly.
-        _stamp_action_kind_on_transaction(session, tx_id)
-
-        _append_child_records_to_buffer(session, tx_id, buffer)
-
-        # After the child append and before the emptiness check: the
-        # headline joins whichever firing carries the transaction's real
-        # records (scalar or child), and its peek-don't-pop guard parks
-        # it across record-less firings instead of defeating the
-        # multi-flush short-circuit below.
-        _inject_action_meta_record(session, buffer)
-
-        if not buffer:
-            # Don't mark tx as processed when nothing was inserted. A
-            # later after_flush firing for the same tx may carry the
-            # records — e.g. when an entity's edit lands across two
-            # flushes (a child-only flush followed by a parent-dirty
-            # flush): the parent shadow only lands in the parent-dirty
-            # flush, so the child-diff path can't find a prior tx to
-            # compare against until then.
-            session.info[_BUFFER_KEY] = {}
-            return
-
+        session.info[_FINALIZING_KEY] = True
         try:
-            _persist_buffered_records(session, tx_id, buffer)
+            session.flush()
+            initial_states: dict[tuple[str, int], tuple[Any, dict[str, Any]]] = (
+                session.info.get(_INITIAL_STATES_KEY, {})
+            )
+            buffer = _build_scalar_buffer(initial_states)
+
+            tx_id = _current_transaction_id(session)
+            if tx_id is None:
+                return
+
+            _stamp_action_kind_on_transaction(session, tx_id)
+            _append_child_records_to_buffer(session, tx_id, buffer)
+            _inject_action_meta_record(session, buffer)
+
+            if buffer:
+                _persist_buffered_records(session, tx_id, buffer)
         finally:
-            session.info[_BUFFER_KEY] = {}
-            processed.add(tx_id)
+            session.info.pop(_FINALIZING_KEY, None)
 
-    def reset_processed_after_commit(session: Session) -> None:
-        # ``_PROCESSED_TXS_KEY`` accumulates Continuum tx ids whose change
-        # records have already been written, to dedup against multiple
-        # ``after_flush`` firings within one transaction. After commit
-        # the tx is closed and its id will never recur on this session
-        # — drop the set so a long-lived session (Celery worker, CLI)
-        # doesn't grow it without bound.
-        session.info.pop(_PROCESSED_TXS_KEY, None)
-        # If a command set the action_kind but no flush fired (e.g. a
-        # save that touched nothing versioned), the value would
-        # otherwise leak into the next transaction. Drop it here as a
-        # belt-and-suspenders cleanup; the
-        # ``_stamp_action_kind_on_transaction`` helper already pops on
-        # the normal path.
-        session.info.pop(ACTION_KIND_KEY, None)
-        session.info.pop(ACTION_META_KEY, None)
-        session.info.pop(_BUFFER_KEY, None)
-
-    def reset_action_kind_after_rollback(session: Session) -> None:
-        # When a command sets ``ACTION_KIND_KEY`` and then an exception
-        # fires before flush (e.g. validation error after the key is
-        # set), the transaction rolls back without the listener ever
-        # popping the key. The next save on the same session would
-        # then inherit the stale value and label an unrelated commit
-        # as "restore" / "import" / "clone". Pop here so a rolled-back
-        # action's intent doesn't leak forward.
-        session.info.pop(ACTION_KIND_KEY, None)
-        session.info.pop(ACTION_META_KEY, None)
-        session.info.pop(_BUFFER_KEY, None)
-
-    event.listen(db.session, "before_flush", compute_change_records)
-    event.listen(db.session, "after_flush", flush_change_records)
-    event.listen(db.session, "after_commit", reset_processed_after_commit)
-    event.listen(db.session, "after_rollback", reset_action_kind_after_rollback)
+    event.listen(db.session, "before_flush", capture_initial_states)
+    event.listen(db.session, "before_commit", finalize_change_records)
+    event.listen(db.session, "after_transaction_end", _reset_after_outer_transaction)
     setattr(db.session, _REGISTERED_SENTINEL, True)

--- a/superset/versioning/changes/state.py
+++ b/superset/versioning/changes/state.py
@@ -24,7 +24,7 @@ Three concerns live here:
 2. **State capture** — :func:`_orm_to_post_state` serialises the
    in-memory ORM object; :func:`_read_pre_state` reads the corresponding
    pre-flush row directly from the DB inside ``session.no_autoflush``.
-3. **Diff dispatch** — :func:`compute_records_for_entity` routes to the
+3. **Diff dispatch** — :func:`compute_records_from_state` routes to the
    right :mod:`superset.versioning.diff` helper based on the model
    class name (string dispatch keeps this module free of hard imports
    on the three entity classes, which avoids import-order coupling at
@@ -156,36 +156,29 @@ def _read_pre_state(
     return {key: jsonable(value) for key, value in result.items()}
 
 
-def compute_records_for_entity(session: Session, obj: Any) -> list[ChangeRecord]:
-    """Diff the pre-state (from DB) against the post-state (in memory).
-
-    Dispatches to :func:`diff_slice` / :func:`diff_dashboard` /
-    :func:`diff_dataset` based on the model class name — string-based
-    dispatch is used to keep this module free of hard imports on the
-    three entity classes, which in turn avoids import-order coupling
-    at app-init time.
-    """
-    model_cls = type(obj)
+def capture_initial_state(session: Session, obj: Any) -> dict[str, Any] | None:
+    """Capture an entity's database state before its first transaction flush."""
     entity_id = getattr(obj, "id", None)
     if entity_id is None:
-        return []
-
+        return None
     try:
-        pre_state = _read_pre_state(session, model_cls, entity_id)
+        return _read_pre_state(session, type(obj), entity_id)
     except Exception:  # pylint: disable=broad-except
         logger.exception(
-            "version_changes: pre-state read failed for %s id=%s",
-            model_cls.__name__,
+            "version_changes: initial-state read failed for %s id=%s",
+            type(obj).__name__,
             entity_id,
         )
-        return []
+        return None
 
-    if pre_state is None:
-        return []
 
+def compute_records_from_state(
+    obj: Any, pre_state: dict[str, Any]
+) -> list[ChangeRecord]:
+    """Diff a retained transaction pre-state against an entity's final state."""
     post_state = _orm_to_post_state(obj)
+    model_cls = type(obj)
     fields = _cached_scalar_fields(model_cls)
-
     name = model_cls.__name__
     if name == "Slice":
         return diff_slice(pre_state, post_state, fields=fields)

--- a/tests/integration_tests/versioning/transaction_correctness_tests.py
+++ b/tests/integration_tests/versioning/transaction_correctness_tests.py
@@ -1,0 +1,224 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Transaction-level correctness tests for entity version history."""
+
+import pytest
+import sqlalchemy as sa
+
+from superset import db
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.slice import Slice
+from superset.utils import json
+from superset.versioning.changes.table import version_changes_table
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
+)
+
+
+def _latest_transaction_id() -> int:
+    """Return the latest semantic-history transaction boundary."""
+    return db.session.scalar(
+        sa.select(
+            sa.func.coalesce(sa.func.max(version_changes_table.c.transaction_id), 0)
+        )
+    )
+
+
+def _changes_for_chart(
+    chart_id: int, *, after_transaction_id: int
+) -> list[dict[str, object]]:
+    """Return ordered semantic changes captured for one chart."""
+    rows = db.session.execute(
+        sa.select(version_changes_table)
+        .where(version_changes_table.c.entity_kind == "chart")
+        .where(version_changes_table.c.entity_id == chart_id)
+        .where(version_changes_table.c.transaction_id > after_transaction_id)
+        .order_by(
+            version_changes_table.c.transaction_id,
+            version_changes_table.c.sequence,
+        )
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def _changes_for_dataset(
+    dataset_id: int, *, after_transaction_id: int
+) -> list[dict[str, object]]:
+    """Return ordered semantic changes captured for one dataset."""
+    rows = db.session.execute(
+        sa.select(version_changes_table)
+        .where(version_changes_table.c.entity_kind == "dataset")
+        .where(version_changes_table.c.entity_id == dataset_id)
+        .where(version_changes_table.c.transaction_id > after_transaction_id)
+        .order_by(
+            version_changes_table.c.transaction_id,
+            version_changes_table.c.sequence,
+        )
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+class TestVersionHistoryTransactionCorrectness(SupersetTestCase):
+    """Verify semantic projections span every flush in one transaction."""
+
+    @staticmethod
+    def _chart(name: str) -> Slice:
+        chart = db.session.query(Slice).filter(Slice.slice_name == name).one()
+        db.session.commit()
+        return chart
+
+    def test_same_entity_multiple_flushes_produce_one_net_change(self) -> None:
+        """Only the initial-to-final scalar transition is materialized."""
+        chart = self._chart("Girls")
+        chart_id = chart.id
+        boundary = _latest_transaction_id()
+        try:
+            chart.slice_name = "Girls intermediate"
+            db.session.flush()
+            chart.slice_name = "Girls final"
+            db.session.commit()
+
+            changes = _changes_for_chart(chart_id, after_transaction_id=boundary)
+            name_changes = [row for row in changes if row["path"] == ["slice_name"]]
+            assert len(name_changes) == 1
+            assert name_changes[0]["from_value"] == "Girls"
+            assert name_changes[0]["to_value"] == "Girls final"
+        finally:
+            chart = db.session.get(Slice, chart_id)
+            assert chart is not None
+            chart.slice_name = "Girls"
+            db.session.commit()
+
+    def test_different_entities_across_flushes_share_complete_history(self) -> None:
+        """A later entity flush is not discarded from the transaction."""
+        girls = self._chart("Girls")
+        boys = self._chart("Boys")
+        boundary = _latest_transaction_id()
+        try:
+            girls.slice_name = "Girls transaction edit"
+            db.session.flush()
+            boys.slice_name = "Boys transaction edit"
+            db.session.commit()
+
+            girls_changes = [
+                row
+                for row in _changes_for_chart(girls.id, after_transaction_id=boundary)
+                if row["to_value"] == "Girls transaction edit"
+            ]
+            boys_changes = [
+                row
+                for row in _changes_for_chart(boys.id, after_transaction_id=boundary)
+                if row["to_value"] == "Boys transaction edit"
+            ]
+            assert len(girls_changes) == 1
+            assert len(boys_changes) == 1
+            assert (
+                girls_changes[0]["transaction_id"] == boys_changes[0]["transaction_id"]
+            )
+        finally:
+            girls.slice_name = "Girls"
+            boys.slice_name = "Boys"
+            db.session.commit()
+
+    def test_return_to_initial_state_produces_no_duplicate_change(self) -> None:
+        """Intermediate-only edits disappear from the net projection."""
+        chart = self._chart("Girls")
+        boundary = _latest_transaction_id()
+        chart.slice_name = "Girls temporary"
+        db.session.flush()
+        chart.slice_name = "Girls"
+        db.session.commit()
+
+        assert not [
+            row
+            for row in _changes_for_chart(chart.id, after_transaction_id=boundary)
+            if row["path"] == ["slice_name"]
+        ]
+
+    def test_child_changes_across_flushes_use_final_shadow_state(self) -> None:
+        """A child-only edit projects the final child state on its parent."""
+        dataset = (
+            db.session.query(SqlaTable)
+            .filter(SqlaTable.table_name == "birth_names")
+            .first()
+        )
+        assert dataset is not None
+        assert dataset.columns
+        column = dataset.columns[0]
+        original = column.description
+        db.session.commit()
+        boundary = _latest_transaction_id()
+        try:
+            column.description = "intermediate child description"
+            db.session.flush()
+            column.description = "final child description"
+            db.session.commit()
+
+            serialized = json.dumps(
+                _changes_for_dataset(dataset.id, after_transaction_id=boundary)
+            )
+            assert "final child description" in serialized
+            assert "intermediate child description" not in serialized
+        finally:
+            column.description = original
+            db.session.commit()
+
+    def _assert_nested_transaction_preserves_outer_initial_state(
+        self, nested_outcome: str
+    ) -> None:
+        """SAVEPOINT completion does not clear the outer transaction registry."""
+        chart = self._chart("Girls")
+        chart_id = chart.id
+        boundary = _latest_transaction_id()
+        try:
+            chart.slice_name = "Girls outer edit"
+            db.session.flush()
+
+            nested = db.session.begin_nested()
+            chart.slice_name = "Girls nested edit"
+            db.session.flush()
+            getattr(nested, nested_outcome)()
+            db.session.commit()
+
+            changes = [
+                row
+                for row in _changes_for_chart(chart_id, after_transaction_id=boundary)
+                if row["path"] == ["slice_name"]
+            ]
+            assert len(changes) == 1
+            assert changes[0]["from_value"] == "Girls"
+            assert changes[0]["to_value"] == (
+                "Girls nested edit"
+                if nested_outcome == "commit"
+                else "Girls outer edit"
+            )
+        finally:
+            chart = db.session.get(Slice, chart_id)
+            assert chart is not None
+            chart.slice_name = "Girls"
+            db.session.commit()
+
+    def test_nested_commit_preserves_outer_initial_state(self) -> None:
+        """Committing a SAVEPOINT keeps the outer transaction registry."""
+        self._assert_nested_transaction_preserves_outer_initial_state("commit")
+
+    def test_nested_rollback_preserves_outer_initial_state(self) -> None:
+        """Rolling back a SAVEPOINT keeps the outer transaction registry."""
+        self._assert_nested_transaction_preserves_outer_initial_state("rollback")

--- a/tests/unit_tests/versioning/test_listener.py
+++ b/tests/unit_tests/versioning/test_listener.py
@@ -1,0 +1,204 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for version-change listener transaction lifecycle behavior."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+from superset.versioning.changes import listener
+from superset.versioning.diff import ChangeRecord
+
+Base: Any = sa.orm.declarative_base()
+
+
+class LifecycleRow(Base):
+    """Minimal row used to characterize SQLAlchemy session events."""
+
+    __tablename__ = "versioning_listener_lifecycle"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    value = sa.Column(sa.String, nullable=False)
+
+
+@pytest.fixture
+def lifecycle_session() -> Iterator[Session]:
+    """Yield an isolated SQLAlchemy session backed by in-memory SQLite."""
+    engine = sa.create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_before_commit_can_force_final_flush_without_reentry(
+    lifecycle_session: Session,
+) -> None:
+    """A before-commit finalizer can flush once before commit preparation."""
+    events: list[str] = []
+
+    @sa.event.listens_for(lifecycle_session, "before_flush")
+    def before_flush(
+        _session: Session, _flush_context: object, _instances: object
+    ) -> None:
+        events.append("before_flush")
+
+    @sa.event.listens_for(lifecycle_session, "after_flush")
+    def after_flush(_session: Session, _flush_context: object) -> None:
+        events.append("after_flush")
+
+    @sa.event.listens_for(lifecycle_session, "before_commit")
+    def before_commit(session: Session) -> None:
+        events.append("before_commit:start")
+        session.flush()
+        events.append("before_commit:end")
+
+    lifecycle_session.add(LifecycleRow(value="saved"))
+    lifecycle_session.commit()
+
+    assert events == [
+        "before_commit:start",
+        "before_flush",
+        "after_flush",
+        "before_commit:end",
+    ]
+
+
+def test_before_commit_with_no_work_does_not_flush(
+    lifecycle_session: Session,
+) -> None:
+    """A no-work commit invokes the finalizer without a flush cycle."""
+    events: list[str] = []
+
+    @sa.event.listens_for(lifecycle_session, "before_flush")
+    def before_flush(
+        _session: Session, _flush_context: object, _instances: object
+    ) -> None:
+        events.append("before_flush")
+
+    @sa.event.listens_for(lifecycle_session, "before_commit")
+    def before_commit(session: Session) -> None:
+        events.append("before_commit")
+        session.flush()
+
+    lifecycle_session.commit()
+
+    assert events == ["before_commit"]
+
+
+def test_rollback_event_can_clear_transaction_state(
+    lifecycle_session: Session,
+) -> None:
+    """Rollback cleanup runs while session-scoped state is still accessible."""
+    state_key = "_versioning_test_state"
+    lifecycle_session.info[state_key] = {"pending": True}
+
+    @sa.event.listens_for(lifecycle_session, "after_rollback")
+    def after_rollback(session: Session) -> None:
+        session.info.pop(state_key, None)
+
+    lifecycle_session.add(LifecycleRow(value="rolled back"))
+    lifecycle_session.flush()
+    lifecycle_session.rollback()
+
+    assert state_key not in lifecycle_session.info
+
+
+def test_capture_retains_the_first_pre_flush_state(
+    lifecycle_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated flushes retain the entity's initial database state once."""
+
+    class Slice:
+        id = 7
+
+    entity = Slice()
+    initial = {"slice_name": "initial"}
+    captures: list[object] = []
+
+    def capture(_session: Session, obj: object) -> dict[str, str]:
+        captures.append(obj)
+        return initial
+
+    monkeypatch.setattr(listener, "capture_initial_state", capture)
+    states: dict[tuple[str, int], tuple[object, dict[str, object]]] = {}
+
+    listener._capture_dirty_entity_initial_state(lifecycle_session, entity, states)
+    listener._capture_dirty_entity_initial_state(lifecycle_session, entity, states)
+
+    assert states == {("chart", 7): (entity, initial)}
+    assert captures == [entity]
+
+
+def test_scalar_buffer_materializes_one_final_net_diff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Final materialization diffs each retained entity exactly once."""
+    entity = object()
+    initial = {"slice_name": "initial"}
+    record = ChangeRecord(
+        kind="property",
+        operation="edit",
+        path=["slice_name"],
+        from_value="initial",
+        to_value="final",
+    )
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def compute(obj: object, pre_state: dict[str, object]) -> list[ChangeRecord]:
+        calls.append((obj, pre_state))
+        return [record]
+
+    monkeypatch.setattr(listener, "compute_records_from_state", compute)
+
+    buffer = listener._build_scalar_buffer({("chart", 7): (entity, initial)})
+
+    assert buffer == {("chart", 7): [record]}
+    assert calls == [(entity, initial)]
+
+
+@pytest.mark.parametrize("terminal_event", ["commit", "rollback"])
+def test_terminal_event_clears_transaction_state(
+    lifecycle_session: Session, terminal_event: str
+) -> None:
+    """Commit and rollback cleanup discard all transaction-scoped state."""
+    lifecycle_session.info.update(
+        {
+            listener.ACTION_KIND_KEY: "restore",
+            listener.ACTION_META_KEY: {"headline": "restored"},
+            listener._INITIAL_STATES_KEY: {("chart", 7): object()},
+            listener._FINALIZING_KEY: True,
+            "unrelated": "preserved",
+        }
+    )
+    sa.event.listen(
+        lifecycle_session,
+        "after_transaction_end",
+        listener._reset_after_outer_transaction,
+    )
+    lifecycle_session.add(LifecycleRow(value=terminal_event))
+    lifecycle_session.flush()
+
+    getattr(lifecycle_session, terminal_event)()
+
+    assert lifecycle_session.info == {"unrelated": "preserved"}


### PR DESCRIPTION
### SUMMARY

Preserves complete semantic version history when one SQLAlchemy transaction flushes an entity more than once.

The listener retains each entity initial database state, performs an explicit final flush from before_commit, and materializes one initial-to-final projection for the Continuum transaction. Transaction-scoped state is cleared only after the outermost transaction ends, so SAVEPOINT commit and rollback cannot discard outer history.

Also scopes regression assertions to transactions created by each test.

Shortcut: [sc-112938](https://app.shortcut.com/preset/story/112938)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend-only correctness fix.

### TESTING INSTRUCTIONS

Run:

    docker compose -f docker-compose-light.yml --profile test run --rm pytest-runner pytest -q tests/unit_tests/versioning/test_listener.py tests/unit_tests/versioning/test_diff_caps.py

Run integration regressions:

    docker compose -f docker-compose-light.yml --profile test run --rm pytest-runner pytest -q tests/integration_tests/versioning/transaction_correctness_tests.py tests/integration_tests/versioning/capture_disabled_tests.py tests/integration_tests/versioning/snapshot_projection_tests.py tests/integration_tests/versioning/versions_api_tests.py

Observed locally: 15 unit tests and 22 integration tests passed. Focused pre-commit passed. The repository-wide mypy hook also reports five pre-existing errors in docker/pythonpath_dev/superset_config_docker.py and tests/unit_tests/semantic_layers/mapper_test.py; this patch adds none.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Shortcut sc-112938
- [x] Required feature flags: ENTITY_VERSIONING
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API