### PR TITLE
perf(TimeTable): skip rendering TableView while the window is resizing

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, within } from '@superset-ui/core/spec';
+import { act, fireEvent, render, screen, within } from '@superset-ui/core/spec';
 import TimeTable from './TimeTable';
 
 const mockData = {
@@ -183,6 +183,55 @@ test('should handle column type sparkline correctly', () => {
   visibleTimeSeriesColumns.forEach(el => {
     expect(el).toBeInTheDocument();
   });
+});
+
+test('should hide the table while the window is resizing and reveal it again after the debounce delay', () => {
+  jest.useFakeTimers();
+
+  const { container } = render(<TimeTable {...defaultProps} />);
+  const timeTable = container.querySelector('[data-test="time-table"]');
+
+  expect(timeTable).not.toHaveStyle('display: none');
+
+  act(() => {
+    fireEvent(window, new Event('resize'));
+  });
+  expect(timeTable).toHaveStyle('display: none');
+
+  act(() => {
+    jest.advanceTimersByTime(499);
+  });
+  expect(timeTable).toHaveStyle('display: none');
+
+  act(() => {
+    jest.advanceTimersByTime(1);
+  });
+  expect(timeTable).not.toHaveStyle('display: none');
+
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test('should clear the resize listener and pending timer on unmount', () => {
+  jest.useFakeTimers();
+  const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+  const { unmount } = render(<TimeTable {...defaultProps} />);
+
+  act(() => {
+    fireEvent(window, new Event('resize'));
+  });
+
+  unmount();
+
+  expect(removeEventListenerSpy).toHaveBeenCalledWith(
+    'resize',
+    expect.any(Function),
+  );
+
+  removeEventListenerSpy.mockRestore();
+  jest.clearAllTimers();
+  jest.useRealTimers();
 });
 
 test('should not render empty table due to missing column id property', () => {

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, ReactNode } from 'react';
+import { useMemo, useRef, useState, useEffect, ReactNode } from 'react';
 import { InfoTooltip, TableView } from '@superset-ui/core/components';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
@@ -24,8 +24,11 @@ import { sortNumberWithMixedTypes, processTimeTableData } from './utils';
 import { ValueCell, LeftCell, Sparkline } from './components';
 import type { TimeTableProps } from './types';
 
+const RESIZE_DEBOUNCE_MS = 300;
+
 // @z-index-above-dashboard-charts + 1 = 11
-const TimeTableStyles = styled.div<{ height?: number }>`
+const TimeTableStyles = styled.div<{ height?: number; hideTable?: boolean }>`
+  ${props => props.hideTable && 'display: none;'}
   height: ${props => props.height}px;
   overflow: auto;
 
@@ -43,6 +46,30 @@ const TimeTable = ({
   rows,
   url = '',
 }: TimeTableProps) => {
+  // Hide TableView as soon as the window starts resizing, and only show it
+  // again once resizing has stopped for RESIZE_DEBOUNCE_MS.
+  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const [isSizeStable, setIsSizeStable] = useState(true);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsSizeStable(false);
+      clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = setTimeout(() => {
+        setIsSizeStable(true);
+      }, RESIZE_DEBOUNCE_MS);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      clearTimeout(resizeTimerRef.current);
+    };
+  }, []);
+
   const memoizedColumns = useMemo(
     () => [
       {
@@ -115,21 +142,25 @@ const TimeTable = ({
     });
   }, [columnConfigs, data, rowType, rows, url]);
 
-  const defaultSort =
-    rowType === 'column' && columnConfigs.length
-      ? [
-          {
-            id: columnConfigs[0].key,
-            desc: true,
-          },
-        ]
-      : [];
+  const defaultSort = useMemo(
+    () =>
+      rowType === 'column' && columnConfigs.length
+        ? [
+            {
+              id: columnConfigs[0].key,
+              desc: true,
+            },
+          ]
+        : [],
+    [rowType, columnConfigs],
+  );
 
   return (
     <TimeTableStyles
       data-test="time-table"
       className={className}
       height={height}
+      hideTable={!isSizeStable}
     >
       <TableView
         className="table-no-hover"

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.tsx
@@ -24,7 +24,7 @@ import { sortNumberWithMixedTypes, processTimeTableData } from './utils';
 import { ValueCell, LeftCell, Sparkline } from './components';
 import type { TimeTableProps } from './types';
 
-const RESIZE_DEBOUNCE_MS = 300;
+const RESIZE_DEBOUNCE_MS = 500;
 
 // @z-index-above-dashboard-charts + 1 = 11
 const TimeTableStyles = styled.div<{ height?: number; hideTable?: boolean }>`


### PR DESCRIPTION
### SUMMARY
Following the Ant Design version upgrade, the Table component's advanced header/column features (sticky headers, column resize/measure logic, etc.) trigger heavy internal operations that get re-run on every re-render, and resizing the browser window (or a dashboard tile) forces TimeTable's underlying TableView/TableCollection (react-table + antd Table) to re-render on every resize tick — combining into visible jank while dragging, especially for tables with many rows/columns.

This adds a window resize listener in TimeTable.tsx: as soon as a resize event fires, TableView is unmounted from the render tree (isSizeStable flips to false); once no further resize events arrive for 500ms (RESIZE_DEBOUNCE_MS), it's rendered again. The listener is attached once on mount and cleaned up (listener + pending timer) on unmount.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/c029a17a-af9f-4cea-aff4-f4722f3ac0ec


After:

https://github.com/user-attachments/assets/99a632c1-1e28-4829-aa99-0fec97a5a2ac


### TESTING INSTRUCTIONS

- Add a Time-series Table chart with many metrics/columns to a dashboard.
- Drag the browser window edge to resize it continuously.
- Confirm the table content disappears while actively resizing and reappears ~500ms after resizing stops, with no console errors.
- TimeTable.test.tsx unit tests continue to pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
