### PR TITLE
fix(pandas_postprocessing): avoid FutureWarning for mean/median in boxplot

### DIFF
--- a/superset/utils/pandas_postprocessing/boxplot.py
+++ b/superset/utils/pandas_postprocessing/boxplot.py
@@ -108,9 +108,13 @@ def boxplot(  # noqa: C901
         below = series[series < whisker_low(series)]
         return above.tolist() + below.tolist()
 
-    operators: dict[str, Callable[[Any], Any]] = {
-        "mean": np.mean,
-        "median": np.median,
+    # "mean"/"median" are passed as strings rather than np.mean/np.median: the
+    # callables trigger a pandas FutureWarning in GroupBy.agg (see
+    # _PANDAS_STRING_AGGREGATORS in pandas_postprocessing/utils.py) and the
+    # string form resolves to the exact same aggregation.
+    operators: dict[str, Union[str, Callable[[Any], Any]]] = {
+        "mean": "mean",
+        "median": "median",
         "max": whisker_high,
         "min": whisker_low,
         "q1": quartile1,

--- a/tests/unit_tests/pandas_postprocessing/test_boxplot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_boxplot.py
@@ -14,12 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
+
 import pytest
 
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.core import PostProcessingBoxplotWhiskerType
 from superset.utils.pandas_postprocessing import boxplot
 from tests.unit_tests.fixtures.dataframes import names_df
+from tests.unit_tests.pandas_postprocessing.utils import series_to_list
 
 
 def test_boxplot_tukey():
@@ -42,6 +45,27 @@ def test_boxplot_tukey():
         "region",
     }
     assert len(df) == 4
+
+
+def test_boxplot_mean_median_no_future_warning():
+    """mean/median must be passed as strings (not np.mean/np.median) to
+    GroupBy.agg, else pandas raises a FutureWarning. Also verify the values
+    match a plain pandas groupby, since the string and callable forms could
+    silently diverge on a future pandas version."""
+    expected = names_df.groupby("region")["cars"].agg(["mean", "median"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        df = boxplot(
+            df=names_df,
+            groupby=["region"],
+            whisker_type=PostProcessingBoxplotWhiskerType.TUKEY,
+            metrics=["cars"],
+        )
+
+    df = df.set_index("region")
+    assert series_to_list(df["cars__mean"]) == series_to_list(expected["mean"])
+    assert series_to_list(df["cars__median"]) == series_to_list(expected["median"])
 
 
 def test_boxplot_min_max():


### PR DESCRIPTION
## What
Production logs showed a high-volume pandas `FutureWarning`:

> The provided callable <function mean/median at 0x...> is currently using SeriesGroupBy.mean/median. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "mean"/"median" instead.

This exact class of warning was previously addressed in #41025, which taught `_get_aggregate_funcs` (in `pandas_postprocessing/utils.py`) to pass the string operator name (e.g. `"mean"`) instead of a raw numpy callable when possible, avoiding the ambiguity pandas warns about.

However, `pandas_postprocessing/boxplot.py` builds its own `operators` dict independently and was passing `np.mean` / `np.median` directly as the `operator` value. Since `_get_aggregate_funcs` special-cases callables first (`if callable(operator): aggfunc = operator`), this bypassed the #41025 fix entirely — so every boxplot chart post-processing call kept emitting the warning. Boxplot charts are common, which is why this was showing up frequently in prod logs.

## Change
In `boxplot.py`, pass `"mean"` / `"median"` as string literals instead of `np.mean` / `np.median`, so they route through the same string-based path `_get_aggregate_funcs` already uses. `np.ma.count` is left untouched, since it intentionally differs from pandas' `"count"` (it includes NaNs).

## No behavior change
Verified empirically that the string and callable forms produce identical output for `mean`/`median` on the currently pinned pandas range (`>=2.1.4,<2.4`). Added a regression test that also guards against a real (not just cosmetic) divergence: on pandas ≥3.0, `np.median` on a group containing NaNs returns `NaN` (no `skipna`), while the `"median"` string aggregator still skips NaNs — so this also prevents a silent numeric regression whenever the pandas pin is eventually bumped.

## Test plan
- Added `test_boxplot_mean_median_no_future_warning` in `tests/unit_tests/pandas_postprocessing/test_boxplot.py`: asserts no `FutureWarning` is raised and that `mean`/`median` values match a plain `df.groupby(...).agg(["mean", "median"])` call.
- Ran the full `tests/unit_tests/pandas_postprocessing/` suite locally (108 tests, all passing).
- Ran `ruff check` / `ruff format` and `mypy` on the changed file — no new issues introduced (two pre-existing, unrelated mypy errors on lines 103-104 remain untouched).