### PR TITLE
test(filters): guard BIGINT filter value precision (#27510)

### DIFF
--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -177,6 +177,28 @@ describe('Filter utils', () => {
       );
     });
 
+    test('Regression for #27510: formats large BIGINT column values as exact strings without precision loss', () => {
+      // A BIGINT column value with 16+ digits arrives as a native `bigint`
+      // (decoded from the `json-bigint` parse of the chart data response).
+      // Historically the filter UI rendered it as a raw BigNumber object
+      // ({ s, e, c }), throwing React error #31, or coerced it through a JS
+      // number and silently corrupted the trailing digits. The label
+      // formatter must turn it into its exact decimal string so the Select
+      // filter option renders correctly and the value keeps full precision.
+      const formatter = getDataRecordFormatter();
+      const largeBigInt = 1234567890125123456n;
+
+      expect(formatter(largeBigInt, GenericDataType.Numeric)).toEqual(
+        '1234567890125123456',
+      );
+      expect(formatter(largeBigInt, GenericDataType.String)).toEqual(
+        '1234567890125123456',
+      );
+      // Guard: routing the same value through a JS number (the pre-fix
+      // behavior) loses precision, which is exactly what broke the filter.
+      expect(String(Number(largeBigInt))).not.toEqual('1234567890125123456');
+    });
+
     test('formatter with defined formatters returns expected values', () => {
       const formatter = getDataRecordFormatter({
         timeFormatter: getTimeFormatter(TimeFormats.DATABASE_DATETIME),


### PR DESCRIPTION
### SUMMARY

This is a test-only TDD pull request validating [#27510](https://github.com/apache/superset/issues/27510) ("Using Filter per value of Column of type BIGINT breaks UI when the value is large"). It adds no product code — only a regression test. The original bug: a native (dashboard) filter on a `BIGINT` column with a large value (16+ digits, exceeding `Number.MAX_SAFE_INTEGER`) broke the filter UI with React error #31 ("Objects are not valid as a React child, found: object with keys {s, e, c}") — the `{s, e, c}` object being a `json-bigint` `BigNumber` that leaked into rendering, plus silent precision loss when such values were coerced through a JS number. The test exercises `getDataRecordFormatter` in `superset-frontend/src/filters/utils.ts` — the label formatter that produces the rendered Select-filter option — and asserts that a large `bigint` column value is formatted to its exact decimal string (full precision, a plain string React can render), while confirming that the pre-fix path of routing the same value through a JS number corrupts the trailing digits.

### How to interpret CI

- **Green (test passes):** the bug is already fixed on current `master` (large BIGINT values are decoded to native `bigint` by the `json-bigint` parse and rendered as exact strings). Merging this PR adds a permanent regression guard and closes the issue.
- **Red (test fails):** the bug is live. The suspected fix location is the filter value handling path: `superset-frontend/src/filters/utils.ts` (`getDataRecordFormatter`) and the `json-bigint` decode in `superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts`, which must yield a native `bigint`/string rather than a `BigNumber` object so large BIGINT values keep full precision in the native filter Select.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest src/filters/utils.test.ts -t "Regression for #27510"
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Closes #27510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
