### PR TITLE
fix(chart-echarts): disable animation for report screenshots so time-shift lines render fully

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
@@ -18,7 +18,7 @@
  */
 import { render, waitFor } from '../../../../spec/helpers/testing-library';
 import type { EChartsCoreOption } from 'echarts/core';
-import Echart from './Echart';
+import Echart, { isReportScreenshotMode } from './Echart';
 import type { EchartsProps } from '../types';
 
 type Handler = (params: unknown) => void;
@@ -130,6 +130,20 @@ const trigger = (name: string) => {
   (listeners[name] || []).forEach(listener => listener.handler({}));
 };
 
+const originalLocation = `${window.location.pathname}${window.location.search}`;
+
+const setStandalone = (standalone?: string) => {
+  window.history.replaceState(
+    {},
+    '',
+    standalone === undefined ? '/' : `/?standalone=${standalone}`,
+  );
+};
+
+afterEach(() => {
+  window.history.replaceState({}, '', originalLocation);
+});
+
 beforeEach(() => {
   Object.keys(listeners).forEach(name => {
     delete listeners[name];
@@ -220,4 +234,41 @@ test('replaces stale query event handlers without clearing regular event handler
   expect(regularClickHandler).toHaveBeenCalledTimes(1);
   expect(firstQueryHandler).not.toHaveBeenCalled();
   expect(secondQueryHandler).not.toHaveBeenCalled();
+});
+
+test.each([
+  // Report/thumbnail screenshots render in standalone "true" (charts) or 3 (reports)
+  ['true', true],
+  ['3', true],
+  // Live embeds use 1/2 and must keep animation
+  ['1', false],
+  ['2', false],
+  ['0', false],
+  [undefined, false],
+])(
+  'isReportScreenshotMode() is %p for standalone=%p',
+  (standalone, expected) => {
+    setStandalone(standalone);
+    expect(isReportScreenshotMode()).toBe(expected);
+  },
+);
+
+test('disables animation when rendering in report screenshot mode', async () => {
+  setStandalone('true');
+  render(renderEchart(), { initialState, useRedux: true });
+
+  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+
+  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
+  expect(lastOptions.animation).toBe(false);
+});
+
+test('keeps animation enabled when not in report screenshot mode', async () => {
+  setStandalone(undefined);
+  render(renderEchart(), { initialState, useRedux: true });
+
+  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+
+  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
+  expect(lastOptions.animation).not.toBe(false);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -131,6 +131,19 @@ const loadLocale = async (locale: string) => {
   return lang?.default;
 };
 
+// Report/thumbnail screenshots use standalone="true" (charts) or 3 (reports);
+// live embeds use 1/2 and keep animation. See superset/utils/screenshots.py.
+export function isReportScreenshotMode(): boolean {
+  try {
+    const standalone = new URLSearchParams(window.location.search).get(
+      'standalone',
+    );
+    return standalone === 'true' || standalone === '3';
+  } catch {
+    return false;
+  }
+}
+
 function Echart(
   {
     width,
@@ -278,13 +291,16 @@ function Echart(
         ? theme.echartsOptionsOverridesByChartType?.[vizType] || {}
         : {};
 
-      // Disable animations during auto-refresh to reduce visual noise
-      const animationOverride = isDashboardRefreshing
-        ? {
-            animation: false,
-            animationDuration: 0,
-          }
-        : {};
+      // Disable animation on auto-refresh and screenshots. Screenshots have no
+      // "render finished" signal, so a running draw can be captured mid-frame,
+      // producing partial/blank charts.
+      const animationOverride =
+        isDashboardRefreshing || isReportScreenshotMode()
+          ? {
+              animation: false,
+              animationDuration: 0,
+            }
+          : {};
 
       const themedEchartOptions = mergeEchartsThemeOverrides(
         baseTheme,


### PR DESCRIPTION
### SUMMARY
Time-shift (time-comparison) line charts intermittently render partially in PDF/PNG email reports and thumbnails — the line "breaks off" or the chart is blank.

**Root cause:** 
report screenshots capture the chart while ECharts is still animating.

The screenshot path has no render-complete signal — it just waits a fixed timeout, which loses the race under load (and the time-comparison series, drawn last, is the first to be cut off). Bumping the timeout only masks it.

**Fix:** 
disable the ECharts draw animation in report/thumbnail standalone mode (`standalone=true` / `3`), reusing the existing `isDashboardRefreshing` animation override. 
Static images don't need animation, so the chart is final before capture. Interactive/embed rendering is unchanged.

### BEFORE/AFTER
- Before 

<img width="1600" height="1200" alt="partial" src="https://github.com/user-attachments/assets/1e9c0193-66cb-47af-a9f1-b94caf77a91b" />

- After

<img width="1600" height="1200" alt="fixed_race0" src="https://github.com/user-attachments/assets/dbfb46bd-40f4-47f6-8bef-dbeccb8f1f40" />


### TESTING INSTRUCTIONS
- `cd superset-frontend && npm run test -- plugins/plugin-chart-echarts/src/components/Echart.test.tsx`
- Or manually: create a time-shift line chart, add it to a report, send as PNG/PDF; the full
  chart (base + shifted series) renders every time.