### PR TITLE
fix(a11y): add accessible labels to EmbedCodeContent height/width inputs

### DIFF
--- a/superset-frontend/src/explore/components/EmbedCodeContent.test.tsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.test.tsx
@@ -51,4 +51,10 @@ describe('EmbedCodeButton', () => {
       }),
     ).toBeVisible();
   });
+
+  test('height and width inputs have accessible names', async () => {
+    render(<EmbedCodeContent formData={mockFormData} />, { useRedux: true });
+    expect(await screen.findByLabelText('Chart height')).toBeVisible();
+    expect(await screen.findByLabelText('Chart width')).toBeVisible();
+  });
 });

--- a/superset-frontend/src/explore/components/EmbedCodeContent.tsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.tsx
@@ -143,6 +143,7 @@ const EmbedCodeContent: FC<EmbedCodeContentProps> = ({
             defaultValue={height}
             name="height"
             onChange={handleInputChange}
+            aria-label={t('Chart height')}
           />
         </div>
         <div>
@@ -153,6 +154,7 @@ const EmbedCodeContent: FC<EmbedCodeContentProps> = ({
             name="width"
             onChange={handleInputChange}
             id="embed-width"
+            aria-label={t('Chart width')}
           />
         </div>
       </Space>

--- a/superset-frontend/src/explore/components/EmbedCodeContent.tsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.tsx
@@ -135,26 +135,31 @@ const EmbedCodeContent: FC<EmbedCodeContentProps> = ({
         `}
       >
         <div>
-          <Typography.Text type="secondary">
-            {t('Chart height')}
-          </Typography.Text>
+          <label htmlFor="embed-height">
+            <Typography.Text type="secondary">
+              {t('Chart height')}
+            </Typography.Text>
+          </label>
           <Input
             type="number"
             defaultValue={height}
             name="height"
             onChange={handleInputChange}
-            aria-label={t('Chart height')}
+            id="embed-height"
           />
         </div>
         <div>
-          <Typography.Text type="secondary">{t('Chart width')}</Typography.Text>
+          <label htmlFor="embed-width">
+            <Typography.Text type="secondary">
+              {t('Chart width')}
+            </Typography.Text>
+          </label>
           <Input
             type="number"
             defaultValue={width}
             name="width"
             onChange={handleInputChange}
             id="embed-width"
-            aria-label={t('Chart width')}
           />
         </div>
       </Space>


### PR DESCRIPTION
## Summary
- `superset-frontend/src/explore/components/EmbedCodeContent.tsx` renders two `<Input type="number">` fields (Chart height, Chart width) with only a sibling `<Typography.Text>` as a visual label — no `<label htmlFor>`, `aria-label`, or `aria-labelledby` tying the label to the input programmatically.
- Wraps each `<Typography.Text>` in a native `<label htmlFor>` and wires it to the input via `id` (the width input already had an unused `id="embed-width"` set up for exactly this, never connected — the height input gets a matching `id="embed-height"`).
- Behavior is unchanged — purely additive markup, no visual or functional change (native `<label>` also gains click-to-focus for sighted mouse users, as a side benefit).

**WCAG 2.1 SC 4.1.2 (Name, Role, Value) — Level A**: the accessible name of a form control must be programmatically determinable.

## Test plan
- Added a test to `EmbedCodeContent.test.tsx` asserting `screen.findByLabelText('Chart height')` and `screen.findByLabelText('Chart width')` both resolve.
- Manual: open the "Embed" dialog in Explore, tab to the height/width inputs with a screen reader running — each input now announces "Chart height"/"Chart width" instead of no name at all.