### PR TITLE
test(rls): assert dataset search returns all mask matches (#29707)

### DIFF
--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -469,6 +469,58 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
         assert all("birth" in table_name.lower() for table_name in received_tables)
         assert len(result) >= 1  # At least birth_names should be returned
 
+    @pytest.mark.usefixtures("load_birth_names_data")
+    def test_rls_tables_related_api_returns_all_masked_matches(self):
+        """
+        Regression for #29707: the RLS dataset selector's async search must
+        return *every* dataset whose name matches the typed mask, not a
+        truncated subset. The reporter had two "birth" datasets (birth_names
+        and birth_france_by_region) and searching "birth" showed an
+        incomplete list. This exercises the backend ``related/tables``
+        endpoint that feeds that selector to prove whether the search-by-mask
+        lookup is the culprit.
+        """
+        self.login(ADMIN_USERNAME)
+
+        birth_names = self.get_table(name="birth_names")
+        # Create a sibling dataset whose name also contains the "birth" mask,
+        # mirroring the two-dataset scenario from the issue.
+        sibling = SqlaTable(
+            table_name="birth_france_by_region",
+            database=birth_names.database,
+            schema=birth_names.schema,
+        )
+        db.session.add(sibling)
+        db.session.commit()
+
+        try:
+            # Datasets in the metadata DB that match the "birth" mask.
+            expected = {
+                t.name
+                for t in db.session.query(SqlaTable)
+                .filter(SqlaTable.table_name.ilike("%birth%"))
+                .all()
+            }
+            # Both datasets must be present in the ground truth for the
+            # assertion below to be meaningful.
+            bare_names = {name.split(".")[-1] for name in expected}
+            assert "birth_names" in bare_names
+            assert "birth_france_by_region" in bare_names
+
+            params = rison.dumps({"filter": "birth", "page": 0, "page_size": 100})
+            rv = self.client.get(f"/api/v1/rowlevelsecurity/related/tables?q={params}")
+            assert rv.status_code == 200
+            data = json.loads(rv.data.decode("utf-8"))
+            received = {table["text"] for table in data["result"]}
+
+            # The masked search must return *all* matching datasets, and the
+            # advertised count must not under-report them.
+            assert received == expected
+            assert data["count"] == len(expected)
+        finally:
+            db.session.delete(sibling)
+            db.session.commit()
+
     def test_rls_tables_related_api_with_filter_no_matches(self):
         self.login(ADMIN_USERNAME)
         # Test with filter that should match nothing

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -494,13 +494,17 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
         db.session.commit()
 
         try:
-            # Datasets in the metadata DB that match the "birth" mask.
-            expected = {
+            # Datasets in the metadata DB that match the "birth" mask. Keep a
+            # sorted list rather than a set so datasets that render the same
+            # display name (same table/schema across databases) are not
+            # collapsed, which would let the multiplicity disagree with the
+            # API's row count below.
+            expected = sorted(
                 t.name
                 for t in db.session.query(SqlaTable)
                 .filter(SqlaTable.table_name.ilike("%birth%"))
                 .all()
-            }
+            )
             # Both datasets must be present in the ground truth for the
             # assertion below to be meaningful.
             bare_names = {name.split(".")[-1] for name in expected}
@@ -511,10 +515,10 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
             rv = self.client.get(f"/api/v1/rowlevelsecurity/related/tables?q={params}")
             assert rv.status_code == 200
             data = json.loads(rv.data.decode("utf-8"))
-            received = {table["text"] for table in data["result"]}
+            received = sorted(table["text"] for table in data["result"])
 
-            # The masked search must return *all* matching datasets, and the
-            # advertised count must not under-report them.
+            # The masked search must return *all* matching datasets (preserving
+            # multiplicity), and the advertised count must not under-report them.
             assert received == expected
             assert data["count"] == len(expected)
         finally:


### PR DESCRIPTION
### SUMMARY

Test-only PR adding regression coverage for #29707, where the Row Level
Security rule form's dataset selector reportedly showed an **incomplete list
of datasets when filtering by a search mask** (typing "birth" returned an
empty/partial list even though `birth_names` and `birth_france_by_region`
both exist).

The RLS dataset selector is backed by the `GET /api/v1/rowlevelsecurity/related/tables`
endpoint, whose search is applied by `FilterRelatedTables`
(`SqlaTable.table_name.ilike("%<mask>%")`). This PR pins that backend
behavior: it creates two datasets whose names both contain the mask,
searches for the mask, and asserts the endpoint returns **every** matching
dataset (and that `count` does not under-report them).

No product code is changed — this is a characterization/regression test to
localize the reported bug.

### How to interpret CI

- **Green (as observed locally):** the backend `related/tables` search-by-mask
  correctly returns all matching datasets and does not truncate them. That
  means the incomplete-list behavior in #29707 does **not** originate in this
  backend endpoint/filter, and the remaining suspect is the frontend
  `AsyncSelect` in `RowLevelSecurityModal` (the reporter's own note — "scroll
  the list to the bottom, then the search works" — is consistent with a
  client-side option-caching/pagination issue rather than a server filter).
- **Red:** the endpoint would be dropping or truncating masked matches,
  confirming the bug lives in the backend lookup and pointing a fix at
  `FilterRelatedTables` / the related-field pagination.

This test currently passes on `master`.

### TESTING INSTRUCTIONS

```bash
pytest tests/integration_tests/security/row_level_security_tests.py::TestRowLevelSecurityWithRelatedAPI::test_rls_tables_related_api_returns_all_masked_matches -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Closes #29707
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
