### PR TITLE
fix(event-log): require segment boundary after 'embedded' in route regex

### DIFF
--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -170,6 +170,8 @@ describe('logger middleware', () => {
     ['/dashboard/123/', 'dashboard'],
     // slug is literally "embedded" - must not be treated as embedded
     ['/dashboard/embedded/', 'dashboard'],
+    // "embedded" must be a full path segment, not a prefix
+    ['/dashboard/123/embeddedXYZ/', 'dashboard'],
   ])('classifies %s as source "%s"', (path, expectedSource) => {
     expect(getSourceForPath(`http://localhost${path}`)).toBe(expectedSource);
   });

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -140,7 +140,7 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
 // `/embedded/:uuid/`. Matching these specific shapes avoids false positives
 // for regular dashboards (e.g. a dashboard whose slug is "embedded").
 const EMBEDDED_ROUTE_REGEX =
-  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
+  /\/dashboard\/[^/]+\/embedded(?:[/?#]|$)|\/embedded\/[^/]+\/?/;
 
 let lastEventId: string | number = 0;
 


### PR DESCRIPTION
### SUMMARY

Backports to 6.1 the segment-boundary fix for embedded-route classification in `loggerMiddleware`.

6.1 already carries the earlier embedded-route work (the regex with an optional trailing slash). However, the first branch of that regex does not enforce an end-of-segment boundary after `embedded`, so `EMBEDDED_ROUTE_REGEX.test(...)` also matches prefixes like `/dashboard/123/embeddedXYZ`, misclassifying those events with `source: 'embedded_dashboard'` instead of `source: 'dashboard'`.

This requires an end-of-segment boundary (`/`, `?`, `#`, or end of string) after `embedded`:

```diff
-  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
+  /\/dashboard\/[^/]+\/embedded(?:[/?#]|$)|\/embedded\/[^/]+\/?/;
```

The second branch (`/embedded/:uuid`) is unchanged — its `[^/]+` already treats the UUID as a full segment.

This mirrors the fix under review for master in apache/superset#42005.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal event-logging metadata change only.

### TESTING INSTRUCTIONS

Unit tests in `superset-frontend/src/middleware/logger.test.ts` add coverage for the prefix case:

- `/dashboard/123/embeddedXYZ/` -> `dashboard`

alongside the existing embedded/regular-dashboard cases.

Run:

```bash
cd superset-frontend
npm run test -- src/middleware/logger.test.ts
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
