### PR TITLE
fix(ci): correct setup-node version comment in tech-debt.yml

### DIFF
--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
 


### PR DESCRIPTION
### SUMMARY
The `actions/setup-node` pin in `tech-debt.yml` is pinned to commit `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`, which is `v6.4.0`, but the trailing comment said `# v6`. Since `v6` is a mutable major-version tag that currently resolves to a different commit (`v6.5.0`), zizmor flags this as a version-comment mismatch (`zizmor/ref-version-mismatch`). This corrects the comment to the truthful pinned version, matching the convention already used for the same pin in `github-action-validator.yml` and `superset-websocket.yml`.

Resolves code-scanning alert #2582 (https://github.com/apache/superset/security/code-scanning/2582).

Note: the same `# v6` comment (pointing at the identical commit) appears on this pin in several other workflow files, each tracked as its own separate open code-scanning alert (#2568-#2581). Keeping this PR scoped to the one alert it was opened for; happy to follow up with the rest in a separate PR if desired.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - one-line comment change in a GitHub Actions workflow file.

### TESTING INSTRUCTIONS
- Ran `zizmor .github/workflows/tech-debt.yml` directly: `No findings to report. Good job!` (previously reported the `ref-version-mismatch` finding).
- Ran `pre-commit run --files .github/workflows/tech-debt.yml`: `check yaml`, `fix end of files`, `trim trailing whitespace`, and `zizmor (GHA security audit)` all passed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API