### PR TITLE
fix(explore): show the beginning date on time-series x-axis line charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -641,7 +641,22 @@ export default function transformProps(
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;
+        let lastValue: number | undefined;
         const wrapper = (value: number | string) => {
+          // ECharts formats the labels in repeated ascending passes. Reset the
+          // dedup state when the sequence restarts so a forced boundary label
+          // (e.g. the min date) isn't blanked by the previous pass's last label
+          // when both format identically (e.g. a May-to-May range).
+          if (
+            typeof value === 'number' &&
+            lastValue !== undefined &&
+            value <= lastValue
+          ) {
+            lastLabel = undefined;
+          }
+          if (typeof value === 'number') {
+            lastValue = value;
+          }
           const label =
             typeof xAxisFormatter === 'function'
               ? (xAxisFormatter as Function)(value)
@@ -743,6 +758,8 @@ export default function transformProps(
         ...(showMaxLabel && {
           showMaxLabel: true,
           alignMaxLabel: 'right',
+          showMinLabel: true,
+          alignMinLabel: 'left',
         }),
       },
       minorTick: { show: minorTicks },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -883,7 +883,22 @@ export default function transformProps(
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;
+        let lastValue: number | undefined;
         const wrapper = (value: number | string) => {
+          // ECharts formats the labels in repeated ascending passes. Reset the
+          // dedup state when the sequence restarts so a forced boundary label
+          // (e.g. the min date) isn't blanked by the previous pass's last label
+          // when both format identically (e.g. a May-to-May range).
+          if (
+            typeof value === 'number' &&
+            lastValue !== undefined &&
+            value <= lastValue
+          ) {
+            lastLabel = undefined;
+          }
+          if (typeof value === 'number') {
+            lastValue = value;
+          }
           const label =
             typeof xAxisFormatter === 'function'
               ? (xAxisFormatter as Function)(value)
@@ -921,12 +936,16 @@ export default function transformProps(
       formatter: deduplicatedFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
-      // Force last label on non-rotated time axes to prevent
-      // hideOverlap from hiding it. Skipped when rotated to
-      // avoid phantom labels at the axis boundary.
+      // Force the boundary labels on non-rotated time axes so the first
+      // and last dates stay visible: hideOverlap can hide the last label,
+      // and a min date that falls between "nice" ticks otherwise renders
+      // no beginning label. Skipped when rotated to avoid phantom labels
+      // at the axis boundary.
       ...(showMaxLabel && {
         showMaxLabel: true,
         alignMaxLabel: 'right',
+        showMinLabel: true,
+        alignMinLabel: 'left',
       }),
     },
     minorTick: { show: minorTicks },

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1106,3 +1106,58 @@ test('tooltip time grain wiring: chart-level time grain drives the tooltip when 
   expect(result).toContain('2021');
   expect(result).not.toContain('2021-01-07');
 });
+
+const createTemporalMixedChartProps = (timeFormat: string) => {
+  const rows = [
+    { __timestamp: Date.UTC(2003, 4, 1), metric: 10 },
+    { __timestamp: Date.UTC(2004, 0, 1), metric: 20 },
+    { __timestamp: Date.UTC(2005, 4, 1), metric: 30 },
+  ];
+  const q = createTestQueryData(rows, {
+    colnames: ['__timestamp', 'metric'],
+    coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+    label_map: { __timestamp: ['__timestamp'], metric: ['metric'] },
+  });
+  return createEchartsTimeseriesTestChartProps<
+    EchartsMixedTimeseriesFormData,
+    EchartsMixedTimeseriesProps
+  >({
+    ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+    defaultQueriesData: [q, q],
+    formData: {
+      ...formData,
+      x_axis: '__timestamp',
+      metrics: ['metric'],
+      metricsB: ['metric'],
+      groupby: [],
+      groupbyB: [],
+      timeGrainSqla: TimeGranularity.MONTH,
+      xAxisTimeFormat: timeFormat,
+    },
+    queriesData: [q, q],
+  });
+};
+
+test('x-axis forces showMinLabel for time grains so the beginning date stays visible (mixed)', () => {
+  const xAxis = transformProps(createTemporalMixedChartProps('smart_date'))
+    .echartOptions.xAxis as any;
+  expect(xAxis.axisLabel.showMinLabel).toBe(true);
+});
+
+test('x-axis dedup keeps the forced min label when the endpoints format identically (mixed)', () => {
+  // May→May range renders "May" at both boundaries; the dedup must reset per
+  // ECharts pass so the forced min label survives the second pass.
+  const { formatter } = (
+    transformProps(createTemporalMixedChartProps('%b')).echartOptions
+      .xAxis as any
+  ).axisLabel;
+  const min = Date.UTC(2003, 4, 1);
+  const mid = Date.UTC(2004, 0, 1);
+  const max = Date.UTC(2005, 4, 1);
+
+  formatter(min);
+  formatter(mid);
+  formatter(max);
+
+  expect(formatter(min)).toBe('May');
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1517,6 +1517,45 @@ test('x-axis formatter deduplicates consecutive identical labels for coarse time
   expect(label4).toBe('');
 });
 
+test('x-axis dedup keeps the forced min label when the endpoints format identically', () => {
+  // A May→May range renders "May" at both boundaries. ECharts formats labels in
+  // repeated ascending passes; the dedup must reset per pass so the forced min
+  // label isn't blanked by the previous pass's (identical) max label.
+  const data = [
+    { __timestamp: Date.UTC(2003, 4, 1), sales: 100 },
+    { __timestamp: Date.UTC(2004, 0, 1), sales: 200 },
+    { __timestamp: Date.UTC(2005, 4, 1), sales: 300 },
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      granularity_sqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      xAxisTimeFormat: '%b',
+    },
+    queriesData: [
+      createTestQueryData(data, {
+        colnames: ['__timestamp', 'sales'],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      }),
+    ],
+  });
+
+  const { formatter } = (transformProps(chartProps).echartOptions.xAxis as any)
+    .axisLabel;
+  const min = Date.UTC(2003, 4, 1);
+  const mid = Date.UTC(2004, 0, 1);
+  const max = Date.UTC(2005, 4, 1);
+
+  // First pass fills the dedup state, ending on the max label ("May").
+  formatter(min);
+  formatter(mid);
+  formatter(max);
+
+  // Second pass restarts at the min; it must not be blanked by the prior "May".
+  expect(formatter(min)).toBe('May');
+});
+
 test('x-axis does not force showMaxLabel when no time grain is set', () => {
   const data = [
     { __timestamp: Date.UTC(2003, 0, 6), sales: 100 },
@@ -1539,6 +1578,36 @@ test('x-axis does not force showMaxLabel when no time grain is set', () => {
 
   const xAxisResult = transformProps(chartProps).echartOptions.xAxis as any;
   expect(xAxisResult.axisLabel.showMaxLabel).not.toBe(true);
+  expect(xAxisResult.axisLabel.showMinLabel).not.toBe(true);
+});
+
+test('x-axis forces showMinLabel for time grains so the beginning date stays visible', () => {
+  // When the first data point is not on a coarse boundary (e.g. a mid-year
+  // month), ECharts places its first label on the next "nice" tick and leaves
+  // the axis-min date unlabeled. showMinLabel forces the beginning date to
+  // render, symmetric to showMaxLabel on the trailing edge.
+  const monthData = [
+    { __timestamp: Date.UTC(2003, 4, 1), sales: 100 },
+    { __timestamp: Date.UTC(2003, 5, 1), sales: 200 },
+    { __timestamp: Date.UTC(2003, 6, 1), sales: 300 },
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      granularity_sqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      xAxisTimeFormat: 'smart_date',
+    },
+    queriesData: [
+      createTestQueryData(monthData, {
+        colnames: ['__timestamp', 'sales'],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      }),
+    ],
+  });
+
+  const xAxisResult = transformProps(chartProps).echartOptions.xAxis as any;
+  expect(xAxisResult.axisLabel.showMinLabel).toBe(true);
 });
 
 test('numeric x coltype routes through the number formatter (not the time formatter)', () => {


### PR DESCRIPTION
### SUMMARY

On a time-based x-axis, line/bar/area charts only forced the **trailing** boundary label to stay visible (`showMaxLabel`). When the first data point falls between ECharts' auto-generated "nice" ticks (for example a mid-year month at Month grain), the axis-min date got no label at all, so the **beginning date was missing** from the axis while the end date stayed.

This forces the min boundary label too (`showMinLabel` / `alignMinLabel`), symmetric to the max.

A second issue surfaced once the min label was forced: the shared boundary-dedup formatter (which suppresses a duplicate label at the axis boundary) blanked it. ECharts formats axis labels in repeated ascending passes, and the dedup state carried across the pass boundary, so when the min and max format to the same string (a range that starts and ends in the same month, e.g. "May" to "May"), the min label in the second pass was suppressed by the max from the first. The dedup now resets when the ascending sequence restarts.

Both `Timeseries` (line/bar/area) and `MixedTimeseries` share this code and are fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Line chart, Month grain, a range that starts mid-year (May 2003 to May 2005).

**Before** — the first label is `July`; the beginning date (May) is missing:

![before](https://files.catbox.moe/80f7hi.png)

**After** — the beginning date (`May`) renders at the left edge:

![after](https://files.catbox.moe/ro2izj.png)

### TESTING INSTRUCTIONS

1. Create a **Line Chart** on a dataset with a temporal column whose data starts mid-period (not on a year boundary), e.g. the examples `cleaned_sales_data` with `order_date`.
2. Set the x-axis to the temporal column, **Time Grain = Month**, and a range that starts mid-year (e.g. a filter `2003-05-01 ≤ order_date < 2005-06-01`).
3. **Update chart.** Before this change the first x-axis label is a later "nice" tick and the beginning date is missing; after, the beginning date renders at the left edge.

Automated: `Timeseries/transformProps.test.ts` asserts `showMinLabel` is forced for time grains, and that the dedup keeps the forced min label when the endpoints format identically. The full `plugin-chart-echarts` suite passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API