### PR TITLE
fix(event-log): match embedded routes without trailing slash in logger middleware

### DIFF
--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -161,6 +161,8 @@ describe('logger middleware', () => {
     ['/dashboard/123/', 'dashboard'],
     // slug is literally "embedded" - must not be treated as embedded
     ['/dashboard/embedded/', 'dashboard'],
+    // "embedded" must be a full path segment, not a prefix
+    ['/dashboard/123/embeddedXYZ/', 'dashboard'],
   ])('classifies %s as source "%s"', (path, expectedSource) => {
     expect(getSourceForPath(`http://localhost${path}`)).toBe(expectedSource);
   });

--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -155,6 +155,9 @@ describe('logger middleware', () => {
   test.each([
     ['/dashboard/123/embedded/', 'embedded_dashboard'],
     ['/embedded/abc-def-uuid/', 'embedded_dashboard'],
+    // React Router also matches these routes without a trailing slash
+    ['/dashboard/123/embedded', 'embedded_dashboard'],
+    ['/embedded/abc-def-uuid', 'embedded_dashboard'],
     ['/dashboard/123/', 'dashboard'],
     // slug is literally "embedded" - must not be treated as embedded
     ['/dashboard/embedded/', 'dashboard'],

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -136,7 +136,7 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
 // `/embedded/:uuid/`. Matching these specific shapes avoids false positives
 // for regular dashboards (e.g. a dashboard whose slug is "embedded").
 const EMBEDDED_ROUTE_REGEX =
-  /\/dashboard\/[^/]+\/embedded\/|\/embedded\/[^/]+\//;
+  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
 
 let lastEventId: string | number = 0;
 

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -136,7 +136,7 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
 // `/embedded/:uuid/`. Matching these specific shapes avoids false positives
 // for regular dashboards (e.g. a dashboard whose slug is "embedded").
 const EMBEDDED_ROUTE_REGEX =
-  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
+  /\/dashboard\/[^/]+\/embedded(?:[/?#]|$)|\/embedded\/[^/]+\/?/;
 
 let lastEventId: string | number = 0;
 


### PR DESCRIPTION
### SUMMARY

Follow-up to #41942, which replaced the substring `/embedded/` check in `loggerMiddleware` with a regex matching the actual embedded route shapes (`/dashboard/:idOrSlug/embedded/` and `/embedded/:uuid/`).

That regex required a **trailing slash** after the slug/UUID. However, the embedded routes are registered non-strict in React Router (`superset-frontend/src/embedded/index.tsx`), so they also match without a final slash — e.g. `/dashboard/123/embedded` and `/embedded/<uuid>`. For those URLs the regex failed to match, so the events were classified with `source: 'dashboard'` (or omitted) instead of `source: 'embedded_dashboard'`, misreporting embedded-dashboard usage in the event log.

This makes the trailing slash optional in both branches of the regex:

```diff
-  /\/dashboard\/[^/]+\/embedded\/|\/embedded\/[^/]+\//;
+  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal event-logging metadata change only.

### TESTING INSTRUCTIONS

Unit tests in `superset-frontend/src/middleware/logger.test.ts` now cover the no-trailing-slash variants:

- `/dashboard/123/embedded` -> `embedded_dashboard`
- `/embedded/abc-def-uuid` -> `embedded_dashboard`

alongside the existing trailing-slash and regular-dashboard cases.

Run:

```bash
cd superset-frontend
npm run test -- src/middleware/logger.test.ts
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
