### PR TITLE
fix(migration): use non-deprecated sqlalchemy.orm.declarative_base

### DIFF
--- a/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
+++ b/superset/migrations/versions/2026-06-30_00-00_d24e6b0a9c7f_strip_metricsqlexpressions_from_ag_grid_params.py
@@ -33,7 +33,7 @@ Create Date: 2026-06-30 00:00:00.000000
 
 from alembic import op
 from sqlalchemy import Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from superset import db
 from superset.utils import json


### PR DESCRIPTION
### SUMMARY

`#41591`'s migration imported `declarative_base` from the deprecated `sqlalchemy.ext.declarative` path. `pytest.ini` promotes that exact deprecation (`declarative_base() is now available as sqlalchemy.orm.declarative_base()`) to an **error**, so the full `--cache-clear` unit-test run dies at collection on the current Python matrix — blocking CI on every PR. This mirrors the sweep already done in `#41981`, which this migration (branched earlier) missed.

```python
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI-only fix.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/migrations/test_strip_metricsqlexpressions_from_ag_grid_params.py` — collects and passes (previously errored at collection under the `declarative_base` warning filter).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: none
- [ ] Changes UI
- [ ] Includes DB Migration — edits an existing migration's import only; no schema/logic change
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Backwards-compatible: identical runtime behavior; only the import source changes to the non-deprecated `sqlalchemy.orm.declarative_base`.
