### PR TITLE
fix(event-log): backport stricter embedded-route regex to 6.1

### DIFF
--- a/superset-frontend/src/middleware/logger.test.ts
+++ b/superset-frontend/src/middleware/logger.test.ts
@@ -170,6 +170,8 @@ describe('logger middleware', () => {
     ['/dashboard/123/', 'dashboard'],
     // slug is literally "embedded" - must not be treated as embedded
     ['/dashboard/embedded/', 'dashboard'],
+    // "embedded" must be a full path segment, not a prefix
+    ['/dashboard/123/embeddedXYZ/', 'dashboard'],
   ])('classifies %s as source "%s"', (path, expectedSource) => {
     expect(getSourceForPath(`http://localhost${path}`)).toBe(expectedSource);
   });

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -140,7 +140,7 @@ const logMessageQueue = new DebouncedMessageQueue<LogEventData>({
 // `/embedded/:uuid/`. Matching these specific shapes avoids false positives
 // for regular dashboards (e.g. a dashboard whose slug is "embedded").
 const EMBEDDED_ROUTE_REGEX =
-  /\/dashboard\/[^/]+\/embedded\/?|\/embedded\/[^/]+\/?/;
+  /\/dashboard\/[^/]+\/embedded(?:[/?#]|$)|\/embedded\/[^/]+\/?/;
 
 let lastEventId: string | number = 0;
 


### PR DESCRIPTION
### SUMMARY

Backports the stricter embedded-route detection regex from `master` to the `6.1` branch.

On `6.1`, `EMBEDDED_ROUTE_REGEX` matched `embedded` followed by an optional slash (`embedded\/?`), which also matched paths where `embedded` was only a prefix of a segment — e.g. `/dashboard/123/embeddedXYZ/` was wrongly classified as an embedded dashboard.

`master` uses a segment-boundary form (`embedded(?:[/?#]|$)`) that requires `embedded` to be a complete path segment. This backport aligns `6.1` with that behavior:

- `/dashboard/:idOrSlug/embedded` and `/embedded/:uuid/` (with or without a trailing slash) still match.
- `/dashboard/123/embeddedXYZ/` is now correctly treated as a regular dashboard.

A guard test case (`/dashboard/123/embeddedXYZ/` -> `dashboard`) is added to lock in the segment-boundary behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — internal event-logging metadata change only.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- src/middleware/logger.test.ts
```

All cases pass, including:

- `/dashboard/123/embedded/` -> `embedded_dashboard`
- `/embedded/abc-def-uuid/` -> `embedded_dashboard`
- `/dashboard/123/embedded` -> `embedded_dashboard`
- `/embedded/abc-def-uuid` -> `embedded_dashboard`
- `/dashboard/123/` -> `dashboard`
- `/dashboard/embedded/` (slug is literally `embedded`) -> `dashboard`
- `/dashboard/123/embeddedXYZ/` -> `dashboard`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
