### PR TITLE
fix(charts): preserve time filter for expression axes

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -245,6 +245,20 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         }
         x_axis = form_data and form_data.get("x_axis")
 
+        should_infer_filter_granularity = (
+            is_adhoc_column(x_axis)  # type: ignore
+            and query_object.granularity is None
+            and bool(query_object.from_dttm or query_object.to_dttm)
+            and (main_dttm_col := getattr(datasource, "main_dttm_col", None))
+            in temporal_columns
+        )
+        if should_infer_filter_granularity:
+            # The inferred column supplies the time-filter subject. It must not be
+            # treated as an explicitly selected granularity, which would rewrite
+            # the x-axis or remove an independent temporal filter below.
+            query_object.granularity = main_dttm_col
+            return
+
         if granularity := query_object.granularity:
             filter_to_remove = None
             if is_adhoc_column(x_axis):  # type: ignore

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -244,11 +244,17 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             if (column["is_dttm"] if isinstance(column, dict) else column.is_dttm)
         }
         x_axis = form_data and form_data.get("x_axis")
+        temporal_range_filters = [
+            filter_
+            for filter_ in query_object.filter
+            if filter_["op"] == "TEMPORAL_RANGE"
+        ]
 
-        should_infer_filter_granularity = (
+        should_infer_filter_granularity: bool = (
             is_adhoc_column(x_axis)  # type: ignore
             and query_object.granularity is None
             and bool(query_object.from_dttm or query_object.to_dttm)
+            and (bool(query_object.time_range) or not temporal_range_filters)
             and (main_dttm_col := getattr(datasource, "main_dttm_col", None))
             in temporal_columns
         )

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 from superset.common.query_context_factory import QueryContextFactory
@@ -372,6 +373,8 @@ class TestQueryContextFactory:
         """Test _apply_granularity when no granularity is set"""
         query_object = Mock(spec=QueryObject)
         query_object.granularity = None
+        query_object.from_dttm = None
+        query_object.to_dttm = None
         query_object.columns = ["ds", "other_col"]
         query_object.post_processing = []
         query_object.filter = []
@@ -383,6 +386,94 @@ class TestQueryContextFactory:
         self.factory._apply_granularity(query_object, form_data, datasource)
 
         assert query_object.columns == ["ds", "other_col"]
+
+    def test_apply_granularity_uses_main_datetime_for_bounded_expression_axis(self):
+        """A bounded expression-axis query retains its physical time subject."""
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        query_object.to_dttm = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        query_object.columns = [
+            {
+                "expressionType": "SQL",
+                "sqlExpression": "value / 10",
+                "label": "value_bucket",
+            }
+        ]
+        query_object.post_processing = []
+        query_object.filter = []
+
+        form_data = {"x_axis": query_object.columns[0]}
+        datasource = Mock()
+        datasource.main_dttm_col = "ds"
+        datasource.columns = [{"column_name": "ds", "is_dttm": True}]
+
+        self.factory._apply_granularity(query_object, form_data, datasource)
+
+        assert query_object.granularity == "ds"
+        assert query_object.columns[0]["sqlExpression"] == "value / 10"
+
+    def test_apply_granularity_preserves_physical_temporal_axis(self):
+        """A bounded physical temporal axis is not replaced by the main column."""
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        query_object.to_dttm = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        query_object.columns = ["event_end"]
+        query_object.post_processing = []
+        query_object.filter = []
+
+        datasource = Mock()
+        datasource.main_dttm_col = "ds"
+        datasource.columns = [
+            {"column_name": "ds", "is_dttm": True},
+            {"column_name": "event_end", "is_dttm": True},
+        ]
+
+        self.factory._apply_granularity(
+            query_object,
+            {"x_axis": "event_end"},
+            datasource,
+        )
+
+        assert query_object.granularity is None
+        assert query_object.columns == ["event_end"]
+
+    def test_inferred_granularity_preserves_independent_temporal_filter(self):
+        """Inferring the filter subject does not remove another temporal filter."""
+        expression = {
+            "expressionType": "SQL",
+            "sqlExpression": "value / 10",
+            "label": "value_bucket",
+        }
+        temporal_filter = {
+            "col": "event_end",
+            "op": "TEMPORAL_RANGE",
+            "val": "2024-01-10 : 2024-01-20",
+        }
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        query_object.to_dttm = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        query_object.columns = [expression]
+        query_object.post_processing = []
+        query_object.filter = [temporal_filter]
+
+        datasource = Mock()
+        datasource.main_dttm_col = "ds"
+        datasource.columns = [
+            {"column_name": "ds", "is_dttm": True},
+            {"column_name": "event_end", "is_dttm": True},
+        ]
+
+        self.factory._apply_granularity(
+            query_object,
+            {"x_axis": expression},
+            datasource,
+        )
+
+        assert query_object.granularity == "ds"
+        assert query_object.filter == [temporal_filter]
 
     def test_apply_granularity_x_axis_not_temporal(self):
         """Test _apply_granularity when x_axis is not a temporal column"""

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -387,12 +387,15 @@ class TestQueryContextFactory:
 
         assert query_object.columns == ["ds", "other_col"]
 
-    def test_apply_granularity_uses_main_datetime_for_bounded_expression_axis(self):
+    def test_apply_granularity_uses_main_datetime_for_bounded_expression_axis(
+        self,
+    ) -> None:
         """A bounded expression-axis query retains its physical time subject."""
         query_object = Mock(spec=QueryObject)
         query_object.granularity = None
         query_object.from_dttm = datetime(2024, 1, 1, tzinfo=timezone.utc)
         query_object.to_dttm = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        query_object.time_range = None
         query_object.columns = [
             {
                 "expressionType": "SQL",
@@ -413,7 +416,7 @@ class TestQueryContextFactory:
         assert query_object.granularity == "ds"
         assert query_object.columns[0]["sqlExpression"] == "value / 10"
 
-    def test_apply_granularity_preserves_physical_temporal_axis(self):
+    def test_apply_granularity_preserves_physical_temporal_axis(self) -> None:
         """A bounded physical temporal axis is not replaced by the main column."""
         query_object = Mock(spec=QueryObject)
         query_object.granularity = None
@@ -439,7 +442,7 @@ class TestQueryContextFactory:
         assert query_object.granularity is None
         assert query_object.columns == ["event_end"]
 
-    def test_inferred_granularity_preserves_independent_temporal_filter(self):
+    def test_inferred_granularity_preserves_independent_temporal_filter(self) -> None:
         """Inferring the filter subject does not remove another temporal filter."""
         expression = {
             "expressionType": "SQL",
@@ -455,6 +458,7 @@ class TestQueryContextFactory:
         query_object.granularity = None
         query_object.from_dttm = datetime(2024, 1, 1, tzinfo=timezone.utc)
         query_object.to_dttm = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        query_object.time_range = "2024-01-01 : 2024-01-31"
         query_object.columns = [expression]
         query_object.post_processing = []
         query_object.filter = [temporal_filter]
@@ -473,6 +477,43 @@ class TestQueryContextFactory:
         )
 
         assert query_object.granularity == "ds"
+        assert query_object.filter == [temporal_filter]
+
+    def test_granularity_not_inferred_from_another_temporal_filter(self) -> None:
+        """A lone temporal filter remains the only time-filter subject."""
+        expression = {
+            "expressionType": "SQL",
+            "sqlExpression": "value / 10",
+            "label": "value_bucket",
+        }
+        temporal_filter = {
+            "col": "event_end",
+            "op": "TEMPORAL_RANGE",
+            "val": "2024-01-10 : 2024-01-20",
+        }
+        query_object = Mock(spec=QueryObject)
+        query_object.granularity = None
+        query_object.from_dttm = datetime(2024, 1, 10, tzinfo=timezone.utc)
+        query_object.to_dttm = datetime(2024, 1, 20, tzinfo=timezone.utc)
+        query_object.time_range = None
+        query_object.columns = [expression]
+        query_object.post_processing = []
+        query_object.filter = [temporal_filter]
+
+        datasource = Mock()
+        datasource.main_dttm_col = "ds"
+        datasource.columns = [
+            {"column_name": "ds", "is_dttm": True},
+            {"column_name": "event_end", "is_dttm": True},
+        ]
+
+        self.factory._apply_granularity(
+            query_object,
+            {"x_axis": expression},
+            datasource,
+        )
+
+        assert query_object.granularity is None
         assert query_object.filter == [temporal_filter]
 
     def test_apply_granularity_x_axis_not_temporal(self):

--- a/tests/unit_tests/models/test_no_filter_time_range.py
+++ b/tests/unit_tests/models/test_no_filter_time_range.py
@@ -23,9 +23,11 @@ from datetime import datetime, timezone
 from flask import Flask
 from pytest_mock import MockerFixture
 
+from superset.common.query_context_factory import QueryContextFactory
+from superset.common.query_object import QueryObject
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.models.core import Database
-from superset.superset_typing import QueryObjectDict
+from superset.superset_typing import AdhocColumn, QueryObjectDict
 
 
 def _make_dataset(mocker: MockerFixture) -> SqlaTable:
@@ -206,6 +208,43 @@ def test_actual_from_to_dttm_produces_time_filter(
     assert "time_start" in generated_sql.lower(), (
         f"Expected time_start column in WHERE clause, got: {generated_sql}"
     )
+
+
+def test_time_range_without_granularity_filters_main_datetime_column(
+    mocker: MockerFixture,
+    app: Flask,
+) -> None:
+    """A SQL-expression dimension must not cause a dashboard range to be dropped."""
+    dataset = _make_dataset(mocker)
+    expression: AdhocColumn = {
+        "sqlExpression": "value / 10",
+        "label": "value_bucket",
+        "columnType": "BASE_AXIS",
+    }
+    query_object = QueryObject(
+        granularity=None,
+        is_timeseries=False,
+        metrics=["count"],
+        columns=[expression],
+        from_dttm=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        to_dttm=datetime(2024, 1, 31, tzinfo=timezone.utc),
+    )
+
+    with app.test_request_context():
+        QueryContextFactory()._apply_granularity(
+            query_object,
+            {"x_axis": expression},
+            dataset,
+        )
+        generated_sql = dataset.get_query_str_extended(
+            query_object.to_dict(), mutate=False
+        ).sql.lower()
+
+    assert query_object.granularity == "time_start"
+    assert "value / 10" in generated_sql
+    assert "group by" in generated_sql
+    assert "where time_start >=" in generated_sql
+    assert "time_start <" in generated_sql
 
 
 def test_series_limit_with_time_filter_includes_time_in_inner_subquery(

--- a/tests/unit_tests/models/test_no_filter_time_range.py
+++ b/tests/unit_tests/models/test_no_filter_time_range.py
@@ -221,11 +221,12 @@ def test_time_range_without_granularity_filters_main_datetime_column(
         "label": "value_bucket",
         "columnType": "BASE_AXIS",
     }
-    query_object = QueryObject(
+    query_object: QueryObject = QueryObject(
         granularity=None,
         is_timeseries=False,
         metrics=["count"],
         columns=[expression],
+        time_range="2024-01-01 : 2024-01-31",
         from_dttm=datetime(2024, 1, 1, tzinfo=timezone.utc),
         to_dttm=datetime(2024, 1, 31, tzinfo=timezone.utc),
     )


### PR DESCRIPTION
### SUMMARY

Fixes query construction for charts whose x-axis is an adhoc SQL expression and whose time range comes from dashboard filtering.

Without an explicit granularity, the physical datetime column was not retained as the time-filter subject. On ClickHouse this could produce an effectively unbounded read and trigger `TOO_MANY_ROWS`, even though the dashboard supplied a narrow time range. The fix infers the dataset main datetime column only for bounded adhoc expression axes and keeps that inferred value out of the legacy axis-rewrite and temporal-filter-removal path.

Regression coverage verifies that the expression remains the grouping dimension, the physical datetime predicate is generated, physical temporal axes are not rewritten, and independent temporal filters are preserved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_**Before**_

<img width="1720" height="566" alt="Screenshot 2026-07-14 at 2 42 03 PM" src="https://github.com/user-attachments/assets/058433e6-6082-49a7-a0de-1632bec0948e" />

_**After**_

<img width="1720" height="566" alt="Screenshot 2026-07-14 at 2 39 47 PM" src="https://github.com/user-attachments/assets/755cfd12-8b6a-41e8-8eea-8166ff71052e" />

_Manual browser reproduction for screenshots:_

1. Configure a ClickHouse table containing:
      - A physical DateTime column used as the dataset’s main datetime column.
      - Columns suitable for a calculated numeric dimension.
      - More total rows than the ClickHouse user’s `max_rows_to_read` setting.
      - Fewer rows than that limit within a narrow time range.

  2. Add the table as a Superset dataset and configure its physical datetime column as the dataset’s main datetime
     column.

  3. Create a chart with:
      - `COUNT(*)` as the metric.
      - An adhoc SQL expression as the x-axis.
      - No explicit granularity or physical datetime x-axis.

  4. Add the chart to a dashboard and create a native time-range filter targeting the dataset’s main datetime
     column.

  5. Select a narrow range whose matching rows are below `max_rows_to_read`.
  6. On master, refresh the dashboard. The chart fails with ClickHouse `TOO_MANY_ROWS` because the generated
     aggregation does not include the physical datetime predicate.

  7. Switch to this branch and refresh the same dashboard. The chart renders successfully.
  8. Inspect the generated SQL and verify that:
      - The adhoc expression remains in `SELECT` and `GROUP BY`.
      - The dataset’s main datetime column appears in `WHERE`.
      - The predicate contains the selected dashboard time bounds.
      - Any independent temporal filters remain present.


### TESTING INSTRUCTIONS

Automated:

```bash
pytest -q tests/unit_tests/common/test_query_context_factory.py tests/unit_tests/models/test_no_filter_time_range.py
```

Expected: 49 tests pass.

Manual ClickHouse reproduction:

1. Configure a ClickHouse dataset with a physical main datetime column and an adhoc SQL expression as the chart x-axis.
2. Set a restrictive `max_rows_to_read` value on the ClickHouse connection.
3. Apply a narrow dashboard native time-range filter.
4. On `master`, refresh the chart and observe `TOO_MANY_ROWS` because the physical time predicate is absent.
5. On this branch, refresh the same chart and verify it renders and the generated SQL filters the main datetime column while grouping by the SQL expression.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
