### PR TITLE
fix(app-root): restore legacy redirects for HEAD and the /superset app root

### DIFF
--- a/superset/middleware/legacy_prefix_redirect.py
+++ b/superset/middleware/legacy_prefix_redirect.py
@@ -42,6 +42,8 @@ shim to see it.
 Disposition rules
 -----------------
 * GET against any enumerated row → 308 Permanent Redirect.
+* HEAD is folded to GET before the method check, so it tracks GET exactly:
+  it 308s wherever GET does, and 410s against a POST-only canonical.
 * POST against a POST-capable canonical → 308 (body-preserving).
 * POST against a GET-only canonical → 410 Gone (308 would 405 on retry).
 * Anything not in :data:`LEGACY_REDIRECT_MAP` → pass through unchanged.
@@ -186,28 +188,21 @@ class LegacyPrefixRedirectMiddleware:
         # produce the same Location prefix at build time. Empty string is
         # correct for app_root == "/".
         self.app_root_prefix: str = app_root.rstrip("/")
-        # If the operator deploys under
-        # APPLICATION_ROOT == "/superset", the legacy prefix collides with
-        # the app-root prefix and `app_root_prefix + canonical_target`
-        # produces the same URL as the inbound path → infinite 308 loop.
-        # In that deployment shape there is no migration to perform anyway
-        # (legacy URLs are already at their canonical location), so the
-        # shim becomes a no-op.
-        self._enabled: bool = self.app_root_prefix != _LEGACY_PREFIX
 
     def __call__(
         self,
         environ: "WSGIEnvironment",
         start_response: "StartResponse",
     ) -> Iterable[bytes]:
-        # Short-circuit when APPLICATION_ROOT == _LEGACY_PREFIX
-        # (legacy and canonical prefixes coincide → 308 self-loop). See
-        # `__init__` for the full rationale.
-        if not self._enabled:
-            return self.wsgi_app(environ, start_response)
-
         path_info: str = environ.get("PATH_INFO", "")
         method: str = environ.get("REQUEST_METHOD", "GET").upper()
+        # HEAD is GET-without-a-body (RFC 9110 §9.3.2) and Werkzeug registers
+        # it implicitly on every GET rule, so LEGACY_REDIRECT_MAP spells only
+        # the methods the canonical @expose decorators name explicitly — never
+        # HEAD. Fold it to GET for the method checks below; otherwise every
+        # legacy HEAD probe (link-checkers, uptime monitors, `curl -I`) falls
+        # into the wrong-method branch and gets a spurious 410 Gone.
+        method_for_match: str = "GET" if method == "HEAD" else method
 
         # Under a subdirectory deployment, legacy bookmarks carry the app
         # root too (`/myapp/superset/dashboard/1/`) — this shim sits outside
@@ -216,6 +211,15 @@ class LegacyPrefixRedirectMiddleware:
         # check so both `/superset/...` and `{app_root}/superset/...` forms
         # are recognised. The Location below is built from the captured
         # app_root either way, so both forms 308 to the same canonical URL.
+        #
+        # This strip is also what makes APPLICATION_ROOT == "/superset" safe,
+        # the one deployment where the app-root and legacy prefixes are the
+        # same token. A legacy bookmark there carries it twice
+        # (`/superset/superset/dashboard/1/`) and 308s to
+        # `/superset/dashboard/1/`; that target strips to `/dashboard/1/`,
+        # which is not a legacy path, so it passes through on the next hop.
+        # Because the strip runs *before* the legacy check, a canonical URL
+        # can never re-enter the redirect branch — there is no self-loop.
         candidate = path_info
         if self.app_root_prefix and candidate.startswith(self.app_root_prefix + "/"):
             candidate = candidate[len(self.app_root_prefix) :]
@@ -233,7 +237,7 @@ class LegacyPrefixRedirectMiddleware:
         # Redirect it explicitly (numeric id only) so legacy SQL Lab deep links
         # survive one release cycle instead of hard-404ing.
         if sql_match := _LEGACY_SQL_RE.match(canonical_after_strip):
-            if method != "GET":
+            if method_for_match != "GET":
                 # The old /superset/sql/<id>/ route was GET-only; a 308 would
                 # have the client retry-POST against /sqllab/ → 405. Emit 410.
                 return _response_with_location(410, None)(environ, start_response)
@@ -252,7 +256,7 @@ class LegacyPrefixRedirectMiddleware:
             return self.wsgi_app(environ, start_response)
 
         allowed_methods, canonical_target = match
-        if method not in allowed_methods:
+        if method_for_match not in allowed_methods:
             # POST against GET-only canonical (308 would have the client
             # retry-POST against the canonical → 405). Emit 410 explicitly
             # so the operator-facing signal is unambiguous.
@@ -264,6 +268,16 @@ class LegacyPrefixRedirectMiddleware:
         # unset at this outer layer) and never from X-Forwarded-*. See
         # module docstring for the proxy-strips-prefix operator caveat.
         location = self.app_root_prefix + canonical_target
+
+        # Belt-and-braces: a 308 whose target is the inbound path would never
+        # converge. No enumerated row can produce one (no canonical target
+        # begins with the legacy prefix, so the rewrite always shortens the
+        # path), but a future map edit could — pass through rather than emit a
+        # redirect that loops. Compared before the query string is appended:
+        # the query is carried over verbatim and cannot break a tie.
+        if location == path_info:
+            return self.wsgi_app(environ, start_response)
+
         if query_string := environ.get("QUERY_STRING", ""):
             location = f"{location}?{query_string}"
 

--- a/tests/unit_tests/middleware/test_legacy_prefix_redirect.py
+++ b/tests/unit_tests/middleware/test_legacy_prefix_redirect.py
@@ -144,9 +144,8 @@ def test_legacy_get_redirects_308_under_subdir(legacy: str, canonical: str) -> N
     `Location` is built from the construction-time `app_root` capture,
     not from `environ["SCRIPT_NAME"]`.
 
-    The `/superset` deployment collides with
-    `_LEGACY_PREFIX` → covered separately by
-    `test_degenerate_app_root_equals_superset_disables_shim`."""
+    The `/superset` app root, where this prefix and `_LEGACY_PREFIX` are the
+    same token, is covered separately in Section A.1."""
     client = _build_client(app_root="/myapp")
     resp = client.get(legacy)
     assert resp.status_code == 308
@@ -240,6 +239,59 @@ def test_app_root_prefixed_legacy_post_against_get_only_canonical_410(
     resp = client.post(f"/myapp{legacy}", data={"k": "v"})
     assert resp.status_code == 410
     assert "Location" not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# Section A.0 — HEAD is folded to GET.
+#
+# HEAD is "GET without a response body" (RFC 9110 §9.3.2): a resource that
+# serves GET must serve HEAD, and Werkzeug registers HEAD implicitly on every
+# GET rule. `LEGACY_REDIRECT_MAP` therefore lists only the *explicit* methods
+# from each canonical `@expose` decorator and never spells HEAD — so the shim
+# has to fold HEAD→GET before the method check. Without the fold, every legacy
+# HEAD probe falls into the `method not in allowed_methods` branch and gets a
+# spurious 410 Gone, which is what link-checkers, uptime monitors and
+# `curl -I` all send.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("legacy", "canonical"), _GET_REDIRECT_ROWS)
+def test_legacy_head_redirects_308_like_get(legacy: str, canonical: str) -> None:
+    """HEAD against a GET-capable canonical → the same 308 a GET gets."""
+    client = _build_client(app_root="/")
+    resp = client.head(legacy)
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == canonical
+
+
+@pytest.mark.parametrize(("legacy", "canonical"), _GET_REDIRECT_ROWS)
+def test_app_root_prefixed_legacy_head_redirects_308_like_get(
+    legacy: str, canonical: str
+) -> None:
+    """The HEAD fold applies to the app-root-prefixed form too."""
+    client = _build_client(app_root="/myapp")
+    resp = client.head(f"/myapp{legacy}")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == f"/myapp{canonical}"
+
+
+def test_legacy_head_against_post_only_canonical_410() -> None:
+    """`/log/` is the one POST-only row. HEAD folds to GET, which the
+    canonical does not serve, so 410 is correct here — the fold must not
+    blanket-allow HEAD, only make it track GET."""
+    client = _build_client(app_root="/")
+    resp = client.head("/superset/log/")
+    assert resp.status_code == 410
+    assert "Location" not in resp.headers
+
+
+def test_legacy_sql_deep_link_head_redirects_308() -> None:
+    """The SQL Lab deep-link branch has its own method check
+    (`!= "GET"`); HEAD must fold there as well, not 410."""
+    client = _build_client(app_root="/")
+    resp = client.head("/superset/sql/5/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/sqllab/?dbid=5"
 
 
 def test_unenumerated_superset_path_passes_through() -> None:
@@ -359,52 +411,82 @@ def test_legacy_sql_non_numeric_passes_through(path: str) -> None:
     assert resp.data == _SENTINEL_BODY
 
 
-def test_degenerate_app_root_equals_superset_disables_shim() -> None:
-    """When `APPLICATION_ROOT == "/superset"`,
-    legacy and canonical prefixes coincide. If the shim were active, an
-    inbound `/superset/welcome/` would 308 to `/superset/welcome/` — the
-    same URL → infinite redirect loop.
+@pytest.mark.parametrize(("legacy", "canonical"), _GET_REDIRECT_ROWS)
+def test_app_root_superset_redirects_doubled_legacy_path(
+    legacy: str, canonical: str
+) -> None:
+    """`APPLICATION_ROOT == "/superset"` is the one deployment where the
+    app-root prefix and the legacy prefix are the same token, so a legacy
+    bookmark carries it twice: `/superset/superset/welcome/`.
 
-    The shim short-circuits in that deployment shape via `_enabled = False`
-    and falls through to the inner app, which routes the path through the
-    canonical Flask routes."""
-    shim = LegacyPrefixRedirectMiddleware(_sentinel_inner_app, "/superset")
-    assert shim._enabled is False  # noqa: SLF001
-    client = Client(shim, response_wrapper=Response)
-    # Inbound legacy path falls through to inner app (no 308).
-    resp = client.get("/superset/welcome/")
+    The app-root strip runs first, leaving `/superset/welcome/` — a genuine
+    legacy path — so the doubled form 308s to the single-prefixed canonical.
+    Previously the shim disabled itself wholesale in this deployment shape
+    and these URLs hard-404'd."""
+    client = _build_client(app_root="/superset")
+    resp = client.get(f"/superset{legacy}")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == f"/superset{canonical}"
+
+
+@pytest.mark.parametrize(("legacy", "canonical"), _GET_REDIRECT_ROWS)
+def test_app_root_superset_canonical_path_passes_through(
+    legacy: str, canonical: str
+) -> None:
+    """The redirect target from the test above must itself pass through
+    rather than redirect again — this is what makes the doubled-path 308
+    converge instead of looping.
+
+    Inbound `/superset/welcome/` strips its app root to `/welcome/`, which
+    is not a legacy path, so it falls through to the inner app. A canonical
+    URL cannot re-enter the redirect branch, because the app-root strip
+    happens *before* the legacy-prefix check."""
+    client = _build_client(app_root="/superset")
+    resp = client.get(f"/superset{canonical}")
+    assert resp.status_code == 200
+    assert resp.data == _SENTINEL_BODY
+
+
+def test_app_root_superset_doubled_sql_deep_link_redirects() -> None:
+    """The SQL Lab deep-link branch also survives the `/superset` app root."""
+    client = _build_client(app_root="/superset")
+    resp = client.get("/superset/superset/sql/5/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/superset/sqllab/?dbid=5"
+
+
+def test_bare_app_root_superset_passes_through() -> None:
+    """Inbound `/superset` (bare, no trailing slash) under the `/superset`
+    app root does not hit the segment-boundary strip, so it reaches the
+    legacy check as the bare prefix. It maps to no row and passes through
+    — it must not be mistaken for a legacy path with an empty tail."""
+    client = _build_client(app_root="/superset")
+    resp = client.get("/superset")
     assert resp.status_code == 200
     assert resp.data == _SENTINEL_BODY
 
 
 @pytest.mark.parametrize(
     "app_root",
-    ["/", "", "/superset/", "/other", "/a/b"],
+    ["/", "", "/superset", "/superset/", "/other", "/a/b"],
 )
-def test_shim_enabled_for_non_legacy_app_roots(app_root: str) -> None:
-    """The disable-shim short-circuit is targeted at the exact
-    `/superset` collision case — every other `APPLICATION_ROOT` (including
-    root, empty, `/superset/` with trailing slash that strips to
-    `/superset`, and arbitrary subdirs) keeps the shim active."""
-    shim = LegacyPrefixRedirectMiddleware(_sentinel_inner_app, app_root)
-    if shim.app_root_prefix == "/superset":
-        # `/superset/` strips to `/superset`, also a collision → disabled.
-        assert shim._enabled is False  # noqa: SLF001
-    else:
-        assert shim._enabled is True  # noqa: SLF001
+def test_shim_active_for_every_app_root(app_root: str) -> None:
+    """The shim performs its rewrite under every `APPLICATION_ROOT`,
+    including `/superset` itself. No deployment shape disables it."""
+    client = _build_client(app_root=app_root)
+    prefix = app_root.rstrip("/")
+    resp = client.get(f"{prefix}/superset/welcome/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == f"{prefix}/welcome/"
 
 
 # ---------------------------------------------------------------------------
-# Section A.1 — APPLICATION_ROOT case-sensitivity.
-# A deferred MEDIUM review finding noted that `_enabled` uses byte-equality
-# rather than `casefold()`.
-# These tests pin TODAY's documented behaviour so that:
-#   - A future `casefold()` introduction is a deliberate contract change
-#     (test updates alongside the code change).
-#   - An operator who deploys under `APPLICATION_ROOT=/Superset` or
-#     `/SUPERSET` (which is unusual but legal) gets the documented shape
-#     today: the shim stays enabled, and lowercase `/superset/...` inbound
-#     paths still 308 to the operator's casing.
+# Section A.1 — APPLICATION_ROOT casing and trailing-slash shapes.
+# `_LEGACY_PREFIX` is the lowercase literal `/superset` and the inbound-path
+# check is byte-comparison, so the shim recognises exactly the legacy URL
+# token Superset used to emit — no casefold(). These tests pin that the
+# app-root value's own shape (casing, trailing slashes) only affects the
+# prefix that gets stripped and re-attached, never whether the shim runs.
 # ---------------------------------------------------------------------------
 
 
@@ -412,47 +494,36 @@ def test_shim_enabled_for_non_legacy_app_roots(app_root: str) -> None:
     "app_root",
     ["/Superset", "/SUPERSET", "/SuperSet"],
 )
-def test_shim_enabled_for_mixed_case_app_roots(app_root: str) -> None:
-    """Mixed-case APPLICATION_ROOT values are NOT treated as the legacy
-    prefix — `_LEGACY_PREFIX` is the lowercase literal `/superset`, and
-    `_enabled` is computed via byte-equality (no `casefold()`). The shim
-    therefore stays active under any non-lowercase casing.
-
-    Pinning the case-sensitive comparison serves two purposes:
-      1. Documents the deliberate scope choice — the shim targets the
-         hardcoded `/superset/*` legacy URL pattern, not arbitrary casing
-         of the app-root config value.
-      2. Anchors the deferred MEDIUM finding: if a future commit graduates
-         the comparison to `casefold()` so `/Superset` == `/superset`, this
-         test fires and forces the contract change to be explicit.
-    """
-    shim = LegacyPrefixRedirectMiddleware(_sentinel_inner_app, app_root)
-    assert shim._enabled is True  # noqa: SLF001
-    assert shim.app_root_prefix == app_root
+def test_mixed_case_app_root_is_not_the_legacy_prefix(app_root: str) -> None:
+    """A mixed-case APPLICATION_ROOT is an ordinary subdirectory as far as
+    the shim is concerned — it is not the lowercase `/superset` legacy
+    token, so a legacy bookmark under it carries both prefixes and 308s to
+    the operator's casing."""
+    client = _build_client(app_root=app_root)
+    resp = client.get(f"{app_root}/superset/welcome/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == f"{app_root}/welcome/"
 
 
 @pytest.mark.parametrize(
     "app_root",
-    [
-        # Multiple trailing slashes — rstrip("/") strips all of them, so
-        # both collapse to `/superset` and the shim disables.
-        "/superset/",
-        "/superset//",
-        "/superset///",
-    ],
+    ["/superset/", "/superset//", "/superset///"],
 )
-def test_shim_disabled_for_trailing_slash_variants(app_root: str) -> None:
-    """Trailing-slash variants of `/superset` all collapse to `/superset`
-    via `rstrip("/")` and disable the shim — the collision short-
-    circuit catches every shape an operator might write the app root as.
+def test_trailing_slash_app_root_variants_normalise(app_root: str) -> None:
+    """Trailing-slash variants all collapse to `/superset` via `rstrip("/")`,
+    so they behave identically to the bare `/superset` app root: the doubled
+    legacy path 308s to the single-prefixed canonical.
 
     Pinning the multi-slash branch protects against a future maintainer
-    swapping `rstrip("/")` for `removesuffix("/")` (which strips only one)
-    and silently re-enabling the self-loop under `/superset//`.
+    swapping `rstrip("/")` for `removesuffix("/")`, which strips only one and
+    would leave a stray slash in every `Location`.
     """
     shim = LegacyPrefixRedirectMiddleware(_sentinel_inner_app, app_root)
     assert shim.app_root_prefix == "/superset"
-    assert shim._enabled is False  # noqa: SLF001
+    client = Client(shim, response_wrapper=Response)
+    resp = client.get("/superset/superset/welcome/")
+    assert resp.status_code == 308
+    assert resp.headers["Location"] == "/superset/welcome/"
 
 
 @pytest.mark.parametrize(
@@ -544,10 +615,7 @@ def test_query_string_preserved_in_location() -> None:
 
 
 def test_query_string_preserved_under_subdir() -> None:
-    """Subdir + query string: single prefix, query intact.
-
-    Uses a non-colliding subdir (`/myapp`) — the shim is disabled under
-    `/superset` (see `test_degenerate_app_root_equals_superset_disables_shim`)."""
+    """Subdir + query string: single prefix, query intact."""
     client = _build_client(app_root="/myapp")
     resp = client.get("/superset/explore/?form_data=%7B%7D")
     assert resp.status_code == 308


### PR DESCRIPTION
### SUMMARY

Two bugs in the legacy `/superset/*` → canonical route redirect shim
(`LegacyPrefixRedirectMiddleware`), both of which break real deployments.

**1. `HEAD` against any legacy route returns `410 Gone` instead of redirecting.**

`LEGACY_REDIRECT_MAP` spells only the methods each canonical route's `@expose`
decorator names explicitly, which never includes `HEAD` — Werkzeug registers
`HEAD` implicitly on every `GET` rule, so no route declares it. The middleware
compared the raw request method against that map, so every legacy `HEAD` request
fell into the wrong-method branch and got `410 Gone`. That breaks link-checkers,
uptime monitors, and plain `curl -I` against any legacy URL.

`HEAD` is `GET`-without-a-body (RFC 9110 §9.3.2), so it is now folded to `GET`
before the method check. It *tracks* `GET` rather than being blanket-allowed:
`HEAD` against the one `POST`-only canonical (`/log/`) still correctly returns
`410`.

**2. The shim is disabled entirely when `APPLICATION_ROOT` is `/superset`.**

An `_enabled` guard turned the middleware off in that deployment, on the premise
that the legacy prefix and the app-root prefix being the same token would produce
an infinite 308 loop.

**That premise was incorrect.** The app-root strip runs *before* the legacy-prefix
check, so a canonical URL can never re-enter the redirect branch: inbound
`/superset/welcome/` strips to `/welcome/`, which is not a legacy path, and passes
through untouched. No redirect, no loop. The guard's only actual effect was to
make legacy bookmarks under that root — which arrive carrying the prefix twice,
`/superset/superset/dashboard/1/` — hard-404 rather than 308 to
`/superset/dashboard/1/`.

The guard is removed. In its place is a precise per-request check: if the computed
redirect target is byte-identical to the inbound path, pass through instead of
emitting a redirect that could not converge. No enumerated row can produce that
today (no canonical target begins with the legacy prefix, so the rewrite always
shortens the path) — it's a guard against a future map edit, not a live condition.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/middleware/test_legacy_prefix_redirect.py` — 206 pass.

Both fixes were written test-first; the 58 new tests fail against the previous
middleware and pass against this one.

- **HEAD:** new "Section A.0" parametrizes every `GET`-redirecting row over `HEAD`,
  with and without an app-root prefix, plus the SQL Lab deep-link special case and
  a `/log/` control asserting `HEAD` against a `POST`-only canonical still `410`s.
- **App root:** new tests assert that under `APPLICATION_ROOT=/superset` a doubled
  legacy path 308s to the canonical one, a canonical path passes straight through
  (the no-loop invariant), and the bare app root is untouched. Four existing tests
  that pinned the buggy `_enabled` behavior were rewritten to pin the fixed
  behavior.

Manual: deploy with `SUPERSET_APP_ROOT=/superset` and confirm
`curl -I <host>/superset/superset/dashboard/1/` returns `308` with
`Location: /superset/dashboard/1/` (both bugs at once — it was `410` before,
and `404` on the followed target).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
