### PR TITLE
fix(ci): make pre-commit fail closed instead of silently passing on an empty file list

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+          # Full history so we can diff a PR/push against its base commit to
+          # determine changed files (see "Determine changed files" below).
+          fetch-depth: 0
 
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
@@ -69,19 +72,82 @@ jobs:
           restore-keys: |
             pre-commit-v2-${{ runner.os }}-py${{ matrix.python-version }}-
 
-      - name: Get changed files
+      - name: Determine changed files
         id: changed_files
-        uses: ./.github/actions/file-changes-action
-        with:
-          output: " "
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Scheduled runs check the whole tree (see the pre-commit step).
+          if [ "${EVENT_NAME}" = "schedule" ]; then
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Resolve the commit to diff against.
+          base=""
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            base="${BASE_SHA}"
+          elif [ -n "${BEFORE_SHA:-}" ] && \
+               [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            base="${BEFORE_SHA}"
+          fi
+
+          # Fail closed: if the diff base can't be resolved, check every file
+          # instead of silently checking nothing. Previously an empty file list
+          # made `pre-commit run --files` a no-op that still reported success,
+          # which let unlinted code reach master.
+          if [ -z "${base}" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "::notice::Could not resolve a diff base; falling back to --all-files."
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Files present in HEAD that changed since the base (drop deletions).
+          files="$(git diff --name-only --diff-filter=ACMRT "${base}...HEAD")"
+
+          if [ -z "${files}" ]; then
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=files" >> "$GITHUB_OUTPUT"
+            {
+              echo "files<<__CHANGED_FILES_EOF__"
+              echo "${files}"
+              echo "__CHANGED_FILES_EOF__"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: pre-commit
         env:
+          MODE: ${{ steps.changed_files.outputs.mode }}
           CHANGED_FILES: ${{ steps.changed_files.outputs.files }}
         run: |
           set +e  # Don't exit immediately on failure
           export SKIP=type-checking-frontend
-          pre-commit run --files $CHANGED_FILES
+
+          case "${MODE}" in
+            all)
+              echo "ℹ️ Running pre-commit on all files."
+              pre-commit run --all-files
+              ;;
+            files)
+              echo "ℹ️ Running pre-commit on changed files:"
+              echo "${CHANGED_FILES}"
+              # shellcheck disable=SC2086
+              pre-commit run --files ${CHANGED_FILES}
+              ;;
+            none)
+              echo "ℹ️ No source files changed; nothing for pre-commit to check."
+              exit 0
+              ;;
+            *)
+              echo "⚠️ Unrecognized changed-files mode '${MODE}'; checking all files."
+              pre-commit run --all-files
+              ;;
+          esac
           PRE_COMMIT_EXIT_CODE=$?
           git diff --quiet --exit-code
           GIT_DIFF_EXIT_CODE=$?

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,11 @@ on:
       - "[0-9].[0-9]*"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+  # Nightly full-tree sweep. Per-PR runs only lint changed files, so a change
+  # that invalidates an untouched file (e.g. a type change that breaks an
+  # importing test) can pass every PR yet leave master red. This catches that.
+  schedule:
+    - cron: "0 6 * * *"
 
 permissions:
   contents: read

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,9 +21,6 @@
 [submodule ".github/actions/pr-lint-action"]
 	path = .github/actions/pr-lint-action
 	url = https://github.com/morrisoncole/pr-lint-action
-[submodule ".github/actions/file-changes-action"]
-	path = .github/actions/file-changes-action
-	url = https://github.com/trilom/file-changes-action
 [submodule ".github/actions/cached-dependencies"]
 	path = .github/actions/cached-dependencies
 	url = https://github.com/apache-superset/cached-dependencies


### PR DESCRIPTION
### SUMMARY

The `pre-commit checks` job is a required status check, yet lint/type violations have been reaching `master` in files the linters never actually ran on (recently a `ruff` `C901` complexity error in `execute_sql.py` and a `mypy` typing error in the semantic-layers tests, both cleaned up after the fact in #42014).

Root cause is in the job itself, not the hooks:

1. **It fails open.** The step runs `pre-commit run --files $CHANGED_FILES` under `set +e`. When the changed-files list is empty, `pre-commit run --files` with no files is a no-op that exits `0` — so the required check reports success having linted nothing.
2. **The file list came from a dead action.** `steps.changed_files` used [`trilom/file-changes-action`](https://github.com/trilom/file-changes-action) — archived, last released in 2020, pinned as a git submodule — which is known to silently return empty/partial lists. Combined with (1), any hiccup there turned the whole gate into a silent pass.

#### What this PR changes

**Commit 1 — fail closed, drop the archived action.** Replace the third-party action with a small, dependency-free `git diff` against the PR/push base and make the empty case explicit:
- Diff base unresolvable → run `--all-files` (never "nothing").
- Genuinely empty diff → pass explicitly (`mode=none`).
- Otherwise → `pre-commit run --files <changed>` (unchanged behavior).

`fetch-depth: 0` is added so the base commit is available for the diff, and the now-unused `file-changes-action` submodule is removed (it was referenced only in this workflow).

**Commit 2 — nightly all-files backstop.** Per-PR runs only lint changed files, which is fundamentally leaky for whole-program checkers like `mypy`: a PR that changes a type in module A never re-checks the tests/modules that import A. A scheduled daily `pre-commit run --all-files` catches that cross-file drift. This is defense-in-depth and can be dropped independently if the nightly signal isn't wanted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI workflow change.

### TESTING INSTRUCTIONS

The changed-files detection logic was exercised locally across every branch:

| Event | Base | Expected | Result |
|---|---|---|---|
| `schedule` | — | `mode=all` | ✅ |
| `pull_request` | real base | `mode=files` (correct list) | ✅ |
| `push` | all-zero SHA | fail-closed `mode=all` | ✅ |
| `push` | bogus SHA | fail-closed `mode=all` | ✅ |
| `pull_request` | base == HEAD | `mode=none` | ✅ |

Also validated: `yaml` parses, `zizmor` reports no findings, and `github.event`-derived SHAs are passed via `env:` (no template injection). Reviewers can confirm on this PR that the job scopes to the changed workflow file (not `--all-files`), proving the changed-files path still works.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
