### PR TITLE
fix(versioning): make baseline capture atomic

### DIFF
--- a/superset/versioning/baseline/insertion.py
+++ b/superset/versioning/baseline/insertion.py
@@ -48,16 +48,23 @@ logger = logging.getLogger(__name__)
 def insert_baseline_and_children(
     session: Session, obj: Any, version_table: Any
 ) -> None:
-    """Insert the parent baseline row, then baseline the parent's child
-    collections under the same transaction id.
+    """Insert one atomic baseline for a parent and its children.
 
     Wrapped in ``no_autoflush`` so ``session.connection()`` inside
     ``_insert_baseline_row`` does not trigger a flush of Continuum's
     pending Transaction object before our direct-SQL insert claims its
-    tx_id.
+    tx_id. A connection-level SAVEPOINT is required because this helper runs
+    inside ``before_flush``, where ``Session.begin_nested()`` would flush
+    recursively. One SAVEPOINT contains the transaction row, parent shadow,
+    and every child shadow so optional baseline capture is all-or-nothing and
+    a failed PostgreSQL statement cannot poison the user's transaction.
+
+    Continuum runs later in the same ``before_flush`` listener chain. The
+    PostgreSQL failure tests assert that releasing or rolling back this
+    SAVEPOINT preserves Continuum's canonical update shadow and transaction.
     """
     try:
-        with session.no_autoflush:
+        with session.no_autoflush, session.connection().begin_nested():
             tx_id = _insert_baseline_row(session, obj, version_table)
             if tx_id is None:
                 return
@@ -132,18 +139,12 @@ def _baseline_children_for_parent(
 
     Dispatches via the
     :data:`~superset.versioning.baseline.children.CHILD_BASELINE_HANDLERS`
-    table to per-entity handlers. A handler failure is logged but does
-    not block the parent baseline.
+    table to per-entity handlers. Handler failures propagate to
+    :func:`insert_baseline_and_children`, which rolls back the complete
+    optional baseline unit before logging the failure.
     """
     parent_name = type(parent_obj).__name__
     handler = CHILD_BASELINE_HANDLERS.get(parent_name)
     if handler is None:
         return
-    try:
-        handler(session, parent_obj, tx_id)
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "baseline_listener: failed to baseline children of %s id=%s",
-            parent_name,
-            getattr(parent_obj, "id", None),
-        )
+    handler(session, parent_obj, tx_id)

--- a/tests/integration_tests/versioning/conftest.py
+++ b/tests/integration_tests/versioning/conftest.py
@@ -65,7 +65,8 @@ def _assert_table_list_covers_schema() -> None:
     )
 
 
-def _clear_version_tables() -> None:
+def clear_version_tables() -> None:
+    """Delete all entity-versioning capture rows and commit the cleanup."""
     with app.app_context():
         _assert_table_list_covers_schema()
         for table in _VERSION_TABLES:
@@ -88,6 +89,6 @@ def clean_version_tables() -> Iterator[None]:
     Table names are interpolated from the fixed ``_VERSION_TABLES`` tuple, not
     from any test input, so the ``DELETE`` is not an injection surface.
     """
-    _clear_version_tables()
+    clear_version_tables()
     yield
-    _clear_version_tables()
+    clear_version_tables()

--- a/tests/integration_tests/versioning/versions_api_tests.py
+++ b/tests/integration_tests/versioning/versions_api_tests.py
@@ -28,9 +28,13 @@ The suite runs with ``ENABLE_VERSIONING_CAPTURE=True`` (see
 autouse fixture clears the version tables around each test.
 """
 
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import Session
 
 from superset import db
 from superset.connectors.sqla.models import SqlaTable
@@ -43,6 +47,7 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
 )
+from tests.integration_tests.versioning.conftest import clear_version_tables
 
 # A syntactically valid UUID that matches no entity / version.
 MISSING_UUID = str(uuid4())
@@ -202,6 +207,73 @@ class TestChartVersionsApi(SupersetTestCase):
         finally:
             self.client.put(f"/api/v1/chart/{chart_id}", json={"slice_name": "Girls"})
 
+    def test_parent_baseline_sql_failure_does_not_break_save(self) -> None:
+        """A failed optional parent baseline leaves the save committable."""
+        chart_id = self._girls_chart().id
+        clear_version_tables()
+        self.login(ADMIN_USERNAME)
+
+        def fail_parent_baseline(
+            conn: Connection, *args: object, **kwargs: object
+        ) -> None:
+            conn.execute(
+                sa.text("INSERT INTO __missing_parent_shadow__ (x) VALUES (1)")
+            )
+
+        try:
+            with patch(
+                "superset.versioning.baseline.insertion.insert_baseline_shadow_row",
+                side_effect=fail_parent_baseline,
+            ):
+                rv = self.client.put(
+                    f"/api/v1/chart/{chart_id}",
+                    json={"slice_name": "Girls survives parent baseline failure"},
+                )
+
+            assert rv.status_code == 200, rv.data
+            got = json.loads(self.client.get(f"/api/v1/chart/{chart_id}").data)[
+                "result"
+            ]
+            assert got["slice_name"] == "Girls survives parent baseline failure"
+            baseline_count = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM slices_version "
+                    "WHERE id = :id AND operation_type = 0"
+                ),
+                {"id": chart_id},
+            )
+            assert baseline_count == 0
+            canonical_updates = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM slices_version "
+                    "WHERE id = :id AND operation_type = 1 "
+                    "AND slice_name = :name"
+                ),
+                {
+                    "id": chart_id,
+                    "name": "Girls survives parent baseline failure",
+                },
+            )
+            assert canonical_updates == 1
+            assert (
+                db.session.scalar(sa.text("SELECT count(*) FROM version_transaction"))
+                == 1
+            )
+
+            listing = json.loads(
+                self.client.get(f"/api/v1/chart/{got['uuid']}/versions/").data
+            )
+            assert listing["count"] == 1
+            assert listing["result"][0]["operation_type"] == "update"
+
+            follow_up = self.client.put(
+                f"/api/v1/chart/{chart_id}",
+                json={"slice_name": "Girls session remains usable"},
+            )
+            assert follow_up.status_code == 200, follow_up.data
+        finally:
+            self.client.put(f"/api/v1/chart/{chart_id}", json={"slice_name": "Girls"})
+
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
 class TestDashboardVersionsApi(SupersetTestCase):
@@ -301,3 +373,86 @@ class TestDatasetVersionsApi(SupersetTestCase):
         body = json.loads(rv.data.decode("utf-8"))
         assert set(body) >= {"old_version", "new_version", "new_version_uuid"}
         assert body["new_version_uuid"] is not None
+
+    def test_child_baseline_sql_failure_rolls_back_complete_optional_unit(
+        self,
+    ) -> None:
+        """A child failure preserves the save without partial baseline rows."""
+        dataset = self._dataset()
+        dataset_id = dataset.id
+        original = dataset.description
+        clear_version_tables()
+        self.login(ADMIN_USERNAME)
+
+        def fail_children(session: Session, _parent: object, _tx_id: int) -> None:
+            session.connection().execute(
+                sa.text("INSERT INTO __missing_child_shadow__ (x) VALUES (1)")
+            )
+
+        try:
+            with patch.dict(
+                "superset.versioning.baseline.insertion.CHILD_BASELINE_HANDLERS",
+                {"SqlaTable": fail_children},
+            ):
+                rv = self.client.put(
+                    f"/api/v1/dataset/{dataset_id}",
+                    json={"description": "survives child baseline failure"},
+                )
+
+            assert rv.status_code == 200, rv.data
+            got = json.loads(self.client.get(f"/api/v1/dataset/{dataset_id}").data)[
+                "result"
+            ]
+            assert got["description"] == "survives child baseline failure"
+
+            parent_baselines = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM tables_version "
+                    "WHERE id = :id AND operation_type = 0"
+                ),
+                {"id": dataset_id},
+            )
+            child_baselines = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM table_columns_version "
+                    "WHERE table_id = :id AND operation_type = 0"
+                ),
+                {"id": dataset_id},
+            )
+            metric_baselines = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM sql_metrics_version "
+                    "WHERE table_id = :id AND operation_type = 0"
+                ),
+                {"id": dataset_id},
+            )
+            assert parent_baselines == 0
+            assert child_baselines == 0
+            assert metric_baselines == 0
+            canonical_updates = db.session.scalar(
+                sa.text(
+                    "SELECT count(*) FROM tables_version "
+                    "WHERE id = :id AND operation_type = 1 "
+                    "AND description = :description"
+                ),
+                {
+                    "id": dataset_id,
+                    "description": "survives child baseline failure",
+                },
+            )
+            assert canonical_updates == 1
+            assert (
+                db.session.scalar(sa.text("SELECT count(*) FROM version_transaction"))
+                == 1
+            )
+
+            listing = json.loads(
+                self.client.get(f"/api/v1/dataset/{got['uuid']}/versions/").data
+            )
+            assert listing["count"] == 1
+            assert listing["result"][0]["operation_type"] == "update"
+        finally:
+            self.client.put(
+                f"/api/v1/dataset/{dataset_id}",
+                json={"description": original},
+            )


### PR DESCRIPTION
### SUMMARY

Makes optional entity-version baseline capture genuinely fail-open and all-or-nothing.

A single SAVEPOINT now contains the synthetic baseline transaction row, parent shadow row, and every child shadow row. Child-handler failures propagate to that boundary so the complete optional baseline unit rolls back before the error is logged, while the outer user save remains committable.

This supersedes the parent-only approach in #41910, which was closed in favor of the broader parent/child atomicity work tracked by [sc-112938](https://app.shortcut.com/preset/story/112938).

#### Parent/child atomicity

The parent is the versioned entity baseline:

- Dataset: `tables_version`
- Dashboard: `dashboards_version`

Children are the related shadows required to reconstruct that entity:

- Dataset columns and metrics: `table_columns_version` and `sql_metrics_version`
- Dashboard/chart membership and required chart snapshots: `dashboard_slices_version` and `slices_version`

The atomic baseline unit is:

    version_transaction
    └── parent baseline shadow
        ├── child baseline shadow
        ├── child baseline shadow
        └── ...

If every optional write succeeds, the SAVEPOINT is released and the complete baseline remains. If any parent or child write fails, the SAVEPOINT removes the synthetic transaction, parent baseline, and every child baseline written so far. The actual user edit still commits with its normal canonical Continuum update history.

This prevents partial history such as a dataset baseline that exists without its column or metric baselines, which could make a later restore incomplete or incorrect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend transaction-safety fix.

### TESTING INSTRUCTIONS

Run the focused PostgreSQL failure cases:

    docker compose -f docker-compose-light.yml --profile test run --rm pytest-runner pytest -q tests/integration_tests/versioning/versions_api_tests.py -k "parent_baseline_sql_failure or child_baseline_sql_failure"

Run the complete baseline/capture regression set:

    docker compose -f docker-compose-light.yml --profile test run --rm pytest-runner pytest -q tests/integration_tests/versioning/capture_disabled_tests.py tests/integration_tests/versioning/snapshot_projection_tests.py tests/integration_tests/versioning/versions_api_tests.py

Observed locally: 2 fault-injection cases and 18 complete regression cases passed on PostgreSQL. The failure cases assert that canonical `operation_type=1` history and the versions API result survive rollback of the optional baseline.

GitHub CI passes on PostgreSQL, MySQL, and SQLite, including pre-commit.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Shortcut sc-112938
- [x] Required feature flags: ENABLE_VERSIONING_CAPTURE
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API