### PR TITLE
refactor: import from sqlalchemy.orm

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -38,7 +38,7 @@ filterwarnings =
 #    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
 #    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
-#    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
+    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
     error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
     error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
     error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -49,10 +49,10 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.engine.base import Connection
-from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     backref,
+    declared_attr,
     foreign,
     Mapped,
     Query,

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -25,7 +25,7 @@ from uuid import UUID
 from flask_babel import lazy_gettext as _
 from sqlalchemy.engine.url import URL as SqlaURL  # noqa: N811
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy.ext.declarative import DeclarativeMeta
+from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.orm.exc import ObjectDeletedError
 from sqlalchemy.sql.type_api import TypeEngine
 

--- a/superset/migrations/shared/catalogs.py
+++ b/superset/migrations/shared/catalogs.py
@@ -24,8 +24,7 @@ from typing import Any, Type, Union
 import sqlalchemy as sa
 from alembic import op
 from flask import current_app
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import lazyload, Session
+from sqlalchemy.orm import declarative_base, lazyload, Session
 
 from superset import db, security_manager
 from superset.db_engine_specs.base import GenericDBException

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -20,8 +20,7 @@ from typing import Any
 
 from flask import current_app
 from sqlalchemy import and_, Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import declarative_base, Session
 
 from superset.constants import TimeGrain
 from superset.migrations.shared.utils import paginated_update, try_load_json

--- a/superset/migrations/shared/security_converge.py
+++ b/superset/migrations/shared/security_converge.py
@@ -26,8 +26,7 @@ from sqlalchemy import (
     Table,
     UniqueConstraint,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Load, relationship, Session
+from sqlalchemy.orm import declarative_base, Load, relationship, Session
 
 logger = logging.getLogger("alembic.env")
 

--- a/superset/migrations/versions/2016-04-25_08-54_c3a8f8611885_materializing_permission.py
+++ b/superset/migrations/versions/2016-04-25_08-54_c3a8f8611885_materializing_permission.py
@@ -25,7 +25,7 @@ Create Date: 2016-04-25 08:54:04.303859
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2016-06-07_12-33_d8bc074f7aad_add_new_field_is_restricted_to_.py
+++ b/superset/migrations/versions/2016-06-07_12-33_d8bc074f7aad_add_new_field_is_restricted_to_.py
@@ -29,7 +29,7 @@ down_revision = "1226819ee0e3"
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 from sqlalchemy import Boolean, Column, Integer  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 

--- a/superset/migrations/versions/2016-06-27_08-43_27ae655e4247_make_creator_owners.py
+++ b/superset/migrations/versions/2016-06-27_08-43_27ae655e4247_make_creator_owners.py
@@ -28,8 +28,7 @@ down_revision = "d8bc074f7aad"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, ForeignKey, Integer, Table  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base, declared_attr  # noqa: E402
-from sqlalchemy.orm import relationship  # noqa: E402
+from sqlalchemy.orm import declarative_base, declared_attr, relationship  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils.core import get_user_id  # noqa: E402

--- a/superset/migrations/versions/2016-09-07_23-50_33d996bcc382_update_slice_model.py
+++ b/superset/migrations/versions/2016-09-07_23-50_33d996bcc382_update_slice_model.py
@@ -25,7 +25,7 @@ Create Date: 2016-09-07 23:50:59.366779
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2016-09-22_11-31_eca4694defa7_sqllab_setting_defaults.py
+++ b/superset/migrations/versions/2016-09-22_11-31_eca4694defa7_sqllab_setting_defaults.py
@@ -24,7 +24,7 @@ Create Date: 2016-09-22 11:31:50.543820
 
 from alembic import op
 from sqlalchemy import Boolean, Column, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2017-01-24_12-31_db0c65b146bd_update_slice_model_json.py
+++ b/superset/migrations/versions/2017-01-24_12-31_db0c65b146bd_update_slice_model_json.py
@@ -28,7 +28,7 @@ down_revision = "f18570e03440"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2017-02-08_14-16_a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
+++ b/superset/migrations/versions/2017-02-08_14-16_a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
@@ -30,7 +30,7 @@ from urllib import parse  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2017-12-08_08-19_67a6ac9b727b_update_spatial_params.py
+++ b/superset/migrations/versions/2017-12-08_08-19_67a6ac9b727b_update_spatial_params.py
@@ -24,7 +24,7 @@ Create Date: 2017-12-08 08:19:21.148775
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2017-12-17_11-06_21e88bc06c02_annotation_migration.py
+++ b/superset/migrations/versions/2017-12-17_11-06_21e88bc06c02_annotation_migration.py
@@ -24,7 +24,7 @@ Create Date: 2017-12-17 11:06:30.180267
 
 from alembic import op
 from sqlalchemy import Column, Integer, or_, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-02-13_08-07_e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/2018-02-13_08-07_e866bd2d4976_smaller_grid.py
@@ -23,7 +23,7 @@ Create Date: 2018-02-13 08:07:40.766277
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-04-03_08-19_130915240929_is_sqllab_viz_flow.py
+++ b/superset/migrations/versions/2018-04-03_08-19_130915240929_is_sqllab_viz_flow.py
@@ -24,7 +24,7 @@ Create Date: 2018-04-03 08:19:34.098789
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2018-04-10_11-19_bf706ae5eb46_cal_heatmap_metric_to_metrics.py
+++ b/superset/migrations/versions/2018-04-10_11-19_bf706ae5eb46_cal_heatmap_metric_to_metrics.py
@@ -24,7 +24,7 @@ Create Date: 2018-04-10 11:19:47.621878
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-06-04_11-12_c5756bec8b47_time_grain_sqla.py
+++ b/superset/migrations/versions/2018-06-04_11-12_c5756bec8b47_time_grain_sqla.py
@@ -28,7 +28,7 @@ down_revision = "e502db2af7be"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2018-06-07_09-52_afb7730f6a9c_remove_empty_filters.py
+++ b/superset/migrations/versions/2018-06-07_09-52_afb7730f6a9c_remove_empty_filters.py
@@ -28,7 +28,7 @@ down_revision = "c5756bec8b47"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
@@ -36,7 +36,7 @@ from sqlalchemy import (  # noqa: E402
     String,
     Text,
 )
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2018-06-13_14-54_bddc498dd179_adhoc_filters.py
+++ b/superset/migrations/versions/2018-06-13_14-54_bddc498dd179_adhoc_filters.py
@@ -29,7 +29,7 @@ down_revision = "80a67c5192fa"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2018-06-14_14-31_80a67c5192fa_single_pie_chart_metric.py
+++ b/superset/migrations/versions/2018-06-14_14-31_80a67c5192fa_single_pie_chart_metric.py
@@ -29,7 +29,7 @@ down_revision = "afb7730f6a9c"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2018-07-05_15-19_3dda56f1c4c6_migrate_num_period_compare_and_period_.py
+++ b/superset/migrations/versions/2018-07-05_15-19_3dda56f1c4c6_migrate_num_period_compare_and_period_.py
@@ -29,7 +29,7 @@ import datetime
 import isodate
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-07-19_23-41_c617da68de7d_form_nullable.py
+++ b/superset/migrations/versions/2018-07-19_23-41_c617da68de7d_form_nullable.py
@@ -28,7 +28,7 @@ down_revision = "18dc26817ad2"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils.core import MediumText  # noqa: E402

--- a/superset/migrations/versions/2018-07-20_15-31_7f2635b51f5d_update_base_columns.py
+++ b/superset/migrations/versions/2018-07-20_15-31_7f2635b51f5d_update_base_columns.py
@@ -31,7 +31,7 @@ down_revision = "937d04c16b64"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, engine, Integer, String  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils.core import generic_find_uq_constraint_name  # noqa: E402

--- a/superset/migrations/versions/2018-07-20_15-57_e9df189e5c7e_update_base_metrics.py
+++ b/superset/migrations/versions/2018-07-20_15-57_e9df189e5c7e_update_base_metrics.py
@@ -31,7 +31,7 @@ down_revision = "7f2635b51f5d"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, engine, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils.core import generic_find_uq_constraint_name  # noqa: E402

--- a/superset/migrations/versions/2018-07-22_11-59_bebcf3fed1fe_convert_dashboard_v1_positions.py
+++ b/superset/migrations/versions/2018-07-22_11-59_bebcf3fed1fe_convert_dashboard_v1_positions.py
@@ -30,8 +30,7 @@ from functools import reduce
 
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-07-26_11-10_c82ee8a39623_add_implicit_tags.py
+++ b/superset/migrations/versions/2018-07-26_11-10_c82ee8a39623_add_implicit_tags.py
@@ -31,7 +31,7 @@ from datetime import datetime  # noqa: E402
 from alembic import op  # noqa: E402
 from flask_appbuilder.models.mixins import AuditMixin  # noqa: E402
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base, declared_attr  # noqa: E402
+from sqlalchemy.orm import declarative_base, declared_attr  # noqa: E402
 
 from superset.tags.models import ObjectType, TagType  # noqa: E402
 from superset.utils.core import get_user_id  # noqa: E402

--- a/superset/migrations/versions/2018-08-01_11-47_7fcdcde0761c_.py
+++ b/superset/migrations/versions/2018-08-01_11-47_7fcdcde0761c_.py
@@ -27,7 +27,7 @@ import re
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-11-12_13-31_4ce8df208545_migrate_time_range_for_default_filters.py
+++ b/superset/migrations/versions/2018-11-12_13-31_4ce8df208545_migrate_time_range_for_default_filters.py
@@ -25,7 +25,7 @@ Create Date: 2018-11-12 13:31:07.578090
 # revision identifiers, used by Alembic.
 from alembic import op
 from sqlalchemy import Column, Integer, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2018-12-11_22-03_fb13d49b72f9_better_filters.py
+++ b/superset/migrations/versions/2018-12-11_22-03_fb13d49b72f9_better_filters.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2019-03-21_10-22_d94d33dbe938_form_strip.py
+++ b/superset/migrations/versions/2019-03-21_10-22_d94d33dbe938_form_strip.py
@@ -28,7 +28,7 @@ down_revision = "80aa3f04bc82"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils.core import MediumText  # noqa: E402

--- a/superset/migrations/versions/2019-04-09_16-27_80aa3f04bc82_add_parent_ids_in_dashboard_layout.py
+++ b/superset/migrations/versions/2019-04-09_16-27_80aa3f04bc82_add_parent_ids_in_dashboard_layout.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2019-06-28_13-17_ab8c66efdd01_resample.py
+++ b/superset/migrations/versions/2019-06-28_13-17_ab8c66efdd01_resample.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2019-07-15_12-00_190188938582_adding_unique_constraint_on_dashboard_slices_tbl.py
+++ b/superset/migrations/versions/2019-07-15_12-00_190188938582_adding_unique_constraint_on_dashboard_slices_tbl.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import and_, Column, ForeignKey, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2019-09-11_21-49_5afa9079866a_serialize_schema_permissions_py.py
+++ b/superset/migrations/versions/2019-09-11_21-49_5afa9079866a_serialize_schema_permissions_py.py
@@ -25,8 +25,7 @@ Create Date: 2019-09-11 21:49:00.608346
 # revision identifiers, used by Alembic.
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 from superset import db
 

--- a/superset/migrations/versions/2019-09-19_13-40_258b5280a45e_form_strip_leading_and_trailing_whitespace.py
+++ b/superset/migrations/versions/2019-09-19_13-40_258b5280a45e_form_strip_leading_and_trailing_whitespace.py
@@ -26,7 +26,7 @@ import re
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils.core import MediumText

--- a/superset/migrations/versions/2019-10-10_13-52_1495eb914ad3_time_range.py
+++ b/superset/migrations/versions/2019-10-10_13-52_1495eb914ad3_time_range.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.legacy import update_time_range

--- a/superset/migrations/versions/2019-11-06_15-23_78ee127d0d1d_reconvert_legacy_filters_into_adhoc.py
+++ b/superset/migrations/versions/2019-11-06_15-23_78ee127d0d1d_reconvert_legacy_filters_into_adhoc.py
@@ -31,7 +31,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2020-02-07_14-13_3325d4caccc8_dashboard_scoped_filters.py
+++ b/superset/migrations/versions/2020-02-07_14-13_3325d4caccc8_dashboard_scoped_filters.py
@@ -27,8 +27,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2020-03-25_10-42_f9a30386bd74_cleanup_time_grainularity.py
+++ b/superset/migrations/versions/2020-03-25_10-42_f9a30386bd74_cleanup_time_grainularity.py
@@ -28,7 +28,7 @@ down_revision = "b5998378c225"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2020-04-29_09-24_620241d1153f_update_time_grain_sqla.py
+++ b/superset/migrations/versions/2020-04-29_09-24_620241d1153f_update_time_grain_sqla.py
@@ -28,7 +28,7 @@ down_revision = "f9a30386bd74"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, ForeignKey, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db, db_engine_specs  # noqa: E402
 from superset.databases.utils import make_url_safe  # noqa: E402

--- a/superset/migrations/versions/2020-08-12_00-24_978245563a02_migrate_iframe_to_dash_markdown.py
+++ b/superset/migrations/versions/2020-08-12_00-24_978245563a02_migrate_iframe_to_dash_markdown.py
@@ -28,8 +28,7 @@ from collections import defaultdict
 
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2020-09-24_12-04_3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
+++ b/superset/migrations/versions/2020-09-24_12-04_3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
@@ -40,8 +40,7 @@ from sqlalchemy import (  # noqa: E402
     UniqueConstraint,
 )
 from sqlalchemy.exc import SQLAlchemyError  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import backref, relationship  # noqa: E402
+from sqlalchemy.orm import backref, declarative_base, relationship  # noqa: E402
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/2020-09-28_17-57_b56500de1855_add_uuid_column_to_import_mixin.py
+++ b/superset/migrations/versions/2020-09-28_17-57_b56500de1855_add_uuid_column_to_import_mixin.py
@@ -27,8 +27,7 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import load_only
+from sqlalchemy.orm import declarative_base, load_only
 from sqlalchemy_utils import UUIDType
 
 from superset import db

--- a/superset/migrations/versions/2020-10-05_18-10_af30ca79208f_collapse_alerting_models_into_a_single_.py
+++ b/superset/migrations/versions/2020-10-05_18-10_af30ca79208f_collapse_alerting_models_into_a_single_.py
@@ -25,8 +25,13 @@ Create Date: 2020-10-05 18:10:52.272047
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.orm import backref, relationship, RelationshipProperty
+from sqlalchemy.orm import (
+    backref,
+    declarative_base,
+    declared_attr,
+    relationship,
+    RelationshipProperty,
+)
 
 from superset import db
 from superset.migrations.shared.utils import create_table

--- a/superset/migrations/versions/2020-10-21_21-09_96e99fb176a0_add_import_mixing_to_saved_query.py
+++ b/superset/migrations/versions/2020-10-21_21-09_96e99fb176a0_add_import_mixing_to_saved_query.py
@@ -28,7 +28,7 @@ from uuid import uuid4
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy_utils import UUIDType
 
 from superset import db

--- a/superset/migrations/versions/2021-01-23_16-25_260bf0649a77_migrate_x_dateunit_in_time_range.py
+++ b/superset/migrations/versions/2021-01-23_16-25_260bf0649a77_migrate_x_dateunit_in_time_range.py
@@ -34,7 +34,7 @@ from sqlalchemy import Column, Integer, or_, Text  # noqa: E402
 from sqlalchemy.dialects.mysql.base import MySQLDialect  # noqa: E402
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
 from sqlalchemy.exc import OperationalError  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-02-04_09-34_070c043f2fdb_add_granularity_to_charts_where_missing.py
+++ b/superset/migrations/versions/2021-02-04_09-34_070c043f2fdb_add_granularity_to_charts_where_missing.py
@@ -28,7 +28,7 @@ down_revision = "41ce8799acc3"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import and_, Boolean, Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-02-10_12-32_41ce8799acc3_rename_pie_label_type.py
+++ b/superset/migrations/versions/2021-02-10_12-32_41ce8799acc3_rename_pie_label_type.py
@@ -28,7 +28,7 @@ down_revision = "e11ccdd12658"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import and_, Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-02-14_11-46_1412ec1e5a7b_legacy_force_directed_to_echart.py
+++ b/superset/migrations/versions/2021-02-14_11-46_1412ec1e5a7b_legacy_force_directed_to_echart.py
@@ -24,7 +24,7 @@ Create Date: 2021-02-14 11:46:02.379832
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2021-03-24_09-47_989bbe479899_rename_filter_configuration_in_.py
+++ b/superset/migrations/versions/2021-03-24_09-47_989bbe479899_rename_filter_configuration_in_.py
@@ -28,7 +28,7 @@ down_revision = "67da9ef1ef9c"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-04-07_07-21_134cea61c5e7_remove_dataset_health_check_message.py
+++ b/superset/migrations/versions/2021-04-07_07-21_134cea61c5e7_remove_dataset_health_check_message.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-04-09_16-14_085f06488938_country_map_use_lowercase_country_name.py
+++ b/superset/migrations/versions/2021-04-09_16-14_085f06488938_country_map_use_lowercase_country_name.py
@@ -24,7 +24,7 @@ Create Date: 2021-04-09 16:14:19.040884
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2021-04-12_12-38_fc3a3a8ff221_migrate_filter_sets_to_new_format.py
+++ b/superset/migrations/versions/2021-04-12_12-38_fc3a3a8ff221_migrate_filter_sets_to_new_format.py
@@ -31,7 +31,7 @@ from typing import Any  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-04-29_15-32_f1410ed7ec95_migrate_native_filters_to_new_schema.py
+++ b/superset/migrations/versions/2021-04-29_15-32_f1410ed7ec95_migrate_native_filters_to_new_schema.py
@@ -31,7 +31,7 @@ from typing import Any  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-08-02_16-39_e323605f370a_fix_schemas_allowed_for_csv_upload.py
+++ b/superset/migrations/versions/2021-08-02_16-39_e323605f370a_fix_schemas_allowed_for_csv_upload.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2021-08-03_15-36_143b6f2815da_migrate_pivot_table_v2_heatmaps_to_new_.py
+++ b/superset/migrations/versions/2021-08-03_15-36_143b6f2815da_migrate_pivot_table_v2_heatmaps_to_new_.py
@@ -28,7 +28,7 @@ down_revision = "e323605f370a"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import and_, Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-08-31_11-37_021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/2021-08-31_11-37_021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-09-27_11-31_60dc453f4e2e_migrate_timeseries_limit_metric_to_.py
+++ b/superset/migrations/versions/2021-09-27_11-31_60dc453f4e2e_migrate_timeseries_limit_metric_to_.py
@@ -28,7 +28,7 @@ down_revision = "3ebe0993c770"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import and_, Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-10-12_11-15_32646df09c64_update_time_grain_sqla.py
+++ b/superset/migrations/versions/2021-10-12_11-15_32646df09c64_update_time_grain_sqla.py
@@ -28,7 +28,7 @@ down_revision = "60dc453f4e2e"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-11-11_04-18_0ca9e5f1dacd_rename_to_schemas_allowed_for_file_.py
+++ b/superset/migrations/versions/2021-11-11_04-18_0ca9e5f1dacd_rename_to_schemas_allowed_for_file_.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-12-10_19-25_bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
+++ b/superset/migrations/versions/2021-12-10_19-25_bb38f40aa3ff_add_force_screenshot_to_alerts_reports.py
@@ -28,7 +28,7 @@ down_revision = "31bb738bd1d2"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 

--- a/superset/migrations/versions/2021-12-13_14-06_fe23025b9441_rename_big_viz_total_form_data_fields.py
+++ b/superset/migrations/versions/2021-12-13_14-06_fe23025b9441_rename_big_viz_total_form_data_fields.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2021-12-17_16-56_31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
+++ b/superset/migrations/versions/2021-12-17_16-56_31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
@@ -31,7 +31,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2022-03-02_09-20_b5a422d8e252_fix_query_and_saved_query_null_schema.py
+++ b/superset/migrations/versions/2022-03-02_09-20_b5a422d8e252_fix_query_and_saved_query_null_schema.py
@@ -24,7 +24,7 @@ Create Date: 2022-03-02 09:20:02.919490
 
 from alembic import op
 from sqlalchemy import Column, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/2022-03-02_16-41_7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
+++ b/superset/migrations/versions/2022-03-02_16-41_7293b0ca7944_change_adhoc_filter_b_from_none_to_.py
@@ -29,7 +29,7 @@ down_revision = "ab9a9d86e695"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
@@ -31,8 +31,13 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import select, text
 from sqlalchemy.exc import NoSuchModuleError
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.orm import backref, relationship, Session
+from sqlalchemy.orm import (
+    backref,
+    declarative_base,
+    declared_attr,
+    relationship,
+    Session,
+)
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import functions as func
 from sqlalchemy.sql.expression import and_, or_

--- a/superset/migrations/versions/2022-04-04_15-04_b0d0249074e4_deprecate_time_range_endpoints_v2.py
+++ b/superset/migrations/versions/2022-04-04_15-04_b0d0249074e4_deprecate_time_range_endpoints_v2.py
@@ -24,7 +24,7 @@ Create Date: 2022-04-04 15:04:05.606340
 
 from alembic import op
 from sqlalchemy import Column, Integer, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2022-04-18_11-20_ad07e4fdbaba_rm_time_range_endpoints_from_qc_3.py
+++ b/superset/migrations/versions/2022-04-18_11-20_ad07e4fdbaba_rm_time_range_endpoints_from_qc_3.py
@@ -28,7 +28,7 @@ down_revision = "cecc6bf46990"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2022-05-03_19-39_cbe71abde154_fix_report_schedule_and_log.py
+++ b/superset/migrations/versions/2022-05-03_19-39_cbe71abde154_fix_report_schedule_and_log.py
@@ -28,7 +28,7 @@ down_revision = "a9422eeaae74"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Float, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.reports.models import ReportState  # noqa: E402

--- a/superset/migrations/versions/2022-05-18_16-07_e786798587de_delete_none_permissions.py
+++ b/superset/migrations/versions/2022-05-18_16-07_e786798587de_delete_none_permissions.py
@@ -36,8 +36,7 @@ from sqlalchemy import (  # noqa: E402
     Table,
     UniqueConstraint,
 )
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import relationship, Session  # noqa: E402
+from sqlalchemy.orm import declarative_base, relationship, Session  # noqa: E402
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/2022-06-19_16-17_f3afaf1f11f0_add_unique_name_desc_rls.py
+++ b/superset/migrations/versions/2022-06-19_16-17_f3afaf1f11f0_add_unique_name_desc_rls.py
@@ -28,8 +28,7 @@ down_revision = "e09b4ae78457"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.orm import declarative_base, Session  # noqa: E402
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/2022-06-27_14-59_7fb8bca906d2_permalink_rename_filterstate.py
+++ b/superset/migrations/versions/2022-06-27_14-59_7fb8bca906d2_permalink_rename_filterstate.py
@@ -30,8 +30,7 @@ import pickle  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, LargeBinary, String  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.orm import declarative_base, Session  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
+++ b/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
@@ -24,7 +24,7 @@ Create Date: 2022-07-05 15:48:06.029190
 
 from alembic import op
 from sqlalchemy import and_, Column, insert, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 # revision identifiers, used by Alembic.
 from superset import db

--- a/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
+++ b/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
@@ -24,7 +24,7 @@ Create Date: 2022-08-16 15:23:42.860038
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
+++ b/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
@@ -28,7 +28,7 @@ down_revision = "deb4c9d4a4ef"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
+++ b/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
@@ -28,7 +28,7 @@ down_revision = "9c2a5681ddfd"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-03-05_10-06_d0ac08bb5b83_invert_horizontal_bar_chart_order.py
+++ b/superset/migrations/versions/2023-03-05_10-06_d0ac08bb5b83_invert_horizontal_bar_chart_order.py
@@ -28,7 +28,7 @@ down_revision = "c0a3ea245b61"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import and_, Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-03-17_13-24_b5ea9d343307_bar_chart_stack_options.py
+++ b/superset/migrations/versions/2023-03-17_13-24_b5ea9d343307_bar_chart_stack_options.py
@@ -28,7 +28,7 @@ down_revision = "d0ac08bb5b83"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
+++ b/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-05-01_12-03_9c2a5681ddfd_convert_key_value_entries_to_json.py
+++ b/superset/migrations/versions/2023-05-01_12-03_9c2a5681ddfd_convert_key_value_entries_to_json.py
@@ -31,8 +31,7 @@ import pickle  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, LargeBinary, String  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.orm import declarative_base, Session  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2023-05-11_12-41_4ea966691069_cross_filter_global_scoping.py
+++ b/superset/migrations/versions/2023-05-11_12-41_4ea966691069_cross_filter_global_scoping.py
@@ -31,7 +31,7 @@ import logging  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2023-07-18_15-30_863adcf72773_delete_obsolete_druid_nosql_slice_parameters.py
+++ b/superset/migrations/versions/2023-07-18_15-30_863adcf72773_delete_obsolete_druid_nosql_slice_parameters.py
@@ -30,7 +30,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-07-19_16-48_a23c6f8b1280_cleanup_erroneous_parent_filter_ids.py
+++ b/superset/migrations/versions/2023-07-19_16-48_a23c6f8b1280_cleanup_erroneous_parent_filter_ids.py
@@ -31,7 +31,7 @@ import logging  # noqa: E402
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.utils import json  # noqa: E402

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, or_, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json

--- a/superset/migrations/versions/2023-08-02_15-23_0769ef90fddd_fix_schema_perm_for_datasets.py
+++ b/superset/migrations/versions/2023-08-02_15-23_0769ef90fddd_fix_schema_perm_for_datasets.py
@@ -29,7 +29,7 @@ down_revision = "ee179a490af9"
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 

--- a/superset/migrations/versions/2023-08-14_09-38_9f4a086c2676_add_normalize_columns_to_sqla_model.py
+++ b/superset/migrations/versions/2023-08-14_09-38_9f4a086c2676_add_normalize_columns_to_sqla_model.py
@@ -28,7 +28,7 @@ down_revision = "4448fa6deeb1"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
+++ b/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
@@ -28,7 +28,7 @@ down_revision = "ec54aca4c8a2"
 
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import (  # noqa: E402

--- a/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
+++ b/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
@@ -24,7 +24,7 @@ Create Date: 2023-12-15 17:58:18.277951
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.migrations.shared.utils import paginated_update

--- a/superset/migrations/versions/2024-01-18_15-20_214f580d09c9_migrate_filter_boxes_to_native_filters.py
+++ b/superset/migrations/versions/2024-01-18_15-20_214f580d09c9_migrate_filter_boxes_to_native_filters.py
@@ -28,8 +28,7 @@ down_revision = "a32e0c4d8646"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
-from sqlalchemy.orm import relationship  # noqa: E402
+from sqlalchemy.orm import declarative_base, relationship  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.native_filters import migrate_dashboard  # noqa: E402

--- a/superset/migrations/versions/2024-03-01_10-47_be1b217cd8cd_big_number_kpi_single_metric.py
+++ b/superset/migrations/versions/2024-03-01_10-47_be1b217cd8cd_big_number_kpi_single_metric.py
@@ -29,7 +29,7 @@ down_revision = "17fcea065655"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from alembic import op
 from sqlalchemy import Column, Integer, or_, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.migrations.shared.utils import paginated_update

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -28,7 +28,7 @@ down_revision = "32bf93dfe2a4"
 
 from alembic import op  # noqa: E402
 from sqlalchemy import Column, Integer, String, Text  # noqa: E402
-from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+from sqlalchemy.orm import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
 from superset.migrations.shared.utils import paginated_update  # noqa: E402

--- a/superset/migrations/versions/2025-06-06_00-39_363a9b1e8992_convert_metric_currencies_from_str_to_json.py
+++ b/superset/migrations/versions/2025-06-06_00-39_363a9b1e8992_convert_metric_currencies_from_str_to_json.py
@@ -27,7 +27,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, JSON, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.migrations.shared.utils import paginated_update

--- a/superset/migrations/versions/2025-12-16_12-00_f5b5f88d8526_fix_form_data_string_in_query_context.py
+++ b/superset/migrations/versions/2025-12-16_12-00_f5b5f88d8526_fix_form_data_string_in_query_context.py
@@ -26,7 +26,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.migrations.shared.utils import paginated_update

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -59,9 +59,15 @@ from markupsafe import escape, Markup
 from pandas import DateOffset
 from sqlalchemy import and_, Column, or_, UniqueConstraint
 from sqlalchemy.exc import MultipleResultsFound
-from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, Mapper, Session, validates, with_loader_criteria
+from sqlalchemy.orm import (
+    declared_attr,
+    Mapped,
+    Mapper,
+    Session,
+    validates,
+    with_loader_criteria,
+)
 from sqlalchemy.orm.session import ORMExecuteState
 from sqlalchemy.sql.elements import ColumnElement, Grouping, literal_column, TextClause
 from sqlalchemy.sql.expression import Label, Select, TextAsFrom

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -32,8 +32,7 @@ from flask_appbuilder.security.sqla import models as ab_models
 from flask_testing import TestCase
 from sqlalchemy.dialects.mysql import dialect
 from sqlalchemy.engine.interfaces import Dialect
-from sqlalchemy.ext.declarative import DeclarativeMeta
-from sqlalchemy.orm import Session  # noqa: F401
+from sqlalchemy.orm import DeclarativeMeta, Session  # noqa: F401
 from sqlalchemy.sql import func
 
 from superset import db, security_manager

--- a/tests/integration_tests/dao/base_dao_test.py
+++ b/tests/integration_tests/dao/base_dao_test.py
@@ -35,7 +35,7 @@ import pytest
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import Column, DateTime, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.session import Session
 
 from superset.daos.base import BaseDAO, ColumnOperator, ColumnOperatorEnum

--- a/tests/integration_tests/fixtures/datasource.py
+++ b/tests/integration_tests/fixtures/datasource.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 from sqlalchemy import Column, create_engine, Date, Integer, MetaData, String, Table
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.extensions import db

--- a/tests/unit_tests/dao/base_dao_test.py
+++ b/tests/unit_tests/dao/base_dao_test.py
@@ -24,7 +24,7 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from superset_core.common.models import CoreModel
 
 from superset.daos.base import BaseDAO, ColumnOperatorEnum


### PR DESCRIPTION
See #40273 .

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enable errors on `declarative_base`, and fix them all.

In addition to fixing all broken tests, I manually went through all results of `git grep declarative_base` and `git grep sqlalchemy.ext.declarative`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
