### PR TITLE
fix(pivot-table): include aggregation type in subtotal labels

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1073,7 +1073,9 @@ export function TableRenderer(props: TableRendererProps) {
                 true,
               )}
             >
-              {t('Subtotal')}
+              {t('Subvalue (%(aggregatorName)s)', {
+                aggregatorName: t(aggregatorName),
+              })}
             </th>,
           );
         }
@@ -1333,7 +1335,9 @@ export function TableRenderer(props: TableRendererProps) {
               true,
             )}
           >
-            {t('Subtotal')}
+            {t('Subvalue (%(aggregatorName)s)', {
+              aggregatorName: t(aggregatorName),
+            })}
           </th>
         ) : null;
 


### PR DESCRIPTION
### SUMMARY

This PR updates the Pivot Table subtotal labels to include the selected aggregation function.

Previously, subtotal rows and columns always displayed the generic label **"Subtotal"**, regardless of the selected aggregation function.

This change updates the subtotal labels to display the selected aggregation function, making them consistent with the existing total labels.

Examples:

- Before: `Subtotal`
- After:
  - `Subvalue (Sum)`
  - `Subvalue (Average)`
  - `Subvalue (Count)`

Fixes #35089.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**After**

The Pivot Table subtotal labels now include the aggregation type.

Example:

- **Subvalue (Sum)**
<img width="787" height="427" alt="image" src="https://github.com/user-attachments/assets/8c77a5b1-ae21-4252-a06f-d303d7977507" />

- **Subvalue (Average)**
<img width="780" height="383" alt="image" src="https://github.com/user-attachments/assets/e8f2b931-adf0-4dc1-9055-5e924fd9fa28" />

### TESTING INSTRUCTIONS

1. Open Explore.
2. Select the Pivot Table visualization.
3. Add at least one row and one metric.
4. Enable row or column subtotals.
5. Change the aggregation function (for example, Sum, Average, or Count).
6. Verify that the subtotal labels display the selected aggregation function.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #35089
- [ ] Required feature flags
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API