### PR TITLE
chore(a11y): enable jsx-a11y/no-static-element-interactions as error

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -221,11 +221,7 @@
     "jsx-a11y/no-noninteractive-element-to-interactive-role": "error",
     "jsx-a11y/no-noninteractive-tabindex": "error",
     "jsx-a11y/no-redundant-roles": "error",
-    // TODO: Graduate to "error" — remaining violations are event-boundary
-    // wrappers (divs/spans whose handlers only stopPropagation) and test
-    // scaffolding where adding a role is semantically wrong. Needs a
-    // dedicated pass; see PR enabling the other jsx-a11y interactive rules.
-    "jsx-a11y/no-static-element-interactions": "off",
+    "jsx-a11y/no-static-element-interactions": "error",
     "jsx-a11y/role-has-required-aria-props": "error",
     "jsx-a11y/role-supports-aria-props": "error",
     "jsx-a11y/scope": "error",

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
@@ -80,6 +80,8 @@ test('stops propagation of navigation keys to parent elements', async () => {
   const handleParentKeyDown = jest.fn();
 
   render(
+    // Test-only harness div asserting keydown doesn't bubble past the modal.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div onKeyDown={handleParentKeyDown}>
       <ModalTrigger
         triggerNode={<span>Trigger</span>}

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
@@ -156,6 +156,9 @@ export const ModalTrigger = forwardRef(
           draggableConfig={draggableConfig}
           destroyOnHidden={destroyOnHidden}
         >
+          {/* Pure event-boundary wrapper: only stops menu-navigation keys
+              from bubbling out of the modal, not itself interactive. */}
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
           <div
             style={{ display: 'contents' }}
             onKeyDown={e => {

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -322,6 +322,8 @@ test('does not leak tab-editing keystrokes from the rename input to the surround
   const onContainerKeyDown = jest.fn();
   const store = mockStore(initialState);
   render(
+    // Test-only harness div asserting keydown doesn't leak past the tab header.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div onKeyDown={onContainerKeyDown}>
       <SqlEditorTabHeader queryEditor={defaultQueryEditor} />
     </div>,

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -184,6 +184,9 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
         <ColumnElement
           column={data.columnData}
           actions={
+            // Pure event-boundary wrapper: only stops the click/keydown from
+            // reaching the row's select handler, not itself interactive.
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <span
               className="col-copy-action"
               onClick={e => e.stopPropagation()}
@@ -205,6 +208,11 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
   }
 
   return (
+    // react-arborist's row wrapper (an ancestor of this element) already
+    // supplies role="treeitem" and roving tabIndex/keyboard nav; this div
+    // just forwards clicks/keys to node.select()/toggle(), so adding its
+    // own role would create a nested-interactive-role anti-pattern.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className="tree-node"
       style={style}
@@ -245,6 +253,9 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
         {highlightText(data.name, searchTerm)}
       </Typography.Text>
       {identifier === 'schema' && (
+        // Pure event-boundary wrapper: only stops the click/keydown from
+        // reaching the row's select handler, not itself interactive.
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
           className="side-action-container"
           onClick={e => e.stopPropagation()}
@@ -313,6 +324,9 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
           const isPinned = pinnedTableKeys.has(tableKey);
           const selectStar = selectStarMap[tableKey];
           return (
+            // Pure event-boundary wrapper: only stops the click/keydown from
+            // reaching the row's select handler, not itself interactive.
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div
               className="side-action-container"
               onClick={e => e.stopPropagation()}


### PR DESCRIPTION
### SUMMARY

Continues the incremental `jsx-a11y` rollout (follows #42006, #42009, #42078) by turning on `no-static-element-interactions` as `error`. This rule flags static elements (`<div>`/`<span>`, no interactive role) that have an event handler — the theory being that if it's clickable, it should be operable/discoverable via a role.

This rule's scope turned out much smaller than expected (7 violations, vs. 154 for `prefer-tag-over-role`): most of the codebase's bare clickable `<div>`s already got `role="button"` in earlier passes, which exempts them from this rule entirely. What's left are genuinely non-interactive elements that only happen to carry an event handler:

- **Pure event-boundary wrappers** (5 of 7): `<div>`/`<span>` whose only handler is `e.stopPropagation()`, used to stop a click/keydown from bubbling up to a parent's real handler (`ModalTrigger`'s modal-body wrapper blocking menu-nav keys, and three action-button containers in SQL Lab's `TreeNodeRenderer` blocking clicks from reaching the tree row's select/toggle handler). Adding a role here would be misleading — these elements don't do anything themselves.
- **`TreeNodeRenderer`'s row div** (1 of 7): forwards clicks/keys to `node.select()`/`node.toggle()`, but it renders *inside* a `react-arborist` row that already supplies `role="treeitem"` and roving `tabIndex` — giving this inner div its own role would be a nested-interactive-role anti-pattern.
- **Test scaffolding** (2 of 7): harness `<div onKeyDown={...}>` wrappers in `ModalTrigger.test.tsx` and `SqlEditorTabHeader.test.tsx` that exist purely to assert keydown doesn't leak past the component under test.

All 7 are suppressed with an inline `eslint-disable-next-line` and a one-line comment explaining why, rather than restructured — restructuring any of these would either be misleading (event-boundary wrappers aren't interactive) or actively wrong (nested roles inside `react-arborist`'s own ARIA tree semantics).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no behavior or visual change; every fix is a suppression comment.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npx oxlint -c oxlint.json` — 0 errors with the rule set to `error`.
- `npx tsc --noEmit -p tsconfig.json` — 0 errors (after a full `npm run plugins:build -- "*"` rebuild).
- Ran the 3 co-located Jest suites for the touched components (`ModalTrigger`, `SqlEditorTabHeader`, `TableExploreTree`) — 37 tests pass.
- `pre-commit run` (prettier, oxlint, custom-rules, stylelint, type-checking) all pass on the changed-file set.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)