### PR TITLE
refactor: begin transaction to automatically commit

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -37,7 +37,7 @@ filterwarnings =
 #    error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
-#    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
+    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
 #    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
     error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
     error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -417,12 +417,12 @@ class SupersetShillelaghAdapter(Adapter):
         query = self._build_sql(bounds, order, limit, offset)
 
         with self.engine_context() as engine:
-            connection = engine.connect()
-            rows = connection.execute(query)
-            for i, row in enumerate(rows):
-                data = dict(zip(self.columns, row, strict=False))
-                data["rowid"] = data[self._rowid] if self._rowid else i
-                yield data
+            with engine.connect() as connection:
+                rows = connection.execute(query)
+                for i, row in enumerate(rows):
+                    data = dict(zip(self.columns, row, strict=False))
+                    data["rowid"] = data[self._rowid] if self._rowid else i
+                    yield data
 
     @check_dml
     def insert_row(self, row: Row) -> int:
@@ -445,15 +445,16 @@ class SupersetShillelaghAdapter(Adapter):
         query = self._table.insert().values(**row)
 
         with self.engine_context() as engine:
-            connection = engine.connect()
-            result = connection.execute(query)
+            with engine.begin() as connection:
+                result = connection.execute(query)
 
-            # return rowid
-            if self._rowid:
-                return result.inserted_primary_key[0]
+                # return rowid
+                if self._rowid:
+                    return result.inserted_primary_key[0]
 
             query = select(func.count()).select_from(self._table)
-            return connection.execute(query).scalar()
+            with engine.connect() as connection:
+                return connection.execute(query).scalar()
 
     @check_dml
     @has_rowid
@@ -464,8 +465,8 @@ class SupersetShillelaghAdapter(Adapter):
         query = self._table.delete().where(self._table.c[self._rowid] == row_id)
 
         with self.engine_context() as engine:
-            connection = engine.connect()
-            connection.execute(query)
+            with engine.begin() as connection:
+                connection.execute(query)
 
     @check_dml
     @has_rowid
@@ -488,5 +489,5 @@ class SupersetShillelaghAdapter(Adapter):
         )
 
         with self.engine_context() as engine:
-            connection = engine.connect()
-            connection.execute(query)
+            with engine.begin() as connection:
+                connection.execute(query)

--- a/tests/unit_tests/db_engine_specs/test_sqlite.py
+++ b/tests/unit_tests/db_engine_specs/test_sqlite.py
@@ -121,12 +121,13 @@ def test_time_grain_expressions(dttm: str, grain: str, expected: str) -> None:  
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
     engine = create_engine("sqlite://")
-    connection = engine.connect()
-    connection.execute(text("CREATE TABLE t (dttm DATETIME)"))
-    connection.execute(text("INSERT INTO t VALUES (:dttm)"), {"dttm": dttm})
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE t (dttm DATETIME)"))
+        connection.execute(text("INSERT INTO t VALUES (:dttm)"), {"dttm": dttm})
 
     # pylint: disable=protected-access
     expression = SqliteEngineSpec._time_grain_expressions[grain].format(col="dttm")
     sql = f"SELECT {expression} FROM t"  # noqa: S608
-    result = connection.execute(text(sql)).scalar()
+    with engine.connect() as connection:
+        result = connection.execute(text(sql)).scalar()
     assert result == expected

--- a/tests/unit_tests/extensions/test_sqlalchemy.py
+++ b/tests/unit_tests/extensions/test_sqlalchemy.py
@@ -63,16 +63,17 @@ def database1(session: Session) -> Iterator["Database"]:
 @pytest.fixture
 def table1(session: Session, database1: "Database") -> Iterator[None]:
     with database1.get_sqla_engine() as engine:
-        conn = engine.connect()
-        conn.execute(
-            text("CREATE TABLE table1 (a INTEGER NOT NULL PRIMARY KEY, b INTEGER)")
-        )
-        conn.execute(text("INSERT INTO table1 (a, b) VALUES (1, 10), (2, 20)"))
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE table1 (a INTEGER NOT NULL PRIMARY KEY, b INTEGER)")
+            )
+            conn.execute(text("INSERT INTO table1 (a, b) VALUES (1, 10), (2, 20)"))
         db.session.commit()
 
         yield
 
-        conn.execute(text("DROP TABLE table1"))
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE table1"))
         db.session.commit()
 
 
@@ -99,16 +100,19 @@ def database2(session: Session) -> Iterator["Database"]:
 @pytest.fixture
 def table2(session: Session, database2: "Database") -> Iterator[None]:
     with database2.get_sqla_engine() as engine:
-        conn = engine.connect()
-        conn.execute(
-            text("CREATE TABLE table2 (a INTEGER NOT NULL PRIMARY KEY, b TEXT)")
-        )
-        conn.execute(text("INSERT INTO table2 (a, b) VALUES (1, 'ten'), (2, 'twenty')"))
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE table2 (a INTEGER NOT NULL PRIMARY KEY, b TEXT)")
+            )
+            conn.execute(
+                text("INSERT INTO table2 (a, b) VALUES (1, 'ten'), (2, 'twenty')")
+            )
         db.session.commit()
 
         yield
 
-        conn.execute(text("DROP TABLE table2"))
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE table2"))
         db.session.commit()
 
 
@@ -137,9 +141,9 @@ def test_superset(mocker: MockerFixture, app_context: None, table1: None) -> Non
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10), (2, 20)]
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10), (2, 20)]
 
 
 @with_config(
@@ -178,9 +182,9 @@ def test_superset_limit(mocker: MockerFixture, app_context: None, table1: None) 
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10)]
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10)]
 
 
 @with_feature_flags(ENABLE_SUPERSET_META_DB=True)
@@ -213,16 +217,16 @@ def test_superset_joins(
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
-    results = conn.execute(
-        text("""
-        SELECT t1.b, t2.b
-        FROM "database1.table1" AS t1
-        JOIN "database2.table2" AS t2
-        ON t1.a = t2.a
-        """)
-    )
-    assert list(results) == [(10, "ten"), (20, "twenty")]
+    with engine.connect() as conn:
+        results = conn.execute(
+            text("""
+            SELECT t1.b, t2.b
+            FROM "database1.table1" AS t1
+            JOIN "database2.table2" AS t2
+            ON t1.a = t2.a
+            """)
+        )
+        assert list(results) == [(10, "ten"), (20, "twenty")]
 
 
 @with_feature_flags(ENABLE_SUPERSET_META_DB=True)
@@ -257,22 +261,27 @@ def test_dml(
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
+    with engine.begin() as conn:
+        conn.execute(text('INSERT INTO "database1.table1" (a, b) VALUES (3, 30)'))
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10), (2, 20), (3, 30)]
+    with engine.begin() as conn:
+        conn.execute(text('UPDATE "database1.table1" SET b=35 WHERE a=3'))
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10), (2, 20), (3, 35)]
+    with engine.begin() as conn:
+        conn.execute(text('DELETE FROM "database1.table1" WHERE b>20'))
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10), (2, 20)]
 
-    conn.execute(text('INSERT INTO "database1.table1" (a, b) VALUES (3, 30)'))
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10), (2, 20), (3, 30)]
-    conn.execute(text('UPDATE "database1.table1" SET b=35 WHERE a=3'))
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10), (2, 20), (3, 35)]
-    conn.execute(text('DELETE FROM "database1.table1" WHERE b>20'))
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10), (2, 20)]
-
-    with pytest.raises(ProgrammingError) as excinfo:
-        conn.execute(
-            text("""INSERT INTO "database2.table2" (a, b) VALUES (3, 'thirty')""")
-        )
+    with engine.begin() as conn:
+        with pytest.raises(ProgrammingError) as excinfo:
+            conn.execute(
+                text("""INSERT INTO "database2.table2" (a, b) VALUES (3, 'thirty')""")
+            )
     assert str(excinfo.value).strip() == (
         "(shillelagh.exceptions.ProgrammingError) DML not enabled in database "
         '"database2"\n[SQL: INSERT INTO "database2.table2" (a, b) '
@@ -324,9 +333,9 @@ def test_security_manager(
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
-    with pytest.raises(SupersetSecurityException) as excinfo:
-        conn.execute(text('SELECT * FROM "database1.table1"'))
+    with engine.connect() as conn:
+        with pytest.raises(SupersetSecurityException) as excinfo:
+            conn.execute(text('SELECT * FROM "database1.table1"'))
     assert str(excinfo.value) == (
         "You need access to the following tables: `table1`,\n            "
         "`all_database_access` or `all_datasource_access` permission"
@@ -358,13 +367,13 @@ def test_allowed_dbs(mocker: MockerFixture, app_context: None, table1: None) -> 
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
 
-    conn = engine.connect()
+    with engine.connect() as conn:
+        results = conn.execute(text('SELECT * FROM "database1.table1"'))
+        assert list(results) == [(1, 10), (2, 20)]
 
-    results = conn.execute(text('SELECT * FROM "database1.table1"'))
-    assert list(results) == [(1, 10), (2, 20)]
-
-    with pytest.raises(ProgrammingError) as excinfo:
-        conn.execute(text('SELECT * FROM "database2.table2"'))
+    with engine.connect() as conn:
+        with pytest.raises(ProgrammingError) as excinfo:
+            conn.execute(text('SELECT * FROM "database2.table2"'))
     assert str(excinfo.value) == (
         """
 (shillelagh.exceptions.ProgrammingError) Unsupported table: database2.table2

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_dashboards.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_dashboards.py
@@ -103,7 +103,7 @@ def _indexes(engine: Engine) -> set[str]:
 
 
 def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -115,7 +115,7 @@ def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
 
 
 def test_downgrade_drops_deleted_at_column_and_index(engine: Engine) -> None:
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -138,7 +138,7 @@ def test_downgrade_preserves_soft_deleted_row_data(engine: Engine) -> None:
     hard-delete, restore, or rename BEFORE downgrading. See the
     "Rollback note" in ``UPDATING.md``.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -198,7 +198,7 @@ def test_sqlite_slug_constraint_swap_is_a_no_op(engine: Engine) -> None:
         "pre-condition: legacy slug constraint must exist before the migration runs"
     )
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -207,7 +207,7 @@ def test_sqlite_slug_constraint_swap_is_a_no_op(engine: Engine) -> None:
         "upgrade() must keep the legacy slug constraint on SQLite (no-op branch)"
     )
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.downgrade()
@@ -222,7 +222,7 @@ def test_upgrade_is_idempotent(engine: Engine) -> None:
     idempotent skip-if-exists; running ``upgrade()`` twice must not
     raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -233,7 +233,7 @@ def test_downgrade_is_idempotent(engine: Engine) -> None:
     """``drop_columns`` / ``drop_index`` are skip-if-not-exists; running
     ``downgrade()`` twice must not raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_slices.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_slices.py
@@ -88,7 +88,7 @@ def _indexes(engine: Engine) -> set[str]:
 
 def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
     """upgrade() adds the nullable ``deleted_at`` column and its index."""
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -101,7 +101,7 @@ def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
 
 def test_downgrade_drops_deleted_at_column_and_index(engine: Engine) -> None:
     """downgrade() removes both schema artifacts (column and index)."""
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -124,7 +124,7 @@ def test_downgrade_preserves_soft_deleted_row_data(engine: Engine) -> None:
     hard-delete, restore, or rename BEFORE downgrading. See the
     "Rollback note" in ``UPDATING.md``.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -171,7 +171,7 @@ def test_upgrade_is_idempotent(engine: Engine) -> None:
     idempotent skip-if-exists; running ``upgrade()`` twice must not
     raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -182,7 +182,7 @@ def test_downgrade_is_idempotent(engine: Engine) -> None:
     """``drop_columns`` / ``drop_index`` are skip-if-not-exists; running
     ``downgrade()`` twice must not raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_tables.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_tables.py
@@ -85,7 +85,7 @@ def _indexes(engine: Engine) -> set[str]:
 
 
 def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -97,7 +97,7 @@ def test_upgrade_adds_deleted_at_column_and_index(engine: Engine) -> None:
 
 
 def test_downgrade_drops_deleted_at_column_and_index(engine: Engine) -> None:
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -120,7 +120,7 @@ def test_downgrade_preserves_soft_deleted_row_data(engine: Engine) -> None:
     hard-delete, restore, or rename BEFORE downgrading. See the
     "Rollback note" in ``UPDATING.md``.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -170,7 +170,7 @@ def test_upgrade_is_idempotent(engine: Engine) -> None:
     idempotent skip-if-exists; running ``upgrade()`` twice must not
     raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()
@@ -181,7 +181,7 @@ def test_downgrade_is_idempotent(engine: Engine) -> None:
     """``drop_columns`` / ``drop_index`` are skip-if-not-exists; running
     ``downgrade()`` twice must not raise.
     """
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         with Operations.context(ctx):
             migration.upgrade()


### PR DESCRIPTION
See #40273 

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enable errors for Engine.connect() (no autocommit) with DML statements, and fix them all.

In addition to fixing all broken tests, I manually went through all results of `git grep connect(`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
