### PR TITLE
fix(databricks): classify insufficient-permissions errors as 4xx

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
+from re import Pattern
 from typing import Any, Callable, cast, TYPE_CHECKING, TypedDict, Union
 
 from apispec import APISpec
@@ -55,6 +57,10 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+INSUFFICIENT_PERMISSIONS_REGEX: Pattern[str] = re.compile(
+    r"\[INSUFFICIENT_PERMISSIONS\]|SQLSTATE: 42501"
+)
 
 
 try:
@@ -500,6 +506,16 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
 
         for key, value in cls.context_key_mapping.items():
             context[key] = context.get(value)
+
+        if INSUFFICIENT_PERMISSIONS_REGEX.search(raw_message):
+            return [
+                SupersetError(
+                    error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
+                    message=raw_message,
+                    level=ErrorLevel.WARNING,
+                    extra={"engine_name": cls.engine_name},
+                )
+            ]
 
         db_engine_custom_errors = cls.get_database_custom_errors(database_name)
         if not isinstance(db_engine_custom_errors, dict):

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 INSUFFICIENT_PERMISSIONS_REGEX: Pattern[str] = re.compile(
-    r"\[INSUFFICIENT_PERMISSIONS\]|SQLSTATE: 42501"
+    r"\[INSUFFICIENT_PERMISSIONS\]|\bSQLSTATE:\s*42501\b"
 )
 
 
@@ -268,6 +268,25 @@ class DatabricksBaseEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return HiveEngineSpec.epoch_to_dttm()
+
+    @classmethod
+    def extract_errors(
+        cls,
+        ex: Exception,
+        context: dict[str, Any] | None = None,
+        database_name: str | None = None,
+    ) -> list[SupersetError]:
+        raw_message = cls._extract_error_message(ex)
+        if INSUFFICIENT_PERMISSIONS_REGEX.search(raw_message):
+            return [
+                SupersetError(
+                    error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
+                    message=raw_message,
+                    level=ErrorLevel.WARNING,
+                    extra={"engine_name": cls.engine_name},
+                )
+            ]
+        return super().extract_errors(ex, context, database_name)
 
 
 class DatabricksODBCEngineSpec(DatabricksBaseEngineSpec):
@@ -496,56 +515,15 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         context: dict[str, Any] | None = None,
         database_name: str | None = None,
     ) -> list[SupersetError]:
-        raw_message = cls._extract_error_message(ex)
-
         context = context or {}
 
         # access_token isn't currently parseable from the
         # databricks error response, but adding it in here
         # for reference if their error message changes
-
         for key, value in cls.context_key_mapping.items():
             context[key] = context.get(value)
 
-        if INSUFFICIENT_PERMISSIONS_REGEX.search(raw_message):
-            return [
-                SupersetError(
-                    error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
-                    message=raw_message,
-                    level=ErrorLevel.WARNING,
-                    extra={"engine_name": cls.engine_name},
-                )
-            ]
-
-        db_engine_custom_errors = cls.get_database_custom_errors(database_name)
-        if not isinstance(db_engine_custom_errors, dict):
-            db_engine_custom_errors = {}
-
-        for regex, (message, error_type, extra) in [
-            *db_engine_custom_errors.items(),
-            *cls.custom_errors.items(),
-        ]:
-            match = regex.search(raw_message)
-            if match:
-                params = {**context, **match.groupdict()}
-                extra["engine_name"] = cls.engine_name
-                return [
-                    SupersetError(
-                        error_type=error_type,
-                        message=message % params,
-                        level=ErrorLevel.ERROR,
-                        extra=extra,
-                    )
-                ]
-
-        return [
-            SupersetError(
-                error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
-                message=cls._extract_error_message(ex),
-                level=ErrorLevel.ERROR,
-                extra={"engine_name": cls.engine_name},
-            )
-        ]
+        return super().extract_errors(ex, context, database_name)
 
     @classmethod
     def validate_parameters(  # type: ignore

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -107,9 +107,13 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
         if data.get("status") == QueryStatus.FAILED:  # type: ignore
             # new error payload with rich context
             if data["errors"]:  # type: ignore
-                raise SupersetErrorsException(
-                    [SupersetError(**params) for params in data["errors"]]  # type: ignore
+                errors = [SupersetError(**params) for params in data["errors"]]  # type: ignore
+                status = (
+                    400
+                    if all(error.level == ErrorLevel.WARNING for error in errors)
+                    else 500
                 )
+                raise SupersetErrorsException(errors, status=status)
             # old string-only error message
             raise SupersetGenericDBErrorException(data["error"])  # type: ignore
 

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -109,9 +109,9 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             if data["errors"]:  # type: ignore
                 errors = [SupersetError(**params) for params in data["errors"]]  # type: ignore
                 status = (
-                    400
-                    if all(error.level == ErrorLevel.WARNING for error in errors)
-                    else 500
+                    500
+                    if any(error.level == ErrorLevel.ERROR for error in errors)
+                    else 400
                 )
                 raise SupersetErrorsException(errors, status=status)
             # old string-only error message

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -235,16 +235,28 @@ def test_extract_errors_with_context() -> None:
     ]
 
 
-def test_extract_errors_insufficient_permissions() -> None:
+@pytest.mark.parametrize(
+    "msg",
+    [
+        # tag only
+        "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not "
+        "have USE CATALOG on Catalog 'platform_production'.",
+        # SQLSTATE only
+        "Insufficient privileges: User does not have USE CATALOG on Catalog "
+        "'platform_production'. SQLSTATE: 42501.",
+        # SQLSTATE with irregular spacing
+        "Insufficient privileges on Catalog 'platform_production'. SQLSTATE:42501",
+        # both, as seen in real Databricks responses
+        "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not "
+        "have USE CATALOG on Catalog 'platform_production'. SQLSTATE: 42501.",
+    ],
+)
+def test_extract_errors_insufficient_permissions(msg: str) -> None:
     """
     Test that Databricks catalog/schema permission errors are classified as
-    a client-side, warning-level error instead of a generic server error.
+    a client-side, warning-level error instead of a generic server error,
+    regardless of which half of the pattern is present in the raw message.
     """
-
-    msg = (
-        "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not "
-        "have USE CATALOG on Catalog 'platform_production'. SQLSTATE: 42501."
-    )
     result = DatabricksNativeEngineSpec.extract_errors(Exception(msg))
 
     assert result == [
@@ -254,6 +266,38 @@ def test_extract_errors_insufficient_permissions() -> None:
             level=ErrorLevel.WARNING,
             extra={
                 "engine_name": "Databricks (legacy)",
+                "issue_codes": [
+                    {
+                        "code": 1017,
+                        "message": "Issue 1017 - User doesn't have the proper permissions.",  # noqa: E501
+                    }
+                ],
+            },
+        )
+    ]
+
+
+def test_extract_errors_insufficient_permissions_covers_odbc() -> None:
+    """
+    The insufficient-permissions classification lives on the shared
+    ``DatabricksBaseEngineSpec`` so that the ODBC ("SQL Endpoint") connector
+    benefits too, not just the native/Python-connector engines.
+    """
+    from superset.db_engine_specs.databricks import DatabricksODBCEngineSpec
+
+    msg = (
+        "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not "
+        "have USE CATALOG on Catalog 'platform_production'. SQLSTATE: 42501."
+    )
+    result = DatabricksODBCEngineSpec.extract_errors(Exception(msg))
+
+    assert result == [
+        SupersetError(
+            message=msg,
+            error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
+            level=ErrorLevel.WARNING,
+            extra={
+                "engine_name": "Databricks SQL Endpoint",
                 "issue_codes": [
                     {
                         "code": 1017,

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -235,6 +235,36 @@ def test_extract_errors_with_context() -> None:
     ]
 
 
+def test_extract_errors_insufficient_permissions() -> None:
+    """
+    Test that Databricks catalog/schema permission errors are classified as
+    a client-side, warning-level error instead of a generic server error.
+    """
+
+    msg = (
+        "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not "
+        "have USE CATALOG on Catalog 'platform_production'. SQLSTATE: 42501."
+    )
+    result = DatabricksNativeEngineSpec.extract_errors(Exception(msg))
+
+    assert result == [
+        SupersetError(
+            message=msg,
+            error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
+            level=ErrorLevel.WARNING,
+            extra={
+                "engine_name": "Databricks (legacy)",
+                "issue_codes": [
+                    {
+                        "code": 1017,
+                        "message": "Issue 1017 - User doesn't have the proper permissions.",  # noqa: E501
+                    }
+                ],
+            },
+        )
+    ]
+
+
 @pytest.mark.parametrize(
     "target_type,expected_result",
     [

--- a/tests/unit_tests/sqllab/test_sql_json_executer.py
+++ b/tests/unit_tests/sqllab/test_sql_json_executer.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,7 +24,7 @@ from superset.sqllab.sql_json_executer import SynchronousSqlJsonExecutor
 from superset.utils.core import QueryStatus
 
 
-def _make_executor(data: dict) -> SynchronousSqlJsonExecutor:
+def _make_executor(data: dict[str, Any]) -> SynchronousSqlJsonExecutor:
     query_dao = MagicMock()
     get_sql_results_task = MagicMock(return_value=data)
     return SynchronousSqlJsonExecutor(
@@ -66,10 +67,63 @@ def test_execute_raises_400_when_all_errors_are_warnings() -> None:
     assert excinfo.value.status == 400
 
 
+def test_execute_raises_400_when_errors_are_warning_and_info() -> None:
+    """
+    A mix of WARNING and INFO errors (no ERROR-level entries) should still
+    surface as a 4xx, since nothing in the list indicates a server fault.
+    """
+    data = {
+        "status": QueryStatus.FAILED,
+        "errors": [
+            {
+                "message": "Insufficient privileges on Catalog 'foo'.",
+                "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
+                "level": "warning",
+                "extra": {},
+            },
+            {
+                "message": "For your information.",
+                "error_type": "GENERIC_DB_ENGINE_ERROR",
+                "level": "info",
+                "extra": {},
+            },
+        ],
+    }
+    executor = _make_executor(data)
+
+    with pytest.raises(SupersetErrorsException) as excinfo:
+        executor.execute(_make_execution_context(), "SELECT 1", None)
+
+    assert excinfo.value.status == 400
+
+
 def test_execute_raises_500_when_any_error_is_error_level() -> None:
     """
-    Existing behavior is preserved: any ERROR-level (or mixed) rich error
-    still surfaces as a 500.
+    Existing behavior is preserved: a single ERROR-level rich error still
+    surfaces as a 500.
+    """
+    data = {
+        "status": QueryStatus.FAILED,
+        "errors": [
+            {
+                "message": "Something went wrong.",
+                "error_type": "GENERIC_DB_ENGINE_ERROR",
+                "level": "error",
+                "extra": {},
+            },
+        ],
+    }
+    executor = _make_executor(data)
+
+    with pytest.raises(SupersetErrorsException) as excinfo:
+        executor.execute(_make_execution_context(), "SELECT 1", None)
+
+    assert excinfo.value.status == 500
+
+
+def test_execute_raises_500_when_errors_are_mixed_warning_and_error() -> None:
+    """
+    A mix of WARNING and ERROR still surfaces as a 500: any ERROR wins.
     """
     data = {
         "status": QueryStatus.FAILED,

--- a/tests/unit_tests/sqllab/test_sql_json_executer.py
+++ b/tests/unit_tests/sqllab/test_sql_json_executer.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock
+
+import pytest
+
+from superset.exceptions import SupersetErrorsException
+from superset.sqllab.sql_json_executer import SynchronousSqlJsonExecutor
+from superset.utils.core import QueryStatus
+
+
+def _make_executor(data: dict) -> SynchronousSqlJsonExecutor:
+    query_dao = MagicMock()
+    get_sql_results_task = MagicMock(return_value=data)
+    return SynchronousSqlJsonExecutor(
+        query_dao,
+        get_sql_results_task,
+        timeout_duration_in_seconds=60,
+        sqllab_backend_persistence_feature_enable=False,
+    )
+
+
+def _make_execution_context() -> MagicMock:
+    execution_context = MagicMock()
+    execution_context.query.id = 1
+    execution_context.expand_data = False
+    execution_context.select_as_cta = False
+    return execution_context
+
+
+def test_execute_raises_400_when_all_errors_are_warnings() -> None:
+    """
+    All-WARNING rich errors (e.g. a Databricks insufficient-permissions
+    error) should surface as a 4xx client error, not a 500.
+    """
+    data = {
+        "status": QueryStatus.FAILED,
+        "errors": [
+            {
+                "message": "Insufficient privileges on Catalog 'foo'.",
+                "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
+                "level": "warning",
+                "extra": {},
+            }
+        ],
+    }
+    executor = _make_executor(data)
+
+    with pytest.raises(SupersetErrorsException) as excinfo:
+        executor.execute(_make_execution_context(), "SELECT 1", None)
+
+    assert excinfo.value.status == 400
+
+
+def test_execute_raises_500_when_any_error_is_error_level() -> None:
+    """
+    Existing behavior is preserved: any ERROR-level (or mixed) rich error
+    still surfaces as a 500.
+    """
+    data = {
+        "status": QueryStatus.FAILED,
+        "errors": [
+            {
+                "message": "Insufficient privileges on Catalog 'foo'.",
+                "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
+                "level": "warning",
+                "extra": {},
+            },
+            {
+                "message": "Something went wrong.",
+                "error_type": "GENERIC_DB_ENGINE_ERROR",
+                "level": "error",
+                "extra": {},
+            },
+        ],
+    }
+    executor = _make_executor(data)
+
+    with pytest.raises(SupersetErrorsException) as excinfo:
+        executor.execute(_make_execution_context(), "SELECT 1", None)
+
+    assert excinfo.value.status == 500


### PR DESCRIPTION
### SUMMARY
Databricks catalog/schema permission errors (e.g. `[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not have USE CATALOG on Catalog 'foo'. SQLSTATE: 42501.`) were classified as `SupersetErrorType.GENERIC_DB_ENGINE_ERROR` and always returned to the client as HTTP 500, even though this is a customer-side permission misconfiguration, not a server error.

Two changes were needed to fix this end-to-end:

- `DatabricksDynamicBaseEngineSpec.extract_errors` (`superset/db_engine_specs/databricks.py`) now detects the `SQLSTATE: 42501` / `[INSUFFICIENT_PERMISSIONS]` pattern and classifies it as `SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR` at `ErrorLevel.WARNING`, instead of falling through to the generic catch-all at `ErrorLevel.ERROR`.
- `SynchronousSqlJsonExecutor.execute` (`superset/sqllab/sql_json_executer.py`) previously raised `SupersetErrorsException` with no `status`, which always inherits the default 500 regardless of the contained errors' `level`. It now derives the status from the aggregate error level (all `WARNING` -> 400, any `ERROR` -> 500), mirroring the existing pattern in `commands/report/execute.py`. This is a shared code path used by every DB engine's rich-error responses; today every engine's `extract_errors` only emits `ERROR` level here, so this is a no-op for all engines except the new Databricks `WARNING` case above.

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/db_engine_specs/test_databricks.py` — includes a new regression test asserting the SQLSTATE 42501 message yields `CONNECTION_DATABASE_PERMISSIONS_ERROR` at `ErrorLevel.WARNING`.
- `pytest tests/unit_tests/sqllab/test_sql_json_executer.py` — new test file covering an all-`WARNING` errors list resulting in HTTP 400, and an `ERROR`/mixed-level list still resulting in HTTP 500.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API