### PR TITLE
fix(ci): skip unsupported React 19 Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,15 @@ updates:
   - package-ecosystem: "npm"
     ignore:
       - dependency-name: "@rjsf/*"
-      # TODO: remove below entries until React >= 19.0.0
+      # TODO: remove below entries once the application supports React >= 19.0.0
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react-icons"
       # JSDOM v30 doesn't play well with Jest v30
       # Source: https://jestjs.io/blog#known-issues


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Ignore semver-major Dependabot updates for React, React DOM, and their type packages until Superset supports React 19.

The scheduled [Dependabot Updates run](https://github.com/apache/superset/actions/runs/29313202923/job/87021331160) attempted to update React from 18.3.1 to 19.2.7 and failed dependency resolution after roughly 12 minutes. Superset's frontend remains on React 18, and the existing Dependabot configuration already documents React 19 as unsupported. Keeping the four coordinated packages on their current major prevents the updater job from repeatedly failing while allowing minor and patch updates.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Not applicable; this changes Dependabot configuration only.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `pre-commit run --files .github/dependabot.yml`
- Confirm the next scheduled Dependabot run no longer attempts React 19 updates.

`pre-commit run --all-files` was also executed. It reached unrelated baseline/environment failures in unchanged files: an existing oxlint error, missing frontend/docs dependencies and `helm-docs`, and repository-wide Ruff findings. The changed-file run passes all applicable hooks.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
