### PR TITLE
fix(reports): write a single execution log row per report run (#29857)

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -227,22 +227,47 @@ class BaseReportState:
     def create_log(self, error_message: Optional[str] = None) -> None:
         """
         Creates a Report execution log, uses the current computed last_value for Alerts
+
+        A single execution transitions through the WORKING state before reaching a
+        terminal state (SUCCESS/ERROR/NOOP/GRACE). To avoid duplicated rows in the
+        execution-log view (see issue #29857), the terminal result is written onto
+        the WORKING "trigger" row created earlier in the same execution rather than
+        inserting a second row. The WORKING row is only used as a placeholder while
+        the execution is in flight (``find_last_entered_working_log`` relies on it
+        for working-timeout detection), so promoting it in place keeps one row per
+        execution ``uuid`` without losing that behavior. The intentional
+        error-notification marker row is a terminal-to-terminal transition, so it is
+        still recorded as a distinct row.
         """
         from sqlalchemy.orm.exc import StaleDataError
 
         try:
-            log = ReportExecutionLog(
-                scheduled_dttm=self._scheduled_dttm,
-                start_dttm=self._start_dttm,
-                end_dttm=datetime.now(timezone.utc).replace(tzinfo=None),
-                value=self._report_schedule.last_value,
-                value_row_json=self._report_schedule.last_value_row_json,
-                state=self._report_schedule.last_state,
-                error_message=error_message,
-                report_schedule=self._report_schedule,
-                uuid=self._execution_id,
+            # Reuse the in-flight WORKING trigger row for this execution, if any,
+            # so a single execution surfaces as a single log entry.
+            log = (
+                db.session.query(ReportExecutionLog)
+                .filter(
+                    ReportExecutionLog.uuid == self._execution_id,
+                    ReportExecutionLog.state == ReportState.WORKING,
+                    ReportExecutionLog.error_message.is_(None),
+                )
+                .first()
+                if self._report_schedule.last_state != ReportState.WORKING
+                else None
             )
-            db.session.add(log)
+            if log is None:
+                log = ReportExecutionLog(
+                    scheduled_dttm=self._scheduled_dttm,
+                    start_dttm=self._start_dttm,
+                    report_schedule=self._report_schedule,
+                    uuid=self._execution_id,
+                )
+                db.session.add(log)
+            log.end_dttm = datetime.now(timezone.utc).replace(tzinfo=None)
+            log.value = self._report_schedule.last_value
+            log.value_row_json = self._report_schedule.last_value_row_json
+            log.state = self._report_schedule.last_state
+            log.error_message = error_message
             db.session.commit()  # pylint: disable=consider-using-transaction
         except StaleDataError as ex:
             # Report schedule was modified or deleted by another process

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from unittest.mock import call, Mock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from flask.ctx import AppContext
@@ -181,6 +181,11 @@ def assert_log(state: str, error_message: Optional[str] = None):
     # only assert an explicitly expected message.
     if error_message is not None:
         assert error_message in [log.error_message for log in logs]
+
+    for log in logs:
+        if log.state == ReportState.WORKING:
+            assert log.value is None
+            assert log.value_row_json is None
 
 
 @contextmanager
@@ -842,7 +847,7 @@ def test_email_chart_report_schedule_single_log_per_execution(
         db.session.commit()
         logs = (
             db.session.query(ReportExecutionLog)
-            .filter(ReportExecutionLog.uuid == TEST_ID)
+            .filter(ReportExecutionLog.uuid == UUID(TEST_ID))
             .all()
         )
         # A single execution (one uuid) must map to a single log entry, not one

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -806,6 +806,45 @@ def test_email_chart_report_schedule(
 
 
 @pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices", "create_report_email_chart"
+)
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
+def test_email_chart_report_schedule_single_log_per_execution(
+    screenshot_mock,
+    email_mock,
+    create_report_email_chart,
+):
+    """
+    ExecuteReport Command: a single execution should produce a single log row.
+
+    Regression for #29857: the Alerts & Reports execution log shows duplicated
+    entries for a single execution. Each execution transitions through the
+    WORKING state and then a terminal state (SUCCESS/ERROR), and every
+    transition writes a ReportExecutionLog row sharing the same execution
+    ``uuid``. As a result one execution surfaces as two rows in the log view
+    (the "trigger" row and the "result" row). This test asserts that one
+    execution -- identified by its execution uuid -- yields exactly one log row.
+    """
+    screenshot_mock.return_value = SCREENSHOT_FILE
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_report_email_chart.id, datetime.utcnow()
+        ).run()
+
+        db.session.commit()
+        logs = (
+            db.session.query(ReportExecutionLog)
+            .filter(ReportExecutionLog.uuid == TEST_ID)
+            .all()
+        )
+        # A single execution (one uuid) must map to a single log entry, not one
+        # row per intermediate state transition.
+        assert len(logs) == 1
+
+
+@pytest.mark.usefixtures(
     "load_birth_names_dashboard_with_slices", "create_report_email_chart_alpha_owner"
 )
 @patch("superset.reports.notifications.email.send_email_smtp")

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -161,20 +161,26 @@ def assert_log(state: str, error_message: Optional[str] = None):
     db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
 
-    if state == ReportState.ERROR:
-        # On error we send an email
-        assert len(logs) == 3
-    else:
+    if state == ReportState.WORKING:
+        # A report that is already in the WORKING state logs an extra WORKING row
+        # for the refused re-computation, on top of the row seeded by the fixture.
         assert len(logs) == 2
+    elif state == ReportState.ERROR:
+        # On error we also send a notification, which is recorded as a separate
+        # error-notification marker row.
+        assert len(logs) == 2
+    else:
+        # A single execution yields a single log row: the terminal result replaces
+        # the WORKING "trigger" row rather than adding a second row (issue #29857).
+        assert len(logs) == 1
     log_states = [log.state for log in logs]
-    assert ReportState.WORKING in log_states
     assert state in log_states
-    assert error_message in [log.error_message for log in logs]
-
-    for log in logs:
-        if log.state == ReportState.WORKING:
-            assert log.value is None
-            assert log.value_row_json is None
+    # Previously a standalone WORKING "trigger" row always contributed a ``None``
+    # error_message, so the default ``None`` match was trivially satisfied and never
+    # verified the terminal row. With the result now written onto that single row,
+    # only assert an explicitly expected message.
+    if error_message is not None:
+        assert error_message in [log.error_message for log in logs]
 
 
 @contextmanager

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -2468,6 +2468,9 @@ def test_create_log_success_commits(mocker: MockerFixture) -> None:
     state._report_schedule = schedule
 
     mock_db = mocker.patch("superset.commands.report.execute.db")
+    # No in-flight WORKING "trigger" row exists for this execution, so create_log
+    # inserts a fresh row rather than promoting an existing one.
+    mock_db.session.query.return_value.filter.return_value.first.return_value = None
     mock_log_cls = mocker.patch(
         "superset.commands.report.execute.ReportExecutionLog",
         return_value=mocker.Mock(),


### PR DESCRIPTION
### SUMMARY

Fixes #29857 — the Alerts & Reports execution log shows **duplicated entries for a single execution**.

**Root cause.** A single report execution runs through the state machine in `superset/commands/report/execute.py`: it first transitions to `WORKING` and then to a terminal state (`SUCCESS`/`ERROR`/`NOOP`/`GRACE`). Every transition calls `create_log`, and `create_log` unconditionally **inserted a new `ReportExecutionLog` row**. All those rows share the same execution `uuid`, so one execution surfaced as (at least) two rows in the log view: an empty `WORKING` "trigger" row and the real "result" row.

**Fix.** `create_log` now **promotes the in-flight `WORKING` trigger row in place** when the terminal result is written, instead of inserting a second row. The lookup is scoped to the current execution's `uuid` (and the still-empty `WORKING`, `error_message IS NULL` placeholder), so:
- one execution = one log row;
- a genuinely stuck execution keeps its standalone `WORKING` row, so `find_last_entered_working_log` / working-timeout detection is unchanged;
- separate executions and retries still get their own rows (the query only ever matches the same `uuid`);
- the intentional error-notification marker is a terminal→terminal transition and is still recorded as a distinct row.

Ships with the regression test from this PR (red before the fix, green after) plus reconciled `assert_log` / unit-test expectations.

### BEFORE/AFTER

- **Before:** one execution wrote **two** `ReportExecutionLog` rows sharing the same `uuid` (a blank `WORKING` row + the result row) — duplicated entries in the execution log.
- **After:** one execution writes **exactly one** `ReportExecutionLog` row (the `WORKING` placeholder is promoted to the terminal result in place).

### TESTING INSTRUCTIONS

```bash
SUPERSET_CONFIG=tests.integration_tests.superset_test_config \
  pytest "tests/integration_tests/reports/commands_tests.py::test_email_chart_report_schedule_single_log_per_execution" -v
```

The test asserts that a single execution (identified by its execution `uuid`) yields exactly one `ReportExecutionLog` row. It fails on master (`assert 2 == 1`) and passes with this fix. The report-command unit suite (`tests/unit_tests/commands/report/execute_test.py`) also passes.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Closes #29857
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
