### PR TITLE
fix(async-queries): back off polling when async event requests keep failing

### DIFF
--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -174,6 +174,10 @@ describe('asyncEvent middleware', () => {
     });
 
     test('backs off exponentially when polling requests keep failing', async () => {
+      // stop the real-timer polling loop started by beforeEach before
+      // switching to fake timers, so all polls run on the fake clock
+      mockedIsFeatureEnabled.mockReturnValueOnce(false);
+      asyncEvent.init(config);
       jest.useFakeTimers();
       try {
         fetchMock.clearHistory().removeRoutes();
@@ -214,6 +218,10 @@ describe('asyncEvent middleware', () => {
     });
 
     test('resumes the configured polling delay after a successful poll', async () => {
+      // stop the real-timer polling loop started by beforeEach before
+      // switching to fake timers, so all polls run on the fake clock
+      mockedIsFeatureEnabled.mockReturnValueOnce(false);
+      asyncEvent.init(config);
       jest.useFakeTimers();
       try {
         fetchMock.clearHistory().removeRoutes();

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -306,6 +306,104 @@ describe('asyncEvent middleware', () => {
       }
     });
 
+    test('does not start a second loop when re-initialized during an in-flight poll', async () => {
+      // stop the real-timer polling loop started by beforeEach before
+      // switching to fake timers, so all polls run on the fake clock
+      mockedIsFeatureEnabled.mockReturnValueOnce(false);
+      asyncEvent.init(config);
+      jest.useFakeTimers();
+      try {
+        fetchMock.clearHistory().removeRoutes();
+        let resolveFetch: (response: any) => void = () => {};
+        fetchMock.get(
+          EVENTS_ENDPOINT,
+          new Promise(resolve => {
+            resolveFetch = resolve;
+          }),
+        );
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+
+        // first poll fires and stays in-flight
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        // re-init while that fetch is pending, then let it resolve; the
+        // stale invocation must not schedule a second loop
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+        resolveFetch({ status: 200, body: { result: [] } });
+        await jest.advanceTimersByTimeAsync(0);
+
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, {
+          status: 200,
+          body: { result: [] },
+        });
+
+        // exactly one poll per delay from here on
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('does not resume polling when re-initialized with the feature disabled during an in-flight poll', async () => {
+      // stop the real-timer polling loop started by beforeEach before
+      // switching to fake timers, so all polls run on the fake clock
+      mockedIsFeatureEnabled.mockReturnValueOnce(false);
+      asyncEvent.init(config);
+      jest.useFakeTimers();
+      try {
+        fetchMock.clearHistory().removeRoutes();
+        let resolveFetch: (response: any) => void = () => {};
+        fetchMock.get(
+          EVENTS_ENDPOINT,
+          new Promise(resolve => {
+            resolveFetch = resolve;
+          }),
+        );
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+
+        // first poll fires and stays in-flight
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        // disable the feature and re-init while the fetch is pending; the
+        // stale invocation must not restart the stopped loop when it resumes
+        mockedIsFeatureEnabled.mockReturnValueOnce(false);
+        asyncEvent.init(config);
+        resolveFetch({ status: 200, body: { result: [] } });
+        await jest.advanceTimersByTimeAsync(0);
+
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, {
+          status: 200,
+          body: { result: [] },
+        });
+
+        await jest.advanceTimersByTimeAsync(
+          10 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     // Regression guard for the motivating CodeQL case: a job_id that collides
     // with a built-in Object property (e.g. "__proto__"/"constructor") must be
     // routed through the Map-based registries without triggering prototype

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -258,6 +258,54 @@ describe('asyncEvent middleware', () => {
       }
     });
 
+    test('caps the polling backoff delay at 60 seconds', async () => {
+      const MAX_ERROR_POLLING_DELAY_MS = 60000;
+      // stop the real-timer polling loop started by beforeEach before
+      // switching to fake timers, so all polls run on the fake clock
+      mockedIsFeatureEnabled.mockReturnValueOnce(false);
+      asyncEvent.init(config);
+      jest.useFakeTimers();
+      try {
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+
+        // first poll fires after the configured delay and fails
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        // walk the uncapped backoff: after failure N the next delay is
+        // 2^N times the configured delay, which stays below the cap through
+        // failure 10 (50ms * 2^10 = 51.2s)
+        for (let failures = 1; failures <= 10; failures += 1) {
+          await jest.advanceTimersByTimeAsync(
+            config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY * 2 ** failures,
+          );
+          expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(
+            failures + 1,
+          );
+        }
+
+        // after failure 11 the uncapped delay would be 102.4s, so the cap
+        // takes over: no poll just before the 60s mark...
+        await jest.advanceTimersByTimeAsync(MAX_ERROR_POLLING_DELAY_MS - 1);
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(11);
+
+        // ...and the next poll fires exactly at 60s
+        await jest.advanceTimersByTimeAsync(1);
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(12);
+
+        // additional failures remain capped at 60s
+        await jest.advanceTimersByTimeAsync(MAX_ERROR_POLLING_DELAY_MS);
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(13);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     // Regression guard for the motivating CodeQL case: a job_id that collides
     // with a built-in Object property (e.g. "__proto__"/"constructor") must be
     // routed through the Map-based registries without triggering prototype

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -173,6 +173,83 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(1);
     });
 
+    test('backs off exponentially when polling requests keep failing', async () => {
+      jest.useFakeTimers();
+      try {
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+
+        // first poll fires after the configured delay and fails
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        // next poll is delayed by 2x the configured delay, so nothing yet
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
+
+        // after the second failure the delay grows to 4x
+        await jest.advanceTimersByTimeAsync(
+          3 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
+
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(3);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('resumes the configured polling delay after a successful poll', async () => {
+      jest.useFakeTimers();
+      try {
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
+        asyncEvent.init(config);
+        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
+
+        // two failed polls: 1x delay, then 2x delay
+        await jest.advanceTimersByTimeAsync(
+          3 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
+
+        // subsequent polls succeed, resetting the backoff
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, {
+          status: 200,
+          body: { result: [] },
+        });
+
+        // third poll fires 4x delay after the second failure and succeeds
+        await jest.advanceTimersByTimeAsync(
+          4 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
+
+        // polling is back to the configured delay
+        await jest.advanceTimersByTimeAsync(
+          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
+        );
+        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     // Regression guard for the motivating CodeQL case: a job_id that collides
     // with a built-in Object property (e.g. "__proto__"/"constructor") must be
     // routed through the Map-based registries without triggering prototype

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -58,6 +58,9 @@ const LOCALSTORAGE_KEY = 'last_async_event_id';
 const POLLING_URL = '/api/v1/async_event/';
 const MAX_RETRIES = 6;
 const RETRY_DELAY = 100;
+// Cap for the exponential backoff applied when polling requests fail
+// repeatedly (e.g. expired session, server or network errors)
+const MAX_ERROR_POLLING_DELAY_MS = 60000;
 
 let config: AppConfig;
 let transport: string;
@@ -66,6 +69,7 @@ let pollingTimeoutId: number;
 let listenersByJobId: Map<string, ListenerFn>;
 let retriesByJobId: Map<string, number>;
 let lastReceivedEventId: string | null | undefined;
+let consecutivePollingErrorCount = 0;
 
 const addListener = (id: string, fn: ListenerFn) => {
   listenersByJobId.set(id, fn);
@@ -170,19 +174,30 @@ export const processEvents = async (events: AsyncEvent[]) => {
   });
 };
 
+const getPollingDelay = () => {
+  if (!consecutivePollingErrorCount) return pollingDelayMs;
+  const backoffDelayMs = pollingDelayMs * 2 ** consecutivePollingErrorCount;
+  return Math.max(
+    pollingDelayMs,
+    Math.min(backoffDelayMs, MAX_ERROR_POLLING_DELAY_MS),
+  );
+};
+
 const loadEventsFromApi = async () => {
   const eventArgs = lastReceivedEventId ? { last_id: lastReceivedEventId } : {};
   if (listenersByJobId.size) {
     try {
       const { result: events } = await fetchEvents(eventArgs);
+      consecutivePollingErrorCount = 0;
       if (events?.length) await processEvents(events);
     } catch (err) {
+      consecutivePollingErrorCount += 1;
       logging.warn(err);
     }
   }
 
   if (transport === TRANSPORT_POLLING) {
-    pollingTimeoutId = window.setTimeout(loadEventsFromApi, pollingDelayMs);
+    pollingTimeoutId = window.setTimeout(loadEventsFromApi, getPollingDelay());
   }
 };
 
@@ -238,6 +253,7 @@ export const init = (appConfig?: AppConfig) => {
   listenersByJobId = new Map();
   retriesByJobId = new Map();
   lastReceivedEventId = null;
+  consecutivePollingErrorCount = 0;
 
   config = appConfig || getBootstrapData().common.conf;
   transport = config.GLOBAL_ASYNC_QUERIES_TRANSPORT || TRANSPORT_POLLING;

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -247,8 +247,8 @@ const wsConnect = (): void => {
 };
 
 export const init = (appConfig?: AppConfig) => {
-  if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
+  if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
 
   listenersByJobId = new Map();
   retriesByJobId = new Map();

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -70,6 +70,10 @@ let listenersByJobId: Map<string, ListenerFn>;
 let retriesByJobId: Map<string, number>;
 let lastReceivedEventId: string | null | undefined;
 let consecutivePollingErrorCount = 0;
+// Incremented on every init() so polling invocations that are already
+// awaiting a fetch when re-init happens can detect they are stale and
+// stop, instead of mutating fresh state or scheduling a second loop
+let pollingGeneration = 0;
 
 const addListener = (id: string, fn: ListenerFn) => {
   listenersByJobId.set(id, fn);
@@ -184,18 +188,22 @@ const getPollingDelay = () => {
 };
 
 const loadEventsFromApi = async () => {
+  const generation = pollingGeneration;
   const eventArgs = lastReceivedEventId ? { last_id: lastReceivedEventId } : {};
   if (listenersByJobId.size) {
     try {
       const { result: events } = await fetchEvents(eventArgs);
+      if (generation !== pollingGeneration) return;
       consecutivePollingErrorCount = 0;
       if (events?.length) await processEvents(events);
     } catch (err) {
+      if (generation !== pollingGeneration) return;
       consecutivePollingErrorCount += 1;
       logging.warn(err);
     }
   }
 
+  if (generation !== pollingGeneration) return;
   if (transport === TRANSPORT_POLLING) {
     pollingTimeoutId = window.setTimeout(loadEventsFromApi, getPollingDelay());
   }
@@ -247,6 +255,7 @@ const wsConnect = (): void => {
 };
 
 export const init = (appConfig?: AppConfig) => {
+  pollingGeneration += 1;
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
 


### PR DESCRIPTION
### SUMMARY
When `GLOBAL_ASYNC_QUERIES` is enabled with the `polling` transport, the client polls `/api/v1/async_event/` every `GLOBAL_ASYNC_QUERIES_POLLING_DELAY` ms (500ms by default) while there are registered job listeners. When a polling request fails, the error is logged and the next poll is scheduled at the full configured rate, unconditionally and forever.

This becomes a problem when the failure is persistent. The most common case is an expired session: a dashboard tab left open keeps polling at 2 requests/second indefinitely, receiving a 401/403 on every request. The pending job listeners never resolve (the completion events can never be read), so polling never stops on its own. Since every request still executes the full authentication and authorization stack server-side, idle browser tabs can generate significant sustained load on the web workers and the metadata database.

This PR applies exponential backoff to the polling loop when requests fail consecutively:

- Each consecutive failure doubles the polling delay (`delay * 2^failures`), capped at 60 seconds.
- The first successful poll resets the delay back to the configured value.
- Behavior during normal operation is unchanged — backoff only kicks in on failures.

With the default 500ms delay, a permanently failing client converges to ~1 request/minute instead of ~120/minute, while still recovering automatically (e.g. after the user logs back in) since polling never fully stops.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — no UI changes.

### TESTING INSTRUCTIONS
Unit tests added in `superset-frontend/src/middleware/asyncEvent.test.ts` covering the backoff growth and the reset-on-success behavior.

Manual verification:
1. Enable `GLOBAL_ASYNC_QUERIES` with the `polling` transport and open a dashboard so async jobs register listeners.
2. Invalidate the session (e.g. delete the session cookie) while the tab stays open.
3. Observe in the network tab that requests to `/api/v1/async_event/` back off exponentially (500ms → 1s → 2s → ... → 60s cap) instead of continuing at 500ms.
4. Log back in — after the next successful poll, the polling interval returns to the configured delay.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (polling transport)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
