### PR TITLE
fix(alerts): paginate and cache Slack channels to resolve timeout issues.

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2711,6 +2711,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                         email_subject={currentAlert?.email_subject || ''}
                         defaultSubject={emailSubject || ''}
                         setErrorSubject={handleErrorUpdate}
+                        addDangerToast={addDangerToast}
                       />
                     </StyledNotificationMethodWrapper>
                   ))}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2701,9 +2701,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               children: (
                 <>
                   {notificationSettings.map((notificationSetting, i) => (
-                    <StyledNotificationMethodWrapper
-                      key={`notification-${notificationSetting.method || 'new'}-${notificationSetting.recipients || 'empty'}-${i}`}
-                    >
+                    <StyledNotificationMethodWrapper key={`notification-${i}`}>
                       <NotificationMethod
                         setting={notificationSetting}
                         index={i}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -2708,7 +2707,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                         onUpdate={updateNotificationSetting}
                         onRemove={removeNotificationSetting}
                         onInputChange={onInputChange}
-                        emailSubject={currentAlert?.email_subject || ''}
+                        email_subject={currentAlert?.email_subject || ''}
                         defaultSubject={emailSubject || ''}
                         setErrorSubject={handleErrorUpdate}
                         addDangerToast={addDangerToast}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -2700,15 +2701,16 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               children: (
                 <>
                   {notificationSettings.map((notificationSetting, i) => (
-                    <StyledNotificationMethodWrapper>
+                    <StyledNotificationMethodWrapper
+                      key={`notification-${notificationSetting.method || 'new'}-${notificationSetting.recipients || 'empty'}-${i}`}
+                    >
                       <NotificationMethod
                         setting={notificationSetting}
                         index={i}
-                        key={`NotificationMethod-${i}`}
                         onUpdate={updateNotificationSetting}
                         onRemove={removeNotificationSetting}
                         onInputChange={onInputChange}
-                        email_subject={currentAlert?.email_subject || ''}
+                        emailSubject={currentAlert?.email_subject || ''}
                         defaultSubject={emailSubject || ''}
                         setErrorSubject={handleErrorUpdate}
                         addDangerToast={addDangerToast}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -927,3 +927,63 @@ test('NotificationMethod - AsyncSelect should clear recipients and reload channe
     );
   });
 });
+
+test('NotificationMethod - data cache prevents redundant API calls when selecting channels', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannels = [
+    { name: 'general', id: 'C001', is_private: false, is_member: true },
+    { name: 'random', id: 'C002', is_private: false, is_member: true },
+  ];
+
+  let callCount = 0;
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockImplementation(async url => {
+      if (typeof url === 'object' && url.endpoint?.includes('slack_channels')) {
+        callCount += 1;
+      }
+      return {
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      } as unknown as Promise<Response | JsonResponse | TextResponse>;
+    });
+
+  const { getByRole } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const recipientsSelect = getByRole('combobox', {
+    name: /select channels/i,
+  });
+
+  fireEvent.mouseDown(recipientsSelect);
+
+  await waitFor(
+    () => {
+      expect(callCount).toBe(1);
+    },
+    { timeout: 3000 },
+  );
+
+  fireEvent.blur(recipientsSelect);
+  fireEvent.mouseDown(recipientsSelect);
+
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  expect(callCount).toBe(1);
+
+  getSpy.mockRestore();
+});

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -246,7 +246,7 @@ test('NotificationMethod - should render the component', () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -266,7 +266,7 @@ test('NotificationMethod - should call onRemove when the delete button is clicke
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -287,7 +287,7 @@ test('NotificationMethod - should update recipient value when input changes', ()
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -313,7 +313,7 @@ test('NotificationMethod - should call onRecipientsChange when the recipients va
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -466,7 +466,7 @@ test('NotificationMethod - should render CC and BCC fields when method is Email 
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -491,7 +491,7 @@ test('NotificationMethod - should render CC and BCC fields with correct values w
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -516,7 +516,7 @@ test('NotificationMethod - should not render CC and BCC fields when method is no
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -541,7 +541,7 @@ test('NotificationMethod - should handle empty recipients list gracefully', () =
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -575,7 +575,7 @@ test('shows the right combo when ff is false', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -613,7 +613,7 @@ test('shows the textbox when the fetch fails', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -656,7 +656,7 @@ test('shows the dropdown when ff is true and slackChannels succeed', async () =>
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -692,7 +692,7 @@ test('shows the textarea when ff is true and slackChannels fail', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -728,7 +728,7 @@ test('shows the textarea when ff is true and slackChannels fail and slack is sel
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -757,7 +757,7 @@ test('shows the textarea when ff is true, slackChannels fail and slack is select
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -791,7 +791,7 @@ test('NotificationMethod - AsyncSelect should render for SlackV2 method', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -830,7 +830,7 @@ test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API resp
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -872,7 +872,7 @@ test('NotificationMethod - AsyncSelect should render refresh button for SlackV2'
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -916,7 +916,7 @@ test('NotificationMethod - AsyncSelect should reload channels without clearing r
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -990,7 +990,7 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1057,7 +1057,7 @@ test('NotificationMethod - should preserve selected channels on refresh', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1132,7 +1132,7 @@ test('NotificationMethod - should initialize Slack recipients when editing exist
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1237,7 +1237,7 @@ test('NotificationMethod - should preserve selected channels during search and p
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1296,6 +1296,185 @@ test('NotificationMethod - should preserve selected channels during search and p
     call => !call[1]?.hasOwnProperty('recipients') || call[1].recipients !== '',
   );
   expect(updateCallsWithEmptyRecipientsCheck).toBe(true);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - should support comma-separated channel search', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannelsPage1 = [
+    { id: 'C001', name: 'engineering', is_private: false, is_member: true },
+    {
+      id: 'C002',
+      name: 'engineering-team',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+  const mockChannelsPage2 = [
+    { id: 'C003', name: 'marketing', is_private: false, is_member: true },
+    { id: 'C004', name: 'sales', is_private: false, is_member: true },
+  ];
+
+  let callCount = 0;
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    callCount += 1;
+    if (callCount === 1) {
+      return Promise.resolve({
+        json: {
+          result: mockChannelsPage1,
+          next_cursor: 'cursor_2',
+          has_more: true,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>;
+    }
+    return Promise.resolve({
+      json: {
+        result: mockChannelsPage2,
+        next_cursor: null,
+        has_more: false,
+      },
+    }) as unknown as Promise<Response | JsonResponse | TextResponse>;
+  });
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const apiCalls = getSpy.mock.calls;
+  expect(apiCalls.length).toBeGreaterThan(0);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - AsyncSelect should not filter results client-side', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannels = [
+    { id: 'C001', name: 'analytics-team', is_private: false, is_member: true },
+    { id: 'C002', name: 'analytics-ops', is_private: false, is_member: true },
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+  ];
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const recipientsSelect = getByTestId('recipients');
+  expect(recipientsSelect).toBeInTheDocument();
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - AsyncSelect should not use comma as token separator', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannels = [
+    { id: 'C001', name: 'engineering', is_private: false, is_member: true },
+    { id: 'C002', name: 'marketing', is_private: false, is_member: true },
+  ];
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const recipientsSelect = getByTestId('recipients');
+  expect(recipientsSelect).toBeInTheDocument();
 
   getSpy.mockRestore();
 });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -246,7 +246,7 @@ test('NotificationMethod - should render the component', () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -266,7 +266,7 @@ test('NotificationMethod - should call onRemove when the delete button is clicke
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -287,7 +287,7 @@ test('NotificationMethod - should update recipient value when input changes', ()
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -313,7 +313,7 @@ test('NotificationMethod - should call onRecipientsChange when the recipients va
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -466,7 +466,7 @@ test('NotificationMethod - should render CC and BCC fields when method is Email 
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    emailSubject: 'Test Subject',
+    email_subject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -491,7 +491,7 @@ test('NotificationMethod - should render CC and BCC fields with correct values w
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    emailSubject: 'Test Subject',
+    email_subject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -516,7 +516,7 @@ test('NotificationMethod - should not render CC and BCC fields when method is no
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    emailSubject: 'Test Subject',
+    email_subject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -541,7 +541,7 @@ test('NotificationMethod - should handle empty recipients list gracefully', () =
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    emailSubject: 'Test Subject',
+    email_subject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -575,7 +575,7 @@ test('shows the right combo when ff is false', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -613,7 +613,7 @@ test('shows the textbox when the fetch fails', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -656,7 +656,7 @@ test('shows the dropdown when ff is true and slackChannels succeed', async () =>
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -692,7 +692,7 @@ test('shows the textarea when ff is true and slackChannels fail', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -728,7 +728,7 @@ test('shows the textarea when ff is true and slackChannels fail and slack is sel
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -757,7 +757,7 @@ test('shows the textarea when ff is true, slackChannels fail and slack is select
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -791,7 +791,7 @@ test('NotificationMethod - AsyncSelect should render for SlackV2 method', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -830,7 +830,7 @@ test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API resp
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -872,7 +872,7 @@ test('NotificationMethod - AsyncSelect should render refresh button for SlackV2'
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -916,7 +916,7 @@ test('NotificationMethod - AsyncSelect should reload channels without clearing r
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -990,7 +990,7 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1057,7 +1057,7 @@ test('NotificationMethod - should preserve selected channels on refresh', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1132,7 +1132,7 @@ test('NotificationMethod - should initialize Slack recipients when editing exist
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1237,7 +1237,7 @@ test('NotificationMethod - should preserve selected channels during search and p
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1345,7 +1345,7 @@ test('NotificationMethod - should support comma-separated channel search', async
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1399,7 +1399,7 @@ test('NotificationMethod - AsyncSelect should not filter results client-side', a
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1452,7 +1452,7 @@ test('NotificationMethod - AsyncSelect should not use comma as token separator',
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      emailSubject={mockEmailSubject}
+      email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -232,562 +232,698 @@ const mockSettingSlackV2: NotificationSetting = {
   ],
 };
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('NotificationMethod', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    cleanup();
+beforeEach(() => {
+  jest.clearAllMocks();
+  cleanup();
+});
+
+test('NotificationMethod - should render the component', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  expect(screen.getByText('Notification Method')).toBeInTheDocument();
+  expect(screen.getByText('Email subject name (optional)')).toBeInTheDocument();
+  expect(screen.getByText('Email recipients')).toBeInTheDocument();
+});
+
+test('NotificationMethod - should call onRemove when the delete button is clicked', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={1}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const deleteButton = document.querySelector('.delete-button');
+  if (deleteButton) userEvent.click(deleteButton);
+
+  expect(mockOnRemove).toHaveBeenCalledWith(1);
+});
+
+test('NotificationMethod - should update recipient value when input changes', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const recipientsInput = screen.getByTestId('recipients');
+  fireEvent.change(recipientsInput, {
+    target: { value: 'test1@example.com' },
   });
 
-  test('should render the component', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+  expect(mockOnUpdate).toHaveBeenCalledWith(0, {
+    ...mockSetting,
+    recipients: 'test1@example.com',
+  });
+});
 
-    expect(screen.getByText('Notification Method')).toBeInTheDocument();
-    expect(
-      screen.getByText('Email subject name (optional)'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Email recipients')).toBeInTheDocument();
+test('NotificationMethod - should call onRecipientsChange when the recipients value is changed', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const recipientsInput = screen.getByTestId('recipients');
+  fireEvent.change(recipientsInput, {
+    target: { value: 'test1@example.com' },
   });
 
-  test('should call onRemove when the delete button is clicked', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={1}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    const deleteButton = document.querySelector('.delete-button');
-    if (deleteButton) userEvent.click(deleteButton);
-
-    expect(mockOnRemove).toHaveBeenCalledWith(1);
+  expect(mockOnUpdate).toHaveBeenCalledWith(0, {
+    ...mockSetting,
+    recipients: 'test1@example.com',
   });
+});
 
-  test('should update recipient value when input changes', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+test('NotificationMethod - should correctly map recipients when method is SlackV2', () => {
+  const method = 'SlackV2';
+  const recipientValue = 'user1,user2';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-    const recipientsInput = screen.getByTestId('recipients');
-    fireEvent.change(recipientsInput, {
-      target: { value: 'test1@example.com' },
-    });
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(0, {
-      ...mockSetting,
-      recipients: 'test1@example.com',
-    });
-  });
+  expect(result).toEqual([
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ]);
+});
 
-  test('should call onRecipientsChange when the recipients value is changed', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+test('NotificationMethod - should return an empty array when recipientValue is an empty string', () => {
+  const method = 'SlackV2';
+  const recipientValue = '';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-    const recipientsInput = screen.getByTestId('recipients');
-    fireEvent.change(recipientsInput, {
-      target: { value: 'test1@example.com' },
-    });
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(0, {
-      ...mockSetting,
-      recipients: 'test1@example.com',
-    });
-  });
+  expect(result).toEqual([]);
+});
 
-  test('should load email recipient options from report users', async () => {
-    jest.spyOn(SupersetClient, 'get').mockResolvedValueOnce({
-      json: {
-        count: 1,
-        result: [
-          {
-            text: 'Test User',
-            value: 1,
-            extra: {
-              email: 'test@example.com',
-            },
+test('should load email recipient options from report users', async () => {
+  jest.spyOn(SupersetClient, 'get').mockResolvedValueOnce({
+    json: {
+      count: 1,
+      result: [
+        {
+          text: 'Test User',
+          value: 1,
+          extra: {
+            email: 'test@example.com',
           },
-        ],
-      },
-    } as unknown as JsonResponse);
+        },
+      ],
+    },
+  } as unknown as JsonResponse);
 
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          options: [NotificationMethodOption.Email],
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        options: [NotificationMethodOption.Email],
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
 
-    const filterValue = 'test +&#';
-    fireEvent.change(screen.getByTestId('recipients'), {
-      target: { value: filterValue },
-    });
-    fireEvent.click(screen.getByTestId('recipients-load-options'));
-
-    expect(
-      await screen.findByText('Test User <test@example.com>'),
-    ).toBeInTheDocument();
-    expect(SupersetClient.get).toHaveBeenCalledWith(
-      expect.objectContaining({
-        endpoint: expect.stringContaining(
-          '/api/v1/report/related/created_by?q=',
-        ),
-      }),
-    );
-    expect(SupersetClient.get).toHaveBeenCalledWith(
-      expect.objectContaining({
-        endpoint: expect.stringContaining(
-          `q=${rison.encode_uri({
-            filter: filterValue,
-            page: 0,
-            page_size: 25,
-            order_column: 'username',
-            order_direction: 'asc',
-          })}`,
-        ),
-      }),
-    );
+  const filterValue = 'test +&#';
+  fireEvent.change(screen.getByTestId('recipients'), {
+    target: { value: filterValue },
   });
+  fireEvent.click(screen.getByTestId('recipients-load-options'));
 
-  test('should correctly map recipients when method is SlackV2', () => {
-    const method = 'SlackV2';
-    const recipientValue = 'user1,user2';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+  expect(
+    await screen.findByText('Test User <test@example.com>'),
+  ).toBeInTheDocument();
+  expect(SupersetClient.get).toHaveBeenCalledWith(
+    expect.objectContaining({
+      endpoint: expect.stringContaining(
+        '/api/v1/report/related/created_by?q=',
+      ),
+    }),
+  );
+  expect(SupersetClient.get).toHaveBeenCalledWith(
+    expect.objectContaining({
+      endpoint: expect.stringContaining(
+        `q=${rison.encode_uri({
+          filter: filterValue,
+          page: 0,
+          page_size: 25,
+          order_column: 'username',
+          order_direction: 'asc',
+        })}`,
+      ),
+    }),
+  );
+});
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+test('should correctly map recipients when method is SlackV2', () => {
+  const method = 'SlackV2';
+  const recipientValue = 'user1,user2';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
+  expect(result).toEqual([
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ]);
+});
 
-    expect(result).toEqual([
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ]);
-  });
+test('NotificationMethod - should correctly map recipients when method is Slack with updated recipient values', () => {
+  const method = 'Slack';
+  const recipientValue = 'User One,User Two';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-  test('should return an empty array when recipientValue is an empty string', () => {
-    const method = 'SlackV2';
-    const recipientValue = '';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+  expect(result).toEqual([
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ]);
+});
 
-    expect(result).toEqual([]);
-  });
+test('NotificationMethod - should render CC and BCC fields when method is Email and visibility flags are true', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-  test('should correctly map recipients when method is Slack with updated recipient values', () => {
-    const method = 'Slack';
-    const recipientValue = 'User One,User Two';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+  const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+  // Check if CC and BCC fields are rendered
+  expect(getByTestId('cc')).toBeInTheDocument();
+  expect(getByTestId('bcc')).toBeInTheDocument();
+});
 
-    expect(result).toEqual([
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ]);
-  });
-  test('should render CC and BCC fields when method is Email and visibility flags are true', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+test('NotificationMethod - should render CC and BCC fields with correct values when method is Email', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
+  const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    // Check if CC and BCC fields are rendered
-    expect(getByTestId('cc')).toBeInTheDocument();
-    expect(getByTestId('bcc')).toBeInTheDocument();
-  });
-  test('should render CC and BCC fields with correct values when method is Email', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  // Check if CC and BCC fields are rendered with correct values
+  expect(getByTestId('cc')).toHaveValue('cc1@example.com');
+  expect(getByTestId('bcc')).toHaveValue('bcc1@example.com');
+});
 
-    const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
+test('NotificationMethod - should not render CC and BCC fields when method is not Email', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Slack,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    // Check if CC and BCC fields are rendered with correct values
-    expect(getByTestId('cc')).toHaveValue('cc1@example.com');
-    expect(getByTestId('bcc')).toHaveValue('bcc1@example.com');
-  });
-  test('should not render CC and BCC fields when method is not Email', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Slack,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
+  // Check if CC and BCC fields are not rendered
+  expect(queryByTestId('cc')).not.toBeInTheDocument();
+  expect(queryByTestId('bcc')).not.toBeInTheDocument();
+});
+// Handle empty recipients list gracefully
+test('NotificationMethod - should handle empty recipients list gracefully', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: '',
+      cc: '',
+      bcc: '',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    // Check if CC and BCC fields are not rendered
-    expect(queryByTestId('cc')).not.toBeInTheDocument();
-    expect(queryByTestId('bcc')).not.toBeInTheDocument();
-  });
-  // Handle empty recipients list gracefully
-  test('should handle empty recipients list gracefully', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: '',
-        cc: '',
-        bcc: '',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
+  // Check if CC and BCC fields are not rendered
+  expect(queryByTestId('cc')).not.toBeInTheDocument();
+  expect(queryByTestId('bcc')).not.toBeInTheDocument();
+});
 
-    // Check if CC and BCC fields are not rendered
-    expect(queryByTestId('cc')).not.toBeInTheDocument();
-    expect(queryByTestId('bcc')).not.toBeInTheDocument();
-  });
-  test('shows the right combo when ff is false', async () => {
-    /* should show the div with "Recipients are separated by"
+test('shows the right combo when ff is false', async () => {
+  /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is false and fetchSlackChannels errors
     */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(
-        screen.getByText('Recipients are separated by "," or ";"'),
-      ).toBeInTheDocument();
-    });
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
-  test('shows the textbox when the fetch fails', async () => {
-    /* should show the div with "Recipients are separated by"
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
+    expect(
+      screen.getByText('Recipients are separated by "," or ";"'),
+    ).toBeInTheDocument();
+  });
+});
+
+test('shows the textbox when the fetch fails', async () => {
+  /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels errors
     */
 
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(
-        screen.getByText('Recipients are separated by "," or ";"'),
-      ).toBeInTheDocument();
-    });
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
-  test('shows the dropdown when ff is true and slackChannels succeed', async () => {
-    /* should show the Select channels dropdown
-    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
-    */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest
-      .spyOn(SupersetClient, 'get')
-      .mockImplementation(
-        () =>
-          Promise.resolve({ json: { result: [] } }) as unknown as Promise<
-            Response | JsonResponse | TextResponse
-          >,
-      );
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
 
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.SlackV2,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(screen.getByTitle('Slack')).toBeInTheDocument();
-    });
-  });
-  test('shows the textarea when ff is true and slackChannels fail', async () => {
-    /* should show the Select channels dropdown
-    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
-    */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
     expect(
       screen.getByText('Recipients are separated by "," or ";"'),
     ).toBeInTheDocument();
   });
-  test('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
-    /* should show the Select channels dropdown
+});
+
+test('shows the dropdown when ff is true and slackChannels succeed', async () => {
+  /* should show the Select channels dropdown
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
     */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
+  // Mock the SupersetClient.get to simulate an error
+  jest
+    .spyOn(SupersetClient, 'get')
+    .mockImplementation(
+      () =>
+        Promise.resolve({ json: { result: [] } }) as unknown as Promise<
+          Response | JsonResponse | TextResponse
+        >,
     );
 
-    // Wait for the component to handle the error and render the expected div
-    expect(
-      screen.getByText('Recipients are separated by "," or ";"'),
-    ).toBeInTheDocument();
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.SlackV2,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
+    expect(screen.getByTitle('Slack')).toBeInTheDocument();
+  });
+});
+
+test('shows the textarea when ff is true and slackChannels fail', async () => {
+  /* should show the Select channels dropdown
+    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
+    */
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
 
-  test('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
 
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSettingSlackV2,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
+  // Wait for the component to handle the error and render the expected div
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
+  /* should show the Select channels dropdown
+    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
+    */
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
+  });
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
+  });
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSettingSlackV2,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('NotificationMethod - AsyncSelect should render for SlackV2 method', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    { name: 'general', id: 'C001', is_private: false, is_member: true },
+    { name: 'random', id: 'C002', is_private: false, is_member: true },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify AsyncSelect is rendered for SlackV2
+  await waitFor(() => {
+    expect(screen.getByTitle('Slack')).toBeInTheDocument();
+  });
+});
+
+test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API response', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  const { container } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify AsyncSelect container is present (not a textarea)
+  await waitFor(() => {
+    const textarea = container.querySelector(
+      'textarea[data-test="recipients"]',
     );
+    expect(textarea).toBeNull(); // Should NOT have textarea for SlackV2
+  });
+});
 
-    expect(
-      screen.getByText('Recipients are separated by "," or ";"'),
-    ).toBeInTheDocument();
+test('NotificationMethod - AsyncSelect should render refresh button for SlackV2', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify refresh button is present (icon only button)
+  await waitFor(() => {
+    const refreshButton = screen.getByTestId('refresh-slack-channels');
+    expect(refreshButton).toBeInTheDocument();
+    expect(refreshButton).toHaveAttribute('title', 'Refresh channels');
+  });
+});
+
+test('NotificationMethod - AsyncSelect should clear recipients and reload channels when refresh button clicked', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSettingSlackV2,
+        recipients: 'C123', // Pre-existing recipient
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for initial render
+  await waitFor(() => {
+    expect(screen.getByTestId('refresh-slack-channels')).toBeInTheDocument();
   });
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('RefreshLabel functionality', () => {
-    test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {
-      // Set feature flag so that SlackV2 branch renders RefreshLabel
-      window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-      // Spy on SupersetClient.get which is called by updateSlackOptions
-      const supersetClientSpy = jest
-        .spyOn(SupersetClient, 'get')
-        .mockImplementation(
-          () =>
-            Promise.resolve({ json: { result: [] } }) as unknown as Promise<
-              Response | JsonResponse | TextResponse
-            >,
-        );
+  // Click refresh button
+  const refreshButton = screen.getByTestId('refresh-slack-channels');
+  fireEvent.click(refreshButton);
 
-      render(
-        <NotificationMethod
-          setting={mockSettingSlackV2}
-          index={0}
-          onUpdate={mockOnUpdate}
-          onRemove={mockOnRemove}
-          onInputChange={mockOnInputChange}
-          email_subject={mockEmailSubject}
-          defaultSubject={mockDefaultSubject}
-          setErrorSubject={mockSetErrorSubject}
-        />,
-      );
-
-      // Wait for RefreshLabel to be rendered (it may have a tooltip with the provided content)
-      const refreshLabel = await waitFor(() => screen.getByLabelText('sync'));
-      // Simulate a click on the RefreshLabel
-      userEvent.click(refreshLabel);
-      // Verify that the SupersetClient.get was called indicating that updateSlackOptions executed
-      await waitFor(() => {
-        expect(supersetClientSpy).toHaveBeenCalled();
-      });
-    });
+  // Verify onUpdate was called with empty recipients
+  await waitFor(() => {
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        recipients: '',
+      }),
+    );
   });
 });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -208,6 +208,7 @@ const mockOnUpdate = jest.fn();
 const mockOnRemove = jest.fn();
 const mockOnInputChange = jest.fn();
 const mockSetErrorSubject = jest.fn();
+const mockAddDangerToast = jest.fn();
 
 const mockSetting: NotificationSetting = {
   method: NotificationMethodOption.Email,
@@ -248,6 +249,7 @@ test('NotificationMethod - should render the component', () => {
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -267,6 +269,7 @@ test('NotificationMethod - should call onRemove when the delete button is clicke
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -287,6 +290,7 @@ test('NotificationMethod - should update recipient value when input changes', ()
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -312,6 +316,7 @@ test('NotificationMethod - should call onRecipientsChange when the recipients va
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -573,6 +578,7 @@ test('shows the right combo when ff is false', async () => {
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -610,6 +616,7 @@ test('shows the textbox when the fetch fails', async () => {
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -652,6 +659,7 @@ test('shows the dropdown when ff is true and slackChannels succeed', async () =>
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -687,6 +695,7 @@ test('shows the textarea when ff is true and slackChannels fail', async () => {
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -722,6 +731,7 @@ test('shows the textarea when ff is true and slackChannels fail and slack is sel
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -750,6 +760,7 @@ test('shows the textarea when ff is true, slackChannels fail and slack is select
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -783,6 +794,7 @@ test('NotificationMethod - AsyncSelect should render for SlackV2 method', async 
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -821,6 +833,7 @@ test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API resp
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -862,6 +875,7 @@ test('NotificationMethod - AsyncSelect should render refresh button for SlackV2'
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -873,7 +887,7 @@ test('NotificationMethod - AsyncSelect should render refresh button for SlackV2'
   });
 });
 
-test('NotificationMethod - AsyncSelect should clear recipients and reload channels when refresh button clicked', async () => {
+test('NotificationMethod - AsyncSelect should reload channels without clearing recipients when refresh button clicked', async () => {
   window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
   const mockChannels = [
     {
@@ -884,7 +898,7 @@ test('NotificationMethod - AsyncSelect should clear recipients and reload channe
     },
   ];
 
-  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
     json: {
       result: mockChannels,
       next_cursor: null,
@@ -905,6 +919,7 @@ test('NotificationMethod - AsyncSelect should clear recipients and reload channe
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -913,19 +928,25 @@ test('NotificationMethod - AsyncSelect should clear recipients and reload channe
     expect(screen.getByTestId('refresh-slack-channels')).toBeInTheDocument();
   });
 
+  const initialCallCount = getSpy.mock.calls.length;
+
   // Click refresh button
   const refreshButton = screen.getByTestId('refresh-slack-channels');
   fireEvent.click(refreshButton);
 
-  // Verify onUpdate was called with empty recipients
+  // Verify the API was called again to reload channels
   await waitFor(() => {
-    expect(mockOnUpdate).toHaveBeenCalledWith(
-      0,
-      expect.objectContaining({
-        recipients: '',
-      }),
-    );
+    expect(getSpy.mock.calls.length).toBeGreaterThan(initialCallCount);
   });
+
+  // Verify onUpdate was NOT called with empty recipients (recipients should be preserved)
+  const updateCalls = mockOnUpdate.mock.calls;
+  const callsWithEmptyRecipients = updateCalls.filter(
+    call => call[1]?.recipients === '',
+  );
+  expect(callsWithEmptyRecipients).toHaveLength(0);
+
+  getSpy.mockRestore();
 });
 
 test('NotificationMethod - data cache prevents redundant API calls when selecting channels', async () => {
@@ -935,6 +956,16 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
     { name: 'general', id: 'C001', is_private: false, is_member: true },
     { name: 'random', id: 'C002', is_private: false, is_member: true },
   ];
+
+  const mockSettingWithoutRecipients: NotificationSetting = {
+    method: NotificationMethodOption.SlackV2,
+    recipients: '', // Empty to avoid initialization call
+    options: [
+      NotificationMethodOption.Email,
+      NotificationMethodOption.Slack,
+      NotificationMethodOption.SlackV2,
+    ],
+  };
 
   let callCount = 0;
   const getSpy = jest
@@ -954,7 +985,7 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
 
   const { getByRole } = render(
     <NotificationMethod
-      setting={mockSettingSlackV2}
+      setting={mockSettingWithoutRecipients}
       index={0}
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
@@ -962,6 +993,7 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
       email_subject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
     />,
   );
 
@@ -983,7 +1015,287 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
 
   await new Promise(resolve => setTimeout(resolve, 200));
 
+  // Should still be 1 because of caching
   expect(callCount).toBe(1);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - should preserve selected channels on refresh', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    { id: 'C001', name: 'general', is_private: false, is_member: true },
+    { id: 'C002', name: 'random', is_private: false, is_member: true },
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+  ];
+
+  const mockSettingWithRecipients: NotificationSetting = {
+    method: NotificationMethodOption.SlackV2,
+    recipients: 'C001,C002',
+    options: [
+      NotificationMethodOption.Email,
+      NotificationMethodOption.Slack,
+      NotificationMethodOption.SlackV2,
+    ],
+  };
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingWithRecipients}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  // Wait for initial load
+  await waitFor(
+    () => {
+      expect(getByTestId('refresh-slack-channels')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  const initialCallCount = getSpy.mock.calls.length;
+
+  // Find and click the refresh button
+  const refreshButton = getByTestId('refresh-slack-channels');
+  fireEvent.click(refreshButton);
+
+  // Wait for refresh to complete
+  await waitFor(
+    () => {
+      expect(getSpy.mock.calls.length).toBeGreaterThan(initialCallCount);
+    },
+    { timeout: 3000 },
+  );
+
+  // Verify that recipients are preserved (not cleared to empty string)
+  const updateCalls = mockOnUpdate.mock.calls;
+  const callsWithEmptyRecipients = updateCalls.filter(
+    call => call[1]?.recipients === '',
+  );
+  expect(callsWithEmptyRecipients).toHaveLength(0);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - should initialize Slack recipients when editing existing alert', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    { id: 'C001', name: 'general', is_private: false, is_member: true },
+    { id: 'C002', name: 'random', is_private: false, is_member: true },
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+  ];
+
+  const mockSettingWithRecipients: NotificationSetting = {
+    method: NotificationMethodOption.SlackV2,
+    recipients: 'C001,C002',
+    options: [
+      NotificationMethodOption.Email,
+      NotificationMethodOption.Slack,
+      NotificationMethodOption.SlackV2,
+    ],
+  };
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingWithRecipients}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  // Wait for the component to render and recipients dropdown to be available
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  // Verify that the component fetched channels for initialization
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  // Verify that the component attempted to initialize recipients
+  expect(getSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      endpoint: expect.stringContaining('/api/v1/report/slack_channels/'),
+    }),
+  );
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - should preserve selected channels during search and pagination', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  // Mock channels for different pages and search results
+  const page1Channels = [
+    { id: 'C001', name: 'general', is_private: false, is_member: true },
+    { id: 'C002', name: 'random', is_private: false, is_member: true },
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+  ];
+
+  const page2Channels = [
+    { id: 'C004', name: 'design', is_private: false, is_member: true },
+    { id: 'C005', name: 'product', is_private: false, is_member: true },
+  ];
+
+  const searchChannels = [
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+    { id: 'C006', name: 'eng-team', is_private: false, is_member: true },
+  ];
+
+  // Setting with pre-selected recipients
+  const mockSettingWithRecipients: NotificationSetting = {
+    method: NotificationMethodOption.SlackV2,
+    recipients: 'C001,C002', // Pre-selected: general, random
+    options: [
+      NotificationMethodOption.Email,
+      NotificationMethodOption.Slack,
+      NotificationMethodOption.SlackV2,
+    ],
+  };
+
+  // Mock API to return different results based on search string
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockImplementation(({ endpoint }) => {
+      const url = endpoint as string;
+      const isSearch = url.includes('search_string');
+      const isPage2 = url.includes('cursor');
+
+      let result;
+      let next_cursor = null;
+      let has_more = false;
+
+      if (isSearch) {
+        // Search returns matching channels
+        result = searchChannels;
+      } else if (isPage2) {
+        // Page 2 returns additional channels
+        result = page2Channels;
+      } else {
+        // Page 1 returns initial channels
+        result = page1Channels;
+        next_cursor = 'page2cursor';
+        has_more = true;
+      }
+
+      return Promise.resolve({
+        json: {
+          result,
+          next_cursor,
+          has_more,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>;
+    });
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingWithRecipients}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  // Wait for initial page to load
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  // Verify initial API call was made
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const initialCallCount = getSpy.mock.calls.length;
+
+  // Simulate search and pagination scenarios
+  // Note: AsyncSelect is complex to simulate directly, so we verify via API calls
+  // that selections aren't cleared during search and pagination operations
+
+  // Verify no calls to onUpdate cleared the recipients
+  let updateCalls = mockOnUpdate.mock.calls;
+  let callsWithEmptyRecipients = updateCalls.filter(
+    call => call[1]?.recipients === '',
+  );
+  expect(callsWithEmptyRecipients).toHaveLength(0);
+
+  // Simulate pagination by triggering additional API calls
+  // In the real component, this happens when user scrolls in AsyncSelect
+  await waitFor(
+    () => {
+      // The component should have made at least the initial call
+      expect(getSpy.mock.calls.length).toBeGreaterThanOrEqual(initialCallCount);
+    },
+    { timeout: 3000 },
+  );
+
+  // After pagination, verify recipients are still not cleared
+  updateCalls = mockOnUpdate.mock.calls;
+  callsWithEmptyRecipients = updateCalls.filter(
+    call => call[1]?.recipients === '',
+  );
+  expect(callsWithEmptyRecipients).toHaveLength(0);
+
+  // Verify that all onUpdate calls (if any) preserved the recipients
+  // Every call should either have no recipients field touched, or have recipients
+  const updateCallsWithEmptyRecipientsCheck = updateCalls.every(
+    call => !call[1]?.hasOwnProperty('recipients') || call[1].recipients !== '',
+  );
+  expect(updateCallsWithEmptyRecipientsCheck).toBe(true);
 
   getSpy.mockRestore();
 });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -45,6 +45,7 @@ import {
 } from '../types';
 import { StyledInputContainer } from '../AlertReportModal';
 import { styled, useTheme } from '@apache-superset/core/ui';
+import { useSlackChannels } from '../hooks/useSlackChannels';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
@@ -299,18 +300,15 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   );
 
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
-  const cursorRef = useRef<Record<string, string | null>>({});
-  const dataCache = useRef<
-    Record<
-      string,
-      { data: { label: string; value: string }[]; totalCount: number }
-    >
-  >({});
-  const forceRefreshRef = useRef(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   const hasShownErrorToast = useRef(false);
   const [searchGeneration, setSearchGeneration] = useState(0);
   const lastSearchValueRef = useRef('');
+
+  const {
+    fetchChannels: fetchSlackChannelsFromHook,
+    refreshChannels,
+    isRefreshing,
+  } = useSlackChannels(addDangerToast);
 
   const onMethodChange = (selected: {
     label: string;
@@ -343,69 +341,11 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       totalCount: number;
     }> => {
       try {
-        const cacheKey = `${search}:${page}`;
+        const result = await fetchSlackChannelsFromHook(search, page, pageSize);
 
-        if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
-          return dataCache.current[cacheKey];
-        }
+        hasShownErrorToast.current = false;
 
-        // Clear cache for previous searches to prevent stale data
-        if (page === 0) {
-          Object.keys(dataCache.current).forEach(key => {
-            if (!key.startsWith(`${search}:`)) {
-              delete dataCache.current[key];
-              delete cursorRef.current[key];
-            }
-          });
-        }
-
-        const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
-
-        const params: Record<string, any> = {
-          types: ['public_channel', 'private_channel'],
-          limit: pageSize,
-        };
-
-        if (page === 0 && forceRefreshRef.current) {
-          params.force = true;
-          forceRefreshRef.current = false;
-        }
-
-        if (search) {
-          params.search_string = search;
-        }
-
-        if (cursor) {
-          params.cursor = cursor;
-        }
-
-        const queryString = rison.encode(params);
-        const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
-        const response = await SupersetClient.get({ endpoint });
-
-        const { result, next_cursor, has_more } = response.json;
-
-        if (next_cursor) {
-          cursorRef.current[`${search}:${page + 1}`] = next_cursor;
-        }
-
-        const options = result.map((channel: SlackChannel) => ({
-          label: channel.name,
-          value: channel.id,
-        }));
-
-        const totalCount = has_more
-          ? (page + 1) * pageSize + 1
-          : page * pageSize + options.length;
-
-        const responseData = {
-          data: options,
-          totalCount,
-        };
-
-        dataCache.current[cacheKey] = responseData;
-
-        return responseData;
+        return result;
       } catch (error) {
         logging.error('Failed to fetch Slack channels:', error);
 
@@ -445,33 +385,17 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     // Purpose: Trigger function reference change when search changes (after debounce)
     // Effect: Forces AsyncSelect to clear internal state and show fresh results
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [addDangerToast, onUpdate, setting, index, searchGeneration],
+    [
+      fetchSlackChannelsFromHook,
+      addDangerToast,
+      onUpdate,
+      setting,
+      index,
+      searchGeneration,
+    ],
   );
 
-  const handleRefreshSlackChannels = async () => {
-    setIsRefreshing(true);
-
-    try {
-      // Clear cache and cursor to force fresh data fetch
-      forceRefreshRef.current = true;
-      cursorRef.current = {};
-      dataCache.current = {};
-
-      // Fetch fresh channel list without clearing user selections
-      await fetchSlackChannels('', 0, 100);
-    } catch (error) {
-      logging.error('Error refreshing channels:', error);
-
-      // Show error toast if available
-      if (addDangerToast) {
-        addDangerToast(
-          t('Failed to refresh Slack channels. Please try again.'),
-        );
-      }
-    } finally {
-      setIsRefreshing(false);
-    }
-  };
+  const handleRefreshSlackChannels = refreshChannels;
 
   useEffect(() => {
     if (recipients !== undefined && recipientValue !== recipients) {
@@ -530,10 +454,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     };
 
     initializeSlackRecipients();
-    // Note: fetchSlackChannels and slackRecipients are intentionally omitted
-    // - fetchSlackChannels: Would cause re-initialization on every search change
-    // - slackRecipients: Would cause infinite loop (we modify it inside)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, recipients]);
 
   const debouncedSearchUpdate = useMemo(

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -24,7 +24,9 @@ import {
   ChangeEvent,
   useMemo,
   useRef,
+  useCallback,
 } from 'react';
+import { debounce } from 'lodash';
 import rison from 'rison';
 
 import { t } from '@apache-superset/core/translation';
@@ -42,7 +44,7 @@ import {
   SlackChannel,
 } from '../types';
 import { StyledInputContainer } from '../AlertReportModal';
-import { styled, useTheme } from '@apache-superset/core';
+import { styled, useTheme } from '@apache-superset/core/ui';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
@@ -304,10 +306,11 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       { data: { label: string; value: string }[]; totalCount: number }
     >
   >({});
-  const [refreshKey, setRefreshKey] = useState(0);
   const forceRefreshRef = useRef(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const hasShownErrorToast = useRef(false); // Track if we've shown the error toast
+  const hasShownErrorToast = useRef(false);
+  const [searchGeneration, setSearchGeneration] = useState(0);
+  const lastSearchValueRef = useRef('');
 
   const onMethodChange = (selected: {
     label: string;
@@ -330,105 +333,120 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const fetchSlackChannels = async (
-    search: string,
-    page: number,
-    pageSize: number,
-  ): Promise<{
-    data: { label: string; value: string }[];
-    totalCount: number;
-  }> => {
-    try {
-      const cacheKey = `${search}:${page}`;
+  const fetchSlackChannels = useCallback(
+    async (
+      search: string,
+      page: number,
+      pageSize: number,
+    ): Promise<{
+      data: { label: string; value: string }[];
+      totalCount: number;
+    }> => {
+      try {
+        const cacheKey = `${search}:${page}`;
 
-      if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
-        return dataCache.current[cacheKey];
+        if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
+          return dataCache.current[cacheKey];
+        }
+
+        // Clear cache for previous searches to prevent stale data
+        if (page === 0) {
+          Object.keys(dataCache.current).forEach(key => {
+            if (!key.startsWith(`${search}:`)) {
+              delete dataCache.current[key];
+              delete cursorRef.current[key];
+            }
+          });
+        }
+
+        const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
+
+        const params: Record<string, any> = {
+          types: ['public_channel', 'private_channel'],
+          limit: pageSize,
+        };
+
+        if (page === 0 && forceRefreshRef.current) {
+          params.force = true;
+          forceRefreshRef.current = false;
+        }
+
+        if (search) {
+          params.search_string = search;
+        }
+
+        if (cursor) {
+          params.cursor = cursor;
+        }
+
+        const queryString = rison.encode(params);
+        const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+        const response = await SupersetClient.get({ endpoint });
+
+        const { result, next_cursor, has_more } = response.json;
+
+        if (next_cursor) {
+          cursorRef.current[`${search}:${page + 1}`] = next_cursor;
+        }
+
+        const options = result.map((channel: SlackChannel) => ({
+          label: channel.name,
+          value: channel.id,
+        }));
+
+        const totalCount = has_more
+          ? (page + 1) * pageSize + 1
+          : page * pageSize + options.length;
+
+        const responseData = {
+          data: options,
+          totalCount,
+        };
+
+        dataCache.current[cacheKey] = responseData;
+
+        return responseData;
+      } catch (error) {
+        logging.error('Failed to fetch Slack channels:', error);
+
+        // Show user-friendly error message
+        if (addDangerToast && !hasShownErrorToast.current) {
+          addDangerToast(
+            t(
+              'Unable to load Slack channels. Please check your Slack API token configuration. ' +
+                'Switching to manual channel input.',
+            ),
+          );
+          hasShownErrorToast.current = true;
+        }
+
+        // Fallback to Slack v1 without clearing recipients to prevent data loss
+        setUseSlackV1(true);
+
+        // Auto-switch to Slack V1 in the notification method dropdown
+        if (
+          onUpdate &&
+          setting &&
+          setting.method === NotificationMethodOption.SlackV2
+        ) {
+          onUpdate(index, {
+            ...setting,
+            method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
+          });
+        }
+
+        return {
+          data: [],
+          totalCount: 0,
+        };
       }
-
-      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
-
-      const params: Record<string, any> = {
-        types: ['public_channel', 'private_channel'],
-        limit: pageSize,
-      };
-
-      if (page === 0 && forceRefreshRef.current) {
-        params.force = true;
-        forceRefreshRef.current = false;
-      }
-
-      if (search) {
-        params.search_string = search;
-      }
-
-      if (cursor) {
-        params.cursor = cursor;
-      }
-
-      const queryString = rison.encode(params);
-      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
-      const response = await SupersetClient.get({ endpoint });
-
-      const { result, next_cursor, has_more } = response.json;
-
-      if (next_cursor) {
-        cursorRef.current[`${search}:${page + 1}`] = next_cursor;
-      }
-
-      const options = result.map((channel: SlackChannel) => ({
-        label: channel.name,
-        value: channel.id,
-      }));
-
-      const totalCount = has_more
-        ? (page + 1) * pageSize + 1
-        : page * pageSize + options.length;
-
-      const responseData = {
-        data: options,
-        totalCount,
-      };
-
-      dataCache.current[cacheKey] = responseData;
-
-      return responseData;
-    } catch (error) {
-      logging.error('Failed to fetch Slack channels:', error);
-
-      // Show user-friendly error message
-      if (addDangerToast && !hasShownErrorToast.current) {
-        addDangerToast(
-          t(
-            'Unable to load Slack channels. Please check your Slack API token configuration. ' +
-              'Switching to manual channel input.',
-          ),
-        );
-        hasShownErrorToast.current = true;
-      }
-
-      // Fallback to Slack v1 without clearing recipients to prevent data loss
-      setUseSlackV1(true);
-
-      // Auto-switch to Slack V1 in the notification method dropdown
-      if (
-        onUpdate &&
-        setting &&
-        setting.method === NotificationMethodOption.SlackV2
-      ) {
-        onUpdate(index, {
-          ...setting,
-          method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
-          // Keep recipients to preserve user data
-        });
-      }
-
-      // Return empty result instead of throwing to allow UI to continue
-      return {
-        data: [],
-        totalCount: 0,
-      };
-    }
-  };
+    },
+    // Note: searchGeneration is intentionally included even though not used in function body
+    // Purpose: Trigger function reference change when search changes (after debounce)
+    // Effect: Forces AsyncSelect to clear internal state and show fresh results
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [addDangerToast, onUpdate, setting, index, searchGeneration],
+  );
 
   const handleRefreshSlackChannels = async () => {
     setIsRefreshing(true);
@@ -441,8 +459,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       // Fetch fresh channel list without clearing user selections
       await fetchSlackChannels('', 0, 100);
-
-      setRefreshKey(prev => prev + 1);
     } catch (error) {
       logging.error('Error refreshing channels:', error);
 
@@ -514,8 +530,28 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     };
 
     initializeSlackRecipients();
+    // Note: fetchSlackChannels and slackRecipients are intentionally omitted
+    // - fetchSlackChannels: Would cause re-initialization on every search change
+    // - slackRecipients: Would cause infinite loop (we modify it inside)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, recipients]);
+
+  const debouncedSearchUpdate = useMemo(
+    () =>
+      debounce((search: string) => {
+        const trimmedSearch = search.trim();
+        if (lastSearchValueRef.current !== trimmedSearch) {
+          lastSearchValueRef.current = trimmedSearch;
+          setSearchGeneration(prev => prev + 1);
+        }
+      }, 500),
+    [],
+  );
+
+  useEffect(
+    () => () => debouncedSearchUpdate.cancel(),
+    [debouncedSearchUpdate],
+  );
 
   const methodOptions = useMemo(
     () =>
@@ -598,6 +634,10 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       onUpdate(index, updatedSetting);
     }
+  };
+
+  const handleSlackSearch = (search: string) => {
+    debouncedSearchUpdate(search);
   };
 
   const onSubjectChange = (

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -154,7 +154,7 @@ interface NotificationMethodProps {
   onInputChange?: (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => void;
-  emailSubject: string;
+  email_subject: string;
   defaultSubject: string;
   setErrorSubject: (hasError: boolean) => void;
   addDangerToast?: (msg: string) => void;
@@ -267,7 +267,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   onUpdate,
   onRemove,
   onInputChange,
-  emailSubject,
+  email_subject,
   defaultSubject,
   setErrorSubject,
   addDangerToast,
@@ -619,7 +619,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                     <Input
                       type="text"
                       name="email_subject"
-                      value={emailSubject}
+                      value={email_subject}
                       placeholder={defaultSubject}
                       onChange={onSubjectChange}
                     />

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -341,7 +341,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       totalCount: number;
     }> => {
       try {
-        const result = await fetchSlackChannelsFromHook(search, page, pageSize);
+        const result = await fetchSlackChannelsFromHook({ search, page, pageSize });
 
         hasShownErrorToast.current = false;
 

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -294,6 +294,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
   const cursorRef = useRef<Record<string, string | null>>({});
+  const dataCache = useRef<
+    Record<
+      string,
+      { data: { label: string; value: string }[]; totalCount: number }
+    >
+  >({});
   const [refreshKey, setRefreshKey] = useState(0);
   const forceRefreshRef = useRef(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -329,6 +335,11 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   }> => {
     try {
       const cacheKey = `${search}:${page}`;
+
+      if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
+        return dataCache.current[cacheKey];
+      }
+
       const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
 
       const params: Record<string, any> = {
@@ -365,16 +376,24 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       }));
 
       const totalCount = has_more
-        ? (page + 1) * pageSize + 1 // Fake "has more"
-        : page * pageSize + options.length; // Last page
+        ? (page + 1) * pageSize + 1
+        : page * pageSize + options.length;
 
-      return {
+      const responseData = {
         data: options,
         totalCount,
       };
+
+      dataCache.current[cacheKey] = responseData;
+
+      return responseData;
     } catch (error) {
       console.error('Failed to fetch Slack channels:', error);
       setUseSlackV1(true);
+      onMethodChange({
+        label: NotificationMethodOption.Slack,
+        value: NotificationMethodOption.Slack,
+      });
       throw error;
     }
   };
@@ -385,6 +404,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     try {
       forceRefreshRef.current = true;
       cursorRef.current = {};
+      dataCache.current = {};
 
       setSlackRecipients([]);
 

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -18,24 +18,23 @@
  */
 import {
   FunctionComponent,
+  useEffect,
   useState,
   ChangeEvent,
-  useEffect,
   useMemo,
+  useRef,
 } from 'react';
 import rison from 'rison';
 
 import { t } from '@apache-superset/core/translation';
 import {
   FeatureFlag,
-  JsonResponse,
   SupersetClient,
   isFeatureEnabled,
 } from '@superset-ui/core';
 import { styled, useTheme } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { AsyncSelect, Input, Select } from '@superset-ui/core/components';
-import RefreshLabel from '@superset-ui/core/components/RefreshLabel';
 import {
   NotificationMethodOption,
   NotificationSetting,
@@ -76,6 +75,17 @@ const StyledNotificationMethod = styled.div`
         margin-left: ${theme.sizeUnit * 2}px;
         padding-top: ${theme.sizeUnit}px;
       }
+
+      .refresh-button {
+        margin-left: ${theme.sizeUnit * 2}px;
+        cursor: pointer;
+        color: ${theme.colorTextSecondary};
+
+        &:hover {
+          color: ${theme.colorPrimary};
+        }
+      }
+
       .anticon {
         margin-left: ${theme.sizeUnit}px;
       }
@@ -165,47 +175,6 @@ export const mapSlackValues = ({
     .filter(val => !!val) as { label: string; value: string }[];
 };
 
-export const mapChannelsToOptions = (result: SlackChannel[]) => {
-  const publicChannels: SlackChannel[] = [];
-  const privateChannels: SlackChannel[] = [];
-
-  result.forEach(channel => {
-    if (channel.is_private) {
-      privateChannels.push(channel);
-    } else {
-      publicChannels.push(channel);
-    }
-  });
-
-  return [
-    {
-      label: 'Public Channels',
-      options: publicChannels.map((channel: SlackChannel) => ({
-        label: `${channel.name} ${
-          channel.is_member ? '' : t('(Bot not in channel)')
-        }`,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'public',
-    },
-    {
-      label: t('Private Channels (Bot in channel)'),
-      options: privateChannels.map((channel: SlackChannel) => ({
-        label: channel.name,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'private',
-    },
-  ];
-};
-
-type SlackOptionsType = {
-  label: string;
-  options: { label: string; value: string }[];
-}[];
-
 type EmailRecipientField = 'recipients' | 'cc' | 'bcc';
 
 type EmailRecipientOption = {
@@ -285,6 +254,7 @@ const fetchEmailRecipientOptions = async (
   };
 };
 
+
 export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   setting = null,
   index,
@@ -308,14 +278,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [ccValue, setCcValue] = useState<string>(cc || '');
   const [bccValue, setBccValue] = useState<string>(bcc || '');
   const theme = useTheme();
-  const [methodOptionsLoading, setMethodOptionsLoading] =
-    useState<boolean>(true);
-  const [slackOptions, setSlackOptions] = useState<SlackOptionsType>([
-    {
-      label: '',
-      options: [],
-    },
-  ]);
   const recipientEmailOptions = useMemo(
     () => recipientStringToOptions(recipientValue),
     [recipientValue],
@@ -329,15 +291,17 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     [bccValue],
   );
 
+
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
-  const [isSlackChannelsLoading, setIsSlackChannelsLoading] =
-    useState<boolean>(true);
+  const cursorRef = useRef<Record<string, string | null>>({});
+  const [refreshKey, setRefreshKey] = useState(0);
+  const forceRefreshRef = useRef(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const onMethodChange = (selected: {
     label: string;
     value: NotificationMethodOption;
   }) => {
-    // Since we're swapping the method, reset the recipients
     setRecipientValue('');
     setCcValue('');
     setBccValue('');
@@ -355,84 +319,91 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const fetchSlackChannels = async ({
-    searchString = '',
-    types = [],
-    exactMatch = false,
-    force = false,
-  }: {
-    searchString?: string | undefined;
-    types?: string[];
-    exactMatch?: boolean | undefined;
-    force?: boolean | undefined;
-  } = {}): Promise<JsonResponse> => {
-    const queryString = rison.encode({
-      searchString,
-      types,
-      exactMatch,
-      force,
-    });
-    const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
-    return SupersetClient.get({ endpoint });
-  };
+  const fetchSlackChannels = async (
+    search: string,
+    page: number,
+    pageSize: number,
+  ): Promise<{
+    data: { label: string; value: string }[];
+    totalCount: number;
+  }> => {
+    try {
+      const cacheKey = `${search}:${page}`;
+      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
 
-  const updateSlackOptions = async ({
-    force,
-  }: {
-    force?: boolean | undefined;
-  } = {}) => {
-    setIsSlackChannelsLoading(true);
-    fetchSlackChannels({ types: ['public_channel', 'private_channel'], force })
-      .then(({ json }) => {
-        const { result } = json;
-        const options: SlackOptionsType = mapChannelsToOptions(result);
+      const params: Record<string, any> = {
+        types: ['public_channel', 'private_channel'],
+        limit: pageSize,
+      };
 
-        setSlackOptions(options);
+      if (page === 0 && forceRefreshRef.current) {
+        params.force = true;
+        forceRefreshRef.current = false;
+      }
 
-        if (isFeatureEnabled(FeatureFlag.AlertReportSlackV2)) {
-          // for edit mode, map existing ids to names for display if slack v2
-          // or names to ids if slack v1
-          const [publicOptions, privateOptions] = options;
-          if (
-            method &&
-            [
-              NotificationMethodOption.SlackV2,
-              NotificationMethodOption.Slack,
-            ].includes(method)
-          ) {
-            setSlackRecipients(
-              mapSlackValues({
-                method,
-                recipientValue,
-                slackOptions: [
-                  ...publicOptions.options,
-                  ...privateOptions.options,
-                ],
-              }),
-            );
-          }
-        }
-      })
-      .catch(() => {
-        // Fallback to slack v1 if slack v2 is not compatible
-        setUseSlackV1(true);
-      })
-      .finally(() => {
-        setMethodOptionsLoading(false);
-        setIsSlackChannelsLoading(false);
-      });
-  };
+      if (search) {
+        params.search_string = search;
+      }
 
-  useEffect(() => {
-    const slackEnabled = options?.some(
-      option =>
-        option === NotificationMethodOption.Slack ||
-        option === NotificationMethodOption.SlackV2,
-    );
-    if (slackEnabled && !slackOptions[0]?.options.length) {
-      updateSlackOptions();
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const queryString = rison.encode(params);
+      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+      const response = await SupersetClient.get({ endpoint });
+
+      const { result, next_cursor, has_more } = response.json;
+
+      if (next_cursor) {
+        cursorRef.current[`${search}:${page + 1}`] = next_cursor;
+      }
+
+      const options = result.map((channel: SlackChannel) => ({
+        label: channel.name,
+        value: channel.id,
+      }));
+
+      const totalCount = has_more
+        ? (page + 1) * pageSize + 1 // Fake "has more"
+        : page * pageSize + options.length; // Last page
+
+      return {
+        data: options,
+        totalCount,
+      };
+    } catch (error) {
+      console.error('Failed to fetch Slack channels:', error);
+      setUseSlackV1(true);
+      throw error;
     }
-  }, []);
+  };
+
+  const handleRefreshSlackChannels = async () => {
+    setIsRefreshing(true);
+
+    try {
+      forceRefreshRef.current = true;
+      cursorRef.current = {};
+
+      setSlackRecipients([]);
+
+      if (onUpdate && setting) {
+        onUpdate(index, {
+          ...setting,
+          recipients: '',
+        } as NotificationSetting);
+      }
+
+      await fetchSlackChannels('', 0, 100);
+
+      setRefreshKey(prev => prev + 1);
+    } catch (error) {
+      console.error('Error refreshing channels:', error);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
 
   useEffect(() => {
     if (recipients !== undefined && recipientValue !== recipients) {
@@ -566,7 +537,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               options={methodOptions}
               showSearch
               value={methodOptions.find(option => option.value === method)}
-              loading={methodOptionsLoading}
             />
             {index !== 0 && !!onRemove ? (
               <span
@@ -663,26 +633,32 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                       </div>
                     </div>
                   ) : (
-                    // for SlackV2
                     <div className="input-container">
-                      <Select
+                      <AsyncSelect
+                        key={refreshKey}
                         ariaLabel={t('Select channels')}
                         mode="multiple"
                         name="recipients"
                         value={slackRecipients}
-                        options={slackOptions}
+                        options={fetchSlackChannels}
                         onChange={onSlackRecipientsChange}
                         allowClear
                         data-test="recipients"
-                        loading={isSlackChannelsLoading}
-                        allowSelectAll={false}
-                        labelInValue
+                        fetchOnlyOnSearch={false}
+                        pageSize={100}
+                        placeholder={t('Select Slack channels')}
                       />
-                      <RefreshLabel
-                        onClick={() => updateSlackOptions({ force: true })}
-                        tooltipContent={t('Force refresh Slack channels list')}
-                        disabled={isSlackChannelsLoading}
-                      />
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        className="refresh-button"
+                        onClick={handleRefreshSlackChannels}
+                        data-test="refresh-slack-channels"
+                        title={t('Refresh channels')}
+                        style={{ opacity: isRefreshing ? 0.5 : 1 }}
+                      >
+                        <Icons.SyncOutlined iconSize="l" spin={isRefreshing} />
+                      </span>
                     </div>
                   )}
                 </div>

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -31,8 +32,8 @@ import {
   FeatureFlag,
   SupersetClient,
   isFeatureEnabled,
+  logging,
 } from '@superset-ui/core';
-import { styled, useTheme } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { AsyncSelect, Input, Select } from '@superset-ui/core/components';
 import {
@@ -41,6 +42,7 @@ import {
   SlackChannel,
 } from '../types';
 import { StyledInputContainer } from '../AlertReportModal';
+import { styled, useTheme } from '@apache-superset/core';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
@@ -149,9 +151,10 @@ interface NotificationMethodProps {
   onInputChange?: (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => void;
-  email_subject: string;
+  emailSubject: string;
   defaultSubject: string;
   setErrorSubject: (hasError: boolean) => void;
+  addDangerToast?: (msg: string) => void;
 }
 
 export const mapSlackValues = ({
@@ -261,10 +264,13 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   onUpdate,
   onRemove,
   onInputChange,
-  email_subject,
+  emailSubject,
   defaultSubject,
   setErrorSubject,
+  addDangerToast,
 }) => {
+  const theme = useTheme();
+
   const { method, recipients, cc, bcc, options } = setting || {};
   const [recipientValue, setRecipientValue] = useState<string>(
     recipients || '',
@@ -277,7 +283,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [bccVisible, setBccVisible] = useState<boolean>(!!bcc);
   const [ccValue, setCcValue] = useState<string>(cc || '');
   const [bccValue, setBccValue] = useState<string>(bcc || '');
-  const theme = useTheme();
   const recipientEmailOptions = useMemo(
     () => recipientStringToOptions(recipientValue),
     [recipientValue],
@@ -291,7 +296,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     [bccValue],
   );
 
-
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
   const cursorRef = useRef<Record<string, string | null>>({});
   const dataCache = useRef<
@@ -303,6 +307,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [refreshKey, setRefreshKey] = useState(0);
   const forceRefreshRef = useRef(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const hasShownErrorToast = useRef(false); // Track if we've shown the error toast
 
   const onMethodChange = (selected: {
     label: string;
@@ -388,13 +393,40 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       return responseData;
     } catch (error) {
-      console.error('Failed to fetch Slack channels:', error);
+      logging.error('Failed to fetch Slack channels:', error);
+
+      // Show user-friendly error message
+      if (addDangerToast && !hasShownErrorToast.current) {
+        addDangerToast(
+          t(
+            'Unable to load Slack channels. Please check your Slack API token configuration. ' +
+              'Switching to manual channel input.',
+          ),
+        );
+        hasShownErrorToast.current = true;
+      }
+
+      // Fallback to Slack v1 without clearing recipients to prevent data loss
       setUseSlackV1(true);
-      onMethodChange({
-        label: NotificationMethodOption.Slack,
-        value: NotificationMethodOption.Slack,
-      });
-      throw error;
+
+      // Auto-switch to Slack V1 in the notification method dropdown
+      if (
+        onUpdate &&
+        setting &&
+        setting.method === NotificationMethodOption.SlackV2
+      ) {
+        onUpdate(index, {
+          ...setting,
+          method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
+          // Keep recipients to preserve user data
+        });
+      }
+
+      // Return empty result instead of throwing to allow UI to continue
+      return {
+        data: [],
+        totalCount: 0,
+      };
     }
   };
 
@@ -402,24 +434,24 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     setIsRefreshing(true);
 
     try {
+      // Clear cache and cursor to force fresh data fetch
       forceRefreshRef.current = true;
       cursorRef.current = {};
       dataCache.current = {};
 
-      setSlackRecipients([]);
-
-      if (onUpdate && setting) {
-        onUpdate(index, {
-          ...setting,
-          recipients: '',
-        } as NotificationSetting);
-      }
-
+      // Fetch fresh channel list without clearing user selections
       await fetchSlackChannels('', 0, 100);
 
       setRefreshKey(prev => prev + 1);
     } catch (error) {
-      console.error('Error refreshing channels:', error);
+      logging.error('Error refreshing channels:', error);
+
+      // Show error toast if available
+      if (addDangerToast) {
+        addDangerToast(
+          t('Failed to refresh Slack channels. Please try again.'),
+        );
+      }
     } finally {
       setIsRefreshing(false);
     }
@@ -442,6 +474,48 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       setBccValue(bcc);
     }
   }, [bcc, bccValue]);
+
+  // Reset error toast flag when method changes
+  useEffect(() => {
+    hasShownErrorToast.current = false;
+  }, [method]);
+
+  // Initialize slackRecipients when editing an existing alert with SlackV2
+  useEffect(() => {
+    const initializeSlackRecipients = async () => {
+      if (
+        method === NotificationMethodOption.SlackV2 &&
+        recipients &&
+        slackRecipients.length === 0
+      ) {
+        try {
+          const channelData = await fetchSlackChannels('', 0, 100);
+          const recipientIds = recipients.split(',').map(id => id.trim());
+
+          const mappedRecipients = recipientIds
+            .map(id => {
+              const channel = channelData.data.find(
+                ch => ch.value.toLowerCase() === id.toLowerCase(),
+              );
+              return channel || { label: id, value: id };
+            })
+            .filter(r => r.value);
+
+          setSlackRecipients(mappedRecipients);
+        } catch (error) {
+          const recipientIds = recipients.split(',').map(id => id.trim());
+          const fallbackRecipients = recipientIds.map(id => ({
+            label: id,
+            value: id,
+          }));
+          setSlackRecipients(fallbackRecipients);
+        }
+      }
+    };
+
+    initializeSlackRecipients();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method, recipients]);
 
   const methodOptions = useMemo(
     () =>
@@ -585,7 +659,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                     <Input
                       type="text"
                       name="email_subject"
-                      value={email_subject}
+                      value={emailSubject}
                       placeholder={defaultSubject}
                       onChange={onSubjectChange}
                     />

--- a/superset-frontend/src/features/alerts/hooks/useSlackChannels.test.ts
+++ b/superset-frontend/src/features/alerts/hooks/useSlackChannels.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { SupersetClient } from '@superset-ui/core';
+import { useSlackChannels } from './useSlackChannels';
+
+// Mock SupersetClient
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  SupersetClient: {
+    get: jest.fn(),
+  },
+  logging: {
+    error: jest.fn(),
+  },
+}));
+
+const mockChannels = [
+  { id: 'C001', name: 'general', is_private: false },
+  { id: 'C002', name: 'engineering', is_private: false },
+  { id: 'C003', name: 'random', is_private: false },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('fetches channels successfully', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  const channels = await result.current.fetchChannels('', 0, 100);
+
+  expect(channels.data).toHaveLength(3);
+  expect(channels.data[0]).toEqual({ label: 'general', value: 'C001' });
+  expect(channels.totalCount).toBe(3);
+});
+
+test('caches results and avoids duplicate requests', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First call
+  await result.current.fetchChannels('', 0, 100);
+
+  // Second call with same parameters
+  await result.current.fetchChannels('', 0, 100);
+
+  // Should only call API once
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+});
+
+test('deduplicates concurrent requests', async () => {
+  (SupersetClient.get as jest.Mock).mockImplementation(
+    () =>
+      new Promise(resolve =>
+        setTimeout(
+          () =>
+            resolve({
+              json: {
+                result: mockChannels,
+                next_cursor: null,
+                has_more: false,
+              },
+            }),
+          100,
+        ),
+      ),
+  );
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // Make concurrent requests
+  const promise1 = result.current.fetchChannels('', 0, 100);
+  const promise2 = result.current.fetchChannels('', 0, 100);
+
+  const [result1, result2] = await Promise.all([promise1, promise2]);
+
+  // Should return same data
+  expect(result1).toEqual(result2);
+
+  // Should only call API once
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+});
+
+test('clears cache when search changes', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First search
+  await result.current.fetchChannels('eng', 0, 100);
+
+  // Different search
+  await result.current.fetchChannels('gen', 0, 100);
+
+  // Should call API twice (once for each search)
+  expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+});
+
+test('handles pagination with cursors', async () => {
+  (SupersetClient.get as jest.Mock)
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(0, 2),
+        next_cursor: 'cursor_page_2',
+        has_more: true,
+      },
+    })
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(2),
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First page
+  const page1 = await result.current.fetchChannels('', 0, 2);
+  expect(page1.data).toHaveLength(2);
+  expect(page1.has_more).toBe(true);
+
+  // Second page
+  const page2 = await result.current.fetchChannels('', 1, 2);
+  expect(page2.data).toHaveLength(1);
+});
+
+test('refreshChannels clears cache and refetches', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // Initial fetch
+  await result.current.fetchChannels('', 0, 100);
+
+  // Cache hit - no new API call
+  await result.current.fetchChannels('', 0, 100);
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+
+  // Refresh
+  await result.current.refreshChannels();
+
+  // Should call API again
+  expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+});
+
+test('isRefreshing state updates correctly', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  expect(result.current.isRefreshing).toBe(false);
+
+  await result.current.refreshChannels();
+
+  // Should be false after refresh completes
+  expect(result.current.isRefreshing).toBe(false);
+});
+
+test('calls onError callback when fetch fails', async () => {
+  (SupersetClient.get as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+  const onError = jest.fn();
+  const { result } = renderHook(() => useSlackChannels(onError));
+
+  await result.current.fetchChannels('', 0, 100);
+
+  expect(onError).toHaveBeenCalledWith(
+    expect.stringContaining('Unable to load Slack channels'),
+  );
+});
+
+test('returns empty data on error', async () => {
+  (SupersetClient.get as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  const channels = await result.current.fetchChannels('', 0, 100);
+
+  expect(channels.data).toEqual([]);
+  expect(channels.totalCount).toBe(0);
+});
+
+test('includes search_string in API params when provided', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: [],
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  await result.current.fetchChannels('engineering', 0, 100);
+
+  expect(SupersetClient.get).toHaveBeenCalledWith({
+    endpoint: expect.stringContaining('search_string'),
+  });
+});
+
+test('includes cursor in API params for pagination', async () => {
+  (SupersetClient.get as jest.Mock)
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(0, 2),
+        next_cursor: 'test_cursor',
+        has_more: true,
+      },
+    })
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(2),
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First page
+  await result.current.fetchChannels('', 0, 2);
+
+  // Second page
+  await result.current.fetchChannels('', 1, 2);
+
+  expect(SupersetClient.get).toHaveBeenCalledWith({
+    endpoint: expect.stringContaining('cursor'),
+  });
+});

--- a/superset-frontend/src/features/alerts/hooks/useSlackChannels.ts
+++ b/superset-frontend/src/features/alerts/hooks/useSlackChannels.ts
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { logging, SupersetClient, t } from '@superset-ui/core';
+import rison from 'rison';
+import { SlackChannel } from '../types';
+
+export interface SlackChannelOption {
+  label: string;
+  value: string;
+}
+
+export interface SlackChannelsResult {
+  data: SlackChannelOption[];
+  totalCount: number;
+  has_more?: boolean;
+  next_cursor?: string | null;
+}
+
+export interface UseSlackChannelsResult {
+  fetchChannels: (
+    search: string,
+    page: number,
+    pageSize: number,
+  ) => Promise<SlackChannelsResult>;
+  refreshChannels: () => Promise<void>;
+  isRefreshing: boolean;
+}
+
+/**
+ * Cache types for managing Slack channel data
+ */
+type CursorCache = Record<string, string | null>;
+type DataCache = Record<string, SlackChannelsResult>;
+type PendingRequestsCache = Record<string, Promise<SlackChannelsResult>>;
+
+/**
+ * Custom hook for managing Slack channels with caching and pagination
+ */
+export function useSlackChannels(
+  onError?: (message: string) => void,
+): UseSlackChannelsResult {
+  const cursorRef = useRef<CursorCache>({});
+  const dataCache = useRef<DataCache>({});
+  const pendingRequests = useRef<PendingRequestsCache>({});
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const fetchChannels = useCallback(
+    async (
+      search: string,
+      page: number,
+      pageSize: number,
+    ): Promise<SlackChannelsResult> => {
+      const cacheKey = `${search}:${page}`;
+
+      if (dataCache.current[cacheKey]) {
+        return dataCache.current[cacheKey];
+      }
+
+      if (cacheKey in pendingRequests.current) {
+        return pendingRequests.current[cacheKey];
+      }
+
+      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
+
+      const params: Record<string, any> = {
+        types: ['public_channel', 'private_channel'],
+        limit: pageSize,
+      };
+
+      if (search) {
+        params.search_string = search;
+      }
+
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const queryString = rison.encode(params);
+      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+
+      const fetchPromise = (async () => {
+        try {
+          const response = await SupersetClient.get({ endpoint });
+
+          const {
+            result,
+            next_cursor: nextCursor,
+            has_more: hasMore,
+          } = response.json;
+
+          if (nextCursor) {
+            cursorRef.current[`${search}:${page + 1}`] = nextCursor;
+          }
+
+          const options = result.map((channel: SlackChannel) => ({
+            label: channel.name,
+            value: channel.id,
+          }));
+
+          const totalCount = hasMore
+            ? (page + 1) * pageSize + 1
+            : page * pageSize + options.length;
+
+          const responseData = {
+            data: options,
+            totalCount,
+            has_more: hasMore,
+            next_cursor: nextCursor,
+          };
+
+          dataCache.current[cacheKey] = responseData;
+
+          return responseData;
+        } catch (error) {
+          logging.error('Failed to fetch Slack channels:', error);
+
+          if (onError) {
+            onError(
+              t(
+                'Unable to load Slack channels. Please check your Slack API token configuration.',
+              ),
+            );
+          }
+
+          return {
+            data: [],
+            totalCount: 0,
+          };
+        } finally {
+          delete pendingRequests.current[cacheKey];
+        }
+      })();
+
+      pendingRequests.current[cacheKey] = fetchPromise;
+
+      return fetchPromise;
+    },
+    [onError],
+  );
+
+  const refreshChannels = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      cursorRef.current = {};
+      dataCache.current = {};
+      pendingRequests.current = {};
+
+      await fetchChannels('', 0, 100);
+    } catch (error) {
+      logging.error('Error refreshing channels:', error);
+
+      if (onError) {
+        onError(t('Failed to refresh Slack channels. Please try again.'));
+      }
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [fetchChannels, onError]);
+
+  return {
+    fetchChannels,
+    refreshChannels,
+    isRefreshing,
+  };
+}

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -187,7 +187,7 @@ class BaseReportState:
                 channel_names = (slack_recipients["target"] or "").replace("#", "")
                 # we need to ensure that existing reports can also fetch
                 # ids from private channels
-                channels = get_channels_with_search(
+                channels_data = get_channels_with_search(
                     search_string=channel_names,
                     types=[
                         SlackChannelTypes.PRIVATE,
@@ -195,6 +195,7 @@ class BaseReportState:
                     ],
                     exact_match=True,
                 )
+                channels = channels_data["result"]
                 channels_list = recipients_string_to_list(channel_names)
                 if len(channels_list) != len(channels):
                     missing_channels = set(channels_list) - {

--- a/superset/config.py
+++ b/superset/config.py
@@ -1678,7 +1678,9 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         #     "schedule": crontab(minute=0, hour=0),
         #     "kwargs": {"max_rows_per_run": 10000},
         # },
-        # Uncomment to enable Slack channel cache warm-up
+        # Uncomment to enable Slack channel cache warm-up. Beat-scheduled runs
+        # use the default time limit; add "options" to override, e.g.
+        # "options": {"time_limit": 600, "soft_time_limit": 480}.
         # "slack.cache_channels": {
         #     "task": "slack.cache_channels",
         #     "schedule": crontab(minute="0", hour="*"),
@@ -2369,13 +2371,16 @@ SLACK_API_TIMEOUT = 30
 SLACK_ENABLE_CACHING: bool = True
 
 # Maximum number of channels to cache during warmup
-# Prevents excessive memory usage in very large workspaces
-# The cache warmup task will stop after reaching this limit
+# Prevents excessive memory usage in very large workspaces. The cache warmup
+# task stops after reaching this limit and stores a continuation cursor so that
+# channels beyond the cap are streamed from the Slack API on demand.
 # Default: 20000 channels (~100MB cache size)
 SLACK_CACHE_MAX_CHANNELS: int = 20000
 
-# Celery task timeout for Slack cache warmup (seconds)
-# Prevents runaway cache warmup tasks in extremely large workspaces
+# Hard time limit (in seconds) for the Slack channel cache warm-up Celery task.
+# Guards against a runaway warm-up in extremely large workspaces. Applied when
+# the task is dispatched on demand (e.g. a force refresh); the soft time limit
+# is derived as 80% of this value.
 # Default: 300 seconds (5 minutes)
 SLACK_CACHE_WARMUP_TIMEOUT: int = 300
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -2362,6 +2362,23 @@ SLACK_API_RATE_LIMIT_RETRY_COUNT = 2
 # patching code, consistent with the SMTP/CSV/screenshot timeouts.
 SLACK_API_TIMEOUT = 30
 
+# Enable/disable caching for Slack channels list
+# When enabled, all channels are cached in memory for fast lookups
+# Disable this for very large workspaces (50k+ channels) to reduce memory usage
+# Default: True (caching enabled)
+SLACK_ENABLE_CACHING: bool = True
+
+# Maximum number of channels to cache during warmup
+# Prevents excessive memory usage in very large workspaces
+# The cache warmup task will stop after reaching this limit
+# Default: 20000 channels (~100MB cache size)
+SLACK_CACHE_MAX_CHANNELS: int = 20000
+
+# Celery task timeout for Slack cache warmup (seconds)
+# Prevents runaway cache warmup tasks in extremely large workspaces
+# Default: 300 seconds (5 minutes)
+SLACK_CACHE_WARMUP_TIMEOUT: int = 300
+
 # The webdriver to use for generating reports when using Selenium (not Playwright).
 # This setting is ignored when PLAYWRIGHT_REPORTS_AND_THUMBNAILS is enabled, as
 # Playwright always uses Chromium regardless of this value.

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -63,7 +63,7 @@ from superset.reports.schemas import (
     ReportScheduleSubscribeSchema,
 )
 from superset.subjects.filters import FilterRelatedSubjects, subject_type_filter
-from superset.tasks.slack import cache_channels
+from superset.tasks.slack import cache_channels, get_cache_warmup_options
 from superset.utils.slack import (
     get_channels_with_search,
     SLACK_CHANNELS_CACHE_KEY,
@@ -694,14 +694,12 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             # Clear cache if force refresh requested
             if force:
                 cache_manager.cache.delete(SLACK_CHANNELS_CACHE_KEY)
-                cache_manager.cache.delete(
-                    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
-                )
+                cache_manager.cache.delete(SLACK_CHANNELS_CONTINUATION_CURSOR_KEY)
                 logger.info("Slack channels cache cleared due to force=True")
 
                 # Trigger async cache warmup if caching is enabled
                 if current_app.config.get("SLACK_ENABLE_CACHING", True):
-                    cache_channels.delay()
+                    cache_channels.apply_async(**get_cache_warmup_options())
                     logger.info("Triggered async cache warmup task")
 
             channels_data = get_channels_with_search(

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Any, Optional
 
-from flask import request, Response
+from flask import current_app, request, Response
 from flask_appbuilder.api import (
     expose,
     permission_name,
@@ -50,7 +50,7 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.dashboards.filters import DashboardAccessFilter
 from superset.databases.filters import DatabaseFilter
 from superset.exceptions import SupersetException
-from superset.extensions import event_logger
+from superset.extensions import cache_manager, event_logger
 from superset.reports.filters import ReportScheduleAllTextFilter, ReportScheduleFilter
 from superset.reports.models import ReportCreationMethod, ReportSchedule
 from superset.reports.schemas import (
@@ -63,7 +63,12 @@ from superset.reports.schemas import (
     ReportScheduleSubscribeSchema,
 )
 from superset.subjects.filters import FilterRelatedSubjects, subject_type_filter
-from superset.utils.slack import get_channels_with_search
+from superset.tasks.slack import cache_channels
+from superset.utils.slack import (
+    get_channels_with_search,
+    SLACK_CHANNELS_CACHE_KEY,
+    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
+)
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
@@ -684,6 +689,20 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             exact_match = params.get("exact_match", False)
             cursor = params.get("cursor")
             limit = params.get("limit", 100)
+            force = params.get("force", False)
+
+            # Clear cache if force refresh requested
+            if force:
+                cache_manager.cache.delete(SLACK_CHANNELS_CACHE_KEY)
+                cache_manager.cache.delete(
+                    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+                )
+                logger.info("Slack channels cache cleared due to force=True")
+
+                # Trigger async cache warmup if caching is enabled
+                if current_app.config.get("SLACK_ENABLE_CACHING", True):
+                    cache_channels.delay()
+                    logger.info("Triggered async cache warmup task")
 
             channels_data = get_channels_with_search(
                 search_string=search_string,

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -682,14 +682,17 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             search_string = params.get("search_string")
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
-            force = params.get("force", False)
-            channels = get_channels_with_search(
+            cursor = params.get("cursor")
+            limit = params.get("limit", 100)
+
+            channels_data = get_channels_with_search(
                 search_string=search_string,
                 types=types,
                 exact_match=exact_match,
-                force=force,
+                cursor=cursor,
+                limit=limit,
             )
-            return self.response(200, result=channels)
+            return self.response(200, **channels_data)
         except SupersetException as ex:
             logger.error("Error fetching slack channels %s", str(ex))
             return self.response_422(message=str(ex))

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -60,7 +60,7 @@ get_slack_channels_schema = {
         },
         "exact_match": {"type": "boolean"},
         "cursor": {"type": ["string", "null"]},
-        "limit": {"type": "integer", "default": 100},
+        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 1000},
         "force": {"type": "boolean"},
     },
 }

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -59,6 +59,9 @@ get_slack_channels_schema = {
             "items": {"type": "string", "enum": ["public_channel", "private_channel"]},
         },
         "exact_match": {"type": "boolean"},
+        "cursor": {"type": ["string", "null"]},
+        "limit": {"type": "integer", "default": 100},
+        "force": {"type": "boolean"},
     },
 }
 

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -60,7 +60,7 @@ get_slack_channels_schema = {
         },
         "exact_match": {"type": "boolean"},
         "cursor": {"type": ["string", "null"]},
-        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 1000},
+        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 999},
         "force": {"type": "boolean"},
     },
 }

--- a/superset/tasks/slack.py
+++ b/superset/tasks/slack.py
@@ -15,27 +15,50 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from flask import current_app
 
 from superset.extensions import cache_manager, celery_app
 from superset.utils.slack import (
-    get_channels_with_search,
+    _fetch_from_api,
     SLACK_CHANNELS_CACHE_KEY,
+    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
     SlackChannelTypes,
 )
 
 logger = logging.getLogger(__name__)
 
-CACHE_WARMUP_TIME_LIMIT = 300  # 5 minutes
-CACHE_WARMUP_SOFT_TIME_LIMIT = int(CACHE_WARMUP_TIME_LIMIT * 0.8)  # 80% of time_limit
+# Fallback time limits used when the task is dispatched without explicit
+# options (e.g. a bare Celery beat schedule entry). On-demand callers should
+# pass config-driven limits via ``cache_channels.apply_async`` using
+# ``get_cache_warmup_options`` so that ``SLACK_CACHE_WARMUP_TIMEOUT`` is honored.
+DEFAULT_CACHE_WARMUP_TIME_LIMIT = 300  # 5 minutes
+DEFAULT_CACHE_WARMUP_SOFT_TIME_LIMIT = int(DEFAULT_CACHE_WARMUP_TIME_LIMIT * 0.8)
+
+
+def get_cache_warmup_options() -> dict[str, int]:
+    """
+    Build Celery ``apply_async`` options with config-driven time limits.
+
+    Read at dispatch time (inside an application context) rather than at import
+    so operator overrides of ``SLACK_CACHE_WARMUP_TIMEOUT`` are respected. The
+    soft limit is derived as 80% of the hard limit so the task can wind down
+    before Celery force-kills it.
+    """
+    time_limit = current_app.config.get(
+        "SLACK_CACHE_WARMUP_TIMEOUT", DEFAULT_CACHE_WARMUP_TIME_LIMIT
+    )
+    return {
+        "time_limit": time_limit,
+        "soft_time_limit": int(time_limit * 0.8),
+    }
 
 
 @celery_app.task(
     name="slack.cache_channels",
-    time_limit=CACHE_WARMUP_TIME_LIMIT,
-    soft_time_limit=CACHE_WARMUP_SOFT_TIME_LIMIT,
+    time_limit=DEFAULT_CACHE_WARMUP_TIME_LIMIT,
+    soft_time_limit=DEFAULT_CACHE_WARMUP_SOFT_TIME_LIMIT,
 )
 def cache_channels() -> None:
     """
@@ -46,6 +69,10 @@ def cache_channels() -> None:
     Respects the following config variables:
     - SLACK_ENABLE_CACHING: If False, this task does nothing
     - SLACK_CACHE_TIMEOUT: How long to keep cached data
+    - SLACK_CACHE_MAX_CHANNELS: Maximum number of channels to cache. When the
+      workspace has more channels than this, the cache is truncated and a
+      continuation cursor is stored so paginated lookups can stream the
+      remainder from the Slack API.
     """
     enable_caching = current_app.config.get("SLACK_ENABLE_CACHING", True)
     if not enable_caching:
@@ -55,26 +82,36 @@ def cache_channels() -> None:
         return
 
     cache_timeout = current_app.config["SLACK_CACHE_TIMEOUT"]
+    max_channels = current_app.config.get("SLACK_CACHE_MAX_CHANNELS", 20000)
     retry_count = current_app.config.get("SLACK_API_RATE_LIMIT_RETRY_COUNT", 2)
 
     logger.info(
         "Starting Slack channels cache warm-up task "
-        "(cache_timeout=%ds, retry_count=%d)",
+        "(cache_timeout=%ds, max_channels=%d, retry_count=%d)",
         cache_timeout,
+        max_channels,
         retry_count,
     )
 
     try:
-        all_channels = []
+        all_channels: list[Any] = []
         cursor: Optional[str] = None
         page_count = 0
+        # When the workspace exceeds ``max_channels`` we cache the first
+        # ``max_channels`` and remember the Slack cursor for the rest so that
+        # in-memory cache pagination can fall back to the API at the boundary.
+        continuation_cursor: Optional[str] = None
 
+        # Fetch directly from the Slack API (bypassing the cache-aware
+        # ``get_channels_with_search``) so a warm cache never feeds the warmup
+        # back into itself and real continuation cursors are produced.
         while True:
             page_count += 1
 
-            result = get_channels_with_search(
+            result = _fetch_from_api(
                 search_string="",
                 types=list(SlackChannelTypes),
+                exact_match=False,
                 cursor=cursor,
                 limit=999,
             )
@@ -94,6 +131,18 @@ def cache_channels() -> None:
             if not cursor or not result.get("has_more"):
                 break
 
+            if len(all_channels) >= max_channels:
+                continuation_cursor = cursor
+                logger.info(
+                    "Reached SLACK_CACHE_MAX_CHANNELS (%d); caching the first "
+                    "%d channels and storing a continuation cursor for the rest.",
+                    max_channels,
+                    max_channels,
+                )
+                break
+
+        all_channels = all_channels[:max_channels]
+
         cache_size_mb = len(str(all_channels)) / (1024 * 1024)
         logger.info(
             "Successfully fetched %d Slack channels in %d pages (%.1f MB). "
@@ -106,6 +155,17 @@ def cache_channels() -> None:
         cache_manager.cache.set(
             SLACK_CHANNELS_CACHE_KEY, all_channels, timeout=cache_timeout
         )
+
+        # Persist (or clear) the continuation cursor so the cache path knows
+        # whether more channels exist beyond the cached set.
+        if continuation_cursor:
+            cache_manager.cache.set(
+                SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
+                continuation_cursor,
+                timeout=cache_timeout,
+            )
+        else:
+            cache_manager.cache.delete(SLACK_CHANNELS_CONTINUATION_CURSOR_KEY)
 
         logger.info("Slack channels cache warm-up completed successfully")
 

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -209,11 +209,10 @@ def _fetch_channels_without_search(
     """Fetch channels without search filtering, paginating for large limits."""
     channels: list[SlackChannelSchema] = []
     slack_cursor = cursor
-    page_size = min(limit, 1000)
 
     while True:
         response = client.conversations_list(
-            limit=page_size,
+            limit=999,
             cursor=slack_cursor,
             exclude_archived=True,
             types=types_param,
@@ -226,7 +225,7 @@ def _fetch_channels_without_search(
 
         slack_cursor = response.data.get("response_metadata", {}).get("next_cursor")
 
-        if not slack_cursor or len(page_channels) < page_size or len(channels) >= limit:
+        if not slack_cursor or len(channels) >= limit:
             break
 
     return {
@@ -254,7 +253,7 @@ def _fetch_channels_with_search(
 
     while len(matches) < limit:
         response = client.conversations_list(
-            limit=1000,
+            limit=999,
             cursor=slack_cursor,
             exclude_archived=True,
             types=types_param,
@@ -384,7 +383,6 @@ def _fetch_from_cache(  # noqa: C901
             offset = 0
 
     # Check if we're trying to paginate beyond cached data
-    # This happens when cache is partial (hit SLACK_CACHE_MAX_CHANNELS limit)
     if offset >= len(channels):
         logger.info(
             "Pagination offset (%d) exceeds cached data (%d channels). "

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -200,36 +200,34 @@ def _fetch_channels_without_search(
     cursor: Optional[str],
     limit: int,
 ) -> dict[str, Any]:
-    """Fetch channels without search filtering, paginating as needed."""
-    response = client.conversations_list(
-        limit=limit,
-        cursor=cursor,
-        exclude_archived=True,
-        types=types_param,
-    )
+    """Fetch channels without search filtering, paginating for large limits."""
+    channels: list[SlackChannelSchema] = []
+    slack_cursor = cursor
+    page_size = min(limit, 200)
 
-    channels = [channel_schema.load(channel) for channel in response.data["channels"]]
+    while True:
+        response = client.conversations_list(
+            limit=page_size,
+            cursor=slack_cursor,
+            exclude_archived=True,
+            types=types_param,
+        )
 
-    next_cursor = response.data.get("response_metadata", {}).get("next_cursor")
+        page_channels = [
+            channel_schema.load(channel) for channel in response.data["channels"]
+        ]
+        channels.extend(page_channels)
+
+        slack_cursor = response.data.get("response_metadata", {}).get("next_cursor")
+
+        if not slack_cursor or len(page_channels) < page_size or len(channels) >= limit:
+            break
 
     return {
-        "result": channels,
-        "next_cursor": next_cursor,
-        "has_more": bool(next_cursor),
+        "result": channels[:limit],
+        "next_cursor": slack_cursor,
+        "has_more": bool(slack_cursor),
     }
-
-
-def _channel_matches_search(
-    channel: dict[str, Any], search_string: str, exact_match: bool
-) -> bool:
-    """Check if a channel matches the search criteria."""
-    search_lower = search_string.lower()
-    name_lower = channel["name"].lower()
-    id_lower = channel["id"].lower()
-
-    if exact_match:
-        return search_lower == name_lower or search_lower == id_lower
-    return search_lower in name_lower or search_lower in id_lower
 
 
 def _fetch_channels_with_search(
@@ -246,6 +244,7 @@ def _fetch_channels_with_search(
     slack_cursor = cursor
     max_pages_to_fetch = 50
     pages_fetched = 0
+    search_string_lower = search_string.lower()
 
     while len(matches) < limit and pages_fetched < max_pages_to_fetch:
         response = client.conversations_list(
@@ -256,9 +255,23 @@ def _fetch_channels_with_search(
         )
 
         for channel_data in response.data["channels"]:
-            channel = channel_schema.load(channel_data)
+            channel_name_lower = channel_data["name"].lower()
+            channel_id_lower = channel_data["id"].lower()
 
-            if _channel_matches_search(channel, search_string, exact_match):
+            is_match = False
+            if exact_match:
+                is_match = (
+                    search_string_lower == channel_name_lower
+                    or search_string_lower == channel_id_lower
+                )
+            else:
+                is_match = (
+                    search_string_lower in channel_name_lower
+                    or search_string_lower in channel_id_lower
+                )
+
+            if is_match:
+                channel = channel_schema.load(channel_data)
                 matches.append(channel)
 
             if len(matches) >= limit:
@@ -294,8 +307,9 @@ def get_channels_with_search(
     - next_cursor: cursor for next page (None if no more pages)
     - has_more: boolean indicating if more pages exist
 
-    The Slack API is paginated but does not include search. We handle two cases:
-    1. WITHOUT search: Fetch single page from Slack API (fast, no timeout)
+    The Slack API is paginated but does not include search.
+    We handle two cases:
+    1. WITHOUT search: Fetch single page from Slack API
     2. WITH search: Stream through Slack API pages until we find enough matches
        (stops early to prevent timeouts on large workspaces)
     """

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -28,6 +28,7 @@ from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
 from superset import feature_flag_manager
 from superset.exceptions import SupersetException
+from superset.extensions import cache_manager
 from superset.reports.schemas import SlackChannelSchema
 from superset.utils.backports import StrEnum
 
@@ -41,6 +42,11 @@ _SLACK_V1_DEPRECATION_MESSAGE = (
     "bot the `channels:read` and `groups:read` scopes so existing v1 "
     "recipients can be auto-upgraded to SlackV2 on "
     "their next send."
+)
+
+SLACK_CHANNELS_CACHE_KEY = "slack_conversations_list"
+SLACK_CHANNELS_CONTINUATION_CURSOR_KEY = (
+    f"{SLACK_CHANNELS_CACHE_KEY}_continuation_cursor"
 )
 
 
@@ -59,6 +65,7 @@ def _emit_v1_flag_off_deprecation() -> None:
 @functools.cache
 def _emit_v1_scope_missing_deprecation() -> None:
     warnings.warn(_SLACK_V1_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
+
 
 
 class SlackChannelTypes(StrEnum):
@@ -294,34 +301,149 @@ def _fetch_channels_with_search(
     }
 
 
-def get_channels_with_search(
-    search_string: str = "",
-    types: Optional[list[SlackChannelTypes]] = None,
-    exact_match: bool = False,
-    cursor: Optional[str] = None,
-    limit: int = 100,
-) -> dict[str, Any]:
+def _fetch_from_cache(  # noqa: C901
+    cached_channels: list[SlackChannelSchema],
+    search_string: str,
+    types: Optional[list[SlackChannelTypes]],
+    exact_match: bool,
+    cursor: Optional[str],
+    limit: int,
+) -> Optional[dict[str, Any]]:
     """
-    Fetches Slack channels with pagination and search support.
+    Fetch channels from cache with in-memory filtering and pagination.
+
+    This is the fast path - operates entirely in-memory on cached data.
+    Used when cache is available and warm.
 
     Args:
-        search_string: Search term(s). Can be comma-separated for OR logic.
-                      e.g., "engineering,marketing" matches channels containing
-                      "engineering" OR "marketing"
-        types: Channel types to filter (public_channel, private_channel)
-        exact_match: If True, search term must exactly match channel name/ID
-        cursor: Pagination cursor for fetching next page
-        limit: Maximum number of channels to return
+        cached_channels: Complete list of all cached channels
+        search_string: Search term(s) for filtering
+        types: Channel types to filter
+        exact_match: If True, search term must exactly match
+        cursor: Cache pagination cursor (format: "cache:N")
+        limit: Maximum channels to return
 
-    Returns a dict with:
-    - result: list of channels
-    - next_cursor: cursor for next page (None if no more pages)
-    - has_more: boolean indicating if more pages exist
+    Returns:
+        Dict with filtered and paginated results, or None if pagination
+        exceeds cached data (signals need to fall back to API)
+    """
+    # Start with all cached channels
+    channels = list(cached_channels)
 
-    The Slack API is paginated but does not include search.
-    We handle two cases:
-    1. WITHOUT search: Fetch single page from Slack API
-    2. WITH search: Stream through Slack API pages until we find enough matches
+    # Filter by channel types if specified
+    if types and len(types) < len(SlackChannelTypes):
+        type_set = set(types)
+        channels = [
+            ch
+            for ch in channels
+            if (
+                (SlackChannelTypes.PRIVATE in type_set and ch.get("is_private"))
+                or (SlackChannelTypes.PUBLIC in type_set and not ch.get("is_private"))
+            )
+        ]
+
+    # Filter by search string with comma-separated OR logic
+    if search_string:
+        search_terms = [
+            term.strip().lower() for term in search_string.split(",") if term.strip()
+        ]
+        filtered = []
+
+        for ch in channels:
+            channel_name_lower = ch.get("name", "").lower()
+            channel_id_lower = ch.get("id", "").lower()
+            is_match = False
+
+            for search_term in search_terms:
+                if exact_match:
+                    if (
+                        search_term == channel_name_lower
+                        or search_term == channel_id_lower
+                    ):
+                        is_match = True
+                        break
+                else:
+                    if (
+                        search_term in channel_name_lower
+                        or search_term in channel_id_lower
+                    ):
+                        is_match = True
+                        break
+
+            if is_match:
+                filtered.append(ch)
+
+        channels = filtered
+
+    # Calculate pagination offset from cursor
+    offset = 0
+    if cursor and cursor.startswith("cache:"):
+        try:
+            offset = int(cursor.split(":", 1)[1])
+        except (ValueError, IndexError):
+            offset = 0
+
+    # Check if we're trying to paginate beyond cached data
+    # This happens when cache is partial (hit SLACK_CACHE_MAX_CHANNELS limit)
+    if offset >= len(channels):
+        logger.info(
+            "Pagination offset (%d) exceeds cached data (%d channels). "
+            "Falling back to API.",
+            offset,
+            len(channels),
+        )
+        return None
+
+    # Paginate in memory
+    page = channels[offset : offset + limit]
+    next_offset = offset + limit
+    has_more = next_offset < len(channels)
+
+    # Check if we have a continuation cursor (cache was truncated)
+    continuation_cursor = cache_manager.cache.get(
+        SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+    )
+
+    # If we've reached the end of cached data but there's a continuation cursor,
+    # signal that more data exists via API
+    next_cursor: Optional[str]
+    if not has_more and continuation_cursor:
+        # Return special cursor that signals transition to API
+        next_cursor = "api:continue"
+        has_more = True
+    else:
+        # Use synthetic cursor for cache pagination
+        next_cursor = f"cache:{next_offset}" if has_more else None
+
+    return {
+        "result": page,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
+def _fetch_from_api(
+    search_string: str,
+    types: Optional[list[SlackChannelTypes]],
+    exact_match: bool,
+    cursor: Optional[str],
+    limit: int,
+) -> dict[str, Any]:
+    """
+    Fetch from Slack API with pagination.
+
+    This is the original pagination implementation extracted into a helper.
+    Used when cache is cold or disabled.
+
+    Args:
+        search_string: Search term(s) for filtering
+        types: Channel types to filter
+        exact_match: If True, search term must exactly match
+        cursor: Real Slack API cursor for pagination
+        limit: Maximum channels to return
+
+    Returns:
+        Dict with results from Slack API
     """
     try:
         client = get_slack_client()
@@ -360,6 +482,93 @@ def get_channels_with_search(
         raise SupersetException(f"Failed to list channels: {ex}") from ex
     except SlackClientError as ex:
         raise SupersetException(f"Failed to list channels: {ex}") from ex
+
+
+def get_channels_with_search(
+    search_string: str = "",
+    types: Optional[list[SlackChannelTypes]] = None,
+    exact_match: bool = False,
+    cursor: Optional[str] = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """
+    Fetches Slack channels with pagination and search support.
+
+    Args:
+        search_string: Search term(s). Can be comma-separated for OR logic.
+                      e.g., "engineering,marketing" matches channels containing
+                      "engineering" OR "marketing"
+        types: Channel types to filter (public_channel, private_channel)
+        exact_match: If True, search term must exactly match channel name/ID
+        cursor: Pagination cursor (format: "cache:N" for cache path,
+                "api:continue" for transitioning to API continuation,
+                base64 string for API path, None for first page)
+        limit: Maximum number of channels to return per page
+
+    Returns a dict with:
+    - result: list of channels for this page
+    - next_cursor: cursor for next page (None if no more pages)
+    - has_more: boolean indicating if more pages exist
+    """
+    enable_caching = app.config.get("SLACK_ENABLE_CACHING", True)
+
+    # Handle transition from cache to API continuation
+    if cursor == "api:continue":
+        continuation_cursor = cache_manager.cache.get(
+            SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+        )
+        if continuation_cursor:
+            logger.info("Transitioning from cache to API using continuation cursor")
+            return _fetch_from_api(
+                search_string, types, exact_match, continuation_cursor, limit
+            )
+        else:
+            logger.warning(
+                "No continuation cursor available, cannot fetch more channels"
+            )
+            return {"result": [], "next_cursor": None, "has_more": False}
+
+    # Try cache path for first page or cache cursor
+    if enable_caching and (cursor is None or (cursor and cursor.startswith("cache:"))):
+        cached_channels = cache_manager.cache.get(SLACK_CHANNELS_CACHE_KEY)
+        if cached_channels:
+            if cursor is None:
+                logger.info(
+                    "Using cache path (%d channels available)", len(cached_channels)
+                )
+
+            result = _fetch_from_cache(
+                cached_channels, search_string, types, exact_match, cursor, limit
+            )
+
+            # If cache returns None, we've exceeded cache boundary
+            if result is None:
+                # Fall back to API using continuation cursor
+                continuation_cursor = cache_manager.cache.get(
+                    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+                )
+                if continuation_cursor:
+                    logger.info(
+                        "Cache boundary exceeded, falling back to API "
+                        "with continuation cursor"
+                    )
+                    return _fetch_from_api(
+                        search_string, types, exact_match, continuation_cursor, limit
+                    )
+                else:
+                    logger.warning(
+                        "Cache boundary exceeded but no continuation cursor available"
+                    )
+                    return {"result": [], "next_cursor": None, "has_more": False}
+
+            return result
+        else:
+            logger.debug("Cache not available, using API path")
+            cursor = None  # Reset cursor for API call
+
+    # API path for real Slack cursors
+    logger.debug("Using API path")
+    return _fetch_from_api(search_string, types, exact_match, cursor, limit)
 
 
 _SCOPE_MISSING_ERROR_CODES = frozenset(

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -19,7 +19,7 @@
 import functools
 import logging
 import warnings
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from flask import current_app as app
 from slack_sdk import WebClient
@@ -32,7 +32,6 @@ from superset.extensions import cache_manager
 from superset.reports.schemas import SlackChannelSchema
 from superset.utils import cache as cache_util
 from superset.utils.backports import StrEnum
-from superset.utils.core import recipients_string_to_list
 
 logger = logging.getLogger(__name__)
 
@@ -194,22 +193,137 @@ def _get_channels(
         raise
 
 
+def _fetch_channels_without_search(
+    client: WebClient,
+    channel_schema: SlackChannelSchema,
+    types_param: str,
+    cursor: Optional[str],
+    limit: int,
+) -> dict[str, Any]:
+    """Fetch channels without search filtering, paginating as needed."""
+    response = client.conversations_list(
+        limit=limit,
+        cursor=cursor,
+        exclude_archived=True,
+        types=types_param,
+    )
+
+    channels = [channel_schema.load(channel) for channel in response.data["channels"]]
+
+    next_cursor = response.data.get("response_metadata", {}).get("next_cursor")
+
+    return {
+        "result": channels,
+        "next_cursor": next_cursor,
+        "has_more": bool(next_cursor),
+    }
+
+
+def _channel_matches_search(
+    channel: dict[str, Any], search_string: str, exact_match: bool
+) -> bool:
+    """Check if a channel matches the search criteria."""
+    search_lower = search_string.lower()
+    name_lower = channel["name"].lower()
+    id_lower = channel["id"].lower()
+
+    if exact_match:
+        return search_lower == name_lower or search_lower == id_lower
+    return search_lower in name_lower or search_lower in id_lower
+
+
+def _fetch_channels_with_search(
+    client: WebClient,
+    channel_schema: SlackChannelSchema,
+    types_param: str,
+    search_string: str,
+    exact_match: bool,
+    cursor: Optional[str],
+    limit: int,
+) -> dict[str, Any]:
+    """Fetch channels with search filtering, streaming through pages."""
+    matches: list[SlackChannelSchema] = []
+    slack_cursor = cursor
+    max_pages_to_fetch = 50
+    pages_fetched = 0
+
+    while len(matches) < limit and pages_fetched < max_pages_to_fetch:
+        response = client.conversations_list(
+            limit=200,
+            cursor=slack_cursor,
+            exclude_archived=True,
+            types=types_param,
+        )
+
+        for channel_data in response.data["channels"]:
+            channel = channel_schema.load(channel_data)
+
+            if _channel_matches_search(channel, search_string, exact_match):
+                matches.append(channel)
+
+            if len(matches) >= limit:
+                break
+
+        slack_cursor = response.data.get("response_metadata", {}).get("next_cursor")
+        if not slack_cursor:
+            break
+
+        pages_fetched += 1
+
+    has_more = bool(slack_cursor) and len(matches) >= limit
+
+    return {
+        "result": matches[:limit],
+        "next_cursor": slack_cursor if has_more else None,
+        "has_more": has_more,
+    }
+
+
 def get_channels_with_search(
     search_string: str = "",
     types: Optional[list[SlackChannelTypes]] = None,
     exact_match: bool = False,
-    force: bool = False,
-) -> list[SlackChannelSchema]:
+    cursor: Optional[str] = None,
+    limit: int = 100,
+) -> dict[str, Any]:
     """
-    The slack api is paginated but does not include search, so we need to fetch
-    all channels and filter them ourselves
-    This will search by slack name or id
+    Fetches Slack channels with pagination and search support.
+
+    Returns a dict with:
+    - result: list of channels
+    - next_cursor: cursor for next page (None if no more pages)
+    - has_more: boolean indicating if more pages exist
+
+    The Slack API is paginated but does not include search. We handle two cases:
+    1. WITHOUT search: Fetch single page from Slack API (fast, no timeout)
+    2. WITH search: Stream through Slack API pages until we find enough matches
+       (stops early to prevent timeouts on large workspaces)
     """
     try:
-        channels = get_channels(
-            force=force,
-            cache_timeout=app.config["SLACK_CACHE_TIMEOUT"],
+        client = get_slack_client()
+        channel_schema = SlackChannelSchema()
+
+        types_param = (
+            ",".join(types)
+            if types and len(types) < len(SlackChannelTypes)
+            else ",".join(SlackChannelTypes)
         )
+
+        if not search_string:
+            return _fetch_channels_without_search(
+                client, channel_schema, types_param, cursor, limit
+            )
+
+        return _fetch_channels_with_search(
+            client,
+            channel_schema,
+            types_param,
+            search_string,
+            exact_match,
+            cursor,
+            limit,
+        )
+
     except SlackApiError as ex:
         # Check if it's a rate limit error
         status_code = getattr(ex.response, "status_code", None)
@@ -222,38 +336,6 @@ def get_channels_with_search(
         raise SupersetException(f"Failed to list channels: {ex}") from ex
     except SlackClientError as ex:
         raise SupersetException(f"Failed to list channels: {ex}") from ex
-
-    if types and not len(types) == len(SlackChannelTypes):
-        conditions: list[Callable[[SlackChannelSchema], bool]] = []
-        if SlackChannelTypes.PUBLIC in types:
-            conditions.append(lambda channel: not channel["is_private"])
-        if SlackChannelTypes.PRIVATE in types:
-            conditions.append(lambda channel: channel["is_private"])
-
-        channels = [
-            channel for channel in channels if any(cond(channel) for cond in conditions)
-        ]
-
-    # The search string can be multiple channels separated by commas
-    if search_string:
-        search_array = recipients_string_to_list(search_string)
-        channels = [
-            channel
-            for channel in channels
-            if any(
-                (
-                    search.lower() == channel["name"].lower()
-                    or search.lower() == channel["id"].lower()
-                    if exact_match
-                    else (
-                        search.lower() in channel["name"].lower()
-                        or search.lower() in channel["id"].lower()
-                    )
-                )
-                for search in search_array
-            )
-        ]
-    return channels
 
 
 _SCOPE_MISSING_ERROR_CODES = frozenset(

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -28,9 +28,7 @@ from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
 from superset import feature_flag_manager
 from superset.exceptions import SupersetException
-from superset.extensions import cache_manager
 from superset.reports.schemas import SlackChannelSchema
-from superset.utils import cache as cache_util
 from superset.utils.backports import StrEnum
 
 logger = logging.getLogger(__name__)
@@ -193,6 +191,7 @@ def _get_channels(
         raise
 
 
+
 def _fetch_channels_without_search(
     client: WebClient,
     channel_schema: SlackChannelSchema,
@@ -203,7 +202,7 @@ def _fetch_channels_without_search(
     """Fetch channels without search filtering, paginating for large limits."""
     channels: list[SlackChannelSchema] = []
     slack_cursor = cursor
-    page_size = min(limit, 200)
+    page_size = min(limit, 1000)
 
     while True:
         response = client.conversations_list(
@@ -242,13 +241,13 @@ def _fetch_channels_with_search(
     """Fetch channels with search filtering, streaming through pages."""
     matches: list[SlackChannelSchema] = []
     slack_cursor = cursor
-    max_pages_to_fetch = 50
-    pages_fetched = 0
-    search_string_lower = search_string.lower()
+    search_terms = [
+        term.strip().lower() for term in search_string.split(",") if term.strip()
+    ]
 
-    while len(matches) < limit and pages_fetched < max_pages_to_fetch:
+    while len(matches) < limit:
         response = client.conversations_list(
-            limit=200,
+            limit=1000,
             cursor=slack_cursor,
             exclude_archived=True,
             types=types_param,
@@ -259,16 +258,21 @@ def _fetch_channels_with_search(
             channel_id_lower = channel_data["id"].lower()
 
             is_match = False
-            if exact_match:
-                is_match = (
-                    search_string_lower == channel_name_lower
-                    or search_string_lower == channel_id_lower
-                )
-            else:
-                is_match = (
-                    search_string_lower in channel_name_lower
-                    or search_string_lower in channel_id_lower
-                )
+            for search_term in search_terms:
+                if exact_match:
+                    if (
+                        search_term == channel_name_lower
+                        or search_term == channel_id_lower
+                    ):
+                        is_match = True
+                        break
+                else:
+                    if (
+                        search_term in channel_name_lower
+                        or search_term in channel_id_lower
+                    ):
+                        is_match = True
+                        break
 
             if is_match:
                 channel = channel_schema.load(channel_data)
@@ -280,8 +284,6 @@ def _fetch_channels_with_search(
         slack_cursor = response.data.get("response_metadata", {}).get("next_cursor")
         if not slack_cursor:
             break
-
-        pages_fetched += 1
 
     has_more = bool(slack_cursor) and len(matches) >= limit
 
@@ -302,6 +304,15 @@ def get_channels_with_search(
     """
     Fetches Slack channels with pagination and search support.
 
+    Args:
+        search_string: Search term(s). Can be comma-separated for OR logic.
+                      e.g., "engineering,marketing" matches channels containing
+                      "engineering" OR "marketing"
+        types: Channel types to filter (public_channel, private_channel)
+        exact_match: If True, search term must exactly match channel name/ID
+        cursor: Pagination cursor for fetching next page
+        limit: Maximum number of channels to return
+
     Returns a dict with:
     - result: list of channels
     - next_cursor: cursor for next page (None if no more pages)
@@ -311,7 +322,6 @@ def get_channels_with_search(
     We handle two cases:
     1. WITHOUT search: Fetch single page from Slack API
     2. WITH search: Stream through Slack API pages until we find enough matches
-       (stops early to prevent timeouts on large workspaces)
     """
     try:
         client = get_slack_client()

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -67,7 +67,6 @@ def _emit_v1_scope_missing_deprecation() -> None:
     warnings.warn(_SLACK_V1_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
 
 
-
 class SlackChannelTypes(StrEnum):
     PUBLIC = "public_channel"
     PRIVATE = "private_channel"
@@ -116,97 +115,22 @@ def get_team_id() -> Optional[str]:
     return team_id or None
 
 
-def get_channels(
-    team_id: Optional[str] = None, **kwargs: Any
-) -> list[SlackChannelSchema]:
-    """
-    Retrieves a list of all conversations accessible by the bot
-    from the Slack API, and caches results (to avoid rate limits).
-
-    The Slack API does not provide search so to apply a search use
-    get_channels_with_search instead.
-
-    :param team_id: workspace (team) ID to target, required for org-scoped tokens
-        on an Enterprise Grid org. Defaults to the configured ``SLACK_TEAM_ID``
-        (via get_team_id) when not given. When set it also keys the cache so that
-        distinct workspaces never share cached channel lists; when unset, the
-        legacy cache key is used so that upgrading does not invalidate existing
-        caches.
-    :param kwargs: forwarded to the memoized fetch (``force``, ``cache_timeout``,
-        ``cache``).
-    """
-    if team_id is None:
-        team_id = get_team_id()
-    cache_key = "slack_conversations_list"
-    if team_id:
-        cache_key = f"{cache_key}_{team_id}"
-    return _get_channels(cache_key, team_id=team_id, **kwargs)
-
-
-@cache_util.memoized_func(
-    key="{cache_key}",
-    cache=cache_manager.cache,
-)
-def _get_channels(
-    cache_key: str, team_id: Optional[str] = None
-) -> list[SlackChannelSchema]:
-    client = get_slack_client()
-    channel_schema = SlackChannelSchema()
-    channels: list[SlackChannelSchema] = []
-    extra_params = {"types": _SLACK_CONVERSATION_TYPES}
-    if team_id:
-        extra_params["team_id"] = team_id
-    cursor = None
-    page_count = 0
-
-    logger.info("Starting Slack channels fetch")
-
-    try:
-        while True:
-            page_count += 1
-
-            response = client.conversations_list(
-                limit=999, cursor=cursor, exclude_archived=True, **extra_params
-            )
-            page_channels = response.data["channels"]
-            channels.extend(channel_schema.load(channel) for channel in page_channels)
-
-            logger.debug(
-                "Fetched page %d: %d channels (total: %d)",
-                page_count,
-                len(page_channels),
-                len(channels),
-            )
-
-            cursor = response.data.get("response_metadata", {}).get("next_cursor")
-            if not cursor:
-                break
-
-        logger.info(
-            "Successfully fetched %d Slack channels in %d pages",
-            len(channels),
-            page_count,
-        )
-        return channels
-    except SlackApiError as ex:
-        logger.error(
-            "Failed to fetch Slack channels after %d pages: %s",
-            page_count,
-            str(ex),
-            exc_info=True,
-        )
-        raise
-
-
-
 def _fetch_channels_without_search(
     client: WebClient,
     channel_schema: SlackChannelSchema,
     types_param: str,
     cursor: Optional[str],
     limit: int,
+    cache_full_list: bool = False,
 ) -> dict[str, Any]:
-    """Fetch channels without search filtering, paginating for large limits."""
+    """Fetch channels without search filtering, paginating for large limits.
+
+    When ``cache_full_list`` is True and the entire workspace is returned in a
+    single page (``has_more`` is False), the complete channel list is written
+    through to the cache so instances without a Celery warmup worker keep the
+    in-memory fast path on subsequent requests. Larger, multi-page workspaces
+    are left to the async warmup task to avoid blocking the request.
+    """
     channels: list[SlackChannelSchema] = []
     slack_cursor = cursor
 
@@ -228,10 +152,27 @@ def _fetch_channels_without_search(
         if not slack_cursor or len(channels) >= limit:
             break
 
+    has_more = bool(slack_cursor)
+
+    # Write-through cache: only when the full, unfiltered workspace fits in the
+    # pages already fetched (has_more is False). ``channels`` is the complete
+    # list here, so it can back the in-memory search/pagination path.
+    if cache_full_list and not has_more:
+        cache_timeout = app.config["SLACK_CACHE_TIMEOUT"]
+        cache_manager.cache.set(
+            SLACK_CHANNELS_CACHE_KEY, channels, timeout=cache_timeout
+        )
+        cache_manager.cache.delete(SLACK_CHANNELS_CONTINUATION_CURSOR_KEY)
+        logger.info(
+            "Warmed Slack channel cache with %d channels without a Celery "
+            "worker (single-page workspace)",
+            len(channels),
+        )
+
     return {
         "result": channels[:limit],
         "next_cursor": slack_cursor,
-        "has_more": bool(slack_cursor),
+        "has_more": has_more,
     }
 
 
@@ -426,6 +367,7 @@ def _fetch_from_api(
     exact_match: bool,
     cursor: Optional[str],
     limit: int,
+    cache_full_list: bool = False,
 ) -> dict[str, Any]:
     """
     Fetch from Slack API with pagination.
@@ -439,6 +381,10 @@ def _fetch_from_api(
         exact_match: If True, search term must exactly match
         cursor: Real Slack API cursor for pagination
         limit: Maximum channels to return
+        cache_full_list: When True and the whole (unfiltered) workspace is
+            returned in this fetch, populate the channel cache as a
+            write-through so deployments without a Celery warmup worker still
+            benefit from caching. Only honored for the no-search path.
 
     Returns:
         Dict with results from Slack API
@@ -455,7 +401,7 @@ def _fetch_from_api(
 
         if not search_string:
             return _fetch_channels_without_search(
-                client, channel_schema, types_param, cursor, limit
+                client, channel_schema, types_param, cursor, limit, cache_full_list
             )
 
         return _fetch_channels_with_search(
@@ -509,6 +455,17 @@ def get_channels_with_search(
     - has_more: boolean indicating if more pages exist
     """
     enable_caching = app.config.get("SLACK_ENABLE_CACHING", True)
+
+    # A cold cache on an unfiltered first-page request is eligible for a
+    # synchronous write-through warm (handled in _fetch_channels_without_search)
+    # so deployments without a Celery worker keep the cache fast path. Computed
+    # from the original request before any cursor reset below.
+    cache_full_list = (
+        enable_caching
+        and cursor is None
+        and not search_string
+        and (not types or len(types) >= len(SlackChannelTypes))
+    )
 
     # Handle transition from cache to API continuation
     if cursor == "api:continue":
@@ -566,7 +523,9 @@ def get_channels_with_search(
 
     # API path for real Slack cursors
     logger.debug("Using API path")
-    return _fetch_from_api(search_string, types, exact_match, cursor, limit)
+    return _fetch_from_api(
+        search_string, types, exact_match, cursor, limit, cache_full_list
+    )
 
 
 _SCOPE_MISSING_ERROR_CODES = frozenset(

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -3187,3 +3187,61 @@ class TestReportSchedulesApi(SupersetTestCase):
 
         data = json.loads(rv.data.decode("utf-8"))
         assert "Slack API error" in data["message"]
+
+    @patch("superset.reports.api.cache_channels")
+    @patch("superset.reports.api.cache_manager")
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_with_force_clears_cache(
+        self, mock_get_channels, mock_cache_manager, mock_cache_channels
+    ):
+        """
+        Test /api/v1/report/slack_channels/ endpoint with force=true clears cache
+        and triggers async cache warmup
+        """
+        self.login(ADMIN_USERNAME)
+
+        mock_get_channels.return_value = {
+            "result": [{"id": "C123", "name": "general"}],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        uri = "api/v1/report/slack_channels/?q=(force:!t)"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        # Verify cache was cleared
+        assert mock_cache_manager.cache.delete.call_count == 2
+
+        # Verify async cache warmup was triggered
+        mock_cache_channels.delay.assert_called_once()
+
+    @patch("superset.reports.api.cache_channels")
+    @patch("superset.reports.api.cache_manager")
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_force_respects_caching_config(
+        self, mock_get_channels, mock_cache_manager, mock_cache_channels
+    ):
+        """
+        Test /api/v1/report/slack_channels/ with force=true
+        respects SLACK_ENABLE_CACHING
+        """
+        self.login(ADMIN_USERNAME)
+
+        mock_get_channels.return_value = {
+            "result": [{"id": "C123", "name": "general"}],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        # Test with caching disabled
+        with patch.dict(self.app.config, {"SLACK_ENABLE_CACHING": False}, clear=False):
+            uri = "api/v1/report/slack_channels/?q=(force:!t)"
+            rv = self.client.get(uri)
+            assert rv.status_code == 200
+
+            # Cache should still be cleared
+            assert mock_cache_manager.cache.delete.call_count == 2
+
+            # But async warmup should NOT be triggered
+            mock_cache_channels.delay.assert_not_called()

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -2986,8 +2986,18 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response without pagination
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
-                {"id": "C002", "name": "random", "is_private": False, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "general",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "id": "C002",
+                    "name": "random",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -3022,7 +3032,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with pagination
         mock_get_channels.return_value = {
             "result": [
-                {"id": f"C{i:03d}", "name": f"channel-{i}", "is_private": False, "is_member": True}
+                {
+                    "id": f"C{i:03d}",
+                    "name": f"channel-{i}",
+                    "is_private": False,
+                    "is_member": True,
+                }
                 for i in range(100)
             ],
             "next_cursor": "page_1",
@@ -3048,7 +3063,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response for second page
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C100", "name": "channel-100", "is_private": False, "is_member": True},
+                {
+                    "id": "C100",
+                    "name": "channel-100",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -3081,8 +3101,18 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with search results
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "engineering", "is_private": False, "is_member": True},
-                {"id": "C002", "name": "engineering-ops", "is_private": True, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "engineering",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "id": "C002",
+                    "name": "engineering-ops",
+                    "is_private": True,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -3115,7 +3145,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with filtered types
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "general",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -3213,8 +3213,11 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Verify cache was cleared
         assert mock_cache_manager.cache.delete.call_count == 2
 
-        # Verify async cache warmup was triggered
-        mock_cache_channels.delay.assert_called_once()
+        # Verify async cache warmup was triggered with config-driven time limits
+        mock_cache_channels.apply_async.assert_called_once()
+        _, warmup_kwargs = mock_cache_channels.apply_async.call_args
+        assert "time_limit" in warmup_kwargs
+        assert "soft_time_limit" in warmup_kwargs
 
     @patch("superset.reports.api.cache_channels")
     @patch("superset.reports.api.cache_manager")
@@ -3244,4 +3247,4 @@ class TestReportSchedulesApi(SupersetTestCase):
             assert mock_cache_manager.cache.delete.call_count == 2
 
             # But async warmup should NOT be triggered
-            mock_cache_channels.delay.assert_not_called()
+            mock_cache_channels.apply_async.assert_not_called()

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -2975,3 +2975,180 @@ class TestReportSchedulesApi(SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         assert "Celery" in data["message"]
         assert "broker" in data["message"].lower()
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_without_pagination(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint without pagination
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock response without pagination
+        mock_get_channels.return_value = {
+            "result": [
+                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
+                {"id": "C002", "name": "random", "is_private": False, "is_member": True},
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        uri = "api/v1/report/slack_channels/"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert len(data["result"]) == 2
+        assert data["result"][0]["name"] == "general"
+        assert data["next_cursor"] is None
+        assert data["has_more"] is False
+
+        # Verify get_channels_with_search was called with defaults
+        mock_get_channels.assert_called_once_with(
+            search_string=None,
+            types=[],
+            exact_match=False,
+            cursor=None,
+            limit=100,
+        )
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_with_pagination(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint with pagination
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock response with pagination
+        mock_get_channels.return_value = {
+            "result": [
+                {"id": f"C{i:03d}", "name": f"channel-{i}", "is_private": False, "is_member": True}
+                for i in range(100)
+            ],
+            "next_cursor": "page_1",
+            "has_more": True,
+        }
+
+        uri = "api/v1/report/slack_channels/?q=(limit:100)"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert len(data["result"]) == 100
+        assert data["next_cursor"] == "page_1"
+        assert data["has_more"] is True
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_with_cursor(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint with cursor for next page
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock response for second page
+        mock_get_channels.return_value = {
+            "result": [
+                {"id": "C100", "name": "channel-100", "is_private": False, "is_member": True},
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        uri = "api/v1/report/slack_channels/?q=(cursor:'page_1',limit:100)"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert len(data["result"]) == 1
+        assert data["next_cursor"] is None
+
+        # Verify cursor was passed
+        mock_get_channels.assert_called_once_with(
+            search_string=None,
+            types=[],
+            exact_match=False,
+            cursor="page_1",
+            limit=100,
+        )
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_with_search(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint with search parameter
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock response with search results
+        mock_get_channels.return_value = {
+            "result": [
+                {"id": "C001", "name": "engineering", "is_private": False, "is_member": True},
+                {"id": "C002", "name": "engineering-ops", "is_private": True, "is_member": True},
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        uri = "api/v1/report/slack_channels/?q=(search_string:'engineering')"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert len(data["result"]) == 2
+        assert all("engineering" in ch["name"] for ch in data["result"])
+
+        # Verify search_string was passed
+        mock_get_channels.assert_called_once_with(
+            search_string="engineering",
+            types=[],
+            exact_match=False,
+            cursor=None,
+            limit=100,
+        )
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_with_types(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint with channel types filter
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock response with filtered types
+        mock_get_channels.return_value = {
+            "result": [
+                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+        uri = "api/v1/report/slack_channels/?q=(types:!('public_channel'))"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        # Verify types were passed
+        mock_get_channels.assert_called_once_with(
+            search_string=None,
+            types=["public_channel"],
+            exact_match=False,
+            cursor=None,
+            limit=100,
+        )
+
+    @patch("superset.reports.api.get_channels_with_search")
+    def test_slack_channels_api_error_handling(self, mock_get_channels):
+        """
+        Test /api/v1/report/slack_channels/ endpoint error handling
+        """
+        self.login(ADMIN_USERNAME)
+
+        # Mock Slack API error
+        from superset.exceptions import SupersetException
+
+        mock_get_channels.side_effect = SupersetException("Slack API error")
+
+        uri = "api/v1/report/slack_channels/"
+        rv = self.client.get(uri)
+        assert rv.status_code == 422
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "Slack API error" in data["message"]

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -198,7 +198,7 @@ def create_test_table_context(database: Database):
 def create_report_email_chart():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart
+        email_target="target@email.com", chart=chart, name="report_email_chart"
     )
     yield report_schedule
 
@@ -213,6 +213,7 @@ def create_report_email_chart_with_cc_and_bcc():
         ccTarget="cc@email.com",
         bccTarget="bcc@email.com",
         chart=chart,
+        name="report_email_chart_with_cc_and_bcc",
     )
     yield report_schedule
 
@@ -225,7 +226,10 @@ def create_report_email_chart_alpha_owner(get_user):
     editors = _subjects_for_users([alpha])
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart, editors=editors
+        email_target="target@email.com",
+        chart=chart,
+        editors=editors,
+        name="report_email_chart_alpha_owner",
     )
     yield report_schedule
 
@@ -236,7 +240,10 @@ def create_report_email_chart_alpha_owner(get_user):
 def create_report_email_chart_force_screenshot():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart, force_screenshot=True
+        email_target="target@email.com",
+        chart=chart,
+        force_screenshot=True,
+        name="report_email_chart_force_screenshot",
     )
     yield report_schedule
 
@@ -251,6 +258,7 @@ def create_report_email_chart_with_csv():
         email_target="target@email.com",
         chart=chart,
         report_format=ReportDataFormat.CSV,
+        name="report_email_chart_with_csv",
     )
     yield report_schedule
     cleanup_report_schedule(report_schedule)
@@ -264,6 +272,7 @@ def create_report_email_chart_with_text():
         email_target="target@email.com",
         chart=chart,
         report_format=ReportDataFormat.TEXT,
+        name="report_email_chart_with_text",
     )
     yield report_schedule
     cleanup_report_schedule(report_schedule)
@@ -287,7 +296,9 @@ def create_report_email_chart_with_csv_no_query_context():
 def create_report_email_dashboard():
     dashboard = db.session.query(Dashboard).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", dashboard=dashboard
+        email_target="target@email.com",
+        dashboard=dashboard,
+        name="report_email_dashboard",
     )
     yield report_schedule
 
@@ -298,7 +309,10 @@ def create_report_email_dashboard():
 def create_report_email_dashboard_force_screenshot():
     dashboard = db.session.query(Dashboard).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", dashboard=dashboard, force_screenshot=True
+        email_target="target@email.com",
+        dashboard=dashboard,
+        force_screenshot=True,
+        name="report_email_dashboard_force_screenshot",
     )
     yield report_schedule
 
@@ -309,7 +323,7 @@ def create_report_email_dashboard_force_screenshot():
 def create_report_slack_chart():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="slack_channel", chart=chart
+        slack_channel="slack_channel", chart=chart, name="report_slack_chart"
     )
     yield report_schedule
 
@@ -338,6 +352,7 @@ def create_report_slack_chart_with_csv():
         slack_channel="slack_channel",
         chart=chart,
         report_format=ReportDataFormat.CSV,
+        name="report_slack_chart_with_csv",
     )
     yield report_schedule
 
@@ -352,6 +367,7 @@ def create_report_slack_chart_with_text():
         slack_channel="slack_channel",
         chart=chart,
         report_format=ReportDataFormat.TEXT,
+        name="report_slack_chart_with_text",
     )
     yield report_schedule
 
@@ -362,7 +378,7 @@ def create_report_slack_chart_with_text():
 def create_report_slack_chart_working():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="slack_channel", chart=chart
+        slack_channel="slack_channel", chart=chart, name="report_slack_chart_working"
     )
     report_schedule.last_state = ReportState.WORKING
     report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -394,6 +410,7 @@ def create_alert_slack_chart_success():
         slack_channel="slack_channel",
         chart=chart,
         report_type=ReportScheduleType.ALERT,
+        name="alert_slack_chart_success",
     )
     report_schedule.last_state = ReportState.SUCCESS
     report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -436,6 +453,7 @@ def create_alert_slack_chart_grace(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"alert_slack_chart_grace_{request.param}",
         )
         report_schedule.last_state = ReportState.GRACE
         report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -521,6 +539,7 @@ def create_alert_email_chart(request):
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
             force_screenshot=True,
+            name=f"alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -599,6 +618,7 @@ def create_no_alert_email_chart(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"no_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -630,6 +650,7 @@ def create_mul_alert_email_chart(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"mul_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -662,6 +683,7 @@ def create_invalid_sql_alert_email_chart(request, app_context: AppContext):
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
             grace_period=60 * 60,
+            name=f"invalid_sql_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -1226,6 +1248,7 @@ def test_email_dashboard_report_schedule_with_tab_anchor(
                         "urlParams": [["native_filters", "()"]],
                     }
                 },
+                name="dashboard_report_with_tab_anchor",
             )
             AsyncExecuteReportScheduleCommand(
                 TEST_ID, report_schedule.id, datetime.utcnow()
@@ -1282,6 +1305,7 @@ def test_email_dashboard_report_schedule_disabled_tabs(
                         "urlParams": [["native_filters", "()"]],
                     }
                 },
+                name="dashboard_report_disabled_tabs",
             )
             AsyncExecuteReportScheduleCommand(
                 TEST_ID, report_schedule.id, datetime.utcnow()
@@ -1354,14 +1378,18 @@ def test_slack_chart_report_schedule_converts_to_v2(
     # setup screenshot mock
     screenshot_mock.return_value = SCREENSHOT_FILE
     channel_id = "slack_channel_id"
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with freeze_time("2020-01-01T00:00:00Z"):
         with patch(
@@ -1417,16 +1445,22 @@ def test_slack_chart_report_schedule_converts_to_v2_channel_with_hash(
     channel_id = "slack_channel_id"
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="#slack_channel", chart=chart
+        slack_channel="#slack_channel",
+        chart=chart,
+        name="slack_converts_to_v2_with_hash",
     )
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with freeze_time("2020-01-01T00:00:00Z"):
         with patch(
@@ -1480,16 +1514,22 @@ def test_slack_chart_report_schedule_fails_to_converts_to_v2(
     channel_id = "slack_channel_id"
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="#slack_channel,my_member_ID", chart=chart
+        slack_channel="#slack_channel,my_member_ID",
+        chart=chart,
+        name="slack_fails_to_convert_to_v2",
     )
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with pytest.raises(ReportScheduleSystemErrorsException):
         AsyncExecuteReportScheduleCommand(

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -1517,20 +1517,24 @@ def test_update_recipient_to_slack_v2(mocker: MockerFixture):
     """
     mocker.patch(
         "superset.commands.report.execute.get_channels_with_search",
-        return_value=[
-            {
-                "id": "abc124f",
-                "name": "channel-1",
-                "is_member": True,
-                "is_private": False,
-            },
-            {
-                "id": "blah_!channel_2",
-                "name": "Channel_2",
-                "is_member": True,
-                "is_private": False,
-            },
-        ],
+        return_value={
+            "result": [
+                {
+                    "id": "abc124f",
+                    "name": "channel-1",
+                    "is_member": True,
+                    "is_private": False,
+                },
+                {
+                    "id": "blah_!channel_2",
+                    "name": "Channel_2",
+                    "is_member": True,
+                    "is_private": False,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        },
     )
     mock_report_schedule = ReportSchedule(
         recipients=[
@@ -1560,14 +1564,18 @@ def test_update_recipient_to_slack_v2_missing_channels(mocker: MockerFixture):
     """
     mocker.patch(
         "superset.commands.report.execute.get_channels_with_search",
-        return_value=[
-            {
-                "id": "blah_!channel_2",
-                "name": "Channel 2",
-                "is_member": True,
-                "is_private": False,
-            },
-        ],
+        return_value={
+            "result": [
+                {
+                    "id": "blah_!channel_2",
+                    "name": "Channel 2",
+                    "is_member": True,
+                    "is_private": False,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        },
     )
     mock_report_schedule = ReportSchedule(
         name="Test Report",

--- a/tests/unit_tests/tasks/test_slack.py
+++ b/tests/unit_tests/tasks/test_slack.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Optional
+
+from superset.tasks.slack import (
+    cache_channels,
+    DEFAULT_CACHE_WARMUP_TIME_LIMIT,
+    get_cache_warmup_options,
+)
+from superset.utils.slack import (
+    SLACK_CHANNELS_CACHE_KEY,
+    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
+)
+
+
+def _page(ids: list[str], next_cursor: Optional[str], has_more: bool) -> dict[str, Any]:
+    return {
+        "result": [{"id": channel_id} for channel_id in ids],
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
+def _patch_task(mocker, config, fetch_pages):
+    """Patch the task's collaborators and return the mocked cache."""
+    mock_app = mocker.patch("superset.tasks.slack.current_app")
+    mock_app.config = config
+    mock_fetch = mocker.patch(
+        "superset.tasks.slack._fetch_from_api", side_effect=fetch_pages
+    )
+    mock_cache = mocker.patch("superset.tasks.slack.cache_manager")
+    return mock_fetch, mock_cache
+
+
+def test_get_cache_warmup_options_uses_configured_timeout(mocker):
+    mock_app = mocker.patch("superset.tasks.slack.current_app")
+    mock_app.config = {"SLACK_CACHE_WARMUP_TIMEOUT": 600}
+
+    assert get_cache_warmup_options() == {
+        "time_limit": 600,
+        "soft_time_limit": 480,
+    }
+
+
+def test_get_cache_warmup_options_falls_back_to_default(mocker):
+    mock_app = mocker.patch("superset.tasks.slack.current_app")
+    mock_app.config = {}
+
+    options = get_cache_warmup_options()
+
+    assert options["time_limit"] == DEFAULT_CACHE_WARMUP_TIME_LIMIT
+    assert options["soft_time_limit"] == int(DEFAULT_CACHE_WARMUP_TIME_LIMIT * 0.8)
+
+
+def test_cache_channels_skips_when_caching_disabled(mocker):
+    _, mock_cache = _patch_task(mocker, {"SLACK_ENABLE_CACHING": False}, fetch_pages=[])
+
+    cache_channels()
+
+    mock_cache.cache.set.assert_not_called()
+
+
+def test_cache_channels_caches_all_and_clears_continuation(mocker):
+    """When the whole workspace fits under the cap, cache everything and clear
+    the continuation cursor."""
+    config = {
+        "SLACK_ENABLE_CACHING": True,
+        "SLACK_CACHE_TIMEOUT": 86400,
+        "SLACK_CACHE_MAX_CHANNELS": 20000,
+    }
+    pages = [
+        _page(["C1", "C2"], next_cursor="cur1", has_more=True),
+        _page(["C3"], next_cursor=None, has_more=False),
+    ]
+    _, mock_cache = _patch_task(mocker, config, pages)
+
+    cache_channels()
+
+    mock_cache.cache.set.assert_called_once_with(
+        SLACK_CHANNELS_CACHE_KEY,
+        [{"id": "C1"}, {"id": "C2"}, {"id": "C3"}],
+        timeout=86400,
+    )
+    # No truncation -> continuation cursor is cleared, not set.
+    mock_cache.cache.delete.assert_called_once_with(
+        SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+    )
+
+
+def test_cache_channels_truncates_and_stores_continuation(mocker):
+    """When the workspace exceeds SLACK_CACHE_MAX_CHANNELS, the cache is
+    truncated to the cap and a continuation cursor is stored for the rest."""
+    config = {
+        "SLACK_ENABLE_CACHING": True,
+        "SLACK_CACHE_TIMEOUT": 86400,
+        "SLACK_CACHE_MAX_CHANNELS": 2,
+    }
+    pages = [
+        _page(["C1", "C2"], next_cursor="cur1", has_more=True),
+        # This page must never be requested because the cap is hit first.
+        _page(["C3"], next_cursor="cur2", has_more=True),
+    ]
+    mock_fetch, mock_cache = _patch_task(mocker, config, pages)
+
+    cache_channels()
+
+    # Only the first page is fetched before the cap is reached.
+    assert mock_fetch.call_count == 1
+    mock_cache.cache.set.assert_any_call(
+        SLACK_CHANNELS_CACHE_KEY,
+        [{"id": "C1"}, {"id": "C2"}],
+        timeout=86400,
+    )
+    mock_cache.cache.set.assert_any_call(
+        SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
+        "cur1",
+        timeout=86400,
+    )
+    mock_cache.cache.delete.assert_not_called()

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -1232,3 +1232,168 @@ class TestGetChannelsWithSearchPagination:
         assert "sales" in channel_names
         assert "engineering-team" not in channel_names
         assert "general" not in channel_names
+
+    def test_cache_boundary_exceeded_fallback_to_api(self, mocker):
+        """Test fallback to API when pagination exceeds cached data"""
+        # Mock cached channels (only 100 channels cached)
+        cached_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(100)
+        ]
+
+        # Mock continuation channels from API
+        api_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(100, 150)
+        ]
+
+        def cache_get_side_effect(key):
+            if key == "slack_conversations_list":
+                return cached_channels
+            if key == "slack_conversations_list_continuation_cursor":
+                return "continuation_cursor_value"
+            return None
+
+        mocker.patch(
+            "superset.utils.slack.cache_manager.cache.get",
+            side_effect=cache_get_side_effect,
+        )
+
+        mock_data = {
+            "channels": api_channels,
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Try to paginate beyond cached data (offset 100)
+        result = get_channels_with_search(cursor="cache:100", limit=50)
+
+        # Should fall back to API and return channels from continuation
+        assert len(result["result"]) == 50
+        assert result["result"][0]["name"] == "channel-100"
+
+    def test_cache_with_continuation_cursor_signals_more_data(self, mocker):
+        """Test that reaching end of cache with continuation cursor signals more data"""
+        # Mock cached channels
+        cached_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(100)
+        ]
+
+        def cache_get_side_effect(key):
+            if key == "slack_conversations_list":
+                return cached_channels
+            if key == "slack_conversations_list_continuation_cursor":
+                return "continuation_cursor_value"
+            return None
+
+        mocker.patch(
+            "superset.utils.slack.cache_manager.cache.get",
+            side_effect=cache_get_side_effect,
+        )
+
+        # Get last page of cached data (offset 90, limit 10)
+        result = get_channels_with_search(cursor="cache:90", limit=10)
+
+        # Should return last 10 channels
+        assert len(result["result"]) == 10
+        assert result["result"][0]["name"] == "channel-90"
+
+        # Should signal more data available via API
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "api:continue"
+
+    def test_api_continue_cursor_transitions_to_api(self, mocker):
+        """Test that 'api:continue' cursor properly transitions to API"""
+        api_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(100, 150)
+        ]
+
+        def cache_get_side_effect(key):
+            if key == "slack_conversations_list_continuation_cursor":
+                return "slack_api_cursor_value"
+            return None
+
+        mocker.patch(
+            "superset.utils.slack.cache_manager.cache.get",
+            side_effect=cache_get_side_effect,
+        )
+
+        mock_data = {
+            "channels": api_channels,
+            "response_metadata": {"next_cursor": "next_slack_cursor"},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Use api:continue cursor
+        result = get_channels_with_search(cursor="api:continue", limit=50)
+
+        # Should call API with continuation cursor
+        mock_client.conversations_list.assert_called_once()
+        call_args = mock_client.conversations_list.call_args
+        assert call_args[1]["cursor"] == "slack_api_cursor_value"
+
+        # Should return API results
+        assert len(result["result"]) == 50
+        assert result["next_cursor"] == "next_slack_cursor"
+        assert result["has_more"] is True
+
+    def test_cache_boundary_without_continuation_cursor(self, mocker):
+        """Test graceful handling when cache boundary exceeded without cursor"""
+        cached_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(100)
+        ]
+
+        def cache_get_side_effect(key):
+            if key == "slack_conversations_list":
+                return cached_channels
+            # No continuation cursor available
+            return None
+
+        mocker.patch(
+            "superset.utils.slack.cache_manager.cache.get",
+            side_effect=cache_get_side_effect,
+        )
+
+        # Try to paginate beyond cached data
+        result = get_channels_with_search(cursor="cache:100", limit=50)
+
+        # Should return empty result gracefully
+        assert len(result["result"]) == 0
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -398,15 +398,17 @@ The server responded with: missing scope: channels:read"""
 
     def test_handle_pagination_without_search(self, mocker):
         """Test pagination returns single page with cursor"""
+        channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(150)
+        ]
         mock_data_page1 = {
-            "channels": [
-                {
-                    "name": "general",
-                    "id": "C12345",
-                    "is_private": False,
-                    "is_member": True,
-                }
-            ],
+            "channels": channels,
             "response_metadata": {"next_cursor": "page2_cursor"},
         }
 
@@ -416,18 +418,9 @@ The server responded with: missing scope: channels:read"""
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(limit=100)
-        assert result == {
-            "result": [
-                {
-                    "name": "general",
-                    "id": "C12345",
-                    "is_private": False,
-                    "is_member": True,
-                }
-            ],
-            "next_cursor": "page2_cursor",
-            "has_more": True,
-        }
+        assert len(result["result"]) == 100
+        assert result["next_cursor"] == "page2_cursor"
+        assert result["has_more"] is True
 
     def test_handle_pagination_with_cursor(self, mocker):
         """Test pagination with cursor fetches next page"""
@@ -964,18 +957,17 @@ class TestGetChannelsWithSearchPagination:
 
         def mock_conversations_list(**kwargs):
             nonlocal call_count
-            limit = kwargs.get("limit", 100)
+            limit = kwargs.get("limit", 999)
             cursor = kwargs.get("cursor")
 
-            # Simulate Slack API pagination (max 1000 per page)
             if cursor is None:
                 start = 0
-            elif cursor == "cursor_1000":
-                start = 1000
-            elif cursor == "cursor_2000":
-                start = 2000
+            elif cursor == "cursor_999":
+                start = 999
+            elif cursor == "cursor_1998":
+                start = 1998
             else:
-                start = 3000
+                start = 2500
 
             end = min(start + limit, 2500)
             next_cursor = f"cursor_{end}" if end < 2500 else None
@@ -992,14 +984,14 @@ class TestGetChannelsWithSearchPagination:
         mock_client.conversations_list.side_effect = mock_conversations_list
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        # Request 1500 channels (requires 2 pages of 1000 each)
+        # Request 1500 channels (requires 2 pages of 999 each)
         result = get_channels_with_search(limit=1500)
 
         # Should return exactly 1500 channels
         assert len(result["result"]) == 1500
         assert result["has_more"] is True
-        assert result["next_cursor"] == "cursor_2000"
-        # Should have made 2 API calls
+        assert result["next_cursor"] == "cursor_1998"
+        # Should have made 2 API calls (999 + 501)
         assert call_count == 2
 
     def test_search_with_exact_match_optimization(self, mocker):

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -195,19 +195,13 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string="general,random", exact_match=True, limit=100
+            search_string="general", exact_match=True, limit=100
         )
         assert result == {
             "result": [
                 {
                     "name": "general",
                     "id": "C12345",
-                    "is_private": False,
-                    "is_member": True,
-                },
-                {
-                    "name": "random",
-                    "id": "C67890",
                     "is_private": False,
                     "is_member": True,
                 },
@@ -246,7 +240,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="general,random", limit=100)
+        result = get_channels_with_search(search_string="general", limit=100)
         assert result == {
             "result": [
                 {
@@ -258,12 +252,6 @@ class TestGetChannelsWithSearch:
                 {
                     "name": "general2",
                     "id": "C13454",
-                    "is_private": False,
-                    "is_member": True,
-                },
-                {
-                    "name": "random",
-                    "id": "C67890",
                     "is_private": False,
                     "is_member": True,
                 },
@@ -306,21 +294,30 @@ The server responded with: missing scope: channels:read"""
     def test_filter_channels_by_specified_types(
         self, types: list[SlackChannelTypes], expected_channel_ids: set[str], mocker
     ):
+        # Determine which channels to return based on types parameter
+        public_channel = {
+            "id": "public_channel_id",
+            "name": "open",
+            "is_member": False,
+            "is_private": False,
+        }
+        private_channel = {
+            "id": "private_channel_id",
+            "name": "secret",
+            "is_member": False,
+            "is_private": True,
+        }
+
+        # Mock should return channels matching the requested types
+        # (simulating Slack API's type filtering)
+        channels = []
+        if not types or SlackChannelTypes.PUBLIC in types:
+            channels.append(public_channel)
+        if not types or SlackChannelTypes.PRIVATE in types:
+            channels.append(private_channel)
+
         mock_data = {
-            "channels": [
-                {
-                    "id": "public_channel_id",
-                    "name": "open",
-                    "is_member": False,
-                    "is_private": False,
-                },
-                {
-                    "id": "private_channel_id",
-                    "name": "secret",
-                    "is_member": False,
-                    "is_private": True,
-                },
-            ],
+            "channels": channels,
             "response_metadata": {"next_cursor": None},
         }
 
@@ -514,7 +511,7 @@ The server responded with: missing scope: channels:read"""
         }
 
     def test_streaming_search_max_pages_safety_limit(self, mocker):
-        """Test that streaming search stops after 50 pages to prevent runaway requests"""
+        """Test streaming search stops after 50 pages to prevent runaway requests"""
 
         # Create a response that always has a next cursor (infinite pagination)
         mock_data = {
@@ -858,7 +855,7 @@ class TestGetChannelsWithSearchPagination:
         page2_channels = [
             {
                 "name": f"test-{i}",
-                "id": f"C{i+60}",
+                "id": f"C{i + 60}",
                 "is_private": False,
                 "is_member": True,
             }
@@ -889,9 +886,9 @@ class TestGetChannelsWithSearchPagination:
 
         # Should return exactly 100 channels (60 from page1 + 40 from page2)
         assert len(result["result"]) == 100
-        # Should indicate more results available (stopped at page2 cursor)
+        # Should indicate more results available (next cursor points to page3)
         assert result["has_more"] is True
-        assert result["next_cursor"] == "page2"
+        assert result["next_cursor"] == "page3"
 
     def test_cursor_format_with_special_characters(self, mocker):
         """Test that cursor with special characters is handled correctly"""
@@ -912,7 +909,7 @@ class TestGetChannelsWithSearchPagination:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call with special cursor
-        result = get_channels_with_search(cursor=special_cursor, limit=100)
+        get_channels_with_search(cursor=special_cursor, limit=100)
 
         # Verify cursor was passed to Slack API
         mock_client.conversations_list.assert_called_once()
@@ -943,7 +940,7 @@ class TestGetChannelsWithSearchPagination:
     def test_custom_limit_parameter(self, mocker):
         """Test that custom limit parameter is respected"""
 
-        channels = [
+        all_channels = [
             {
                 "name": f"channel-{i}",
                 "id": f"C{i}",
@@ -953,14 +950,18 @@ class TestGetChannelsWithSearchPagination:
             for i in range(200)
         ]
 
-        mock_data = {
-            "channels": channels,
-            "response_metadata": {"next_cursor": "next_page"},
-        }
-        mock_response = MockResponse(mock_data)
+        # Mock should respect the limit parameter (simulating Slack API behavior)
+        def mock_conversations_list(**kwargs):
+            limit = kwargs.get("limit", 100)
+            return MockResponse(
+                {
+                    "channels": all_channels[:limit],
+                    "response_metadata": {"next_cursor": "next_page"},
+                }
+            )
 
         mock_client = mocker.Mock()
-        mock_client.conversations_list.return_value = mock_response
+        mock_client.conversations_list.side_effect = mock_conversations_list
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Request custom limit of 50
@@ -969,3 +970,139 @@ class TestGetChannelsWithSearchPagination:
         # Should return exactly 50 channels
         assert len(result["result"]) == 50
         assert result["has_more"] is True
+
+    def test_non_search_pagination_over_200_limit(self, mocker):
+        """Test non-search queries paginate correctly for limits > 200"""
+        # Create 500 channels
+        all_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(500)
+        ]
+
+        call_count = 0
+
+        def mock_conversations_list(**kwargs):
+            nonlocal call_count
+            limit = kwargs.get("limit", 100)
+            cursor = kwargs.get("cursor")
+
+            # Simulate Slack API pagination (max 200 per page)
+            if cursor is None:
+                start = 0
+            elif cursor == "cursor_200":
+                start = 200
+            elif cursor == "cursor_400":
+                start = 400
+            else:
+                start = 600
+
+            end = min(start + limit, 500)
+            next_cursor = f"cursor_{end}" if end < 500 else None
+
+            call_count += 1
+            return MockResponse(
+                {
+                    "channels": all_channels[start:end],
+                    "response_metadata": {"next_cursor": next_cursor},
+                }
+            )
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.side_effect = mock_conversations_list
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request 300 channels (requires 2 pages of 200 each)
+        result = get_channels_with_search(limit=300)
+
+        # Should return exactly 300 channels
+        assert len(result["result"]) == 300
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "cursor_400"
+        # Should have made 2 API calls
+        assert call_count == 2
+
+    def test_search_with_exact_match_optimization(self, mocker):
+        """Test exact match search uses optimized string comparison"""
+        channels = [
+            {"name": "test", "id": "C1", "is_private": False, "is_member": True},
+            {"name": "test-dev", "id": "C2", "is_private": False, "is_member": True},
+            {"name": "testing", "id": "C3", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(
+            search_string="TEST", exact_match=True, limit=100
+        )
+
+        # Only "test" should match (case-insensitive exact match)
+        assert len(result["result"]) == 1
+        assert result["result"][0]["name"] == "test"
+
+    def test_search_substring_match_optimization(self, mocker):
+        """Test substring search uses optimized string comparison"""
+        channels = [
+            {"name": "prod-api", "id": "C1", "is_private": False, "is_member": True},
+            {"name": "dev-api", "id": "C2", "is_private": False, "is_member": True},
+            {"name": "staging", "id": "C3", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(search_string="API", limit=100)
+
+        # Both "prod-api" and "dev-api" should match (case-insensitive)
+        assert len(result["result"]) == 2
+        assert {ch["name"] for ch in result["result"]} == {"prod-api", "dev-api"}
+
+    def test_search_by_channel_id(self, mocker):
+        """Test search can match by channel ID"""
+        channels = [
+            {"name": "general", "id": "C12345", "is_private": False, "is_member": True},
+            {"name": "random", "id": "C67890", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(
+            search_string="c12345", exact_match=True, limit=100
+        )
+
+        # Should match by ID (case-insensitive)
+        assert len(result["result"]) == 1
+        assert result["result"][0]["id"] == "C12345"
+
+    def test_non_search_empty_result_handling(self, mocker):
+        """Test non-search query handles empty channel list"""
+        mock_data = {
+            "channels": [],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+
+        assert len(result["result"]) == 0
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -48,7 +48,14 @@ class TestGetChannelsWithSearch:
     def test_fetch_all_channels_no_search_string(self, mocker):
         # Mock data
         mock_data = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -60,12 +67,30 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search()
-        assert result == [{"name": "general", "id": "C12345"}]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     # Handle an empty search string gracefully
     def test_handle_empty_search_string(self, mocker):
         mock_data = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -75,15 +100,41 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(search_string="")
-        assert result == [{"name": "general", "id": "C12345"}]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_exact_match_search_string_single_channel(self, mocker):
         # Mock data with multiple channels
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -95,17 +146,45 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call the function with a search string that matches a single channel
-        result = get_channels_with_search(search_string="general", exact_match=True)
+        result = get_channels_with_search(
+            search_string="general", exact_match=True, limit=100
+        )
 
-        # Assert that the result is a list with a single channel dictionary
-        assert result == [{"name": "general", "id": "C12345"}]
+        # Assert that the result is a dict with proper structure
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_exact_match_search_string_multiple_channels(self, mocker):
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -116,19 +195,48 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string="general,random", exact_match=True
+            search_string="general,random", exact_match=True, limit=100
         )
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "random", "id": "C67890"},
-        ]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_loose_match_search_string_multiple_channels(self, mocker):
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -138,12 +246,31 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="general,random")
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "general2", "id": "C13454"},
-            {"name": "random", "id": "C67890"},
-        ]
+        result = get_channels_with_search(search_string="general,random", limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_slack_client_error_listing_channels(self, mocker):
         from slack_sdk.errors import SlackApiError
@@ -203,7 +330,7 @@ The server responded with: missing scope: channels:read"""
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(types=types)
-        assert {channel["id"] for channel in result} == expected_channel_ids
+        assert {channel["id"] for channel in result["result"]} == expected_channel_ids
 
     def test_passes_team_id_to_conversations_list_when_configured(self, mocker):
         # When SLACK_TEAM_ID is set (org-scoped token on an Enterprise Grid org),
@@ -272,13 +399,91 @@ The server responded with: missing scope: channels:read"""
         assert should_use_v2_api() is True
         assert mock_client.conversations_list.call_args.kwargs["team_id"] == "T123456"
 
-    def test_handle_pagination_multiple_pages(self, mocker):
+    def test_handle_pagination_without_search(self, mocker):
+        """Test pagination returns single page with cursor"""
         mock_data_page1 = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "response_metadata": {"next_cursor": "page2_cursor"},
+        }
+
+        mock_response_instance_page1 = MockResponse(mock_data_page1)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response_instance_page1
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": "page2_cursor",
+            "has_more": True,
+        }
+
+    def test_handle_pagination_with_cursor(self, mocker):
+        """Test pagination with cursor fetches next page"""
+        mock_data_page2 = {
+            "channels": [
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response_instance_page2 = MockResponse(mock_data_page2)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response_instance_page2
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(cursor="page2_cursor", limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_streaming_search_pagination(self, mocker):
+        """Test search mode streams through pages until limit is reached"""
+        mock_data_page1 = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {"name": "random", "id": "C2", "is_private": False, "is_member": True},
+            ],
             "response_metadata": {"next_cursor": "page2"},
         }
         mock_data_page2 = {
-            "channels": [{"name": "random", "id": "C67890"}],
+            "channels": [
+                {
+                    "name": "general-2",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {"name": "other", "id": "C4", "is_private": False, "is_member": True},
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -292,12 +497,98 @@ The server responded with: missing scope: channels:read"""
         ]
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search()
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "random", "id": "C67890"},
+        # Search for "general" - should find 2 channels across 2 pages
+        result = get_channels_with_search(search_string="general", limit=100)
+        assert result == {
+            "result": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {
+                    "name": "general-2",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_streaming_search_max_pages_safety_limit(self, mocker):
+        """Test that streaming search stops after 50 pages to prevent runaway requests"""
+
+        # Create a response that always has a next cursor (infinite pagination)
+        mock_data = {
+            "channels": [
+                {"name": "channel", "id": "C1", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search that matches the channel - should stop at 50 pages
+        result = get_channels_with_search(search_string="channel", limit=100)
+
+        # Should have called conversations_list exactly 50 times (max pages)
+        assert mock_client.conversations_list.call_count == 50
+        # Should return the matches found (50 channels, one per page)
+        assert len(result["result"]) == 50
+
+    def test_search_with_no_matches(self, mocker):
+        """Test search that finds no matching channels"""
+
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {"name": "random", "id": "C2", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search for non-existent channel
+        result = get_channels_with_search(search_string="nonexistent", limit=100)
+
+        assert result == {
+            "result": [],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_search_returns_exactly_limit(self, mocker):
+        """Test search that returns exactly the requested limit"""
+
+        # Create 100 matching channels
+        channels = [
+            {"name": f"test-{i}", "id": f"C{i}", "is_private": False, "is_member": True}
+            for i in range(100)
         ]
 
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search that matches all channels
+        result = get_channels_with_search(search_string="test", limit=100)
+
+        # Should return exactly 100 channels
+        assert len(result["result"]) == 100
+        # Should indicate more results available
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "next_page"
 
 # ---------------------------------------------------------------------------
 # should_use_v2_api: drives the v1→v2 auto-upgrade decision and emits
@@ -520,3 +811,161 @@ class TestShouldUseV2Api:
 
         with pytest.raises(RuntimeError):
             should_use_v2_api()
+
+
+class TestGetChannelsWithSearchPagination:
+    def test_partial_page_results(self, mocker):
+        """Test pagination with partial page (less than limit)"""
+
+        # Only 50 channels returned (less than default 100 limit)
+        channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(50)
+        ]
+
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+
+        # Should return all 50 channels
+        assert len(result["result"]) == 50
+        # Should indicate no more results
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+
+    def test_streaming_search_stops_when_limit_reached(self, mocker):
+        """Test that streaming search stops immediately when limit is reached"""
+
+        # First page with 60 matching channels
+        page1_channels = [
+            {"name": f"test-{i}", "id": f"C{i}", "is_private": False, "is_member": True}
+            for i in range(60)
+        ]
+        # Second page with 60 more matching channels (should not be fully processed)
+        page2_channels = [
+            {
+                "name": f"test-{i}",
+                "id": f"C{i+60}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(60)
+        ]
+
+        mock_data_page1 = {
+            "channels": page1_channels,
+            "response_metadata": {"next_cursor": "page2"},
+        }
+        mock_data_page2 = {
+            "channels": page2_channels,
+            "response_metadata": {"next_cursor": "page3"},
+        }
+
+        mock_response_page1 = MockResponse(mock_data_page1)
+        mock_response_page2 = MockResponse(mock_data_page2)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.side_effect = [
+            mock_response_page1,
+            mock_response_page2,
+        ]
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request limit of 100
+        result = get_channels_with_search(search_string="test", limit=100)
+
+        # Should return exactly 100 channels (60 from page1 + 40 from page2)
+        assert len(result["result"]) == 100
+        # Should indicate more results available (stopped at page2 cursor)
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "page2"
+
+    def test_cursor_format_with_special_characters(self, mocker):
+        """Test that cursor with special characters is handled correctly"""
+
+        # Slack cursors are base64 encoded strings that might contain special chars
+        special_cursor = "dGVhbTpDMDYxRkE1UEw="
+
+        mock_data = {
+            "channels": [
+                {"name": "test", "id": "C123", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Call with special cursor
+        result = get_channels_with_search(cursor=special_cursor, limit=100)
+
+        # Verify cursor was passed to Slack API
+        mock_client.conversations_list.assert_called_once()
+        call_kwargs = mock_client.conversations_list.call_args[1]
+        assert call_kwargs["cursor"] == special_cursor
+
+    def test_empty_channel_list_response(self, mocker):
+        """Test handling of empty channels list from Slack API"""
+
+        mock_data = {
+            "channels": [],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search()
+
+        assert result == {
+            "result": [],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_custom_limit_parameter(self, mocker):
+        """Test that custom limit parameter is respected"""
+
+        channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(200)
+        ]
+
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request custom limit of 50
+        result = get_channels_with_search(limit=50)
+
+        # Should return exactly 50 channels
+        assert len(result["result"]) == 50
+        assert result["has_more"] is True

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -510,30 +510,6 @@ The server responded with: missing scope: channels:read"""
             "has_more": False,
         }
 
-    def test_streaming_search_max_pages_safety_limit(self, mocker):
-        """Test streaming search stops after 50 pages to prevent runaway requests"""
-
-        # Create a response that always has a next cursor (infinite pagination)
-        mock_data = {
-            "channels": [
-                {"name": "channel", "id": "C1", "is_private": False, "is_member": True},
-            ],
-            "response_metadata": {"next_cursor": "next_page"},
-        }
-        mock_response = MockResponse(mock_data)
-
-        mock_client = mocker.Mock()
-        mock_client.conversations_list.return_value = mock_response
-        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
-
-        # Search that matches the channel - should stop at 50 pages
-        result = get_channels_with_search(search_string="channel", limit=100)
-
-        # Should have called conversations_list exactly 50 times (max pages)
-        assert mock_client.conversations_list.call_count == 50
-        # Should return the matches found (50 channels, one per page)
-        assert len(result["result"]) == 50
-
     def test_search_with_no_matches(self, mocker):
         """Test search that finds no matching channels"""
 
@@ -971,9 +947,9 @@ class TestGetChannelsWithSearchPagination:
         assert len(result["result"]) == 50
         assert result["has_more"] is True
 
-    def test_non_search_pagination_over_200_limit(self, mocker):
-        """Test non-search queries paginate correctly for limits > 200"""
-        # Create 500 channels
+    def test_non_search_pagination_over_1000_limit(self, mocker):
+        """Test non-search queries paginate correctly for limits > 1000"""
+        # Create 2500 channels
         all_channels = [
             {
                 "name": f"channel-{i}",
@@ -981,7 +957,7 @@ class TestGetChannelsWithSearchPagination:
                 "is_private": False,
                 "is_member": True,
             }
-            for i in range(500)
+            for i in range(2500)
         ]
 
         call_count = 0
@@ -991,18 +967,18 @@ class TestGetChannelsWithSearchPagination:
             limit = kwargs.get("limit", 100)
             cursor = kwargs.get("cursor")
 
-            # Simulate Slack API pagination (max 200 per page)
+            # Simulate Slack API pagination (max 1000 per page)
             if cursor is None:
                 start = 0
-            elif cursor == "cursor_200":
-                start = 200
-            elif cursor == "cursor_400":
-                start = 400
+            elif cursor == "cursor_1000":
+                start = 1000
+            elif cursor == "cursor_2000":
+                start = 2000
             else:
-                start = 600
+                start = 3000
 
-            end = min(start + limit, 500)
-            next_cursor = f"cursor_{end}" if end < 500 else None
+            end = min(start + limit, 2500)
+            next_cursor = f"cursor_{end}" if end < 2500 else None
 
             call_count += 1
             return MockResponse(
@@ -1016,13 +992,13 @@ class TestGetChannelsWithSearchPagination:
         mock_client.conversations_list.side_effect = mock_conversations_list
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        # Request 300 channels (requires 2 pages of 200 each)
-        result = get_channels_with_search(limit=300)
+        # Request 1500 channels (requires 2 pages of 1000 each)
+        result = get_channels_with_search(limit=1500)
 
-        # Should return exactly 300 channels
-        assert len(result["result"]) == 300
+        # Should return exactly 1500 channels
+        assert len(result["result"]) == 1500
         assert result["has_more"] is True
-        assert result["next_cursor"] == "cursor_400"
+        assert result["next_cursor"] == "cursor_2000"
         # Should have made 2 API calls
         assert call_count == 2
 
@@ -1106,3 +1082,153 @@ class TestGetChannelsWithSearchPagination:
         assert len(result["result"]) == 0
         assert result["has_more"] is False
         assert result["next_cursor"] is None
+
+    def test_comma_separated_search_strings(self, mocker):
+        """Test search with comma-separated search strings (OR logic)"""
+        mock_data = {
+            "channels": [
+                {
+                    "name": "engineering",
+                    "id": "C1",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "marketing",
+                    "id": "C2",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "sales",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "design",
+                    "id": "C4",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general",
+                    "id": "C5",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search for "engineering,marketing,sales"
+        result = get_channels_with_search(
+            search_string="engineering,marketing,sales", limit=100
+        )
+
+        # Should match 3 channels: engineering, marketing, sales
+        assert len(result["result"]) == 3
+        channel_names = [channel["name"] for channel in result["result"]]
+        assert "engineering" in channel_names
+        assert "marketing" in channel_names
+        assert "sales" in channel_names
+        assert "design" not in channel_names
+        assert "general" not in channel_names
+
+    def test_comma_separated_search_with_whitespace(self, mocker):
+        """Test comma-separated search handles extra whitespace correctly"""
+        mock_data = {
+            "channels": [
+                {
+                    "name": "engineering-team",
+                    "id": "C1",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "marketing-ops",
+                    "id": "C2",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search with extra whitespace: " engineering , marketing "
+        result = get_channels_with_search(
+            search_string=" engineering , marketing ", limit=100
+        )
+
+        # Should match 2 channels, whitespace should be stripped
+        assert len(result["result"]) == 2
+        channel_names = [channel["name"] for channel in result["result"]]
+        assert "engineering-team" in channel_names
+        assert "marketing-ops" in channel_names
+        assert "general" not in channel_names
+
+    def test_comma_separated_exact_match(self, mocker):
+        """Test comma-separated search with exact_match=True"""
+        mock_data = {
+            "channels": [
+                {
+                    "name": "engineering",
+                    "id": "C1",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "engineering-team",
+                    "id": "C2",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "sales",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general",
+                    "id": "C4",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Exact match search for "engineering,sales"
+        result = get_channels_with_search(
+            search_string="engineering,sales", exact_match=True, limit=100
+        )
+
+        # Should match only exact names: engineering and sales (not engineering-team)
+        assert len(result["result"]) == 2
+        channel_names = [channel["name"] for channel in result["result"]]
+        assert "engineering" in channel_names
+        assert "sales" in channel_names
+        assert "engineering-team" not in channel_names
+        assert "general" not in channel_names

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -30,6 +30,8 @@ from superset.utils.slack import (
     _SLACK_V1_DEPRECATION_MESSAGE,
     get_channels_with_search,
     should_use_v2_api,
+    SLACK_CHANNELS_CACHE_KEY,
+    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY,
     SlackChannelTypes,
 )
 
@@ -112,6 +114,101 @@ class TestGetChannelsWithSearch:
             "next_cursor": None,
             "has_more": False,
         }
+
+    def test_cold_cache_single_page_warms_cache(self, mocker):
+        """An unfiltered first-page request on a cold cache writes the full
+        channel list through to the cache, so deployments without a Celery
+        warmup worker keep the in-memory fast path."""
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {"name": "random", "id": "C2", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = MockResponse(mock_data)
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        mock_cache = mocker.patch("superset.utils.slack.cache_manager.cache")
+        mock_cache.get.return_value = None  # cold cache
+
+        result = get_channels_with_search()
+
+        assert result["has_more"] is False
+        assert len(result["result"]) == 2
+        # Full list written through, continuation cursor cleared.
+        mock_cache.set.assert_called_once()
+        key, cached = mock_cache.set.call_args.args
+        assert key == SLACK_CHANNELS_CACHE_KEY
+        assert len(cached) == 2
+        mock_cache.delete.assert_called_once_with(
+            SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+        )
+
+    def test_cold_cache_multi_page_does_not_warm(self, mocker):
+        """A multi-page workspace is left to the async warmup task; the
+        synchronous write-through only fires when the whole workspace fits in
+        the fetched pages (has_more is False)."""
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True}
+            ],
+            "response_metadata": {"next_cursor": "CURSOR2"},
+        }
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = MockResponse(mock_data)
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        mock_cache = mocker.patch("superset.utils.slack.cache_manager.cache")
+        mock_cache.get.return_value = None
+
+        result = get_channels_with_search(limit=1)
+
+        assert result["has_more"] is True
+        mock_cache.set.assert_not_called()
+
+    def test_cold_cache_search_does_not_warm(self, mocker):
+        """A search request returns a filtered subset, not the full list, so it
+        must never write through to the cache."""
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True}
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = MockResponse(mock_data)
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        mock_cache = mocker.patch("superset.utils.slack.cache_manager.cache")
+        mock_cache.get.return_value = None
+
+        get_channels_with_search(search_string="general")
+
+        mock_cache.set.assert_not_called()
+
+    def test_cold_cache_warm_skipped_when_caching_disabled(self, mocker):
+        """With SLACK_ENABLE_CACHING disabled, no write-through occurs."""
+        from flask import current_app
+
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True}
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = MockResponse(mock_data)
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        mock_cache = mocker.patch("superset.utils.slack.cache_manager.cache")
+        mock_cache.get.return_value = None
+        mocker.patch.dict(current_app.config, {"SLACK_ENABLE_CACHING": False})
+
+        get_channels_with_search()
+
+        mock_cache.set.assert_not_called()
 
     def test_handle_exact_match_search_string_single_channel(self, mocker):
         # Mock data with multiple channels
@@ -555,6 +652,7 @@ The server responded with: missing scope: channels:read"""
         # Should indicate more results available
         assert result["has_more"] is True
         assert result["next_cursor"] == "next_page"
+
 
 # ---------------------------------------------------------------------------
 # should_use_v2_api: drives the v1→v2 auto-upgrade decision and emits


### PR DESCRIPTION
### SUMMARY

#### Problem
Users could not edit Slack recipients in Alerts & Reports when their Slack workspace had a large number of channels. The dropdown failed to load, showing a timeout after 30+ seconds, making the feature unusable for large organizations.

#### Root Cause
The previous implementation loaded **all** Slack channels in a single blocking request:
- For large workspaces this meant fetching thousands of channels before returning anything.
- The Slack `conversations.list` API is paginated but has no server-side search.
- The request timed out before any results were returned.

#### Solution
Server-side pagination + search, backed by an optional cache, continuing the work started in https://github.com/apache/superset/pull/35832

**Backend — pagination & search** (`superset/utils/slack.py`, `superset/reports/api.py`, `superset/reports/schemas.py`)
- New `get_channels_with_search()` with two paths:
  - **No search** — returns a single page directly from the Slack API (fast).
  - **With search** — streams Slack API pages, filtering matches until the page limit is reached; supports comma-separated OR terms (e.g. `engineering,marketing`).
- `GET /api/v1/report/slack_channels/` now accepts `search_string`, `types`, `exact_match`, `cursor`, `limit` (bounded 1–999), and `force`.
- Page size raised 200 → 999 to cut API calls and reduce rate-limiting.
- Removed the legacy fetch-everything `get_channels()` helper.

**Backend — caching** (`superset/tasks/slack.py`, `superset/config.py`)
- The `slack.cache_channels` Celery task warms an in-memory cache of the full channel list; `get_channels_with_search` serves paginated/filtered results from cache when warm (no Slack API calls).
- Bounded by `SLACK_CACHE_MAX_CHANNELS`; when a workspace exceeds it, a continuation cursor is stored so lookups transparently fall back to the API past the cache boundary.
- `force=true` clears the cache and re-triggers warm-up.
- **Works without a Celery worker**: on a cold cache, an unfiltered first page that returns the whole workspace in one page is written through to the cache (non-blocking); larger workspaces rely on the async warm-up task.
- New config: `SLACK_ENABLE_CACHING` (default on), `SLACK_CACHE_MAX_CHANNELS` (20000), `SLACK_CACHE_WARMUP_TIMEOUT` (300s, applied per dispatch so operator overrides are honored). Reuses existing `SLACK_CACHE_TIMEOUT`.

**Frontend** (`NotificationMethod.tsx`, `hooks/useSlackChannels.ts`, `AlertReportModal.tsx`)
- Replaced the load-everything dropdown with `AsyncSelect` incremental pagination + debounced server-side search, extracted into a `useSlackChannels` hook.
- Added a "refresh channels" button (cache-bypass) that preserves current selections.
- Graceful fallback to Slack V1 manual input on fetch errors, **without clearing already-saved recipients**.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
![slack-bug-before](https://github.com/user-attachments/assets/47fccd1f-f82e-4f2e-8470-67950fd755c6)
#### After
![slack-channels-after](https://github.com/user-attachments/assets/f8776fad-4f19-423b-90f4-8f089892a706)

### TESTING INSTRUCTIONS

#### Automated (no Slack workspace needed)
```bash
pytest tests/unit_tests/utils/slack_test.py tests/unit_tests/tasks/test_slack.py -v
pytest tests/integration_tests/reports/api_tests.py -k slack_channels -v
cd superset-frontend && npm run test -- NotificationMethod useSlackChannels
```

#### Manual
Prereqs: `FEATURE_FLAGS = {"ALERT_REPORTS": True, "ALERT_REPORT_SLACK_V2": True}` and `SLACK_API_TOKEN` set (bot scopes `channels:read`, `groups:read`).
1. Open an Alert/Report → **Notification method → Slack**. The channel dropdown loads quickly and paginates as you scroll; typing filters server-side — no timeout even on very large workspaces.
2. Select channels, click **refresh** — selections are preserved.
3. (No Celery worker) open the dropdown on a small workspace; server logs show `Warmed Slack channel cache ... without a Celery worker`, and a second load shows `Using cache path`.
4. (With Celery worker) set `SLACK_CACHE_WARMUP_TIMEOUT`; a `force` refresh dispatches `slack.cache_channels` with the configured time limit.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: Closely related to #35661
- [x] Required feature flags: `ALERT_REPORTS`, `ALERT_REPORT_SLACK_V2`
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API