### PR TITLE
fix(migrations): use sqlalchemy.orm.declarative_base

### DIFF
--- a/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
+++ b/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
@@ -33,7 +33,7 @@ Create Date: 2026-06-30 00:00:00.000000
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json


### PR DESCRIPTION
### SUMMARY
Migration `d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params` (#41591) imports `declarative_base` from the deprecated `sqlalchemy.ext.declarative` module instead of `sqlalchemy.orm`. With `SQLALCHEMY_WARN_20=1` (set in this repo's test configuration), calling the deprecated `declarative_base()` raises `sqlalchemy.exc.MovedIn20Warning` at module import time. `pytest.ini`'s `filterwarnings` escalates this to a hard error, which aborts collection of the migration's test module and fails the entire `Python-Unit` CI run for every PR built on top of `master`.

This PR changes the import to `from sqlalchemy.orm import declarative_base`, which is the SQLAlchemy 1.4/2.0-recommended location and avoids the deprecation warning entirely. No other lines are touched.

This unblocks CI (`Python-Unit`) on other open PRs targeting `master`, e.g. #41924.

[sc-113463]

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (import-only fix, no behavior or UI change)

### TESTING INSTRUCTIONS
1. `PYTHONPATH=. SQLALCHEMY_WARN_20=1 SUPERSET_TESTENV=true SUPERSET_SECRET_KEY=not-a-secret pytest tests/unit_tests/migrations/test_strip_metricsqlexpressions_from_ag_grid_params.py -v`
2. Before this fix, pytest aborts with `1 error during collection` (`sqlalchemy.exc.MovedIn20Warning` raised at import time).
3. After this fix, all 9 tests in that module pass with no collection error.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API