### PR TITLE
test(sqla): assert simple metric quotes columns requiring quoting (#30637)

### DIFF
--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3672,3 +3672,52 @@ def test_temporal_non_numeric_string_filter_is_not_coerced() -> None:
     )
 
     assert value == "2025-12-20"
+
+
+def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> None:
+    """
+    Regression for #30637: a SIMPLE adhoc metric that aggregates a column whose
+    name requires identifier quoting (e.g. it contains a space) must render the
+    column with the dialect's quote characters, otherwise the emitted SQL is
+    invalid for dialects that need quoting.
+
+    This exercises the metric compilation path named in the issue
+    (``adhoc_metric_to_sqla`` -> ``TableColumn.get_sqla_col`` -> ``column()``),
+    asserting the identifier is quoted rather than emitted bare.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.utils.core import AdhocMetricExpressionType
+
+    column_name = "Amount HT"
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="test_table",
+        columns=[TableColumn(column_name=column_name, type="INTEGER")],
+    )
+    columns_by_name = {col.column_name: col for col in table.columns}
+
+    metric: AdhocMetric = {
+        "expressionType": AdhocMetricExpressionType.SIMPLE,
+        "aggregate": "SUM",
+        "column": {"column_name": column_name},
+        "label": "total",
+    }
+
+    sqla_metric = table.adhoc_metric_to_sqla(metric, columns_by_name)
+
+    with database.get_sqla_engine() as engine:
+        dialect = engine.dialect
+
+    rendered = str(
+        sqla_metric.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+    # The spaced identifier must be quoted (double quotes for the SQLite/ANSI
+    # dialect used here) and must never appear bare.
+    assert f'"{column_name}"' in rendered, (
+        f"Expected quoted identifier in rendered metric SQL, got: {rendered}"
+    )
+    assert f"SUM({column_name})" not in rendered, (
+        f"Column requiring quoting was emitted unquoted: {rendered}"
+    )

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3686,7 +3686,6 @@ def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> No
     asserting the identifier is quoted rather than emitted bare.
     """
     from superset.connectors.sqla.models import SqlaTable, TableColumn
-    from superset.utils.core import AdhocMetricExpressionType
 
     column_name = "Amount HT"
     table = SqlaTable(
@@ -3698,7 +3697,7 @@ def test_simple_metric_quotes_column_requiring_quoting(database: Database) -> No
     columns_by_name = {col.column_name: col for col in table.columns}
 
     metric: AdhocMetric = {
-        "expressionType": AdhocMetricExpressionType.SIMPLE,
+        "expressionType": "SIMPLE",
         "aggregate": "SUM",
         "column": {"column_name": column_name},
         "label": "total",


### PR DESCRIPTION
### SUMMARY

Test-only regression coverage for the backend half of #30637 ("When creating a metric, CUSTOM SQL does not use quotation marks even though the column requires it").

The issue reports that a metric referencing a column whose name requires identifier quoting (e.g. it contains a space, as in `Amount HT`) can be emitted without quotes, producing invalid SQL for dialects that require quoting.

This PR adds a focused unit test that pins the behavior of the backend metric compilation path: `adhoc_metric_to_sqla` -> `TableColumn.get_sqla_col` -> SQLAlchemy `column()`. It builds a SIMPLE adhoc metric over a column named `Amount HT` and asserts the compiled SQL quotes the identifier rather than emitting it bare.

**Scope note:** this does not cover the client-side Simple → Custom SQL transition (`AdhocMetric.translateToSql()` in `superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.ts`), which is a plain string interpolation with no identifier-quoting logic and is the more literal reproduction of the original bug report's screenshots. That transition isn't backed by any dialect-aware quoting utility on the frontend, so covering/fixing it is a separate, larger change and out of scope for this test-only PR. This PR documents and guards the backend invariant only; it does not close #30637.

The test **passes on `master`**, documenting that the SIMPLE metric compilation path correctly quotes columns requiring quoting. It is a green guard that will fail if that quoting ever regresses. (Note: free-form Custom SQL expressions are rendered verbatim via `literal_column`/`sanitize_clause` by design — quoting there is the author's responsibility — so this test targets the compilation path a fix would actually harden.)

### How to interpret CI

- **Green (expected):** master already quotes columns requiring quoting in the SIMPLE metric path; the test locks that in as a regression guard.
- **Red:** would indicate the metric compilation path stopped quoting identifiers that need it — a real regression of the backend half of #30637.

### TESTING INSTRUCTIONS

```bash
python -m pytest tests/unit_tests/models/helpers_test.py::test_simple_metric_quotes_column_requiring_quoting -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Relates to #30637 (does not close it — see Scope note above)
- [x] Test-only change; no runtime code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
