### PR TITLE
fix(tests): correct stale TYPE_CHECKING import path in base_data_loader

### DIFF
--- a/tests/example_data/data_loading/base_data_loader.py
+++ b/tests/example_data/data_loading/base_data_loader.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from tests.common.example_data.data_loading.data_definitions.types import Table
+    from tests.example_data.data_loading.data_definitions.types import Table
 
 
 class DataLoader(ABC):


### PR DESCRIPTION
### SUMMARY

`tests/example_data/data_loading/base_data_loader.py:23` imports `tests.common.example_data.data_loading.data_definitions.types` under `TYPE_CHECKING`, but no `example_data` package exists under `tests/common/` — the real module is `tests/example_data/data_loading/data_definitions/types.py` (where `Table` is defined). Any type-check that resolves this file fails on the dead path.

One-line path fix. No runtime behavior change (import is `TYPE_CHECKING`-only).

Found while validating DACIP, a static contract-analysis tool I'm building, against open-source codebases; verified against `49dc0acd827ae59845dc079e980a0ff701114396` (master, 2026-07-12).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

n/a

### TESTING INSTRUCTIONS

`ls tests/common/` — no `example_data` package exists there. `ls tests/example_data/data_loading/data_definitions/types.py` — the real module. After the change, the `TYPE_CHECKING` import resolves; `mypy tests/example_data/data_loading/base_data_loader.py` no longer reports the missing module.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
