### PR TITLE
fix(matrixify): handle async (202) chart-data responses in Matrixify grid cells

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { render, waitFor, configure } from '@testing-library/react';
+import { render, waitFor, configure, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import StatefulChart from './StatefulChart';
 import getChartControlPanelRegistry from '../registries/ChartControlPanelRegistrySingleton';
@@ -718,6 +718,435 @@ test('should refetch when mixing renderTrigger string control with non-renderTri
     // Should refetch because metrics changed (non-renderTrigger)
     expect(mockChartClient.client.post).toHaveBeenCalledTimes(2);
   });
+});
+
+test('resolves async (202) responses via the injected handleAsyncChartData hook', async () => {
+  const asyncJob = {
+    channel_id: 'c1',
+    job_id: 'j1',
+    status: 'running',
+    result_url: '/api/v1/chart/data/abc',
+  };
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: asyncJob,
+  });
+  const handleAsyncChartData = jest
+    .fn()
+    .mockResolvedValue([{ data: 'async result' }]);
+
+  const { getByTestId } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+  // Delegates the raw response + job metadata (and useLegacyApi + abort signal)
+  expect(handleAsyncChartData).toHaveBeenCalledWith(
+    { status: 202 },
+    asyncJob,
+    false,
+    expect.any(AbortSignal),
+  );
+  // Chart renders once the async data resolves
+  await waitFor(() => {
+    expect(getByTestId('super-chart')).toBeInTheDocument();
+  });
+});
+
+test('errors on async (202) response when no async handler is provided', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j1', channel_id: 'c1', status: 'running' },
+  });
+  const onError = jest.fn();
+
+  const { findByText } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      onError={onError}
+    />,
+  );
+
+  // Fails loudly instead of rendering the job metadata as empty data
+  expect(await findByText(/async handler/i)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('renders synchronous (200) responses that include a response object', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 200 } as Response,
+    json: [{ result: [{ data: 'sync result' }] }],
+  });
+
+  const { getByTestId } = render(
+    <StatefulChart formData={mockFormData} chartType="test_chart" />,
+  );
+
+  await waitFor(() => {
+    expect(getByTestId('super-chart')).toBeInTheDocument();
+  });
+  // Synchronous path: no async handler needed, single request
+  expect(mockChartClient.client.post).toHaveBeenCalledTimes(1);
+});
+
+test('wraps the legacy async body as { result: [body] } for the async handler', async () => {
+  const legacyBody = { job_id: 'j1', channel_id: 'c1', status: 'running' };
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: legacyBody,
+  });
+  // Force the legacy API path for this viz type
+  (getChartMetadataRegistry as any).mockReturnValue({
+    get: jest.fn().mockReturnValue({ useLegacyApi: true }),
+  });
+  const handleAsyncChartData = jest
+    .fn()
+    .mockResolvedValue([{ data: 'legacy result' }]);
+
+  const { getByTestId } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+  // Legacy body must be wrapped to match the V1 response signature
+  expect(handleAsyncChartData).toHaveBeenCalledWith(
+    { status: 202 },
+    { result: [legacyBody] },
+    true,
+    expect.any(AbortSignal),
+  );
+  await waitFor(() => {
+    expect(getByTestId('super-chart')).toBeInTheDocument();
+  });
+});
+
+test('does not apply a superseded async response over a newer one', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  let resolveFirst: (data: unknown) => void = () => {};
+  let resolveSecond: (data: unknown) => void = () => {};
+  const handleAsyncChartData = jest
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFirst = resolve;
+        }),
+    )
+    .mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveSecond = resolve;
+        }),
+    );
+  const onLoad = jest.fn();
+
+  const { rerender } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+      onLoad={onLoad}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+
+  // A newer request supersedes the first (viz_type change forces a refetch)
+  const newFormData = { ...mockFormData, viz_type: 'different_chart' };
+  rerender(
+    <StatefulChart
+      formData={newFormData}
+      chartType="different_chart"
+      hooks={{ handleAsyncChartData }}
+      onLoad={onLoad}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(2);
+  });
+
+  // Resolve the newer request first, then the stale one
+  await act(async () => {
+    resolveSecond([{ data: 'B' }]);
+  });
+  await act(async () => {
+    resolveFirst([{ data: 'A' }]);
+  });
+
+  await waitFor(() => {
+    expect(onLoad).toHaveBeenCalledWith([{ data: 'B' }]);
+  });
+  // The stale (superseded) response must not overwrite the newer one
+  expect(onLoad).not.toHaveBeenCalledWith([{ data: 'A' }]);
+  expect(onLoad).toHaveBeenCalledTimes(1);
+});
+
+test('preserves the detailed message from an async (array) rejection', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  const handleAsyncChartData = jest
+    .fn()
+    .mockRejectedValue([{ error: 'Async query failed: table not found' }]);
+  const onError = jest.fn();
+
+  const { findByText } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+      onError={onError}
+    />,
+  );
+
+  // The detailed message survives instead of collapsing to the generic one
+  expect(await findByText(/table not found/i)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toContain('table not found');
+  });
+});
+
+test('refetches with the latest formData rather than the initial props', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 200 } as Response,
+    json: [{ result: [{ data: 'x' }] }],
+  });
+
+  const { rerender } = render(
+    <StatefulChart
+      formData={{ ...mockFormData, metrics: ['metric_v1'] }}
+      chartType="test_chart"
+    />,
+  );
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(1);
+  });
+
+  // Change a data-affecting control -> triggers a refetch
+  rerender(
+    <StatefulChart
+      formData={{ ...mockFormData, metrics: ['metric_v2'] }}
+      chartType="test_chart"
+    />,
+  );
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(2);
+  });
+
+  // The second request must carry the updated formData, not the initial props
+  const secondRequestConfig = mockChartClient.client.post.mock.calls[1][0];
+  expect(JSON.stringify(secondRequestConfig)).toContain('metric_v2');
+  expect(JSON.stringify(secondRequestConfig)).not.toContain('metric_v1');
+});
+
+test('does not revert a render-only change when a slow async request resolves', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  // color_scheme is a renderTrigger control -> its change does not refetch
+  (getChartControlPanelRegistry as any).mockReturnValue({
+    get: jest.fn().mockReturnValue({
+      controlPanelSections: [
+        {
+          controlSetRows: [
+            [{ name: 'color_scheme', config: { renderTrigger: true } }],
+          ],
+        },
+      ],
+    }),
+  });
+  let resolveAsync: (data: unknown) => void = () => {};
+  const handleAsyncChartData = jest.fn(
+    () =>
+      new Promise(resolve => {
+        resolveAsync = resolve;
+      }),
+  );
+
+  const { rerender, getByTestId } = render(
+    <StatefulChart
+      formData={{ ...mockFormData, color_scheme: 'scheme_one' }}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+
+  // Render-only change while the async request is still pending (no refetch)
+  rerender(
+    <StatefulChart
+      formData={{ ...mockFormData, color_scheme: 'scheme_two' }}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+  expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+
+  // The stale request resolves; it must not revert color_scheme back
+  await act(async () => {
+    resolveAsync([{ data: 'd' }]);
+  });
+
+  await waitFor(() => {
+    expect(getByTestId('super-chart')).toHaveTextContent('scheme_two');
+  });
+  expect(getByTestId('super-chart')).not.toHaveTextContent('scheme_one');
+});
+
+test('passes an abort signal to the async handler and aborts it on unmount', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  // Typed with a rest param so mock.calls is indexable (the 4th arg is the signal)
+  const handleAsyncChartData = jest.fn(
+    (..._args: unknown[]) => new Promise<never>(() => {}), // never resolves
+  );
+
+  const { unmount } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+  const signal = handleAsyncChartData.mock.calls[0][3] as AbortSignal;
+  expect(signal).toBeInstanceOf(AbortSignal);
+  expect(signal.aborted).toBe(false);
+
+  // Unmounting aborts the signal so a signal-aware handler can stop polling
+  unmount();
+  expect(signal.aborted).toBe(true);
+});
+
+test('suppresses stale error state from a superseded request', async () => {
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  let rejectFirst: (err: unknown) => void = () => {};
+  const handleAsyncChartData = jest
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    )
+    .mockImplementationOnce(() => new Promise(() => {})); // newer request stays pending
+  const onError = jest.fn();
+
+  const { rerender } = render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+      onError={onError}
+    />,
+  );
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+
+  // Supersede the first request (aborts its controller)
+  rerender(
+    <StatefulChart
+      formData={{ ...mockFormData, viz_type: 'different_chart' }}
+      chartType="different_chart"
+      hooks={{ handleAsyncChartData }}
+      onError={onError}
+    />,
+  );
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(2);
+  });
+
+  // The stale request now fails; its error must not surface
+  await act(async () => {
+    rejectFirst(new Error('stale failure'));
+  });
+  expect(onError).not.toHaveBeenCalled();
+});
+
+test('does not publish stale data when switching from chartId to formData mode', async () => {
+  mockChartClient.loadFormData.mockResolvedValue({ ...mockFormData });
+  mockChartClient.client.post.mockResolvedValue({
+    response: { status: 202 } as Response,
+    json: { job_id: 'j', channel_id: 'c' },
+  });
+  let resolveFirst: (data: unknown) => void = () => {};
+  const handleAsyncChartData = jest
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFirst = resolve;
+        }),
+    )
+    .mockImplementationOnce(() => new Promise(() => {}));
+  const onLoad = jest.fn();
+
+  // Start in chartId mode
+  const { rerender } = render(
+    <StatefulChart
+      chartId={1}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+      onLoad={onLoad}
+    />,
+  );
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(1);
+  });
+
+  // Switch to direct-formData mode
+  rerender(
+    <StatefulChart
+      formData={{ ...mockFormData, metrics: ['m'] }}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+      onLoad={onLoad}
+    />,
+  );
+  await waitFor(() => {
+    expect(handleAsyncChartData).toHaveBeenCalledTimes(2);
+  });
+
+  // The stale chartId-mode request resolves; its data must not be published
+  await act(async () => {
+    resolveFirst([{ data: 'stale' }]);
+  });
+  expect(onLoad).not.toHaveBeenCalledWith([{ data: 'stale' }]);
 });
 
 test('should display error message when HTTP request fails with Response object', async () => {

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -18,17 +18,19 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { isEqual } from 'lodash';
 import { ParentSize } from '@visx/responsive';
 import { t } from '@apache-superset/core/translation';
 import {
   QueryFormData,
   QueryData,
+  JsonObject,
   SupersetClientInterface,
   buildQueryContext,
   RequestConfig,
   getClientErrorObject,
+  ensureIsArray,
 } from '../..';
-import type { HandlerFunction } from '../types/Base';
 import { Loading } from '../../components/Loading';
 import ChartClient from '../clients/ChartClient';
 import getChartBuildQueryRegistry from '../registries/ChartBuildQueryRegistrySingleton';
@@ -189,6 +191,12 @@ export default function StatefulChart(props: StatefulChartProps) {
   const chartClientRef = useRef<ChartClient>();
   const abortControllerRef = useRef<AbortController>();
 
+  // fetchData is memoized with an empty dep list, so it would otherwise close
+  // over the first render's props. Keep the latest props in a ref so refetches
+  // (triggered by updated filters/formData/overrides) use current values.
+  const propsRef = useRef(props);
+  propsRef.current = props;
+
   // Initialize chart client
   if (!chartClientRef.current) {
     chartClientRef.current = new ChartClient({ client: props.client });
@@ -199,20 +207,48 @@ export default function StatefulChart(props: StatefulChartProps) {
       chartId,
       formData: propsFormData,
       formDataOverrides,
-      onError,
-      onLoad,
       chartType,
       force,
       timeout,
-    } = props;
+      hooks,
+    } = propsRef.current;
 
     // Cancel any in-flight requests
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
 
-    // Create new abort controller
-    abortControllerRef.current = new AbortController();
+    // Create new abort controller (kept in a local so we can detect when this
+    // request has been superseded by a newer one, even across async awaits).
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    // A request is superseded if it was aborted, or if the props changed in a
+    // data-affecting way since it began - including switching between chartId
+    // and direct-formData modes. Props are captured during render but the abort
+    // happens in a passive effect, so the abort signal alone can let a stale
+    // success or error slip through in the render->effect gap. This mirrors the
+    // effect's own refetch decision; render-only changes are intentionally not
+    // treated as superseding.
+    const isSuperseded = () => {
+      if (controller.signal.aborted) {
+        return true;
+      }
+      const latest = propsRef.current;
+      const vizTypeForCompare = latest.formData?.viz_type || latest.chartType;
+      return (
+        latest.chartId !== chartId ||
+        // Deep compare overrides: callers commonly pass a fresh object with the
+        // same contents each render, which should not count as superseding.
+        !isEqual(latest.formDataOverrides, formDataOverrides) ||
+        latest.force !== force ||
+        Boolean(propsFormData) !== Boolean(latest.formData) ||
+        (!!propsFormData &&
+          !!latest.formData &&
+          latest.formData !== propsFormData &&
+          shouldRefetchData(propsFormData, latest.formData, vizTypeForCompare))
+      );
+    };
 
     setStatus('loading');
     setError(undefined);
@@ -224,7 +260,7 @@ export default function StatefulChart(props: StatefulChartProps) {
         // Load formData from chartId
         finalFormData = await chartClientRef.current!.loadFormData(
           { sliceId: chartId },
-          { signal: abortControllerRef.current.signal } as RequestConfig,
+          { signal: controller.signal } as RequestConfig,
         );
       } else if (propsFormData) {
         // Use provided formData
@@ -263,11 +299,13 @@ export default function StatefulChart(props: StatefulChartProps) {
       if (!useLegacyApi && !queryContext.queries) {
         queryContext = { queries: [queryContext] };
       }
-      const endpoint = useLegacyApi ? '/explore_json/' : '/api/v1/chart/data';
+      const endpoint = useLegacyApi
+        ? '/superset/explore_json/'
+        : '/api/v1/chart/data';
 
       const requestConfig: RequestConfig = {
         endpoint,
-        signal: abortControllerRef.current.signal,
+        signal: controller.signal,
         ...(timeout && { timeout: timeout * 1000 }),
       };
 
@@ -285,39 +323,136 @@ export default function StatefulChart(props: StatefulChartProps) {
         };
       }
 
-      const response = await chartClientRef.current!.client.post(requestConfig);
-      let responseData = Array.isArray(response.json)
-        ? response.json
-        : [response.json];
+      const clientResponse =
+        await chartClientRef.current!.client.post(requestConfig);
 
-      // Handle the nested result structure from the new API
-      if (!useLegacyApi && responseData[0]?.result) {
-        responseData = responseData[0].result;
-      }
-
-      setStatus('loaded');
-      setData(responseData);
-      setFormData(finalFormData);
-
-      if (onLoad) {
-        onLoad(responseData);
-      }
-    } catch (err) {
-      // Ignore abort errors
-      if ((err as Error).name === 'AbortError') {
+      // A newer request may have started while the POST was in flight; discard
+      // this stale response so it can't overwrite the newer chart data.
+      if (isSuperseded()) {
         return;
       }
 
-      const parsedError = await getClientErrorObject(
-        err as Parameters<typeof getClientErrorObject>[0],
-      );
-      const errorMessage =
-        parsedError.error || parsedError.message || 'An error occurred';
+      const rawResponse = clientResponse.response as Response | undefined;
 
-      const errorObj = new Error(errorMessage);
+      let responseData: QueryData[];
+      if (rawResponse?.status === 202) {
+        // With GLOBAL_ASYNC_QUERIES the query is dispatched to a Celery worker
+        // and the 202 body is job metadata (channel_id, job_id, result_url),
+        // not chart data. Delegate to the injected handler, which polls the
+        // async event channel and resolves the cached results. Without a
+        // handler we fail loudly rather than rendering the job metadata as if
+        // it were an (empty) result set.
+        if (!hooks?.handleAsyncChartData) {
+          throw new Error(
+            'Received an async chart data response (HTTP 202) but no async ' +
+              'handler was provided, so results cannot be retrieved. Wire up ' +
+              'the async handler or disable GLOBAL_ASYNC_QUERIES for this chart.',
+          );
+        }
+        // The async handler (handleChartDataResponse) expects the V1 chart data
+        // response signature. The legacy endpoint returns a flat body, so wrap
+        // it as { result: [body] } exactly like legacyChartDataRequest does for
+        // the standard chart path; the V1 body is already correctly shaped.
+        const asyncPayload = useLegacyApi
+          ? ({ result: [clientResponse.json] } as JsonObject)
+          : (clientResponse.json as JsonObject);
+        responseData = ensureIsArray(
+          await hooks.handleAsyncChartData(
+            rawResponse,
+            asyncPayload,
+            useLegacyApi,
+            controller.signal,
+          ),
+        );
+
+        // Async results can resolve well after a newer request began polling.
+        if (isSuperseded()) {
+          return;
+        }
+      } else {
+        const rows = (
+          Array.isArray(clientResponse.json)
+            ? clientResponse.json
+            : [clientResponse.json]
+        ) as JsonObject[];
+
+        // Handle the nested result structure from the new API
+        responseData = (
+          !useLegacyApi && rows[0]?.result ? rows[0].result : rows
+        ) as QueryData[];
+      }
+
+      // Don't pair this request's data with newer props or fire a stale onLoad
+      // if it has been superseded (see isSuperseded).
+      if (isSuperseded()) {
+        return;
+      }
+
+      const latestProps = propsRef.current;
+      setStatus('loaded');
+      setData(responseData);
+      // Render the resolved data with the latest formData so a render-only
+      // change made while the request was in flight isn't reverted.
+      setFormData(
+        latestProps.formData
+          ? {
+              ...latestProps.formData,
+              ...(latestProps.formDataOverrides || {}),
+              viz_type: finalFormData.viz_type,
+            }
+          : finalFormData,
+      );
+
+      // Read onLoad from the latest props (like setFormData above) so a stale
+      // callback captured at request start isn't invoked.
+      if (latestProps.onLoad) {
+        latestProps.onLoad(responseData);
+      }
+    } catch (err) {
+      // Ignore aborted requests, whether they threw AbortError or were
+      // superseded by a newer request (including the render->effect gap).
+      if ((err as Error)?.name === 'AbortError' || isSuperseded()) {
+        return;
+      }
+
+      // waitForAsyncData rejects with an array of already-parsed client-error
+      // objects; unwrap the first element so its detailed message survives.
+      const rawError = Array.isArray(err) ? err[0] : err;
+
+      let errorMessage: string | undefined;
+      if (
+        rawError &&
+        typeof rawError === 'object' &&
+        !(rawError instanceof Error) &&
+        !(rawError instanceof Response) &&
+        typeof (rawError as { error?: unknown }).error === 'string'
+      ) {
+        // Already a parsed client-error object (e.g. from the async handler);
+        // getClientErrorObject would discard its `error` field, so read it here.
+        const parsed = rawError as { error?: string; message?: string };
+        errorMessage = parsed.error || parsed.message;
+      } else {
+        const parsedError = await getClientErrorObject(
+          rawError as Parameters<typeof getClientErrorObject>[0],
+        );
+        errorMessage = parsedError.error || parsedError.message;
+      }
+
+      const errorObj = new Error(errorMessage || 'An error occurred');
+
+      // The request may have been superseded while its error response was being
+      // parsed above (or in the render->effect gap before its abort ran); don't
+      // set stale error state or call onError in that case.
+      if (isSuperseded()) {
+        return;
+      }
+
       setStatus('error');
       setError(errorObj);
 
+      // Read onError from the latest props so a stale callback captured at
+      // request start isn't invoked.
+      const { onError } = propsRef.current;
       if (onError) {
         onError(errorObj);
       }
@@ -481,7 +616,7 @@ export default function StatefulChart(props: StatefulChartProps) {
         enableNoResults={enableNoResults}
         noResults={NoDataComponent && <NoDataComponent />}
         onRenderSuccess={onRenderSuccess}
-        onRenderFailure={onRenderFailure as HandlerFunction | undefined}
+        onRenderFailure={onRenderFailure}
         hooks={hooks}
       />
     );

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -300,7 +300,7 @@ export default function StatefulChart(props: StatefulChartProps) {
         queryContext = { queries: [queryContext] };
       }
       const endpoint = useLegacyApi
-        ? '/superset/explore_json/'
+        ? '/explore_json/'
         : '/api/v1/chart/data';
 
       const requestConfig: RequestConfig = {

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -66,6 +66,18 @@ type Hooks = {
   setTooltip?: HandlerFunction;
   /* handle legend scroll changes */
   onLegendScroll?: HandlerFunction;
+  /**
+   * Resolve an async chart-data response (HTTP 202 from GLOBAL_ASYNC_QUERIES).
+   * Injected by the app so components in this package (e.g. Matrixify's
+   * StatefulChart) can await async results without importing app-level
+   * async-event middleware. Returns the resolved query results.
+   */
+  handleAsyncChartData?: (
+    response: Response,
+    json: JsonObject,
+    useLegacyApi?: boolean,
+    signal?: AbortSignal,
+  ) => Promise<QueryData[]> | QueryData[];
 } & PlainObject;
 
 /**

--- a/superset-frontend/src/components/Chart/ChartRenderer.tsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.tsx
@@ -56,6 +56,7 @@ import type { Dispatch } from 'redux';
 import ChartContextMenu, {
   ChartContextMenuRef,
 } from './ChartContextMenu/ChartContextMenu';
+import { handleChartDataResponse } from './chartAction';
 
 // Types for filter values
 type FilterValue = string | number | boolean | null | undefined;
@@ -162,6 +163,15 @@ interface ChartHooks {
   setDataMask: (dataMask: DataMask) => void;
   onLegendScroll: (legendIndex: number) => void;
   onChartStateChange?: (chartState: AgGridChartState) => void;
+  // Resolve async (HTTP 202 / GLOBAL_ASYNC_QUERIES) chart-data responses for
+  // self-contained chart components in superset-ui-core (e.g. StatefulChart),
+  // which cannot import app-level async-event middleware.
+  handleAsyncChartData?: (
+    response: Response,
+    json: JsonObject,
+    useLegacyApi?: boolean,
+    signal?: AbortSignal,
+  ) => Promise<QueryData[]> | QueryData[];
 }
 
 const BLANK = {};
@@ -385,6 +395,10 @@ function ChartRendererComponent({
       setDataMask: setDataMaskCallback,
       onLegendScroll: handleLegendScroll,
       onChartStateChange,
+      // Lets self-contained chart components in superset-ui-core (e.g.
+      // StatefulChart) resolve async (202) chart-data responses without
+      // depending on app-level async-event middleware.
+      handleAsyncChartData: handleChartDataResponse,
     }),
     [
       handleAddFilter,

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -48,7 +48,7 @@ import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
-import { ensureAppRoot } from 'src/utils/pathUtils';
+import { ensureAppRoot } from 'src/utils/navigationUtils';
 import { safeStringify } from 'src/utils/safeStringify';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import type { Dispatch, Action, AnyAction } from 'redux';

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -42,15 +42,13 @@ import {
   getQuerySettings,
   getChartDataUri,
 } from 'src/explore/exploreUtils';
-import {
-  addDangerToast,
-  addWarningToast,
-} from 'src/components/MessageToasts/actions';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { logEvent } from 'src/logger/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 import { safeStringify } from 'src/utils/safeStringify';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import type { Dispatch, Action, AnyAction } from 'redux';
@@ -699,6 +697,7 @@ export function handleChartDataResponse(
   response: Response,
   json: { result: QueryData[] },
   useLegacyApi?: boolean,
+  signal?: AbortSignal,
 ): Promise<QueryData[]> | QueryData[] {
   if (isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) {
     // deal with getChartDataRequest transforming the response data
@@ -711,13 +710,17 @@ export function handleChartDataResponse(
         // Query is running asynchronously and we must await the results.
         // When status is 202, result contains async event data (job_id, channel_id, etc.)
         // which differs from QueryData. We cast through unknown to handle this safely.
+        // The optional signal lets a caller (e.g. StatefulChart) cancel the wait
+        // when its chart is superseded or unmounted, avoiding leaked listeners.
         if (useLegacyApi) {
           return waitForAsyncData(
             result[0] as unknown as Parameters<typeof waitForAsyncData>[0],
+            signal,
           ) as Promise<QueryData[]>;
         }
         return waitForAsyncData(
           result as unknown as Parameters<typeof waitForAsyncData>[0],
+          signal,
         ) as Promise<QueryData[]>;
       default:
         throw new Error(
@@ -783,15 +786,6 @@ export function exploreJSON(
         handleChartDataResponse(response, json, useLegacyApi),
       )
       .then(queriesResponse => {
-        // Drop stale responses: if a newer query has started for this chart,
-        // its controller will have replaced ours in state, so ignore this
-        // response to avoid clobbering newer data with older results.
-        if (key != null) {
-          const currentController = getState().charts?.[key]?.queryController;
-          if (currentController && currentController !== controller) {
-            return undefined;
-          }
-        }
         (queriesResponse as QueryData[]).forEach(
           (resultItem: QueryData & { applied_filters?: JsonObject[] }) =>
             dispatch(
@@ -816,12 +810,6 @@ export function exploreJSON(
               }),
             ),
         );
-        (queriesResponse as QueryData[]).forEach(response => {
-          const { warning } = response as { warning?: string | null };
-          if (warning) {
-            dispatch(addWarningToast(warning, { noDuplicate: true }));
-          }
-        });
         return dispatch(
           chartUpdateSucceeded(queriesResponse as QueryData[], key as number),
         );
@@ -843,21 +831,41 @@ export function exploreJSON(
             );
           }
 
-          // Drop stale failures the same way we drop stale successes,
-          // so a slow earlier request can't mark a newer one as failed.
-          if (key != null) {
-            const currentController = getState().charts?.[key]?.queryController;
-            if (currentController && currentController !== controller) {
-              return undefined;
-            }
-          }
-
           if (isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) {
-            // In async mode we just pass the raw error response through
-            return dispatch(
-              chartUpdateFailed(
-                [response as JsonObject],
-                key as string | number,
+            // `waitForAsyncData` rejects with an already-normalized async-event
+            // error object (JOB_STATUS.ERROR) or with an array of client error
+            // objects (cached-data fetch failure). Those carry a usable
+            // `error`/`errors` field and can be passed straight through.
+            // Synchronous HTTP failures — e.g. a QueryObjectValidationError
+            // surfaced by the pre-cache probe in `_run_async` — reject with a
+            // raw response that still needs parsing, otherwise the chart error
+            // banner renders a bare "Data error" with no description.
+            if (Array.isArray(response)) {
+              return dispatch(
+                chartUpdateFailed(
+                  response as JsonObject[],
+                  key as string | number,
+                ),
+              );
+            }
+            if (
+              response != null &&
+              typeof response === 'object' &&
+              !(response instanceof Response) &&
+              ('error' in response || 'errors' in response)
+            ) {
+              return dispatch(
+                chartUpdateFailed(
+                  [response as JsonObject],
+                  key as string | number,
+                ),
+              );
+            }
+            return getClientErrorObject(
+              response as unknown as Parameters<typeof getClientErrorObject>[0],
+            ).then((parsedResponse: JsonObject) =>
+              dispatch(
+                chartUpdateFailed([parsedResponse], key as string | number),
               ),
             );
           }
@@ -960,7 +968,7 @@ export function redirectSQLLab(
             requestedQuery: payload,
           });
         } else {
-          SupersetClient.postForm(redirectUrl, {
+          SupersetClient.postForm(ensureAppRoot(redirectUrl), {
             form_data: safeStringify(payload),
           });
         }

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -18,7 +18,11 @@
  */
 import fetchMock from 'fetch-mock';
 import WS from 'jest-websocket-mock';
-import { parseErrorJson, isFeatureEnabled } from '@superset-ui/core';
+import {
+  parseErrorJson,
+  isFeatureEnabled,
+  SupersetClient,
+} from '@superset-ui/core';
 import * as asyncEvent from 'src/middleware/asyncEvent';
 
 jest.mock('@superset-ui/core', () => ({
@@ -172,265 +176,6 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
       expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(1);
     });
-
-    test('backs off exponentially when polling requests keep failing', async () => {
-      // stop the real-timer polling loop started by beforeEach before
-      // switching to fake timers, so all polls run on the fake clock
-      mockedIsFeatureEnabled.mockReturnValueOnce(false);
-      asyncEvent.init(config);
-      jest.useFakeTimers();
-      try {
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-
-        // first poll fires after the configured delay and fails
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        // next poll is delayed by 2x the configured delay, so nothing yet
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
-
-        // after the second failure the delay grows to 4x
-        await jest.advanceTimersByTimeAsync(
-          3 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
-
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(3);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    test('resumes the configured polling delay after a successful poll', async () => {
-      // stop the real-timer polling loop started by beforeEach before
-      // switching to fake timers, so all polls run on the fake clock
-      mockedIsFeatureEnabled.mockReturnValueOnce(false);
-      asyncEvent.init(config);
-      jest.useFakeTimers();
-      try {
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-
-        // two failed polls: 1x delay, then 2x delay
-        await jest.advanceTimersByTimeAsync(
-          3 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
-
-        // subsequent polls succeed, resetting the backoff
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, {
-          status: 200,
-          body: { result: [] },
-        });
-
-        // third poll fires 4x delay after the second failure and succeeds
-        await jest.advanceTimersByTimeAsync(
-          4 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        // polling is back to the configured delay
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    test('caps the polling backoff delay at 60 seconds', async () => {
-      const MAX_ERROR_POLLING_DELAY_MS = 60000;
-      // stop the real-timer polling loop started by beforeEach before
-      // switching to fake timers, so all polls run on the fake clock
-      mockedIsFeatureEnabled.mockReturnValueOnce(false);
-      asyncEvent.init(config);
-      jest.useFakeTimers();
-      try {
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, { status: 403 });
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-
-        // first poll fires after the configured delay and fails
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        // walk the uncapped backoff: after failure N the next delay is
-        // 2^N times the configured delay, which stays below the cap through
-        // failure 10 (50ms * 2^10 = 51.2s)
-        for (let failures = 1; failures <= 10; failures += 1) {
-          await jest.advanceTimersByTimeAsync(
-            config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY * 2 ** failures,
-          );
-          expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(
-            failures + 1,
-          );
-        }
-
-        // after failure 11 the uncapped delay would be 102.4s, so the cap
-        // takes over: no poll just before the 60s mark...
-        await jest.advanceTimersByTimeAsync(MAX_ERROR_POLLING_DELAY_MS - 1);
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(11);
-
-        // ...and the next poll fires exactly at 60s
-        await jest.advanceTimersByTimeAsync(1);
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(12);
-
-        // additional failures remain capped at 60s
-        await jest.advanceTimersByTimeAsync(MAX_ERROR_POLLING_DELAY_MS);
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(13);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    test('does not start a second loop when re-initialized during an in-flight poll', async () => {
-      // stop the real-timer polling loop started by beforeEach before
-      // switching to fake timers, so all polls run on the fake clock
-      mockedIsFeatureEnabled.mockReturnValueOnce(false);
-      asyncEvent.init(config);
-      jest.useFakeTimers();
-      try {
-        fetchMock.clearHistory().removeRoutes();
-        let resolveFetch: (response: any) => void = () => {};
-        fetchMock.get(
-          EVENTS_ENDPOINT,
-          new Promise(resolve => {
-            resolveFetch = resolve;
-          }),
-        );
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-
-        // first poll fires and stays in-flight
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        // re-init while that fetch is pending, then let it resolve; the
-        // stale invocation must not schedule a second loop
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-        resolveFetch({ status: 200, body: { result: [] } });
-        await jest.advanceTimersByTimeAsync(0);
-
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, {
-          status: 200,
-          body: { result: [] },
-        });
-
-        // exactly one poll per delay from here on
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(2);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    test('does not resume polling when re-initialized with the feature disabled during an in-flight poll', async () => {
-      // stop the real-timer polling loop started by beforeEach before
-      // switching to fake timers, so all polls run on the fake clock
-      mockedIsFeatureEnabled.mockReturnValueOnce(false);
-      asyncEvent.init(config);
-      jest.useFakeTimers();
-      try {
-        fetchMock.clearHistory().removeRoutes();
-        let resolveFetch: (response: any) => void = () => {};
-        fetchMock.get(
-          EVENTS_ENDPOINT,
-          new Promise(resolve => {
-            resolveFetch = resolve;
-          }),
-        );
-        asyncEvent.init(config);
-        asyncEvent.waitForAsyncData(asyncPendingEvent).catch(() => {});
-
-        // first poll fires and stays in-flight
-        await jest.advanceTimersByTimeAsync(
-          config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
-
-        // disable the feature and re-init while the fetch is pending; the
-        // stale invocation must not restart the stopped loop when it resumes
-        mockedIsFeatureEnabled.mockReturnValueOnce(false);
-        asyncEvent.init(config);
-        resolveFetch({ status: 200, body: { result: [] } });
-        await jest.advanceTimersByTimeAsync(0);
-
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, {
-          status: 200,
-          body: { result: [] },
-        });
-
-        await jest.advanceTimersByTimeAsync(
-          10 * config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY,
-        );
-        expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(0);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    // Regression guard for the motivating CodeQL case: a job_id that collides
-    // with a built-in Object property (e.g. "__proto__"/"constructor") must be
-    // routed through the Map-based registries without triggering prototype
-    // pollution or losing the listener to a prototype-bearing lookup.
-    test.each(['__proto__', 'constructor', 'prototype', 'hasOwnProperty'])(
-      'resolves listeners keyed by reserved job_id "%s"',
-      async jobId => {
-        fetchMock.clearHistory().removeRoutes();
-        fetchMock.get(EVENTS_ENDPOINT, {
-          status: 200,
-          body: { result: [{ ...asyncDoneEvent, job_id: jobId }] },
-        });
-        fetchMock.get(CACHED_DATA_ENDPOINT, {
-          status: 200,
-          body: { result: chartData },
-        });
-
-        const actualResolved = await asyncEvent.waitForAsyncData({
-          ...asyncPendingEvent,
-          job_id: jobId,
-        });
-        expect(actualResolved).toEqual([chartData]);
-        expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(
-          1,
-        );
-      },
-    );
   });
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
@@ -523,6 +268,61 @@ describe('asyncEvent middleware', () => {
 
       expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(1);
       expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(0);
+    });
+
+    test('rejects with AbortError and stops listening when the signal aborts', async () => {
+      await wsServer.connected;
+
+      const controller = new AbortController();
+      const promise = asyncEvent.waitForAsyncData(
+        asyncPendingEvent,
+        controller.signal,
+      );
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      controller.abort();
+      await assertion;
+
+      // A late DONE event must not trigger a cached-data fetch: the listener
+      // was removed on abort, so no leak / stray request.
+      wsServer.send(JSON.stringify(asyncDoneEvent));
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+      expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(0);
+    });
+
+    test('rejects immediately if the signal is already aborted', async () => {
+      await wsServer.connected;
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        asyncEvent.waitForAsyncData(asyncPendingEvent, controller.signal),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    test('forwards the abort signal to the cached-data download', async () => {
+      await wsServer.connected;
+
+      const getSpy = jest.spyOn(SupersetClient, 'get');
+      const controller = new AbortController();
+
+      const promise = asyncEvent.waitForAsyncData(
+        asyncPendingEvent,
+        controller.signal,
+      );
+      wsServer.send(JSON.stringify(asyncDoneEvent));
+      await expect(promise).resolves.toEqual([chartData]);
+
+      // The cached-result download must receive the signal so it can be
+      // cancelled if the caller aborts mid-fetch.
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: controller.signal }),
+      );
+      getSpy.mockRestore();
     });
   });
 });

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -75,7 +75,7 @@ let consecutivePollingErrorCount = 0;
 // stop, instead of mutating fresh state or scheduling a second loop
 let pollingGeneration = 0;
 
-const addListener = (id: string, fn: any) => {
+const addListener = (id: string, fn: ListenerFn) => {
   listenersByJobId[id] = fn;
 };
 
@@ -150,11 +150,10 @@ export const waitForAsyncData = async (
           break;
         }
         default: {
-          logging.warn('received event with status', asyncEvent.status);
-          // Non-terminal status: drop this (stale) job listener but keep the
-          // abort handler so an unmount/supersede can still reject the pending
-          // promise (full cleanup here would leave it hanging on abort).
-          removeListener(jobId);
+          // Non-terminal status (e.g., 'pending', 'running'): keep the listener
+          // registered so it can receive the eventual terminal event ('done', 'error').
+          // Only cleanup happens on terminal states or abort.
+          logging.info('received non-terminal event with status', asyncEvent.status);
         }
       }
     };

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -66,8 +66,8 @@ let config: AppConfig;
 let transport: string;
 let pollingDelayMs: number;
 let pollingTimeoutId: number;
-let listenersByJobId: Map<string, ListenerFn>;
-let retriesByJobId: Map<string, number>;
+let listenersByJobId: Record<string, ListenerFn>;
+let retriesByJobId: Record<string, number>;
 let lastReceivedEventId: string | null | undefined;
 let consecutivePollingErrorCount = 0;
 // Incremented on every init() so polling invocations that are already
@@ -75,23 +75,25 @@ let consecutivePollingErrorCount = 0;
 // stop, instead of mutating fresh state or scheduling a second loop
 let pollingGeneration = 0;
 
-const addListener = (id: string, fn: ListenerFn) => {
-  listenersByJobId.set(id, fn);
+const addListener = (id: string, fn: any) => {
+  listenersByJobId[id] = fn;
 };
 
 const removeListener = (id: string) => {
-  if (!listenersByJobId.has(id)) return;
-  listenersByJobId.delete(id);
+  if (!listenersByJobId[id]) return;
+  delete listenersByJobId[id];
 };
 
 const fetchCachedData = async (
   asyncEvent: AsyncEvent,
+  signal?: AbortSignal,
 ): Promise<CachedDataResponse> => {
   let status = 'success';
   let data;
   try {
     const { json } = await SupersetClient.get({
       endpoint: String(asyncEvent.result_url),
+      signal,
     });
     data = 'result' in json ? json.result : json;
   } catch (response) {
@@ -102,32 +104,71 @@ const fetchCachedData = async (
   return { status, data };
 };
 
-export const waitForAsyncData = async (asyncResponse: AsyncEvent) =>
+export const waitForAsyncData = async (
+  asyncResponse: AsyncEvent,
+  signal?: AbortSignal,
+) =>
   new Promise((resolve, reject) => {
     const jobId = asyncResponse.job_id;
+
+    let onAbort: (() => void) | undefined;
+    const cleanup = () => {
+      removeListener(jobId);
+      if (onAbort && signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    };
+
+    // Bail immediately if the caller has already aborted (e.g. the chart was
+    // unmounted before the job started), avoiding a leaked listener.
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
     const listener = async (asyncEvent: AsyncEvent) => {
       switch (asyncEvent.status) {
         case JOB_STATUS.DONE: {
-          let { data, status } = await fetchCachedData(asyncEvent); // eslint-disable-line prefer-const
+          // Forward the signal so the cached-result download is cancelled too if
+          // the caller aborts mid-fetch, rather than wasting network/processing.
+          let { data, status } = await fetchCachedData(asyncEvent, signal); // eslint-disable-line prefer-const
           data = ensureIsArray(data);
           if (status === 'success') {
             resolve(data);
           } else {
             reject(data);
           }
+          // Terminal status: the promise is settled, so fully clean up.
+          cleanup();
           break;
         }
         case JOB_STATUS.ERROR: {
           const err = parseErrorJson(asyncEvent);
           reject(err);
+          // Terminal status: the promise is settled, so fully clean up.
+          cleanup();
           break;
         }
         default: {
           logging.warn('received event with status', asyncEvent.status);
+          // Non-terminal status: drop this (stale) job listener but keep the
+          // abort handler so an unmount/supersede can still reject the pending
+          // promise (full cleanup here would leave it hanging on abort).
+          removeListener(jobId);
         }
       }
-      removeListener(jobId);
     };
+
+    // When the caller aborts (chart superseded/unmounted), stop listening so the
+    // listener and its retained closure don't leak and keep the poller busy.
+    if (signal) {
+      onAbort = () => {
+        cleanup();
+        reject(new DOMException('Aborted', 'AbortError'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
     addListener(jobId, listener);
   });
 
@@ -151,26 +192,22 @@ const setLastId = (asyncEvent: AsyncEvent) => {
 export const processEvents = async (events: AsyncEvent[]) => {
   events.forEach((asyncEvent: AsyncEvent) => {
     const jobId = asyncEvent.job_id;
-    const listener = listenersByJobId.get(jobId);
-    // `jobId` originates from server/WebSocket payloads, so the listener is
-    // resolved exclusively through a Map (never plain-object property access,
-    // which would expose the prototype chain), and we confirm the retrieved
-    // value is a registered function before dispatching the event to it.
-    if (typeof listener === 'function') {
+    const listener = listenersByJobId[jobId];
+    if (listener) {
       listener(asyncEvent);
-      retriesByJobId.delete(jobId);
+      delete retriesByJobId[jobId];
     } else {
       // handle race condition where event is received
       // before listener is registered
-      const retries = (retriesByJobId.get(jobId) ?? 0) + 1;
-      retriesByJobId.set(jobId, retries);
+      if (!retriesByJobId[jobId]) retriesByJobId[jobId] = 0;
+      retriesByJobId[jobId] += 1;
 
-      if (retries <= MAX_RETRIES) {
+      if (retriesByJobId[jobId] <= MAX_RETRIES) {
         setTimeout(() => {
           processEvents([asyncEvent]);
-        }, RETRY_DELAY * retries);
+        }, RETRY_DELAY * retriesByJobId[jobId]);
       } else {
-        retriesByJobId.delete(jobId);
+        delete retriesByJobId[jobId];
         logging.warn('listener not found for job_id', asyncEvent.job_id);
       }
     }
@@ -190,7 +227,7 @@ const getPollingDelay = () => {
 const loadEventsFromApi = async () => {
   const generation = pollingGeneration;
   const eventArgs = lastReceivedEventId ? { last_id: lastReceivedEventId } : {};
-  if (listenersByJobId.size) {
+  if (Object.keys(listenersByJobId).length) {
     try {
       const { result: events } = await fetchEvents(eventArgs);
       if (generation !== pollingGeneration) return;
@@ -259,8 +296,8 @@ export const init = (appConfig?: AppConfig) => {
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
 
-  listenersByJobId = new Map();
-  retriesByJobId = new Map();
+  listenersByJobId = {};
+  retriesByJobId = {};
   lastReceivedEventId = null;
   consecutivePollingErrorCount = 0;
 


### PR DESCRIPTION
### SUMMARY

With `GLOBAL_ASYNC_QUERIES` enabled, uncached chart-data requests return **HTTP 202** with job metadata (`channel_id`, `job_id`, `result_url`) rather than inline results. Every Matrixify grid cell renders through `StatefulChart` (`@superset-ui/core`), which previously treated that 202 body as chart data — so each cell showed **"No data"** until a manual refresh warmed the cache.

`StatefulChart` now detects a 202 and delegates to an injected `handleAsyncChartData` hook, which polls the async event channel and resolves the cached results. The handler is wired in from `ChartRenderer` (reusing the existing `handleChartDataResponse` / `waitForAsyncData`) and flows through the standard hooks chain, keeping `superset-ui-core` decoupled from app-level async-event middleware. If a 202 arrives with no handler, `StatefulChart` fails loudly instead of silently rendering empty data.

Because a matrix fires many concurrent per-cell requests that can be superseded by filter/formData changes and unmounted by scrolling, the change also hardens the async lifecycle:

- **Correct response shapes** — the legacy endpoint's flat 202 body is wrapped as `{ result: [body] }` to match the V1 signature the async handler expects (legacy async previously received `undefined`); V1 bodies pass through unchanged.
- **Supersession guards** — each request captures its own `AbortController`; a late sync/async result or error is discarded if a newer request has superseded it, so stale data can't overwrite fresh chart data.
- **Cancellation & no leaks** — `waitForAsyncData` accepts an `AbortSignal`, removes its event listener on abort/unmount (no leaked listeners keeping the poller busy), and cancels the in-flight cached-result download when aborted mid-fetch.
- **Latest props on refetch** — `fetchData` reads current props via a ref (it's memoized with an empty dep list), so updated filters/formData are used on refetch.
- **Render-only changes preserved** — resolving an older async request renders with the latest formData, so color/zoom changes aren't reverted.
- **Detailed error messages** — array-shaped `waitForAsyncData` rejections are unwrapped so the parsed client-error message survives instead of collapsing to a generic "An error occurred".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE:** Matrixify cells show "No data" on first load when cache is cold.
<img width="1676" height="595" alt="Screenshot 2569-07-14 at 10 54 37" src="https://github.com/user-attachments/assets/c8cc7c32-cfff-47fa-934f-6bf4890d47c6" />

**AFTER:** Cells show loading state, then resolve and render charts without requiring a manual refresh.
<img width="1684" height="727" alt="Screenshot 2569-07-14 at 10 57 31" src="https://github.com/user-attachments/assets/3c399c72-8c32-46e1-b18c-1b3cab77c2c8" />


### TESTING INSTRUCTIONS

1. Enable `GLOBAL_ASYNC_QUERIES` (and its required Celery worker + cache/results backend + websocket/polling config)
2. Open a dashboard containing a Matrixify chart whose per-cell queries are **not** already cached (clear cache or use `force`)
3. Verify cells show a loading state, then resolve and render each chart on first load (not "No data")
4. Verify a **legacy-API** viz (e.g. deck.gl / world map / country map) in a matrix cell also resolves
5. Rapidly change a dashboard filter while cells are still resolving — confirm cells settle on the **latest** filter's data (no stale overwrite) and no console errors/leaked listeners
6. Scroll a large matrix so cells unmount mid-load — confirm no "setState on unmounted component" warnings and pending downloads are cancelled
7. Run automated tests:
   ```bash
   cd superset-frontend
   npm run test -- StatefulChart.test.tsx
   npm run test -- asyncEvent.test.ts
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (behavior only differs when enabled; unchanged when off)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
