### PR TITLE
fix(async-queries): add Celery task expiry to GAQ async query tasks

### DIFF
--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -293,13 +293,18 @@ class AsyncQueryManager:
         from superset import security_manager
 
         job_metadata = self.init_job(channel_id, user_id)
-        self._load_explore_json_into_cache_job.delay(
-            {**job_metadata, "guest_token": guest_user.guest_token}
-            if (guest_user := security_manager.get_current_guest_user_if_guest())
-            else job_metadata,
-            form_data,
-            response_type,
-            force,
+        self._load_explore_json_into_cache_job.apply_async(
+            args=[
+                {**job_metadata, "guest_token": guest_user.guest_token}
+                if (
+                    guest_user := security_manager.get_current_guest_user_if_guest()
+                )
+                else job_metadata,
+                form_data,
+                response_type,
+                force,
+            ],
+            expires=self._jwt_expiration_seconds,
         )
         return job_metadata
 
@@ -317,11 +322,16 @@ class AsyncQueryManager:
         # this way we can keep the cache key consistent between sync and async command
         # so that it can be looked up consistently
         job_metadata = self.init_job(channel_id, user_id)
-        self._load_chart_data_into_cache_job.delay(
-            {**job_metadata, "guest_token": guest_user.guest_token}
-            if (guest_user := security_manager.get_current_guest_user_if_guest())
-            else job_metadata,
-            form_data,
+        self._load_chart_data_into_cache_job.apply_async(
+            args=[
+                {**job_metadata, "guest_token": guest_user.guest_token}
+                if (
+                    guest_user := security_manager.get_current_guest_user_if_guest()
+                )
+                else job_metadata,
+                form_data,
+            ],
+            expires=self._jwt_expiration_seconds,
         )
         return job_metadata
 

--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -296,9 +296,7 @@ class AsyncQueryManager:
         self._load_explore_json_into_cache_job.apply_async(
             args=[
                 {**job_metadata, "guest_token": guest_user.guest_token}
-                if (
-                    guest_user := security_manager.get_current_guest_user_if_guest()
-                )
+                if (guest_user := security_manager.get_current_guest_user_if_guest())
                 else job_metadata,
                 form_data,
                 response_type,
@@ -325,9 +323,7 @@ class AsyncQueryManager:
         self._load_chart_data_into_cache_job.apply_async(
             args=[
                 {**job_metadata, "guest_token": guest_user.guest_token}
-                if (
-                    guest_user := security_manager.get_current_guest_user_if_guest()
-                )
+                if (guest_user := security_manager.get_current_guest_user_if_guest())
                 else job_metadata,
                 form_data,
             ],

--- a/tests/unit_tests/async_events/async_query_manager_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_tests.py
@@ -41,6 +41,7 @@ def async_query_manager():
     query_manager = AsyncQueryManager()
     query_manager._jwt_secret = JWT_TOKEN_SECRET
     query_manager._jwt_cookie_name = JWT_TOKEN_COOKIE_NAME
+    query_manager._jwt_expiration_seconds = 3600
     return query_manager
 
 
@@ -246,25 +247,28 @@ def test_submit_chart_data_job_as_guest_user(
         form_data={},
     )
 
-    job_mock.delay.assert_called_once_with(
-        {
-            "channel_id": "test_channel_id",
-            "errors": [],
-            "guest_token": {
-                "user": {},
-                "resources": [{"type": "dashboard", "id": "some-uuid"}],
-                "rls_rules": [{"clause": '"STATEID" = 3'}],
-                "iat": 1700000000.0,
-                "exp": 1700000300.0,
-                "aud": "http://0.0.0.0:8080/",
-                "type": "guest",
+    job_mock.apply_async.assert_called_once_with(
+        args=[
+            {
+                "channel_id": "test_channel_id",
+                "errors": [],
+                "guest_token": {
+                    "user": {},
+                    "resources": [{"type": "dashboard", "id": "some-uuid"}],
+                    "rls_rules": [{"clause": '"STATEID" = 3'}],
+                    "iat": 1700000000.0,
+                    "exp": 1700000300.0,
+                    "aud": "http://0.0.0.0:8080/",
+                    "type": "guest",
+                },
+                "job_id": ANY,
+                "result_url": None,
+                "status": "pending",
+                "user_id": None,
             },
-            "job_id": ANY,
-            "result_url": None,
-            "status": "pending",
-            "user_id": None,
-        },
-        {},
+            {},
+        ],
+        expires=3600,
     )
 
     assert "guest_token" not in job_meta
@@ -349,27 +353,30 @@ def test_submit_explore_json_job_as_guest_user(
         response_type="json",
     )
 
-    job_mock.delay.assert_called_once_with(
-        {
-            "channel_id": "test_channel_id",
-            "errors": [],
-            "guest_token": {
-                "user": {},
-                "resources": [{"type": "dashboard", "id": "some-uuid"}],
-                "rls_rules": [{"clause": '"STATEID" = 3'}],
-                "iat": 1700000000.0,
-                "exp": 1700000300.0,
-                "aud": "http://0.0.0.0:8080/",
-                "type": "guest",
+    job_mock.apply_async.assert_called_once_with(
+        args=[
+            {
+                "channel_id": "test_channel_id",
+                "errors": [],
+                "guest_token": {
+                    "user": {},
+                    "resources": [{"type": "dashboard", "id": "some-uuid"}],
+                    "rls_rules": [{"clause": '"STATEID" = 3'}],
+                    "iat": 1700000000.0,
+                    "exp": 1700000300.0,
+                    "aud": "http://0.0.0.0:8080/",
+                    "type": "guest",
+                },
+                "job_id": ANY,
+                "result_url": None,
+                "status": "pending",
+                "user_id": None,
             },
-            "job_id": ANY,
-            "result_url": None,
-            "status": "pending",
-            "user_id": None,
-        },
-        {},
-        "json",
-        False,
+            {},
+            "json",
+            False,
+        ],
+        expires=3600,
     )
 
     assert "guest_token" not in job_meta


### PR DESCRIPTION
### SUMMARY

When Celery workers are unavailable for extended periods (e.g. autoscaling, pod restarts), GAQ tasks (`load_chart_data_into_cache` and `load_explore_json_into_cache`) accumulate in the queue and get executed hours or days later — wasting compute on results nobody is waiting for and producing misleading queue-wait metrics.

This PR switches `.delay()` to `.apply_async(expires=...)` for both task dispatch sites, using the existing `GLOBAL_ASYNC_QUERIES_JWT_EXPIRATION_SECONDS` (default: 1 hour) as the expiry value. This is the right bound because once the JWT the client uses to poll for results has expired, the client can no longer retrieve them — so there is no point executing the task.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI changes.

### TESTING INSTRUCTIONS

1. Enable Global Async Queries (`GLOBAL_ASYNC_QUERIES_TRANSPORT = "polling"`)
2. Verify chart data and explore requests still dispatch and complete normally
3. Optionally: stop workers, enqueue tasks, wait past `GLOBAL_ASYNC_QUERIES_JWT_EXPIRATION_SECONDS`, restart workers — confirm expired tasks are discarded (visible in Celery/Flower logs)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API