### PR TITLE
fix(event-log): match embedded routes precisely in logger middleware

### DIFF
--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -137,6 +137,31 @@ describe('logger middleware', () => {
     }
   });
 
+  const getSourceForPath = (href: string): string | undefined => {
+    const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
+      ...window.location,
+      href,
+    } as Location);
+    try {
+      (logger as Function)(mockStore)(next)(action);
+      jest.advanceTimersByTime(2000);
+      const { events } = postStub.mock.calls[0][0].postPayload;
+      return events[0].source;
+    } finally {
+      locationSpy.mockRestore();
+    }
+  };
+
+  test.each([
+    ['/dashboard/123/embedded/', 'embedded_dashboard'],
+    ['/embedded/abc-def-uuid/', 'embedded_dashboard'],
+    ['/dashboard/123/', 'dashboard'],
+    // slug is literally "embedded" - must not be treated as embedded
+    ['/dashboard/embedded/', 'dashboard'],
+  ])('classifies %s as source "%s"', (path, expectedSource) => {
+    expect(getSourceForPath(`http://localhost${path}`)).toBe(expectedSource);
+  });
+
   test('should debounce a few log requests to one', () => {
     (logger as Function)(mockStore)(next)(action);
     (logger as Function)(mockStore)(next)(action);

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -132,6 +132,12 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
   delayThreshold: 1000,
 });
 
+// Embedded dashboards are served from `/dashboard/:idOrSlug/embedded/` and
+// `/embedded/:uuid/`. Matching these specific shapes avoids false positives
+// for regular dashboards (e.g. a dashboard whose slug is "embedded").
+const EMBEDDED_ROUTE_REGEX =
+  /\/dashboard\/[^/]+\/embedded\/|\/embedded\/[^/]+\//;
+
 let lastEventId: string | number = 0;
 
 const loggerMiddleware: Middleware<
@@ -163,7 +169,10 @@ const loggerMiddleware: Middleware<
     }
     const path = navPath || window?.location?.href;
 
-    const isEmbedded = path?.includes('/embedded/');
+    // Match the actual embedded route patterns (`/dashboard/:idOrSlug/embedded/`
+    // and `/embedded/:uuid/`) rather than any URL containing "/embedded/", which
+    // would misclassify a regular dashboard whose slug is "embedded".
+    const isEmbedded = EMBEDDED_ROUTE_REGEX.test(path ?? '');
     if (dashboardInfo?.id && (path?.includes('/dashboard/') || isEmbedded)) {
       logMetadata = {
         source: isEmbedded ? 'embedded_dashboard' : 'dashboard',


### PR DESCRIPTION
### SUMMARY

This implements a suggestion raised by a review bot on [PR #41938](https://github.com/apache/superset/pull/41938).

The embedded-dashboard detection in `loggerMiddleware` classified events by checking whether the URL contained the substring `/embedded/`. That check is too broad: a regular dashboard whose slug is literally `embedded` (URL `/dashboard/embedded/`) also contains `/embedded/`, so its events were incorrectly tagged with `source: 'embedded_dashboard'` instead of `source: 'dashboard'`.

This replaces the generic substring check with a regular expression that matches only the actual embedded route shapes:

- `/dashboard/:idOrSlug/embedded/`
- `/embedded/:uuid/`

As a result, regular dashboard events are no longer misclassified as embedded, while genuine embedded routes continue to be detected correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal event-logging metadata change only.

### TESTING INSTRUCTIONS

Unit tests were added in `superset-frontend/src/middleware/logger.test.ts` covering source classification across paths:

- `/dashboard/123/embedded/` -> `embedded_dashboard`
- `/embedded/abc-def-uuid/` -> `embedded_dashboard`
- `/dashboard/123/` -> `dashboard`
- `/dashboard/embedded/` (slug is literally `embedded`) -> `dashboard`

Run:

```bash
cd superset-frontend
npm run test -- src/middleware/logger.test.ts
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
