### PR TITLE
fix(alerts): remove double border on InputNumber fields in report modal

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -624,13 +624,13 @@ test('disables condition threshold if not null condition is selected', async () 
   await screen.findByText(/smaller than/i);
   const condition = screen.getByRole('combobox', { name: /condition/i });
   const spinButton = screen.getByRole('spinbutton');
-  expect(spinButton).toHaveValue(10);
+  expect(spinButton).toHaveValue('10');
   await comboboxSelect(
     condition,
     'not null',
     () => screen.getAllByText(/not null/i)[0],
   );
-  expect(spinButton).toHaveValue(null);
+  expect(spinButton).toHaveValue('');
   expect(spinButton).toBeDisabled();
 });
 

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -615,6 +615,9 @@ test('renders all Alert Condition fields', async () => {
   expect(sql).toBeInTheDocument();
   expect(condition).toBeInTheDocument();
   expect(threshold).toBeInTheDocument();
+  // Guard against a double border: passing type="number" leaks onto the inner
+  // input and matches the StyledInputContainer input[type='number'] border rule.
+  expect(threshold).not.toHaveAttribute('type', 'number');
 });
 test('disables condition threshold if not null condition is selected', async () => {
   render(<AlertReportModal {...generateMockedProps(false, true, false)} />, {
@@ -852,7 +855,11 @@ test('shows screenshot width when PDF is selected', async () => {
     () => screen.getAllByText(/Send as PDF/i)[0],
   );
   expect(screen.getByText(/screenshot width/i)).toBeInTheDocument();
-  expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  const screenshotWidth = screen.getByRole('spinbutton');
+  expect(screenshotWidth).toBeInTheDocument();
+  // Guard against a double border: passing type="number" leaks onto the inner
+  // input and matches the StyledInputContainer input[type='number'] border rule.
+  expect(screenshotWidth).not.toHaveAttribute('type', 'number');
 });
 
 // Schedule Section

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2267,7 +2267,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                             <div className="input-container">
                               <InputNumber
                                 disabled={conditionNotNull}
-                                type="number"
                                 name="threshold"
                                 value={
                                   currentAlert?.validator_config_json
@@ -2573,7 +2572,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                       </div>
                       <div className="input-container">
                         <InputNumber
-                          type="number"
                           name="custom_width"
                           value={currentAlert?.custom_width || undefined}
                           min={600}


### PR DESCRIPTION
### SUMMARY

The **Screenshot width** field (and the alert **Value**/threshold field) in the Alert/Report modal rendered a "box within a box": a bordered input nested inside the already-bordered `InputNumber` control, with native browser number spinners layered on top of antd's own step handles.

**Root cause:** both fields passed `type="number"` to antd's `InputNumber`. antd forwards unrecognized props to the inner `<input>`, so it became `<input type="number">`. That matched a rule in the modal's `StyledInputContainer` styled component:

```css
input[type='number'] {
  padding: ...;
  border: 1px solid ${theme.colorBorder};
  border-radius: ${theme.borderRadius}px;
}
```

which gave the inner `<input>` its own border/padding on top of the wrapping `.ant-input-number` border — hence the nested box. The `type` prop was redundant anyway: `InputNumber` already restricts input to numeric values.

The fix removes `type="number"` from both `InputNumber` instances so the component owns its single border. Other `type="number"` usages in the codebase are on antd's plain `Input` (a single bordered element) and are unaffected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Rendered with the project's antd version and the exact `StyledInputContainer` CSS:

- **Before:** 

https://github.com/user-attachments/assets/07d83311-b99f-471f-94ca-7276ce8b366a

- **After:** 

https://github.com/user-attachments/assets/26196cda-d77d-4c69-b189-0e756e10eb03



### TESTING INSTRUCTIONS

1. Go to **Settings → Alerts & Reports** and create a new report.
2. Under **Report Contents**, note the **Screenshot width** field.
3. Confirm it renders as a single input (no nested box) and shows only antd's up/down step handles on hover — no duplicated native browser spinners.
4. Repeat for a new alert's **Value** (threshold) field under Alert Condition.

Unit tests: `AlertReportModal.test.tsx` passes (68/68).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### FEATURE FLAGS
FEATURE_ALERT_REPORTS=true
FEATURE_ALERT_REPORT_TABS=true
FEATURE_ALERT_REPORTS_FILTER=true