### PR TITLE
fix(migration): use sqlalchemy.orm.declarative_base to avoid MovedIn20Warning

### DIFF
--- a/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
+++ b/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
@@ -33,7 +33,7 @@ Create Date: 2026-06-30 00:00:00.000000
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json


### PR DESCRIPTION
### SUMMARY

The migration added in #41591 imported `declarative_base` from the deprecated `sqlalchemy.ext.declarative` path. SQLAlchemy 1.4 moved it to `sqlalchemy.orm.declarative_base` and emits `MovedIn20Warning` on the old path.

The migration file is imported at pytest collection time by its unit test, which means any test run with warnings-as-errors fails at collection — blocking unrelated PRs (e.g. #42052).

One-line fix: update the import to the canonical `sqlalchemy.orm` path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. `pytest tests/unit_tests/migrations/test_strip_metricsqlexpressions_from_ag_grid_params.py` — should pass with no `MovedIn20Warning`
2. Confirm no `sqlalchemy.exc.MovedIn20Warning` at collection time

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API