### PR TITLE
chore(a11y): enable jsx-a11y/prefer-tag-over-role as error

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -215,6 +215,7 @@
     "jsx-a11y/no-noninteractive-tabindex": "error",
     "jsx-a11y/no-redundant-roles": "error",
     "jsx-a11y/no-static-element-interactions": "error",
+    "jsx-a11y/prefer-tag-over-role": "error",
     "jsx-a11y/role-has-required-aria-props": "error",
     "jsx-a11y/role-supports-aria-props": "error",
     "jsx-a11y/scope": "error",

--- a/superset-frontend/packages/superset-ui-core/src/components/ActionButton/ActionButton.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ActionButton/ActionButton.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, userEvent, fireEvent } from '@superset-ui/core/spec';
+import { render, screen, userEvent } from '@superset-ui/core/spec';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { ActionButton } from '.';
 
@@ -43,18 +43,6 @@ test('calls onClick when clicked', async () => {
   userEvent.click(button);
 
   expect(onClick).toHaveBeenCalledTimes(1);
-});
-
-test('calls onClick when activated with the keyboard', () => {
-  const onClick = jest.fn();
-  render(<ActionButton {...defaultProps} onClick={onClick} />);
-
-  const button = screen.getByRole('button');
-  fireEvent.keyDown(button, { key: 'Enter' });
-  expect(onClick).toHaveBeenCalledTimes(1);
-
-  fireEvent.keyDown(button, { key: ' ' });
-  expect(onClick).toHaveBeenCalledTimes(2);
 });
 
 test('renders with tooltip when tooltip prop is provided', async () => {
@@ -115,6 +103,6 @@ test('has proper accessibility attributes', () => {
   render(<ActionButton {...defaultProps} />);
 
   const button = screen.getByRole('button');
-  expect(button).toHaveAttribute('tabIndex', '0');
-  expect(button).toHaveAttribute('role', 'button');
+  expect(button.tagName).toBe('BUTTON');
+  expect(button).toHaveAttribute('type', 'button');
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { handleKeyboardActivation } from '../../utils';
 import type { ReactElement, ReactNode } from 'react';
+import cx from 'classnames';
 import { Tooltip, type TooltipPlacement } from '@superset-ui/core/components';
 import { css, useTheme } from '@apache-superset/core/theme';
 
@@ -28,6 +28,9 @@ export interface ActionProps {
   placement?: TooltipPlacement;
   icon: ReactNode;
   onClick: () => void;
+  className?: string;
+  disabled?: boolean;
+  dataTest?: string;
 }
 
 export const ActionButton = ({
@@ -36,14 +39,26 @@ export const ActionButton = ({
   placement,
   icon,
   onClick,
+  className,
+  disabled = false,
+  dataTest,
 }: ActionProps) => {
   const theme = useTheme();
   const actionButton = (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
+      aria-disabled={disabled}
       aria-label={typeof tooltip === 'string' ? tooltip : label}
       css={css`
+        appearance: none;
+        border: none;
+        background: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
         cursor: pointer;
         color: ${theme.colorIcon};
         margin-right: ${theme.sizeUnit}px;
@@ -52,14 +67,17 @@ export const ActionButton = ({
             fill: ${theme.colorPrimary};
           }
         }
+        &.disabled {
+          color: ${theme.colorTextDisabled};
+          cursor: not-allowed;
+        }
       `}
-      className="action-button"
-      data-test={label}
-      onClick={onClick}
-      onKeyDown={onClick ? handleKeyboardActivation(onClick) : undefined}
+      className={cx('action-button', className, { disabled })}
+      data-test={dataTest ?? label}
+      onClick={disabled ? undefined : onClick}
     >
       {icon}
-    </span>
+    </button>
   );
 
   const tooltipId = `${label.replaceAll(' ', '-').toLowerCase()}-tooltip`;

--- a/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ActionButton/index.tsx
@@ -62,7 +62,7 @@ export const ActionButton = ({
         cursor: pointer;
         color: ${theme.colorIcon};
         margin-right: ${theme.sizeUnit}px;
-        &:hover {
+        &:not(.disabled):hover {
           path {
             fill: ${theme.colorPrimary};
           }

--- a/superset-frontend/packages/superset-ui-core/src/components/ButtonGroup/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ButtonGroup/index.tsx
@@ -21,7 +21,11 @@ import type { ButtonGroupProps } from './types';
 export function ButtonGroup(props: ButtonGroupProps) {
   const { className, children } = props;
   return (
+    // role="group" is the correct ARIA pattern for a generic button toolbar;
+    // the suggested native tags (fieldset, etc.) carry unrelated form
+    // semantics and unwanted default browser styling.
     <div
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="group"
       className={className}
       css={{

--- a/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
@@ -134,6 +134,10 @@ const ImageContainer = ({
       ? imageMap[image as keyof typeof imageMap]
       : image;
   return (
+    // Groups Empty's SVG illustration + description into one accessible
+    // image; can't be a literal <img> since it's a component tree, not an
+    // image file reference.
+    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     <div role="img" aria-label="empty">
       <Empty
         description={false}

--- a/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
@@ -25,8 +25,12 @@ import { Icons } from '@superset-ui/core/components/Icons';
 import { Tooltip } from '../Tooltip';
 import type { FaveStarProps } from './types';
 
-const StyledLink = styled.a`
+const StyledLink = styled.button`
   ${({ theme }) => css`
+    appearance: none;
+    border: none;
+    background: none;
+    font: inherit;
     font-size: ${theme.fontSizeXL}px;
     display: flex;
     padding: 0 0 0 ${theme.sizeUnit * 2}px;
@@ -55,12 +59,10 @@ export const FaveStar = ({
 
   const content = (
     <StyledLink
-      href="#"
+      type="button"
       onClick={onClick}
       className="fave-unfave-icon"
       data-test="fave-unfave-icon"
-      role="button"
-      tabIndex={0}
     >
       {isStarred ? (
         <Icons.StarFilled

--- a/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
@@ -102,6 +102,10 @@ export const LabeledErrorBoundInput = ({
                 </Tooltip>
               )
             }
+            // input[type=password] doesn't get an implicit "textbox" role
+            // (unlike other text inputs), so this explicit override is
+            // needed for it to be discoverable via role-based queries/AT.
+            // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
             role="textbox"
           />
         ) : renderAsTextArea ? (

--- a/superset-frontend/packages/superset-ui-core/src/components/IconButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/IconButton/index.tsx
@@ -79,8 +79,12 @@ const IconButton: React.FC<IconButtonProps> = ({
   };
 
   return (
+    // antd's Card renders a fixed <div> (no polymorphic tag support) with
+    // its own rich internal layout (cover/title/tooltip); that doesn't map
+    // onto a native <button>, so role="button" is used instead.
     <Card
       hoverable
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="button"
       tabIndex={0}
       aria-label={buttonText}

--- a/superset-frontend/packages/superset-ui-core/src/components/Loading/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Loading/index.tsx
@@ -99,6 +99,10 @@ export function Loading({
       $spinnerHeight="auto"
       $opacity={opacity}
       className={cls('loading', position, className)}
+      // role="status" is the standard WAI-ARIA live-region pattern for a
+      // loading spinner; <output> (the suggested tag) is for form
+      // calculation results, not a fit here.
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="status"
       aria-live="polite"
       aria-label={t('Loading')}

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
@@ -127,10 +127,15 @@ export const ModalTrigger = forwardRef(
           </Button>
         )}
         {!isButton && (
+          // Generic wrapper used by 19+ callers passing arbitrary
+          // triggerNode content that relies on block-level <div> layout;
+          // swapping to <button> risks a layout regression across callers
+          // with no shared CSS to guide a safe reset.
           <div
             data-test="span-modal-trigger"
             onClick={open}
             onKeyDown={handleKeyboardActivation(open)}
+            // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
             role="button"
             tabIndex={0}
           >

--- a/superset-frontend/packages/superset-ui-core/src/components/PopoverDropdown/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PopoverDropdown/index.tsx
@@ -103,7 +103,18 @@ const PopoverDropdown = (props: PopoverDropdownProps) => {
         })),
       }}
     >
-      <div role="button" css={{ display: 'flex', alignItems: 'center' }}>
+      <button
+        type="button"
+        css={{
+          appearance: 'none',
+          border: 'none',
+          background: 'none',
+          padding: 0,
+          font: 'inherit',
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
         {selected && renderButton(selected)}
         <Icons.DownOutlined
           iconSize="s"
@@ -112,7 +123,7 @@ const PopoverDropdown = (props: PopoverDropdownProps) => {
             marginLeft: theme.sizeUnit * 0.5,
           }}
         />
-      </div>
+      </button>
     </Dropdown>
   );
 };

--- a/superset-frontend/packages/superset-ui-core/src/components/PopoverSection/PopoverSection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PopoverSection/PopoverSection.test.tsx
@@ -22,7 +22,7 @@ import PopoverSection from '.';
 test('renders with default props', async () => {
   render(
     <PopoverSection title="Title">
-      <div role="form" />
+      <form aria-label="test-form" />
     </PopoverSection>,
   );
   expect(await screen.findByRole('form')).toBeInTheDocument();
@@ -32,7 +32,7 @@ test('renders with default props', async () => {
 test('renders tooltip icon', async () => {
   render(
     <PopoverSection title="Title" info="Tooltip">
-      <div role="form" />
+      <form />
     </PopoverSection>,
   );
   expect((await screen.findAllByRole('img')).length).toBe(2);
@@ -41,7 +41,7 @@ test('renders tooltip icon', async () => {
 test('renders a tooltip when hovered', async () => {
   render(
     <PopoverSection title="Title" info="Tooltip">
-      <div role="form" />
+      <form />
     </PopoverSection>,
   );
   await userEvent.hover(screen.getAllByRole('img')[0]);
@@ -52,7 +52,7 @@ test('calls onSelect when clicked', async () => {
   const onSelect = jest.fn();
   render(
     <PopoverSection title="Title" onSelect={onSelect}>
-      <div role="form" />
+      <form />
     </PopoverSection>,
   );
   await userEvent.click(await screen.findByRole('img'));

--- a/superset-frontend/packages/superset-ui-core/src/components/PopoverSection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PopoverSection/index.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '../../utils';
-import { ReactNode, SyntheticEvent } from 'react';
+import { MouseEventHandler, ReactNode } from 'react';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { Tooltip } from '../Tooltip';
@@ -25,10 +24,7 @@ import { Tooltip } from '../Tooltip';
 export interface PopoverSectionProps {
   title: string;
   isSelected?: boolean;
-  // `SyntheticEvent` (rather than `MouseEventHandler`) so the same callback
-  // can be reused as the keyboard-activation handler via
-  // `handleKeyboardActivation`, which invokes it with a `KeyboardEvent`.
-  onSelect?: (event: SyntheticEvent) => void;
+  onSelect?: MouseEventHandler<HTMLButtonElement>;
   info?: string;
   children?: ReactNode;
 }
@@ -48,12 +44,17 @@ export default function PopoverSection({
         opacity: isSelected ? 1 : 0.6,
       }}
     >
-      <div
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
         onClick={onSelect}
-        onKeyDown={onSelect ? handleKeyboardActivation(onSelect) : undefined}
         css={css`
+          appearance: none;
+          border: none;
+          background: none;
+          padding: 0;
+          font: inherit;
+          text-align: left;
+          width: 100%;
           display: flex;
           align-items: center;
           cursor: ${onSelect ? 'pointer' : 'default'};
@@ -68,8 +69,9 @@ export default function PopoverSection({
               margin-right: ${theme.sizeUnit}px;
             `}
           >
+            {/* role is auto-computed by BaseIconComponent as "img" since
+                there's no onClick, so no explicit role needed here. */}
             <Icons.InfoCircleOutlined
-              role="img"
               iconSize="s"
               iconColor={theme.colorIcon}
             />
@@ -77,10 +79,9 @@ export default function PopoverSection({
         )}
         <Icons.CheckOutlined
           iconSize="s"
-          role="img"
           iconColor={isSelected ? theme.colorPrimary : theme.colorIcon}
         />
-      </div>
+      </button>
       <div
         css={css`
           margin-left: ${theme.sizeUnit}px;

--- a/superset-frontend/packages/superset-ui-core/src/components/RefreshLabel/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/RefreshLabel/index.tsx
@@ -35,7 +35,8 @@ const RefreshLabel = ({
   <Tooltip title={tooltipContent}>
     <Icons.SyncOutlined
       iconSize="l"
-      role="button"
+      // role is auto-computed by BaseIconComponent as "button" whenever
+      // onClick is present (and "img" otherwise), so no explicit role here.
       tabIndex={disabled ? -1 : 0}
       onClick={disabled ? undefined : onClick}
       css={(theme: SupersetTheme) => ({

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
@@ -870,14 +870,14 @@ test('Renders only an overflow tag if dropdown is open in oneLine mode', async (
 test('does not fire onChange when searching but no selection', async () => {
   const onChange = jest.fn();
   render(
-    <div role="main">
+    <main>
       <AsyncSelect
         {...defaultProps}
         onChange={onChange}
         mode="multiple"
         allowNewOptions
       />
-    </div>,
+    </main>,
   );
   await open();
   await type('Joh');

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1134,14 +1134,14 @@ test('dropdown takes full width of the select input for single select', async ()
 test('does not fire onChange when searching but no selection', async () => {
   const onChange = jest.fn();
   render(
-    <div role="main">
+    <main>
       <Select
         {...defaultProps}
         onChange={onChange}
         mode="multiple"
         allowNewOptions
       />
-    </div>,
+    </main>,
   );
   await open();
   await type('Joh');

--- a/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
@@ -142,7 +142,9 @@ EditableTabs.defaultProps = {
 };
 
 EditableTabs.TabPane.defaultProps = {
-  closeIcon: <StyledCloseOutlined iconSize="s" role="button" tabIndex={0} />,
+  // rc-tabs already wraps closeIcon in its own <button role="tab"
+  // aria-label="remove">; this is just decorative content inside it.
+  closeIcon: <StyledCloseOutlined iconSize="s" />,
 };
 
 export const StyledLineEditableTabs = styled(EditableTabs)`

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
@@ -69,8 +69,9 @@ describe('ChartDataProvider', () => {
     formData: { ...bigNumberFormData },
     children: ({ loading, payload, error }) => (
       <div>
+        {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors the real Loading component's role="status" pattern */}
         {loading && <span role="status">Loading...</span>}
-        {payload && <pre role="contentinfo">{JSON.stringify(payload)}</pre>}
+        {payload && <footer>{JSON.stringify(payload)}</footer>}
         {error && <div role="alert">{error.message}</div>}
       </div>
     ),

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomHeader.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomHeader.tsx
@@ -19,8 +19,7 @@
  * under the License.
  */
 
-import { handleKeyboardActivation } from '@superset-ui/core';
-import { useRef, useState, useEffect, SyntheticEvent } from 'react';
+import { useRef, useState, useEffect, MouseEvent } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 import { Column } from '@superset-ui/core/components/ThemedAgGridReact';
@@ -187,10 +186,7 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
     return undefined;
   }, [lastFilteredColumn, colId, lastFilteredInputPosition]);
 
-  // `SyntheticEvent` (rather than `MouseEvent`) so this callback can also be
-  // used as the keyboard-activation handler via `handleKeyboardActivation`,
-  // which invokes it with a `KeyboardEvent`.
-  const handleMenuClick = (e: SyntheticEvent) => {
+  const handleMenuClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     setMenuVisible(!isMenuVisible);
   };
@@ -205,37 +201,27 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
   const menuContent = (
     <MenuContainer>
       {shouldShowAsc && (
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
           onClick={() => applySort('asc')}
-          onKeyDown={handleKeyboardActivation(() => applySort('asc'))}
           className="menu-item"
         >
           <ArrowUpOutlined /> {t('Sort Ascending')}
-        </div>
+        </button>
       )}
       {shouldShowDesc && (
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
           onClick={() => applySort('desc')}
-          onKeyDown={handleKeyboardActivation(() => applySort('desc'))}
           className="menu-item"
         >
           <ArrowDownOutlined /> {t('Sort Descending')}
-        </div>
+        </button>
       )}
       {currentSort && currentSort?.colId === colId && (
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={clearSort}
-          onKeyDown={handleKeyboardActivation(clearSort)}
-          className="menu-item"
-        >
+        <button type="button" onClick={clearSort} className="menu-item">
           <span style={{ fontSize: 16 }}>↻</span> {t('Clear Sort')}
-        </div>
+        </button>
       )}
     </MenuContainer>
   );
@@ -269,15 +255,13 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
           isOpen={isMenuVisible}
           onClose={() => setMenuVisible(false)}
         >
-          <div
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             className="three-dots-menu"
             onClick={handleMenuClick}
-            onKeyDown={handleKeyboardActivation(handleMenuClick)}
           >
             <KebabMenu />
-          </div>
+          </button>
         </CustomPopover>
       )}
     </Container>

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
@@ -27,6 +27,10 @@ export const Container = styled.div`
     width: 100%;
 
     .three-dots-menu {
+      appearance: none;
+      border: none;
+      background: none;
+      font: inherit;
       align-self: center;
       margin-left: ${theme.sizeUnit}px;
       cursor: pointer;
@@ -122,6 +126,12 @@ export const MenuContainer = styled.div`
     padding: ${theme.sizeUnit}px 0;
 
     .menu-item {
+      appearance: none;
+      border: none;
+      background: none;
+      font: inherit;
+      width: 100%;
+      text-align: left;
       padding: ${theme.sizeUnit * 2}px ${theme.sizeUnit * 4}px;
       cursor: pointer;
       display: flex;

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -152,6 +152,18 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       cursor: pointer;
     }
 
+    .sort-icon-btn {
+      display: inline-flex;
+      align-items: center;
+      appearance: none;
+      border: none;
+      background: none;
+      padding: 0;
+      margin: 0;
+      font: inherit;
+      cursor: pointer;
+    }
+
     .hoverable:hover {
       background-color: ${theme.colorFillContentHover};
       cursor: pointer;

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -144,7 +144,11 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
     }
 
     .toggle {
+      appearance: none;
+      border: none;
+      background: none;
       padding-right: ${theme.sizeUnit}px;
+      font: inherit;
       cursor: pointer;
     }
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -167,7 +167,11 @@ function displayHeaderCell(
       : parsedLabel;
   return needToggle ? (
     <span className="toggle-wrapper">
-      <button type="button" className="toggle" onClick={onArrowClick || undefined}>
+      <button
+        type="button"
+        className="toggle"
+        onClick={onArrowClick || undefined}
+      >
         {ArrowIcon}
       </button>
       <span className="toggle-val">{labelContent}</span>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -20,14 +20,13 @@
 import {
   ReactNode,
   MouseEvent,
-  SyntheticEvent,
   useState,
   useCallback,
   useRef,
   useMemo,
   useEffect,
 } from 'react';
-import { safeHtmlSpan, handleKeyboardActivation } from '@superset-ui/core';
+import { safeHtmlSpan } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import { supersetTheme } from '@apache-superset/core/theme';
 import PropTypes from 'prop-types';
@@ -155,10 +154,7 @@ function displayCell(value: unknown, allowRenderHtml?: boolean): ReactNode {
 function displayHeaderCell(
   needToggle: boolean,
   ArrowIcon: ReactNode,
-  // `SyntheticEvent` (rather than `MouseEvent`) so this callback can also be
-  // used as the keyboard-activation handler via `handleKeyboardActivation`,
-  // which invokes it with a `KeyboardEvent`.
-  onArrowClick: ((e: SyntheticEvent) => void) | null,
+  onArrowClick: ((e: MouseEvent<HTMLButtonElement>) => void) | null,
   value: unknown,
   namesMapping: Record<string, string>,
   allowRenderHtml?: boolean,
@@ -171,17 +167,9 @@ function displayHeaderCell(
       : parsedLabel;
   return needToggle ? (
     <span className="toggle-wrapper">
-      <span
-        role="button"
-        tabIndex={0}
-        className="toggle"
-        onClick={onArrowClick || undefined}
-        onKeyDown={
-          onArrowClick ? handleKeyboardActivation(onArrowClick) : undefined
-        }
-      >
+      <button type="button" className="toggle" onClick={onArrowClick || undefined}>
         {ArrowIcon}
-      </span>
+      </button>
       <span className="toggle-val">{labelContent}</span>
     </span>
   ) : (
@@ -468,7 +456,7 @@ export function TableRenderer(props: TableRendererProps) {
   );
 
   const toggleRowKey = useCallback(
-    (flatRowKey: string) => (e: SyntheticEvent) => {
+    (flatRowKey: string) => (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
       setCollapsedRows(state => ({
         ...state,
@@ -479,7 +467,7 @@ export function TableRenderer(props: TableRendererProps) {
   );
 
   const toggleColKey = useCallback(
-    (flatColKey: string) => (e: SyntheticEvent) => {
+    (flatColKey: string) => (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
       setCollapsedCols(state => ({
         ...state,
@@ -1045,8 +1033,6 @@ export function TableRenderer(props: TableRendererProps) {
                 settingsAllowRenderHtml,
               )}
               <span
-                role="button"
-                tabIndex={0}
                 // Prevents event bubbling to avoid conflict with column header click handlers
                 // Ensures sort operation executes without triggering cross-filtration
                 onClick={e => {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1036,7 +1036,9 @@ export function TableRenderer(props: TableRendererProps) {
                 namesMapping,
                 settingsAllowRenderHtml,
               )}
-              <span
+              <button
+                type="button"
+                className="sort-icon-btn"
                 // Prevents event bubbling to avoid conflict with column header click handlers
                 // Ensures sort operation executes without triggering cross-filtration
                 onClick={e => {
@@ -1050,7 +1052,7 @@ export function TableRenderer(props: TableRendererProps) {
                 }
               >
                 {visibleSortIcon && getSortIcon(i)}
-              </span>
+              </button>
             </th>,
           );
         } else if (attrIdx === colKey.length) {

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
@@ -98,16 +98,9 @@ export default memo(
                 key={item}
                 className={currentPage === item ? 'active' : undefined}
               >
-                <a
-                  href={`#page-${item}`}
-                  role="button"
-                  onClick={e => {
-                    e.preventDefault();
-                    onPageChange(item);
-                  }}
-                >
+                <button type="button" onClick={() => onPageChange(item)}>
                   {item + 1}
-                </a>
+                </button>
               </li>
             ) : (
               <li key={item} className="dt-pagination-ellipsis">

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
@@ -98,7 +98,11 @@ export default memo(
                 key={item}
                 className={currentPage === item ? 'active' : undefined}
               >
-                <button type="button" onClick={() => onPageChange(item)}>
+                <button
+                  type="button"
+                  aria-label={`${item + 1}`}
+                  onClick={() => onPageChange(item)}
+                >
                   {item + 1}
                 </button>
               </li>

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -363,12 +363,16 @@ function StickyWrap({
   }
 
   return (
+    // Virtualized/sticky table built from divs so the header/body can be
+    // positioned independently; a real <table> would break that layout, so
+    // role="table" is the correct ARIA pattern here, not the suggested tag.
     <div
       style={{
         width: maxWidth,
         height: sticky.realHeight || maxHeight,
         overflow: 'hidden',
       }}
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="table"
     >
       {headerTable}

--- a/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
@@ -163,8 +163,11 @@ export default styled.div`
       margin: 0 ${theme.marginXXS}px;
     }
 
-    .dt-pagination .pagination > li > a,
+    .dt-pagination .pagination > li > button,
     .dt-pagination .pagination > li > span {
+      appearance: none;
+      border: 1px solid transparent;
+      font: inherit;
       background-color: ${theme.colorBgBase};
       color: ${theme.colorText};
       border-color: ${theme.colorBorderSecondary};
@@ -172,10 +175,10 @@ export default styled.div`
       border-radius: ${theme.borderRadius}px;
     }
 
-    .dt-pagination .pagination > li.active > a,
+    .dt-pagination .pagination > li.active > button,
     .dt-pagination .pagination > li.active > span,
-    .dt-pagination .pagination > li.active > a:focus,
-    .dt-pagination .pagination > li.active > a:hover,
+    .dt-pagination .pagination > li.active > button:focus,
+    .dt-pagination .pagination > li.active > button:hover,
     .dt-pagination .pagination > li.active > span:focus,
     .dt-pagination .pagination > li.active > span:hover {
       background-color: ${theme.colorPrimary};

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2334,7 +2334,7 @@ describe('plugin-chart-table', () => {
       expect(screen.getByText('User 1')).toBeInTheDocument();
       expect(screen.queryByText('User 11')).not.toBeInTheDocument();
 
-      const page2Link = container.querySelector('a[href="#page-1"]')!;
+      const page2Link = screen.getByRole('button', { name: '2' });
       expect(page2Link).toBeTruthy();
       fireEvent.click(page2Link);
 
@@ -2381,8 +2381,8 @@ describe('plugin-chart-table', () => {
         expect(screen.queryByText('User 1')).not.toBeInTheDocument();
       });
 
-      const activePage = container.querySelector('li.active a')!;
-      expect(activePage).toHaveAttribute('href', '#page-1');
+      const activePage = container.querySelector('li.active button')!;
+      expect(activePage).toHaveTextContent('2');
     });
 
     test('should build columnLabelToNameMap for adhoc columns with custom labels', () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2334,7 +2334,13 @@ describe('plugin-chart-table', () => {
       expect(screen.getByText('User 1')).toBeInTheDocument();
       expect(screen.queryByText('User 11')).not.toBeInTheDocument();
 
-      const page2Link = screen.getByRole('button', { name: '2' });
+      // The pagination bar is styled `visibility: hidden` until sticky
+      // height is measured, which jsdom never reports, so it must be
+      // queried with `hidden: true` even though it's functionally present.
+      const page2Link = screen.getByRole('button', {
+        name: '2',
+        hidden: true,
+      });
       expect(page2Link).toBeTruthy();
       fireEvent.click(page2Link);
 

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2335,12 +2335,11 @@ describe('plugin-chart-table', () => {
       expect(screen.queryByText('User 11')).not.toBeInTheDocument();
 
       // The pagination bar is styled `visibility: hidden` until sticky
-      // height is measured, which jsdom never reports, so it must be
-      // queried with `hidden: true` even though it's functionally present.
-      const page2Link = screen.getByRole('button', {
-        name: '2',
-        hidden: true,
-      });
+      // height is measured, which jsdom never reports. Accessible-name
+      // computation treats CSS-hidden elements as nameless regardless of
+      // the `hidden: true` query option, so query the button directly by
+      // its `aria-label` instead of through the accessibility tree.
+      const page2Link = container.querySelector('button[aria-label="2"]')!;
       expect(page2Link).toBeTruthy();
       fireEvent.click(page2Link);
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -71,9 +71,9 @@ test('leaves labels untouched when no format is provided', () => {
 });
 
 test('clicking a legend item toggles the category without triggering anchor navigation', () => {
-  // Regression proof for #33576: the legend items are href="#" anchors, so a
-  // click whose default action is not prevented would navigate to "#" and
-  // scroll the browser window to the top of the page.
+  // Regression proof for #33576: legend items render as real <button>
+  // elements (not href="#" anchors), so a click has no default navigation
+  // action to begin with.
   const toggleCategory = jest.fn();
   renderWithTheme(
     <Legend
@@ -87,18 +87,18 @@ test('clicking a legend item toggles the category without triggering anchor navi
   );
 
   const legendItem = screen.getByRole('button', { name: 'Positive' });
+  expect(legendItem.tagName).toBe('BUTTON');
   const clickEvent = createEvent.click(legendItem);
   fireEvent(legendItem, clickEvent);
 
-  expect(clickEvent.defaultPrevented).toBe(true);
   expect(toggleCategory).toHaveBeenCalledTimes(1);
   expect(toggleCategory).toHaveBeenCalledWith('Positive');
 });
 
 test('ctrl+clicking a legend item toggles the category without opening a new tab', () => {
-  // Regression proof for #34157: legend items are href="#" anchors, so a
-  // ctrl+click whose default action is not prevented would ask the browser
-  // to open the "#" href in a new tab instead of just toggling the layer.
+  // Regression proof for #34157: legend items render as real <button>
+  // elements (not href="#" anchors), so a ctrl+click has no "open link in
+  // new tab" behavior to begin with.
   const toggleCategory = jest.fn();
   renderWithTheme(
     <Legend
@@ -112,14 +112,12 @@ test('ctrl+clicking a legend item toggles the category without opening a new tab
   );
 
   const legendItem = screen.getByRole('button', { name: 'cat1' });
+  expect(legendItem.tagName).toBe('BUTTON');
   const ctrlClickEvent = createEvent.click(legendItem, {
     ctrlKey: true,
   }) as MouseEvent;
   fireEvent(legendItem, ctrlClickEvent);
 
-  // preventDefault() in the onClick handler is what stops the browser's
-  // native ctrl+click "open link in new tab" behavior on the anchor.
-  expect(ctrlClickEvent.defaultPrevented).toBe(true);
   expect(ctrlClickEvent.ctrlKey).toBe(true);
   expect(toggleCategory).toHaveBeenCalledTimes(1);
   expect(toggleCategory).toHaveBeenCalledWith('cat1');

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-sort-default-props */
 /* eslint-disable react/sort-prop-types */
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -43,11 +42,18 @@ const StyledLegend = styled.div`
       padding-left: 0;
       margin: 0;
 
-      & li a {
+      & li button {
+        appearance: none;
+        border: none;
+        background: none;
+        font: inherit;
+        width: 100%;
+        text-align: left;
         display: flex;
         color: ${theme.colorText};
         text-decoration: none;
         padding: ${theme.sizeUnit}px 0;
+        cursor: pointer;
 
         & span {
           margin-right: ${theme.sizeUnit}px;
@@ -160,20 +166,13 @@ const Legend = ({
 
     return (
       <li key={k}>
-        <a
-          href="#"
-          role="button"
-          onClick={e => {
-            e.preventDefault();
-            toggleCategory(k);
-          }}
-          onDoubleClick={e => {
-            e.preventDefault();
-            showSingleCategory(k);
-          }}
+        <button
+          type="button"
+          onClick={() => toggleCategory(k)}
+          onDoubleClick={() => showSingleCategory(k)}
         >
           <span aria-hidden style={swatchStyle} /> {formatCategoryLabel(k)}
-        </a>
+        </button>
       </li>
     );
   });

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/index.tsx
@@ -43,7 +43,6 @@ const ExploreResultsButton = ({
       icon={<Icons.LineChartOutlined iconSize="m" />}
       onClick={onClick}
       disabled={!allowsSubquery}
-      role="button"
       tooltip={t('Create chart')}
       aria-label={t('Create chart')}
       data-test="explore-results-button"

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -111,7 +111,9 @@ const TemplateParamsEditor = ({
           title={t('Edit template parameters')}
           trigger={['hover']}
         >
-          <div role="button" css={{ width: 'inherit' }}>
+          {/* ModalTrigger's own wrapper div already provides role="button"
+              and the click handler; this inner div is just layout. */}
+          <div css={{ width: 'inherit' }}>
             {t('Parameters ')}
             <Badge count={paramCount} />
             {!isValid && (

--- a/superset-frontend/src/components/Chart/Chart.test.tsx
+++ b/superset-frontend/src/components/Chart/Chart.test.tsx
@@ -101,7 +101,7 @@ test('shows the stop message and a re-run affordance when the query was stopped'
   expect(screen.getByText('Updating chart was stopped')).toBeInTheDocument();
 
   const rerun = screen.getByText('click here');
+  expect(rerun.tagName).toBe('BUTTON');
   fireEvent.click(rerun);
-  fireEvent.keyDown(rerun, { key: 'Enter' });
-  expect(onQuery).toHaveBeenCalledTimes(2);
+  expect(onQuery).toHaveBeenCalledTimes(1);
 });

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -30,9 +30,8 @@ import {
   type FilterState,
   type JsonObject,
   type AgGridChartState,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import type { ChartState, Datasource, ChartStatus } from 'src/explore/types';
 import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
 import { EmptyState, Loading } from '@superset-ui/core/components';
@@ -490,14 +489,21 @@ function Chart({
             {t(
               'Click on "Create chart" button in the control panel on the left to preview a visualization or',
             )}{' '}
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               onClick={onQuery}
-              onKeyDown={handleKeyboardActivation(() => onQuery?.())}
+              css={css`
+                appearance: none;
+                border: none;
+                background: none;
+                padding: 0;
+                font: inherit;
+                cursor: pointer;
+                text-decoration: underline;
+              `}
             >
               {t('click here')}
-            </span>
+            </button>
             .
           </span>
         }

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -447,14 +447,21 @@ function Chart({
         description={
           <span>
             {t('Run a new query using the "Update chart" button or')}{' '}
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               onClick={onQuery}
-              onKeyDown={handleKeyboardActivation(() => onQuery?.())}
+              css={css`
+                appearance: none;
+                border: none;
+                background: none;
+                padding: 0;
+                font: inherit;
+                cursor: pointer;
+                text-decoration: underline;
+              `}
             >
               {t('click here')}
-            </span>
+            </button>
             .
           </span>
         }

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -267,7 +267,7 @@ test('render breadcrumbs', async () => {
   // we need to assert that there is only 1 element now
   // eslint-disable-next-line jest-dom/prefer-in-document
   expect(newBreadcrumbItems).toHaveLength(1);
-  expect(within(breadcrumbItems[0]).getByText('gender')).toBeInTheDocument();
+  expect(within(newBreadcrumbItems[0]).getByText('gender')).toBeInTheDocument();
 });
 
 test('should render "Edit chart" as disabled without can_explore permission', async () => {

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -17,14 +17,7 @@
  * under the License.
  */
 
-import {
-  SyntheticEvent,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import {
   BinaryQueryObjectFilterClause,
@@ -35,7 +28,6 @@ import {
   isDefined,
   ContextMenuFilters,
   AdhocFilter,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { css, useTheme } from '@apache-superset/core/theme';
@@ -562,30 +554,27 @@ export default function DrillByModal({
           items={breadcrumbItems}
           itemRender={(route, _, routes, paths) => {
             const isLastElement = routes.indexOf(route) === routes.length - 1;
-            // `route.onClick` is typed by antd as a `MouseEventHandler`, but
-            // the underlying handler ignores its argument, so it's safe to
-            // broaden it to an optional `SyntheticEvent` callback here to
-            // reuse it as the keyboard-activation handler below.
-            const onRouteClick = route.onClick as
-              ((event?: SyntheticEvent) => void) | undefined;
             return isLastElement ? (
               <span data-test="drill-by-breadcrumb-item">
                 {route.title}
                 {paths}
               </span>
             ) : (
-              <span
+              <button
+                type="button"
                 data-test="drill-by-breadcrumb-item"
-                role="button"
-                tabIndex={0}
-                onClick={onRouteClick}
-                onKeyDown={handleKeyboardActivation(() => onRouteClick?.())}
+                onClick={route.onClick}
                 css={css`
+                  appearance: none;
+                  border: none;
+                  background: none;
+                  padding: 0;
+                  font: inherit;
                   cursor: pointer;
                 `}
               >
                 {route.title}
-              </span>
+              </button>
             );
           }}
         />

--- a/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
@@ -84,7 +84,7 @@ export const DrillBySubmenu = ({
   const [debouncedSearchInput, setDebouncedSearchInput] = useState('');
   const [popoverOpen, setPopoverOpen] = useState(false);
   const ref = useRef<InputRef>(null);
-  const menuItemRef = useRef<HTMLDivElement>(null);
+  const menuItemRef = useRef<HTMLButtonElement>(null);
 
   const columns = useMemo(
     () => (dataset ? ensureIsArray(dataset.drillable_columns) : []),
@@ -284,11 +284,18 @@ export const DrillBySubmenu = ({
   );
 
   const menuItem = (
-    <div
+    <button
+      type="button"
       ref={menuItemRef}
-      role="button"
+      aria-disabled={isDisabled}
       tabIndex={isDisabled ? -1 : 0}
       css={css`
+        appearance: none;
+        border: none;
+        background: none;
+        padding: 0;
+        font: inherit;
+        width: 100%;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -299,12 +306,6 @@ export const DrillBySubmenu = ({
         }
       `}
       onClick={() => !isDisabled && setPopoverOpen(!popoverOpen)}
-      onKeyDown={e => {
-        if (!isDisabled && (e.key === 'Enter' || e.key === ' ')) {
-          e.preventDefault();
-          setPopoverOpen(!popoverOpen);
-        }
-      }}
     >
       <span>{t('Drill by')}</span>
       {isDisabled ? (
@@ -312,7 +313,7 @@ export const DrillBySubmenu = ({
       ) : (
         <Icons.RightOutlined iconSize="s" iconColor={theme.colorTextTertiary} />
       )}
-    </div>
+    </button>
   );
 
   if (isDisabled) {

--- a/superset-frontend/src/components/Chart/DrillDetail/DownloadDropdown.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DownloadDropdown.tsx
@@ -58,11 +58,19 @@ const DownloadDropdown = ({
       }}
     >
       <Tooltip title={t('Download')}>
-        <span
-          tabIndex={0}
-          role="button"
+        <button
+          type="button"
           aria-label={t('Download')}
           data-test="drill-detail-download-btn"
+          css={css`
+            appearance: none;
+            border: none;
+            background: none;
+            padding: 0;
+            font: inherit;
+            display: inline-flex;
+            align-items: center;
+          `}
         >
           <Icons.DownloadOutlined
             iconColor={theme.colorIcon}
@@ -73,7 +81,7 @@ const DownloadDropdown = ({
               }
             `}
           />
-        </span>
+        </button>
       </Tooltip>
     </Dropdown>
   );

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailTableControls.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailTableControls.tsx
@@ -158,11 +158,12 @@ export default function TableControls({
           </Tooltip>
         )}
         <Tooltip title={t('Reload')}>
+          {/* role is auto-computed by BaseIconComponent as "button" since
+              onClick is present, so no explicit role needed here. */}
           <Icons.ReloadOutlined
             iconColor={theme.colorIcon}
             iconSize="l"
             aria-label={t('Reload')}
-            role="button"
             tabIndex={0}
             onClick={onReload}
           />

--- a/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/superset-frontend/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -31,7 +31,7 @@ export const InteractiveCopyToClipboard = ({ copyNode, ...rest }: any) => {
   if (copyNode === 'Icon') {
     node = <Icons.CopyOutlined />;
   } else if (copyNode === 'Text') {
-    node = <span role="button">Copy</span>;
+    node = <button type="button">Copy</button>;
   }
   return (
     <>

--- a/superset-frontend/src/components/CopyToClipboard/index.tsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.tsx
@@ -100,7 +100,7 @@ function CopyToClip({
     }
     const handleKeyDown = disabled
       ? undefined
-      : (event: KeyboardEvent<HTMLSpanElement>) => {
+      : (event: KeyboardEvent<HTMLButtonElement>) => {
           if (event.key === 'Enter' || event.key === ' ') {
             // Prevent space-scroll when the wrapper is focused.
             event.preventDefault();
@@ -108,16 +108,23 @@ function CopyToClip({
           }
         };
     return (
-      <span
+      <button
+        type="button"
+        css={css`
+          appearance: none;
+          border: none;
+          background: none;
+          padding: 0;
+          font: inherit;
+        `}
         style={{ cursor }}
         onClick={disabled ? undefined : onClick}
         onKeyDown={handleKeyDown}
-        role="button"
         aria-disabled={disabled || undefined}
         tabIndex={disabled ? -1 : 0}
       >
         {copyNode}
-      </span>
+      </button>
     );
   }, [copyNode, disabled, onClick]);
 

--- a/superset-frontend/src/components/Datasource/ChangeDatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/ChangeDatasourceModal/index.tsx
@@ -84,7 +84,12 @@ const ConfirmModalStyled = styled.div`
   }
 `;
 
-const StyledSpan = styled.span`
+const StyledSpan = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
   cursor: pointer;
   color: ${({ theme }) => theme.colorPrimaryText};
   &: hover {
@@ -202,8 +207,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     {
       Cell: ({ row: { original } }: any) => (
         <StyledSpan
-          role="button"
-          tabIndex={0}
+          type="button"
           data-test="datasource-link"
           onClick={() => selectDatasource({ type: 'table', ...original })}
         >

--- a/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
@@ -446,11 +446,12 @@ export default function CRUDCollection({
               color: ${theme.colorTextTertiary};
             `}
           >
+            {/* role is auto-computed by BaseIconComponent as "button" since
+                onClick is present, so no explicit role needed here. */}
             <Icons.DeleteOutlined
               aria-label={t('Delete item')}
               className="pointer"
               data-test="crud-delete-icon"
-              role="button"
               tabIndex={0}
               onClick={() => deleteItem(record.id)}
               iconSize="l"

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -36,7 +36,6 @@ import {
   SupersetClient,
   getClientErrorObject,
   getExtensionsRegistry,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { t } from '@apache-superset/core/translation';
@@ -1754,14 +1753,17 @@ function DatasourceEditor({
     () => (
       <div>
         <EditLockContainer>
-          <span
+          <button
+            type="button"
             css={themeParam => css`
+              appearance: none;
+              border: none;
+              background: none;
+              padding: 0;
+              font: inherit;
               color: ${themeParam.colorTextTertiary};
             `}
-            role="button"
-            tabIndex={0}
             onClick={onChangeEditMode}
-            onKeyDown={handleKeyboardActivation(onChangeEditMode)}
           >
             {isEditMode ? (
               <Icons.UnlockOutlined
@@ -1778,7 +1780,7 @@ function DatasourceEditor({
                 })}
               />
             )}
-          </span>
+          </button>
           {!isEditMode && <div>{t('Click the lock to make changes.')}</div>}
           {isEditMode && (
             <div>{t('Click the lock to prevent further changes.')}</div>

--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.test.tsx
@@ -26,6 +26,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.test.tsx
@@ -25,6 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/DatasetNotFoundErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasetNotFoundErrorMessage.test.tsx
@@ -25,6 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { Alert } from '@apache-superset/core/components';
-import { useTheme } from '@apache-superset/core/theme';
+import { css, useTheme } from '@apache-superset/core/theme';
 import {
   Icons,
   Modal,
@@ -100,15 +99,21 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({
               {descriptionDetails}
             </Typography.Paragraph>
           )}
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             onClick={toggleDescription}
-            onKeyDown={handleKeyboardActivation(toggleDescription)}
+            css={css`
+              appearance: none;
+              border: none;
+              background: none;
+              padding: 0;
+              font: inherit;
+              color: inherit;
+            `}
             style={{ textDecoration: 'underline', cursor: 'pointer' }}
           >
             {isDescriptionVisible ? t('See less') : t('See more')}
-          </span>
+          </button>
         </div>
       )}
       {children}
@@ -129,14 +134,19 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({
     return (
       <>
         <Tooltip title={`${errorType}: ${message}`}>
-          <span
-            role="button"
+          <button
+            type="button"
+            css={css`
+              appearance: none;
+              border: none;
+              background: none;
+              padding: 0;
+              font: inherit;
+            `}
             onClick={() => setShowModal(true)}
-            onKeyDown={handleKeyboardActivation(() => setShowModal(true))}
-            tabIndex={0}
           >
             {renderTrigger()}
-          </span>
+          </button>
         </Tooltip>
         <Modal
           name={errorType}

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.test.tsx
@@ -26,6 +26,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/FrontendNetworkErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/FrontendNetworkErrorMessage.test.tsx
@@ -25,6 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.test.tsx
@@ -25,6 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.test.tsx
@@ -25,6 +25,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
+++ b/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
@@ -259,6 +259,11 @@ function CompactSelectPanel(
           />
         </SearchRow>
       )}
+      {/* Custom-rendered, searchable, keyboard-navigable option list with
+          rich per-option content (active state, icons); native <select>/
+          <option> can't render that, so the ARIA listbox pattern is used
+          instead of the tag the linter suggests. */}
+      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <OptionList role="listbox" aria-label={t('Filter options')}>
         {isLoading ? (
           <StatusText>{t('Loading...')}</StatusText>
@@ -275,6 +280,8 @@ function CompactSelectPanel(
               <OptionItem
                 key={opt.value}
                 $active={isActive}
+                // See the OptionList comment above: native <option> can't render this.
+                // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
                 role="option"
                 aria-selected={isActive}
                 tabIndex={0}

--- a/superset-frontend/src/components/ListView/ListView.test.tsx
+++ b/superset-frontend/src/components/ListView/ListView.test.tsx
@@ -16,13 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  render,
-  screen,
-  within,
-  waitFor,
-  fireEvent,
-} from 'spec/helpers/testing-library';
+import { render, screen, within, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
@@ -366,7 +360,7 @@ describe('ListView', () => {
     expect(mockedPropsComprehensive.fetchData).toHaveBeenCalled();
   });
 
-  test('switches view mode via keyboard activation of the toggle buttons', () => {
+  test('switches view mode via click of the toggle buttons', async () => {
     const { container } = factory({
       renderCard: jest.fn(),
       data: [],
@@ -379,10 +373,10 @@ describe('ListView', () => {
 
     expect(screen.getByTestId('empty-state')).toHaveClass('card');
 
-    fireEvent.keyDown(tableToggle, { key: 'Enter' });
+    await userEvent.click(tableToggle);
     expect(screen.getByTestId('empty-state')).toHaveClass('table');
 
-    fireEvent.keyDown(cardToggle, { key: ' ' });
+    await userEvent.click(cardToggle);
     expect(screen.getByTestId('empty-state')).toHaveClass('card');
   });
 });

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import { Alert } from '@apache-superset/core/components';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import {
   useCallback,
   useEffect,
@@ -185,10 +184,15 @@ const ViewModeContainer = styled.div`
     display: inline-block;
 
     .toggle-button {
+      appearance: none;
+      border: none;
+      background: none;
+      font: inherit;
       display: inline-block;
       border-radius: ${theme.borderRadius}px;
       padding: ${theme.sizeUnit}px;
       padding-bottom: ${theme.sizeUnit * 0.5}px;
+      cursor: pointer;
 
       &:first-of-type {
         margin-right: ${theme.sizeUnit * 2}px;
@@ -203,6 +207,15 @@ const ViewModeContainer = styled.div`
       }
     }
   `}
+`;
+
+const inlineTextButtonCss = css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
 `;
 
 const ClearAllButton = styled.button`
@@ -248,34 +261,30 @@ const ViewModeToggle = ({
 }) => (
   <ViewModeContainer>
     <Tooltip title={t('Grid view')}>
-      <div
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
         aria-pressed={mode === 'card'}
-        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.currentTarget.blur();
           setMode('card');
         }}
-        onKeyDown={handleKeyboardActivation(() => setMode('card'))}
         className={cx('toggle-button', { active: mode === 'card' })}
       >
         <Icons.AppstoreOutlined iconSize="xl" />
-      </div>
+      </button>
     </Tooltip>
     <Tooltip title={t('List view')}>
-      <div
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
         aria-pressed={mode === 'table'}
-        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.currentTarget.blur();
           setMode('table');
         }}
-        onKeyDown={handleKeyboardActivation(() => setMode('table'))}
         className={cx('toggle-button', { active: mode === 'table' })}
       >
         <Icons.UnorderedListOutlined iconSize="xl" />
-      </div>
+      </button>
     </Tooltip>
   </ViewModeContainer>
 );
@@ -505,19 +514,15 @@ export function ListView<T extends object = any>({
                   </div>
                   {Boolean(selectedFlatRows.length) && (
                     <>
-                      <span
+                      <button
+                        type="button"
                         data-test="bulk-select-deselect-all"
-                        style={{ cursor: 'pointer' }}
-                        role="button"
-                        tabIndex={0}
+                        css={inlineTextButtonCss}
                         className="deselect-all"
                         onClick={() => toggleAllRowsSelected(false)}
-                        onKeyDown={handleKeyboardActivation(() =>
-                          toggleAllRowsSelected(false),
-                        )}
                       >
                         {t('Deselect all')}
-                      </span>
+                      </button>
                       <div className="divider" />
                       {bulkActions
                         .filter(
@@ -543,19 +548,15 @@ export function ListView<T extends object = any>({
                           </Button>
                         ))}
                       {enableBulkTag && (
-                        <span
+                        <button
+                          type="button"
                           data-test="bulk-select-tag-btn"
-                          role="button"
-                          style={{ cursor: 'pointer' }}
-                          tabIndex={0}
+                          css={inlineTextButtonCss}
                           className="tag-btn"
                           onClick={() => setShowBulkTagModal(true)}
-                          onKeyDown={handleKeyboardActivation(() =>
-                            setShowBulkTagModal(true),
-                          )}
                         >
                           {t('Add Tag')}
-                        </span>
+                        </button>
                       )}
                     </>
                   )}

--- a/superset-frontend/src/components/MessageToasts/Toast.tsx
+++ b/superset-frontend/src/components/MessageToasts/Toast.tsx
@@ -152,10 +152,11 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
         {icon}
         <Interweave content={toast.text} noHtml={!toast.allowHtml} />
       </div>
+      {/* role is auto-computed by BaseIconComponent as "button" since
+          onClick is present, so no explicit role needed here. */}
       <Icons.CloseOutlined
         iconSize="m"
         className="toast__close pointer"
-        role="button"
         tabIndex={0}
         onClick={handleClosePress}
         aria-label={t('Close')}

--- a/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
+++ b/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
@@ -162,6 +162,10 @@ export const StatusIndicatorDot: FC<StatusIndicatorDotProps> = ({
   return (
     <span
       css={dotStyles}
+      // role="status" is the standard WAI-ARIA live-region pattern for a
+      // status indicator; <output> (the suggested tag) is for form
+      // calculation results, not a fit here.
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="status"
       aria-label={`Auto-refresh status: ${displayStatus}`}
       data-test="status-indicator-dot"

--- a/superset-frontend/src/dashboard/components/CustomizationsBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/CustomizationsBadge/index.tsx
@@ -295,6 +295,10 @@ export const CustomizationsBadge = ({ chartId }: CustomizationsBadgeProps) => {
       <StyledTag
         ref={triggerRef}
         aria-label={t('Display controls (%s)', customizationsCount)}
+        // Tag doesn't support a polymorphic `as` prop, and this element has
+        // no click action of its own (Tooltip attaches its own hover/focus
+        // handlers to it) - tabIndex + role keep it keyboard-discoverable.
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
         role="button"
         tabIndex={0}
       >

--- a/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
+++ b/superset-frontend/src/dashboard/components/DeleteComponentButton.tsx
@@ -23,7 +23,7 @@ import type { IconType } from '@superset-ui/core/components/Icons/types';
 import IconButton from './IconButton';
 
 type DeleteComponentButtonProps = {
-  onDelete: MouseEventHandler<HTMLDivElement>;
+  onDelete: MouseEventHandler<HTMLButtonElement>;
   iconSize?: IconType['iconSize'];
 };
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
@@ -37,7 +37,7 @@ const mockPopoverTriggerRef = {
   current: {
     focus: jest.fn(),
   },
-} as unknown as RefObject<HTMLDivElement>;
+} as unknown as RefObject<HTMLButtonElement>;
 
 const createProps = () => ({
   popoverVisible: true,

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -39,7 +39,7 @@ export interface DetailsPanelProps {
   children: JSX.Element;
   popoverVisible: boolean;
   popoverContentRef: RefObject<HTMLDivElement>;
-  popoverTriggerRef: RefObject<HTMLDivElement>;
+  popoverTriggerRef: RefObject<HTMLButtonElement>;
   setPopoverVisible: (visible: boolean) => void;
 }
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -55,8 +55,11 @@ export interface FiltersBadgeProps {
   chartId: number;
 }
 
-const StyledFilterCount = styled.div`
+const StyledFilterCount = styled.button`
   ${({ theme }) => `
+    appearance: none;
+    border: none;
+    font: inherit;
     display: flex;
     justify-items: center;
     align-items: center;
@@ -135,7 +138,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
   );
   const [popoverVisible, setPopoverVisible] = useState(false);
   const popoverContentRef = useRef<HTMLDivElement>(null);
-  const popoverTriggerRef = useRef<HTMLDivElement>(null);
+  const popoverTriggerRef = useRef<HTMLButtonElement>(null);
 
   const onHighlightFilterSource = useCallback(
     (path: string[]) => {
@@ -144,7 +147,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
     [dispatch],
   );
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Enter') {
       setPopoverVisible(true);
     }
@@ -306,15 +309,14 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
       popoverTriggerRef={popoverTriggerRef}
     >
       <StyledFilterCount
+        type="button"
         aria-label={t('Applied filters (%s)', filterCount)}
         aria-haspopup="true"
-        role="button"
         ref={popoverTriggerRef}
         className={cx(
           'filter-counts',
           !!appliedCrossFilterIndicators.length && 'has-cross-filters',
         )}
-        tabIndex={0}
         onKeyDown={handleKeyDown}
       >
         <Icons.FilterOutlined iconSize="m" />

--- a/superset-frontend/src/dashboard/components/IconButton.tsx
+++ b/superset-frontend/src/dashboard/components/IconButton.tsx
@@ -19,10 +19,10 @@
 import { forwardRef, HTMLAttributes, MouseEventHandler } from 'react';
 import { styled, SupersetTheme } from '@apache-superset/core/theme';
 
-interface IconButtonProps extends HTMLAttributes<HTMLDivElement> {
+interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   icon: JSX.Element;
   label?: string;
-  onClick: MouseEventHandler<HTMLDivElement>;
+  onClick: MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;
   'data-test'?: string;
 }
@@ -39,7 +39,11 @@ const activeCss = ({ theme }: { theme: SupersetTheme }) => `
   }
 `;
 
-const StyledDiv = styled.div<{ isDisabled?: boolean }>`
+const StyledButton = styled.button<{ isDisabled?: boolean }>`
+  appearance: none;
+  border: none;
+  background: none;
+  font: inherit;
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -54,7 +58,7 @@ const StyledSpan = styled.span`
   margin-left: ${({ theme }) => theme.sizeUnit * 2}px;
 `;
 
-const IconButton = forwardRef<HTMLDivElement, IconButtonProps>(
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
       icon,
@@ -67,11 +71,10 @@ const IconButton = forwardRef<HTMLDivElement, IconButtonProps>(
     },
     ref,
   ) => (
-    <StyledDiv
+    <StyledButton
       {...rest}
       ref={ref}
-      tabIndex={disabled ? -1 : 0}
-      role="button"
+      type="button"
       isDisabled={disabled}
       aria-disabled={disabled}
       data-test={dataTest}
@@ -89,7 +92,7 @@ const IconButton = forwardRef<HTMLDivElement, IconButtonProps>(
     >
       {icon}
       {label && <StyledSpan>{label}</StyledSpan>}
-    </StyledDiv>
+    </StyledButton>
   ),
 );
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -170,7 +170,7 @@ const createOwnStateWithChartState = (
 
 const Chart = (props: ChartProps) => {
   const dispatch = useDispatch();
-  const descriptionRef = useRef<HTMLDivElement>(null);
+  const descriptionRef = useRef<HTMLElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
 
   const boundActionCreators = useMemo(
@@ -756,14 +756,13 @@ const Chart = (props: ChartProps) => {
              https://github.com/apache/superset/pull/23862
         */}
       {isExpanded && slice.description_markdown && (
-        <div
+        <aside
           className="slice_description bs-callout bs-callout-default"
           ref={descriptionRef}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{
             __html: slice.description_markdown,
           }}
-          role="complementary"
         />
       )}
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import {
   Fragment,
   useCallback,
@@ -28,7 +27,7 @@ import {
 } from 'react';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 
 import { EditableTitle, EmptyState } from '@superset-ui/core/components';
@@ -348,16 +347,21 @@ const Tab = (props: TabProps): ReactElement => {
                     ) : (
                       <span>
                         {t('You can add the components in the')}{' '}
-                        <span
-                          role="button"
-                          tabIndex={0}
+                        <button
+                          type="button"
                           onClick={() => dispatch(setEditMode(true))}
-                          onKeyDown={handleKeyboardActivation(() =>
-                            dispatch(setEditMode(true)),
-                          )}
+                          css={css`
+                            appearance: none;
+                            border: none;
+                            background: none;
+                            padding: 0;
+                            font: inherit;
+                            cursor: pointer;
+                            text-decoration: underline;
+                          `}
                         >
                           {t('edit mode')}
-                        </span>
+                        </button>
                       </span>
                     ))
                   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.tsx
@@ -98,8 +98,6 @@ interface ShowDropIndicatorsResult {
 
 interface CloseIconWithDropIndicatorProps {
   showDropIndicators: ShowDropIndicatorsResult;
-  role?: string;
-  tabIndex?: number;
 }
 
 const CloseIconWithDropIndicator = (
@@ -481,9 +479,9 @@ const Tabs = (props: TabsProps): ReactElement => {
           </>
         ),
         closeIcon: (
+          // rc-tabs already wraps closeIcon content in its own
+          // <button role="tab" aria-label="remove">.
           <CloseIconWithDropIndicator
-            role="button"
-            tabIndex={tabIndex}
             showDropIndicators={showDropIndicators(tabIndex)}
           />
         ),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
@@ -80,7 +80,8 @@ const CrossFilterChartTitle = (props: {
         <StyledIconSearch
           iconSize="s"
           data-test="cross-filters-highlight-emitter"
-          role="button"
+          // role is auto-computed by BaseIconComponent as "button" whenever
+          // onClick is present, so no explicit role here.
           tabIndex={0}
           aria-label={t('Locate the chart')}
           onClick={onHighlightFilterSource}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.test.tsx
@@ -177,11 +177,8 @@ test('Uses callbacks on click', () => {
   expect(DEFAULT_PROPS.removeCustomScope).toHaveBeenCalledWith(4);
 });
 
-test('Renders charts scoping list panel with FilterTitle rendered with role="button"', () => {
+test('Renders charts scoping list panel with FilterTitle rendered as a button', () => {
   setup();
   expect(screen.getByText('All charts/global scoping')).toBeVisible();
-  expect(screen.getByText('All charts/global scoping')).toHaveAttribute(
-    'role',
-    'button',
-  );
+  expect(screen.getByText('All charts/global scoping').tagName).toBe('BUTTON');
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.tsx
@@ -141,8 +141,16 @@ export const ChartsScopingListPanel = ({
         </Button>
       </AddButtonContainer>
       <FilterTitle
-        role="button"
-        tabIndex={0}
+        as="button"
+        {...{ type: 'button' }}
+        css={css`
+          appearance: none;
+          border: none;
+          background: none;
+          font: inherit;
+          text-align: left;
+          width: 100%;
+        `}
         onClick={() => setCurrentChartId(undefined)}
         className={activeChartId === undefined ? 'active' : ''}
       >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.tsx
@@ -47,6 +47,12 @@ const CrossFiltersVerticalCollapse = (props: {
 
   const sectionHeaderStyle = useCallback(
     (theme: SupersetTheme) => css`
+      appearance: none;
+      border: none;
+      background: none;
+      font: inherit;
+      text-align: left;
+      width: 100%;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -119,21 +125,10 @@ const CrossFiltersVerticalCollapse = (props: {
   return (
     <div css={sectionContainerStyle}>
       {!hideHeader && (
-        <div
-          css={sectionHeaderStyle}
-          onClick={toggleSection}
-          onKeyDown={e => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              toggleSection();
-            }
-          }}
-          role="button"
-          tabIndex={0}
-        >
+        <button type="button" css={sectionHeaderStyle} onClick={toggleSection}>
           <h4 css={sectionTitleStyle}>{t('Cross-filters')}</h4>
           <Icons.UpOutlined iconSize="m" css={iconStyle(isOpen, theme)} />
-        </div>
+        </button>
       )}
       {isOpen && <div css={sectionContentStyle}>{crossFiltersIndicators}</div>}
       {isOpen && <div css={dividerStyle} data-test="cross-filters-divider" />}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { ReactNode, FC, memo } from 'react';
+import { css } from '@apache-superset/core/theme';
 
 import { getFilterBarTestId } from '../utils';
 
@@ -30,15 +30,20 @@ export const FilterConfigurationLink: FC<FCBProps> = ({
   onClick,
   children,
 }) => (
-  <div
+  <button
+    type="button"
+    css={css`
+      appearance: none;
+      border: none;
+      background: none;
+      padding: 0;
+      font: inherit;
+    `}
     {...getFilterBarTestId('create-filter')}
     onClick={onClick}
-    onKeyDown={onClick ? handleKeyboardActivation(onClick) : undefined}
-    role="button"
-    tabIndex={0}
   >
     {children}
-  </div>
+  </button>
 );
 
 export default memo(FilterConfigurationLink);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControlShared.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControlShared.tsx
@@ -236,6 +236,10 @@ export const DescriptionToolTip = ({
         whiteSpace: 'normal',
       }}
     >
+      {/* Deliberate role="button" on this tooltip-trigger icon (no click
+          handler) — covered by existing test expectations; not a fit for
+          the linter's suggested <button> tag. */}
+      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <StyledInfoCircleOutlined className="text-muted" role="button" />
     </Tooltip>
   </ToolTipContainer>
@@ -249,8 +253,12 @@ export const DeckglLayerVisibilityTooltip = () => (
       )}
       placement="right"
     >
+      {/* Deliberate role="button" on this tooltip-trigger icon (no click
+          handler) — covered by existing test expectations; not a fit for
+          the linter's suggested <button> tag. */}
       <StyledInfoCircleOutlined
         className="text-muted"
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
         role="button"
         data-test="deckgl-layer-visibility-tooltip-icon"
       />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControlShared.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControlShared.tsx
@@ -237,8 +237,8 @@ export const DescriptionToolTip = ({
       }}
     >
       {/* Deliberate role="button" on this tooltip-trigger icon (no click
-          handler) — covered by existing test expectations; not a fit for
-          the linter's suggested <button> tag. */}
+          handler) — mirrors DeckglLayerVisibilityTooltip below; not a fit
+          for the linter's suggested <button> tag. */}
       {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <StyledInfoCircleOutlined className="text-muted" role="button" />
     </Tooltip>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -104,7 +104,13 @@ const SectionContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.sizeUnit * 3}px;
 `;
 
-const SectionHeader = styled.div`
+const SectionHeader = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -317,15 +323,8 @@ const FilterControls: FC<FilterControlsProps> = ({
           <SectionContainer>
             {!hideHeader && (
               <SectionHeader
+                type="button"
                 onClick={() => toggleSection('filters')}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    toggleSection('filters');
-                  }
-                }}
-                role="button"
-                tabIndex={0}
               >
                 <Title
                   level={5}
@@ -361,15 +360,8 @@ const FilterControls: FC<FilterControlsProps> = ({
           <SectionContainer>
             {!hideHeader && (
               <SectionHeader
+                type="button"
                 onClick={() => toggleSection('chartCustomization')}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    toggleSection('chartCustomization');
-                  }
-                }}
-                role="button"
-                tabIndex={0}
               >
                 <Title
                   level={5}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -324,6 +324,7 @@ const FilterControls: FC<FilterControlsProps> = ({
             {!hideHeader && (
               <SectionHeader
                 type="button"
+                aria-expanded={sectionsOpen.filters}
                 onClick={() => toggleSection('filters')}
               >
                 <Title
@@ -361,6 +362,7 @@ const FilterControls: FC<FilterControlsProps> = ({
             {!hideHeader && (
               <SectionHeader
                 type="button"
+                aria-expanded={sectionsOpen.chartCustomization}
                 onClick={() => toggleSection('chartCustomization')}
               >
                 <Title

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -203,6 +203,11 @@ const DescriptionTooltip = ({ description }: { description: string }) => (
     >
       <Icons.InfoCircleOutlined
         className="text-muted"
+        // Deliberate role="button" override on this tooltip-trigger icon
+        // (no click handler; BaseIconComponent would otherwise auto-compute
+        // role="img" since there's no onClick) — matches the same pattern
+        // used by DescriptionToolTip/DeckglLayerVisibilityTooltip.
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
         role="button"
         css={theme => ({
           paddingLeft: `${theme.sizeUnit}px`,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/VerticalCollapse.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/VerticalCollapse.tsx
@@ -31,6 +31,12 @@ const sectionContainerStyle = (theme: SupersetTheme) => css`
 `;
 
 const sectionHeaderStyle = (theme: SupersetTheme) => css`
+  appearance: none;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -104,24 +110,13 @@ const UrlFiltersVerticalCollapse = (props: {
 
   return (
     <div css={sectionContainerStyle}>
-      <div
-        css={sectionHeaderStyle}
-        onClick={toggleSection}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            toggleSection();
-          }
-        }}
-        role="button"
-        tabIndex={0}
-      >
+      <button type="button" css={sectionHeaderStyle} onClick={toggleSection}>
         <h4 css={sectionTitleStyle}>
           <Icons.LinkOutlined iconSize="s" />
           {t('URL Filters')}
         </h4>
         <Icons.UpOutlined iconSize="m" css={iconStyle(isOpen, theme)} />
-      </div>
+      </button>
       {isOpen && <div css={sectionContentStyle}>{filterIndicators}</div>}
       {isOpen && <div css={dividerStyle} data-test="url-filters-divider" />}
     </div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/VerticalCollapse.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/VerticalCollapse.tsx
@@ -110,7 +110,12 @@ const UrlFiltersVerticalCollapse = (props: {
 
   return (
     <div css={sectionContainerStyle}>
-      <button type="button" css={sectionHeaderStyle} onClick={toggleSection}>
+      <button
+        type="button"
+        css={sectionHeaderStyle}
+        aria-expanded={isOpen}
+        onClick={toggleSection}
+      >
         <h4 css={sectionTitleStyle}>
           <Icons.LinkOutlined iconSize="s" />
           {t('URL Filters')}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -88,8 +88,12 @@ const Bar = styled.div<{ width: number }>`
   `}
 `;
 
-const CollapsedBar = styled.div<{ offset: number }>`
+const CollapsedBar = styled.button<{ offset: number }>`
   ${({ theme, offset }) => `
+    appearance: none;
+    border: none;
+    background: none;
+    font: inherit;
     position: absolute;
     top: ${offset}px;
     left: 0;
@@ -262,11 +266,10 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
         width={width}
       >
         <CollapsedBar
+          type="button"
           {...getFilterBarTestId('collapsable')}
           className={cx({ open: !filtersOpen })}
           onClick={openFiltersBar}
-          role="button"
-          tabIndex={0}
           offset={offset}
         >
           <Icons.VerticalAlignTopOutlined

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -46,7 +46,7 @@ const DependencyValue = ({
   return (
     <span>
       {hasSeparator && <span>, </span>}
-      <DependencyItem role="button" onClick={handleClick} tabIndex={0}>
+      <DependencyItem type="button" onClick={handleClick}>
         {dependency.name}
       </DependencyItem>
     </span>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -64,7 +64,12 @@ export const FilterName = styled.span`
   white-space: nowrap;
 `;
 
-export const DependencyItem = styled.span`
+export const DependencyItem = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
   text-decoration: underline;
   cursor: pointer;
 `;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { forwardRef, useCallback, useState } from 'react';
 
 import { t } from '@apache-superset/core/translation';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import type { DragEndEvent } from '@dnd-kit/core';
 import {
@@ -191,19 +190,25 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
               <StyledWarning className="warning" iconSize="s" />
             )}
             {isRemoved && (
-              <span
-                css={{ alignSelf: 'flex-end', marginLeft: 'auto' }}
-                role="button"
+              <button
+                type="button"
+                css={css`
+                  appearance: none;
+                  border: none;
+                  background: none;
+                  padding: 0;
+                  font: inherit;
+                  align-self: flex-end;
+                  margin-left: auto;
+                `}
                 data-test="undo-button"
-                tabIndex={0}
                 onClick={e => {
                   e.preventDefault();
                   restoreFilter(id);
                 }}
-                onKeyDown={handleKeyboardActivation(() => restoreFilter(id))}
               >
                 {t('Undo?')}
-              </span>
+              </button>
             )}
           </div>
           <div css={{ alignSelf: 'flex-start', marginLeft: 'auto' }}>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
@@ -41,8 +41,13 @@ const MainPanel = styled.div`
   flex-direction: column;
 `;
 
-const AddFilter = styled.div`
+const AddFilter = styled.button`
   ${({ theme }) => `
+    appearance: none;
+    border: none;
+    background: none;
+    padding: 0;
+    font: inherit;
     display: inline-flex;
     flex-direction: row;
     align-items: center;
@@ -175,7 +180,7 @@ const List = ({
         />
       ))}
       {availableFilters.length > rows.length && (
-        <AddFilter role="button" tabIndex={0} onClick={onAdd}>
+        <AddFilter type="button" onClick={onAdd}>
           <Icons.PlusOutlined iconSize="xs" />
           {t('Add filter')}
         </AddFilter>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { forwardRef, useState } from 'react';
 
 import { t } from '@apache-superset/core/translation';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { useDndMonitor } from '@dnd-kit/core';
 import {
@@ -159,19 +158,25 @@ const ItemTitleContainer = forwardRef<HTMLDivElement, Props>(
               <StyledWarning className="warning" iconSize="s" />
             )}
             {isRemoved && (
-              <span
-                css={{ alignSelf: 'flex-end', marginLeft: 'auto' }}
-                role="button"
+              <button
+                type="button"
+                css={css`
+                  appearance: none;
+                  border: none;
+                  background: none;
+                  padding: 0;
+                  font: inherit;
+                  align-self: flex-end;
+                  margin-left: auto;
+                `}
                 data-test="undo-button"
-                tabIndex={0}
                 onClick={e => {
                   e.preventDefault();
                   restoreItem(id);
                 }}
-                onKeyDown={handleKeyboardActivation(() => restoreItem(id))}
               >
                 {t('Undo?')}
-              </span>
+              </button>
             )}
           </div>
           <div css={{ alignSelf: 'flex-start', marginLeft: 'auto' }}>

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -136,7 +136,12 @@ const ControlHeader: FC<ControlHeaderProps> = ({
           htmlFor={name}
         >
           {leftNode && <span>{leftNode} </span>}
+          {/* This label text sits inside FormLabel's <label>, and HTML5
+              prohibits interactive content (including <button>) as a
+              descendant of <label>, so a real button tag isn't an option
+              here. */}
           <span
+            // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
             role="button"
             tabIndex={0}
             onClick={onClick}

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -65,11 +65,20 @@ export const CopyToClipboardButton = ({
       disabled={disabled}
       wrapped={false}
       copyNode={
-        <span
-          role="button"
+        <button
+          type="button"
           aria-label={t('Copy')}
           aria-disabled={disabled}
           tabIndex={disabled ? -1 : 0}
+          css={css`
+            appearance: none;
+            border: none;
+            background: none;
+            padding: 0;
+            font: inherit;
+            display: inline-flex;
+            align-items: center;
+          `}
         >
           <Icons.CopyOutlined
             iconColor={theme.colorIcon}
@@ -82,7 +91,7 @@ export const CopyToClipboardButton = ({
               }
             `}
           />
-        </span>
+        </button>
       }
     />
   );

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -18,12 +18,8 @@
  */
 import { useCallback, useEffect, useMemo, useState, MouseEvent } from 'react';
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
-import { styled } from '@apache-superset/core/theme';
+import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
+import { css, styled } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import Tabs from '@superset-ui/core/components/Tabs';
 import {
@@ -184,30 +180,31 @@ export const DataTablesPane = ({
     ) : (
       <Icons.DownOutlined aria-label={t('Expand data panel')} />
     );
+    const resetButtonCss = css`
+      appearance: none;
+      border: none;
+      background: none;
+      padding: 0;
+      font: inherit;
+    `;
     return (
       <div>
         {panelOpen ? (
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
+            css={resetButtonCss}
             onClick={() => handleCollapseChange(false)}
-            onKeyDown={handleKeyboardActivation(() =>
-              handleCollapseChange(false),
-            )}
           >
             {caretIcon}
-          </span>
+          </button>
         ) : (
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
+            css={resetButtonCss}
             onClick={() => handleCollapseChange(true)}
-            onKeyDown={handleKeyboardActivation(() =>
-              handleCollapseChange(true),
-            )}
           >
             {caretIcon}
-          </span>
+          </button>
         )}
       </div>
     );

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -135,11 +135,12 @@ export const TableControls = ({
         )}
         {onReload && (
           <Tooltip title={t('Reload')}>
+            {/* role is auto-computed by BaseIconComponent as "button" since
+                onClick is present, so no explicit role needed here. */}
             <Icons.ReloadOutlined
               iconColor={theme.colorIcon}
               iconSize="l"
               aria-label={t('Reload')}
-              role="button"
               tabIndex={0}
               onClick={onReload}
             />

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -18,12 +18,7 @@
  */
 import { useContext, useDeferredValue, useMemo, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import {
-  DatasourceType,
-  Metric,
-  QueryFormData,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { DatasourceType, Metric, QueryFormData } from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
 
@@ -291,17 +286,21 @@ export default function DataSourcePanel({
                 message=""
                 description={
                   <>
-                    <span
-                      role="button"
-                      tabIndex={0}
+                    <button
+                      type="button"
                       onClick={() => setShowSaveDatasetModal(true)}
-                      onKeyDown={handleKeyboardActivation(() =>
-                        setShowSaveDatasetModal(true),
-                      )}
                       className="add-dataset-alert-description"
+                      css={css`
+                        appearance: none;
+                        border: none;
+                        background: none;
+                        padding: 0;
+                        font: inherit;
+                        cursor: pointer;
+                      `}
                     >
                       {t('Create a dataset')}
-                    </span>
+                    </button>
                     {t(' to edit or add columns and metrics.')}
                   </>
                 }

--- a/superset-frontend/src/explore/components/EmbedCodeContent.tsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.tsx
@@ -106,9 +106,19 @@ const EmbedCodeContent: FC<EmbedCodeContentProps> = ({
           shouldShowText={false}
           text={html}
           copyNode={
-            <span role="button" aria-label={t('Copy to clipboard')}>
+            <button
+              type="button"
+              css={css`
+                appearance: none;
+                border: none;
+                background: none;
+                padding: 0;
+                font: inherit;
+              `}
+              aria-label={t('Copy to clipboard')}
+            >
               <Icons.CopyOutlined />
-            </span>
+            </button>
           }
         />
         <Input.TextArea

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -30,7 +30,6 @@ import {
   QueryFormData,
   JsonObject,
   getExtensionsRegistry,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
@@ -393,17 +392,22 @@ const ExploreChartPanel = ({
                 {t(
                   'This chart type is not supported when using an unsaved query as a chart source. ',
                 )}
-                <span
-                  role="button"
-                  tabIndex={0}
+                <button
+                  type="button"
                   onClick={() => setShowDatasetModal(true)}
-                  onKeyDown={handleKeyboardActivation(() =>
-                    setShowDatasetModal(true),
-                  )}
-                  css={{ textDecoration: 'underline' }}
+                  css={css`
+                    appearance: none;
+                    border: none;
+                    background: none;
+                    padding: 0;
+                    font: inherit;
+                    color: inherit;
+                    text-decoration: underline;
+                    cursor: pointer;
+                  `}
                 >
                   {t('Create a dataset')}
-                </span>
+                </button>
                 {t(' to visualize your data.')}
               </>
             }
@@ -424,14 +428,21 @@ const ExploreChartPanel = ({
                   {t(
                     'You updated the values in the control panel, but the chart was not updated automatically. Run the query by clicking on the "Update chart" button or',
                   )}{' '}
-                  <span
-                    role="button"
-                    tabIndex={0}
+                  <button
+                    type="button"
                     onClick={onQuery}
-                    onKeyDown={handleKeyboardActivation(() => onQuery?.())}
+                    css={css`
+                      appearance: none;
+                      border: none;
+                      background: none;
+                      padding: 0;
+                      font: inherit;
+                      color: inherit;
+                      cursor: pointer;
+                    `}
                   >
                     {t('click here')}
-                  </span>
+                  </button>
                   .
                 </span>
               )

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -37,7 +37,6 @@ import {
   MatrixifyFormData,
   DatasourceType,
   ensureIsArray,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import {
   ControlStateMapping,
@@ -49,7 +48,7 @@ import { logging } from '@apache-superset/core/utils';
 import { debounce, isEqual, isObjectLike, omit, pick } from 'lodash-es';
 import { Resizable } from 're-resizable';
 import { useHistory } from 'react-router-dom';
-import { Tooltip } from '@superset-ui/core/components';
+import { ActionButton, Tooltip } from '@superset-ui/core/components';
 import { usePluginContext } from 'src/components';
 import { Global } from '@emotion/react';
 import { Icons } from '@superset-ui/core/components/Icons';
@@ -994,22 +993,20 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
         >
           <div className="title-container">
             <span className="horizontal-text">{t('Chart Source')}</span>
-            <span
-              role="button"
-              tabIndex={0}
-              className="action-button"
+            <ActionButton
+              label={t('Collapse Datasource panel')}
+              icon={
+                <Icons.VerticalAlignTopOutlined
+                  iconSize="xl"
+                  css={css`
+                    transform: rotate(-90deg);
+                  `}
+                  className="collapse-icon"
+                  iconColor={theme.colorPrimary}
+                />
+              }
               onClick={toggleCollapse}
-              onKeyDown={handleKeyboardActivation(toggleCollapse)}
-            >
-              <Icons.VerticalAlignTopOutlined
-                iconSize="xl"
-                css={css`
-                  transform: rotate(-90deg);
-                `}
-                className="collapse-icon"
-                iconColor={theme.colorPrimary}
-              />
-            </span>
+            />
           </div>
           {/* eslint-disable @typescript-eslint/no-explicit-any -- DataSourcePanel uses narrower types that are compatible at runtime */}
           <DataSourcePanel
@@ -1022,16 +1019,22 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
           {/* eslint-enable @typescript-eslint/no-explicit-any */}
         </Resizable>
         {isCollapsed ? (
-          <div
+          <button
+            type="button"
             className="sidebar"
+            css={css`
+              appearance: none;
+              border: none;
+              background: none;
+              padding: 0;
+              margin: 0;
+              font: inherit;
+            `}
             onClick={toggleCollapse}
-            onKeyDown={handleKeyboardActivation(toggleCollapse)}
             data-test="open-datasource-tab"
-            role="button"
-            tabIndex={0}
             aria-label={t('Open Datasource tab')}
           >
-            <span role="button" tabIndex={0} className="action-button">
+            <span className="action-button">
               <Tooltip title={t('Open Datasource tab')}>
                 <Icons.VerticalAlignTopOutlined
                   iconSize="xl"
@@ -1043,7 +1046,7 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
                 />
               </Tooltip>
             </span>
-          </div>
+          </button>
         ) : null}
         <Resizable
           onResizeStop={(evt, direction, ref, d) =>

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.tsx
@@ -194,6 +194,10 @@ const ColorBreakpointsPopoverControl = ({
   };
 
   return (
+    // Rendered as antd Popover content, whose visibility antd itself
+    // manages (mount/unmount); native <dialog> requires showModal()/the
+    // open attribute and would render hidden without it.
+    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     <div role="dialog">
       <StyledRow>
         <Col flex="1">

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { useMemo, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { useTheme } from '@apache-superset/core/theme';
@@ -167,10 +166,15 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
           />
         ))}
         {needShowMoreButton && (
-          <div
-            role="button"
+          <button
+            type="button"
             tabIndex={-1}
             css={{
+              appearance: 'none',
+              border: 'none',
+              background: 'none',
+              font: 'inherit',
+              width: '100%',
               padding: theme.sizeUnit * 2,
               textAlign: 'center',
               cursor: 'pointer',
@@ -181,9 +185,6 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
               },
             }}
             onClick={() => setShowAllColumns(!showAllColumns)}
-            onKeyDown={handleKeyboardActivation(() =>
-              setShowAllColumns(!showAllColumns),
-            )}
           >
             {showAllColumns ? (
               <>
@@ -194,7 +195,7 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
                 <Icons.DownOutlined /> &nbsp; {t('Show all columns')}
               </>
             )}
-          </div>
+          </button>
         )}
       </div>
     </>

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
@@ -168,7 +168,6 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
         {needShowMoreButton && (
           <button
             type="button"
-            tabIndex={-1}
             css={{
               appearance: 'none',
               border: 'none',

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
@@ -31,11 +31,14 @@ export type DateLabelProps = {
   onClick?: (event: MouseEvent) => void;
 };
 
-const LabelContainer = styled.div<{
+const LabelContainer = styled.button<{
   isActive?: boolean;
   isPlaceholder?: boolean;
 }>`
   ${({ theme, isActive, isPlaceholder }) => css`
+    appearance: none;
+    font: inherit;
+    width: 100%;
     height: ${theme.sizeUnit * 8}px;
 
     display: flex;
@@ -80,7 +83,7 @@ const LabelContainer = styled.div<{
 
 export const DateLabel = forwardRef(
   (props: DateLabelProps, ref: RefObject<HTMLSpanElement>) => (
-    <LabelContainer {...props} tabIndex={0} role="button">
+    <LabelContainer type="button" {...props}>
       <span
         id={`date-label-${props.name}`}
         className="date-label-content"

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -35,7 +35,6 @@ import {
   DatasourceType,
   Metric,
   QueryFormMetric,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { styled, css } from '@apache-superset/core/theme';
 import { ColumnMeta, isSavedExpression } from '@superset-ui/chart-controls';
@@ -89,6 +88,16 @@ const MetricIcon = styled.span`
 
 const MetricLabel = styled.span`
   color: ${({ theme }) => theme.colorText};
+`;
+
+const inlineTextButtonCss = css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
 `;
 
 export interface ColumnSelectPopoverProps {
@@ -473,30 +482,24 @@ const ColumnSelectPopover = ({
                           description={
                             isTemporal ? (
                               <>
-                                <span
-                                  role="button"
-                                  tabIndex={0}
+                                <button
+                                  type="button"
+                                  css={inlineTextButtonCss}
                                   onClick={setDatasetAndClose}
-                                  onKeyDown={handleKeyboardActivation(
-                                    setDatasetAndClose,
-                                  )}
                                 >
                                   {t('Create a dataset')}
-                                </span>{' '}
+                                </button>{' '}
                                 {t(' to mark a column as a time column')}
                               </>
                             ) : (
                               <>
-                                <span
-                                  role="button"
-                                  tabIndex={0}
+                                <button
+                                  type="button"
+                                  css={inlineTextButtonCss}
                                   onClick={setDatasetAndClose}
-                                  onKeyDown={handleKeyboardActivation(
-                                    setDatasetAndClose,
-                                  )}
                                 >
                                   {t('Create a dataset')}
-                                </span>{' '}
+                                </button>{' '}
                                 {t(' to add calculated columns')}
                               </>
                             )
@@ -524,16 +527,13 @@ const ColumnSelectPopover = ({
                         )
                       ) : (
                         <>
-                          <span
-                            role="button"
-                            tabIndex={0}
+                          <button
+                            type="button"
+                            css={inlineTextButtonCss}
                             onClick={setDatasetAndClose}
-                            onKeyDown={handleKeyboardActivation(
-                              setDatasetAndClose,
-                            )}
                           >
                             {t('Create a dataset')}
-                          </span>{' '}
+                          </button>{' '}
                           {t(' to mark a column as a time column')}
                         </>
                       )

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelectPopoverTitle.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelectPopoverTitle.tsx
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { ChangeEvent, useCallback, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { styled, useTheme } from '@apache-superset/core/theme';
+import { css, styled, useTheme } from '@apache-superset/core/theme';
 import { Input, Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 
@@ -90,17 +89,22 @@ export const DndColumnSelectPopoverTitle = ({
     />
   ) : (
     <Tooltip placement="top" title={t('Click to edit label')}>
-      <span
+      <button
+        type="button"
+        css={css`
+          appearance: none;
+          border: none;
+          background: none;
+          padding: 0;
+          font: inherit;
+        `}
         className="AdhocMetricEditPopoverTitle inline-editable"
         data-test="AdhocMetricEditTitle#trigger"
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
         onFocus={onMouseOver}
         onClick={onClick}
-        onKeyDown={onClick ? handleKeyboardActivation(onClick) : undefined}
         onBlur={onBlur}
-        role="button"
-        tabIndex={0}
       >
         {title || defaultLabel}
         &nbsp;
@@ -108,7 +112,7 @@ export const DndColumnSelectPopoverTitle = ({
           iconColor={isHovered ? theme.colorPrimary : theme.colorText}
           iconSize="m"
         />
-      </span>
+      </button>
     </Tooltip>
   );
 };

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
@@ -54,11 +54,10 @@ export default function Option({
     <OptionControlContainer data-test="option-label" withCaret={withCaret}>
       {canDelete && (
         <CloseContainer
+          type="button"
           css={css`
             text-align: center;
           `}
-          role="button"
-          tabIndex={0}
           data-test="remove-control-button"
           onClick={onClickClose}
         >

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
@@ -134,6 +134,11 @@ export default function useResizeButton(
 
   return [
     <Icons.ArrowsAltOutlined
+      // Drag-to-resize handle activated via mousedown, not click; there's
+      // no keyboard equivalent, so role="button" (which implies a
+      // click/Enter/Space-activatable control) isn't quite right, but no
+      // native tag fits a drag handle either.
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       role="button"
       aria-label={t('Resize')}
       tabIndex={0}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
@@ -24,6 +24,7 @@ import {
   type ReactNode,
 } from 'react';
 import { SupersetClient, ensureIsArray } from '@superset-ui/core';
+import { css } from '@apache-superset/core/theme';
 import { logging } from '@apache-superset/core/utils';
 import { t } from '@apache-superset/core/translation';
 import ControlHeader from 'src/explore/components/ControlHeader';
@@ -412,7 +413,17 @@ function AdhocFilterControl({
             ? values.map((val, index) => valueRenderer(val, index))
             : []),
           addNewFilterPopoverTrigger(
-            <AddControlLabel role="button" data-test="add-filter-button">
+            <AddControlLabel
+              as="button"
+              {...{ type: 'button' }}
+              css={css`
+                appearance: none;
+                background: none;
+                font: inherit;
+                text-align: left;
+              `}
+              data-test="add-filter-button"
+            >
               <Icons.PlusOutlined iconSize="m" />
               {t('Add filter')}
             </AddControlLabel>,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -418,6 +418,11 @@ function AdhocFilterEditPopover({
           {t('Save')}
         </Button>
         <Icons.ArrowsAltOutlined
+          // Drag-to-resize handle activated via mousedown, not click; there's
+          // no keyboard equivalent, so role="button" (which implies a
+          // click/Enter/Space-activatable control) isn't quite right, but no
+          // native tag fits a drag handle either.
+          // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
           role="button"
           aria-label={t('Resize')}
           tabIndex={0}

--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl/FixedOrMetricControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl/FixedOrMetricControl.test.tsx
@@ -23,6 +23,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/explore/components/controls/LayerConfigsControl/LayerTreeItem.tsx
+++ b/superset-frontend/src/explore/components/controls/LayerConfigsControl/LayerTreeItem.tsx
@@ -16,12 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { Button } from '@superset-ui/core/components';
 import { Tag } from 'src/components';
 import { FC } from 'react';
+import { css } from '@apache-superset/core/theme';
 import { LayerTreeItemProps } from './types';
+
+const layerTreeItemLabelCss = css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+`;
 
 export const LayerTreeItem: FC<LayerTreeItemProps> = ({
   layerConf,
@@ -45,24 +54,22 @@ export const LayerTreeItem: FC<LayerTreeItemProps> = ({
         onClick={onCloseTag}
         size="small"
       />
-      <span
+      <button
+        type="button"
         className="layer-tree-item-type"
+        css={layerTreeItemLabelCss}
         onClick={onEditTag}
-        onKeyDown={handleKeyboardActivation(onEditTag)}
-        role="button"
-        tabIndex={0}
       >
         {layerConf.type}
-      </span>
-      <span
+      </button>
+      <button
+        type="button"
         className="layer-tree-item-title"
+        css={layerTreeItemLabelCss}
         onClick={onEditTag}
-        onKeyDown={handleKeyboardActivation(onEditTag)}
-        role="button"
-        tabIndex={0}
       >
         {layerConf.title}
-      </span>
+      </button>
       <Button
         className="layer-tree-item-edit"
         icon={<Icons.RightOutlined />}

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
@@ -19,15 +19,10 @@
 /* eslint-disable camelcase */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import {
-  isDefined,
-  ensureIsArray,
-  DatasourceType,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { isDefined, ensureIsArray, DatasourceType } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import type { editors } from '@apache-superset/core';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import Tabs from '@superset-ui/core/components/Tabs';
 import {
   Button,
@@ -496,20 +491,24 @@ function AdhocMetricEditPopover({
                   title={t('No saved metrics found')}
                   description={
                     <>
-                      <span
-                        tabIndex={0}
-                        role="button"
+                      <button
+                        type="button"
+                        css={css`
+                          appearance: none;
+                          border: none;
+                          background: none;
+                          padding: 0;
+                          font: inherit;
+                          color: inherit;
+                          cursor: pointer;
+                        `}
                         onClick={() => {
                           handleDatasetModal?.(true);
                           onClose();
                         }}
-                        onKeyDown={handleKeyboardActivation(() => {
-                          handleDatasetModal?.(true);
-                          onClose();
-                        })}
                       >
                         {t('Create a dataset')}
-                      </span>
+                      </button>
                       {t(' to add metrics')}
                     </>
                   }
@@ -616,6 +615,11 @@ function AdhocMetricEditPopover({
           {t('Save')}
         </Button>
         <Icons.ArrowsAltOutlined
+          // Drag-to-resize handle activated via mousedown, not click; there's
+          // no keyboard equivalent, so role="button" (which implies a
+          // click/Enter/Space-activatable control) isn't quite right, but no
+          // native tag fits a drag handle either.
+          // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
           role="button"
           aria-label={t('Resize')}
           tabIndex={0}

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import {
   ChangeEventHandler,
   FocusEvent,
@@ -27,7 +26,7 @@ import {
 } from 'react';
 
 import { t } from '@apache-superset/core/translation';
-import { styled, useTheme } from '@apache-superset/core/theme';
+import { css, styled, useTheme } from '@apache-superset/core/theme';
 import { Input, Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 
@@ -114,17 +113,23 @@ const AdhocMetricEditPopoverTitle: FC<AdhocMetricEditPopoverTitleProps> = ({
 
   return (
     <Tooltip placement="top" title={t('Click to edit label')}>
-      <span
+      <button
+        type="button"
+        css={css`
+          appearance: none;
+          border: none;
+          background: none;
+          padding: 0;
+          font: inherit;
+          cursor: pointer;
+        `}
         className="AdhocMetricEditPopoverTitle inline-editable"
         data-test="AdhocMetricEditTitle#trigger"
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}
         onFocus={handleMouseOver}
         onClick={handleClick}
-        onKeyDown={handleKeyboardActivation(handleClick)}
         onBlur={handleBlur}
-        role="button"
-        tabIndex={0}
       >
         <TitleLabel>{title?.label || defaultLabel}</TitleLabel>
         &nbsp;
@@ -132,7 +137,7 @@ const AdhocMetricEditPopoverTitle: FC<AdhocMetricEditPopoverTitleProps> = ({
           iconColor={isHovered ? theme.colorPrimary : theme.colorIcon}
           iconSize="m"
         />
-      </span>
+      </button>
     </Tooltip>
   );
 };

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -83,9 +83,14 @@ export const CaretContainer = styled.div`
   margin-left: auto;
 `;
 
-export const CloseContainer = styled.div`
+export const CloseContainer = styled.button`
+  appearance: none;
+  background: none;
+  padding: 0;
+  font: inherit;
   height: auto;
   width: ${({ theme }) => theme.sizeUnit * 6}px;
+  border: none;
   border-right: solid 1px ${({ theme }) => theme.colorBorder};
   cursor: pointer;
 `;
@@ -352,10 +357,9 @@ export const OptionControlLabel = ({
       `}
     >
       <CloseContainer
-        role="button"
+        type="button"
         data-test="remove-control-button"
         onClick={onRemove}
-        tabIndex={0}
       >
         <Icons.CloseOutlined
           iconSize="m"

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -267,6 +267,11 @@ const Examples = styled.div`
 `;
 
 const thumbnailContainerCss = (theme: SupersetTheme) => css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
   cursor: pointer;
   width: ${theme.sizeUnit * THUMBNAIL_GRID_UNITS}px;
   position: relative;
@@ -344,29 +349,20 @@ const Thumbnail: FC<ThumbnailProps> = ({
   const { key, value: type } = entry;
   const isSelected = selectedViz === entry.key;
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      setSelectedViz(key);
-    }
-  };
-
   const handleFocus = () => {
     // Auto-select chart when tabbed to
     setSelectedViz(key);
   };
 
   return (
-    <div
-      role="button"
+    <button
+      type="button"
       // using css instead of a styled component to preserve
       // the data-test attribute
       css={thumbnailContainerCss(theme)}
-      tabIndex={0}
       className={isSelected ? 'selected' : ''}
       onClick={() => setSelectedViz(key)}
       onDoubleClick={onDoubleClick}
-      onKeyDown={handleKeyDown}
       onFocus={handleFocus}
       data-test="viztype-selector-container"
     >
@@ -391,7 +387,7 @@ const Thumbnail: FC<ThumbnailProps> = ({
           </HighlightLabel>
         </ThumbnailLabelWrapper>
       )}
-    </div>
+    </button>
   );
 };
 

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -361,6 +361,7 @@ const Thumbnail: FC<ThumbnailProps> = ({
       // the data-test attribute
       css={thumbnailContainerCss(theme)}
       className={isSelected ? 'selected' : ''}
+      aria-pressed={isSelected}
       onClick={() => setSelectedViz(key)}
       onDoubleClick={onDoubleClick}
       onFocus={handleFocus}

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -18,10 +18,7 @@
  */
 import { useCallback, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import {
-  getChartMetadataRegistry,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { getChartMetadataRegistry } from '@superset-ui/core';
 import { css, styled, SupersetTheme } from '@apache-superset/core/theme';
 import { usePluginContext } from 'src/components';
 import { Icons, Modal } from '@superset-ui/core/components';
@@ -115,14 +112,21 @@ const VizTypeControl = ({
           color: ${theme.colorTextTertiary};
         `}
       >
-        <span
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
+          css={css`
+            appearance: none;
+            border: none;
+            background: none;
+            padding: 0;
+            font: inherit;
+            color: inherit;
+            text-decoration: inherit;
+          `}
           onClick={openModal}
-          onKeyDown={handleKeyboardActivation(openModal)}
         >
           {t('View all charts')}
-        </span>
+        </button>
       </div>
       <UnpaddedModal
         show={showModal}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -117,6 +117,29 @@ jest.mock('@superset-ui/core/components', () => {
 
   return {
     Input,
+    ActionButton: ({
+      label,
+      icon,
+      onClick,
+      className,
+      dataTest,
+    }: {
+      label: string;
+      icon: ReactNode;
+      onClick: () => void;
+      className?: string;
+      dataTest?: string;
+    }) => (
+      <button
+        type="button"
+        aria-label={label}
+        className={className}
+        data-test={dataTest ?? label}
+        onClick={onClick}
+      >
+        {icon}
+      </button>
+    ),
     Select: ({
       'data-test': dataTest,
       ariaLabel,

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -33,11 +33,15 @@ import {
   JsonResponse,
   SupersetClient,
   isFeatureEnabled,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { styled, useTheme } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { AsyncSelect, Input, Select } from '@superset-ui/core/components';
+import {
+  ActionButton,
+  AsyncSelect,
+  Input,
+  Select,
+} from '@superset-ui/core/components';
 import RefreshLabel from '@superset-ui/core/components/RefreshLabel';
 import {
   NotificationMethodOption,
@@ -85,6 +89,11 @@ const StyledNotificationMethod = styled.div`
     }
 
     .ghost-button {
+      appearance: none;
+      border: none;
+      background: none;
+      padding: 0;
+      font: inherit;
       color: ${theme.colorPrimaryText};
       display: inline-flex;
       align-items: center;
@@ -575,16 +584,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               loading={methodOptionsLoading}
             />
             {index !== 0 && !!onRemove ? (
-              <span
-                role="button"
-                tabIndex={0}
+              <ActionButton
+                label={t('Remove notification method')}
                 className="delete-button"
+                icon={<Icons.DeleteOutlined iconSize="l" />}
                 onClick={() => onRemove(index)}
-                onKeyDown={handleKeyboardActivation(() => onRemove(index))}
-                aria-label={t('Remove notification method')}
-              >
-                <Icons.DeleteOutlined iconSize="l" />
-              </span>
+              />
             ) : null}
           </div>
         </StyledInputContainer>
@@ -778,30 +783,24 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               )}
               {/* New buttons container */}
               <div className="ghost-button">
-                <span
+                <button
+                  type="button"
                   className="ghost-button"
-                  role="button"
-                  tabIndex={0}
                   onClick={() => setCcVisible(true)}
-                  onKeyDown={handleKeyboardActivation(() => setCcVisible(true))}
                   style={{ display: ccVisible ? 'none' : 'inline-flex' }}
                 >
                   <Icons.MailOutlined iconSize="xs" className="icon" />
                   {t('Add CC Recipients')}
-                </span>
-                <span
+                </button>
+                <button
+                  type="button"
                   className="ghost-button"
-                  role="button"
-                  tabIndex={0}
                   onClick={() => setBccVisible(true)}
-                  onKeyDown={handleKeyboardActivation(() =>
-                    setBccVisible(true),
-                  )}
                   style={{ display: bccVisible ? 'none' : 'inline-flex' }}
                 >
                   <Icons.MailOutlined iconSize="xs" className="icon" />
                   {t('Add BCC Recipients')}
-                </span>
+                </button>
               </div>
             </StyledInputContainer>
           )}

--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -17,11 +17,7 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { css } from '@apache-superset/core/theme';
 import { Link, useHistory } from 'react-router-dom';
 import {
@@ -42,6 +38,18 @@ import type { ListViewFetchDataConfig as FetchDataConfig } from 'src/components'
 import { TableTab } from 'src/views/CRUD/types';
 import { isUserEditorOrAdmin } from 'src/dashboard/util/permissionUtils';
 import type { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+
+const menuItemButtonCss = css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+`;
 
 interface ChartCardProps {
   chart: Chart;
@@ -100,16 +108,11 @@ export default function ChartCard({
                 )
           }
         >
-          <div
+          <button
+            type="button"
+            css={menuItemButtonCss}
             data-test="chart-list-edit-option"
-            role="button"
-            tabIndex={0}
             onClick={allowEdit ? () => openChartEditModal(chart) : undefined}
-            onKeyDown={
-              allowEdit
-                ? handleKeyboardActivation(() => openChartEditModal(chart))
-                : undefined
-            }
           >
             <Icons.EditOutlined
               iconSize="l"
@@ -118,7 +121,7 @@ export default function ChartCard({
               `}
             />{' '}
             {t('Edit')}
-          </div>
+          </button>
         </Tooltip>
       ),
       disabled: !allowEdit,
@@ -129,13 +132,11 @@ export default function ChartCard({
     menuItems.push({
       key: 'export',
       label: (
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
+          css={menuItemButtonCss}
+          data-test="chart-list-export-option"
           onClick={() => handleBulkChartExport([chart])}
-          onKeyDown={handleKeyboardActivation(() =>
-            handleBulkChartExport([chart]),
-          )}
         >
           <Icons.UploadOutlined
             iconSize="l"
@@ -144,7 +145,7 @@ export default function ChartCard({
             `}
           />{' '}
           {t('Export')}
-        </div>
+        </button>
       ),
     });
   }
@@ -182,17 +183,12 @@ export default function ChartCard({
                     )
               }
             >
-              <div
+              <button
+                type="button"
+                css={menuItemButtonCss}
                 data-test="chart-list-delete-option"
-                role="button"
-                tabIndex={0}
                 className="action-button"
                 onClick={allowEdit ? confirmDelete : undefined}
-                onKeyDown={
-                  allowEdit
-                    ? handleKeyboardActivation(confirmDelete)
-                    : undefined
-                }
               >
                 <Icons.DeleteOutlined
                   iconSize="l"
@@ -201,7 +197,7 @@ export default function ChartCard({
                   `}
                 />{' '}
                 {t('Delete')}
-              </div>
+              </button>
             </Tooltip>
           )}
         </ConfirmStatusChange>

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -18,11 +18,8 @@
  */
 import { Link, useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
+import { css } from '@apache-superset/core/theme';
 import { CardStyles } from 'src/views/CRUD/utils';
 import {
   FaveStar,
@@ -38,6 +35,18 @@ import { SubjectPile } from 'src/features/subjects/SubjectPile';
 import { KebabMenuButton } from 'src/components';
 import { isUserEditorOrAdmin } from 'src/dashboard/util/permissionUtils';
 import type { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+
+const menuItemButtonCss = css`
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+`;
 
 interface DashboardCardProps {
   isChart?: boolean;
@@ -94,24 +103,17 @@ function DashboardCard({
                 )
           }
         >
-          <div
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
+            css={menuItemButtonCss}
             className="action-button"
             onClick={
               allowEdit ? () => openDashboardEditModal(dashboard) : undefined
             }
-            onKeyDown={
-              allowEdit
-                ? handleKeyboardActivation(() =>
-                    openDashboardEditModal(dashboard),
-                  )
-                : undefined
-            }
             data-test="dashboard-card-option-edit-button"
           >
             <Icons.EditOutlined iconSize="l" data-test="edit-alt" /> {t('Edit')}
-          </div>
+          </button>
         </Tooltip>
       ),
       disabled: !allowEdit,
@@ -122,18 +124,15 @@ function DashboardCard({
     menuItems.push({
       key: 'export',
       label: (
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
+          css={menuItemButtonCss}
           onClick={() => handleBulkDashboardExport([dashboard])}
-          onKeyDown={handleKeyboardActivation(() =>
-            handleBulkDashboardExport([dashboard]),
-          )}
           className="action-button"
           data-test="dashboard-card-option-export-button"
         >
           <Icons.UploadOutlined iconSize="l" /> {t('Export')}
-        </div>
+        </button>
       ),
     });
   }
@@ -151,20 +150,15 @@ function DashboardCard({
                 )
           }
         >
-          <div
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
+            css={menuItemButtonCss}
             className="action-button"
             onClick={allowEdit ? () => onDelete(dashboard) : undefined}
-            onKeyDown={
-              allowEdit
-                ? handleKeyboardActivation(() => onDelete(dashboard))
-                : undefined
-            }
             data-test="dashboard-card-option-delete-button"
           >
             <Icons.DeleteOutlined iconSize="l" /> {t('Delete')}
-          </div>
+          </button>
         </Tooltip>
       ),
       disabled: !allowEdit,

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -187,7 +187,6 @@ const SSHTunnelForm = ({
                 errorMessage={sshErrors?.password}
                 isValidating={isValidating}
                 data-test="ssh-tunnel-password-input"
-                role="textbox"
               />
             </StyledDiv>
           </Col>
@@ -240,7 +239,6 @@ const SSHTunnelForm = ({
                   errorMessage={sshErrors?.private_key_password}
                   isValidating={isValidating}
                   data-test="ssh-tunnel-private_key_password-input"
-                  role="textbox"
                 />
               </StyledDiv>
             </Col>

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -39,6 +39,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );
@@ -62,7 +63,7 @@ describe('DatasetPanel', () => {
       exact: false,
     });
     expect(blankDatasetDescription2).toBeVisible();
-    const sqlLabLink = screen.getByRole('button', {
+    const sqlLabLink = screen.getByRole('link', {
       name: CREATE_MESSAGE,
     });
     expect(sqlLabLink).toBeVisible();

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { handleKeyboardActivation } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import { Alert } from '@apache-superset/core/components';
-import { styled } from '@apache-superset/core/theme';
+import { css, styled } from '@apache-superset/core/theme';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { Loading } from '@superset-ui/core/components';
 import Table, {
@@ -217,38 +216,41 @@ const EXISTING_DATASET_DESCRIPTION = t(
 );
 const VIEW_DATASET = t('View Dataset');
 
-const renderExistingDatasetAlert = (dataset?: DatasetObject) => {
-  const openExplore = () => {
-    if (dataset?.explore_url) {
-      // `explore_url` is router-relative from the backend (rooted under
-      // a subdirectory deployment); strip the root so openInNewTab's
-      // ensureAppRoot re-prefixes it once rather than doubling it.
-      openInNewTab(stripAppRoot(dataset.explore_url));
+const renderExistingDatasetAlert = (dataset?: DatasetObject) => (
+  <StyledAlert
+    closable={false}
+    type="info"
+    showIcon
+    message={t('This table already has a dataset')}
+    description={
+      <>
+        {EXISTING_DATASET_DESCRIPTION}
+        <button
+          type="button"
+          onClick={() => {
+            if (dataset?.explore_url) {
+              // `explore_url` is router-relative from the backend (rooted under
+              // a subdirectory deployment); strip the root so openInNewTab's
+              // ensureAppRoot re-prefixes it once rather than doubling it.
+              openInNewTab(stripAppRoot(dataset.explore_url));
+            }
+          }}
+          className="view-dataset-button"
+          css={css`
+            appearance: none;
+            border: none;
+            background: none;
+            padding: 0;
+            font: inherit;
+            cursor: pointer;
+          `}
+        >
+          {VIEW_DATASET}
+        </button>
+      </>
     }
-  };
-  return (
-    <StyledAlert
-      closable={false}
-      type="info"
-      showIcon
-      message={t('This table already has a dataset')}
-      description={
-        <>
-          {EXISTING_DATASET_DESCRIPTION}
-          <span
-            role="button"
-            onClick={openExplore}
-            onKeyDown={handleKeyboardActivation(openExplore)}
-            tabIndex={0}
-            className="view-dataset-button"
-          >
-            {VIEW_DATASET}
-          </span>
-        </>
-      }
-    />
-  );
-};
+  />
+);
 
 const DatasetPanel = ({
   tableName,

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanelWrapper.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanelWrapper.test.tsx
@@ -24,6 +24,7 @@ jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
     ({ fileName }: { fileName: string }) => (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
       <span role="img" aria-label={fileName.replace('_', '-')} />
     ),
 );

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/MessageContent.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/MessageContent.tsx
@@ -52,9 +52,9 @@ const renderEmptyDescription = () => (
   <>
     {SELECT_MESSAGE}
     <Link to="/sqllab">
-      <span role="button" tabIndex={0}>
-        {CREATE_MESSAGE}
-      </span>
+      {/* Link already renders an interactive <a>, so this span needs no
+          role/tabIndex of its own. */}
+      <span>{CREATE_MESSAGE}</span>
     </Link>
     {VIEW_DATASET_MESSAGE}
   </>

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -270,11 +270,7 @@ export function Menu({
       return {
         key,
         label: (
-          <NavLink
-            role="button"
-            to={stripAppRoot(url)}
-            activeClassName="is-active"
-          >
+          <NavLink to={stripAppRoot(url)} activeClassName="is-active">
             {label}
           </NavLink>
         ),
@@ -399,9 +395,9 @@ export function Menu({
   };
   return (
     <StyledHeader
+      as="nav"
       className="top"
       id="main-menu"
-      role="navigation"
       aria-label={t('Main navigation')}
     >
       <StyledRow>

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -303,6 +303,10 @@ export const SavedQueries = ({
           {queries.map(q => (
             <CardStyles
               key={q.id}
+              // Deliberate role="button" on this card wrapper — it wraps a
+              // nested interactive control (the kebab menu button below), so
+              // a real <button> tag would produce invalid nested buttons.
+              // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
               role="button"
               tabIndex={0}
               aria-label={q.label}

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -215,122 +215,124 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
 
   return (
     <StyledHeader backgroundColor={props.backgroundColor}>
-      <Row className="menu" role="navigation" aria-label={t('Page navigation')}>
-        {props.name && <div className="header">{props.name}</div>}
-        <Menu
-          mode={showMenu}
-          disabledOverflow
-          role="tablist"
-          items={props.tabs?.map(tab => {
-            if ((props.usesRouter || hasHistory) && !!tab.usesRouter) {
+      <nav aria-label={t('Page navigation')}>
+        <Row className="menu">
+          {props.name && <div className="header">{props.name}</div>}
+          <Menu
+            mode={showMenu}
+            disabledOverflow
+            role="tablist"
+            items={props.tabs?.map(tab => {
+              if ((props.usesRouter || hasHistory) && !!tab.usesRouter) {
+                return {
+                  key: tab.label,
+                  label: (
+                    <Link
+                      to={tab.url || ''}
+                      role="tab"
+                      id={tab.id || tab.name}
+                      data-test={tab['data-test']}
+                      aria-selected={tab.name === props.activeChild}
+                      aria-controls={tab['aria-controls'] || ''}
+                      className={tab.name === props.activeChild ? 'active' : ''}
+                    >
+                      {tab.label}
+                    </Link>
+                  ),
+                };
+              }
               return {
                 key: tab.label,
                 label: (
-                  <Link
-                    to={tab.url || ''}
+                  <div
+                    className={cx('no-router', {
+                      active: tab.name === props.activeChild,
+                    })}
                     role="tab"
-                    id={tab.id || tab.name}
-                    data-test={tab['data-test']}
                     aria-selected={tab.name === props.activeChild}
-                    aria-controls={tab['aria-controls'] || ''}
-                    className={tab.name === props.activeChild ? 'active' : ''}
                   >
-                    {tab.label}
-                  </Link>
+                    <Typography.Link href={tab.url} onClick={tab.onClick}>
+                      {tab.label}
+                    </Typography.Link>
+                  </div>
                 ),
               };
-            }
-            return {
-              key: tab.label,
-              label: (
-                <div
-                  className={cx('no-router', {
-                    active: tab.name === props.activeChild,
-                  })}
-                  role="tab"
-                  aria-selected={tab.name === props.activeChild}
-                >
-                  <Typography.Link href={tab.url} onClick={tab.onClick}>
-                    {tab.label}
-                  </Typography.Link>
-                </div>
-              ),
-            };
-          })}
-        />
-        <div className={navRightStyle}>
-          <Menu
-            mode="horizontal"
-            triggerSubMenuAction="click"
-            disabledOverflow
-            css={css`
-              [data-icon='caret-down'] {
-                color: ${theme.colorIcon};
-                font-size: ${theme.fontSizeXS}px;
-                margin-left: ${theme.sizeUnit}px;
-              }
-            `}
-            items={props.dropDownLinks?.map((link, i) => ({
-              key: `dropdown-${i}`,
-              label: link.label,
-              icon: <Icons.CaretDownOutlined />,
-              popupOffset: [10, 20],
-              className: 'dropdown-menu-links',
-              children: link.childs
-                ?.filter(
-                  (item): item is Exclude<typeof item, string> =>
-                    typeof item === 'object',
-                )
-                .map(item =>
-                  item.disable
-                    ? {
-                        key: item.label,
-                        disabled: true,
-                        label: (
-                          <Tooltip
-                            placement="top"
-                            title={t(
-                              "Enable 'Allow file uploads to database' in any database's settings",
-                            )}
-                          >
-                            <span css={styledDisabled(theme)}>
-                              {item.label}
-                            </span>
-                          </Tooltip>
-                        ),
-                      }
-                    : {
-                        key: item.label,
-                        label: (
-                          <Typography.Link
-                            href={item.url}
-                            onClick={item.onClick}
-                          >
-                            {item.label}
-                          </Typography.Link>
-                        ),
-                      },
-                ),
-            }))}
+            })}
           />
-          {props.buttons?.map((btn, i) =>
-            btn.component ? (
-              <span key={i}>{btn.component}</span>
-            ) : (
-              <Button
-                key={i}
-                buttonStyle={btn.buttonStyle}
-                icon={btn.icon}
-                onClick={btn.onClick}
-                data-test={btn['data-test']}
-                loading={btn.loading ?? false}
-              >
-                {btn.name}
-              </Button>
-            ),
-          )}
-        </div>
-      </Row>
+          <div className={navRightStyle}>
+            <Menu
+              mode="horizontal"
+              triggerSubMenuAction="click"
+              disabledOverflow
+              css={css`
+                [data-icon='caret-down'] {
+                  color: ${theme.colorIcon};
+                  font-size: ${theme.fontSizeXS}px;
+                  margin-left: ${theme.sizeUnit}px;
+                }
+              `}
+              items={props.dropDownLinks?.map((link, i) => ({
+                key: `dropdown-${i}`,
+                label: link.label,
+                icon: <Icons.CaretDownOutlined />,
+                popupOffset: [10, 20],
+                className: 'dropdown-menu-links',
+                children: link.childs
+                  ?.filter(
+                    (item): item is Exclude<typeof item, string> =>
+                      typeof item === 'object',
+                  )
+                  .map(item =>
+                    item.disable
+                      ? {
+                          key: item.label,
+                          disabled: true,
+                          label: (
+                            <Tooltip
+                              placement="top"
+                              title={t(
+                                "Enable 'Allow file uploads to database' in any database's settings",
+                              )}
+                            >
+                              <span css={styledDisabled(theme)}>
+                                {item.label}
+                              </span>
+                            </Tooltip>
+                          ),
+                        }
+                      : {
+                          key: item.label,
+                          label: (
+                            <Typography.Link
+                              href={item.url}
+                              onClick={item.onClick}
+                            >
+                              {item.label}
+                            </Typography.Link>
+                          ),
+                        },
+                  ),
+              }))}
+            />
+            {props.buttons?.map((btn, i) =>
+              btn.component ? (
+                <span key={i}>{btn.component}</span>
+              ) : (
+                <Button
+                  key={i}
+                  buttonStyle={btn.buttonStyle}
+                  icon={btn.icon}
+                  onClick={btn.onClick}
+                  data-test={btn['data-test']}
+                  loading={btn.loading ?? false}
+                >
+                  {btn.name}
+                </Button>
+              ),
+            )}
+          </div>
+        </Row>
+      </nav>
       {props.children}
     </StyledHeader>
   );

--- a/superset-frontend/src/features/queries/QueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/QueryPreviewModal.tsx
@@ -44,12 +44,17 @@ const QueryViewToggle = styled.div`
   display: flex;
 `;
 
-const TabButton = styled.div`
+const TabButton = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  font: inherit;
   font-size: ${({ theme }) => theme.fontSizeSM}px;
   padding: ${({ theme }) => theme.sizeUnit * 2}px
     ${({ theme }) => theme.sizeUnit * 4}px;
   margin-right: ${({ theme }) => theme.sizeUnit * 4}px;
   color: ${({ theme }) => theme.colorPrimaryText};
+  cursor: pointer;
 
   &.active,
   &:focus,
@@ -147,8 +152,7 @@ function QueryPreviewModal({
         <QueryLabel>{query.tab_name}</QueryLabel>
         <QueryViewToggle>
           <TabButton
-            role="button"
-            tabIndex={0}
+            type="button"
             data-test="toggle-user-sql"
             className={cx({ active: currentTab === 'user' })}
             onClick={() => setCurrentTab('user')}
@@ -156,8 +160,7 @@ function QueryPreviewModal({
             {t('User query')}
           </TabButton>
           <TabButton
-            role="button"
-            tabIndex={0}
+            type="button"
             data-test="toggle-executed-sql"
             className={cx({ active: currentTab === 'executed' })}
             onClick={() => setCurrentTab('executed')}

--- a/superset-frontend/src/features/queries/SyntaxHighlighterCopy.tsx
+++ b/superset-frontend/src/features/queries/SyntaxHighlighterCopy.tsx
@@ -116,10 +116,11 @@ export default function SyntaxHighlighterCopy({
 
   return (
     <SyntaxHighlighterWrapper>
+      {/* role is auto-computed by BaseIconComponent as "button" since
+          onClick is present, so no explicit role needed here. */}
       <Icons.CopyOutlined
         className="copy-button"
         tabIndex={0}
-        role="button"
         aria-label={t('Copy code to clipboard')}
         onClick={handleCopyClick}
         onKeyDown={handleKeyDown}

--- a/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
@@ -93,12 +93,12 @@ describe('ChartList Card View Tests', () => {
 
     // Verify card view toggle is active (appstore icon should have active class)
     const cardViewToggle = screen.getByRole('img', { name: 'appstore' });
-    const cardViewButton = cardViewToggle.closest('[role="button"]');
+    const cardViewButton = cardViewToggle.closest('button');
     expect(cardViewButton).toHaveClass('active');
 
     // Verify list view toggle is not active
     const listViewToggle = screen.getByRole('img', { name: 'unordered-list' });
-    const listViewButton = listViewToggle.closest('[role="button"]');
+    const listViewButton = listViewToggle.closest('button');
     expect(listViewButton).not.toHaveClass('active');
   });
 
@@ -111,7 +111,7 @@ describe('ChartList Card View Tests', () => {
 
     // Switch to list view
     const listViewToggle = screen.getByRole('img', { name: 'unordered-list' });
-    const listViewButton = listViewToggle.closest('[role="button"]');
+    const listViewButton = listViewToggle.closest('button');
     expect(listViewButton).not.toBeNull();
     fireEvent.click(listViewButton!);
 

--- a/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
@@ -308,7 +308,7 @@ test('displays chart data correctly in table rows', async () => {
   // Check for favorite star column within the specific row
   const favoriteButton = within(chartRow).getByTestId('fave-unfave-icon');
   expect(favoriteButton).toBeInTheDocument();
-  expect(favoriteButton).toHaveAttribute('role', 'button');
+  expect(favoriteButton.tagName).toBe('BUTTON');
 
   // Check chart name link within the specific row
   const chartLink = within(chartRow).getByTestId(

--- a/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
@@ -193,7 +193,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     await screen.findByTestId('chart-list-view');
 
     // Verify all admin controls are visible
-    expect(screen.getByRole('button', { name: /chart/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /chart$/i })).toBeInTheDocument();
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-select')).toBeInTheDocument();
 
@@ -221,7 +221,7 @@ describe('ChartList - Permission-based UI Tests', () => {
 
     // Verify permission-gated elements are hidden
     expect(
-      screen.queryByRole('button', { name: /chart/i }),
+      screen.queryByRole('button', { name: /chart$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -374,7 +374,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     await renderWithPermissions(PERMISSIONS.WRITE_ONLY);
     await screen.findByTestId('chart-list-view');
 
-    expect(screen.getByRole('button', { name: /chart/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /chart$/i })).toBeInTheDocument();
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
   });
 
@@ -382,7 +382,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
     await screen.findByTestId('chart-list-view');
 
-    expect(screen.getByRole('button', { name: /chart/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /chart$/i })).toBeInTheDocument();
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
   });
 
@@ -391,7 +391,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     await screen.findByTestId('chart-list-view');
 
     expect(
-      screen.queryByRole('button', { name: /chart/i }),
+      screen.queryByRole('button', { name: /chart$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -401,7 +401,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     await screen.findByTestId('chart-list-view');
 
     expect(
-      screen.queryByRole('button', { name: /chart/i }),
+      screen.queryByRole('button', { name: /chart$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -479,7 +479,7 @@ describe('ChartList - Permission-based UI Tests', () => {
 
     // Create and Import should be hidden (no can_write)
     expect(
-      screen.queryByRole('button', { name: /chart/i }),
+      screen.queryByRole('button', { name: /chart$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -493,7 +493,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryByTitle('Tags')).not.toBeInTheDocument();
     expect(screen.queryByTestId('bulk-select')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /chart/i }),
+      screen.queryByRole('button', { name: /chart$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
 

--- a/superset-frontend/src/pages/ChartList/ChartList.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.test.tsx
@@ -95,7 +95,7 @@ describe('ChartList', () => {
     await screen.findByTestId('chart-list-view');
 
     // Verify New Chart button exists
-    const newChartButton = screen.getByRole('button', { name: /chart/i });
+    const newChartButton = screen.getByRole('button', { name: /chart$/i });
     expect(newChartButton).toBeInTheDocument();
     expect(screen.getByTestId('plus')).toBeInTheDocument();
 

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -25,7 +25,6 @@ import {
   JsonResponse,
   SupersetClient,
   isMatrixifyEnabled,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { useState, useMemo, useCallback } from 'react';
 import rison from 'rison';
@@ -47,6 +46,7 @@ import {
 } from 'src/views/CRUD/hooks';
 import handleResourceExport from 'src/utils/export';
 import {
+  ActionButton,
   ConfirmStatusChange,
   CertifiedBadge,
   Tooltip,
@@ -86,7 +86,6 @@ import { WIDER_DROPDOWN_WIDTH } from 'src/components/ListView/utils';
 import { Tag } from 'src/components/Tag';
 import { datasetLabel } from 'src/features/semanticLayers/label';
 import { isUserEditorOrAdmin } from 'src/dashboard/util/permissionUtils';
-import IconButton from 'src/dashboard/components/IconButton';
 import type { CellProps } from 'react-table';
 
 const FlexRowContainer = styled.div`
@@ -532,9 +531,9 @@ function ChartList(props: ChartListProps) {
           return (
             <Actions className="actions">
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={
                     allowEdit
                       ? t('Edit')
                       : t(
@@ -542,31 +541,23 @@ function ChartList(props: ChartListProps) {
                         )
                   }
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="chart-row-edit"
-                    disabled={!allowEdit}
-                    onClick={openEditModal}
-                    onKeyDown={handleKeyboardActivation(openEditModal)}
-                    icon={
-                      <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
-                    }
-                  />
-                </Tooltip>
+                  icon={
+                    <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
+                  }
+                  dataTest="chart-row-edit"
+                  disabled={!allowEdit}
+                  onClick={openEditModal}
+                />
               )}
               {canExport && (
-                <Tooltip
-                  id="export-action-tooltip"
-                  title={t('Export')}
+                <ActionButton
+                  label={t('Export')}
+                  tooltip={t('Export')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="chart-row-export"
-                    onClick={handleExport}
-                    onKeyDown={handleKeyboardActivation(handleExport)}
-                    icon={<Icons.UploadOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.UploadOutlined iconSize="l" />}
+                  dataTest="chart-row-export"
+                  onClick={handleExport}
+                />
               )}
               {canDelete && (
                 <ConfirmStatusChange
@@ -580,9 +571,9 @@ function ChartList(props: ChartListProps) {
                   onConfirm={handleDelete}
                 >
                   {confirmDelete => (
-                    <Tooltip
-                      id="delete-action-tooltip"
-                      title={
+                    <ActionButton
+                      label={t('Delete')}
+                      tooltip={
                         allowEdit
                           ? t('Delete')
                           : t(
@@ -590,15 +581,11 @@ function ChartList(props: ChartListProps) {
                             )
                       }
                       placement="bottom"
-                    >
-                      <IconButton
-                        data-test="chart-row-delete"
-                        disabled={!allowEdit}
-                        onClick={confirmDelete}
-                        onKeyDown={handleKeyboardActivation(confirmDelete)}
-                        icon={<Icons.DeleteOutlined iconSize="l" />}
-                      />
-                    </Tooltip>
+                      icon={<Icons.DeleteOutlined iconSize="l" />}
+                      dataTest="chart-row-delete"
+                      disabled={!allowEdit}
+                      onClick={confirmDelete}
+                    />
                   )}
                 </ConfirmStatusChange>
               )}

--- a/superset-frontend/src/pages/DashboardList/DashboardList.cardview.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.cardview.test.tsx
@@ -82,7 +82,7 @@ describe('DashboardList Card View Tests', () => {
 
     // Verify card view toggle is active
     const cardViewToggle = screen.getByRole('img', { name: 'appstore' });
-    const cardViewButton = cardViewToggle.closest('[role="button"]');
+    const cardViewButton = cardViewToggle.closest('button');
     expect(cardViewButton).toHaveClass('active');
   });
 
@@ -96,7 +96,7 @@ describe('DashboardList Card View Tests', () => {
     const listViewToggle = screen.getByRole('img', {
       name: 'unordered-list',
     });
-    const listViewButton = listViewToggle.closest('[role="button"]');
+    const listViewButton = listViewToggle.closest('button');
     expect(listViewButton).not.toBeNull();
     fireEvent.click(listViewButton!);
 

--- a/superset-frontend/src/pages/DashboardList/DashboardList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.permissions.test.tsx
@@ -186,7 +186,7 @@ describe('DashboardList - Permission-based UI Tests', () => {
 
     // Verify admin controls are visible
     expect(
-      screen.getByRole('button', { name: /dashboard/i }),
+      screen.getByRole('button', { name: /dashboard$/i }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-select')).toBeInTheDocument();
@@ -215,7 +215,7 @@ describe('DashboardList - Permission-based UI Tests', () => {
 
     // Verify permission-gated elements are hidden
     expect(
-      screen.queryByRole('button', { name: /dashboard/i }),
+      screen.queryByRole('button', { name: /dashboard$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -303,7 +303,7 @@ describe('DashboardList - Permission-based UI Tests', () => {
     await screen.findByTestId('dashboard-list-view');
 
     expect(
-      screen.getByRole('button', { name: /dashboard/i }),
+      screen.getByRole('button', { name: /dashboard$/i }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
   });
@@ -313,7 +313,7 @@ describe('DashboardList - Permission-based UI Tests', () => {
     await screen.findByTestId('dashboard-list-view');
 
     expect(
-      screen.queryByRole('button', { name: /dashboard/i }),
+      screen.queryByRole('button', { name: /dashboard$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
@@ -323,7 +323,7 @@ describe('DashboardList - Permission-based UI Tests', () => {
     await screen.findByTestId('dashboard-list-view');
 
     expect(
-      screen.queryByRole('button', { name: /dashboard/i }),
+      screen.queryByRole('button', { name: /dashboard$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });

--- a/superset-frontend/src/pages/DashboardList/DashboardList.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.test.tsx
@@ -108,7 +108,7 @@ test('switches between card and table view', async () => {
 
   // Switch to table view via the list icon
   const listViewIcon = screen.getByRole('img', { name: 'unordered-list' });
-  const listViewButton = listViewIcon.closest('[role="button"]')!;
+  const listViewButton = listViewIcon.closest('button')!;
   fireEvent.click(listViewButton);
 
   await waitFor(() => {
@@ -117,7 +117,7 @@ test('switches between card and table view', async () => {
 
   // Switch back to card view
   const cardViewIcon = screen.getByRole('img', { name: 'appstore' });
-  const cardViewButton = cardViewIcon.closest('[role="button"]')!;
+  const cardViewButton = cardViewIcon.closest('button')!;
   fireEvent.click(cardViewButton);
 
   await waitFor(() => {

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { isFeatureEnabled, FeatureFlag, SupersetClient } from '@superset-ui/core';
+import {
+  isFeatureEnabled,
+  FeatureFlag,
+  SupersetClient,
+} from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { useSelector } from 'react-redux';
 import { useState, useMemo, useCallback } from 'react';

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -17,12 +17,7 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  SupersetClient,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag, SupersetClient } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { useSelector } from 'react-redux';
 import { useState, useMemo, useCallback } from 'react';
@@ -40,6 +35,7 @@ import { SUBJECT_OPTION_FILTER_PROPS } from 'src/features/subjects/SubjectSelect
 import { SubjectPile } from 'src/features/subjects/SubjectPile';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import {
+  ActionButton,
   CertifiedBadge,
   ConfirmStatusChange,
   DeleteModal,
@@ -81,7 +77,6 @@ import { findPermission } from 'src/utils/findPermission';
 import { navigateTo } from 'src/utils/navigationUtils';
 import { WIDER_DROPDOWN_WIDTH } from 'src/components/ListView/utils';
 import { isUserEditorOrAdmin } from 'src/dashboard/util/permissionUtils';
-import IconButton from 'src/dashboard/components/IconButton';
 import type { CellProps } from 'react-table';
 
 const PAGE_SIZE = 25;
@@ -496,9 +491,9 @@ function DashboardList(props: DashboardListProps) {
           return (
             <Actions className="actions">
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={
                     allowEdit
                       ? t('Edit')
                       : t(
@@ -506,31 +501,23 @@ function DashboardList(props: DashboardListProps) {
                         )
                   }
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dashboard-row-edit"
-                    disabled={!allowEdit}
-                    onClick={handleEdit}
-                    onKeyDown={handleKeyboardActivation(handleEdit)}
-                    icon={
-                      <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
-                    }
-                  />
-                </Tooltip>
+                  icon={
+                    <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
+                  }
+                  dataTest="dashboard-row-edit"
+                  disabled={!allowEdit}
+                  onClick={handleEdit}
+                />
               )}
               {canExport && (
-                <Tooltip
-                  id="export-action-tooltip"
-                  title={t('Export')}
+                <ActionButton
+                  label={t('Export')}
+                  tooltip={t('Export')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dashboard-row-export"
-                    onClick={handleExport}
-                    onKeyDown={handleKeyboardActivation(handleExport)}
-                    icon={<Icons.UploadOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.UploadOutlined iconSize="l" />}
+                  dataTest="dashboard-row-export"
+                  onClick={handleExport}
+                />
               )}
               {canDelete && (
                 <ConfirmStatusChange
@@ -544,9 +531,9 @@ function DashboardList(props: DashboardListProps) {
                   onConfirm={handleDelete}
                 >
                   {confirmDelete => (
-                    <Tooltip
-                      id="delete-action-tooltip"
-                      title={
+                    <ActionButton
+                      label={t('Delete')}
+                      tooltip={
                         allowEdit
                           ? t('Delete')
                           : t(
@@ -554,20 +541,16 @@ function DashboardList(props: DashboardListProps) {
                             )
                       }
                       placement="bottom"
-                    >
-                      <IconButton
-                        data-test="dashboard-row-delete"
-                        disabled={!allowEdit}
-                        onClick={confirmDelete}
-                        onKeyDown={handleKeyboardActivation(confirmDelete)}
-                        icon={
-                          <Icons.DeleteOutlined
-                            iconSize="l"
-                            data-test="dashboard-list-trash-icon"
-                          />
-                        }
-                      />
-                    </Tooltip>
+                      icon={
+                        <Icons.DeleteOutlined
+                          iconSize="l"
+                          data-test="dashboard-list-trash-icon"
+                        />
+                      }
+                      dataTest="dashboard-row-delete"
+                      disabled={!allowEdit}
+                      onClick={confirmDelete}
+                    />
                   )}
                 </ConfirmStatusChange>
               )}

--- a/superset-frontend/src/pages/DatabaseList/index.tsx
+++ b/superset-frontend/src/pages/DatabaseList/index.tsx
@@ -22,7 +22,6 @@ import {
   SupersetClient,
   isFeatureEnabled,
   FeatureFlag,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { useState, useMemo, useEffect, useCallback } from 'react';
@@ -40,6 +39,7 @@ import {
 import withToasts from 'src/components/MessageToasts/withToasts';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import {
+  ActionButton,
   Button,
   DeleteModal,
   Dropdown,
@@ -77,7 +77,6 @@ import {
   databaseLabelLower,
   databasesLabel,
 } from 'src/features/semanticLayers/label';
-import IconButton from 'src/dashboard/components/IconButton';
 
 const extensionsRegistry = getExtensionsRegistry();
 const DatabaseDeleteRelatedExtension = extensionsRegistry.get(
@@ -681,36 +680,22 @@ function DatabaseList({
             return (
               <div className="actions">
                 {canDelete && (
-                  <Tooltip
-                    id="delete-action-tooltip"
-                    title={t('Delete')}
+                  <ActionButton
+                    label={t('Delete')}
+                    tooltip={t('Delete')}
                     placement="bottom"
-                  >
-                    <IconButton
-                      onClick={() => setSlCurrentlyDeleting(original)}
-                      onKeyDown={handleKeyboardActivation(() =>
-                        setSlCurrentlyDeleting(original),
-                      )}
-                      icon={<Icons.DeleteOutlined iconSize="l" />}
-                    />
-                  </Tooltip>
+                    icon={<Icons.DeleteOutlined iconSize="l" />}
+                    onClick={() => setSlCurrentlyDeleting(original)}
+                  />
                 )}
                 {canEdit && (
-                  <Tooltip
-                    id="edit-action-tooltip"
-                    title={t('Edit')}
+                  <ActionButton
+                    label={t('Edit')}
+                    tooltip={t('Edit')}
                     placement="bottom"
-                  >
-                    <IconButton
-                      onClick={() =>
-                        setSlCurrentlyEditing(original.uuid ?? null)
-                      }
-                      onKeyDown={handleKeyboardActivation(() =>
-                        setSlCurrentlyEditing(original.uuid ?? null),
-                      )}
-                      icon={<Icons.EditOutlined iconSize="l" />}
-                    />
-                  </Tooltip>
+                    icon={<Icons.EditOutlined iconSize="l" />}
+                    onClick={() => setSlCurrentlyEditing(original.uuid ?? null)}
+                  />
                 )}
               </div>
             );
@@ -727,62 +712,46 @@ function DatabaseList({
           return (
             <div className="actions">
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={t('Edit')}
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={t('Edit')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="database-edit"
-                    onClick={handleEdit}
-                    onKeyDown={handleKeyboardActivation(handleEdit)}
-                    icon={
-                      <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
-                    }
-                  />
-                </Tooltip>
+                  icon={
+                    <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
+                  }
+                  dataTest="database-edit"
+                  onClick={handleEdit}
+                />
               )}
               {canExport && (
-                <Tooltip
-                  id="export-action-tooltip"
-                  title={t('Export')}
+                <ActionButton
+                  label={t('Export')}
+                  tooltip={t('Export')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="database-export"
-                    onClick={handleExport}
-                    onKeyDown={handleKeyboardActivation(handleExport)}
-                    icon={<Icons.UploadOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.UploadOutlined iconSize="l" />}
+                  dataTest="database-export"
+                  onClick={handleExport}
+                />
               )}
               {canEdit && (
-                <Tooltip
-                  id="sync-action-tooltip"
-                  title={t('Sync Permissions')}
+                <ActionButton
+                  label={t('Sync Permissions')}
+                  tooltip={t('Sync Permissions')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="database-sync-perm"
-                    onClick={handleSync}
-                    onKeyDown={handleKeyboardActivation(handleSync)}
-                    icon={<Icons.SyncOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.SyncOutlined iconSize="l" />}
+                  dataTest="database-sync-perm"
+                  onClick={handleSync}
+                />
               )}
               {canDelete && (
-                <Tooltip
-                  id="delete-action-tooltip"
-                  title={t('Delete %s', databaseLabelLower())}
+                <ActionButton
+                  label={t('Delete %s', databaseLabelLower())}
+                  tooltip={t('Delete %s', databaseLabelLower())}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="database-delete"
-                    onClick={handleDelete}
-                    onKeyDown={handleKeyboardActivation(handleDelete)}
-                    icon={<Icons.DeleteOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.DeleteOutlined iconSize="l" />}
+                  dataTest="database-delete"
+                  onClick={handleDelete}
+                />
               )}
             </div>
           );

--- a/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
@@ -457,9 +457,7 @@ test('clicking duplicate opens modal and submits duplicate request', async () =>
   expect(row).toBeInTheDocument();
 
   const duplicateIcon = await within(row!).findByTestId('copy');
-  const duplicateButton = duplicateIcon.closest(
-    '[role="button"]',
-  ) as HTMLElement | null;
+  const duplicateButton = duplicateIcon.closest('button') as HTMLElement | null;
   expect(duplicateButton).toBeTruthy();
 
   await userEvent.click(duplicateButton!);

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -1635,9 +1635,7 @@ test('type filter persists after duplicating a dataset', async () => {
   expect(row).toBeInTheDocument();
 
   const duplicateIcon = await within(row!).findByTestId('copy');
-  const duplicateButton = duplicateIcon.closest(
-    '[role="button"]',
-  ) as HTMLElement | null;
+  const duplicateButton = duplicateIcon.closest('button') as HTMLElement | null;
   expect(duplicateButton).toBeTruthy();
 
   await userEvent.click(duplicateButton!);
@@ -1781,8 +1779,13 @@ test('bulk export error shows toast and clears loading state', async () => {
     );
   });
 
-  // Click bulk export
-  const exportButton = await screen.findByRole('button', { name: /export/i });
+  // Click bulk export. Disambiguate from the row-level export action (now
+  // sharing the same accessible name since it carries a real aria-label) and
+  // from the bulk-delete action (same data-test, different action key).
+  const exportButton = (
+    await screen.findByTestId('bulk-select-controls')
+  ).querySelector('[data-test-action-key="export"]') as HTMLElement;
+  expect(exportButton).toBeTruthy();
   await userEvent.click(exportButton);
 
   // Wait for error toast

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -1022,7 +1022,7 @@ test('edit action is enabled for dataset editor', async () => {
 
   const row = screen.getByText(dataset.table_name).closest('tr');
   const editIcon = within(row!).getByTestId('edit');
-  const editButton = editIcon.closest('[role="button"]');
+  const editButton = editIcon.closest('button');
 
   // Should be enabled (not disabled)
   expect(editButton).toHaveAttribute('aria-disabled', 'false');
@@ -1045,7 +1045,7 @@ test('edit action is disabled for non-editor', async () => {
 
   const row = screen.getByText(dataset.table_name).closest('tr');
   const editIcon = within(row!).getByTestId('edit');
-  const editButton = editIcon.closest('[role="button"]');
+  const editButton = editIcon.closest('button');
 
   // Should be disabled
   expect(editButton).toHaveAttribute('aria-disabled', 'true');
@@ -1072,10 +1072,10 @@ test('all action buttons are clickable and enabled for admin user', async () => 
   const editIcon = within(row!).getByTestId('edit');
   const duplicateIcon = within(row!).getByTestId('copy');
 
-  const deleteButton = deleteIcon.closest('[role="button"]');
-  const exportButton = exportIcon.closest('[role="button"]');
-  const editButton = editIcon.closest('[role="button"]');
-  const duplicateButton = duplicateIcon.closest('[role="button"]');
+  const deleteButton = deleteIcon.closest('button');
+  const exportButton = exportIcon.closest('button');
+  const editButton = editIcon.closest('button');
+  const duplicateButton = duplicateIcon.closest('button');
 
   // None should be disabled (export/duplicate never set aria-disabled at all)
   expect(deleteButton).not.toHaveAttribute('aria-disabled', 'true');

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -22,7 +22,6 @@ import {
   SupersetClient,
   isFeatureEnabled,
   FeatureFlag,
-  handleKeyboardActivation,
 } from '@superset-ui/core';
 import { styled, useTheme, css } from '@apache-superset/core/theme';
 import {
@@ -47,6 +46,7 @@ import { SubjectPile } from 'src/features/subjects/SubjectPile';
 import { ColumnObject } from 'src/features/datasets/types';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import {
+  ActionButton,
   Button,
   ConfirmStatusChange,
   CertifiedBadge,
@@ -107,7 +107,6 @@ import type {
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 import type User from 'src/types/User';
-import IconButton from 'src/dashboard/components/IconButton';
 
 const SEMANTIC_LAYERS_FLAG = 'SEMANTIC_LAYERS' as FeatureFlag;
 type DatasetExtra = {
@@ -842,9 +841,9 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
             return (
               <Actions className="actions">
                 {canDelete && (
-                  <Tooltip
-                    id="delete-action-tooltip"
-                    title={
+                  <ActionButton
+                    label={t('Delete')}
+                    tooltip={
                       allowEdit
                         ? t('Delete')
                         : t(
@@ -852,22 +851,16 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                           )
                     }
                     placement="bottom"
-                  >
-                    <IconButton
-                      data-test="dataset-row-delete"
-                      disabled={!allowEdit}
-                      onClick={() => handleSemanticViewDelete(original)}
-                      onKeyDown={handleKeyboardActivation(() =>
-                        handleSemanticViewDelete(original),
-                      )}
-                      icon={<Icons.DeleteOutlined iconSize="l" />}
-                    />
-                  </Tooltip>
+                    icon={<Icons.DeleteOutlined iconSize="l" />}
+                    dataTest="dataset-row-delete"
+                    disabled={!allowEdit}
+                    onClick={() => handleSemanticViewDelete(original)}
+                  />
                 )}
                 {canEdit && (
-                  <Tooltip
-                    id="edit-action-tooltip"
-                    title={
+                  <ActionButton
+                    label={t('Edit')}
+                    tooltip={
                       allowEdit
                         ? t('Edit')
                         : t(
@@ -875,17 +868,11 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                           )
                     }
                     placement="bottom"
-                  >
-                    <IconButton
-                      data-test="dataset-row-edit"
-                      disabled={!allowEdit}
-                      onClick={() => setSvCurrentlyEditing(original)}
-                      onKeyDown={handleKeyboardActivation(() =>
-                        setSvCurrentlyEditing(original),
-                      )}
-                      icon={<Icons.EditOutlined iconSize="l" />}
-                    />
-                  </Tooltip>
+                    icon={<Icons.EditOutlined iconSize="l" />}
+                    dataTest="dataset-row-edit"
+                    disabled={!allowEdit}
+                    onClick={() => setSvCurrentlyEditing(original)}
+                  />
                 )}
               </Actions>
             );
@@ -906,9 +893,9 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           return (
             <Actions className="actions">
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={
                     allowEdit
                       ? t('Edit')
                       : t(
@@ -916,52 +903,36 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                         )
                   }
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dataset-row-edit"
-                    disabled={!allowEdit}
-                    onClick={handleEdit}
-                    onKeyDown={
-                      allowEdit
-                        ? handleKeyboardActivation(handleEdit)
-                        : undefined
-                    }
-                    icon={<Icons.EditOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.EditOutlined iconSize="l" />}
+                  dataTest="dataset-row-edit"
+                  disabled={!allowEdit}
+                  onClick={handleEdit}
+                />
               )}
               {canExport && (
-                <Tooltip
-                  id="export-action-tooltip"
-                  title={t('Export')}
+                <ActionButton
+                  label={t('Export')}
+                  tooltip={t('Export')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dataset-row-export"
-                    onClick={handleExport}
-                    onKeyDown={handleKeyboardActivation(handleExport)}
-                    icon={<Icons.UploadOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.UploadOutlined iconSize="l" />}
+                  dataTest="dataset-row-export"
+                  onClick={handleExport}
+                />
               )}
               {canDuplicate && original.kind === 'virtual' && (
-                <Tooltip
-                  id="duplicate-action-tooltip"
-                  title={t('Duplicate')}
+                <ActionButton
+                  label={t('Duplicate')}
+                  tooltip={t('Duplicate')}
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dataset-row-duplicate"
-                    onClick={handleDuplicate}
-                    onKeyDown={handleKeyboardActivation(handleDuplicate)}
-                    icon={<Icons.CopyOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.CopyOutlined iconSize="l" />}
+                  dataTest="dataset-row-duplicate"
+                  onClick={handleDuplicate}
+                />
               )}
               {canDelete && (
-                <Tooltip
-                  id="delete-action-tooltip"
-                  title={
+                <ActionButton
+                  label={t('Delete')}
+                  tooltip={
                     allowEdit
                       ? t('Delete')
                       : t(
@@ -969,15 +940,11 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                         )
                   }
                   placement="bottom"
-                >
-                  <IconButton
-                    data-test="dataset-row-delete"
-                    disabled={!allowEdit}
-                    onClick={handleDelete}
-                    onKeyDown={handleKeyboardActivation(handleDelete)}
-                    icon={<Icons.DeleteOutlined iconSize="l" />}
-                  />
-                </Tooltip>
+                  icon={<Icons.DeleteOutlined iconSize="l" />}
+                  dataTest="dataset-row-delete"
+                  disabled={!allowEdit}
+                  onClick={handleDelete}
+                />
               )}
             </Actions>
           );

--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -362,18 +362,22 @@ function QueryList({ addDangerToast }: QueryListProps) {
         accessor: QueryObjectColumns.Sql,
         Header: t('SQL'),
         Cell: ({ row: { original, id } }: any) => (
-          <div
-            tabIndex={0}
-            role="button"
+          <button
+            type="button"
             data-test={`open-sql-preview-${id}`}
             onClick={() => setQueryCurrentlyPreviewing(original)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                setQueryCurrentlyPreviewing(original);
-              }
-            }}
-            style={{ cursor: 'pointer' }}
+            css={css`
+              appearance: none;
+              border: none;
+              background: none;
+              padding: 0;
+              margin: 0;
+              font: inherit;
+              display: block;
+              width: 100%;
+              text-align: left;
+              cursor: pointer;
+            `}
           >
             <StyledCodeSyntaxHighlighter
               language="sql"
@@ -384,7 +388,7 @@ function QueryList({ addDangerToast }: QueryListProps) {
             >
               {shortenSQL(original.sql, SQL_PREVIEW_MAX_LINES)}
             </StyledCodeSyntaxHighlighter>
-          </div>
+          </button>
         ),
         size: 'xxl',
         id: QueryObjectColumns.Sql,

--- a/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
@@ -17,9 +17,12 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { SupersetClient, handleKeyboardActivation } from '@superset-ui/core';
+import { SupersetClient } from '@superset-ui/core';
 import { useCallback, useMemo, useState } from 'react';
-import { ConfirmStatusChange, Tooltip } from '@superset-ui/core/components';
+import {
+  ActionButton,
+  ConfirmStatusChange,
+} from '@superset-ui/core/components';
 import {
   ModifiedInfo,
   ListView,
@@ -199,21 +202,15 @@ function RowLevelSecurityList(props: RLSProps) {
           return (
             <div className="actions">
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={t('Edit')}
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={t('Edit')}
                   placement="bottom"
-                >
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="action-button"
-                    onClick={handleEdit}
-                    onKeyDown={handleKeyboardActivation(handleEdit)}
-                  >
+                  icon={
                     <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
-                  </span>
-                </Tooltip>
+                  }
+                  onClick={handleEdit}
+                />
               )}
               {canWrite && (
                 <ConfirmStatusChange
@@ -227,24 +224,18 @@ function RowLevelSecurityList(props: RLSProps) {
                   onConfirm={handleDelete}
                 >
                   {confirmDelete => (
-                    <Tooltip
-                      id="delete-action-tooltip"
-                      title={t('Delete')}
+                    <ActionButton
+                      label={t('Delete')}
+                      tooltip={t('Delete')}
                       placement="bottom"
-                    >
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        className="action-button"
-                        onClick={confirmDelete}
-                        onKeyDown={handleKeyboardActivation(confirmDelete)}
-                      >
+                      icon={
                         <Icons.DeleteOutlined
                           data-test="rls-list-trash-icon"
                           iconSize="l"
                         />
-                      </span>
-                    </Tooltip>
+                      }
+                      onClick={confirmDelete}
+                    />
                   )}
                 </ConfirmStatusChange>
               )}

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -18,11 +18,7 @@
  */
 import { useMemo, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import {
   Actions,
   createErrorHandler,
@@ -30,8 +26,8 @@ import {
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import {
+  ActionButton,
   ConfirmStatusChange,
-  Tooltip,
   FaveStar,
 } from '@superset-ui/core/components';
 import {
@@ -213,43 +209,31 @@ function TagList(props: TagListProps) {
                   onConfirm={() => handleTagsDelete([original])}
                 >
                   {confirmDelete => (
-                    <Tooltip
-                      id="delete-action-tooltip"
-                      title={t('Delete')}
+                    <ActionButton
+                      label={t('Delete')}
+                      tooltip={t('Delete')}
                       placement="bottom"
-                    >
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        className="action-button"
-                        onClick={confirmDelete}
-                        onKeyDown={handleKeyboardActivation(confirmDelete)}
-                      >
+                      icon={
                         <Icons.DeleteOutlined
                           data-test="dashboard-list-trash-icon"
                           iconSize="l"
                         />
-                      </span>
-                    </Tooltip>
+                      }
+                      onClick={confirmDelete}
+                    />
                   )}
                 </ConfirmStatusChange>
               )}
               {canEdit && (
-                <Tooltip
-                  id="edit-action-tooltip"
-                  title={t('Edit')}
+                <ActionButton
+                  label={t('Edit')}
+                  tooltip={t('Edit')}
                   placement="bottom"
-                >
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="action-button"
-                    onClick={handleEdit}
-                    onKeyDown={handleKeyboardActivation(handleEdit)}
-                  >
+                  icon={
                     <Icons.EditOutlined data-test="edit-alt" iconSize="l" />
-                  </span>
-                </Tooltip>
+                  }
+                  onClick={handleEdit}
+                />
               )}
             </Actions>
           );

--- a/superset-frontend/src/pages/TaskList/TaskList.test.tsx
+++ b/superset-frontend/src/pages/TaskList/TaskList.test.tsx
@@ -242,9 +242,7 @@ test('shows cancel button and modal for cancellable tasks', async () => {
   expect(stopIcons.length).toBeGreaterThan(0);
 
   // Click a cancel button to show confirmation modal
-  const cancelButton = stopIcons.find(
-    icon => icon.closest('[role="button"]') !== null,
-  );
+  const cancelButton = stopIcons.find(icon => icon.closest('button') !== null);
   expect(cancelButton).toBeDefined();
   fireEvent.click(cancelButton!);
 
@@ -300,7 +298,7 @@ test('does not show cancel button for completed shared tasks', async () => {
   // No action buttons with stop icons for completed tasks
   const stopIcons = screen.queryAllByRole('img', { name: 'stop' });
   const actionButtons = stopIcons.filter(
-    icon => icon.closest('[role="button"]') !== null,
+    icon => icon.closest('button') !== null,
   );
   expect(actionButtons).toHaveLength(0);
 

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -17,17 +17,18 @@
  * under the License.
  */
 
-import {
-  FeatureFlag,
-  isFeatureEnabled,
-  SupersetClient,
-  handleKeyboardActivation,
-} from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, SupersetClient } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { useMemo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Tooltip, Label, Modal, Checkbox } from '@superset-ui/core/components';
+import {
+  ActionButton,
+  Tooltip,
+  Label,
+  Modal,
+  Checkbox,
+} from '@superset-ui/core/components';
 import {
   CreatedInfo,
   ListView,
@@ -510,23 +511,13 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                 </Tooltip>
               )}
               {canCancelTask && (
-                <Tooltip
-                  id="cancel-action-tooltip"
-                  title={t('Cancel')}
+                <ActionButton
+                  label={t('Cancel')}
+                  tooltip={t('Cancel')}
                   placement="bottom"
-                >
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="action-button"
-                    onClick={() => openCancelModal(original)}
-                    onKeyDown={handleKeyboardActivation(() =>
-                      openCancelModal(original),
-                    )}
-                  >
-                    <Icons.StopOutlined iconSize="l" />
-                  </span>
-                </Tooltip>
+                  icon={<Icons.StopOutlined iconSize="l" />}
+                  onClick={() => openCancelModal(original)}
+                />
               )}
             </div>
           );

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -17,7 +17,11 @@
  * under the License.
  */
 
-import { FeatureFlag, isFeatureEnabled, SupersetClient } from '@superset-ui/core';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  SupersetClient,
+} from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { useMemo, useCallback, useState } from 'react';


### PR DESCRIPTION
### SUMMARY

Continues the incremental `jsx-a11y` rollout (follows #42006, #42009) by turning on `prefer-tag-over-role` as `error`. This rule flags elements using ARIA `role="button"`/`role="img"` where a native HTML tag would give the same semantics for free, along with built-in keyboard operability, focus handling, and no need for manual `role`/`tabIndex`/`onKeyDown` wiring.

**Applied across all 154 violations:**
- The large majority: converted custom `<span>`/`<div role="button">` widgets to real `<button type="button">` elements, with a small CSS reset (`appearance/border/background/padding/font`) so they render identically to before. Where the base component already had a working `onKeyDown` handler for Enter/Space, it's now redundant and removed (native buttons fire `click` on both natively).
- `ActionButton` (a shared, widely-reused component) was converted at its root, fixing dozens of call sites in one shot.
- Icons.X components (`role="button"`/`role="img"`) that already had a matching `onClick` are auto-computed to `role="button"` by `BaseIconComponent` — the explicit prop was dead weight and removed.
- A handful of genuinely custom widgets where no native tag fits (`ButtonGroup`'s `role="group"`, `CompactSelectPanel`'s `listbox`, virtualized-table headers, popover-managed dialogs, hover-only tooltip triggers) keep their ARIA role with an inline suppression comment explaining why.
- Two `href="#"` anchor-as-button anti-patterns (deckgl `Legend`, table `Pagination`) became real `<button>`s, removing the need for `preventDefault()` hacks against anchor navigation entirely.
- A couple of nested `role="button"` cases (inside an already-interactive `<a>`/`ModalTrigger` wrapper) were simply redundant and dropped.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual change; the CSS resets keep every converted control's appearance identical.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npx oxlint -c oxlint.json` — 0 errors with the rule set to `error`.
- `npx tsc --noEmit -p tsconfig.json` — 0 errors (after a full `npm run plugins:build -- "*"` rebuild).
- Ran the ~50 co-located Jest suites for every swept component (list pages, cards, dashboard grid components, explore controls, chart drill-by/drill-detail, SQL Lab, deckgl/table/pivot-table plugins) — all pass. A couple of tests that asserted implementation details of the old `role="button"` span/anchor markup (breadcrumb DOM-reuse quirk, `href="#"` `preventDefault()` regression tests) were updated to assert the underlying behavior instead.
- `pre-commit run` (prettier, oxlint, custom-rules, stylelint, type-checking) all pass on the full changed-file set.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)