### PR TITLE
chore: as_declarative() warnings are irrelevant

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -35,7 +35,6 @@ filterwarnings =
 #    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
-#    error:The ``as_declarative\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
 #    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
 #    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning


### PR DESCRIPTION
See #40273 .

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Warnings are raised that `as_declarative()` is deprecated.
However, they are not caused by the Superset code but by `flask_appbuilder`.
They have already prepared the migration to SQLAlchemy 2.0. https://github.com/dpgaspar/Flask-AppBuilder/blob/fd929036f3832ea029a5af65e4b90c38afa45c9e/setup.py#L63
So the warnings are safe to ignore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
