### PR TITLE
fix(ci): correct setup-node version comment in tag-release.yml

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Use Node.js 20
         # zizmor: ignore[cache-poisoning] - node only runs the supersetbot CLI; no dependency cache is enabled
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           package-manager-cache: false
@@ -133,7 +133,7 @@ jobs:
 
       - name: Use Node.js 20
         # zizmor: ignore[cache-poisoning] - node only runs the supersetbot CLI; no dependency cache is enabled
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           package-manager-cache: false


### PR DESCRIPTION
### SUMMARY
`actions/setup-node` is pinned by commit SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` with a trailing `# v6` comment in `.github/workflows/tag-release.yml`. The mutable `v6` tag has since moved on to a newer commit, so the comment no longer truthfully reflects which release the pinned SHA corresponds to (it is actually `v6.4.0`). zizmor flags this as `ref-version-mismatch` since the version comment can no longer be trusted to describe the pinned commit.

This updates both occurrences of the pin in this file to `# v6.4.0`, matching the exact-tag convention already used elsewhere in the repo (e.g. `.github/actions/setup-supersetbot/action.yml` and `.github/workflows/github-action-validator.yml`).

Resolves code-scanning alert [#2580](https://github.com/apache/superset/security/code-scanning/2580) (zizmor/ref-version-mismatch), and incidentally fixes the duplicate instance of the identical issue at line 136 of the same file (alert #2581), since both lines pin the exact same commit with the same stale comment.

Note: several other workflow files pin this same `actions/setup-node` SHA with the same `# v6` comment (open alerts #2568–#2582); those are out of scope for this PR and can be addressed as a follow-up.

### TESTING INSTRUCTIONS
- `zizmor .github/workflows/tag-release.yml` no longer reports the `ref-version-mismatch` finding for this file.
- `pre-commit run --files .github/workflows/tag-release.yml` passes (including the `zizmor` hook).
- Confirmed `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` is exactly `refs/tags/v6.4.0` on `actions/setup-node` via `git ls-remote`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API