### PR TITLE
fix(e2e): repair master Playwright smoke tests

### DIFF
--- a/superset-frontend/playwright/components/modals/NativeFiltersConfigModal.ts
+++ b/superset-frontend/playwright/components/modals/NativeFiltersConfigModal.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Locator, Page } from '@playwright/test';
+import { Modal } from '../core';
+
+/**
+ * Native filters and Display Controls configuration modal.
+ */
+export class NativeFiltersConfigModal extends Modal {
+  private static readonly TEST_IDS = {
+    SAVE_BUTTON: 'native-filter-modal-save-button',
+  } as const;
+
+  private static readonly LABELS = {
+    DIALOG: 'Add or edit display controls',
+  } as const;
+
+  private readonly specificLocator: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.specificLocator = page.getByRole('dialog', {
+      name: NativeFiltersConfigModal.LABELS.DIALOG,
+      exact: true,
+    });
+  }
+
+  override get element(): Locator {
+    return this.specificLocator;
+  }
+
+  /**
+   * Gets a Display Control row by name.
+   * @param name - The Display Control name
+   */
+  private getDisplayControlRow(name: string): Locator {
+    return this.element.getByRole('tab').filter({
+      has: this.page.getByText(name, { exact: true }),
+    });
+  }
+
+  /**
+   * Marks a Display Control for removal.
+   * @param name - The Display Control name
+   */
+  async removeDisplayControl(name: string): Promise<void> {
+    const controlRow = this.getDisplayControlRow(name);
+    await controlRow.hover();
+    await controlRow
+      .getByRole('button', { name: 'Remove customization' })
+      .click();
+  }
+
+  /**
+   * Gets the marker shown when a Display Control has been removed.
+   */
+  getRemovedMarker(): Locator {
+    return this.element.getByText('(Removed)', { exact: true }).first();
+  }
+
+  /**
+   * Saves the native filters and Display Controls configuration.
+   */
+  async clickSave(): Promise<void> {
+    await this.element
+      .getByTestId(NativeFiltersConfigModal.TEST_IDS.SAVE_BUTTON)
+      .click();
+  }
+}

--- a/superset-frontend/playwright/pages/DashboardPage.ts
+++ b/superset-frontend/playwright/pages/DashboardPage.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { Page, Download } from '@playwright/test';
+import { Page, Download, Locator } from '@playwright/test';
 import { Menu } from '../components/core';
+import { NativeFiltersConfigModal } from '../components/modals';
 import { gotoWithRetry } from '../helpers/navigation';
 import { TIMEOUT } from '../utils/constants';
 
@@ -33,6 +34,9 @@ export class DashboardPage {
     DASHBOARD_MENU_TRIGGER: '[data-test="actions-trigger"]',
     // The header-actions-menu is the data-test for the dropdown menu content
     HEADER_ACTIONS_MENU: '[data-test="header-actions-menu"]',
+    FILTER_BAR_SETTINGS: '[data-test="filterbar-orientation-icon"]',
+    APPLY_FILTERS_BUTTON:
+      '[data-test="filter-bar__apply-button"], [data-test="filterbar-action-buttons"] button[type="submit"]',
   } as const;
 
   constructor(page: Page) {
@@ -92,6 +96,52 @@ export class DashboardPage {
       undefined,
       { timeout },
     );
+  }
+
+  /**
+   * Gets the Display controls section heading in the filter bar.
+   */
+  getDisplayControlsHeader(): Locator {
+    return this.page.getByRole('heading', {
+      name: 'Display controls',
+      exact: true,
+    });
+  }
+
+  /**
+   * Gets a Display Control heading by name.
+   * @param name - The Display Control name
+   */
+  getDisplayControl(name: string): Locator {
+    return this.page.getByRole('heading', { name, exact: true });
+  }
+
+  /**
+   * Opens the native filters and Display Controls configuration modal.
+   */
+  async openNativeFiltersConfigModal(): Promise<NativeFiltersConfigModal> {
+    await this.page.click(DashboardPage.SELECTORS.FILTER_BAR_SETTINGS);
+    await this.page
+      .getByText('Add or edit filters and controls', { exact: true })
+      .click();
+
+    const modal = new NativeFiltersConfigModal(this.page);
+    await modal.waitForVisible();
+    return modal;
+  }
+
+  /**
+   * Applies pending native filter changes when the Apply button is enabled.
+   */
+  async applyFiltersIfEnabled(): Promise<void> {
+    const applyButton = this.page
+      .locator(DashboardPage.SELECTORS.APPLY_FILTERS_BUTTON)
+      .first();
+    if (!(await applyButton.isEnabled().catch(() => false))) {
+      return;
+    }
+
+    await applyButton.click();
   }
 
   /**

--- a/superset-frontend/playwright/pages/HomePage.ts
+++ b/superset-frontend/playwright/pages/HomePage.ts
@@ -17,13 +17,35 @@
  * under the License.
  */
 
-// Specific modal implementations
-export { ChartPropertiesModal } from './ChartPropertiesModal';
-export { ConfirmDialog } from './ConfirmDialog';
-export { DeleteConfirmationModal } from './DeleteConfirmationModal';
-export { DuplicateDatasetModal } from './DuplicateDatasetModal';
-export { EditDatasetModal } from './EditDatasetModal';
-export { ImportDatasetModal } from './ImportDatasetModal';
-export { NativeFiltersConfigModal } from './NativeFiltersConfigModal';
-export { SaveDatasetModal } from './SaveDatasetModal';
-export { SaveQueryModal } from './SaveQueryModal';
+import { Locator, Page } from '@playwright/test';
+import { gotoWithRetry } from '../helpers/navigation';
+import { URL } from '../utils/urls';
+
+/**
+ * Home/welcome page object.
+ */
+export class HomePage {
+  private readonly page: Page;
+
+  private static readonly SECTION_NAMES = {
+    RECENTS: 'Recents',
+  } as const;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Navigates to the Home/welcome page.
+   */
+  async goto(): Promise<void> {
+    await gotoWithRetry(this.page, URL.WELCOME);
+  }
+
+  /**
+   * Gets the Recents content section.
+   */
+  getRecentsSection(): Locator {
+    return this.page.getByText(HomePage.SECTION_NAMES.RECENTS, { exact: true });
+  }
+}

--- a/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
@@ -20,25 +20,23 @@
 import { testWithAssets, expect } from '../../helpers/fixtures';
 import { apiPost, apiPut } from '../../helpers/api/requests';
 import { apiPostDashboard } from '../../helpers/api/dashboard';
+import { getDatasetByName } from '../../helpers/api/dataset';
 import { DashboardPage } from '../../pages/DashboardPage';
+import { TIMEOUT } from '../../utils/constants';
 
 const DATASET_NAME = 'birth_names';
 const FILTER_COLUMN = 'gender';
 
-async function findDatasetIdByName(page: any, name: string): Promise<number> {
-  const rison = `(filters:!((col:table_name,opr:eq,value:'${name}')))`;
-  const resp = await page.request.get(`api/v1/dataset/?q=${rison}`);
-  const body = await resp.json();
-  if (!body.result?.length) {
-    throw new Error(`Dataset ${name} not found`);
-  }
-  return body.result[0].id;
-}
-
 testWithAssets(
   'Clear all filters waits for Apply (sc-105059)',
   async ({ page, testAssets }) => {
-    const datasetId = await findDatasetIdByName(page, DATASET_NAME);
+    testWithAssets.setTimeout(TIMEOUT.SLOW_TEST);
+
+    const dataset = await getDatasetByName(page, DATASET_NAME);
+    if (!dataset) {
+      throw new Error(`Dataset ${DATASET_NAME} not found`);
+    }
+    const datasetId = dataset.id;
 
     // Create a chart that the dashboard filter will target
     const chartParams = {
@@ -148,7 +146,7 @@ testWithAssets(
     // Visit dashboard
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.gotoById(dashboardId);
-    await dashboardPage.waitForLoad();
+    await dashboardPage.waitForLoad({ timeout: TIMEOUT.SLOW_TEST });
     await dashboardPage.waitForChartsToLoad();
 
     // The Gender select should be visible in the filter bar

--- a/superset-frontend/playwright/tests/dashboard/delete-display-control.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/delete-display-control.spec.ts
@@ -23,10 +23,10 @@
  * filter and a Time grain Display Control, deletes the control via the config
  * modal, then applies and asserts it stays gone.
  */
-import { Page } from '@playwright/test';
 import { testWithAssets, expect } from '../../helpers/fixtures';
 import { apiPost, apiPut } from '../../helpers/api/requests';
 import { apiPostDashboard } from '../../helpers/api/dashboard';
+import { getDatasetByName } from '../../helpers/api/dataset';
 import { DashboardPage } from '../../pages/DashboardPage';
 
 // Record video regardless of pass/fail (before/after clips).
@@ -35,16 +35,6 @@ testWithAssets.use({ video: 'on' });
 const DATASET_NAME = 'birth_names';
 const FILTER_COLUMN = 'gender';
 const TEMPORAL_COLUMN = 'ds';
-
-async function findDatasetIdByName(page: Page, name: string): Promise<number> {
-  const rison = `(filters:!((col:table_name,opr:eq,value:'${name}')))`;
-  const resp = await page.request.get(`api/v1/dataset/?q=${rison}`);
-  const body = await resp.json();
-  if (!body.result?.length) {
-    throw new Error(`Dataset ${name} not found`);
-  }
-  return body.result[0].id;
-}
 
 testWithAssets(
   'Deleted Display Control must not reappear after Apply Filters',
@@ -56,7 +46,11 @@ testWithAssets(
         fullPage: false,
       });
 
-    const datasetId = await findDatasetIdByName(page, DATASET_NAME);
+    const dataset = await getDatasetByName(page, DATASET_NAME);
+    if (!dataset) {
+      throw new Error(`Dataset ${DATASET_NAME} not found`);
+    }
+    const datasetId = dataset.id;
 
     // 1. Seed a chart the filter + control can target.
     const chartParams = {
@@ -183,47 +177,31 @@ testWithAssets(
     await dashboardPage.waitForChartsToLoad({ timeout: 8000 }).catch(() => {});
 
     // Both the Gender filter and the Time grain Display Control should render.
-    const displayControlsHeader = page.locator('text=Display controls').first();
-    await expect(displayControlsHeader).toBeVisible();
-    const timeGrainControl = page.locator('text=Time grain').first();
-    await expect(timeGrainControl).toBeVisible();
+    await expect(dashboardPage.getDisplayControlsHeader()).toBeVisible();
+    await expect(dashboardPage.getDisplayControl('Time grain')).toBeVisible();
     // eslint-disable-next-line no-console
     console.log('STEP 1: Display control "Time grain" is present in the bar.');
     await shot('01-initial-bar');
 
     // 4. Open the filters config modal via the settings gear.
-    await page.locator('[data-test="filterbar-orientation-icon"]').click();
-    await page.locator('text=Add or edit filters and controls').first().click();
-    await expect(
-      page.locator('[data-test="native-filter-modal-save-button"]'),
-    ).toBeVisible();
+    const modal = await dashboardPage.openNativeFiltersConfigModal();
     await shot('02-modal-open');
 
     // 5. Delete the "Time grain" Display Control in the modal sidebar.
-    const modal = page.locator('.ant-modal-content');
-    const controlRow = modal.getByText('Time grain', { exact: false }).first();
-    await controlRow.hover();
-    // Trash icon in the same sidebar row.
-    const rowContainer = controlRow.locator(
-      'xpath=ancestor::*[@role="tab"][1]',
-    );
-    await rowContainer.locator('.anticon-delete, [aria-label]').last().click();
-    await expect(modal.getByText('(Removed)').first()).toBeVisible();
+    await modal.removeDisplayControl('Time grain');
+    await expect(modal.getRemovedMarker()).toBeVisible();
     // eslint-disable-next-line no-console
     console.log('STEP 2: Display control marked (Removed) in modal.');
     await shot('03-modal-removed');
 
     // 6. Save the modal.
-    await page.locator('[data-test="native-filter-modal-save-button"]').click();
-    await expect(
-      page.locator('[data-test="native-filter-modal-save-button"]'),
-    ).toBeHidden({ timeout: 20000 });
+    await modal.clickSave();
+    await modal.waitForHidden({ timeout: 20000 });
     await dashboardPage.waitForChartsToLoad({ timeout: 8000 }).catch(() => {});
     await shot('04-after-save');
 
-    const goneAfterSave = await page
-      .locator('text=Time grain')
-      .first()
+    const goneAfterSave = await dashboardPage
+      .getDisplayControl('Time grain')
       .isVisible()
       .catch(() => false);
     // eslint-disable-next-line no-console
@@ -232,21 +210,13 @@ testWithAssets(
     );
 
     // 7. Click Apply Filters.
-    const applyBtn = page
-      .locator(
-        '[data-test="filter-bar__apply-button"], [data-test="filterbar-action-buttons"] button[type="submit"]',
-      )
-      .first();
-    if (await applyBtn.isEnabled().catch(() => false)) {
-      await applyBtn.click();
-    }
+    await dashboardPage.applyFiltersIfEnabled();
     await dashboardPage.waitForChartsToLoad({ timeout: 8000 }).catch(() => {});
     await page.waitForTimeout(1500);
     await shot('05-after-apply');
 
-    const reappeared = await page
-      .locator('text=Time grain')
-      .first()
+    const reappeared = await dashboardPage
+      .getDisplayControl('Time grain')
       .isVisible()
       .catch(() => false);
     // eslint-disable-next-line no-console
@@ -256,7 +226,7 @@ testWithAssets(
 
     // The deleted Display Control must stay gone.
     await expect(
-      page.locator('text=Time grain'),
+      dashboardPage.getDisplayControl('Time grain'),
       'Deleted Display Control must not reappear after Apply Filters',
     ).toHaveCount(0);
   },

--- a/superset-frontend/playwright/tests/home/welcome.spec.ts
+++ b/superset-frontend/playwright/tests/home/welcome.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { test, expect } from '@playwright/test';
-import { URL } from '../../utils/urls';
+import { HomePage } from '../../pages/HomePage';
 import { TIMEOUT } from '../../utils/constants';
 
 // Smoke test guarding against a blank Home/welcome landing page (e.g. a shell
@@ -25,12 +25,13 @@ import { TIMEOUT } from '../../utils/constants';
 // suite only waits for the welcome URL + session cookie, so it would not catch
 // a welcome page that redirects correctly but renders no content.
 test('welcome page renders its content, not just the nav', async ({ page }) => {
-  await page.goto(`/${URL.WELCOME}`);
+  const homePage = new HomePage(page);
+  await homePage.goto();
 
   // "Recents" is a Home content section header (a Collapse panel) that does not
   // exist in the top navigation, so its presence proves the route content
   // rendered — not just the app shell.
-  await expect(page.getByText('Recents', { exact: true })).toBeVisible({
+  await expect(homePage.getRecentsSection()).toBeVisible({
     timeout: TIMEOUT.PAGE_LOAD,
   });
 });


### PR DESCRIPTION
### SUMMARY

Fix the deterministic Playwright failures recurring on master and harden a cold-load dashboard flake:

- Replace the removed Ant Design 5 `.ant-modal-content` dependency with a dedicated `NativeFiltersConfigModal` component using stable test IDs, roles, and labels.
- Extend `DashboardPage` to own Display Control queries, filter configuration, and Apply interactions.
- Add `HomePage` so welcome navigation uses the shared prefix-safe navigation helper and page content queries stay out of the spec.
- Reuse the existing dataset API helper instead of duplicating Rison lookups in dashboard tests.
- Give the multi-step Clear All regression test the existing slow-test budget for both the test and cold dashboard readiness. CI traces show its first load can stall on JavaScript chunks for more than 30 seconds under the two-worker required matrix, while a warmed retry passes in under 10 seconds.

CI evidence:
- [master root Playwright failure](https://github.com/apache/superset/actions/runs/29277097598/job/86909127637)
- [master APP_PREFIX Playwright failure](https://github.com/apache/superset/actions/runs/29277097598/job/86909127599)
- [cold-load Clear All flake](https://github.com/apache/superset/actions/runs/29291758115/job/86956731799)

The separate Python 3.10 `syntaqlite` master failure is already owned by #42007 and is intentionally not duplicated here.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this changes test selectors, navigation, and test timing only.

### TESTING INSTRUCTIONS

```bash
PATH=/Users/joeli/.nvm/versions/node/v24.16.0/bin:$PATH pre-commit run --files \
  superset-frontend/playwright/components/modals/NativeFiltersConfigModal.ts \
  superset-frontend/playwright/components/modals/index.ts \
  superset-frontend/playwright/pages/DashboardPage.ts \
  superset-frontend/playwright/pages/HomePage.ts \
  superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts \
  superset-frontend/playwright/tests/dashboard/delete-display-control.spec.ts \
  superset-frontend/playwright/tests/home/welcome.spec.ts

cd superset-frontend
npm run playwright:test -- --list \
  tests/dashboard/clear-all-filters.spec.ts \
  tests/dashboard/delete-display-control.spec.ts \
  tests/home/welcome.spec.ts
```

Changed-file validation and Playwright test discovery pass. Browser validation runs in the required, experimental, and `/app/prefix` CI lanes.

The required `pre-commit run --all-files` was also executed locally. It reaches unrelated existing checkout-wide failures (mapper-test mypy findings, absent docs dependencies, unbuilt package declarations, and existing Ruff findings); no all-files failure points to the changed Playwright files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
