### PR TITLE
fix: replace deprecated appbuilder.app with current_app in test_explore_redirect

### DIFF
--- a/tests/integration_tests/views/test_explore_redirect.py
+++ b/tests/integration_tests/views/test_explore_redirect.py
@@ -37,6 +37,7 @@ from unittest import mock
 from urllib.parse import quote
 
 import pytest
+from flask import current_app
 
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
@@ -62,9 +63,7 @@ class TestExploreRedirect(SupersetTestCase):
         wins shapes which view's body runs and which `request.endpoint`
         value the helper's loop guard compares against.
         """
-        from superset.extensions import appbuilder
-
-        adapter = appbuilder.app.url_map.bind("")
+        adapter = current_app.url_map.bind("")
         endpoint, _ = adapter.match("/explore/", method="GET")
         assert endpoint == "ExploreView.root"
 


### PR DESCRIPTION
## Summary

Flask-AppBuilder's `AppBuilder.app` property is deprecated (`appbuilder.app is deprecated and will be removed in a future version. Use current_app instead`), and every call site was migrated to `current_app` in #40876 — except one that slipped through: `tests/integration_tests/views/test_explore_redirect.py`'s `test_explore_root_owns_bare_path`, which still did:

```python
from superset.extensions import appbuilder
adapter = appbuilder.app.url_map.bind("")
```

This fires the deprecation warning (`superset.extensions.appbuilder`'s `app` property, `flask_appbuilder/base.py`) every time the test runs, and shows up repeatedly as log noise (Datadog `deprecat*` search) since flask-appbuilder logs at `WARNING` regardless of caller.

## Change

Swapped the deprecated property access for `current_app` (imported from `flask`), mirroring the exact substitution pattern #40876 used elsewhere (e.g. `superset/initialization/__init__.py`):

```python
from flask import current_app
...
adapter = current_app.url_map.bind("")
```

## No behavior change

`AppBuilder.app`'s implementation is just:
```python
@property
def app(self) -> Flask:
    log.warning(...)
    return current_app
```
So `current_app` is the identical object the old property returned, minus the warning. `current_app.url_map.bind("")` produces the same `MapAdapter` bound to the same Flask app.

Confirmed via `git grep -n 'appbuilder\.app\b'` that no other real (non-comment) usages remain in the repo.

## Test plan

- `pytest tests/integration_tests/views/test_explore_redirect.py` — all 16 tests pass, and the `appbuilder.app is deprecated` warning no longer appears in output.
- `ruff check` / `ruff format --check` clean; pre-commit clean.
