### PR TITLE
fix(bigquery): ensure BigQuery client uses project from engine URI

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -728,15 +728,17 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
                 "Could not import libraries needed to connect to BigQuery."
             )
 
+        project = engine.url.host or None
+
         if credentials_info := engine.dialect.credentials_info:
             credentials = service_account.Credentials.from_service_account_info(
                 credentials_info
             )
-            return bigquery.Client(credentials=credentials)
+            return bigquery.Client(credentials=credentials, project=project)
 
         try:
             credentials = google.auth.default()[0]
-            return bigquery.Client(credentials=credentials)
+            return bigquery.Client(credentials=credentials, project=project)
         except google.auth.exceptions.DefaultCredentialsError as ex:
             raise SupersetDBAPIConnectionError(
                 "The database credentials could not be found."

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -728,7 +728,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
                 "Could not import libraries needed to connect to BigQuery."
             )
 
-        project = engine.url.host or None
+        project: str | None = engine.url.host or engine.url.database or None
 
         if credentials_info := engine.dialect.credentials_info:
             credentials = service_account.Credentials.from_service_account_info(

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -728,7 +728,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
                 "Could not import libraries needed to connect to BigQuery."
             )
 
-        project: str | None = engine.url.host or engine.url.database or None
+        project: str | None = engine.url.host or None
 
         if credentials_info := engine.dialect.credentials_info:
             credentials = service_account.Credentials.from_service_account_info(

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -430,6 +430,52 @@ def test_get_default_catalog(mocker: MockerFixture) -> None:
     assert BigQueryEngineSpec.get_default_catalog(database) == "project"
 
 
+def test_get_client_uses_uri_project_with_service_account_credentials(
+    mocker: MockerFixture,
+) -> None:
+    """Test that service-account clients use the project from the engine URI."""
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    credentials_info = {"project_id": "credential-project"}
+    credentials = mock.Mock()
+    engine = mock.MagicMock()
+    engine.url = make_url("bigquery://uri-project")
+    engine.dialect.credentials_info = credentials_info
+    create_credentials = mocker.patch(
+        "superset.db_engine_specs.bigquery.service_account.Credentials."
+        "from_service_account_info",
+        return_value=credentials,
+    )
+    client = mocker.patch("superset.db_engine_specs.bigquery.bigquery.Client")
+
+    BigQueryEngineSpec._get_client(engine, mock.Mock())
+
+    create_credentials.assert_called_once_with(credentials_info)
+    client.assert_called_once_with(credentials=credentials, project="uri-project")
+
+
+def test_get_client_uses_uri_project_with_application_default_credentials(
+    mocker: MockerFixture,
+) -> None:
+    """Test that ADC clients use the project from the engine URI."""
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    credentials = mock.Mock()
+    engine = mock.MagicMock()
+    engine.url = make_url("bigquery://uri-project")
+    engine.dialect.credentials_info = None
+    get_default_credentials = mocker.patch(
+        "superset.db_engine_specs.bigquery.google.auth.default",
+        return_value=(credentials, "credential-project"),
+    )
+    client = mocker.patch("superset.db_engine_specs.bigquery.bigquery.Client")
+
+    BigQueryEngineSpec._get_client(engine, mock.Mock())
+
+    get_default_credentials.assert_called_once_with()
+    client.assert_called_once_with(credentials=credentials, project="uri-project")
+
+
 def test_get_time_partition_column_uses_catalog_in_table_reference(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -431,16 +431,17 @@ def test_get_default_catalog(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    ("sqlalchemy_uri", "expected_project"),
+    ("sqlalchemy_uri", "schema", "expected_project"),
     [
-        ("bigquery://uri-project", "uri-project"),
-        ("bigquery:///uri-project", "uri-project"),
-        ("bigquery://", None),
+        ("bigquery://uri-project", None, "uri-project"),
+        ("bigquery:///uri-project", None, "uri-project"),
+        ("bigquery://", "dataset_name", None),
     ],
 )
 def test_get_client_resolves_uri_project_with_service_account_credentials(
     mocker: MockerFixture,
     sqlalchemy_uri: str,
+    schema: str | None,
     expected_project: str | None,
 ) -> None:
     """Test that service-account clients use the project from the engine URI."""
@@ -449,7 +450,9 @@ def test_get_client_resolves_uri_project_with_service_account_credentials(
     credentials_info = {"project_id": "credential-project"}
     credentials = mock.Mock()
     engine = mock.MagicMock()
-    engine.url = make_url(sqlalchemy_uri)
+    engine.url = BigQueryEngineSpec.adjust_engine_params(
+        make_url(sqlalchemy_uri), {}, schema=schema
+    )[0]
     engine.dialect.credentials_info = credentials_info
     create_credentials = mocker.patch(
         "superset.db_engine_specs.bigquery.service_account.Credentials."
@@ -465,16 +468,17 @@ def test_get_client_resolves_uri_project_with_service_account_credentials(
 
 
 @pytest.mark.parametrize(
-    ("sqlalchemy_uri", "expected_project"),
+    ("sqlalchemy_uri", "schema", "expected_project"),
     [
-        ("bigquery://uri-project", "uri-project"),
-        ("bigquery:///uri-project", "uri-project"),
-        ("bigquery://", None),
+        ("bigquery://uri-project", None, "uri-project"),
+        ("bigquery:///uri-project", None, "uri-project"),
+        ("bigquery://", "dataset_name", None),
     ],
 )
 def test_get_client_resolves_uri_project_with_application_default_credentials(
     mocker: MockerFixture,
     sqlalchemy_uri: str,
+    schema: str | None,
     expected_project: str | None,
 ) -> None:
     """Test that ADC clients use the project from the engine URI."""
@@ -482,7 +486,9 @@ def test_get_client_resolves_uri_project_with_application_default_credentials(
 
     credentials = mock.Mock()
     engine = mock.MagicMock()
-    engine.url = make_url(sqlalchemy_uri)
+    engine.url = BigQueryEngineSpec.adjust_engine_params(
+        make_url(sqlalchemy_uri), {}, schema=schema
+    )[0]
     engine.dialect.credentials_info = None
     get_default_credentials = mocker.patch(
         "superset.db_engine_specs.bigquery.google.auth.default",

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -430,8 +430,18 @@ def test_get_default_catalog(mocker: MockerFixture) -> None:
     assert BigQueryEngineSpec.get_default_catalog(database) == "project"
 
 
-def test_get_client_uses_uri_project_with_service_account_credentials(
+@pytest.mark.parametrize(
+    ("sqlalchemy_uri", "expected_project"),
+    [
+        ("bigquery://uri-project", "uri-project"),
+        ("bigquery:///uri-project", "uri-project"),
+        ("bigquery://", None),
+    ],
+)
+def test_get_client_resolves_uri_project_with_service_account_credentials(
     mocker: MockerFixture,
+    sqlalchemy_uri: str,
+    expected_project: str | None,
 ) -> None:
     """Test that service-account clients use the project from the engine URI."""
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
@@ -439,7 +449,7 @@ def test_get_client_uses_uri_project_with_service_account_credentials(
     credentials_info = {"project_id": "credential-project"}
     credentials = mock.Mock()
     engine = mock.MagicMock()
-    engine.url = make_url("bigquery://uri-project")
+    engine.url = make_url(sqlalchemy_uri)
     engine.dialect.credentials_info = credentials_info
     create_credentials = mocker.patch(
         "superset.db_engine_specs.bigquery.service_account.Credentials."
@@ -451,18 +461,28 @@ def test_get_client_uses_uri_project_with_service_account_credentials(
     BigQueryEngineSpec._get_client(engine, mock.Mock())
 
     create_credentials.assert_called_once_with(credentials_info)
-    client.assert_called_once_with(credentials=credentials, project="uri-project")
+    client.assert_called_once_with(credentials=credentials, project=expected_project)
 
 
-def test_get_client_uses_uri_project_with_application_default_credentials(
+@pytest.mark.parametrize(
+    ("sqlalchemy_uri", "expected_project"),
+    [
+        ("bigquery://uri-project", "uri-project"),
+        ("bigquery:///uri-project", "uri-project"),
+        ("bigquery://", None),
+    ],
+)
+def test_get_client_resolves_uri_project_with_application_default_credentials(
     mocker: MockerFixture,
+    sqlalchemy_uri: str,
+    expected_project: str | None,
 ) -> None:
     """Test that ADC clients use the project from the engine URI."""
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
     credentials = mock.Mock()
     engine = mock.MagicMock()
-    engine.url = make_url("bigquery://uri-project")
+    engine.url = make_url(sqlalchemy_uri)
     engine.dialect.credentials_info = None
     get_default_credentials = mocker.patch(
         "superset.db_engine_specs.bigquery.google.auth.default",
@@ -473,7 +493,7 @@ def test_get_client_uses_uri_project_with_application_default_credentials(
     BigQueryEngineSpec._get_client(engine, mock.Mock())
 
     get_default_credentials.assert_called_once_with()
-    client.assert_called_once_with(credentials=credentials, project="uri-project")
+    client.assert_called_once_with(credentials=credentials, project=expected_project)
 
 
 def test_get_time_partition_column_uses_catalog_in_table_reference(


### PR DESCRIPTION
### SUMMARY

Fixes BigQuery metadata operations resolving datasets against the Application Default Credentials project instead of the project configured in the connection URI.

`BigQueryEngineSpec._get_client` previously created `bigquery.Client` without specifying a project. When the credentials project differed from the project in a connection such as `bigquery://data-project`, unqualified BigQuery table references were resolved against the credentials project and could return a dataset-not-found error.

This change:

- Reads the project from `engine.url.host`.
- Passes that project to `bigquery.Client` for both service-account credentials and Application Default Credentials.
- Adds focused unit coverage for both authentication paths.

Fixes #41906

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. This is a backend-only change.

### TESTING INSTRUCTIONS

Automated tests:

```bash
python -m pytest \
  tests/unit_tests/db_engine_specs/test_bigquery.py \
  -k "get_client_uses_uri_project" \
  -vv
```

Result:

```text
2 passed, 38 deselected
```

Code-quality checks:

```bash
python -m pre_commit run --files \
  superset/db_engine_specs/bigquery.py \
  tests/unit_tests/db_engine_specs/test_bigquery.py
```

Result:

```text
All applicable hooks passed.
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: #41906
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API