### PR TITLE
fix(sqla): drop stale main_dttm_col from dttm_cols when non-temporal (#30510)

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1628,7 +1628,7 @@ class SqlaTable(
             # it is still referenced by ``main_dttm_col`` (#30510). When the column
             # is not present on the dataset, fall back to the legacy behavior of
             # trusting ``main_dttm_col``.
-            main_dttm_column = next(
+            main_dttm_column: TableColumn | None = next(
                 (c for c in self.columns if c.column_name == self.main_dttm_col),
                 None,
             )

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1622,7 +1622,18 @@ class SqlaTable(
     def dttm_cols(self) -> list[str]:
         l = [c.column_name for c in self.columns if c.is_dttm]  # noqa: E741
         if self.main_dttm_col and self.main_dttm_col not in l:
-            l.append(self.main_dttm_col)
+            # Only treat ``main_dttm_col`` as a datetime column when the column it
+            # points to is actually temporal. A column whose "Is Temporal" flag was
+            # removed must not keep being reported as a datetime column just because
+            # it is still referenced by ``main_dttm_col`` (#30510). When the column
+            # is not present on the dataset, fall back to the legacy behavior of
+            # trusting ``main_dttm_col``.
+            main_dttm_column = next(
+                (c for c in self.columns if c.column_name == self.main_dttm_col),
+                None,
+            )
+            if main_dttm_column is None or main_dttm_column.is_dttm:
+                l.append(self.main_dttm_col)
         return l
 
     @property

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -1521,3 +1521,46 @@ def test_has_extra_cache_key_calls_scans_guest_token_rls(
 
     get_guest_rls.return_value = [{"clause": "tenant = 'acme'"}]
     assert table.has_extra_cache_key_calls(query_obj) is False
+
+
+def test_dttm_cols_excludes_column_after_temporal_flag_removed(
+    session: Session,
+) -> None:
+    """
+    Regression for #30510: when a column is mistakenly marked temporal, set as the
+    dataset's default datetime (``main_dttm_col``) and saved, then later has its
+    ``is_dttm`` flag removed, the dataset must stop treating that column as temporal.
+
+    Otherwise ``dttm_cols`` (which feeds time-column selection and the default time
+    filter for every chart built on the dataset) keeps returning a non-temporal
+    column, corrupting the dataset with a time filter that cannot be removed.
+    """
+    Database.metadata.create_all(session.bind)
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+
+    # A column the user mistakenly marks as temporal ("Is Temporal") and then picks
+    # as the dataset "Default Datetime" (``main_dttm_col``).
+    column = TableColumn(column_name="not_really_a_date", type="VARCHAR", is_dttm=True)
+    dataset = SqlaTable(
+        database=database,
+        table_name="my_table",
+        columns=[column],
+        main_dttm_col="not_really_a_date",
+    )
+    session.add(dataset)
+    session.commit()
+
+    # While flagged temporal, the column is (expectedly) exposed as a datetime column.
+    assert dataset.dttm_cols == ["not_really_a_date"]
+
+    # The user realizes the mistake and unchecks "Is Temporal", then saves. Persisting
+    # the update clears ``is_dttm`` on the column.
+    column.is_dttm = False
+    session.commit()
+
+    # The column is no longer temporal...
+    assert column.is_temporal is False
+    # ...so it must no longer be reported as a datetime column. On master
+    # ``main_dttm_col`` is never cleared, so ``dttm_cols`` still contains the stale,
+    # non-temporal column and this assertion fails (bug reproduced).
+    assert "not_really_a_date" not in dataset.dttm_cols


### PR DESCRIPTION
### SUMMARY

Fixes #30510. When a dataset has no real temporal column, a user can mistakenly check "Is Temporal" on a column, pick it as the "Default Datetime" (`main_dttm_col`), and save; later un-checking "Is Temporal" clears the column's `is_dttm` flag, but `main_dttm_col` still points at it. The stale reference meant the now non-temporal column kept appearing in `SqlaTable.dttm_cols`, forcing an unremovable default time filter on every chart built on the dataset. The root cause is that `dttm_cols` appended `main_dttm_col` unconditionally, without checking whether the referenced column is still temporal. The fix makes `dttm_cols` only include `main_dttm_col` when the column it points to is actually temporal (`is_dttm` true), while falling back to the legacy behavior when the column is not present on the dataset. It ships with the regression test that reproduces the exact sequence (mark temporal + set `main_dttm_col` → save → un-mark temporal → save) — red before this change, green after.

### BEFORE/AFTER

**Before:** after un-marking the column as temporal, `dataset.dttm_cols` still contained the corrected column (e.g. `["not_really_a_date"]`), so the default time filter could not be removed.

**After:** the corrected, non-temporal column is no longer reported — `dataset.dttm_cols` excludes it, and the spurious default time filter disappears.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/connectors/sqla/models_test.py::test_dttm_cols_excludes_column_after_temporal_flag_removed -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: Closes #30510
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime consequences of this change have been noted
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
