### PR TITLE
test(rls): assert related/subjects honors search filter for roles (#31466)

### DIFF
--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -492,6 +492,57 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
         assert data["count"] > 0
         assert len(result) > 0
 
+    def test_rls_subjects_related_api_honors_filter_31466(self):
+        """
+        Regression for #31466: with more than 100 roles the RLS picker could
+        not see or select roles beyond the first (default) page of 100 because
+        the ``related/roles`` endpoint silently ignored the search ``filter``
+        term. The RLS subject/role picker now lives at ``related/subjects``,
+        and this test asserts the search term actually narrows the result to
+        matching subjects, so any role remains reachable by name regardless of
+        how many roles exist.
+        """
+        self.login(ADMIN_USERNAME)
+
+        # A role label that cannot collide with the built-in roles/subjects
+        # (Admin, Public, Alpha, Gamma, sql_lab, ...).
+        unique_marker = "zzz_rls_31466"
+        role_name = f"{unique_marker}_special_role"
+        role = security_manager.add_role(role_name)
+        db.session.commit()
+        subject = _subject_for_role(role)
+        db.session.commit()
+
+        # Ensure ROLE-type subjects are visible in the RLS picker (the scenario
+        # from #31466, where roles drive RLS). This is what the original
+        # ``related/roles`` endpoint used to serve unconditionally.
+        original_types = self.app.config.get("SUBJECTS_RELATED_TYPES_RLS")
+        self.app.config["SUBJECTS_RELATED_TYPES_RLS"] = [SubjectType.ROLE]
+        try:
+            params = rison.dumps({"filter": unique_marker, "page": 0, "page_size": 100})
+            rv = self.client.get(
+                f"/api/v1/rowlevelsecurity/related/subjects?q={params}"
+            )
+            assert rv.status_code == 200
+            data = json.loads(rv.data.decode("utf-8"))
+            received = {r["text"] for r in data["result"]}
+
+            # The role must be findable via the search term ...
+            assert role_name in received
+            # ... and the filter must narrow the result to matching subjects
+            # only. If the search term were ignored (the #31466 bug), other
+            # roles that do not contain the marker would leak through and this
+            # assertion would fail.
+            assert all(unique_marker in text for text in received), (
+                "related/subjects ignored the filter term and returned "
+                f"non-matching subjects: {sorted(received)}"
+            )
+        finally:
+            self.app.config["SUBJECTS_RELATED_TYPES_RLS"] = original_types
+            db.session.delete(subject)
+            db.session.delete(role)
+            db.session.commit()
+
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     @mock.patch(


### PR DESCRIPTION
### SUMMARY

Regression test for #31466 ("More than 100 roles will cause RLS role dropdown and API not showing all roles").

The original bug: the RLS role picker was served by `GET /api/v1/rowlevelsecurity/related/roles`, which had no entry in `related_field_filters`. The search `filter` term was therefore silently ignored, so with more than 100 roles (the default page size) any role past the first page was unreachable — you could neither see nor select it.

Since then, the RLS subject/role picker was refactored (#38831, #41897): roles are now modeled as `Subject` rows and served by `GET /api/v1/rowlevelsecurity/related/subjects`, whose `FilterRelatedSubjects` applies an `ILIKE` on the subject label. That makes any role findable by name regardless of how many roles exist, which resolves the reported bug.

This is a **test-only** change. It adds `test_rls_subjects_related_api_honors_filter_31466` to the existing `TestRowLevelSecurityWithRelatedAPI` class. The test creates a role with a unique marker label, syncs it to a ROLE-type subject, enables ROLE subjects in the RLS picker (`SUBJECTS_RELATED_TYPES_RLS`), then asserts the role is findable via the search term **and** that the filter narrows the result to matching subjects only (i.e. it is no longer ignored). No production code is touched.

### How to interpret CI

- **Green** (expected): the endpoint honors the search filter on current master, confirming #31466 is fixed by the Subject refactor. The test stands as a regression guard against reintroducing the silent-cap behavior.
- **Red**: the search filter is being ignored again (non-matching roles leak through, or the target role is unreachable) — the #31466 bug would have regressed.

### TESTING INSTRUCTIONS

```
pytest "tests/integration_tests/security/row_level_security_tests.py::TestRowLevelSecurityWithRelatedAPI::test_rls_subjects_related_api_honors_filter_31466" -v
```

Passes locally on master.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Closes #31466
- [x] Required feature flags: N/A
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Introduces new feature or API: no (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
