### PR TITLE
fix(trino): quote nested ROW field paths per-segment in physical column expressions

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2005,6 +2005,11 @@ class SqlaTable(
         columns = []
         for col in new_columns:
             old_column = old_columns_by_name.pop(col["column_name"], None)
+            # Some engine specs (e.g. Trino, when expanding nested `ROW` columns)
+            # provide an explicit SQL expression that must be used to select the
+            # physical column, since simply quoting the dotted `column_name` as a
+            # single identifier is not valid syntax for these nested fields.
+            expression = col.get("expression") or ""
             if not old_column:
                 results.added.append(col["column_name"])
                 new_column = TableColumn(
@@ -2017,12 +2022,14 @@ class SqlaTable(
                 if col.get("comment"):
                     new_column.description = col["comment"]
                 db_engine_spec.alter_new_orm_column(new_column)
+                if expression:
+                    new_column.expression = expression
             else:
                 new_column = old_column
                 if new_column.type != col["type"]:
                     results.modified.append(col["column_name"])
                 new_column.type = col["type"]
-                new_column.expression = ""
+                new_column.expression = expression
                 # Set description from comment field if available
                 if col.get("comment"):
                     new_column.description = col["comment"]

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2009,7 +2009,7 @@ class SqlaTable(
             # provide an explicit SQL expression that must be used to select the
             # physical column, since simply quoting the dotted `column_name` as a
             # single identifier is not valid syntax for these nested fields.
-            expression = col.get("expression") or ""
+            expression: str = col.get("expression") or ""
             if not old_column:
                 results.added.append(col["column_name"])
                 new_column = TableColumn(
@@ -2039,8 +2039,13 @@ class SqlaTable(
             if not any_date_col and new_column.is_temporal:
                 any_date_col = col["column_name"]
 
-        # add back calculated (virtual) columns
-        columns.extend([col for col in old_columns if col.expression])
+        # Add back calculated (virtual) columns, i.e. those that weren't matched
+        # against `new_columns` above and are thus still present in
+        # `old_columns_by_name`. Columns that were matched are already appended to
+        # `columns` in the loop above, and re-adding them here (e.g. via `old_columns`)
+        # would duplicate any synced physical column that also carries a truthy
+        # `expression`, such as Trino's expanded nested `ROW` fields.
+        columns.extend([col for col in old_columns_by_name.values() if col.expression])
         self.columns = columns
 
         if not self.main_dttm_col:

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -602,7 +602,11 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         Expanded columns are named foo.bar.baz and we provide a query_as property to
         instruct the base engine spec how to correctly query them: instead of quoting
         the whole string they have to be quoted like "foo"."bar"."baz" and we then
-        alias them to the full dotted string for ease of reference.
+        alias them to the full dotted string for ease of reference. We also provide
+        an `expression` property with the same correctly quoted path (without the
+        alias), so that a physical `TableColumn` created from this metadata selects
+        the column correctly instead of quoting the whole dotted name as a single
+        (invalid) identifier.
         """
         # pylint: disable=import-outside-toplevel
         from trino.sqlalchemy import datatype
@@ -625,6 +629,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 column_name=name,
                 type=inner_type,
                 is_dttm=is_dttm,
+                expression=query_name,
                 query_as=f'{query_name} AS "{name}"',
             )
             cols.extend(cls._expand_columns(inner_col))

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -132,6 +132,12 @@ class ResultSetColumnType(TypedDict):
 
     query_as: NotRequired[Any]
 
+    # A SQL expression (without an alias) that should be used to select this
+    # column, e.g. for a nested field whose path segments must each be quoted
+    # separately rather than the whole dotted name being quoted as a single
+    # identifier.
+    expression: NotRequired[Any]
+
 
 CacheConfig: TypeAlias = dict[str, Any]
 DbapiDescriptionRow: TypeAlias = tuple[

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -568,10 +568,10 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
 
     # Create table with a pre-existing (already synced) expanded column, to also
     # cover the "sync columns from source" (re-fetch) code path
-    table = SqlaTable(table_name="test_table_nested", database=database)
+    table: SqlaTable = SqlaTable(table_name="test_table_nested", database=database)
     table.id = 1
 
-    existing_col = TableColumn(
+    existing_col: TableColumn = TableColumn(
         column_name="metadata.uuid",
         type="VARCHAR",
         table=table,

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from unittest.mock import MagicMock
+
 import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
@@ -558,7 +560,7 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
     See: https://github.com/apache/superset/issues/27034
     """
     # Mock database
-    database = mocker.MagicMock()
+    database: MagicMock = mocker.MagicMock()
     database.get_metrics.return_value = []
 
     # Mock db_engine_spec
@@ -592,7 +594,7 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
         },
     ]
 
-    mock_session = mocker.patch("superset.connectors.sqla.models.db.session")
+    mock_session: MagicMock = mocker.patch("superset.connectors.sqla.models.db.session")
     mock_session.query.return_value.filter.return_value.all.return_value = [
         existing_col
     ]

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -603,7 +603,9 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
 
     table.fetch_metadata()
 
-    columns_by_name = {col.column_name: col for col in table.columns}
+    columns_by_name: dict[str, TableColumn] = {
+        col.column_name: col for col in table.columns
+    }
     assert len(table.columns) == len(mock_columns)
     assert not columns_by_name["metadata"].expression
     assert columns_by_name["metadata.uuid"].expression == '"metadata"."uuid"'

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -579,7 +579,7 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
     )
     table.columns = [existing_col]
 
-    mock_columns = [
+    mock_columns: list[dict[str, str]] = [
         {
             "column_name": "metadata",
             "type": "ROW",
@@ -603,6 +603,23 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
 
     table.fetch_metadata()
 
+    columns_by_name = {col.column_name: col for col in table.columns}
+    assert len(table.columns) == len(mock_columns)
+    assert not columns_by_name["metadata"].expression
+    assert columns_by_name["metadata.uuid"].expression == '"metadata"."uuid"'
+
+    # Re-run fetch_metadata a second time to simulate re-syncing columns from
+    # source. The previously synced physical column now carries a truthy
+    # `expression`, which must not cause it to be duplicated in `self.columns`.
+    mock_session_2 = mocker.patch("superset.connectors.sqla.models.db.session")
+    mock_session_2.query.return_value.filter.return_value.all.return_value = list(
+        table.columns
+    )
+    mocker.patch.object(table, "external_metadata", return_value=mock_columns)
+
+    table.fetch_metadata()
+
+    assert len(table.columns) == len(mock_columns)
     columns_by_name = {col.column_name: col for col in table.columns}
     assert not columns_by_name["metadata"].expression
     assert columns_by_name["metadata.uuid"].expression == '"metadata"."uuid"'

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -542,6 +542,72 @@ def test_fetch_metadata_with_comment_field_existing_columns(
     assert columns_by_name["name"].description == "Updated name description"
 
 
+def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that fetch_metadata uses the `expression` hint provided by the db engine
+    spec (e.g. Trino's expansion of nested `ROW` columns via `expand_rows`) to set
+    the physical `TableColumn.expression`.
+
+    Without this, a nested column like `metadata.uuid` would have no expression,
+    causing SQLAlchemy to render the whole dotted `column_name` as a single quoted
+    identifier (`"metadata.uuid"`), which Trino rejects, instead of the correct
+    per-segment quoting (`"metadata"."uuid"`).
+
+    See: https://github.com/apache/superset/issues/27034
+    """
+    # Mock database
+    database = mocker.MagicMock()
+    database.get_metrics.return_value = []
+
+    # Mock db_engine_spec
+    mock_db_engine_spec = mocker.MagicMock()
+    mock_db_engine_spec.alter_new_orm_column = mocker.MagicMock()
+    database.db_engine_spec = mock_db_engine_spec
+
+    # Create table with a pre-existing (already synced) expanded column, to also
+    # cover the "sync columns from source" (re-fetch) code path
+    table = SqlaTable(table_name="test_table_nested", database=database)
+    table.id = 1
+
+    existing_col = TableColumn(
+        column_name="metadata.uuid",
+        type="VARCHAR",
+        table=table,
+        expression="",
+    )
+    table.columns = [existing_col]
+
+    mock_columns = [
+        {
+            "column_name": "metadata",
+            "type": "ROW",
+        },
+        {
+            "column_name": "metadata.uuid",
+            "type": "VARCHAR",
+            "expression": '"metadata"."uuid"',
+            "query_as": '"metadata"."uuid" AS "metadata.uuid"',
+        },
+    ]
+
+    mock_session = mocker.patch("superset.connectors.sqla.models.db.session")
+    mock_session.query.return_value.filter.return_value.all.return_value = [
+        existing_col
+    ]
+    mocker.patch.object(table, "external_metadata", return_value=mock_columns)
+    mocker.patch(
+        "superset.connectors.sqla.models.config", {"SQLA_TABLE_MUTATOR": lambda x: None}
+    )
+
+    table.fetch_metadata()
+
+    columns_by_name = {col.column_name: col for col in table.columns}
+    assert not columns_by_name["metadata"].expression
+    assert columns_by_name["metadata.uuid"].expression == '"metadata"."uuid"'
+
+
 def test_fetch_metadata_mixed_comment_scenarios(mocker: MockerFixture) -> None:
     """Test fetch_metadata with mix of new/existing columns and with/without
     comments

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -564,7 +564,7 @@ def test_fetch_metadata_sets_expression_for_expanded_nested_columns(
     database.get_metrics.return_value = []
 
     # Mock db_engine_spec
-    mock_db_engine_spec = mocker.MagicMock()
+    mock_db_engine_spec: MagicMock = mocker.MagicMock()
     mock_db_engine_spec.alter_new_orm_column = mocker.MagicMock()
     database.db_engine_spec = mock_db_engine_spec
 

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -758,6 +758,7 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
             column_name="field1.a",
             type=types.VARCHAR(),
             is_dttm=False,
+            expression='"field1"."a"',
             query_as='"field1"."a" AS "field1.a"',
         ),
         ResultSetColumnType(
@@ -765,6 +766,7 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
             column_name="field1.b",
             type=types.DATE(),
             is_dttm=True,
+            expression='"field1"."b"',
             query_as='"field1"."b" AS "field1.b"',
         ),
         ResultSetColumnType(
@@ -775,6 +777,7 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
             column_name="field2.r1",
             type=datatype.parse_sqltype("row(a varchar, b varchar)"),
             is_dttm=False,
+            expression='"field2"."r1"',
             query_as='"field2"."r1" AS "field2.r1"',
         ),
         ResultSetColumnType(
@@ -782,6 +785,7 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
             column_name="field2.r1.a",
             type=types.VARCHAR(),
             is_dttm=False,
+            expression='"field2"."r1"."a"',
             query_as='"field2"."r1"."a" AS "field2.r1.a"',
         ),
         ResultSetColumnType(
@@ -789,6 +793,7 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
             column_name="field2.r1.b",
             type=types.VARCHAR(),
             is_dttm=False,
+            expression='"field2"."r1"."b"',
             query_as='"field2"."r1"."b" AS "field2.r1.b"',
         ),
         ResultSetColumnType(


### PR DESCRIPTION
### SUMMARY
When a Trino database has `Enable row expansion in schemas` (`expand_rows`) turned on, nested `ROW` fields (e.g. `metadata.uuid`) get expanded into dotted-name dataset columns. `TrinoEngineSpec._expand_columns` already computes the correctly per-segment-quoted expression for these (`"metadata"."uuid"`) and exposes it via `query_as`, but that hint was only ever consumed by `select_star` (used by the SQL Lab "View As" preview). `SqlaTable.fetch_metadata`, which is what actually creates the `TableColumn` used by chart/filter/dashboard queries, never set an `expression` for these new columns, so SQLAlchemy fell back to quoting the whole dotted name as a single identifier (`"metadata.uuid"`), which Trino rejects with `COLUMN_NOT_FOUND`.

This adds a plain `expression` field (the quoted path without the `AS` alias) to `_expand_columns`'s output, and has `fetch_metadata` set `TableColumn.expression` from it whenever it's present — both when a column is first synced and on subsequent "sync columns from source" re-fetches (the latter previously always reset `expression` back to `""`, which would have silently re-broken things after a fix).

Custom SQL already worked around this because it went through `select_star`/`query_as`; this fixes the column-picker path so nested fields work in chart dimensions and dashboard filters too.

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/connectors/sqla/models_test.py -k expanded_nested`
- `pytest tests/unit_tests/db_engine_specs/test_trino.py`
- Manually: enable `expand_rows` on a Trino dataset with a nested `ROW` column, add the expanded column as a chart dimension or dashboard filter (not Custom SQL) — the generated query should now quote each path segment separately instead of the whole dotted name.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #27034
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API