### PR TITLE
chore: sqlalchemy.database package warnings are irrelevant

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,7 +39,6 @@ filterwarnings =
 #    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
 #    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
-#    error:The `database` package is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
 #    error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
     error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning


### PR DESCRIPTION
See #40273 

### SUMMARY

Warnings are raised that `sqlalchemy.database` is deprecated.
However, they are not caused by the Superset code but by `pyhive`.
They have already prepared the migration to SQLAlchemy 2.0.
For example: https://github.com/dropbox/PyHive/blob/ac09074a652fd50e10b57a7f0bbc4f6410961301/pyhive/sqlalchemy_hive.py#L29 .
So the warnings are safe to ignore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
