### PR TITLE
fix(alerts): show typed text in email recipients selector

### DIFF
--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -111,8 +111,7 @@ const StyledNotificationMethod = styled.div`
       flex-direction: column;
       align-items: stretch;
 
-      .email-recipient-select,
-      .email-recipient-select > div {
+      .email-recipient-select {
         width: 100%;
       }
 

--- a/superset-frontend/src/features/alerts/components/NotificationMethodEmailRecipients.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethodEmailRecipients.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Unlike NotificationMethod.test.tsx, this file intentionally renders the
+// real AsyncSelect so it can catch regressions in the interaction between
+// the alerts CSS and the antd Select internals.
+import fetchMock from 'fetch-mock';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import { NotificationMethod } from './NotificationMethod';
+import { NotificationMethodOption, NotificationSetting } from '../types';
+
+const RELATED_USERS_ENDPOINT = 'glob:*/api/v1/report/related/created_by?*';
+
+const emailSetting: NotificationSetting = {
+  method: NotificationMethodOption.Email,
+  recipients: '',
+  options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+};
+
+const renderComponent = () =>
+  render(
+    <NotificationMethod
+      setting={emailSetting}
+      index={0}
+      onUpdate={jest.fn()}
+      onRemove={jest.fn()}
+      onInputChange={jest.fn()}
+      email_subject=""
+      defaultSubject=""
+      setErrorSubject={jest.fn()}
+    />,
+  );
+
+fetchMock.get(RELATED_USERS_ENDPOINT, {
+  result: [
+    {
+      text: 'Admin User',
+      value: 1,
+      extra: { email: 'admin@example.com', active: true },
+    },
+  ],
+  count: 1,
+});
+
+test('typed email stays visible in the recipients field and becomes an option', async () => {
+  renderComponent();
+
+  const input = screen.getByRole('combobox', { name: 'Email recipients' });
+  await userEvent.click(input);
+  // AsyncSelect debounces its search handler and cancels the pending call
+  // whenever it re-renders, so wait for the initial options fetch to settle
+  // (its option is visible) before typing to guarantee the search is
+  // processed.
+  await screen.findByRole('option', {
+    name: /Admin User <admin@example\.com>/,
+  });
+  await userEvent.type(input, 'joe@example.com');
+
+  expect(input).toHaveValue('joe@example.com');
+  await waitFor(() =>
+    expect(
+      screen.getByRole('option', { name: /joe@example\.com/ }),
+    ).toBeInTheDocument(),
+  );
+});
+
+test('alerts CSS does not override the width of antd Select internals', () => {
+  // The email recipient selector once used an `.email-recipient-select > div`
+  // rule written for the antd v5 DOM. In the antd v6 DOM that rule matched
+  // `.ant-select-content` instead, collapsing it (and the search input) to
+  // zero width, so typed recipient emails were invisible.
+  const { container } = renderComponent();
+
+  const select = container.querySelector('.email-recipient-select');
+  expect(select).toBeInTheDocument();
+
+  const internalDivs = Array.from(select!.querySelectorAll(':scope > div'));
+  expect(internalDivs.length).toBeGreaterThan(0);
+  internalDivs.forEach(div => {
+    expect(getComputedStyle(div).width).not.toBe('100%');
+  });
+});


### PR DESCRIPTION
### SUMMARY
In the Alerts & Reports modal, typing into the "Email recipients" select (and the CC/BCC fields) showed no visible text — the characters were accepted but invisible, so users couldn't see the emails they were entering.

Root cause: `StyledNotificationMethod` styles the recipient selects with an `.email-recipient-select > div { width: 100% }` rule that was written for the antd v5 DOM, where the select's direct child div was `.ant-select-selector` and forcing full width was correct. After the antd v5→v6 upgrade (#41636), the direct child div is `.ant-select-content`; forcing `width: 100%` on it collapses it to zero width, which shrinks the search input inside it to ~4px — the typed text renders inside an invisible sliver. Verified in a real browser by injecting the modal's CSS cascade rule-by-rule into an isolated Select render: only this rule collapses the input (89px → 4px).

The fix keeps the full-width rule on the select root only and drops the `> div` half. The surrounding `.email-recipient-container` is a stretch flex column, so the selects still fill the modal width.

Also adds `NotificationMethodEmailRecipients.test.tsx`, which renders the real `AsyncSelect` (the existing `NotificationMethod.test.tsx` mocks it, which is why it couldn't catch this):
- a CSS regression test asserting the alerts CSS doesn't override the width of antd Select internals — verified to fail with the old rule and pass with the fix
- behavioral coverage that a typed email stays visible and becomes a selectable option

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** 


https://github.com/user-attachments/assets/1e8180a9-f59e-4062-a884-310602790587



**After:**

https://github.com/user-attachments/assets/fad0200d-dcde-4370-a751-b5fbd664e22a



### TESTING INSTRUCTIONS
1. Go to Alerts & Reports → add (or edit) a report.
2. Expand the "Notification method" section with the Email method selected.
3. Start typing an email address into "Email recipients".
4. The typed text should be visible, and the typed address should appear as a selectable option; selecting it should render a tag. Same for the CC/BCC fields.

Unit tests: `npx jest src/features/alerts/components/NotificationMethodEmailRecipients.test.tsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### FEATURE FLAGS
FEATURE_ALERT_REPORTS=true
FEATURE_ALERT_REPORT_TABS=true
FEATURE_ALERT_REPORTS_FILTER=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)