### PR TITLE
fix(ci): correct mismatched version comment on actions/setup-node pin

### DIFF
--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.frontend
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
           cache: "npm"


### PR DESCRIPTION
### SUMMARY
The `actions/setup-node` hash pin in `superset-translations.yml` was pinned to
commit `48b55a01...4041e`, but annotated with `# v6`. That comment is misleading:
tag `v6` actually points to a *different* commit (`249970729cb0`), while the pinned
SHA corresponds to tag `v6.4.0`. This is exactly the kind of drift `zizmor`'s
`ref-version-mismatch` audit flags, since a reader (or a future auto-updater) could
be misled about which version is actually pinned.

This updates the trailing comment to `# v6.4.0`, matching the truthful version and
the convention already used for the same SHA in `github-action-validator.yml` and
`superset-websocket.yml`.

Resolves code-scanning alert [#2579](https://github.com/apache/superset/security/code-scanning/2579).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - workflow comment only.

### TESTING INSTRUCTIONS
- Confirmed via the GitHub API that SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` resolves to tag `v6.4.0`, and that tag `v6` resolves to a different commit (`249970729cb0`).
- Ran `zizmor --no-exit-codes .github/workflows/superset-translations.yml` directly; no findings reported for the file after the fix.
- `pre-commit run` for `check-yaml`, `end-of-file-fixer`, and `trailing-whitespace` pass on the changed file (the local `zizmor` pre-commit hook could not build its Python env in this sandbox due to offline/network restrictions, so it was verified by direct invocation instead).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API