### PR TITLE
feat(pivot-table): rename Subtotal to Subvalue

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1073,7 +1073,7 @@ export function TableRenderer(props: TableRendererProps) {
                 true,
               )}
             >
-              {t('Subtotal')}
+              {t('Subvalue')}
             </th>,
           );
         }
@@ -1333,7 +1333,7 @@ export function TableRenderer(props: TableRendererProps) {
               true,
             )}
           >
-            {t('Subtotal')}
+            {t('Subvalue')}
           </th>
         ) : null;
 


### PR DESCRIPTION
Fixes #35089

Renames 'Subtotal' to 'Subvalue' in Pivot Tables to be more accurate since the aggregation function might not be a sum.