### PR TITLE
test(security): prove Drill By access does not require can_explore (#27900)

### DIFF
--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -230,6 +230,80 @@ def test_saved_chart_no_access(mocker: MockerFixture) -> None:
             )
 
 
+def test_drill_by_access_without_can_explore(mocker: MockerFixture) -> None:
+    """
+    Regression for #27900: performing Drill By (and Drill to Detail) must not
+    require the broad ``can explore on Superset`` permission.
+
+    ``check_access`` is the backend access gate for the Drill By flow: it is
+    invoked by ``CreateFormDataCommand`` when the client stores the drill
+    ``form_data`` via ``ExploreFormDataRestApi`` (the endpoint commenters on the
+    issue identified as drill-by-specific). This test grants the granular
+    ``can read on Chart`` permission while *explicitly denying*
+    ``can explore on Superset`` and asserts that access is still granted.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.explore.utils import check_access as check_chart_access
+    from superset.models.slice import Slice
+
+    def can_access_side_effect(permission: str, view_menu: str) -> bool:
+        # The broad explore permission is denied; only the granular chart-read
+        # permission is granted.
+        if (permission, view_menu) == ("can_explore", "Superset"):
+            return False
+        return (permission, view_menu) == ("can_read", "Chart")
+
+    mocker.patch(dataset_find_by_id, return_value=SqlaTable())
+    mocker.patch(can_access_datasource, return_value=True)
+    mocker.patch(is_admin, return_value=False)
+    mocker.patch(is_editor, return_value=False)
+    mocker.patch(can_access, side_effect=can_access_side_effect)
+    mocker.patch(chart_find_by_id, return_value=Slice())
+
+    with override_user(User()):
+        assert (
+            check_chart_access(  # noqa: E712
+                datasource_id=1,
+                chart_id=1,
+                datasource_type=DatasourceType.TABLE,
+            )
+            is True
+        )
+
+
+def test_drill_by_access_can_explore_is_not_the_gate(mocker: MockerFixture) -> None:
+    """
+    Regression for #27900: ``can explore on Superset`` is neither necessary nor
+    sufficient for Drill By access. Here the user holds *only*
+    ``can explore on Superset`` (the granular ``can read on Chart`` is denied and
+    the user is not an owner/admin) and access must be refused, proving the gate
+    is governed by the granular chart permission rather than ``can explore``.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.explore.utils import check_access as check_chart_access
+    from superset.models.slice import Slice
+
+    def can_access_side_effect(permission: str, view_menu: str) -> bool:
+        # Only the broad explore permission is granted; the granular chart-read
+        # permission is denied.
+        return (permission, view_menu) == ("can_explore", "Superset")
+
+    mocker.patch(dataset_find_by_id, return_value=SqlaTable())
+    mocker.patch(can_access_datasource, return_value=True)
+    mocker.patch(is_admin, return_value=False)
+    mocker.patch(is_editor, return_value=False)
+    mocker.patch(can_access, side_effect=can_access_side_effect)
+    mocker.patch(chart_find_by_id, return_value=Slice())
+
+    with raises(ChartAccessDeniedError):  # noqa: PT012
+        with override_user(User()):
+            check_chart_access(
+                datasource_id=1,
+                chart_id=1,
+                datasource_type=DatasourceType.TABLE,
+            )
+
+
 def test_dataset_has_access(mocker: MockerFixture) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_datasource_access


### PR DESCRIPTION
### SUMMARY

Test-only PR for #27900 ("Cannot use drill-by/drill-to without `can explore` on Superset permission").

The issue reports that Drill By / Drill to Detail appears to require the broad `can explore on Superset` permission, which also grants the ability to view the underlying query and edit charts. This PR adds regression coverage that pins the actual backend behavior of the Drill By access gate.

`superset/explore/utils.py::check_access` is the access check invoked by `CreateFormDataCommand` when the client stores drill `form_data` through `ExploreFormDataRestApi` — the endpoint issue commenters specifically identified as required "for drill-by". The new tests assert:

- **`test_drill_by_access_without_can_explore`** — with `can read on Chart` granted and `can explore on Superset` *explicitly denied*, access is still granted. Drill By does not require `can explore`.
- **`test_drill_by_access_can_explore_is_not_the_gate`** — with *only* `can explore on Superset` granted (and `can read on Chart` denied, not owner/admin), access is refused. `can explore` is neither necessary nor sufficient; the granular chart-read permission is the real gate.

No production code is changed.

### How to interpret CI

- **Green** (expected on current master): the backend Drill By gate is already decoupled from `can explore` — access is governed by the granular `can read on Chart` permission. This documents/guards the current contract and matches recent maintainer reports that drilling works with granular permissions (`can drill on Dashboard`, `can samples on Datasource`, `can write on ExploreFormDataRestApi`) and no `can explore`.
- **Red**: the gate would still be coupled to `can explore`, meaning the reported bug is live at the backend layer.

Note: this covers the backend permission path. Any residual `can explore` coupling in the frontend menu/UI (e.g. the "Edit chart" affordance inside the drill modal) is out of scope for this backend test.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/explore/utils_test.py::test_drill_by_access_without_can_explore \
       tests/unit_tests/explore/utils_test.py::test_drill_by_access_can_explore_is_not_the_gate -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Closes #27900
- [x] Required feature flags: none
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)
