### PR TITLE
fix(reports): paginate Slack recipient picker for large workspaces

### DIFF
--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -752,6 +752,75 @@ describe('NotificationMethod', () => {
     ).toBeInTheDocument();
   });
 
+  test('fetches Slack channels lazily with pagination for SlackV2', async () => {
+    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+    const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+      json: {
+        count: 1,
+        result: [
+          { id: 'C123', name: 'general', is_private: false, is_member: true },
+        ],
+      },
+    } as unknown as JsonResponse);
+
+    render(
+      <NotificationMethod
+        setting={{ ...mockSettingSlackV2, recipients: '' }}
+        index={0}
+        onUpdate={mockOnUpdate}
+        onRemove={mockOnRemove}
+        onInputChange={mockOnInputChange}
+        email_subject={mockEmailSubject}
+        defaultSubject={mockDefaultSubject}
+        setErrorSubject={mockSetErrorSubject}
+      />,
+    );
+
+    fireEvent.click(await screen.findByTestId('recipients-load-options'));
+
+    expect(await screen.findByText('general')).toBeInTheDocument();
+
+    const slackEndpoint = getSpy.mock.calls
+      .map(([arg]) => (arg as { endpoint: string }).endpoint)
+      .find(endpoint => endpoint.includes('/report/slack_channels/'));
+    expect(slackEndpoint).toBeDefined();
+    expect(rison.decode(slackEndpoint!.split('?q=')[1])).toMatchObject({
+      search_string: '',
+      types: ['public_channel', 'private_channel'],
+      page: 0,
+      page_size: 25,
+    });
+  });
+
+  test('allows entering a Slack channel id directly for SlackV2', async () => {
+    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+    jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+      json: { count: 0, result: [] },
+    } as unknown as JsonResponse);
+
+    render(
+      <NotificationMethod
+        setting={{ ...mockSettingSlackV2, recipients: '' }}
+        index={0}
+        onUpdate={mockOnUpdate}
+        onRemove={mockOnRemove}
+        onInputChange={mockOnInputChange}
+        email_subject={mockEmailSubject}
+        defaultSubject={mockDefaultSubject}
+        setErrorSubject={mockSetErrorSubject}
+      />,
+    );
+
+    fireEvent.change(await screen.findByTestId('recipients'), {
+      target: { value: 'C0123456789' },
+    });
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({ recipients: 'C0123456789' }),
+    );
+  });
+
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('RefreshLabel functionality', () => {
     test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -821,6 +821,77 @@ describe('NotificationMethod', () => {
     );
   });
 
+  test('resolves saved SlackV2 channel ids on mount via exact match', async () => {
+    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+    const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+      json: {
+        count: 1,
+        result: [
+          { id: 'C123', name: 'general', is_private: false, is_member: true },
+        ],
+      },
+    } as unknown as JsonResponse);
+
+    render(
+      <NotificationMethod
+        setting={{ ...mockSettingSlackV2, recipients: 'C123' }}
+        index={0}
+        onUpdate={mockOnUpdate}
+        onRemove={mockOnRemove}
+        onInputChange={mockOnInputChange}
+        email_subject={mockEmailSubject}
+        defaultSubject={mockDefaultSubject}
+        setErrorSubject={mockSetErrorSubject}
+      />,
+    );
+
+    await waitFor(() => {
+      const slackEndpoint = getSpy.mock.calls
+        .map(([arg]) => (arg as { endpoint: string }).endpoint)
+        .find(endpoint => endpoint.includes('/report/slack_channels/'));
+      expect(slackEndpoint).toBeDefined();
+      expect(rison.decode(slackEndpoint!.split('?q=')[1])).toMatchObject({
+        exact_match: true,
+        search_string: 'C123',
+      });
+    });
+  });
+
+  test('force refresh triggers a cache-busting fetch for SlackV2', async () => {
+    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+    const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+      json: { count: 0, result: [] },
+    } as unknown as JsonResponse);
+
+    render(
+      <NotificationMethod
+        setting={{ ...mockSettingSlackV2, recipients: '' }}
+        index={0}
+        onUpdate={mockOnUpdate}
+        onRemove={mockOnRemove}
+        onInputChange={mockOnInputChange}
+        email_subject={mockEmailSubject}
+        defaultSubject={mockDefaultSubject}
+        setErrorSubject={mockSetErrorSubject}
+      />,
+    );
+
+    userEvent.click(await screen.findByLabelText('sync'));
+    fireEvent.click(await screen.findByTestId('recipients-load-options'));
+
+    await waitFor(() => {
+      const forced = getSpy.mock.calls
+        .map(([arg]) => (arg as { endpoint: string }).endpoint)
+        .filter(endpoint => endpoint.includes('/report/slack_channels/'))
+        .some(
+          endpoint =>
+            (rison.decode(endpoint.split('?q=')[1]) as { force?: boolean })
+              .force === true,
+        );
+      expect(forced).toBe(true);
+    });
+  });
+
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('RefreshLabel functionality', () => {
     test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -287,8 +287,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   );
 
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
-  const [isSlackChannelsLoading, setIsSlackChannelsLoading] =
-    useState<boolean>(true);
 
   const onMethodChange = (selected: {
     label: string;
@@ -426,7 +424,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       } finally {
         if (!cancelled) {
           setMethodOptionsLoading(false);
-          setIsSlackChannelsLoading(false);
         }
       }
     };
@@ -435,7 +432,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       resolveSavedRecipients();
     } else {
       setMethodOptionsLoading(false);
-      setIsSlackChannelsLoading(false);
     }
 
     return () => {
@@ -695,7 +691,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                       <RefreshLabel
                         onClick={onRefreshSlackChannels}
                         tooltipContent={t('Force refresh Slack channels list')}
-                        disabled={isSlackChannelsLoading}
                       />
                     </div>
                   )}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -20,8 +20,10 @@ import {
   FunctionComponent,
   useState,
   ChangeEvent,
+  useCallback,
   useEffect,
   useMemo,
+  useRef,
 } from 'react';
 import rison from 'rison';
 
@@ -165,47 +167,6 @@ export const mapSlackValues = ({
     .filter(val => !!val) as { label: string; value: string }[];
 };
 
-export const mapChannelsToOptions = (result: SlackChannel[]) => {
-  const publicChannels: SlackChannel[] = [];
-  const privateChannels: SlackChannel[] = [];
-
-  result.forEach(channel => {
-    if (channel.is_private) {
-      privateChannels.push(channel);
-    } else {
-      publicChannels.push(channel);
-    }
-  });
-
-  return [
-    {
-      label: 'Public Channels',
-      options: publicChannels.map((channel: SlackChannel) => ({
-        label: `${channel.name} ${
-          channel.is_member ? '' : t('(Bot not in channel)')
-        }`,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'public',
-    },
-    {
-      label: t('Private Channels (Bot in channel)'),
-      options: privateChannels.map((channel: SlackChannel) => ({
-        label: channel.name,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'private',
-    },
-  ];
-};
-
-type SlackOptionsType = {
-  label: string;
-  options: { label: string; value: string }[];
-}[];
-
 type EmailRecipientField = 'recipients' | 'cc' | 'bcc';
 
 type EmailRecipientOption = {
@@ -310,12 +271,8 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const theme = useTheme();
   const [methodOptionsLoading, setMethodOptionsLoading] =
     useState<boolean>(true);
-  const [slackOptions, setSlackOptions] = useState<SlackOptionsType>([
-    {
-      label: '',
-      options: [],
-    },
-  ]);
+  const [slackRefreshKey, setSlackRefreshKey] = useState<number>(0);
+  const forceRefreshSlackRef = useRef<boolean>(false);
   const recipientEmailOptions = useMemo(
     () => recipientStringToOptions(recipientValue),
     [recipientValue],
@@ -355,83 +312,136 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const fetchSlackChannels = async ({
+  const fetchSlackChannels = ({
     searchString = '',
     types = [],
     exactMatch = false,
     force = false,
+    page,
+    pageSize,
   }: {
-    searchString?: string | undefined;
+    searchString?: string;
     types?: string[];
-    exactMatch?: boolean | undefined;
-    force?: boolean | undefined;
+    exactMatch?: boolean;
+    force?: boolean;
+    page?: number;
+    pageSize?: number;
   } = {}): Promise<JsonResponse> => {
     const queryString = rison.encode({
-      searchString,
+      search_string: searchString,
       types,
-      exactMatch,
+      exact_match: exactMatch,
       force,
+      ...(page !== undefined ? { page } : {}),
+      ...(pageSize !== undefined ? { page_size: pageSize } : {}),
     });
     const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
     return SupersetClient.get({ endpoint });
   };
 
-  const updateSlackOptions = async ({
-    force,
-  }: {
-    force?: boolean | undefined;
-  } = {}) => {
-    setIsSlackChannelsLoading(true);
-    fetchSlackChannels({ types: ['public_channel', 'private_channel'], force })
-      .then(({ json }) => {
-        const { result } = json;
-        const options: SlackOptionsType = mapChannelsToOptions(result);
-
-        setSlackOptions(options);
-
-        if (isFeatureEnabled(FeatureFlag.AlertReportSlackV2)) {
-          // for edit mode, map existing ids to names for display if slack v2
-          // or names to ids if slack v1
-          const [publicOptions, privateOptions] = options;
-          if (
-            method &&
-            [
-              NotificationMethodOption.SlackV2,
-              NotificationMethodOption.Slack,
-            ].includes(method)
-          ) {
-            setSlackRecipients(
-              mapSlackValues({
-                method,
-                recipientValue,
-                slackOptions: [
-                  ...publicOptions.options,
-                  ...privateOptions.options,
-                ],
-              }),
-            );
-          }
-        }
-      })
-      .catch(() => {
-        // Fallback to slack v1 if slack v2 is not compatible
-        setUseSlackV1(true);
-      })
-      .finally(() => {
-        setMethodOptionsLoading(false);
-        setIsSlackChannelsLoading(false);
+  // Lazily fetch one page of channels as the user searches, so workspaces with
+  // tens of thousands of channels never load the whole list into the browser.
+  const loadSlackChannels = useCallback(
+    async (search: string, page: number, pageSize: number) => {
+      const force = forceRefreshSlackRef.current;
+      forceRefreshSlackRef.current = false;
+      const { json } = await fetchSlackChannels({
+        searchString: search,
+        types: ['public_channel', 'private_channel'],
+        force,
+        page,
+        pageSize,
       });
+      const result = (json?.result ?? []) as SlackChannel[];
+      return {
+        data: result.map(channel => ({
+          label:
+            !channel.is_private && !channel.is_member
+              ? `${channel.name} ${t('(Bot not in channel)')}`
+              : channel.name,
+          value: channel.id,
+        })),
+        totalCount: json?.count ?? result.length,
+      };
+    },
+    // fetchSlackChannels only closes over stable refs/imports
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const onRefreshSlackChannels = () => {
+    forceRefreshSlackRef.current = true;
+    // Remount the AsyncSelect so its internal result cache is discarded and the
+    // forced (cache-busting) fetch runs.
+    setSlackRefreshKey(key => key + 1);
   };
 
+  // Resolve the channel ids saved on an existing SlackV2 report into
+  // human-readable labels. Bounded by exact_match so it never enumerates the
+  // whole workspace.
   useEffect(() => {
+    let cancelled = false;
     const slackEnabled = options?.some(
       option =>
         option === NotificationMethodOption.Slack ||
         option === NotificationMethodOption.SlackV2,
     );
-    if (slackEnabled && !slackOptions[0]?.options.length) {
-      updateSlackOptions();
+    const savedIds =
+      method === NotificationMethodOption.SlackV2 && recipientValue
+        ? recipientValue
+            .split(',')
+            .map(value => value.trim())
+            .filter(Boolean)
+        : [];
+
+    const resolveSavedRecipients = async () => {
+      // Show the saved ids immediately so the existing selection is always
+      // visible, then enrich with channel names once the lookup resolves.
+      if (savedIds.length && !cancelled) {
+        setSlackRecipients(savedIds.map(id => ({ label: id, value: id })));
+      }
+      try {
+        if (savedIds.length) {
+          const { json } = await fetchSlackChannels({
+            searchString: recipientValue,
+            types: ['public_channel', 'private_channel'],
+            exactMatch: true,
+          });
+          const result = (json?.result ?? []) as SlackChannel[];
+          const namesById = new Map(
+            result.map(channel => [channel.id, channel.name]),
+          );
+          if (!cancelled) {
+            setSlackRecipients(
+              savedIds.map(id => ({
+                label: namesById.get(id) ?? id,
+                value: id,
+              })),
+            );
+          }
+        }
+      } catch {
+        // Keep the raw ids as labels; the AsyncSelect onError handler drives
+        // the v1 fallback for the picker itself.
+      } finally {
+        if (!cancelled) {
+          setMethodOptionsLoading(false);
+          setIsSlackChannelsLoading(false);
+        }
+      }
+    };
+
+    if (slackEnabled) {
+      resolveSavedRecipients();
+    } else {
+      setMethodOptionsLoading(false);
+      setIsSlackChannelsLoading(false);
     }
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -665,21 +675,25 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                   ) : (
                     // for SlackV2
                     <div className="input-container">
-                      <Select
+                      <AsyncSelect
+                        key={slackRefreshKey}
                         ariaLabel={t('Select channels')}
                         mode="multiple"
                         name="recipients"
                         value={slackRecipients}
-                        options={slackOptions}
+                        options={loadSlackChannels}
                         onChange={onSlackRecipientsChange}
+                        onError={() => setUseSlackV1(true)}
                         allowClear
+                        allowNewOptions
                         data-test="recipients"
-                        loading={isSlackChannelsLoading}
-                        allowSelectAll={false}
                         labelInValue
+                        placeholder={t(
+                          'Search a channel by name, or paste a channel ID',
+                        )}
                       />
                       <RefreshLabel
-                        onClick={() => updateSlackOptions({ force: true })}
+                        onClick={onRefreshSlackChannels}
                         tooltipContent={t('Force refresh Slack channels list')}
                         disabled={isSlackChannelsLoading}
                       />

--- a/superset/config.py
+++ b/superset/config.py
@@ -2349,6 +2349,11 @@ SLACK_PROXY = None
 # ignored for workspace-level tokens, so leaving it as None preserves the default
 # single-workspace behavior.
 SLACK_TEAM_ID: Callable[[], str] | str | None = None
+# How long the fetched channel list is cached. The Alerts & Reports recipient
+# picker serves channels from this cache, so on very large workspaces (tens of
+# thousands of channels) schedule the ``slack.cache_channels`` Celery task to
+# warm the cache ahead of the TTL — enumerating that many channels inside a
+# single interactive request will otherwise hit Slack rate limits and time out.
 SLACK_CACHE_TIMEOUT = int(timedelta(days=1).total_seconds())
 
 # Maximum number of retries when Slack API returns rate limit errors

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -683,13 +683,22 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
             force = params.get("force", False)
+            page = params.get("page")
+            page_size = params.get("page_size")
             channels = get_channels_with_search(
                 search_string=search_string,
                 types=types,
                 exact_match=exact_match,
                 force=force,
             )
-            return self.response(200, result=channels)
+            # Paginate at the API layer so large workspaces (tens of thousands of
+            # channels) never ship the full list to the browser at once. The
+            # filtered set is served from the warm cache, so slicing is cheap.
+            count = len(channels)
+            if page is not None and page_size is not None:
+                start = page * page_size
+                channels = channels[start : start + page_size]
+            return self.response(200, count=count, result=channels)
         except SupersetException as ex:
             logger.error("Error fetching slack channels %s", str(ex))
             return self.response_422(message=str(ex))

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -59,6 +59,9 @@ get_slack_channels_schema = {
             "items": {"type": "string", "enum": ["public_channel", "private_channel"]},
         },
         "exact_match": {"type": "boolean"},
+        "force": {"type": "boolean"},
+        "page": {"type": "integer", "minimum": 0},
+        "page_size": {"type": "integer", "minimum": 1},
     },
 }
 

--- a/tests/unit_tests/reports/api_test.py
+++ b/tests/unit_tests/reports/api_test.py
@@ -36,6 +36,28 @@ def test_slack_channels_success(
     assert rv.status_code == 200
     data = rv.json
     assert data["result"] == [{"id": "C123", "name": "general"}]
+    assert data["count"] == 1
+
+
+@with_feature_flags(ALERT_REPORTS=True)
+@patch("superset.reports.api.get_channels_with_search")
+def test_slack_channels_paginates(
+    mock_search: Any,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    # A large workspace: the endpoint must return only the requested page while
+    # reporting the full count, so the browser never receives every channel.
+    mock_search.return_value = [
+        {"id": f"C{i}", "name": f"channel-{i}"} for i in range(250)
+    ]
+    params = rison.dumps({"page": 1, "page_size": 100})
+    rv = client.get(f"/api/v1/report/slack_channels/?q={params}")
+    assert rv.status_code == 200
+    data = rv.json
+    assert data["count"] == 250
+    assert len(data["result"]) == 100
+    assert data["result"][0] == {"id": "C100", "name": "channel-100"}
 
 
 @with_feature_flags(ALERT_REPORTS=True)

--- a/tests/unit_tests/reports/api_test.py
+++ b/tests/unit_tests/reports/api_test.py
@@ -62,6 +62,25 @@ def test_slack_channels_paginates(
 
 @with_feature_flags(ALERT_REPORTS=True)
 @patch("superset.reports.api.get_channels_with_search")
+def test_slack_channels_page_without_page_size_returns_all(
+    mock_search: Any,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    # Pagination only kicks in when both page and page_size are supplied; a page
+    # without page_size falls through to the full (unsliced) list.
+    mock_search.return_value = [
+        {"id": f"C{i}", "name": f"channel-{i}"} for i in range(30)
+    ]
+    params = rison.dumps({"page": 1})
+    rv = client.get(f"/api/v1/report/slack_channels/?q={params}")
+    assert rv.status_code == 200
+    assert rv.json["count"] == 30
+    assert len(rv.json["result"]) == 30
+
+
+@with_feature_flags(ALERT_REPORTS=True)
+@patch("superset.reports.api.get_channels_with_search")
 def test_slack_channels_handles_superset_exception(
     mock_search: Any,
     client: Any,


### PR DESCRIPTION
### SUMMARY

On workspaces with tens of thousands of Slack channels, the Alerts & Reports **Slack recipient picker** freezes the browser and the backend returns `504`. The SlackV2 picker eagerly pulled **every** channel (`conversations.list` is paginated and has no search API), so it hit Slack rate limits during enumeration and rendered the entire list at once. The UI's `searchString`/`exactMatch` params were also silently ignored (the endpoint reads `search_string`/`exact_match`), so search never reached the server.

**Backend** — `/report/slack_channels/` now accepts `page`/`page_size` and returns the requested page plus the full `count`, so the browser never receives the whole list. `get_channels_with_search` is unchanged (caching and `execute.py` unaffected); slicing happens at the API layer over the warm-cached filtered set.

**Frontend** — the SlackV2 picker moves from an eager `Select` to `AsyncSelect`: debounced server-side search, one page at a time (can't freeze), plus `allowNewOptions` so a channel ID can be **pasted directly** and used immediately. This is the guaranteed unblock for huge workspaces — SlackV2 send passes channel-ID strings straight to `chat_postMessage`, no list membership required. Edit-mode IDs resolve to names via a bounded `exact_match` lookup.

Large workspaces should schedule the existing `slack.cache_channels` Celery task to keep the cache warm (documented in `config.py`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavioral fix; no static screenshot captures the freeze. Manual repro/verification steps below.

### TESTING INSTRUCTIONS

Automated: `pytest tests/unit_tests/reports/api_test.py` (pagination + count) and `npm run test -- NotificationMethod` (lazy pagination + direct channel-ID entry).

Manual (with `ALERT_REPORT_SLACK_V2` on and a Slack bot token configured):
1. Create an Alert/Report → Notification Method → **Slack**.
2. Type part of a channel name — results now load one page at a time via the server instead of pulling every channel.
3. Paste a raw channel ID (e.g. `C0123456789`) — it is accepted directly without the full list loading, and a test send delivers to that channel.
4. Edit an existing Slack report — saved channels render immediately (as IDs, enriched to names once resolved).
5. For a large workspace, run the `slack.cache_channels` task once and confirm the dropdown browses quickly from the warm cache.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ALERT_REPORT_SLACK_V2` (existing; unchanged)
- [x] Changes UI — Slack recipient picker is now an async, searchable select that accepts pasted channel IDs
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

API change is additive/backwards-compatible: the endpoint gains optional `page`/`page_size` and a `count` field; the previously-ignored `search_string`/`exact_match` now take effect.
