### PR TITLE
fix(plugin-chart-echarts): use echarts 5.6.0 i18n export path for locale import

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -124,7 +124,7 @@ use([
 const loadLocale = async (locale: string) => {
   let lang;
   try {
-    lang = await import(`echarts/lib/i18n/lang${locale}`);
+    lang = await import(`echarts/i18n/lang${locale}.js`);
   } catch {
     // Locale not supported in ECharts
   }


### PR DESCRIPTION
## Summary

Fixes a webpack build warning introduced when echarts 5.6.0 added a `package.json` `exports` field.

### Root cause

echarts 5.6.0 added `exports` to its `package.json`. The catch-all entry `"./*": "./*"` maps `echarts/lib/i18n` → `./lib/i18n` (no `.js` extension). webpack 5's `enhanced-resolve` with `fullySpecified: true` then fails to find the file because it requires an exact match (no extension guessing), producing:

```
WARNING in ./plugins/plugin-chart-echarts/src/components/Echart.tsx
Module not found: Error: Package path ./lib/i18n is exported from package echarts,
but no valid target file was found (see exports field in .../node_modules/echarts/package.json)
```

### Fix

Switch the dynamic locale import from `echarts/lib/i18n/lang${locale}` to `echarts/i18n/lang${locale}.js`.

- `echarts/i18n/` is an explicit export pattern in echarts 5.6.0: `"./i18n/*": "./i18n/*"`
- The locale files (`i18n/langEN.js`, `i18n/langZH.js`, etc.) exist at the package root `i18n/` directory
- The explicit `.js` extension satisfies `enhanced-resolve`'s `fullySpecified` mode

### Testing

- [ ] `cd superset-frontend && npm run build` completes without the `lib/i18n` warning
- [ ] Chart locale loading works correctly (locale changes apply to ECharts charts)