### PR TITLE
chore(ci): correct actions/setup-node version comment to v6.4.0

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -31,7 +31,7 @@ jobs:
       # token, which makes npm attempt token auth and skip the OIDC
       # trusted-publishing exchange. With no .npmrc auth line, npm authenticates
       # via OIDC against the default registry (registry.npmjs.org).
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
       - run: npm ci

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-embedded-sdk/.nvmrc"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,7 +45,7 @@ jobs:
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "superset-frontend/.nvmrc"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Node.js
         if: env.HAS_TAGS
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
 

--- a/.github/workflows/scheduled-docker-image-refresh.yml
+++ b/.github/workflows/scheduled-docker-image-refresh.yml
@@ -117,7 +117,7 @@ jobs:
           build: "true"
 
       - name: Use Node.js 20
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -66,7 +66,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./docs/.nvmrc"
       - name: Setup Python

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./docs/.nvmrc"
       - name: yarn install
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./docs/.nvmrc"
       - name: yarn install

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           run: testdata
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
           cache: "npm"
@@ -238,7 +238,7 @@ jobs:
         with:
           run: playwright_testdata
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
           cache: "npm"

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           run: playwright_testdata
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
           cache: "npm"

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.frontend
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
           cache: "npm"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Use Node.js 20
         # zizmor: ignore[cache-poisoning] - node only runs the supersetbot CLI; no dependency cache is enabled
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           package-manager-cache: false
@@ -133,7 +133,7 @@ jobs:
 
       - name: Use Node.js 20
         # zizmor: ignore[cache-poisoning] - node only runs the supersetbot CLI; no dependency cache is enabled
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           package-manager-cache: false

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "./superset-frontend/.nvmrc"
 


### PR DESCRIPTION
### SUMMARY

The `actions/setup-node` action is pinned by SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` across a dozen workflow files, but the trailing comment reads `# v6`. That SHA actually corresponds to tag **v6.4.0** (confirmed via `gh api repos/actions/setup-node/tags`); the floating `v6` tag has since moved to a newer release (`249970729cb0...`). The comment therefore misrepresents the pinned version, which is exactly what zizmor's `ref-version-mismatch` audit flags.

This updates the comment to the truthful version (`# v6.4.0`) in every file so it matches the pinned commit. **No SHA change** — runtime behavior is identical. This matches the format already used correctly in `.github/workflows/github-action-validator.yml`, and follows the same fix pattern established in #41160, #41383, and #41482 for other actions.

Affected files (one line each, two occurrences in `tag-release.yml` and `superset-e2e.yml`/`superset-docs-verify.yml`):
- `.github/workflows/embedded-sdk-release.yml`
- `.github/workflows/embedded-sdk-test.yml`
- `.github/workflows/pre-commit.yml`
- `.github/workflows/release.yml`
- `.github/workflows/scheduled-docker-image-refresh.yml`
- `.github/workflows/superset-docs-deploy.yml`
- `.github/workflows/superset-docs-verify.yml`
- `.github/workflows/superset-e2e.yml`
- `.github/workflows/superset-playwright.yml`
- `.github/workflows/superset-translations.yml`
- `.github/workflows/tag-release.yml`
- `.github/workflows/tech-debt.yml`

Resolves code-scanning alert #2581 (zizmor `ref-version-mismatch`), and the 14 other open alerts filed against the same underlying pin: #2568, #2569, #2570, #2571, #2572, #2573, #2574, #2575, #2576, #2577, #2578, #2579, #2580, #2582.

### BEFORE/AFTER

Before: `uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6`
After: `uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`

### TESTING INSTRUCTIONS

`pre-commit run --files <all files listed above>` — the `zizmor (GHA security audit)` hook passes, and a direct `zizmor --no-exit-codes` run over the changed files reports zero `ref-version-mismatch` findings for `actions/setup-node`. The pinned SHA is byte-for-byte unchanged, so action behavior is unaffected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)