### PR TITLE
feat(i18n): backfill Romanian (ro) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/ro/LC_MESSAGES/messages.po
+++ b/superset/translations/ro/LC_MESSAGES/messages.po
@@ -2488,7 +2488,7 @@ msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
-"Ești sigur că vrei să revoce această cheie API? Această acțiune nu poate "
+"Ești sigur că vrei să revoci această cheie API? Această acțiune nu poate "
 "fi anulată."
 
 msgid "Are you sure you want to save and apply changes?"
@@ -2570,13 +2570,13 @@ msgstr "Zoom Automat"
 # sr_Latn]
 #, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr "Reîmprospătare automată pausată (setată la %s secunde)"
+msgstr "Reîmprospătare automată pauzată (setată la %s secunde)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]
 #, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
-msgstr "Reîmprospătare automată pausată - fila inactivă (setată la %s secunde)"
+msgstr "Reîmprospătare automată pauzată - fila inactivă (setată la %s secunde)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
 # sr, sr_Latn]

--- a/superset/translations/ro/LC_MESSAGES/messages.po
+++ b/superset/translations/ro/LC_MESSAGES/messages.po
@@ -34,32 +34,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "A soft-deleted dataset (uuid %(uuid)s) already references this table. "
-"Restore it via POST /api/v1/dataset/%(uuid)s/restore before creating a new "
-"dataset over this table, or use a different table name."
+"Restore it via POST /api/v1/dataset/%(uuid)s/restore before creating a "
+"new dataset over this table, or use a different table name."
 msgstr ""
+"Un set de date șters soft (uuid %(uuid)s) face deja referință la acest "
+"tabel. Restaurați-l prin POST /api/v1/dataset/%(uuid)s/restore înainte de"
+" a crea un nou set de date peste acest tabel sau folosiți un alt nume de "
+"tabel."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "A soft-deleted dataset (uuid %(uuid)s) already references this table. "
-"Restore it via POST /api/v1/dataset/%(uuid)s/restore before uploading, or "
-"upload to a different table name."
+"Restore it via POST /api/v1/dataset/%(uuid)s/restore before uploading, or"
+" upload to a different table name."
 msgstr ""
+"Un set de date șters soft (uuid %(uuid)s) face deja referință la acest "
+"tabel. Restaurați-l prin POST /api/v1/dataset/%(uuid)s/restore înainte de"
+" încărcare sau încărcați cu un alt nume de tabel."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "Cannot delete a database whose only remaining datasets are soft-deleted. "
 "Restore them (POST /api/v1/dataset/<uuid>/restore) and delete them "
 "permanently once a purge capability ships, or remove the underlying rows "
 "out-of-band, before deleting the database."
 msgstr ""
+"Nu se poate șterge o bază de date ale cărei singure seturi de date rămase"
+" sunt șterse soft. Restaurați-le (POST /api/v1/dataset/<uuid>/restore) și"
+" ștergeți-le definitiv odată ce o capabilitate de ștergere permanentă "
+"devine disponibilă, sau eliminați rândurile de bază în afara benzii, "
+"înainte de a șterge baza de date."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"Dataset cannot be restored because another active dataset already references "
-"the same physical table (same database, catalog, schema, and table name). "
-"Delete the duplicate or rename the table before restoring."
+"Dataset cannot be restored because another active dataset already "
+"references the same physical table (same database, catalog, schema, and "
+"table name). Delete the duplicate or rename the table before restoring."
 msgstr ""
+"Setul de date nu poate fi restaurat deoarece un alt set de date activ "
+"face deja referință la același tabel fizic (aceeași bază de date, "
+"catalog, schemă și nume de tabel). Ștergeți duplicatul sau redenumiți "
+"tabelul înainte de restaurare."
 
 msgid ""
 "\n"
@@ -245,9 +267,11 @@ msgstr "\"%s\" este acum tema implicită a sistemului"
 msgid "% calculation"
 msgstr "% calcul"
 
-#, no-python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fa, ja, lv, mi, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy, no-python-format
 msgid "% of parent"
-msgstr ""
+msgstr "% din părinte"
 
 #, fuzzy, no-python-format
 msgid "% of total"
@@ -279,11 +303,15 @@ msgstr "%(object)s nu există în această bază de date."
 msgid "%(prefix)s %(title)s"
 msgstr "%(prefix)s %(title)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "%(prefix)sResults truncated to %(row_count)s rows due to memory "
 "constraints."
 msgstr ""
+"%(prefix)sRezultatele au fost trunchiate la %(row_count)s rânduri din "
+"cauza limitărilor de memorie."
 
 #, python-format
 msgid ""
@@ -305,8 +333,12 @@ msgid_plural ""
 "%(firstSuggestions)s or %(lastSuggestion)s instead of "
 "\"%(undefinedParameter)s\"?"
 msgstr[0] "%(lastSuggestion)s în loc de \"%(undefinedParameter)s\"?"
-msgstr[1] "%(firstSuggestions)s sau %(lastSuggestion)s în loc de \"%(undefinedParameter)s\"?"
-msgstr[2] "%(firstSuggestions)s sau %(lastSuggestion)s în loc de \"%(undefinedParameter)s\"?"
+msgstr[1] ""
+"%(firstSuggestions)s sau %(lastSuggestion)s în loc de "
+"\"%(undefinedParameter)s\"?"
+msgstr[2] ""
+"%(firstSuggestions)s sau %(lastSuggestion)s în loc de "
+"\"%(undefinedParameter)s\"?"
 
 #, python-format
 msgid ""
@@ -318,13 +350,17 @@ msgstr ""
 "Vă rugăm să verificați din nou interogarea.\n"
 "Excepție: %(ex)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s %s"
-msgstr ""
+msgstr "%s %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s ENCRYPTED EXTRA"
-msgstr ""
+msgstr "%s EXTRA CRIPTAT"
 
 #, python-format
 msgid "%s Error"
@@ -334,9 +370,11 @@ msgstr "Eroare %s"
 msgid "%s PASSWORD"
 msgstr "PAROLĂ %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s Physical"
-msgstr ""
+msgstr "%s Fizic"
 
 #, python-format
 msgid "%s SSH TUNNEL PASSWORD"
@@ -354,9 +392,11 @@ msgstr "PAROLĂ CHEIE PRIVATĂ SSH TUNNEL %s"
 msgid "%s Selected"
 msgstr "%s Selectat"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s Selected (%s)"
-msgstr ""
+msgstr "%s selectate (%s)"
 
 #, python-format
 msgid "%s Selected (Physical)"
@@ -366,57 +406,73 @@ msgstr "%s Selectat (Fizic)"
 msgid "%s Selected (Virtual)"
 msgstr "%s Selectat (Virtual)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s Semantic View"
-msgstr ""
+msgstr "%s Vizualizare semantică"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "%s URL"
-msgstr ""
+msgstr "%s URL"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s Virtual"
-msgstr ""
+msgstr "%s Virtual"
 
 #, python-format
 msgid "%s aggregates(s)"
 msgstr "%s agregat(e)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s column"
 msgid_plural "%s columns"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s coloană"
+msgstr[1] "%s coloane"
+msgstr[2] "%s de coloane"
 
 #, python-format
 msgid "%s column(s)"
 msgstr "%s coloană(e)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "acum %s zi"
+msgstr[1] "acum %s zile"
+msgstr[2] "acum %s de zile"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s hr ago"
 msgid_plural "%s hr ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "acum %s oră"
+msgstr[1] "acum %s ore"
+msgstr[2] "acum %s de ore"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s imported"
-msgstr ""
+msgstr "%s importate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s item"
 msgid_plural "%s items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s element"
+msgstr[1] "%s elemente"
+msgstr[2] "%s de elemente"
 
 #, python-format
 msgid "%s item(s)"
@@ -430,19 +486,23 @@ msgstr ""
 "%s elemente nu au putut fi etichetate deoarece nu aveți permisiuni de "
 "editare pentru toate obiectele selectate."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s metric"
 msgid_plural "%s metrics"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s metrică"
+msgstr[1] "%s metrici"
+msgstr[2] "%s de metrici"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s min ago"
 msgid_plural "%s min ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "acum %s min"
+msgstr[1] "acum %s min"
+msgstr[2] "acum %s min"
 
 #, python-format
 msgid "%s operator(s)"
@@ -459,23 +519,29 @@ msgstr[2] "%s de opțiuni"
 msgid "%s option(s)"
 msgstr "%s opțiuni"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s column"
 msgid_plural "%s out of %s columns"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s din %s coloană"
+msgstr[1] "%s din %s coloane"
+msgstr[2] "%s din %s de coloane"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s metric"
 msgid_plural "%s out of %s metrics"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s din %s metrică"
+msgstr[1] "%s din %s metrici"
+msgstr[2] "%s din %s de metrici"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s out of %s selected"
-msgstr ""
+msgstr "%s din %s selectate"
 
 #, python-format
 msgid "%s recipients"
@@ -488,12 +554,14 @@ msgstr[0] "%s înregistrare..."
 msgstr[1] "%s înregistrări..."
 msgstr[2] "%s de înregistrări..."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s record..."
 msgid_plural "%s records..."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s înregistrare..."
+msgstr[1] "%s înregistrări..."
+msgstr[2] "%s de înregistrări..."
 
 #, python-format
 msgid "%s row"
@@ -502,35 +570,45 @@ msgstr[0] "%s rând"
 msgstr[1] "%s rânduri"
 msgstr[2] "%s de rânduri"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s s ago"
 msgid_plural "%s s ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "acum %s s"
+msgstr[1] "acum %s s"
+msgstr[2] "acum %s s"
 
 #, python-format
 msgid "%s saved metric(s)"
 msgstr "%s indicator(i) salvat(i)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s second"
 msgid_plural "%s seconds"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s secundă"
+msgstr[1] "%s secunde"
+msgstr[2] "%s de secunde"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) added"
-msgstr ""
+msgstr "%s vizualizări semantice adăugate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add"
-msgstr ""
+msgstr "%s vizualizări semantice nu au putut fi adăugate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "%s semantic view(s) failed to add: %s"
-msgstr ""
+msgstr "%s vizualizări semantice nu au putut fi adăugate: %s"
 
 #, python-format
 msgid "%s tab selected"
@@ -606,13 +684,17 @@ msgstr ""
 "ștergeți cookie-urile sau schimbați browserul.\n"
 "\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "... and %d more"
-msgstr ""
+msgstr "... și încă %d"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "... and %s more records"
-msgstr ""
+msgstr "... și încă %s înregistrări"
 
 #, python-format
 msgid "... and %s others"
@@ -684,6 +766,7 @@ msgstr "10 secunde"
 msgid "10/90 percentiles"
 msgstr "percentile 10/90"
 
+#. do-not-translate
 msgid "10000"
 msgstr "10000"
 
@@ -861,19 +944,31 @@ msgstr ">= (Mai mare sau egal)"
 msgid "A Big Number"
 msgstr "Un Număr Mare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates a label configuration object"
-msgstr ""
+msgstr "O funcție JavaScript care generează un obiect de configurare a etichetei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
-msgstr ""
+msgstr "O funcție JavaScript care generează un obiect de configurare a pictogramei"
 
-#, python-brace-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
 "overriding other control options with higher precedence. (i.e. { title: {"
 " text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
 "https://echarts.apache.org/en/option.html. "
 msgstr ""
+"Un obiect JavaScript care respectă specificația de opțiuni ECharts, "
+"suprascriind alte opțiuni de control cu prioritate mai mare. (de ex. { "
+"title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). "
+"Detalii: https://echarts.apache.org/en/option.html. "
 
 msgid "A comma separated list of columns that should be parsed as dates"
 msgstr "O listă separată prin virgulă de coloane care ar trebui analizate ca date"
@@ -894,8 +989,10 @@ msgstr "Există deja o bază de date cu același nume."
 msgid "A date is required when using custom date shift"
 msgstr "O dată este necesară când utilizați deplasare de dată personalizată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "A description for your dashboard"
-msgstr ""
+msgstr "O descriere pentru tabloul de bord"
 
 #, python-brace-format
 msgid ""
@@ -928,11 +1025,17 @@ msgstr ""
 "O listă de nume de domenii care pot încorpora acest panou de control. "
 "Lăsând acest câmp gol va permite încorporarea de pe orice domeniu."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "A list of subjects who can alter the chart. Searchable by name."
-msgstr ""
+msgstr "O listă de subiecte care pot modifica graficul. Se poate căuta după nume."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "A list of subjects who can view the chart. Searchable by name."
-msgstr ""
+msgstr "O listă de subiecte care pot vizualiza graficul. Se poate căuta după nume."
 
 msgid "A list of tags that have been applied to this chart."
 msgstr "O listă de etichete care au fost aplicate acestui grafic."
@@ -953,10 +1056,14 @@ msgstr ""
 msgid "A metric to use for color"
 msgstr "Un indicator de utilizat pentru culoare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "A multiplier applied to the point radius. Use this to uniformly scale all"
 " points."
 msgstr ""
+"Un multiplicator aplicat razei punctului. Folosiți aceasta pentru a scala"
+" uniform toate punctele."
 
 msgid "A new chart and dashboard will be created."
 msgstr "Un grafic și un panou de control vor fi create."
@@ -1026,29 +1133,50 @@ msgstr ""
 "          Aceste valori intermediare pot fi bazate pe timp sau pe "
 "categorie."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 msgid "AND"
 msgstr "ȘI"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API Key Created"
-msgstr ""
+msgstr "Cheie API creată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API Keys"
-msgstr ""
+msgstr "Chei API"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API key created successfully"
-msgstr ""
+msgstr "Cheia API a fost creată cu succes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API key name is required"
-msgstr ""
+msgstr "Numele cheii API este obligatoriu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API key revoked successfully"
-msgstr ""
+msgstr "Cheia API a fost revocată cu succes"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr ""
+msgstr "Cheile API permit accesul programatic cu domeniu limitat la Superset."
 
 msgid "APPLY"
 msgstr "APLICĂ"
@@ -1062,23 +1190,35 @@ msgstr "AQE"
 msgid "AUG"
 msgstr "AUG"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Aborted"
-msgstr ""
+msgstr "Anulat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Aborting"
-msgstr ""
+msgstr "Anulare"
 
 msgid "About"
 msgstr "Despre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Access"
-msgstr ""
+msgstr "Acces"
 
 msgid "Access token"
 msgstr "Token de acces"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fr,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Account"
-msgstr ""
+msgstr "Cont"
 
 msgid "Action"
 msgstr "Acțiune"
@@ -1116,9 +1256,11 @@ msgstr "Formatare adaptivă"
 msgid "Add"
 msgstr "Adaugă"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Add %s view(s)"
-msgstr ""
+msgstr "Adaugă %s vizualizări"
 
 msgid "Add BCC Recipients"
 msgstr "Adaugă Destinatari BCC"
@@ -1154,8 +1296,11 @@ msgstr "Adaugă Rol"
 msgid "Add Rule"
 msgstr "Adaugă Regulă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Add Semantic View"
-msgstr ""
+msgstr "Adaugă vizualizare semantică"
 
 msgid "Add Tag"
 msgstr "Adaugă Etichetă"
@@ -1212,8 +1357,11 @@ msgstr "Adaugă detalii de certificare pentru acest panou de control"
 msgid "Add color for positive/negative change"
 msgstr "Adaugă culoare pentru schimbare pozitivă/negativă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Add colors to cell bars for +/- for all columns"
-msgstr ""
+msgstr "Adaugă culori barelor de celule pentru +/- pentru toate coloanele"
 
 msgid "Add cross-filter"
 msgstr "Adaugă filtrare încrucișată"
@@ -1232,8 +1380,11 @@ msgstr "Adaugă metodă de livrare"
 msgid "Add description of your tag"
 msgstr "Adaugă descrierea etichetei dvs."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add display control"
-msgstr ""
+msgstr "Adaugă control de afișare"
 
 msgid "Add divider"
 msgstr "Separator"
@@ -1266,8 +1417,11 @@ msgstr ""
 "                    din datele de bază sau să limitați valorile "
 "disponibile afișate în filtru."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, fr,
+# it, ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add folder"
-msgstr ""
+msgstr "Adaugă folder"
 
 msgid "Add item"
 msgstr "Adaugă element"
@@ -1284,14 +1438,23 @@ msgstr "Adaugă nou formatator de culoare"
 msgid "Add new formatter"
 msgstr "Adaugă nou formatator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Add numbered column"
-msgstr ""
+msgstr "Adaugă coloană numerotată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add or edit display controls"
-msgstr ""
+msgstr "Adaugă sau editează controale de afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add or edit filters and controls"
-msgstr ""
+msgstr "Adaugă sau editează filtre și controale"
 
 msgid "Add report"
 msgstr "Adaugă raport"
@@ -1320,8 +1483,11 @@ msgstr "Adaugă temă"
 msgid "Add to dashboard"
 msgstr "Adaugă la panoul de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Add to tabs"
-msgstr ""
+msgstr "Adaugă la file"
 
 msgid "Added"
 msgstr "Adăugat"
@@ -1537,8 +1703,11 @@ msgstr "Alerte & rapoarte"
 msgid "Align +/-"
 msgstr "Aliniază +/-"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Align +/- for all columns"
-msgstr ""
+msgstr "Aliniază +/- pentru toate coloanele"
 
 msgid "All"
 msgstr "Toate"
@@ -1556,8 +1725,11 @@ msgstr "Toate graficele"
 msgid "All charts/global scoping"
 msgstr "Toate graficele/domeniu de aplicare global"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "All dimensions"
-msgstr ""
+msgstr "Toate dimensiunile"
 
 msgid "All filters"
 msgstr "Toate filtrele"
@@ -1631,8 +1803,11 @@ msgstr "Permite explorarea acestei baze de date"
 msgid "Allow this database to be queried in SQL Lab"
 msgstr "Permite interogarea acestei baze de date în SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Allow users to select multiple values"
-msgstr ""
+msgstr "Permite utilizatorilor să selecteze mai multe valori"
 
 msgid "Allowed Domains (comma separated)"
 msgstr "Domenii Permise (separate prin virgulă)"
@@ -1700,8 +1875,11 @@ msgstr "A apărut o eroare la accesarea extensiei."
 msgid "An error occurred while accessing the value."
 msgstr "A apărut o eroare la accesarea valorii."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while adding semantic views"
-msgstr ""
+msgstr "A apărut o eroare la adăugarea vizualizărilor semantice"
 
 msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
@@ -1723,8 +1901,11 @@ msgstr "A apărut o eroare la crearea sursei de date"
 msgid "An error occurred while creating the extension."
 msgstr "A apărut o eroare la crearea extensiei."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while creating the semantic layer"
-msgstr ""
+msgstr "A apărut o eroare la crearea stratului semantic"
 
 msgid "An error occurred while creating the value."
 msgstr "A apărut o eroare la crearea valorii."
@@ -1742,25 +1923,33 @@ msgstr ""
 "A apărut o eroare la extinderea schemei tabelului. Vă rugăm să contactați"
 " administratorul."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s"
-msgstr ""
+msgstr "A apărut o eroare la preluarea %s"
 
 #, python-format
 msgid "An error occurred while fetching %s info: %s"
 msgstr "A apărut o eroare la preluarea informațiilor %s: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s related data"
-msgstr ""
+msgstr "A apărut o eroare la preluarea datelor asociate cu %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s values: %s"
-msgstr ""
+msgstr "A apărut o eroare la preluarea valorilor %s: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching %s: %s"
-msgstr ""
+msgstr "A apărut o eroare la preluarea %s: %s"
 
 #, python-format
 msgid "An error occurred while fetching %ss: %s"
@@ -1772,8 +1961,11 @@ msgstr "A apărut o eroare la preluarea șabloanelor CSS disponibile"
 msgid "An error occurred while fetching available themes"
 msgstr "A apărut o eroare la preluarea temelor disponibile"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching available views"
-msgstr ""
+msgstr "A apărut o eroare la preluarea vizualizărilor disponibile"
 
 #, python-format
 msgid "An error occurred while fetching chart editor values: %s"
@@ -1783,12 +1975,17 @@ msgstr "A apărut o eroare la preluarea valorilor editorilor graficului: %s"
 msgid "An error occurred while fetching chart viewer values: %s"
 msgstr "A apărut o eroare la preluarea valorilor vizualizatorilor graficului: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching connections"
-msgstr ""
+msgstr "A apărut o eroare la preluarea conexiunilor"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching created by values: %s"
-msgstr ""
+msgstr "A apărut o eroare la preluarea valorilor create by: %s"
 
 #, python-format
 msgid "An error occurred while fetching dashboard editor values: %s"
@@ -1796,7 +1993,9 @@ msgstr "A apărut o eroare la preluarea valorilor editorilor tabloului de bord: 
 
 #, python-format
 msgid "An error occurred while fetching dashboard viewer values: %s"
-msgstr "A apărut o eroare la preluarea valorilor vizualizatorilor tabloului de bord: %s"
+msgstr ""
+"A apărut o eroare la preluarea valorilor vizualizatorilor tabloului de "
+"bord: %s"
 
 msgid "An error occurred while fetching dashboards"
 msgstr "A apărut o eroare la preluarea panourilor de control"
@@ -1838,30 +2037,50 @@ msgstr "A apărut o eroare la preluarea numelor de funcții."
 msgid "An error occurred while fetching schema values: %s"
 msgstr "A apărut o eroare la preluarea valorilor schemei: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching semantic layer types"
-msgstr ""
+msgstr "A apărut o eroare la preluarea tipurilor de straturi semantice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching semantic layers"
-msgstr ""
+msgstr "A apărut o eroare la preluarea straturilor semantice"
 
 msgid "An error occurred while fetching tab state"
 msgstr "A apărut o eroare la preluarea stării filei"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "An error occurred while fetching table metadata for %s"
-msgstr ""
+msgstr "A apărut o eroare la preluarea metadatelor tabelului pentru %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the configuration schema"
-msgstr ""
+msgstr "A apărut o eroare la preluarea schemei de configurare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the runtime schema"
-msgstr ""
+msgstr "A apărut o eroare la preluarea schemei de execuție"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the semantic layer"
-msgstr ""
+msgstr "A apărut o eroare la preluarea stratului semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while fetching the semantic view structure"
-msgstr ""
+msgstr "A apărut o eroare la preluarea structurii vizualizării semantice"
 
 #, python-format
 msgid "An error occurred while fetching theme datasource values: %s"
@@ -1881,10 +2100,14 @@ msgstr "A apărut o eroare la formatarea SQL"
 msgid "An error occurred while importing %s: %s"
 msgstr "A apărut o eroare la importarea %s: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "An error occurred while loading SQL Lab. This may be caused by a "
 "corrupted query state."
 msgstr ""
+"A apărut o eroare la încărcarea SQL Lab. Aceasta poate fi cauzată de o "
+"stare coruptă a interogării."
 
 msgid "An error occurred while loading dashboard information."
 msgstr "A apărut o eroare la încărcarea informațiilor panoului de control."
@@ -1901,8 +2124,11 @@ msgstr "A apărut o eroare la analizarea cheii."
 msgid "An error occurred while pruning logs "
 msgstr "A apărut o eroare la curățarea jurnalelor "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while refreshing the configuration schema"
-msgstr ""
+msgstr "A apărut o eroare la reîmprospătarea schemei de configurare"
 
 msgid "An error occurred while removing query. Please contact your administrator."
 msgstr ""
@@ -1920,8 +2146,11 @@ msgstr ""
 msgid "An error occurred while rendering the visualization: %s"
 msgstr "A apărut o eroare la redarea vizualizării: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while saving the semantic view"
-msgstr ""
+msgstr "A apărut o eroare la salvarea vizualizării semantice"
 
 msgid "An error occurred while starring this chart"
 msgstr "A apărut o eroare la marcarea cu steluță a acestui grafic"
@@ -1942,8 +2171,11 @@ msgstr "A apărut o eroare la sincronizarea permisiunilor pentru %s: %s"
 msgid "An error occurred while updating the extension."
 msgstr "A apărut o eroare la actualizarea extensiei."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "An error occurred while updating the semantic layer"
-msgstr ""
+msgstr "A apărut o eroare la actualizarea stratului semantic"
 
 msgid "An error occurred while updating the value."
 msgstr "A apărut o eroare la actualizarea valorii."
@@ -2133,11 +2365,17 @@ msgstr ""
 "că interogarea sursă îndeplinește perioadele minime definite în fereastra"
 " glisantă."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Applies only when \"Cell bars\" formatting is selected: the background of"
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
+"Se aplică doar când este selectată formatarea „Bare de celule\": fundalul"
+" coloanelor histogramului este afișat dacă steagul „Afișați bare de "
+"celule\" este activat."
 
 msgid "Apply"
 msgstr "Aplică"
@@ -2243,10 +2481,15 @@ msgstr ""
 "Sigur doriți să eliminați tema implicită a sistemului? Aplicația va "
 "reveni la valoarea implicită din fișierul de configurare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
+"Ești sigur că vrei să revoce această cheie API? Această acțiune nu poate "
+"fi anulată."
 
 msgid "Are you sure you want to save and apply changes?"
 msgstr "Sigur doriți să salvați și să aplicați modificările?"
@@ -2308,8 +2551,11 @@ msgstr "Atribuție"
 msgid "August"
 msgstr "August"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Authorization Request URI"
-msgstr ""
+msgstr "URI-ul cererii de autorizare"
 
 msgid "Authorization needed"
 msgstr "Autorizație necesară"
@@ -2320,20 +2566,29 @@ msgstr "Auto"
 msgid "Auto Zoom"
 msgstr "Zoom Automat"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused (set to %s seconds)"
-msgstr ""
+msgstr "Reîmprospătare automată pausată (setată la %s secunde)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
-msgstr ""
+msgstr "Reîmprospătare automată pausată - fila inactivă (setată la %s secunde)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Auto refresh set to %s seconds"
-msgstr ""
+msgstr "Reîmprospătare automată setată la %s secunde"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Auto-detect"
-msgstr ""
+msgstr "Detectare automată"
 
 msgid "Autocomplete"
 msgstr "Completare automată"
@@ -2374,8 +2629,11 @@ msgstr "Medie"
 msgid "Average value"
 msgstr "Valoare medie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Awaiting filter selection"
-msgstr ""
+msgstr "Se așteaptă selectarea filtrului"
 
 msgid "Axis"
 msgstr "Axă"
@@ -2454,15 +2712,27 @@ msgstr "Exponent bază"
 msgid "Base height"
 msgstr "Înălțime bază"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr ""
+"Stilul hărții stratului de bază. Acceptă un URL de stil compatibil cu "
+"MapLibre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
+"Stilul hărții stratului de bază. Acceptă un URL de stil Mapbox "
+"(mapbox://styles/...)."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
-msgstr ""
+msgstr "Stilul hărții stratului de bază. Consultați documentația MapLibre: %s"
 
 msgid "Base slope"
 msgstr "Pantă bază"
@@ -2613,8 +2883,11 @@ msgstr "Grafic Cutie"
 msgid "Breakdowns"
 msgstr "Defalcare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Breakpoint Metric"
-msgstr ""
+msgstr "Metrică punct de întrerupere"
 
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
@@ -2691,6 +2964,11 @@ msgstr "Destinatari CC"
 msgid "COPY QUERY"
 msgstr "COPIAZĂ INTEROGAREA"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Copiați interogarea"
+
 msgid "CREATE TABLE AS"
 msgstr "CREEAZĂ TABEL CA"
 
@@ -2718,11 +2996,17 @@ msgstr "Șabloane CSS"
 msgid "CSS applied to the chart"
 msgstr "CSS aplicat la grafic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "CSS styles may be removed by server-side HTML sanitization. If styles are"
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
+"Stilurile CSS pot fi eliminate prin sanitizarea HTML pe partea de server."
+" Dacă stilurile nu se aplică, solicitați administratorului Superset să "
+"ajusteze configurația de sanitizare HTML."
 
 msgid "CSS template"
 msgstr "Șablon CSS"
@@ -2839,14 +3123,20 @@ msgstr "Poate selecta valori multiple"
 msgid "Cancel"
 msgstr "Anulează"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Cancel Task"
-msgstr ""
+msgstr "Anulare sarcină"
 
 msgid "Cancel query on window unload event"
 msgstr "Anulează interogarea la evenimentul de descărcare a ferestrei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Cancellation not available due to missing abort handler"
-msgstr ""
+msgstr "Anularea nu este disponibilă din cauza lipsei gestionarului de întrerupere"
 
 msgid "Cannot access the query"
 msgstr "Nu se poate accesa interogarea"
@@ -2880,15 +3170,21 @@ msgstr "Nu se poate încărca filtrul"
 msgid "Cannot modify system themes."
 msgstr "Nu se pot modifica temele sistemului."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Cannot nest folders in default folders"
-msgstr ""
+msgstr "Nu se pot cuibări foldere în folderele implicite"
 
 #, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
 msgstr "Nu se poate analiza șirul de timp [%(human_readable)s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Captcha"
-msgstr ""
+msgstr "Captcha"
 
 msgid "Cartodiagram"
 msgstr "Cartodiagramă"
@@ -3033,14 +3329,23 @@ msgstr "Schimbarea acestei surse de date este interzisă"
 msgid "Changing this report is forbidden"
 msgstr "Schimbarea acestui raport este interzisă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic layer is forbidden"
-msgstr ""
+msgstr "Modificarea acestui strat semantic este interzisă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this semantic view is forbidden"
-msgstr ""
+msgstr "Modificarea acestei vizualizări semantice este interzisă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Changing this task is forbidden"
-msgstr ""
+msgstr "Modificarea acestei sarcini este interzisă"
 
 msgid "Character to interpret as decimal point"
 msgstr "Caracter de interpretat ca punct zecimal"
@@ -3048,9 +3353,11 @@ msgstr "Caracter de interpretat ca punct zecimal"
 msgid "Chart"
 msgstr "Grafic"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Chart %(chart_id)s is not on dashboard %(dashboard_id)s"
-msgstr ""
+msgstr "Graficul %(chart_id)s nu se află pe tabloul de bord %(dashboard_id)s"
 
 #, python-format
 msgid "Chart %(id)s not found"
@@ -3106,14 +3413,25 @@ msgstr "Modificări grafic"
 msgid "Chart could not be created."
 msgstr "Graficul nu a putut fi creat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid "Chart could not be restored."
+msgstr "Graficul nu a putut fi restaurat."
+
 msgid "Chart could not be updated."
 msgstr "Graficul nu a putut fi actualizat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Chart customization to control deck.gl layer visibility"
-msgstr ""
+msgstr "Personalizarea graficului pentru controlul vizibilității stratului deck.gl"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Chart customization value is required"
-msgstr ""
+msgstr "Valoarea de personalizare a graficului este obligatorie"
 
 msgid "Chart does not exist"
 msgstr "Graficul nu există"
@@ -3165,8 +3483,11 @@ msgstr "Tip grafic"
 msgid "Chart type requires a dataset"
 msgstr "Tipul de grafic necesită un set de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Chart was saved but could not be added to the selected tab."
-msgstr ""
+msgstr "Graficul a fost salvat, dar nu a putut fi adăugat la fila selectată."
 
 msgid "Chart width"
 msgstr "Lățime grafic"
@@ -3211,9 +3532,11 @@ msgstr "Alegerea [Etichetă] trebuie să fie prezentă în [Grupare După]"
 msgid "Choice of [Point Radius] must be present in [Group By]"
 msgstr "Alegerea [Rază Punct] trebuie să fie prezentă în [Grupare După]"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Choose a %s"
-msgstr ""
+msgstr "Alegeți un(o) %s"
 
 msgid "Choose a chart for displaying on the map"
 msgstr "Alege un grafic pentru afișare pe hartă"
@@ -3264,10 +3587,15 @@ msgstr "Alege câte etichete X-Axis să afișezi"
 msgid "Choose index column"
 msgstr "Alege coloana de index"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
+"Alegeți straturile de ascuns din toate graficele deck.gl cu mai multe "
+"straturi din acest tablou de bord."
 
 msgid "Choose notification method and recipients."
 msgstr "Alege metoda de notificare și destinatarii."
@@ -3349,9 +3677,11 @@ msgstr "Clauză"
 msgid "Clear"
 msgstr "Șterge"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Clear %s filter"
-msgstr ""
+msgstr "Ștergeți filtrul %s"
 
 msgid "Clear Sort"
 msgstr "Șterge Sortare"
@@ -3365,11 +3695,17 @@ msgstr "Șterge toate datele"
 msgid "Clear all filters"
 msgstr "Șterge toate filtrele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Clear default dark theme"
-msgstr ""
+msgstr "Ștergeți tema întunecată implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Clear default light theme"
-msgstr ""
+msgstr "Ștergeți tema luminoasă implicită"
 
 msgid "Clear form"
 msgstr "Șterge formularul"
@@ -3380,10 +3716,15 @@ msgstr "Șterge tema locală"
 msgid "Clear the selection to revert to the system default theme"
 msgstr "Șterge selecția pentru a reveni la tema implicită a sistemului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid ""
 "Click on \"Add or edit filters and controls\" option in Settings to "
 "create new dashboard filters"
 msgstr ""
+"Faceți clic pe opțiunea \"Adăugați sau editați filtrele și controalele\" "
+"din Setări pentru a crea noi filtre pentru tabloul de bord"
 
 msgid ""
 "Click on \"Create chart\" button in the control panel on the left to "
@@ -3453,11 +3794,17 @@ msgstr "Faceți clic pentru sortare crescătoare"
 msgid "Click to sort descending"
 msgstr "Faceți clic pentru sortare descrescătoare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Client ID"
-msgstr ""
+msgstr "ID client"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Client Secret"
-msgstr ""
+msgstr "Secret client"
 
 msgid "Close"
 msgstr "Închide"
@@ -3483,8 +3830,11 @@ msgstr "Cod"
 msgid "Code Copied!"
 msgstr "Cod Copiat!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Collapse"
-msgstr ""
+msgstr "Restrângeți"
 
 msgid "Collapse All"
 msgstr "Restrânge Tot"
@@ -3507,11 +3857,17 @@ msgstr "Culoare"
 msgid "Color +/-"
 msgstr "Culoare +/-"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By X-Axis"
-msgstr ""
+msgstr "Colorați după axa X"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color By Y-Axis"
-msgstr ""
+msgstr "Colorați după axa Y"
 
 msgid "Color Metric"
 msgstr "Indicator culoare"
@@ -3525,11 +3881,17 @@ msgstr "Tip Schemă Culori"
 msgid "Color Steps"
 msgstr "Pași Culoare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by x-axis"
-msgstr ""
+msgstr "Colorați barele după axa x"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color bars by y-axis"
-msgstr ""
+msgstr "Colorați barele după axa y"
 
 msgid "Color bounds"
 msgstr "Limite culoare"
@@ -3540,14 +3902,23 @@ msgstr "Puncte de întrerupere culoare"
 msgid "Color by"
 msgstr "Culoare după"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
 msgstr ""
+"Câmpul de culoare trebuie să fie o culoare hexazecimală (#rrggbb) sau "
+"'rgb(r, g, b)'"
 
 msgid "Color for breakpoint"
 msgstr "Culoare pentru punct de întrerupere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Color metric"
-msgstr ""
+msgstr "Metrică de culoare"
 
 msgid "Color of the source location"
 msgstr "Culoarea locației sursă"
@@ -3621,8 +3992,11 @@ msgstr "Coloana referențiată de agregat este nedefinită: %(column)s"
 msgid "Column select"
 msgstr "Selectare coloană"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Column to group by"
-msgstr ""
+msgstr "Coloană pentru grupare"
 
 msgid ""
 "Column to use as the index of the dataframe. If None is given, Index "
@@ -3644,17 +4018,26 @@ msgstr "Coloane"
 msgid "Columns (%s)"
 msgstr "Coloane (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Columns (horizontal layout)"
-msgstr ""
+msgstr "Coloane (aspect orizontal)"
 
 msgid "Columns and metrics"
 msgstr "Coloane și indicatori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Columns and metrics should be inside folders"
-msgstr ""
+msgstr "Coloanele și metricile ar trebui să fie în dosare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Columns folder can only contain column items"
-msgstr ""
+msgstr "Folderul de coloane poate conține doar elemente de coloană"
 
 #, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3664,8 +4047,11 @@ msgstr "Coloane lipsă în setul de date: %(invalid_columns)s"
 msgid "Columns missing in datasource: %(invalid_columns)s"
 msgstr "Coloane lipsă în sursa de date: %(invalid_columns)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Columns should be inside folders"
-msgstr ""
+msgstr "Coloanele ar trebui să fie în interiorul folderelor"
 
 msgid "Columns subtotal position"
 msgstr "Poziție subtotal coloane"
@@ -3715,8 +4101,10 @@ msgstr ""
 "0-2, 2-4 și 4-5. Ultimul număr ar trebui să se potrivească cu valoarea "
 "furnizată pentru MAX."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Common (unit per pixel at zoom 0)"
-msgstr ""
+msgstr "Comun (unitate per pixel la zoom 0)"
 
 msgid "Comparator option"
 msgstr "Opțiune comparator"
@@ -3788,9 +4176,11 @@ msgstr "Intervalul de încredere trebuie să fie între 0 și 1 (exclusiv)"
 msgid "Configuration"
 msgstr "Configurare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Configure %s"
-msgstr ""
+msgstr "Configurați %s"
 
 msgid "Configure Advanced Time Range "
 msgstr "Configurează Interval Timp Avansat "
@@ -3872,8 +4262,11 @@ msgstr "Conectează această bază de date folosind formularul dinamic în schim
 msgid "Connect this database with a SQLAlchemy URI string instead"
 msgstr "Conectează această bază de date cu un șir URI SQLAlchemy în schimb"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Connect to engine"
-msgstr ""
+msgstr "Conectați-vă la motor"
 
 msgid "Connection"
 msgstr "Conexiune"
@@ -3887,9 +4280,11 @@ msgstr "Conexiunea a eșuat, vă rugăm să verificați setările de conexiune."
 msgid "Contains"
 msgstr "Conține"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr ""
+msgstr "Conține text (ILIKE %x%)"
 
 msgid "Content format"
 msgstr "Format conținut"
@@ -3924,8 +4319,11 @@ msgstr "Controale etichetate "
 msgid "Copied to clipboard!"
 msgstr "Copiat în clipboard!"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Copied!"
-msgstr ""
+msgstr "Copiat!"
 
 msgid "Copy"
 msgstr "Copiază"
@@ -3945,8 +4343,11 @@ msgstr "Copiază și Lipește credențiale JSON"
 msgid "Copy code to clipboard"
 msgstr "Copiază codul în clipboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Copy column name"
-msgstr ""
+msgstr "Copiați numele coloanei"
 
 #, python-format
 msgid "Copy of %s"
@@ -4004,8 +4405,10 @@ msgstr "Nu s-au putut prelua toate graficele salvate"
 msgid "Could not find viz object"
 msgstr "Nu s-a putut găsi obiectul viz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Could not load SQL Lab"
-msgstr ""
+msgstr "Nu s-a putut încărca SQL Lab"
 
 msgid "Could not load database driver"
 msgstr "Nu s-a putut încărca driverul bazei de date"
@@ -4054,8 +4457,11 @@ msgstr "Hartă Țară"
 msgid "Create"
 msgstr "Creează"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Create API Key"
-msgstr ""
+msgstr "Creați cheia API"
 
 msgid "Create Tag"
 msgstr "Creează Etichetă"
@@ -4104,9 +4510,11 @@ msgstr "Creat de"
 msgid "Created by me"
 msgstr "Creat de mine"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Created by: %s"
-msgstr ""
+msgstr "Creat de: %s"
 
 msgid "Created on"
 msgstr "Creat pe"
@@ -4123,8 +4531,11 @@ msgstr "Creator"
 msgid "Crimson"
 msgstr "Crimson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Cross-filter column"
-msgstr ""
+msgstr "Coloană de filtrare încrucișată"
 
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
@@ -4149,8 +4560,11 @@ msgstr "Cumulativ"
 msgid "Currency"
 msgstr "Monedă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Currency code column"
-msgstr ""
+msgstr "Coloana codului valutar"
 
 msgid "Currency format"
 msgstr "Format monedă"
@@ -4164,8 +4578,11 @@ msgstr "Simbol monedă"
 msgid "Current"
 msgstr "Curent"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Current Zoom"
-msgstr ""
+msgstr "Zoom curent"
 
 msgid "Current day"
 msgstr "Zi curentă"
@@ -4201,11 +4618,19 @@ msgstr "SQL Personalizat"
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr "Indicatorii SQL personalizați nu sunt activați pentru acest set de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
+"Câmpurile SQL personalizate nu pot fi analizate ca o singură instrucțiune"
+" SQL."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
+msgstr "Câmpurile SQL personalizate nu pot conține operații pe mulțimi."
 
 msgid "Custom SQL fields cannot contain sub-queries."
 msgstr "Câmpurile SQL personalizate nu pot conține sub-interogări."
@@ -4231,21 +4656,35 @@ msgstr "Plugin filtru timp personalizat"
 msgid "Custom width of the screenshot in pixels"
 msgstr "Lățime personalizată a capturii de ecran în pixeli"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Custom..."
-msgstr ""
+msgstr "Personalizat..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Customization and styling"
-msgstr ""
+msgstr "Personalizare și stilizare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Customization type"
-msgstr ""
+msgstr "Tip de personalizare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Customization value is required"
-msgstr ""
+msgstr "Valoarea de personalizare este obligatorie"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy, python-format
 msgid "Customizations out of scope (%d)"
-msgstr ""
+msgstr "Personalizări în afara domeniului (%d)"
 
 msgid "Customize"
 msgstr "Personalizează"
@@ -4325,6 +4764,7 @@ msgstr "Format date DD/MM, format internațional și european"
 msgid "DEC"
 msgstr "DEC"
 
+#. do-not-translate
 msgid "DELETE"
 msgstr "ȘTERGE"
 
@@ -4337,8 +4777,11 @@ msgstr "Sezonalitate zilnică"
 msgid "Dark"
 msgstr "Întunecat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Dark (Carto)"
-msgstr ""
+msgstr "Întunecat (Carto)"
 
 msgid "Dark Cyan"
 msgstr "Cyan Întunecat"
@@ -4349,9 +4792,11 @@ msgstr "Mod întunecat"
 msgid "Dashboard"
 msgstr "Panou de control"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Dashboard %(dashboard_id)s not found"
-msgstr ""
+msgstr "Tabloul de bord %(dashboard_id)s nu a fost găsit"
 
 msgid "Dashboard Filter"
 msgstr "Filtru Panou de Control"
@@ -4374,8 +4819,11 @@ msgstr "Panoul de control nu poate fi marcat ca favorit."
 msgid "Dashboard cannot be unfavorited."
 msgstr "Acest panou de control nu poate fi scos din favorite."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Dashboard chart customizations could not be updated."
-msgstr ""
+msgstr "Personalizările graficelor tabloului de bord nu au putut fi actualizate."
 
 msgid "Dashboard color configuration could not be updated."
 msgstr "Configurația culorii panoului de control nu a putut fi actualizată."
@@ -4383,17 +4831,28 @@ msgstr "Configurația culorii panoului de control nu a putut fi actualizată."
 msgid "Dashboard could not be deleted."
 msgstr "Panoul de control nu a putut fi șters."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid "Dashboard could not be restored."
+msgstr "Tabloul de bord nu a putut fi restaurat."
+
 msgid "Dashboard could not be updated."
 msgstr "Panoul de control nu a putut fi actualizat."
 
 msgid "Dashboard does not exist"
 msgstr "Panoul de control nu există"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Dashboard exported as example successfully"
-msgstr ""
+msgstr "Tabloul de bord a fost exportat cu succes ca exemplu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Dashboard exported successfully"
-msgstr ""
+msgstr "Tabloul de bord a fost exportat cu succes"
 
 msgid "Dashboard imported"
 msgstr "Panoul de control a fost importat"
@@ -4435,9 +4894,11 @@ msgstr ""
 msgid "Dashboard title"
 msgstr "Titlu panou de control"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Dashboard updated %s"
-msgstr ""
+msgstr "Tabloul de bord actualizat %s"
 
 msgid "Dashboard usage"
 msgstr "Utilizare panou de control"
@@ -4457,8 +4918,11 @@ msgstr "Linie întreruptă"
 msgid "Data"
 msgstr "Date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Data Connections"
-msgstr ""
+msgstr "Conexiuni de date"
 
 msgid "Data Export Options"
 msgstr "Opțiuni Export Date"
@@ -4472,11 +4936,17 @@ msgstr "URI de date nu este permis."
 msgid "Data Zoom"
 msgstr "Zoom Date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Data connection"
-msgstr ""
+msgstr "Conexiune de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Data connections"
-msgstr ""
+msgstr "Conexiuni de date"
 
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
@@ -4494,8 +4964,11 @@ msgstr ""
 "Datele nu au putut fi preluate din backend-ul de rezultate. Trebuie să "
 "rulezi din nou interogarea originală."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Data error"
-msgstr ""
+msgstr "Eroare de date"
 
 #, python-format
 msgid "Data for %s"
@@ -4581,8 +5054,11 @@ msgstr "Parole bază de date"
 msgid "Database port"
 msgstr "Port bază de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Database reference is not allowed on a report"
-msgstr ""
+msgstr "Referința la baza de date nu este permisă într-un raport"
 
 msgid "Database schema is not allowed for csv uploads."
 msgstr "Schema bazei de date nu este permisă pentru încărcări csv."
@@ -4593,8 +5069,10 @@ msgstr "Setările bazei de date au fost actualizate"
 msgid "Database type does not support file uploads."
 msgstr "Tipul de bază de date nu acceptă încărcări de fișiere."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
+msgstr "Fișierul de încărcat în baza de date depășește dimensiunea maximă permisă."
 
 msgid "Database upload file failed"
 msgstr "Încărcarea fișierului bazei de date a eșuat"
@@ -4628,6 +5106,11 @@ msgstr "Setul de date nu a putut fi creat."
 
 msgid "Dataset could not be duplicated."
 msgstr "Setul de date nu a putut fi duplicat."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid "Dataset could not be restored."
+msgstr "Setul de date nu a putut fi restaurat."
 
 msgid "Dataset could not be updated."
 msgstr "Setul de date nu a putut fi actualizat."
@@ -4679,8 +5162,11 @@ msgstr "Sursă de Date & Tip Grafic"
 msgid "Datasource does not exist"
 msgstr "Sursa de date nu există"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Datasource is required"
-msgstr ""
+msgstr "Sursa de date este obligatorie"
 
 msgid "Datasource is required for validation"
 msgstr "Sursa de date este obligatorie pentru validare"
@@ -4691,8 +5177,11 @@ msgstr "Tipul sursei de date este invalid"
 msgid "Datasource type is required when datasource_id is given"
 msgstr "Tipul sursei de date este obligatoriu când datasource_id este dat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Datasources"
-msgstr ""
+msgstr "Surse de date"
 
 msgid "Date Time Format"
 msgstr "Format Dată Timp"
@@ -4774,11 +5263,17 @@ msgstr "Deck.gl - Grafic Dispersie"
 msgid "Deck.gl - Screen Grid"
 msgstr "Deck.gl - Grilă Ecran"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Deck.gl Layer Visibility"
-msgstr ""
+msgstr "Vizibilitatea stratului Deck.gl"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Deckgl"
-msgstr ""
+msgstr "Deckgl"
 
 msgid "Decrease"
 msgstr "Scădere"
@@ -4795,8 +5290,11 @@ msgstr "Implicit"
 msgid "Default Catalog"
 msgstr "Catalog Implicit"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Default Column Settings"
-msgstr ""
+msgstr "Setări implicite pentru coloană"
 
 msgid "Default Schema"
 msgstr "Schemă Implicită"
@@ -4817,11 +5315,17 @@ msgstr "Valoare Implicită"
 msgid "Default color"
 msgstr "Culoare implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Default datetime column"
-msgstr ""
+msgstr "Coloana implicită pentru dată/oră"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Default folders cannot be nested"
-msgstr ""
+msgstr "Folderele implicite nu pot fi imbricate"
 
 msgid "Default latitude"
 msgstr "Latitudine implicită"
@@ -4829,8 +5333,11 @@ msgstr "Latitudine implicită"
 msgid "Default longitude"
 msgstr "Longitudine implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Default message"
-msgstr ""
+msgstr "Mesaj implicit"
 
 msgid ""
 "Default minimal column width in pixels, actual width may still be larger "
@@ -4950,22 +5457,29 @@ msgstr ""
 "Definește dacă pasul ar trebui să apară la început, la mijloc sau la "
 "sfârșit între două puncte de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Definition"
-msgstr ""
+msgstr "Definiție"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Întârziat (ratat %s reîmprospătare)"
+msgstr[1] "Întârziat (ratate %s reîmprospătări)"
+msgstr[2] "Întârziat (ratate %s de reîmprospătări)"
 
 msgid "Delete"
 msgstr "Șterge"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Delete %s"
-msgstr ""
+msgstr "Șterge %s"
 
 #, python-format
 msgid "Delete %s?"
@@ -4989,11 +5503,17 @@ msgstr "Șterge Raportul?"
 msgid "Delete Role?"
 msgstr "Șterge Rolul?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Delete Semantic Layer?"
-msgstr ""
+msgstr "Ștergeți stratul semantic?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Delete Semantic View?"
-msgstr ""
+msgstr "Ștergeți vizualizarea semantică?"
 
 msgid "Delete Template?"
 msgstr "Șterge Șablonul?"
@@ -5019,8 +5539,11 @@ msgstr "Șterge raport email"
 msgid "Delete group"
 msgstr "Șterge grup"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Delete item"
-msgstr ""
+msgstr "Șterge elementul"
 
 msgid "Delete role"
 msgstr "Șterge rol"
@@ -5109,12 +5632,14 @@ msgstr[0] "Ștearsă %(num)d interogare salvată"
 msgstr[1] "Șterse %(num)d interogări salvate"
 msgstr[2] "Șterse %(num)d de interogări salvate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Deleted %(num)d semantic view"
 msgid_plural "Deleted %(num)d semantic views"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(num)d vizualizare semantică ștearsă"
+msgstr[1] "%(num)d vizualizări semantice șterse"
+msgstr[2] "%(num)d de vizualizări semantice șterse"
 
 #, python-format
 msgid "Deleted %(num)d theme"
@@ -5127,9 +5652,11 @@ msgstr[2] "Șterse %(num)d de teme"
 msgid "Deleted %s"
 msgstr "Șters %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Deleted %s item(s)"
-msgstr ""
+msgstr "Șterse %s element(e)"
 
 #, python-format
 msgid "Deleted group: %s"
@@ -5209,12 +5736,20 @@ msgstr "Detalii"
 msgid "Details of the certification"
 msgstr "Detalii ale certificării"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
 "operator (default). ILIKE options enable partial text matching with a "
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
+"Determină modul în care filtrul potrivește valorile. „Potrivire exactă\" "
+"utilizează operatorul IN (implicit). Opțiunile ILIKE permit potrivirea "
+"parțială a textului cu o intrare de text liber. Avertisment: Interogările"
+" ILIKE pot fi lente pe seturi de date mari, deoarece nu pot utiliza "
+"indexurile în mod eficient."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Determină modul în care sunt calculate mustățile și valorile aberante."
@@ -5241,11 +5776,18 @@ msgstr "Gri Dismal"
 msgid "Dimension"
 msgstr "Dimensiune"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Dimension column emitted as a cross-filter when a feature is clicked. "
 "Other charts on the dashboard match against this column. If unset, falls "
 "back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
+"Coloana de dimensiune emisă ca filtru încrucișat când se face clic pe un "
+"element. Alte diagrame de pe tabloul de bord sunt comparate cu această "
+"coloană. Dacă nu este setată, se utilizează coloana de geometrie "
+"(comportament vechi, adesea incompatibil)."
 
 msgid "Dimension is required"
 msgstr "Dimensiunea este obligatorie"
@@ -5268,9 +5810,11 @@ msgstr "Valori dimensiune"
 msgid "Dimensions"
 msgstr "Dimensiuni"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Dimensions (%s)"
-msgstr ""
+msgstr "Dimensiuni (%s)"
 
 msgid ""
 "Dimensions contain qualitative values such as names, dates, or "
@@ -5336,31 +5880,53 @@ msgstr "Afișează nume coloană"
 msgid "Display configuration"
 msgstr "Configurare afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display control configuration"
-msgstr ""
+msgstr "Configurarea controlului de afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control has default value"
-msgstr ""
+msgstr "Controlul de afișare are o valoare implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control name"
-msgstr ""
+msgstr "Numele controlului de afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control settings"
-msgstr ""
+msgstr "Setările controlului de afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display control type"
-msgstr ""
+msgstr "Tipul controlului de afișare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Display controls"
-msgstr ""
+msgstr "Controale de afișare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Display controls (%d)"
-msgstr ""
+msgstr "Controale de afișare (%d)"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Display controls (%s)"
-msgstr ""
+msgstr "Controale de afișare (%s)"
 
 msgid "Display cumulative total at end"
 msgstr "Afișează total cumulativ la sfârșit"
@@ -5392,8 +5958,13 @@ msgstr "Afișează subtotal nivel rând"
 msgid "Display row level total"
 msgstr "Afișează total nivel rând"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Display the last queried timestamp on charts in the dashboard view"
 msgstr ""
+"Afișează ultimul timestamp interogat pe grafice în vizualizarea tabloului"
+" de bord"
 
 msgid "Display type icon"
 msgstr "Afișează iconiță tip"
@@ -5438,8 +6009,11 @@ msgstr "Domeniu"
 msgid "Don't refresh"
 msgstr "Nu reîmprospăta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Done"
-msgstr ""
+msgstr "Gata"
 
 msgid "Donut"
 msgstr "Gogoașă"
@@ -5462,8 +6036,11 @@ msgstr "Descărcarea este în curs"
 msgid "Download to CSV"
 msgstr "Descarcă în CSV"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Download to client"
-msgstr ""
+msgstr "Descărcați pe client"
 
 #, python-format
 msgid ""
@@ -5492,8 +6069,11 @@ msgstr ""
 "în tooltip-uri. Apasă butonul pentru a selecta manual coloanele și "
 "indicatorii."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Trageți pentru a reordona"
 
 msgid "Draw a marker on data points. Only applicable for line types."
 msgstr ""
@@ -5593,9 +6173,11 @@ msgstr ""
 msgid "Duplicate dataset"
 msgstr "Duplică set de date"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Duplicate folder name: %s"
-msgstr ""
+msgstr "Nume folder duplicat: %s"
 
 msgid "Duplicate role"
 msgstr "Duplică rol"
@@ -5654,42 +6236,65 @@ msgstr "Durată în ms (1.40008 => 1ms 400µs 80ns)"
 msgid "Duration in ms (100.40008 => 100ms 400µs 80ns)"
 msgstr "Durată în ms (100.40008 => 100ms 400µs 80ns)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fr, it, ja, lv, mi, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Duration in ms (10500 => 0:00:10.5)"
-msgstr ""
+msgstr "Durată în ms (10500 => 0:00:10.5)"
 
 msgid "Duration in ms (66000 => 1m 6s)"
 msgstr "Durată în ms (66000 => 1m 6s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Duration in seconds"
-msgstr ""
+msgstr "Durată în secunde"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamic"
-msgstr ""
+msgstr "Dinamic"
 
 msgid "Dynamic Aggregation Function"
 msgstr "Funcție Agregare Dinamică"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Dynamic Section Label"
-msgstr ""
+msgstr "Etichetă secțiune dinamică"
 
 msgid "Dynamic group by"
 msgstr "Grupare dinamică"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Dynamic section description"
-msgstr ""
+msgstr "Descriere secțiune dinamică"
 
 msgid "Dynamically search all filter values"
 msgstr "Caută dinamic toate valorile filtrului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Dynamically select grouping columns from a dataset"
-msgstr ""
+msgstr "Selectați dinamic coloanele de grupare dintr-un set de date"
 
+#. do-not-translate
 msgid "ECharts"
 msgstr "ECharts"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "ECharts Options (JS object literals)"
-msgstr ""
+msgstr "Opțiuni ECharts (literale de obiecte JS)"
 
+#. do-not-translate
 msgid "EMAIL_REPORTS_CTA"
 msgstr "EMAIL_REPORTS_CTA"
 
@@ -5711,9 +6316,11 @@ msgstr "Lățime muchie"
 msgid "Edit"
 msgstr "Editează"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Edit %s"
-msgstr ""
+msgstr "Editați %s"
 
 #, python-format
 msgid "Edit %s in modal"
@@ -5812,8 +6419,11 @@ msgstr "Editează interval de timp"
 msgid "Edit user"
 msgstr "Editează utilizator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Editable"
-msgstr ""
+msgstr "Editabil"
 
 msgid "Edited"
 msgstr "Editat"
@@ -5833,7 +6443,9 @@ msgstr "Editorii sunt o listă de subiecte care pot modifica tabloul de bord."
 msgid ""
 "Editors is a list of subjects who can alter the dashboard. Searchable by "
 "name."
-msgstr "Editorii sunt o listă de subiecte care pot modifica tabloul de bord. Se pot căuta după nume."
+msgstr ""
+"Editorii sunt o listă de subiecte care pot modifica tabloul de bord. Se "
+"pot căuta după nume."
 
 msgid "Either the database is spelled incorrectly or does not exist."
 msgstr "Fie baza de date este scrisă incorect, fie nu există."
@@ -5853,8 +6465,11 @@ msgstr ""
 msgid "Either the username or the password is wrong."
 msgstr "Fie numele de utilizator, fie parola este greșită."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Elapsed"
-msgstr ""
+msgstr "Scurs"
 
 msgid "Elevation"
 msgstr "Elevație"
@@ -5865,8 +6480,11 @@ msgstr "Email"
 msgid "Email is required"
 msgstr "Email-ul este obligatoriu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Email link"
-msgstr ""
+msgstr "Link email"
 
 msgid "Email reports active"
 msgstr "Rapoarte email active"
@@ -5936,20 +6554,35 @@ msgstr "Activează prognozarea"
 msgid "Enable graph roaming"
 msgstr "Activează roaming grafic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable icon JavaScript mode"
-msgstr ""
+msgstr "Activează modul JavaScript pentru pictograme"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Enable icons"
-msgstr ""
+msgstr "Activează pictogramele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enable label JavaScript mode"
-msgstr ""
+msgstr "Activează modul JavaScript pentru etichete"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Enable labels"
-msgstr ""
+msgstr "Activează etichetele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Enable matrixify"
-msgstr ""
+msgstr "Activează matrixify"
 
 msgid "Enable node dragging"
 msgstr "Activează tragerea nodurilor"
@@ -5963,17 +6596,29 @@ msgstr "Activează extinderea rândurilor în scheme"
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr "Activează paginarea pe server a rezultatelor (funcție experimentală)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
+msgstr "Activează configurarea personalizată a pictogramelor prin JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables custom label configuration via JavaScript"
-msgstr ""
+msgstr "Activează configurarea personalizată a etichetelor prin JavaScript"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr ""
+msgstr "Activează redarea pictogramelor pentru punctele GeoJSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr ""
+msgstr "Activează redarea etichetelor pentru punctele GeoJSON"
 
 msgid ""
 "Encountered invalid NULL spatial entry,"
@@ -5984,8 +6629,11 @@ msgstr ""
 "                                        vă rugăm să luați în considerare "
 "filtrarea acestora"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Encrypted extra fields"
-msgstr ""
+msgstr "Câmpuri suplimentare criptate"
 
 msgid "End"
 msgstr "Sfârșit"
@@ -6017,9 +6665,11 @@ msgstr "Data de sfârșit trebuie să fie după data de început"
 msgid "Ends With"
 msgstr "Se Termină Cu"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Ends with (ILIKE %x)"
-msgstr ""
+msgstr "Se termină cu (ILIKE %x)"
 
 #, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
@@ -6047,8 +6697,11 @@ msgstr "Introduceți un nume pentru această foaie"
 msgid "Enter a new title for the tab"
 msgstr "Introduceți un titlu nou pentru filă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Enter a part of the object name"
-msgstr ""
+msgstr "Introduceți o parte din numele obiectului"
 
 msgid "Enter alert name"
 msgstr "Introduceți numele alertei"
@@ -6090,8 +6743,11 @@ msgstr "Introduceți prenumele utilizatorului"
 msgid "Enter the user's last name"
 msgstr "Introduceți numele de familie al utilizatorului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Enter the user's password"
-msgstr ""
+msgstr "Introduceți parola utilizatorului"
 
 msgid "Enter the user's username"
 msgstr "Introduceți numele de utilizator"
@@ -6124,13 +6780,17 @@ msgstr "Eroare Preluare Obiecte Etichetate"
 msgid "Error deleting %s"
 msgstr "Eroare la ștergerea %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr ""
+msgstr "Eroare la dezactivarea ecranului complet: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Error enabling fullscreen: %s"
-msgstr ""
+msgstr "Eroare la activarea ecranului complet: %s"
 
 msgid "Error executing query. "
 msgstr "Eroare la executarea interogării. "
@@ -6152,9 +6812,11 @@ msgstr "Eroare în expresia jinja din filtrele RLS: %(msg)s"
 msgid "Error in jinja expression in WHERE clause: %(msg)s"
 msgstr "Eroare în expresia jinja din clauza WHERE: %(msg)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr ""
+msgstr "Eroare în expresia jinja în coloana ad hoc: %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
@@ -6257,8 +6919,11 @@ msgstr "Evoluție"
 msgid "Exact"
 msgstr "Exact"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Exact match (IN)"
-msgstr ""
+msgstr "Potrivire exactă (IN)"
 
 msgid "Example"
 msgstr "Exemplu"
@@ -6281,8 +6946,11 @@ msgstr "Încărcare Excel"
 msgid "Exclude selected values"
 msgstr "Exclude valorile selectate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Excluded subjects"
-msgstr ""
+msgstr "Subiecte excluse"
 
 msgid "Executed SQL"
 msgstr "SQL Executat"
@@ -6317,8 +6985,11 @@ msgstr "Extinde panoul de date"
 msgid "Expand row"
 msgstr "Extinde rând"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Expand row to edit"
-msgstr ""
+msgstr "Extindeți rândul pentru editare"
 
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
@@ -6334,8 +7005,11 @@ msgstr ""
 msgid "Experimental"
 msgstr "Experimental"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Expired"
-msgstr ""
+msgstr "Expirat"
 
 msgid "Explore"
 msgstr "Explorează"
@@ -6356,11 +7030,17 @@ msgstr "Exportă Toate Datele"
 msgid "Export Current View"
 msgstr "Exportă Vederea Curentă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Export YAML"
-msgstr ""
+msgstr "Exportați YAML"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Export as Example"
-msgstr ""
+msgstr "Exportați ca exemplu"
 
 msgid "Export cancelled"
 msgstr "Export anulat"
@@ -6391,8 +7071,11 @@ msgstr "Exportă în .CSV"
 msgid "Export to .JSON"
 msgstr "Exportă în .JSON"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "Export to CSV"
-msgstr ""
+msgstr "Exportați în CSV"
 
 msgid "Export to Excel"
 msgstr "Exportă în Excel"
@@ -6424,8 +7107,11 @@ msgstr "Expune baza de date în SQL Lab"
 msgid "Expose in SQL Lab"
 msgstr "Expune în SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Expression"
-msgstr ""
+msgstr "Expresie"
 
 msgid "Expression cannot be empty"
 msgstr "Expresia nu poate fi goală"
@@ -6436,8 +7122,11 @@ msgstr "Extensii"
 msgid "Extent"
 msgstr "Extindere"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "External link warning"
-msgstr ""
+msgstr "Avertisment link extern"
 
 msgid "Extra"
 msgstr "Suplimentar"
@@ -6486,6 +7175,11 @@ msgstr "FEB"
 msgid "FIT DATA"
 msgstr "POTRIVEȘTE DATE"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Ajustare la date"
+
 msgid "FRI"
 msgstr "VIN"
 
@@ -6507,14 +7201,23 @@ msgstr "Eșuat la preluarea rezultatelor"
 msgid "Failed to apply theme: Invalid JSON"
 msgstr "Eșuat la aplicarea temei: JSON Invalid"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Failed to copy API key to clipboard"
-msgstr ""
+msgstr "Copierea cheii API în clipboard a eșuat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Failed to copy stack trace to clipboard"
-msgstr ""
+msgstr "Copierea stack trace-ului în clipboard a eșuat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Failed to create API key"
-msgstr ""
+msgstr "Crearea cheii API a eșuat"
 
 msgid "Failed to create report"
 msgstr "Eșuat la crearea raportului"
@@ -6523,15 +7226,20 @@ msgstr "Eșuat la crearea raportului"
 msgid "Failed to execute %(query)s"
 msgstr "Eșuat la executarea %(query)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Failed to fetch API keys"
-msgstr ""
+msgstr "Preluarea cheilor API a eșuat"
 
 msgid "Failed to generate chart edit URL"
 msgstr "Eșuat la generarea URL-ului de editare grafic"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to generate download: %s"
-msgstr ""
+msgstr "Generarea descărcării a eșuat: %s"
 
 msgid "Failed to load chart data"
 msgstr "Eșuat la încărcarea datelor graficului"
@@ -6539,15 +7247,20 @@ msgstr "Eșuat la încărcarea datelor graficului"
 msgid "Failed to load chart data."
 msgstr "Eșuat la încărcarea datelor graficului."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Failed to load columns for %s %s"
-msgstr ""
+msgstr "Încărcarea coloanelor pentru %s %s a eșuat"
 
 msgid "Failed to load top values"
 msgstr "Eșuat la încărcarea valorilor de top"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Failed to open file. Please try again."
-msgstr ""
+msgstr "Deschiderea fișierului a eșuat. Vă rugăm să încercați din nou."
 
 #, python-format
 msgid "Failed to remove system dark theme: %s"
@@ -6560,8 +7273,11 @@ msgstr "Eșuat la eliminarea temei implicite a sistemului: %s"
 msgid "Failed to retrieve advanced type"
 msgstr "Eșuat la preluarea tipului avansat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Failed to revoke API key"
-msgstr ""
+msgstr "Revocarea cheii API a eșuat"
 
 msgid "Failed to save chart customization"
 msgstr "Eșuat la salvarea personalizării graficului"
@@ -6614,8 +7330,11 @@ msgstr "Fals"
 msgid "Favorite"
 msgstr "Favorit"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Feature Not Enabled"
-msgstr ""
+msgstr "Funcționalitate neactivată"
 
 msgid "Featured"
 msgstr "Recomandat"
@@ -6636,8 +7355,11 @@ msgstr "Preluat %s"
 msgid "Fetching"
 msgstr "Preluare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Fetching data..."
-msgstr ""
+msgstr "Se preiau datele..."
 
 #, python-format
 msgid "Field cannot be decoded by JSON. %(json_error)s"
@@ -6647,8 +7369,11 @@ msgstr "Câmpul nu poate fi decodat de JSON. %(json_error)s"
 msgid "Field cannot be decoded by JSON. %(msg)s"
 msgstr "Câmpul nu poate fi decodat de JSON. %(msg)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "Field cannot be empty."
-msgstr ""
+msgstr "Câmpul nu poate fi gol."
 
 msgid "Field is required"
 msgstr "Câmpul este obligatoriu"
@@ -6656,10 +7381,15 @@ msgstr "Câmpul este obligatoriu"
 msgid "File extension is not allowed."
 msgstr "Extensia fișierului nu este permisă."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "File handling is not supported in this browser. Please use a modern "
 "browser like Chrome or Edge."
 msgstr ""
+"Gestionarea fișierelor nu este acceptată în acest browser. Vă rugăm să "
+"utilizați un browser modern, cum ar fi Chrome sau Edge."
 
 msgid "File settings"
 msgstr "Setări fișier"
@@ -6713,8 +7443,11 @@ msgstr ""
 "Filtrul afișează doar valori relevante pentru selecțiile făcute în alte "
 "filtre."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Filter options"
-msgstr ""
+msgstr "Opțiuni de filtrare"
 
 msgid "Filter results"
 msgstr "Filtrează rezultate"
@@ -6737,8 +7470,11 @@ msgstr "Filtrează graficele tale"
 msgid "Filters"
 msgstr "Filtre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Filters and controls"
-msgstr ""
+msgstr "Filtre și controale"
 
 msgid "Filters by columns"
 msgstr "Filtrează după coloane"
@@ -6827,11 +7563,17 @@ msgstr "Rază punct fix"
 msgid "Flow"
 msgstr "Flux"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Folder with content must have a name"
-msgstr ""
+msgstr "Dosarul cu conținut trebuie să aibă un nume"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Folders"
-msgstr ""
+msgstr "Dosare"
 
 msgid "Font size"
 msgstr "Dimensiune font"
@@ -6871,11 +7613,17 @@ msgstr ""
 "Pentru mai multe informații despre obiectele care sunt în context în "
 "domeniul acestei funcții, consultă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, tr]
+#, fuzzy
 msgid ""
 "For regular filters, these are the subjects (users, roles, groups) this "
 "filter will be applied to. For base filters, these are the subjects that "
 "the filter DOES NOT apply to, e.g. Admin if admin should see all data."
 msgstr ""
+"Pentru filtrele regulate, acestea sunt subiectele (utilizatori, roluri, "
+"grupuri) la care va fi aplicat acest filtru. Pentru filtrele de bază, "
+"acestea sunt subiectele la care filtrul NU se aplică, de ex. Admin dacă "
+"administratorul ar trebui să vadă toate datele."
 
 msgid "Forbidden"
 msgstr "Interzis"
@@ -6886,8 +7634,11 @@ msgstr "Forțează"
 msgid "Force Time Grain as Max Interval"
 msgstr "Forțează Time Grain ca Interval Maxim"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Force abort (stops task for all subscribers)"
-msgstr ""
+msgstr "Forțați întreruperea (oprește sarcina pentru toți abonații)"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -6935,11 +7686,17 @@ msgstr "Date formular nu găsite în cache, revenire la metadatele graficului."
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr "Date formular nu găsite în cache, revenire la metadatele setului de date."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Format"
-msgstr ""
+msgstr "Format"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Format JSON configuration"
-msgstr ""
+msgstr "Formatați configurația JSON"
 
 msgid "Format SQL"
 msgstr "Formatează SQL"
@@ -6957,12 +7714,20 @@ msgstr ""
 "{percent}. \\n reprezintă o linie nouă. Compatibilitate ECharts:\n"
 "{a} (serie), {b} (nume), {c} (valoare), {d} (procent)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
 "Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
 " based on the dataset's currency code column. When multiple currencies "
 "are present, formatting falls back to neutral numbers."
 msgstr ""
+"Formatați metricile sau coloanele cu simboluri monetare ca prefixe sau "
+"sufixe. Alegeți un simbol manual sau utilizați 'Auto-detect' pentru a "
+"aplica simbolul corect pe baza coloanei cu codul monedei din setul de "
+"date. Când sunt prezente mai multe monede, formatarea revine la numere "
+"neutre."
 
 msgid "Formatted CSV attached in email"
 msgstr "CSV formatat atașat în email"
@@ -6973,11 +7738,17 @@ msgstr "Valoare formatată"
 msgid "Formatting"
 msgstr "Formatare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Formatting column"
-msgstr ""
+msgstr "Coloană de formatare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Formatting object"
-msgstr ""
+msgstr "Obiect de formatare"
 
 msgid "Formula"
 msgstr "Formulă"
@@ -7009,8 +7780,11 @@ msgstr "Data de la nu poate fi mai mare decât data până la"
 msgid "Full name"
 msgstr "Nume complet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Fullscreen is not supported in this browser."
-msgstr ""
+msgstr "Ecranul complet nu este acceptat în acest browser."
 
 msgid "Funnel Chart"
 msgstr "Grafic Pâlnie"
@@ -7021,6 +7795,7 @@ msgstr "Personalizează mai departe modul de afișare a fiecărei coloane"
 msgid "Further customize how to display each metric"
 msgstr "Personalizează suplimentar modul de afișare al fiecărui indicator"
 
+#. do-not-translate
 msgid "GROUP BY"
 msgstr "GRUPARE DUPĂ"
 
@@ -7093,8 +7868,11 @@ msgstr "Nume și URL Foaie Google"
 msgid "Grace period"
 msgstr "Perioadă de grație"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Grain"
-msgstr ""
+msgstr "Granularitate"
 
 msgid "Graph Chart"
 msgstr "Grafic Graf"
@@ -7126,8 +7904,11 @@ msgstr "Grilă"
 msgid "Grid Size"
 msgstr "Dimensiune Grilă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Grid view"
-msgstr ""
+msgstr "Vizualizare grilă"
 
 msgid "Group"
 msgstr "Grup"
@@ -7149,8 +7930,11 @@ msgstr "Grupare după"
 msgid "Group remaining as \"Others\""
 msgstr "Grupează restul ca \"Altele\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Grouping"
-msgstr ""
+msgstr "Grupare"
 
 msgid "Groups"
 msgstr "Grupuri"
@@ -7166,8 +7950,11 @@ msgstr ""
 msgid "Guest user cannot modify chart payload"
 msgstr "Utilizatorul oaspete nu poate modifica payload-ul graficului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "HTTP Path"
-msgstr ""
+msgstr "Cale HTTP"
 
 msgid "Handlebars"
 msgstr "Handlebars"
@@ -7187,8 +7974,11 @@ msgstr "Antet"
 msgid "Header row"
 msgstr "Rând antet"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Header row is required"
-msgstr ""
+msgstr "Rândul de antet este obligatoriu"
 
 msgid "Heatmap"
 msgstr "Hartă Termică"
@@ -7202,8 +7992,11 @@ msgstr "Înălțimea fiecărui rând în pixeli"
 msgid "Height of the sparkline"
 msgstr "Înălțimea sparkline-ului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Hidden"
-msgstr ""
+msgstr "Ascuns"
 
 msgid "Hide Column"
 msgstr "Ascunde Coloană"
@@ -7294,17 +8087,29 @@ msgstr "Coduri ISO 3166-2"
 msgid "ISO 8601"
 msgstr "ISO 8601"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon JavaScript config generator"
-msgstr ""
+msgstr "Generator de configurație JavaScript pentru pictogramă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Icon URL"
-msgstr ""
+msgstr "URL pictogramă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Icon size"
-msgstr ""
+msgstr "Dimensiune pictogramă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Icon size unit"
-msgstr ""
+msgstr "Unitate de dimensiune pictogramă"
 
 msgid "Id"
 msgstr "ID"
@@ -7337,10 +8142,15 @@ msgstr ""
 "Dacă este activat, acest control sortează rezultatele/valorile "
 "descrescător, altfel sortează rezultatele crescător."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
+"Dacă rămâne gol, nu va fi salvat și va fi eliminat din listă. Pentru a "
+"elimina folderele, mutați metricele și coloanele în alte foldere."
 
 msgid "If table already exists"
 msgstr "Dacă tabelul există deja"
@@ -7413,8 +8223,11 @@ msgstr "Importă teme"
 msgid "In"
 msgstr "În"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "In Progress"
-msgstr ""
+msgstr "În progres"
 
 msgid "In Range"
 msgstr "În Interval"
@@ -7429,8 +8242,11 @@ msgstr ""
 msgid "In this view you can preview the first 25 rows. "
 msgstr "În această vedere poți previzualiza primele 25 de rânduri. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Inactive"
-msgstr ""
+msgstr "Inactiv"
 
 msgid "Include Series"
 msgstr "Include Serie"
@@ -7500,32 +8316,59 @@ msgstr "Inserează URL Strat"
 msgid "Insert Layer title"
 msgstr "Inserează Titlu Strat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Inside"
-msgstr ""
+msgstr "Interior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside bottom"
-msgstr ""
+msgstr "Interior jos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside bottom left"
-msgstr ""
+msgstr "Interior jos stânga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside bottom right"
-msgstr ""
+msgstr "Interior jos dreapta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Inside left"
-msgstr ""
+msgstr "Interior stânga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Inside right"
-msgstr ""
+msgstr "Interior dreapta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top"
-msgstr ""
+msgstr "Interior sus"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Inside top left"
-msgstr ""
+msgstr "Interior sus stânga"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Inside top right"
-msgstr ""
+msgstr "Interior sus dreapta"
 
 msgid "Intensity"
 msgstr "Intensitate"
@@ -7569,8 +8412,11 @@ msgstr ""
 msgid "Invalid JSON"
 msgstr "JSON Invalid"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Invalid JSON configuration"
-msgstr ""
+msgstr "Configurație JSON nevalidă"
 
 msgid "Invalid JSON metadata"
 msgstr "Metadate JSON invalide"
@@ -7630,8 +8476,11 @@ msgstr "Expresie invalidă"
 msgid "Invalid filter operation type: %(op)s"
 msgstr "Tip operațiune filtru invalid: %(op)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Invalid formula expression"
-msgstr ""
+msgstr "Expresie de formulă nevalidă"
 
 msgid "Invalid geodetic string"
 msgstr "Șir geodezic invalid"
@@ -7682,9 +8531,11 @@ msgstr "Punct spațial invalid întâlnit: %(latlong)s"
 msgid "Invalid state."
 msgstr "Stare invalidă."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, sk, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
-msgstr ""
+msgstr "ID-uri de file nevalide: %(tab_ids)s"
 
 msgid "Invalid username or password"
 msgstr "Nume de utilizator sau parolă invalidă"
@@ -7746,13 +8597,21 @@ msgstr "Problemă 1000 - Setul de date este prea mare pentru interogare."
 msgid "Issue 1001 - The database is under an unusual load."
 msgstr "Problemă 1001 - Baza de date este sub o încărcare neobișnuită."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "It won't be removed even if empty. It won't be shown in chart editing "
 "view if empty."
 msgstr ""
+"Nu va fi eliminat chiar dacă este gol. Nu va fi afișat în vizualizarea de"
+" editare a graficului dacă este gol."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "It’s not recommended to truncate Y axis in Bar chart."
-msgstr ""
+msgstr "Nu se recomandă trunchierea axei Y în graficul cu bare."
 
 msgid "JAN"
 msgstr "IAN"
@@ -7825,14 +8684,20 @@ msgstr "Continuă editarea"
 msgid "Key"
 msgstr "Cheie"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Key Prefix"
-msgstr ""
+msgstr "Prefix cheie"
 
 msgid "Keyboard shortcuts"
 msgstr "Scurtături tastatură"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
-msgstr ""
+msgstr "Cheile sunt afișate o singură dată la creare. Păstrați-le în siguranță."
 
 msgid "Kilometers"
 msgstr "Kilometri"
@@ -7843,8 +8708,11 @@ msgstr "Etichetă"
 msgid "Label Contents"
 msgstr "Conținut Etichetă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label JavaScript config generator"
-msgstr ""
+msgstr "Generator de configurație JavaScript pentru etichetă"
 
 msgid "Label Line"
 msgstr "Linie Etichetă"
@@ -7861,8 +8729,11 @@ msgstr "Eticheta există deja"
 msgid "Label ascending"
 msgstr "Etichetă crescătoare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Label color"
-msgstr ""
+msgstr "Culoarea etichetei"
 
 msgid "Label descending"
 msgstr "Etichetă descrescătoare"
@@ -7876,14 +8747,23 @@ msgstr "Etichetă pentru interogarea ta"
 msgid "Label position"
 msgstr "Poziție etichetă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Label property name"
-msgstr ""
+msgstr "Numele proprietății etichetei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Label size"
-msgstr ""
+msgstr "Dimensiunea etichetei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Label size unit"
-msgstr ""
+msgstr "Unitate de dimensiune a etichetei"
 
 msgid "Label threshold"
 msgstr "Prag etichetă"
@@ -7923,8 +8803,11 @@ msgstr "Ultima Actualizare %s"
 msgid "Last Updated %s by %s"
 msgstr "Ultima Actualizare %s de %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Last Used"
-msgstr ""
+msgstr "Ultima utilizare"
 
 #, python-format
 msgid "Last available value seen on %s"
@@ -7951,15 +8834,20 @@ msgstr "Numele de familie este obligatoriu"
 msgid "Last quarter"
 msgstr "Ultimul trimestru"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Last queried at"
-msgstr ""
+msgstr "Ultima interogare la"
 
 msgid "Last run"
 msgstr "Ultima rulare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Last updated %s ago"
-msgstr ""
+msgstr "Ultima actualizare cu %s în urmă"
 
 msgid "Last week"
 msgstr "Ultima săptămână"
@@ -8062,8 +8950,11 @@ msgstr "Mai mic sau egal (<=)"
 msgid "Less than (<)"
 msgstr "Mai mic decât (<)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Liberty (OpenFreeMap)"
-msgstr ""
+msgstr "Liberty (OpenFreeMap)"
 
 msgid "Lift percent precision"
 msgstr "Precizie procent ridicare"
@@ -8071,8 +8962,11 @@ msgstr "Precizie procent ridicare"
 msgid "Light"
 msgstr "Luminos"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Light (Carto)"
-msgstr ""
+msgstr "Light (Carto)"
 
 msgid "Light mode"
 msgstr "Mod luminos"
@@ -8083,8 +8977,11 @@ msgstr "Ca"
 msgid "Like (case insensitive)"
 msgstr "Ca (insensibil la majuscule)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Limit"
-msgstr ""
+msgstr "Limită"
 
 msgid "Limit type"
 msgstr "Tip limită"
@@ -8198,8 +9095,11 @@ msgstr "Listă de valori de marcat cu triunghiuri"
 msgid "List updated"
 msgstr "Listă actualizată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "List view"
-msgstr ""
+msgstr "Vizualizare listă"
 
 msgid "Live render"
 msgstr "Redare în timp real"
@@ -8213,14 +9113,23 @@ msgstr "Date încărcate cache-uite"
 msgid "Loaded from cache"
 msgstr "Încărcat din cache"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "Loading"
-msgstr ""
+msgstr "Se încarcă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Loading filter values"
-msgstr ""
+msgstr "Se încarcă valorile filtrului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Loading timezones..."
-msgstr ""
+msgstr "Se încarcă fusurile orare..."
 
 msgid "Loading..."
 msgstr "Se încarcă..."
@@ -8316,8 +9225,11 @@ msgstr "LUN"
 msgid "Main"
 msgstr "Principal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Main navigation"
-msgstr ""
+msgstr "Navigare principală"
 
 msgid ""
 "Make sure that the controls are configured properly and the datasource "
@@ -8345,10 +9257,16 @@ msgstr "Gestionați editorii tabloului de bord și permisiunile de acces"
 msgid "Manage email report"
 msgstr "Gestionează raport email"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
+"Gestionați filtrele și personalizările pentru a seta scopul, descrierile "
+"și limitările. Creați elemente noi pentru o mai bună înțelegere a "
+"tabloului de bord."
 
 msgid "Manage your databases"
 msgstr "Gestionează bazele tale de date"
@@ -8365,28 +9283,45 @@ msgstr "Hartă"
 msgid "Map Options"
 msgstr "Opțiuni Hartă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Map Renderer"
-msgstr ""
+msgstr "Renderer hartă"
 
 msgid "Map Style"
 msgstr "Stil Hartă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "MapLibre (open-source)"
-msgstr ""
+msgstr "MapLibre (open-source)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
+"MapLibre este open-source și nu necesită o cheie API. Mapbox necesită "
+"configurarea MAPBOX_API_KEY pe server."
 
 msgid "Mapbox"
 msgstr "Mapbox"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Mapbox (API key required)"
-msgstr ""
+msgstr "Mapbox (cheie API necesară)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr ""
+msgstr "Mapbox necesită configurarea unui MAPBOX_API_KEY pe server."
 
 msgid "March"
 msgstr "Martie"
@@ -8427,8 +9362,11 @@ msgstr "Potrivește sistemul"
 msgid "Match time shift color with original series"
 msgstr "Potrivește culoarea deplasării de timp cu seria originală"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Match type"
-msgstr ""
+msgstr "Tip de potrivire"
 
 msgid "Matrixify"
 msgstr "Matrixify"
@@ -8454,11 +9392,17 @@ msgstr "Dimensiune Font Maximă"
 msgid "Maximum Radius"
 msgstr "Rază Maximă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Maximum Width"
-msgstr ""
+msgstr "Lățime maximă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Maximum folder nesting depth reached"
-msgstr ""
+msgstr "Adâncimea maximă de imbricare a folderelor a fost atinsă"
 
 msgid "Maximum number of features to fetch from service"
 msgstr "Număr maxim de caracteristici de preluat din serviciu"
@@ -8477,8 +9421,11 @@ msgstr "Valoare maximă"
 msgid "Maximum value on the gauge axis"
 msgstr "Valoare maximă pe axa cadranului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Dimensiunea maximă a lățimii traseului, în pixeli sau metri."
 
 msgid "May"
 msgstr "Mai"
@@ -8539,8 +9486,11 @@ msgstr "Parametri Metadate"
 msgid "Metadata has been synced"
 msgstr "Metadatele au fost sincronizate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Meters"
-msgstr ""
+msgstr "Metri"
 
 msgid "Method"
 msgstr "Metodă"
@@ -8646,18 +9596,29 @@ msgstr ""
 msgid "Metrics"
 msgstr "Indicatori"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Metrics (%s)"
-msgstr ""
+msgstr "Metrici (%s)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics can't be used for both rows and columns at the same time"
-msgstr ""
+msgstr "Metricile nu pot fi utilizate simultan pentru rânduri și coloane"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Metrics folder can only contain metric items"
-msgstr ""
+msgstr "Folderul de metrici poate conține doar elemente de tip metrică"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Metrics should be inside folders"
-msgstr ""
+msgstr "Metricile ar trebui să fie în interiorul folderelor"
 
 msgid "Metrics to show in the tooltip."
 msgstr "Indicatori de afișat în tooltip."
@@ -8707,8 +9668,11 @@ msgstr "Dimensiune Font Minimă"
 msgid "Minimum Radius"
 msgstr "Rază Minimă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Minimum Width"
-msgstr ""
+msgstr "Lățime minimă"
 
 msgid "Minimum must be strictly less than maximum"
 msgstr "Minimul trebuie să fie strict mai mic decât maximul"
@@ -8733,8 +9697,11 @@ msgstr "Valoare minimă pentru ca eticheta să fie afișată pe grafic."
 msgid "Minimum value on the gauge axis"
 msgstr "Valoare minimă pe axa cadranului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr ""
+msgstr "Dimensiunea minimă a lățimii traseului, în pixeli sau metri."
 
 msgid "Minor Split Line"
 msgstr "Linie Divizare Minoră"
@@ -8749,15 +9716,20 @@ msgstr "Minut"
 msgid "Minutes %s"
 msgstr "Minute %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Missing %s"
-msgstr ""
+msgstr "Lipsește %s"
 
 msgid "Missing OAuth2 token"
 msgstr "Token OAuth2 lipsă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Missing URL parameter"
-msgstr ""
+msgstr "Parametru URL lipsă"
 
 msgid "Missing URL parameters"
 msgstr "Parametri URL lipsă"
@@ -8803,8 +9775,11 @@ msgstr "Luni %s"
 msgid "More"
 msgstr "Mai mult"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "More Options"
-msgstr ""
+msgstr "Mai multe opțiuni"
 
 msgid "More filters"
 msgstr "Mai multe filtre"
@@ -8812,8 +9787,11 @@ msgstr "Mai multe filtre"
 msgid "MotherDuck token"
 msgstr "Token MotherDuck"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Move icon"
-msgstr ""
+msgstr "Pictogramă de mutare"
 
 msgid "Move only"
 msgstr "Mută doar"
@@ -8849,7 +9827,9 @@ msgstr "Multiplicator"
 msgid ""
 "Must be a chart editor to overwrite this chart. Save as a new chart "
 "instead."
-msgstr "Trebuie să fiți editor al graficului pentru a suprascrie acest grafic. Salvați-l ca un grafic nou."
+msgstr ""
+"Trebuie să fiți editor al graficului pentru a suprascrie acest grafic. "
+"Salvați-l ca un grafic nou."
 
 msgid "Must be unique"
 msgstr "Trebuie să fie unic"
@@ -8878,6 +9858,7 @@ msgstr "Indicatorul meu"
 msgid "N/A"
 msgstr "N/A"
 
+#. do-not-translate
 msgid "NOT GROUPED BY"
 msgstr "NU GRUPAT DUPĂ"
 
@@ -8905,8 +9886,11 @@ msgstr "Numele coloanei care conține id-ul nodului părinte"
 msgid "Name of the id column"
 msgstr "Numele coloanei id"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Name of the semantic layer"
-msgstr ""
+msgstr "Numele stratului semantic"
 
 msgid "Name of the source nodes"
 msgstr "Numele nodurilor sursă"
@@ -8920,8 +9904,13 @@ msgstr "Numele etichetei tale"
 msgid "Name your database"
 msgstr "Denumește baza ta de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
 msgstr ""
+"Dați un nume folderului dvs. și pentru a-l edita ulterior, faceți clic pe"
+" numele folderului"
 
 msgid "Native filter column is required"
 msgstr "Coloana filtrului nativ este obligatorie"
@@ -8947,11 +9936,17 @@ msgstr "Eroare rețea în timpul încercării de preluare a resursei"
 msgid "Network error."
 msgstr "Eroare rețea."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "New"
-msgstr ""
+msgstr "Nou"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "New Semantic Layer"
-msgstr ""
+msgstr "Strat semantic nou"
 
 msgid "New chart"
 msgstr "Grafic nou"
@@ -9002,8 +9997,11 @@ msgstr "Fără Rezultate"
 msgid "No Rules yet"
 msgstr "Nicio regulă încă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "No SQL query found"
-msgstr ""
+msgstr "Nu s-a găsit nicio interogare SQL"
 
 msgid "No Tags created"
 msgstr "Nicio etichetă creată"
@@ -9029,9 +10027,11 @@ msgstr "Fără filtre disponibile."
 msgid "No columns found"
 msgstr "Nicio coloană găsită"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "No compatible %s found"
-msgstr ""
+msgstr "Nu s-a găsit niciun %s compatibil"
 
 msgid "No compatible catalog found"
 msgstr "Niciun catalog compatibil găsit"
@@ -9074,14 +10074,20 @@ msgstr "Niciun filtru nu este selectat."
 msgid "No filters"
 msgstr "Fără filtre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "No filters applied"
-msgstr ""
+msgstr "Niciun filtru aplicat"
 
 msgid "No filters are currently added to this dashboard."
 msgstr "Niciun filtru nu este adăugat în prezent la acest panou de control."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "No filters or customizations created yet"
-msgstr ""
+msgstr "Nu au fost create filtre sau personalizări încă"
 
 msgid "No form settings were maintained"
 msgstr "Nicio setare de formular nu a fost menținută"
@@ -9101,11 +10107,19 @@ msgstr "Fără elemente"
 msgid "No matching records found"
 msgstr "Nicio înregistrare potrivită găsită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "No matching results found"
-msgstr ""
+msgstr "Nu au fost găsite rezultate corespunzătoare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr ""
+"Nu există diagrame deck.gl cu mai multe straturi adăugate în prezent la "
+"acest tablou de bord."
 
 msgid "No records found"
 msgstr "Nicio înregistrare găsită"
@@ -9138,13 +10152,17 @@ msgstr "Fără roluri"
 msgid "No roles yet"
 msgstr "Niciun rol încă"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "No rows were returned for this %s"
-msgstr ""
+msgstr "Nu au fost returnate rânduri pentru acest %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "No samples were returned for this %s"
-msgstr ""
+msgstr "Nu au fost returnate mostre pentru acest %s"
 
 msgid "No saved expressions found"
 msgstr "Nicio expresie salvată găsită"
@@ -9163,8 +10181,11 @@ msgstr ""
 msgid "No table columns"
 msgstr "Fără coloane de tabel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "No tasks yet"
-msgstr ""
+msgstr "Nicio sarcină încă"
 
 msgid "No temporal columns found"
 msgstr "Nicio coloană temporală găsită"
@@ -9251,8 +10272,11 @@ msgstr "Nu este definit"
 msgid "Not equal to (≠)"
 msgstr "Nu egal cu (≠)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Not found"
-msgstr ""
+msgstr "Negăsit"
 
 msgid "Not in"
 msgstr "Nu în"
@@ -9378,8 +10402,11 @@ msgstr "Coloană numerică folosită pentru calcularea histogramei."
 msgid "Numerical range"
 msgstr "Interval numeric"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "OAuth2 client information"
-msgstr ""
+msgstr "Informații despre clientul OAuth2"
 
 msgid "OCT"
 msgstr "OCT"
@@ -9390,6 +10417,7 @@ msgstr "OK"
 msgid "OR"
 msgstr "SAU"
 
+#. do-not-translate
 msgid "OVERWRITE"
 msgstr "SUPRASCRIE"
 
@@ -9471,11 +10499,17 @@ msgstr "Se aplică doar când \"Tip Etichetă\" nu este setat la un procent."
 msgid "Only applies when \"Label Type\" is set to show values."
 msgstr "Se aplică doar când \"Tip Etichetă\" este setat să afișeze valori."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
+msgstr "Doar potrivirea exactă este disponibilă pentru coloanele non-text."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Only proceed if you trust the destination or its source."
-msgstr ""
+msgstr "Continuați doar dacă aveți încredere în destinație sau în sursa acesteia."
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -9517,11 +10551,15 @@ msgstr "Deschide fila Sursă de Date"
 msgid "Open SQL Lab in a new tab"
 msgstr "Deschide SQL Lab într-o filă nouă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Open chart in new tab"
-msgstr ""
+msgstr "Deschide diagrama într-o filă nouă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Open dashboard in new tab"
-msgstr ""
+msgstr "Deschide tabloul de bord într-o filă nouă"
 
 msgid "Open in SQL Lab"
 msgstr "Deschide în SQL Lab"
@@ -9713,8 +10751,11 @@ msgstr "Dimensiune pagină:"
 msgid "Page length"
 msgstr "Lungime pagină"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Page navigation"
-msgstr ""
+msgstr "Navigare în pagină"
 
 msgid "Paired t-test Table"
 msgstr "Tabel test t pereche"
@@ -9775,9 +10816,10 @@ msgstr "Parolă"
 msgid "Password is required"
 msgstr "Parola este obligatorie"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid "Password must be at least %(min_length)s characters long."
-msgstr ""
+msgstr "Parola trebuie să aibă cel puțin %(min_length)s caractere."
 
 msgid "Password:"
 msgstr "Parolă:"
@@ -9800,23 +10842,38 @@ msgstr "Lipește URL-ul partajabil al foii Google aici"
 msgid "Paste your access token here"
 msgstr "Lipește token-ul tău de acces aici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Path Color"
-msgstr ""
+msgstr "Culoarea traseului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Path Size"
-msgstr ""
+msgstr "Dimensiunea traseului"
 
 msgid "Pattern"
 msgstr "Model"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Pause auto refresh if tab is inactive"
-msgstr ""
+msgstr "Suspendă actualizarea automată dacă fila este inactivă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy
 msgid "Pause auto-refresh"
-msgstr ""
+msgstr "Suspendă actualizarea automată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Pending"
-msgstr ""
+msgstr "În așteptare"
 
 msgid "Per user caching"
 msgstr "Cache per utilizator"
@@ -9879,8 +10936,11 @@ msgstr "Persoană sau grup care a certificat acest panou de control."
 msgid "Person or group that has certified this metric"
 msgstr "Persoană sau grup care a certificat acest indicator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Personal info"
-msgstr ""
+msgstr "Informații personale"
 
 msgid "Physical"
 msgstr "Fizic"
@@ -9945,11 +11005,17 @@ msgstr "Fixare stânga"
 msgid "Pin Right"
 msgstr "Fixare dreapta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Pin to the result panel"
-msgstr ""
+msgstr "Fixează în panoul de rezultate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Pin to top"
-msgstr ""
+msgstr "Fixează sus"
 
 msgid "Pivot Mode"
 msgstr "Mod pivot"
@@ -10086,9 +11152,13 @@ msgstr ""
 msgid "Please select at least one role or group"
 msgstr "Vă rugăm să selectați cel puțin un rol sau grup"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Please select both a %s and a Chart type to proceed"
 msgstr ""
+"Vă rugăm să selectați atât un %s cât și un tip de diagramă pentru a "
+"continua"
 
 #, python-format
 msgid ""
@@ -10117,8 +11187,11 @@ msgstr ""
 msgid "Plugins"
 msgstr "Plugin-uri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Point Cluster Map"
-msgstr ""
+msgstr "Hartă de clustere de puncte"
 
 msgid "Point Color"
 msgstr "Culoare punct"
@@ -10132,8 +11205,10 @@ msgstr "Scală rază punct"
 msgid "Point Radius Unit"
 msgstr "Unitate rază punct"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Point Radius Units"
-msgstr ""
+msgstr "Unități pentru raza punctului"
 
 msgid "Point Size"
 msgstr "Dimensiune punct"
@@ -10246,8 +11321,11 @@ msgstr "Limite axa y primară"
 msgid "Primary y-axis format"
 msgstr "Format axa y principală"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Private"
-msgstr ""
+msgstr "Privat"
 
 msgid "Private Channels (Bot in channel)"
 msgstr "Canale private (Bot în canal)"
@@ -10283,11 +11361,17 @@ msgstr "ID proiect"
 msgid "Proportional"
 msgstr "Proporțional"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Public and privately shared sheets"
-msgstr ""
+msgstr "Foi partajate public și privat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Publicly shared sheets only"
-msgstr ""
+msgstr "Doar foi partajate public"
 
 msgid "Published"
 msgstr "Publicat"
@@ -10333,8 +11417,11 @@ msgstr "Interogare B"
 msgid "Query History"
 msgstr "Istoric interogări"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Query State"
-msgstr ""
+msgstr "Starea interogării"
 
 msgid "Query cannot be loaded."
 msgstr "Interogarea nu poate fi încărcată."
@@ -10372,8 +11459,11 @@ msgstr "Interogarea a fost oprită"
 msgid "Query was stopped."
 msgstr "Interogarea a fost oprită."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Queued"
-msgstr ""
+msgstr "În coadă"
 
 msgid "RGB Color"
 msgstr "Culoare RGB"
@@ -10453,8 +11543,11 @@ msgstr "Recente"
 msgid "Recipients are separated by \",\" or \";\""
 msgstr "Destinatarii sunt separați prin \",\" sau \";\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Records"
-msgstr ""
+msgstr "Înregistrări"
 
 msgid "Rectangle"
 msgstr "Dreptunghi"
@@ -10497,8 +11590,11 @@ msgstr "Reîncarcă rezultatele"
 msgid "Refresh dashboard"
 msgstr "Actualizează panoul de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Refresh delayed"
-msgstr ""
+msgstr "Reîmprospătare întârziată"
 
 msgid "Refresh frequency"
 msgstr "Frecvență actualizare"
@@ -10537,8 +11633,11 @@ msgstr "Înregistrare"
 msgid "Registration date"
 msgstr "Data înregistrării"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Registration successful"
-msgstr ""
+msgstr "Înregistrare reușită"
 
 msgid "Regular"
 msgstr "Regulat"
@@ -10573,8 +11672,10 @@ msgstr "Cantitate relativă"
 msgid "Reload"
 msgstr "Reîncarcă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Reload SQL Lab"
-msgstr ""
+msgstr "Reîncărcați SQL Lab"
 
 msgid "Remove"
 msgstr "Elimină"
@@ -10588,11 +11689,17 @@ msgstr "Elimină tema implicită de sistem"
 msgid "Remove cross-filter"
 msgstr "Elimină filtru transversal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Remove customization"
-msgstr ""
+msgstr "Eliminați personalizarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Remove filter"
-msgstr ""
+msgstr "Eliminați filtrul"
 
 msgid "Remove item"
 msgstr "Elimină element"
@@ -10691,8 +11798,10 @@ msgstr "Raportul este activ"
 msgid "Report name"
 msgstr "Nume raport"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Report not yet run"
-msgstr ""
+msgstr "Raportul nu a fost executat încă"
 
 msgid "Report schedule client error"
 msgstr "Eroare client programare raport"
@@ -10746,9 +11855,10 @@ msgstr "Valorile de control obligatorii au fost eliminate"
 msgid "Resample"
 msgstr "Re-eșantionare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid "Resample method '%(method)s' is not supported."
-msgstr ""
+msgstr "Metoda de reeșantionare '%(method)s' nu este acceptată."
 
 msgid "Resample method should be in "
 msgstr "Metoda de re-eșantionare ar trebui să fie în "
@@ -10762,8 +11872,11 @@ msgstr "Resetează"
 msgid "Reset Columns"
 msgstr "Resetează coloanele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset all folders to default"
-msgstr ""
+msgstr "Resetați toate folderele la valorile implicite"
 
 msgid "Reset columns"
 msgstr "Resetează coloanele"
@@ -10777,11 +11890,17 @@ msgstr "Resetează parola"
 msgid "Reset state"
 msgstr "Resetează starea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Reset to default folders?"
-msgstr ""
+msgstr "Resetați la folderele implicite?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Resize"
-msgstr ""
+msgstr "Redimensionare"
 
 msgid "Resource already has an attached report."
 msgstr "Resursa are deja un raport atașat."
@@ -10789,8 +11908,13 @@ msgstr "Resursa are deja un raport atașat."
 msgid "Resource was not found."
 msgstr "Resursa nu a fost găsită."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fi, fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Resource was removed before editorship could be verified"
 msgstr ""
+"Resursa a fost eliminată înainte ca dreptul de editare să poată fi "
+"verificat"
 
 msgid "Restore filter"
 msgstr "Restaurează filtru"
@@ -10810,8 +11934,11 @@ msgstr ""
 "Backend-ul de rezultate necesar pentru interogările asincrone nu este "
 "configurat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Resume auto-refresh"
-msgstr ""
+msgstr "Reluați reîmprospătarea automată"
 
 msgid "Retry"
 msgstr "Reîncearcă"
@@ -10819,8 +11946,11 @@ msgstr "Reîncearcă"
 msgid "Retry fetching results"
 msgstr "Reîncearcă preluarea rezultatelor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Return to Superset"
-msgstr ""
+msgstr "Întoarceți-vă la Superset"
 
 msgid "Return to specific datetime."
 msgstr "Revenire la dată/ora specifică."
@@ -10831,17 +11961,29 @@ msgstr "Inversează Lat & Long"
 msgid "Reverse lat/long "
 msgstr "Inversează lat/long "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Revoke"
-msgstr ""
+msgstr "Revocare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Revoke API Key"
-msgstr ""
+msgstr "Revocare cheie API"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Revoke this API key"
-msgstr ""
+msgstr "Revocați această cheie API"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Revoked"
-msgstr ""
+msgstr "Revocat"
 
 msgid "Rich Tooltip"
 msgstr "Tooltip bogat"
@@ -10858,11 +12000,18 @@ msgstr "Format axa dreaptă"
 msgid "Right Axis Metric"
 msgstr "Indicator axa dreaptă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Right Panel"
-msgstr ""
+msgstr "Panoul din dreapta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, sr, sr_Latn,
+# tr, uk, zh, zh_TW]
+#, fuzzy
 msgid "Right axis metric"
-msgstr ""
+msgstr "Metrica axei drepte"
 
 msgid "Right to Left"
 msgstr "Dreapta la Stânga"
@@ -10951,8 +12100,11 @@ msgstr "Limită rânduri"
 msgid "Rows"
 msgstr "Rânduri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Rows (vertical layout)"
-msgstr ""
+msgstr "Rânduri (aspect vertical)"
 
 msgid "Rows per page, 0 means no pagination"
 msgstr "Rânduri pe pagină, 0 înseamnă fără paginare"
@@ -11018,11 +12170,17 @@ msgstr "SQL"
 msgid "SQL Lab"
 msgstr "SQL Lab"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "SQL Lab cannot authorise a statement that could not be fully parsed. "
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
+"SQL Lab nu poate autoriza o instrucțiune care nu a putut fi complet "
+"analizată. Calificați tabelele explicit și evitați SQL dinamic în "
+"procedurile stocate sau apelurile specifice furnizorului."
 
 msgid "SQL Lab queries"
 msgstr "Interogări SQL Lab"
@@ -11093,8 +12251,11 @@ msgstr "Parametrii tunelului SSH sunt invalizi."
 msgid "SSH Tunneling is not enabled"
 msgstr "Tunelarea SSH nu este activată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "SSL"
-msgstr ""
+msgstr "SSL"
 
 msgid "SSL Mode \"require\" will be used."
 msgstr "Modul SSL \"require\" va fi folosit."
@@ -11151,9 +12312,11 @@ msgstr "Salvează (Suprascrie)"
 msgid "Save as"
 msgstr "Salvează ca"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Save as %s"
-msgstr ""
+msgstr "Salvare ca %s"
 
 msgid "Save as Dataset"
 msgstr "Salvează ca set de date"
@@ -11197,8 +12360,11 @@ msgstr "Salvează sau suprascrie setul de date"
 msgid "Save query"
 msgstr "Salvează interogare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Save this API key securely"
-msgstr ""
+msgstr "Salvați această cheie API în siguranță"
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr ""
@@ -11235,8 +12401,11 @@ msgstr "Se salvează..."
 msgid "Scale and Move"
 msgstr "Scalare și mutare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
-msgstr ""
+msgstr "Factor de scalare aplicat lățimilor de linie bazate pe metrici"
 
 msgid "Scale only"
 msgstr "Doar scalare"
@@ -11326,20 +12495,29 @@ msgstr "Caută indicatori și coloane"
 msgid "Search all charts"
 msgstr "Caută în toate graficele"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Search all metrics & columns"
-msgstr ""
+msgstr "Căutați toate metricile și coloanele"
 
 msgid "Search box"
 msgstr "Caseta de căutare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# ru, sr, sr_Latn]
+#, fuzzy
 msgid "Search by"
-msgstr ""
+msgstr "Căutare după"
 
 msgid "Search by query text"
 msgstr "Caută după textul interogării"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Search calculated columns by name"
-msgstr ""
+msgstr "Căutați coloanele calculate după nume"
 
 msgid "Search charts by name, editor, or dashboard"
 msgstr "Căutați grafice după nume, editor sau tablou de bord"
@@ -11347,8 +12525,11 @@ msgstr "Căutați grafice după nume, editor sau tablou de bord"
 msgid "Search columns"
 msgstr "Caută coloane"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Search columns by name"
-msgstr ""
+msgstr "Căutați coloanele după nume"
 
 msgid "Search columns..."
 msgstr "Caută coloane..."
@@ -11359,8 +12540,11 @@ msgstr "Căutați editori"
 msgid "Search in filters"
 msgstr "Caută în filtre"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Search metrics by key or label"
-msgstr ""
+msgstr "Căutați metrici după cheie sau etichetă"
 
 msgid "Search tags"
 msgstr "Caută etichete"
@@ -11402,8 +12586,11 @@ msgstr "Extra securizat"
 msgid "Security"
 msgstr "Securitate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "See "
-msgstr ""
+msgstr "Consultați "
 
 #, python-format
 msgid "See all %(tableName)s"
@@ -11421,9 +12608,11 @@ msgstr "Vezi detalii interogare"
 msgid "Select"
 msgstr "Selectează"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Select %s or type to search %s"
-msgstr ""
+msgstr "Selectați %s sau tastați pentru a căuta %s"
 
 msgid "Select ..."
 msgstr "Selectează ..."
@@ -11432,8 +12621,11 @@ msgstr "Selectează ..."
 msgid "Select All"
 msgstr "Golește"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select Database and Schema"
-msgstr ""
+msgstr "Selectați baza de date și schema"
 
 msgid "Select Delivery Method"
 msgstr "Selectează metoda de livrare"
@@ -11447,9 +12639,11 @@ msgstr "Selectează etichete"
 msgid "Select Value"
 msgstr "Selectează valoare"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Select a %s"
-msgstr ""
+msgstr "Selectați un %s"
 
 msgid "Select a CSS template"
 msgstr "Selectează un șablon CSS"
@@ -11506,11 +12700,17 @@ msgstr "Selectează o schemă"
 msgid "Select a schema if the database supports this"
 msgstr "Selectează o schemă dacă baza de date suportă acest lucru"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select a semantic layer"
-msgstr ""
+msgstr "Selectați un strat semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select a semantic layer type"
-msgstr ""
+msgstr "Selectați un tip de strat semantic"
 
 msgid "Select a sheet name from the uploaded file"
 msgstr "Selectează un nume de foaie din fișierul încărcat"
@@ -11534,8 +12734,11 @@ msgstr "Selectează un tip de vizualizare"
 msgid "Select aggregate options"
 msgstr "Selectează opțiuni agregare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select all"
-msgstr ""
+msgstr "Selectați tot"
 
 msgid "Select all data"
 msgstr "Selectează toate datele"
@@ -11567,8 +12770,11 @@ msgstr "Selectează schemă de culori"
 msgid "Select column"
 msgstr "Selectează coloană"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select column name"
-msgstr ""
+msgstr "Selectați numele coloanei"
 
 msgid ""
 "Select columns that will be displayed in the table. You can multiselect "
@@ -11580,8 +12786,11 @@ msgstr ""
 msgid "Select content type"
 msgstr "Selectează tip conținut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select currency code column"
-msgstr ""
+msgstr "Selectați coloana codului de monedă"
 
 msgid "Select current page"
 msgstr "Selectează pagina curentă"
@@ -11610,8 +12819,11 @@ msgstr ""
 msgid "Select dataset source"
 msgstr "Selectează sursa setului de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select datetime column"
-msgstr ""
+msgstr "Selectați coloana dată/oră"
 
 msgid "Select dimension"
 msgstr "Selectează dimensiune"
@@ -11646,6 +12858,9 @@ msgstr "Selectează format"
 msgid "Select groups"
 msgstr "Selectează grupuri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select layers in the order you want them stacked. First selected appears "
 "at the bottom.Layers let you combine multiple visualizations on one map. "
@@ -11653,12 +12868,24 @@ msgid ""
 "arcs) that displays different data or insights. Stack them to reveal "
 "patterns and relationships across your data."
 msgstr ""
+"Selectați straturile în ordinea în care doriți să fie suprapuse. Primul "
+"selectat apare în partea de jos. Straturile vă permit să combinați mai "
+"multe vizualizări pe o singură hartă. Fiecare strat este un grafic "
+"deck.gl salvat (precum diagrame de dispersie, poligoane sau arce) care "
+"afișează date sau perspective diferite. Suprapuneți-le pentru a descoperi"
+" tipare și relații în datele dvs."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Select layers to hide"
-msgstr ""
+msgstr "Selectați straturile de ascuns"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select object name"
-msgstr ""
+msgstr "Selectați numele obiectului"
 
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
@@ -11695,8 +12922,11 @@ msgstr "Selectează sau tastează numele setului de date"
 msgid "Select page size"
 msgstr "Selectează dimensiune pagină"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select permissions"
-msgstr ""
+msgstr "Selectați permisiuni"
 
 msgid "Select roles"
 msgstr "Selectează roluri"
@@ -11707,14 +12937,20 @@ msgstr "Selectați indicatorii salvați"
 msgid "Select saved queries"
 msgstr "Selectează interogări salvate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select schema"
-msgstr ""
+msgstr "Selectați schema"
 
 msgid "Select scheme"
 msgstr "Selectează schemă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Select semantic views"
-msgstr ""
+msgstr "Selectați vizualizări semantice"
 
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
@@ -11778,12 +13014,20 @@ msgstr ""
 "Selectați culoarea folosită pentru valorile care indică o scădere în "
 "grafic."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Select the column containing currency codes such as USD, EUR, GBP, etc. "
 "Used when building charts when 'Auto-detect' currency formatting is "
 "enabled. If this column is not set or if a chart metric contains multiple"
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
+"Selectați coloana care conține coduri de valută, cum ar fi USD, EUR, GBP "
+"etc. Utilizată la crearea diagramelor când formatarea valutară 'Auto-"
+"detect' este activată. Dacă această coloană nu este setată sau dacă o "
+"metrică a diagramei conține mai multe valute, diagramele vor reveni la "
+"formatarea numerică neutră."
 
 msgid "Select the fixed color"
 msgstr "Selectați culoarea fixă"
@@ -11791,15 +13035,26 @@ msgstr "Selectați culoarea fixă"
 msgid "Select the geojson column"
 msgstr "Selectați coloana geojson"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
+"Selectați furnizorul de tile-uri pentru hartă. MapLibre este open-source "
+"și nu necesită cheie API. Mapbox necesită configurarea MAPBOX_API_KEY în "
+"Superset."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select the metric used to determine which color breakpoint range each "
 "path falls into."
 msgstr ""
+"Selectați metrica utilizată pentru a determina în ce interval de puncte "
+"de culoare se încadrează fiecare cale."
 
 msgid "Select the type of color scheme to use."
 msgstr "Selectați tipul de schemă de culori de folosit."
@@ -11818,14 +13073,24 @@ msgstr ""
 "Selectează valori în câmpurile evidențiate din panoul de control. Apoi "
 "rulează interogarea făcând clic pe butonul %s."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Select which time grains are available in the filter control. This is a "
 "UI allow list only and does not add extra conditions to the underlying "
 "queries."
 msgstr ""
+"Selectați care intervale de timp sunt disponibile în controlul de "
+"filtrare. Aceasta este doar o listă de permisiuni pentru interfața "
+"utilizatorului și nu adaugă condiții suplimentare interogărilor "
+"subiacente."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Selected"
-msgstr ""
+msgstr "Selectat"
 
 msgid "Selecting a database is required"
 msgstr "Selectarea unei baze de date este obligatorie"
@@ -11833,65 +13098,125 @@ msgstr "Selectarea unei baze de date este obligatorie"
 msgid "Selection method"
 msgstr "Metodă selecție"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic"
-msgstr ""
+msgstr "Semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic Layer"
-msgstr ""
+msgstr "Strat semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic View"
-msgstr ""
+msgstr "Vizualizare semantică"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic Views"
-msgstr ""
+msgstr "Vizualizări semantice"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer"
-msgstr ""
+msgstr "Strat semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be created."
-msgstr ""
+msgstr "Stratul semantic nu a putut fi creat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be deleted."
-msgstr ""
+msgstr "Stratul semantic nu a putut fi șters."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer could not be updated."
-msgstr ""
+msgstr "Stratul semantic nu a putut fi actualizat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer created"
-msgstr ""
+msgstr "Strat semantic creat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer does not exist"
-msgstr ""
+msgstr "Stratul semantic nu există"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer parameters are invalid."
-msgstr ""
+msgstr "Parametrii stratului semantic sunt invalizi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer type"
-msgstr ""
+msgstr "Tipul stratului semantic"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic layer updated"
-msgstr ""
+msgstr "Strat semantic actualizat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be created."
-msgstr ""
+msgstr "Vizualizarea semantică nu a putut fi creată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be deleted."
-msgstr ""
+msgstr "Vizualizarea semantică nu a putut fi ștearsă."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic view could not be updated."
-msgstr ""
+msgstr "Vizualizarea semantică nu a putut fi actualizată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Semantic view does not exist"
-msgstr ""
+msgstr "Vizualizarea semantică nu există"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view parameters are invalid."
-msgstr ""
+msgstr "Parametrii vizualizării semantice sunt invalizi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic view updated"
-msgstr ""
+msgstr "Vizualizare semantică actualizată"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Semantic views"
-msgstr ""
+msgstr "Vizualizări semantice"
 
 msgid "Send as CSV"
 msgstr "Trimite ca CSV"
@@ -11966,11 +13291,17 @@ msgstr "Setează tema întunecată a sistemului"
 msgid "Set System Default Theme"
 msgstr "Setează tema implicită a sistemului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default dark theme"
-msgstr ""
+msgstr "Setați ca temă întunecată implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Set as default light theme"
-msgstr ""
+msgstr "Setați ca temă luminoasă implicită"
 
 msgid "Set auto-refresh"
 msgstr "Setează actualizare automată"
@@ -11978,8 +13309,11 @@ msgstr "Setează actualizare automată"
 msgid "Set filter mapping"
 msgstr "Setează mapare filtru"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Set local theme for testing"
-msgstr ""
+msgstr "Setați tema locală pentru testare"
 
 msgid "Set local theme for testing (preview only)"
 msgstr "Setează temă locală pentru testare (doar previzualizare)"
@@ -12003,11 +13337,18 @@ msgstr "Configurează un raport email"
 msgid "Set up basic details, such as name and description."
 msgstr "Configurează detalii de bază, cum ar fi numele și descrierea."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Sets the default temporal column for this dataset. Automatically selected"
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
+"Setează coloana temporală implicită pentru acest set de date. Selectată "
+"automat ca coloană de timp la construirea graficelor care necesită o "
+"dimensiune temporală și utilizată în filtrele de timp la nivel de tablou "
+"de bord."
 
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
@@ -12036,8 +13377,11 @@ msgstr "Partajează grafic prin email"
 msgid "Share permalink by email"
 msgstr "Partajează link permanent prin email"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Shared"
-msgstr ""
+msgstr "Partajat"
 
 msgid "Shared query"
 msgstr "Interogare partajată"
@@ -12112,8 +13456,11 @@ msgstr "Afișează nume indicatori"
 msgid "Show Range Filter"
 msgstr "Afișează filtru interval"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Show SQL"
-msgstr ""
+msgstr "Afișați SQL"
 
 msgid "Show Timestamp"
 msgstr "Afișează marcaj temporal"
@@ -12155,14 +13502,20 @@ msgstr "Afișează gradațiile axei"
 msgid "Show cell bars"
 msgstr "Afișează bare în celule"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Show cell bars for all columns"
-msgstr ""
+msgstr "Afișați bare de celule pentru toate coloanele"
 
 msgid "Show chart description"
 msgstr "Afișează descrierea graficului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Show chart query timestamps"
-msgstr ""
+msgstr "Afișați marcajele de timp ale interogărilor graficului"
 
 msgid "Show column headers"
 msgstr "Afișează antetele coloanelor"
@@ -12360,8 +13713,11 @@ msgstr "Sare peste liniile goale în loc să le interpreteze ca valori Not A Num
 msgid "Skip rows"
 msgstr "Sare rânduri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Skip rows is required"
-msgstr ""
+msgstr "Numărul de rânduri de sărit este obligatoriu"
 
 msgid "Skip spaces after delimiter"
 msgstr "Sare spații după delimitator"
@@ -12402,14 +13758,23 @@ msgstr ""
 msgid "Solid"
 msgstr "Solid"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Unele grupuri nu au putut fi rezolvate și sunt afișate ca ID-uri."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
-msgstr ""
+msgstr "Unele permisiuni nu au putut fi rezolvate și sunt afișate ca ID-uri."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Some required filters on other tabs have values and will not be cleared"
-msgstr ""
+msgstr "Unele filtre obligatorii de pe alte file au valori și nu vor fi șterse"
 
 msgid "Some roles do not exist"
 msgstr "Unele roluri nu există"
@@ -12511,11 +13876,17 @@ msgstr "Sortează după date"
 msgid "Sort by metric"
 msgstr "Sortează după indicator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Sort by original table order"
-msgstr ""
+msgstr "Sortare după ordinea originală a tabelului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Sort by series"
-msgstr ""
+msgstr "Sortare după serie"
 
 msgid "Sort columns alphabetically"
 msgstr "Sortează coloanele alfabetic"
@@ -12526,8 +13897,11 @@ msgstr "Sortează coloane după"
 msgid "Sort descending"
 msgstr "Sortează descrescător"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Sort display control values"
-msgstr ""
+msgstr "Sortați valorile controlului de afișare"
 
 msgid "Sort filter values"
 msgstr "Sortează valorile filtrului"
@@ -12541,11 +13915,18 @@ msgstr "Sortează indicator"
 msgid "Sort query by"
 msgstr "Sortează interogare după"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Sort results by series name in ascending order. When combined with \"Sort"
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
+"Sortați rezultatele după numele seriei în ordine crescătoare. Când este "
+"combinat cu „Sortare după metrică\", acesta acționează ca un factor de "
+"departajare pentru valorile egale ale metricii. Adăugarea acestei sortări"
+" poate reduce performanța interogărilor pe unele baze de date."
 
 msgid "Sort rows by"
 msgstr "Sortează rânduri după"
@@ -12568,8 +13949,11 @@ msgstr "SQL sursă"
 msgid "Source category"
 msgstr "Categorie sursă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Source location"
-msgstr ""
+msgstr "Locație sursă"
 
 msgid "Sparkline"
 msgstr "Sparkline"
@@ -12676,8 +14060,11 @@ msgstr "Început"
 msgid "Starts With"
 msgstr "Începe cu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Starts with (ILIKE x%)"
-msgstr ""
+msgstr "Începe cu (ILIKE x%)"
 
 msgid "State"
 msgstr "Stare"
@@ -12735,11 +14122,16 @@ msgstr "Flux"
 msgid "Streets"
 msgstr "Străzi"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Streets (Carto)"
-msgstr ""
+msgstr "Străzi (Carto)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Streets (OSM)"
-msgstr ""
+msgstr "Străzi (OSM)"
 
 msgid "Strength to pull the graph toward center"
 msgstr "Forță pentru a trage graficul spre centru"
@@ -12756,8 +14148,13 @@ msgstr "Cu contur"
 msgid "Structural"
 msgstr "Structural"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
 msgstr ""
+"Structura este gestionată de stratul semantic upstream și este doar "
+"pentru citire."
 
 msgid "Style"
 msgstr "Stil"
@@ -12774,23 +14171,38 @@ msgstr "Subcategorii"
 msgid "Subdomain"
 msgstr "Subdomeniu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Subject"
-msgstr ""
+msgstr "Subiect"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Subject type"
-msgstr ""
+msgstr "Tipul subiectului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Subjects"
-msgstr ""
+msgstr "Subiecte"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid "Subjects are invalid"
-msgstr ""
+msgstr "Subiectele nu sunt valide"
 
 msgid "Submit"
 msgstr "Trimite"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Subscribers"
-msgstr ""
+msgstr "Abonați"
 
 msgid "Subtitle"
 msgstr "Subtitlu"
@@ -12801,9 +14213,11 @@ msgstr "Subtotal"
 msgid "Success"
 msgstr "Succes"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Successfully changed %s!"
-msgstr ""
+msgstr "%s a fost modificat cu succes!"
 
 msgid "Suffix"
 msgstr "Sufix"
@@ -12847,8 +14261,11 @@ msgstr "Documentația Superset Embedded SDK."
 msgid "Superset chart"
 msgstr "Grafic Superset"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Superset docs link"
-msgstr ""
+msgstr "Link documentație Superset"
 
 msgid "Superset encountered an error while running a command."
 msgstr "Superset a întâmpinat o eroare în timpul rulării unei comenzi."
@@ -12859,9 +14276,11 @@ msgstr "Superset a întâmpinat o eroare neașteptată."
 msgid "Supported databases"
 msgstr "Baze de date suportate"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Swap %s"
-msgstr ""
+msgstr "Schimbați %s"
 
 msgid "Swap rows and columns"
 msgstr "Schimbă rânduri și coloane"
@@ -12928,6 +14347,7 @@ msgstr "Tema implicită a sistemului a fost eliminată"
 msgid "TABLES"
 msgstr "TABELE"
 
+#. do-not-translate
 msgid "TEMPORAL_RANGE"
 msgstr "INTERVAL_TEMPORAL"
 
@@ -12985,8 +14405,11 @@ msgstr "Coloane tabel"
 msgid "Table name"
 msgstr "Nume tabel"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Table name is required"
-msgstr ""
+msgstr "Numele tabelului este obligatoriu"
 
 msgid "Table name undefined"
 msgstr "Numele tabelului este nedefinit"
@@ -13063,35 +14486,65 @@ msgstr "Categorie țintă"
 msgid "Target value"
 msgstr "Valoare țintă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Task"
-msgstr ""
+msgstr "Sarcină"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "Task cancelled: %s"
-msgstr ""
+msgstr "Sarcină anulată: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Task could not be aborted."
-msgstr ""
+msgstr "Sarcina nu a putut fi întreruptă."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Task could not be created."
-msgstr ""
+msgstr "Sarcina nu a putut fi creată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Task could not be updated."
-msgstr ""
+msgstr "Sarcina nu a putut fi actualizată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
+"Sarcina nu poate fi întreruptă. Sarcina este în curs de desfășurare, dar "
+"nu a înregistrat un handler de anulare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Task parameters are invalid."
-msgstr ""
+msgstr "Parametrii sarcinii nu sunt valizi."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Tasks"
-msgstr ""
+msgstr "Sarcini"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Tasks will appear here as background operations are executed."
 msgstr ""
+"Sarcinile vor apărea aici pe măsură ce operațiunile din fundal sunt "
+"executate."
 
 msgid "Template"
 msgstr "Șablon"
@@ -13113,9 +14566,11 @@ msgstr "Parametri șablon"
 msgid "Template processing error: %(error)s"
 msgstr "Eroare procesare șablon: %(error)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr ""
+msgstr "Procesarea șablonului a eșuat: %(ex)s"
 
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
@@ -13151,13 +14606,17 @@ msgstr "Aliniere text"
 msgid "Text embedded in email"
 msgstr "Text încorporat în email"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "The %s"
-msgstr ""
+msgstr "%s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "The %s linked to this chart may have been deleted."
-msgstr ""
+msgstr "%s legat de acest grafic poate fi șters."
 
 #, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
@@ -13186,21 +14645,40 @@ msgstr ""
 "GeoJsonLayer preia date formatate GeoJSON și le redă ca poligoane, linii "
 "și puncte interactive (cercuri, icoane și/sau texte)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Please contact your "
 "administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
+"Global Task Framework nu este activat. Contactați administratorul pentru "
+"a activa flag-ul de funcționalitate GLOBAL_TASK_FRAMEWORK."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
 "in your feature flags to use @task. See "
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
+"Global Task Framework nu este activat. Setați GLOBAL_TASK_FRAMEWORK=True "
+"în flag-urile de funcționalitate pentru a utiliza @task. Consultați "
+"https://superset.apache.org/docs/configuration/async-queries-celery "
+"pentru detalii de configurare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "The SSH server host key could not be verified against the expected key."
 msgstr ""
+"Cheia gazdă a serverului SSH nu a putut fi verificată față de cheia "
+"așteptată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The Sankey chart visually tracks the movement and transformation of "
 "values across\n"
@@ -13210,6 +14688,13 @@ msgid ""
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
+"Graficul Sankey urmărește vizual mișcarea și transformarea valorilor prin"
+"\n"
+"          etapele sistemului. Nodurile reprezintă etape, conectate prin "
+"legături care ilustrează fluxul de valori. Înălțimea\n"
+"          nodului corespunde metricii vizualizate, oferind o reprezentare"
+" clară a\n"
+"          distribuției și transformării valorilor."
 
 msgid "The URL is missing the dataset_id or slice_id parameters."
 msgstr "URL-ului îi lipsesc parametrii dataset_id sau slice_id."
@@ -13242,8 +14727,22 @@ msgstr ""
 "Categoria nodurilor sursă folosite pentru atribuirea culorilor. Dacă un "
 "nod este asociat cu mai mult de o categorie, doar prima va fi folosită."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid ""
+"The chart this report targets was deleted. Restore the chart, or update "
+"the report to point at an active chart."
+msgstr ""
+"Graficul vizat de acest raport a fost șters. Restaurați graficul sau "
+"actualizați raportul pentru a indica un grafic activ."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fi, ja, lv, sk, sr, sr_Latn, th, uk]
+#, fuzzy
 msgid "The chart is still loading. Please wait a moment and try again."
 msgstr ""
+"Graficul se mai încarcă. Vă rugăm așteptați un moment și încercați din "
+"nou."
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
@@ -13274,8 +14773,11 @@ msgstr "Culoarea izobandei"
 msgid "The color of the isoline"
 msgstr "Culoarea izolinei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The color of the point labels"
-msgstr ""
+msgstr "Culoarea etichetelor punctelor"
 
 msgid "The color scheme for rendering chart"
 msgstr "Schema de culori pentru randarea graficului"
@@ -13324,18 +14826,17 @@ msgstr ""
 "Standardul codului de țară pe care Superset ar trebui să-l găsească în "
 "coloana [country]"
 
-msgid ""
-"The chart this report targets was deleted. Restore the chart, or update "
-"the report to point at an active chart."
-msgstr ""
-
 msgid "The dashboard has been saved"
 msgstr "Panoul de control a fost salvat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "The dashboard this report targets was deleted. Restore the dashboard, or "
 "update the report to point at an active dashboard."
 msgstr ""
+"Tabloul de bord vizat de acest raport a fost șters. Restaurați tabloul de"
+" bord sau actualizați raportul pentru a indica un tablou de bord activ."
 
 msgid "The data source seems to have been deleted"
 msgstr "Sursa de date pare să fi fost ștearsă"
@@ -13475,8 +14976,11 @@ msgstr ""
 "extinderea astfel încât toate punctele de date sunt incluse în viewport. "
 "CUSTOM permite utilizatorilor să definească extinderea manual."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The feature property to use for point labels"
-msgstr ""
+msgstr "Proprietatea entității de utilizat pentru etichetele punctelor"
 
 #, python-format
 msgid ""
@@ -13486,10 +14990,15 @@ msgstr ""
 "Următoarele intrări din `series_columns` lipsesc din `columns`: "
 "%(columns)s. "
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
+"Câmpurile de mai jos conțin informații sensibile care au fost mascate la "
+"exportare. Furnizați valorile pentru a importa această bază de date."
 
 #, python-format
 msgid ""
@@ -13504,8 +15013,11 @@ msgstr ""
 " panoul de control\n"
 "                    să se încarce: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The font size of the point labels"
-msgstr ""
+msgstr "Dimensiunea fontului etichetelor punctelor"
 
 msgid "The function to use when aggregating points into groups"
 msgstr "Funcția de folosit la agregarea punctelor în grupuri"
@@ -13559,11 +15071,17 @@ msgstr "Hostname-ul furnizat nu poate fi rezolvat."
 msgid "The id of the active chart"
 msgstr "ID-ul graficului activ"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "The image URL of the icon to display for GeoJSON points. Note that the "
 "image URL must conform to the content security policy (CSP) in order to "
 "load correctly."
 msgstr ""
+"URL-ul imaginii iconiței care se va afișa pentru punctele GeoJSON. "
+"Rețineți că URL-ul imaginii trebuie să fie conform politicii de "
+"securitate a conținutului (CSP) pentru a se încărca corect."
 
 msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
@@ -13651,9 +15169,11 @@ msgstr ""
 "Numărul de ore, negativ sau pozitiv, pentru a deplasa coloana de timp. "
 "Aceasta poate fi folosită pentru a muta ora UTC la ora locală."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy, python-format
 msgid "The number of results displayed is limited to %(rows)d."
-msgstr ""
+msgstr "Numărul de rezultate afișate este limitat la %(rows)d."
 
 #, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
@@ -13756,8 +15276,13 @@ msgstr ""
 "date nu sunt prezente în fișierele de export și ar trebui adăugate manual"
 " după import dacă sunt necesare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "The passwords for the databases below are needed in order to import them."
 msgstr ""
+"Parolele pentru bazele de date de mai jos sunt necesare pentru a le "
+"importa."
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr "Modelul formatului timestamp. Pentru șiruri folosește "
@@ -13855,10 +15380,15 @@ msgstr ""
 "coloană numerică, fie `Auto`, care scalează punctul pe baza celui mai "
 "mare cluster"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "The radius of point features, in the units specified below. The final "
 "rendered size is this value multiplied by Point Radius Scale."
 msgstr ""
+"Raza elementelor punctiforme, în unitățile specificate mai jos. "
+"Dimensiunea finală redată este această valoare înmulțită cu Scala Razei "
+"Punctului."
 
 msgid "The report has been created"
 msgstr "Raportul a fost creat"
@@ -13946,8 +15476,11 @@ msgstr "URL-ul serviciului stratului"
 msgid "The size of each cell in meters"
 msgstr "Dimensiunea fiecărei celule în metri"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "The size of the point icons"
-msgstr ""
+msgstr "Dimensiunea icoanelor punctelor"
 
 msgid "The size of the square cell, in pixels"
 msgstr "Dimensiunea celulei pătrate, în pixeli"
@@ -14057,16 +15590,26 @@ msgstr "Tipul stratului"
 msgid "The type of visualization to display"
 msgstr "Tipul de vizualizare de afișat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for icon size"
-msgstr ""
+msgstr "Unitatea pentru dimensiunea iconiței"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "The unit for label size"
-msgstr ""
+msgstr "Unitatea pentru dimensiunea etichetei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "The unit for point radius. Use \"pixels\" for consistent screen-space "
 "sizing regardless of zoom level."
 msgstr ""
+"Unitatea pentru raza punctului. Utilizați \"pixeli\" pentru dimensionare "
+"uniformă în spațiul ecranului, indiferent de nivelul de zoom."
 
 msgid "The unit of measure for the specified point radius"
 msgstr "Unitatea de măsură pentru raza punctului specificat"
@@ -14074,8 +15617,11 @@ msgstr "Unitatea de măsură pentru raza punctului specificat"
 msgid "The upper limit of the threshold range of the Isoband"
 msgstr "Limita superioară a intervalului de prag al izobandei"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "The user has been created successfully."
-msgstr ""
+msgstr "Utilizatorul a fost creat cu succes."
 
 msgid "The user has been updated successfully."
 msgstr "Utilizatorul a fost actualizat cu succes."
@@ -14124,10 +15670,15 @@ msgstr "Lățimea bordurii elementelor"
 msgid "The width of the lines"
 msgstr "Lățimea liniilor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "The width of the lines as either a fixed value or variable width based on"
 " a metric."
 msgstr ""
+"Lățimea liniilor ca valoare fixă sau lățime variabilă pe baza unei "
+"metrici."
 
 msgid "Theme"
 msgstr "Temă"
@@ -14187,11 +15738,15 @@ msgstr ""
 "Nu există suficient spațiu pentru acest component. Încercați să micșorați"
 " lățimea sa sau să măriți lățimea destinației."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
+"A apărut o problemă la actualizarea tabloului de bord. Vom încerca din "
+"nou în %s, conform programului."
 
 msgid "There was an error creating the group. Please, try again."
 msgstr "A apărut o eroare la crearea grupului. Vă rugăm, încercați din nou."
@@ -14220,11 +15775,17 @@ msgstr ""
 "A apărut o eroare la preluarea graficelor și panourilor de control "
 "filtrate:"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "There was an error loading groups."
-msgstr ""
+msgstr "A apărut o eroare la încărcarea grupurilor."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "There was an error loading permissions."
-msgstr ""
+msgstr "A apărut o eroare la încărcarea permisiunilor."
 
 msgid "There was an error loading the catalogs"
 msgstr "A apărut o eroare la încărcarea cataloagelor"
@@ -14259,11 +15820,17 @@ msgstr ""
 "A apărut o eroare la actualizarea utilizatorului. Vă rugăm, încercați din"
 " nou."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "There was an error while fetching groups"
-msgstr ""
+msgstr "A apărut o eroare la preluarea grupurilor"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "There was an error while fetching permissions"
-msgstr ""
+msgstr "A apărut o eroare la preluarea permisiunilor"
 
 msgid "There was an error while fetching users"
 msgstr "A apărut o eroare la preluarea utilizatorilor"
@@ -14271,9 +15838,11 @@ msgstr "A apărut o eroare la preluarea utilizatorilor"
 msgid "There was an error with your request"
 msgstr "A apărut o eroare cu cererea dvs."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue cancelling the task: %s"
-msgstr ""
+msgstr "A apărut o problemă la anularea sarcinii: %s"
 
 #, python-format
 msgid "There was an issue deleting %s"
@@ -14291,9 +15860,11 @@ msgstr "A apărut o problemă la ștergerea înregistrării pentru utilizator: %
 msgid "There was an issue deleting rules: %s"
 msgstr "A apărut o problemă la ștergerea regulilor: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue deleting the selected %s"
-msgstr ""
+msgstr "A apărut o problemă la ștergerea %s selectat"
 
 #, python-format
 msgid "There was an issue deleting the selected %s: %s"
@@ -14326,21 +15897,29 @@ msgstr "A apărut o problemă la ștergerea temelor selectate: %s"
 msgid "There was an issue deleting: %s"
 msgstr "A apărut o problemă la ștergerea: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue duplicating the %s."
-msgstr ""
+msgstr "A apărut o problemă la duplicarea %s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue duplicating the selected %s: %s"
-msgstr ""
+msgstr "A apărut o problemă la duplicarea %s selectat: %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue exporting the %s"
-msgstr ""
+msgstr "A apărut o problemă la exportarea %s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, it,
+# ja, sr, sr_Latn]
+#, fuzzy, python-format
 msgid "There was an issue exporting the selected %s"
-msgstr ""
+msgstr "A apărut o problemă la exportarea %s selectate"
 
 msgid "There was an issue exporting the selected charts"
 msgstr "A apărut o problemă la exportul graficelor selectate"
@@ -14354,8 +15933,11 @@ msgstr "A apărut o problemă la exportul temelor selectate"
 msgid "There was an issue favoriting this dashboard."
 msgstr "A apărut o problemă la marcarea acestui panou de control ca favorit."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "There was an issue fetching reports."
-msgstr ""
+msgstr "A apărut o problemă la preluarea rapoartelor."
 
 msgid "There was an issue fetching the favorite status of this dashboard."
 msgstr ""
@@ -14444,8 +16026,11 @@ msgstr ""
 msgid "This chart has been moved to a different filter scope."
 msgstr "Acest grafic a fost mutat într-un domeniu de filtru diferit."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr ""
+msgstr "Acest grafic este gestionat extern și nu poate fi suprascris în Superset."
 
 msgid "This chart is managed externally, and can't be edited in Superset"
 msgstr "Acest grafic este gestionat extern și nu poate fi editat în Superset"
@@ -14462,9 +16047,11 @@ msgstr ""
 "Acest tip de grafic nu este suportat când se folosește o interogare "
 "nesalvată ca sursă de grafic. "
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This column might be incompatible with current %s"
-msgstr ""
+msgstr "Această coloană ar putea fi incompatibilă cu %s curent"
 
 msgid "This column might be incompatible with current dataset"
 msgstr "Această coloană ar putea fi incompatibilă cu setul de date curent"
@@ -14567,12 +16154,19 @@ msgstr ""
 "Acest tabel de bază de date nu conține date. Vă rugăm să selectați un "
 "tabel diferit."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This database uses OAuth2 for authentication. Please click the link above"
 " to grant Apache Superset permission to access the data. Your personal "
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
+"Această bază de date utilizează OAuth2 pentru autentificare. Vă rugăm să "
+"faceți clic pe linkul de mai sus pentru a acorda Apache Superset "
+"permisiunea de a accesa datele. Token-ul dvs. personal de acces va fi "
+"stocat criptat și va fi utilizat numai pentru interogările rulate de dvs."
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr "Acest set de date este gestionat extern și nu poate fi editat în Superset"
@@ -14608,33 +16202,56 @@ msgstr ""
 msgid "This filter already exist on the report"
 msgstr "Acest filtru există deja pe raport"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "This filter might be incompatible with current %s"
-msgstr ""
+msgstr "Acest filtru ar putea fi incompatibil cu %s curent"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This folder is currently empty"
-msgstr ""
+msgstr "Acest dosar este în prezent gol"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports columns"
-msgstr ""
+msgstr "Acest dosar acceptă doar coloane"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This folder only supports metrics"
-msgstr ""
+msgstr "Acest dosar acceptă doar metrici"
 
 msgid "This functionality is disabled in your environment for security reasons."
 msgstr ""
 "Această funcționalitate este dezactivată în mediul dvs. din motive de "
 "securitate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
+"Acesta este dosarul implicit pentru coloane. Numele său nu poate fi "
+"schimbat sau eliminat. Poate rămâne gol, dar va accepta numai elemente de"
+" tip coloană."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
+"Acesta este dosarul implicit pentru metrici. Numele său nu poate fi "
+"schimbat sau eliminat. Poate rămâne gol, dar va accepta numai elemente de"
+" tip metrică."
 
 msgid "This is custom error message for a"
 msgstr "Aceasta este mesajul de eroare personalizat pentru a"
@@ -14655,17 +16272,31 @@ msgstr ""
 "decât dacă un utilizator aparține unui rol de filtru RLS, se poate crea "
 "un filtru de bază cu clauza `1 = 0` (întotdeauna fals)."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default dark theme"
-msgstr ""
+msgstr "Aceasta este tema întunecată implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default folder"
-msgstr ""
+msgstr "Acesta este dosarul implicit"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
+# it, ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "This is the default light theme"
-msgstr ""
+msgstr "Aceasta este tema luminoasă implicită"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
 msgstr ""
+"Aceasta este singura dată când veți vedea această cheie. Păstrați-o în "
+"siguranță."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -14676,10 +16307,20 @@ msgstr ""
 "control. Este generat dinamic când se ajustează dimensiunea și pozițiile "
 "widget-urilor folosind drag & drop în vizualizarea panoului de control."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid "This link cannot be followed because its address is unsafe."
+msgstr "Acest link nu poate fi accesat deoarece adresa sa este nesigură."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
+"Acest link vă va duce la un site web extern. Nu putem garanta siguranța "
+"destinațiilor externe."
 
 msgid "This markdown component has an error."
 msgstr "Acest component markdown are o eroare."
@@ -14699,9 +16340,11 @@ msgstr ""
 msgid "This may be triggered by:"
 msgstr "Acest lucru poate fi declanșat de:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "This metric might be incompatible with current %s"
-msgstr ""
+msgstr "Această metrică ar putea fi incompatibilă cu %s curent"
 
 msgid "This name is already taken. Please choose another one."
 msgstr "Acest nume este deja folosit. Vă rugăm alegeți altul."
@@ -14716,8 +16359,12 @@ msgstr ""
 "Această pagină este destinată să fie încorporată într-un iframe, dar se "
 "pare că nu este cazul."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "This password is too common; please choose a less guessable one."
 msgstr ""
+"Această parolă este prea comună; vă rugăm să alegeți una mai greu de "
+"ghicit."
 
 msgid ""
 "This section allows you to configure how to use the slice\n"
@@ -14784,9 +16431,11 @@ msgstr[0] "Aceasta a fost declanșată de:"
 msgstr[1] "Acestea pot fi declanșate de:"
 msgstr[2] "Acestea pot fi declanșate de către:"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr ""
+msgstr "Aceasta va anula (opri) sarcina pentru toți %s abonați."
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
@@ -14798,16 +16447,24 @@ msgstr ""
 "condițională de bază poate fi suprascrisă de formatarea condițională de "
 "mai jos."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "This will cancel the task."
-msgstr ""
+msgstr "Aceasta va anula sarcina."
 
 msgid "This will remove your current embed configuration."
 msgstr "Aceasta va elimina configurația actuală de integrare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
+"Aceasta va reorganiza toate metricile și coloanele în dosare implicite. "
+"Orice dosare personalizate vor fi eliminate."
 
 msgid "Threshold"
 msgstr "Prag"
@@ -14891,8 +16548,11 @@ msgstr "Coloană timp"
 msgid "Time column \"%(col)s\" does not exist in dataset"
 msgstr "Coloana de timp \"%(col)s\" nu există în setul de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time column chart customization plugin"
-msgstr ""
+msgstr "Plugin de personalizare a graficului pentru coloana de timp"
 
 msgid "Time column filter plugin"
 msgstr "Plugin filtru coloană timp"
@@ -14930,8 +16590,11 @@ msgstr "Format timp"
 msgid "Time grain"
 msgstr "Granularitate timp"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Time grain chart customization plugin"
-msgstr ""
+msgstr "Plugin de personalizare a graficului pentru granularitatea de timp"
 
 msgid "Time grain filter plugin"
 msgstr "Plugin filtru granularitate timp"
@@ -14939,8 +16602,11 @@ msgstr "Plugin filtru granularitate timp"
 msgid "Time grain missing"
 msgstr "Granularitate timp lipsă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Time grain options"
-msgstr ""
+msgstr "Opțiuni de granularitate a timpului"
 
 msgid "Time granularity"
 msgstr "Granularitate timp"
@@ -14986,17 +16652,24 @@ msgstr "Serie de timp - Pivot perioadă"
 msgid "Time-series Table"
 msgstr "Tabel serie de timp"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Timed Out"
-msgstr ""
+msgstr "Timp expirat"
 
 msgid "Timeline"
 msgstr "Cronologie"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
+"Timeout configurat (%s secunde), dar nu a fost definit niciun handler de "
+"anulare. Sarcina va continua să ruleze după expirarea timeout-ului."
 
 msgid "Timeout error"
 msgstr "Eroare timeout"
@@ -15025,12 +16698,20 @@ msgstr "Titlul este obligatoriu"
 msgid "Title or Slug"
 msgstr "Titlu sau Slug"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
 "Databases are used as a way to identify your data so that it can be "
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
+"Pentru a începe să utilizați Google Sheets, trebuie mai întâi să creați o"
+" bază de date. Bazele de date sunt utilizate ca modalitate de "
+"identificare a datelor dvs., astfel încât acestea să poată fi interogate "
+"și vizualizate. Această bază de date va conține toate fișierele "
+"individuale Google Sheets pe care alegeți să le conectați aici."
 
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
@@ -15045,20 +16726,29 @@ msgstr "Pentru a filtra după un indicator, utilizați fila „SQL personalizat�
 msgid "To get a readable URL for your dashboard"
 msgstr "Pentru un URL accesibil al panoului de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Token Request URI"
-msgstr ""
+msgstr "URI de solicitare a tokenului"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "Too many sub-slices requested. The maximum allowed is %(max)s, but "
 "%(count)s were requested."
 msgstr ""
+"Au fost solicitate prea multe sub-secțiuni. Maximul permis este %(max)s, "
+"dar au fost solicitate %(count)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "Too many time comparisons requested. The maximum allowed is %(max)s, but "
 "%(count)s were requested."
 msgstr ""
+"Au fost solicitate prea multe comparații de timp. Maximul permis este "
+"%(max)s, dar au fost solicitate %(count)s."
 
 msgid "Tool Panel"
 msgstr "Panou instrumente"
@@ -15192,8 +16882,11 @@ msgstr "Trunchiază celulele lungi la \"lățimea min\" setată mai sus"
 msgid "Truncates the specified date to the accuracy specified by the date unit."
 msgstr "Trunchiază data specificată la precizia specificată de unitatea de dată."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Trust this URL and don't ask again"
-msgstr ""
+msgstr "Aveți încredere în acest URL și nu mai întrebați"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
@@ -15222,14 +16915,20 @@ msgstr "Introduceți o valoare"
 msgid "Type a value here"
 msgstr "Introduceți o valoare aici"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "Type a value..."
-msgstr ""
+msgstr "Introduceți o valoare..."
 
 msgid "Type is required"
 msgstr "Tipul este obligatoriu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Type of Google Sheets allowed"
-msgstr ""
+msgstr "Tip de Google Sheets permis"
 
 msgid "Type of chart to display in sparkline"
 msgstr "Tip de grafic de afișat în sparkline"
@@ -15237,14 +16936,23 @@ msgstr "Tip de grafic de afișat în sparkline"
 msgid "Type of comparison, value difference or percentage"
 msgstr "Tip de comparație, diferență valoare sau procentaj"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Type to search (contains)..."
-msgstr ""
+msgstr "Tastați pentru a căuta (conține)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Type to search (ends with)..."
-msgstr ""
+msgstr "Tastați pentru a căuta (se termină cu)..."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Type to search (starts with)..."
-msgstr ""
+msgstr "Tastați pentru a căuta (începe cu)..."
 
 msgid "UI Configuration"
 msgstr "Configurare interfață"
@@ -15255,8 +16963,11 @@ msgstr "Administrarea temelor interfeței nu este activată."
 msgid "URL"
 msgstr "URL"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "URL Filters"
-msgstr ""
+msgstr "Filtre URL"
 
 msgid "URL Parameters"
 msgstr "Parametri URL"
@@ -15289,19 +17000,31 @@ msgstr ""
 "Viewer\", \"BigQuery Job User\" și că următoarele permisiuni sunt setate "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
+"Imposibil de conectat. Verificați că următoarele roluri sunt setate pe "
+"contul de serviciu: \"Cloud Datastore Viewer\", \"Cloud Datastore User\","
+" \"Cloud Datastore Creator\""
 
 msgid "Unable to create chart without a query id."
 msgstr "Nu se poate crea grafic fără un ID de interogare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
+"Imposibil de creat raportul: adresa de e-mail a utilizatorului este "
+"necesară, dar nu a fost găsită. Vă rugăm să vă asigurați că profilul dvs."
+" de utilizator are o adresă de e-mail validă."
 
 msgid "Unable to decode value"
 msgstr "Nu se poate decodifica valoarea"
@@ -15309,15 +17032,23 @@ msgstr "Nu se poate decodifica valoarea"
 msgid "Unable to encode value"
 msgstr "Nu se poate codifica valoarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
+"Imposibil de preluat vizualizările semantice. Verificați configurația "
+"stratului."
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
 msgstr "Nu se poate găsi un astfel de sărbătoare: [%(holiday)s]"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Unable to generate download payload"
-msgstr ""
+msgstr "Imposibil de generat conținutul pentru descărcare"
 
 msgid ""
 "Unable to identify temporal column for date range time comparison.Please "
@@ -15387,8 +17118,11 @@ msgstr "Anulează acțiunea"
 msgid "Undo?"
 msgstr "Anulezi?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr ""
+msgstr "Răspuns HTTP 401 neașteptat. Verificați-vă acreditările."
 
 msgid "Unexpected error"
 msgstr "Eroare neașteptată"
@@ -15421,8 +17155,11 @@ msgstr "Necunoscut"
 msgid "Unknown Doris server host \"%(hostname)s\"."
 msgstr "Gazdă server Doris necunoscută \"%(hostname)s\"."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Unknown Error"
-msgstr ""
+msgstr "Eroare necunoscută"
 
 #, python-format
 msgid "Unknown MySQL server host \"%(hostname)s\"."
@@ -15448,8 +17185,11 @@ msgstr "Eroare necunoscută"
 msgid "Unknown input format"
 msgstr "Format de intrare necunoscut"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr ""
+msgstr "Tokenurile necunoscute vor fi evidențiate ca avertismente."
 
 msgid "Unknown type"
 msgstr "Tip necunoscut"
@@ -15460,11 +17200,22 @@ msgstr "Valoare necunoscută"
 msgid "Unpin"
 msgstr "Desecheează"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from the result panel"
-msgstr ""
+msgstr "Desprinde din panoul de rezultate"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Unpin from top"
-msgstr ""
+msgstr "Desprinde din vârf"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
+msgid "Unsafe link blocked"
+msgstr "Link nesigur blocat"
 
 #, python-format
 msgid "Unsafe return type for function %(func)s: %(value_type)s"
@@ -15478,8 +17229,13 @@ msgstr "Valoare șablon nesigură pentru cheia %(key)s: %(value_type)s"
 msgid "Unsupported clause type: %(clause)s"
 msgstr "Tip de clauză neacceptat: %(clause)s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
 msgstr ""
+"Tip de fișier neacceptat. Vă rugăm să utilizați fișiere CSV, Excel sau în"
+" format columnar."
 
 #, python-format
 msgid "Unsupported post processing operation: %(operation)s"
@@ -15512,8 +17268,11 @@ msgstr "Neverificat"
 msgid "Update"
 msgstr "Actualizează"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Update auto-refresh"
-msgstr ""
+msgstr "Actualizare reîmprospătare automată"
 
 msgid "Update chart"
 msgstr "Actualizează grafic"
@@ -15677,14 +17436,27 @@ msgstr "Înregistrări utilizatori"
 msgid "User doesn't have the proper permissions."
 msgstr "Utilizatorul nu are permisiunile corespunzătoare."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, uk]
+#, fuzzy
 msgid "User info"
-msgstr ""
+msgstr "Informații utilizator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the chart customization"
 msgstr ""
+"Utilizatorul trebuie să selecteze o valoare înainte de a aplica "
+"personalizarea graficului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "User must select a value before applying the customization"
 msgstr ""
+"Utilizatorul trebuie să selecteze o valoare înainte de a aplica "
+"personalizarea"
 
 msgid "User must select a value before applying the filter"
 msgstr "Utilizatorul trebuie să selecteze o valoare înainte de a aplica filtrul"
@@ -15739,14 +17511,20 @@ msgstr ""
 "înțelege etapele pe care le-a parcurs o valoare. Util pentru vizualizarea"
 " pâlniilor și pipeline-urilor multi-etapă, multi-grup."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Uses the first 25 values if the dimension has more."
-msgstr ""
+msgstr "Folosește primele 25 de valori dacă dimensiunea conține mai multe."
 
 msgid "Valid SQL expression"
 msgstr "Expresie SQL validă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Validate query"
-msgstr ""
+msgstr "Validare interogare"
 
 msgid "Validate your expression"
 msgstr "Validează expresia ta"
@@ -15874,11 +17652,18 @@ msgstr "Vizualizator"
 msgid "Viewers"
 msgstr "Vizualizatori"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
+# fr, it, ja, lv, mi, nl, ru, sk, sl, tr, uk]
+#, fuzzy
 msgid ""
 "Viewers is a list of subjects who can view the dashboard. If no viewers "
 "are defined, the dashboard is accessible to all users with appropriate "
 "datasource permissions."
 msgstr ""
+"Vizualizatorii reprezintă o listă de subiecți care pot vizualiza tabloul "
+"de bord. Dacă nu sunt definiți vizualizatori, tabloul de bord este "
+"accesibil tuturor utilizatorilor cu permisiuni adecvate pentru sursa de "
+"date."
 
 msgid "Viewport"
 msgstr "Viewport"
@@ -16017,14 +17802,19 @@ msgstr "Tip viz"
 msgid "WED"
 msgstr "MIE"
 
+#. do-not-translate
 msgid "WFS"
 msgstr "WFS"
 
+#. do-not-translate
 msgid "WMS"
 msgstr "WMS"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Waiting for first refresh"
-msgstr ""
+msgstr "Se așteaptă prima reîmprospătare"
 
 #, python-format
 msgid "Waiting on %s"
@@ -16036,8 +17826,11 @@ msgstr "Așteaptă pe baza de date..."
 msgid "Want to add a new database?"
 msgstr "Vrei să adaugi o bază de date nouă?"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Warehouse"
-msgstr ""
+msgstr "Depozit"
 
 msgid "Warning"
 msgstr "Avertisment"
@@ -16052,10 +17845,15 @@ msgstr ""
 "Avertisment! Schimbarea setului de date poate strica graficul dacă "
 "metadatele nu există."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
+"Avertisment: Interogările ILIKE pot fi lente pe seturi de date mari, "
+"deoarece nu pot utiliza indexurile în mod eficient."
 
 msgid "Was unable to check your query"
 msgstr "Nu s-a putut verifica interogarea dvs."
@@ -16089,8 +17887,11 @@ msgstr ""
 msgid "We have the following keys: %s"
 msgstr "Avem următoarele chei: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "We were unable to activate or deactivate this report."
-msgstr ""
+msgstr "Nu am putut activa sau dezactiva acest raport."
 
 msgid ""
 "We were unable to carry over any controls when switching to this new "
@@ -16355,8 +18156,11 @@ msgstr "Dacă să afișeze valorile min și max ale axei X"
 msgid "Whether to display the min and max values of the Y-axis"
 msgstr "Dacă să afișeze valorile min și max ale axei Y"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Whether to display the numbered column"
-msgstr ""
+msgstr "Dacă să se afișeze coloana numerotată"
 
 msgid "Whether to display the numerical values within the cells"
 msgstr "Dacă să afișeze valorile numerice în celule"
@@ -16465,8 +18269,11 @@ msgstr "Ce înrudiri să evidențieze la hover"
 msgid "Whisker/outlier options"
 msgstr "Opțiuni whisker/valori aberante"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Why do I need to create a database?"
-msgstr ""
+msgstr "De ce trebuie să creez o bază de date?"
 
 msgid "Width"
 msgstr "Lățime"
@@ -16477,8 +18284,11 @@ msgstr "Lățimea intervalului de încredere. Ar trebui să fie între 0 și 1"
 msgid "Width of the sparkline"
 msgstr "Lățimea sparkline-ului"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "Width scale multiplier"
-msgstr ""
+msgstr "Multiplicator scară lățime"
 
 msgid "Window must be > 0"
 msgstr "Fereastra trebuie să fie > 0"
@@ -16555,6 +18365,7 @@ msgstr "axă X"
 msgid "X-scale interval"
 msgstr "interval scală X"
 
+#. do-not-translate
 msgid "XYZ"
 msgstr "XYZ"
 
@@ -16628,8 +18439,11 @@ msgstr "Ani %s"
 msgid "Yes"
 msgstr "Da"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "Yes, Cancel"
-msgstr ""
+msgstr "Da, Anulare"
 
 msgid "Yes, cancel"
 msgstr "Da, anulează"
@@ -16641,8 +18455,11 @@ msgstr "Da, suprascrie modificările"
 msgid "You are adding tags to %s %ss"
 msgstr "Adăugați tag-uri la %s %ss"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "You are editing a query from the virtual dataset "
-msgstr ""
+msgstr "Editați o interogare din setul de date virtual "
 
 msgid ""
 "You are importing one or more charts that already exist. Overwriting "
@@ -16778,8 +18595,11 @@ msgstr "Nu aveți permisiunea de a edita acest grafic"
 msgid "You do not have permission to edit this dashboard"
 msgstr "Nu aveți permisiunea de a edita acest panou de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You do not have permission to perform this operation"
-msgstr ""
+msgstr "Nu aveți permisiunea de a efectua această operațiune"
 
 msgid "You do not have permission to read tags"
 msgstr "Nu aveți permisiunea de a citi tag-uri"
@@ -16790,8 +18610,10 @@ msgstr "Nu aveți permisiuni pentru a edita acest panou de control."
 msgid "You do not have sufficient permissions to edit the chart"
 msgstr "Nu aveți permisiuni suficiente pentru a edita graficul"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "You don't have access to one or more of the referenced datasources."
-msgstr ""
+msgstr "Nu aveți acces la una sau mai multe surse de date referențiate."
 
 msgid "You don't have access to this chart."
 msgstr "Nu aveți acces la acest grafic."
@@ -16805,17 +18627,29 @@ msgstr "Nu aveți acces la acest set de date."
 msgid "You don't have access to this embedded dashboard config."
 msgstr "Nu aveți acces la configurația acestui panou de control încorporat."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You don't have access to this semantic view."
-msgstr ""
+msgstr "Nu aveți acces la această vizualizare semantică."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You don't have permission to copy to clipboard"
-msgstr ""
+msgstr "Nu aveți permisiunea de a copia în clipboard"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export data"
-msgstr ""
+msgstr "Nu aveți permisiunea de a exporta date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You don't have permission to export images"
-msgstr ""
+msgstr "Nu aveți permisiunea de a exporta imagini"
 
 msgid "You don't have permission to modify the value."
 msgstr "Nu aveți permisiunea de a modifica valoarea."
@@ -16839,12 +18673,17 @@ msgstr "Nu aveți drepturile de a crea un grafic"
 msgid "You don't have the rights to create a dashboard"
 msgstr "Nu aveți drepturile pt. crea un panou de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "You don't have the rights to export data"
-msgstr ""
+msgstr "Nu aveți drepturile necesare pentru a exporta date"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "You have been removed from task: %s"
-msgstr ""
+msgstr "Ați fost eliminat din sarcina: %s"
 
 msgid "You have removed this filter."
 msgstr "Ați eliminat acest filtru."
@@ -16869,15 +18708,22 @@ msgstr ""
 msgid ""
 "You must be a %s editor in order to edit. Please reach out to a %s editor"
 " to request modifications or edit access."
-msgstr "Trebuie să fiți editor pentru %s pentru a edita. Contactați un editor pentru %s pentru a solicita modificări sau acces de editare."
+msgstr ""
+"Trebuie să fiți editor pentru %s pentru a edita. Contactați un editor "
+"pentru %s pentru a solicita modificări sau acces de editare."
 
 msgid ""
 "You must be a dataset editor in order to edit. Please reach out to a "
 "dataset editor to request modifications or edit access."
-msgstr "Trebuie să fiți editor al setului de date pentru a edita. Contactați un editor al setului de date pentru a solicita modificări sau acces de editare."
-
-msgid "You must change your password before continuing."
 msgstr ""
+"Trebuie să fiți editor al setului de date pentru a edita. Contactați un "
+"editor al setului de date pentru a solicita modificări sau acces de "
+"editare."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja, tr]
+#, fuzzy
+msgid "You must change your password before continuing."
+msgstr "Trebuie să vă schimbați parola înainte de a continua."
 
 msgid "You must pick a name for the new dashboard"
 msgstr "Trebuie să alegeți un nume pentru panoul de control"
@@ -16885,14 +18731,20 @@ msgstr "Trebuie să alegeți un nume pentru panoul de control"
 msgid "You must run the query successfully first"
 msgstr "Trebuie să executați mai întâi interogarea cu succes"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "You need access to the following tables: %(tables)s, "
 "'all_database_access' or 'all_datasource_access' permission"
 msgstr ""
+"Aveți nevoie de acces la următoarele tabele: %(tables)s, permisiunea "
+"'all_database_access' sau 'all_datasource_access'"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
+# fi, ja, lv, pl, sk, sr, sr_Latn, th, uk]
+#, fuzzy
 msgid "You need to"
-msgstr ""
+msgstr "Trebuie să"
 
 msgid ""
 "You updated the values in the control panel, but the chart was not "
@@ -16903,11 +18755,15 @@ msgstr ""
 "actualizat automat. Rulați interogarea făcând clic pe butonul "
 "\"Actualizează grafic\" sau"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
+"Veți fi eliminat din această sarcină. Aceasta va continua să ruleze "
+"pentru %s alți abonați."
 
 msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
@@ -16916,8 +18772,11 @@ msgstr ""
 "Ați schimbat setul de date. Orice controale cu date (coloane, indicatori)"
 " care se potrivesc cu acest nou set de date au fost păstrate."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
+# lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "Your account is activated. You can log in with your credentials."
-msgstr ""
+msgstr "Contul dvs. este activat. Vă puteți conecta cu acreditările dvs."
 
 msgid "Your changes will be lost if you leave without saving."
 msgstr "Modificările dvs. vor fi pierdute dacă plecați fără să salvați."
@@ -16964,14 +18823,22 @@ msgstr "Interogarea dvs. a fost actualizată"
 msgid "Your report could not be deleted"
 msgstr "Raportul dvs. nu a putut fi șters"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Your session has ended. Please sign in again."
-msgstr ""
+msgstr "Sesiunea dvs. s-a încheiat. Vă rugăm să vă conectați din nou."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "Your user information"
-msgstr ""
+msgstr "Informațiile dvs. de utilizator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, sr,
+# sr_Latn]
+#, fuzzy
 msgid "Z-A"
-msgstr ""
+msgstr "Z-A"
 
 msgid "ZIP file contains multiple file types"
 msgstr "Fișierul ZIP conține mai multe tipuri de fișiere"
@@ -17023,8 +18890,11 @@ msgstr ""
 "culoarea ca raport față de indicatorul primar. Atunci când este omis, "
 "culoarea este categorială și se bazează pe etichete."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, it,
+# ja, lv, ru, sk, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "[untitled customization]"
-msgstr ""
+msgstr "[personalizare fără titlu]"
 
 msgid "`compare_columns` must have the same length as `source_columns`."
 msgstr "`compare_columns` trebuie să aibă aceeași lungime ca `source_columns`."
@@ -17048,9 +18918,10 @@ msgstr ""
 msgid "`operation` property of post processing object undefined"
 msgstr "proprietatea `operation` a obiectului de post-procesare nedefinită"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr ""
+msgstr "`periods` trebuie să fie între 1 și %(max)s"
 
 msgid "`prophet` package not installed"
 msgstr "pachetul `prophet` nu este instalat"
@@ -17071,11 +18942,16 @@ msgstr "`row_offset` trebuie să fie mai mare sau egal cu 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` trebuie să fie mai mare sau egal cu 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "`window` must be between 1 and 10000"
-msgstr ""
+msgstr "`window` trebuie să fie între 1 și 10000"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "a few seconds"
-msgstr ""
+msgstr "câteva secunde"
 
 msgid "aggregate"
 msgstr "agregare"
@@ -17104,8 +18980,10 @@ msgstr "adnotare"
 msgid "annotation_layer"
 msgstr "strat_adnotare"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "apple"
-msgstr ""
+msgstr "măr"
 
 msgid "asfreq"
 msgstr "asfreq"
@@ -17119,11 +18997,16 @@ msgstr "auto"
 msgid "background"
 msgstr "fundal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "background color"
-msgstr ""
+msgstr "culoare fundal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "banana"
-msgstr ""
+msgstr "banană"
 
 msgid "basis"
 msgstr "bază"
@@ -17144,11 +19027,15 @@ msgstr "între {down} și {up} {name}"
 msgid "bfill"
 msgstr "bfill"
 
+#. do-not-translate
 msgid "bolt"
 msgstr "fulger"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "boolean"
-msgstr ""
+msgstr "boolean"
 
 msgid "boolean type icon"
 msgstr "iconiță tip boolean"
@@ -17168,8 +19055,11 @@ msgstr "nu poate fi gol"
 msgid "cardinal"
 msgstr "cardinal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "cell bar"
-msgstr ""
+msgstr "bară celulă"
 
 msgid "change"
 msgstr "schimbare"
@@ -17229,6 +19119,7 @@ msgstr "creează un grafic nou"
 msgid "create dataset from SQL query"
 msgstr "creează set de date din interogare SQL"
 
+#. do-not-translate
 msgid "crontab"
 msgstr "crontab"
 
@@ -17247,17 +19138,26 @@ msgstr "panou de control"
 msgid "dashboards"
 msgstr "panouri de control"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "data connection"
-msgstr ""
+msgstr "conexiune de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "data connections"
-msgstr ""
+msgstr "conexiuni de date"
 
 msgid "database"
 msgstr "bază de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "databases"
-msgstr ""
+msgstr "baze de date"
 
 msgid "dataset"
 msgstr "set de date"
@@ -17265,14 +19165,23 @@ msgstr "set de date"
 msgid "dataset name"
 msgstr "nume set de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn, tr]
+#, fuzzy
 msgid "datasets"
-msgstr ""
+msgstr "seturi de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "datasource"
-msgstr ""
+msgstr "sursă de date"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "datasources"
-msgstr ""
+msgstr "surse de date"
 
 msgid "date"
 msgstr "dată"
@@ -17295,6 +19204,7 @@ msgstr "deck.gl Arc"
 msgid "deck.gl Contour"
 msgstr "deck.gl Contur"
 
+#. do-not-translate
 msgid "deck.gl Geojson"
 msgstr "deck.gl Geojson"
 
@@ -17319,8 +19229,11 @@ msgstr "deck.gl Diagramă de Dispersie"
 msgid "deck.gl Screen Grid"
 msgstr "deck.gl Rețea Ecran"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
+# ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "deck.gl layers (charts)"
-msgstr ""
+msgstr "straturi deck.gl (grafice)"
 
 msgid "deckGL"
 msgstr "deckGL"
@@ -17343,6 +19256,7 @@ msgstr "dialect+driver://username:password@host:port/database"
 msgid "documentation"
 msgstr "documentație"
 
+#. do-not-translate
 msgid "dttm"
 msgstr "dttm"
 
@@ -17382,8 +19296,11 @@ msgstr "ex. world_population"
 msgid "e.g. xy12345.us-east-2.aws"
 msgstr "ex. xy12345.us-east-2.aws"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "e.g., CI/CD Pipeline, Analytics Script"
-msgstr ""
+msgstr "ex., CI/CD Pipeline, Script Analytics"
 
 msgid "edit mode"
 msgstr "mod editare"
@@ -17397,8 +19314,11 @@ msgstr "subiect email"
 msgid "ends with"
 msgstr "se termină cu"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "entire row"
-msgstr ""
+msgstr "rând întreg"
 
 msgid "entries"
 msgstr "intrări"
@@ -17409,6 +19329,7 @@ msgstr "intrări pe pagină"
 msgid "error"
 msgstr "eroare"
 
+#. do-not-translate
 msgid "error_message"
 msgstr "mesaj_eroare"
 
@@ -17433,14 +19354,20 @@ msgstr "fiecare lună"
 msgid "expand"
 msgstr "extinde"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "extra.dashboard must be an object"
-msgstr ""
+msgstr "extra.dashboard trebuie să fie un obiect"
 
 msgid "failed"
 msgstr "eșuat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "farewell"
-msgstr ""
+msgstr "farewell"
 
 msgid "fetching"
 msgstr "preluare"
@@ -17451,8 +19378,11 @@ msgstr "ffill"
 msgid "flat"
 msgstr "plat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "for a list of available helpers."
-msgstr ""
+msgstr "pentru o listă de helpere disponibile."
 
 msgid "for more information on how to structure your URI."
 msgstr "pentru mai multe informații despre cum să structurați URI-ul dvs."
@@ -17466,8 +19396,11 @@ msgstr "iconiță tip funcție"
 msgid "geohash (square)"
 msgstr "geohash (pătrat)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, sr,
+# sr_Latn]
+#, fuzzy
 msgid "greeting"
-msgstr ""
+msgstr "salut"
 
 msgid "heatmap"
 msgstr "hartă termică"
@@ -17475,8 +19408,11 @@ msgstr "hartă termică"
 msgid "heatmap: values are normalized across the entire heatmap"
 msgstr "hartă termică: valorile sunt normalizate pe întreaga hartă termică"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "hello"
-msgstr ""
+msgstr "salut"
 
 msgid "here"
 msgstr "aici"
@@ -17487,8 +19423,11 @@ msgstr "oră"
 msgid "in"
 msgstr "în"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "in order to run this operation."
-msgstr ""
+msgstr "pentru a rula această operațiune."
 
 msgid "invalid email"
 msgstr "email nevalid"
@@ -17565,8 +19504,11 @@ msgstr "mai mic decât {min} {name}"
 msgid "linear"
 msgstr "liniar"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "locale_key"
-msgstr ""
+msgstr "locale_key"
 
 msgid "log"
 msgstr "jurnal"
@@ -17593,8 +19535,11 @@ msgstr "metri"
 msgid "metric"
 msgstr "indicator"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, tr, uk]
+#, fuzzy
 msgid "metric type icon"
-msgstr ""
+msgstr "pictogramă tip metrică"
 
 msgid "min"
 msgstr "min"
@@ -17621,30 +19566,47 @@ msgstr "trebuie să aibă o valoare"
 msgid "name"
 msgstr "nume"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "nativeFilters must be a list"
-msgstr ""
+msgstr "nativeFilters trebuie să fie o listă"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] lipsesc cheile obligatorii: %(keys)s"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr ""
+msgstr "nativeFilters[%(idx)s] trebuie să fie un obiect"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].filterValues must be a list"
-msgstr ""
+msgstr "nativeFilters[%(idx)s].filterValues trebuie să fie o listă"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
 "the dashboard"
 msgstr ""
+"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' nu există pe "
+"tabloul de bord"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
 msgstr ""
+"nativeFilters[%(idx)s].nativeFilterId trebuie să fie un șir de caractere "
+"nevid"
 
 msgid "no SQL validator is configured"
 msgstr "nu este configurat niciun validator SQL"
@@ -17656,8 +19618,11 @@ msgstr "nu este configurat niciun validator SQL pentru %(engine_spec)s"
 msgid "not containing"
 msgstr "nu conține"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "numeric"
-msgstr ""
+msgstr "numeric"
 
 msgid "numeric type icon"
 msgstr "iconiță tip numeric"
@@ -17692,15 +19657,19 @@ msgstr "general"
 msgid "p-value precision"
 msgstr "precizie p-value"
 
+#. do-not-translate
 msgid "p1"
 msgstr "p1"
 
+#. do-not-translate
 msgid "p5"
 msgstr "p5"
 
+#. do-not-translate
 msgid "p95"
 msgstr "p95"
 
+#. do-not-translate
 msgid "p99"
 msgstr "p99"
 
@@ -17717,6 +19686,7 @@ msgstr ""
 msgid "permalink state not found"
 msgstr "starea permalink-ului nu a fost găsită"
 
+#. do-not-translate
 msgid "pivoted_xlsx"
 msgstr "pivoted_xlsx"
 
@@ -17735,8 +19705,11 @@ msgstr "săptămâna calendaristică anterioară"
 msgid "previous calendar year"
 msgstr "anul calendaristic anterior"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
+# sr_Latn]
+#, fuzzy
 msgid "provide authorization"
-msgstr ""
+msgstr "furnizați autorizarea"
 
 msgid "quarter"
 msgstr "trimestru"
@@ -17777,6 +19750,7 @@ msgstr "rulează"
 msgid "save"
 msgstr "salvează"
 
+#. do-not-translate
 msgid "schema1,schema2"
 msgstr ""
 
@@ -17795,6 +19769,7 @@ msgstr ""
 "folosesc aceeași scală; schimbare: Afișează schimbările comparate cu "
 "primul punct de date din fiecare serie"
 
+#. do-not-translate
 msgid "sql"
 msgstr "sql"
 
@@ -17810,9 +19785,11 @@ msgstr "în eșalon"
 msgid "std"
 msgstr "std"
 
+#. do-not-translate
 msgid "step-after"
 msgstr "pas-după"
 
+#. do-not-translate
 msgid "step-before"
 msgstr "pas-înainte"
 
@@ -17822,8 +19799,11 @@ msgstr "oprit"
 msgid "stream"
 msgstr "flux"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "string"
-msgstr ""
+msgstr "șir de caractere"
 
 msgid "string type icon"
 msgstr "iconiță tip șir"
@@ -17834,6 +19814,7 @@ msgstr "succes"
 msgid "sum"
 msgstr "sumă"
 
+#. do-not-translate
 msgid "superset.example.com"
 msgstr ""
 
@@ -17843,26 +19824,38 @@ msgstr "sintaxă."
 msgid "tag"
 msgstr "tag"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "task"
-msgstr ""
+msgstr "sarcină"
 
 msgid "temporal type icon"
 msgstr "iconiță tip temporal"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "text color"
-msgstr ""
+msgstr "culoarea textului"
 
 msgid "textarea"
 msgstr "textarea"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "the Handlebars chart documentation"
-msgstr ""
+msgstr "documentația graficului Handlebars"
 
 msgid "theme"
 msgstr "temă"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# sr, sr_Latn]
+#, fuzzy
 msgid "timestamp"
-msgstr ""
+msgstr "marcaj temporal"
 
 msgid "to"
 msgstr "la"
@@ -17892,8 +19885,11 @@ msgstr ""
 msgid "use latest_partition template"
 msgstr "folosește șablonul latest_partition"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, it, ja,
+# lv, ru, sr, sr_Latn, uk]
+#, fuzzy
 msgid "username"
-msgstr ""
+msgstr "nume de utilizator"
 
 msgid "value ascending"
 msgstr "valoare crescătoare"
@@ -17943,6 +19939,7 @@ msgstr "y: valorile sunt normalizate în cadrul fiecărui rând"
 msgid "year"
 msgstr "an"
 
+#. do-not-translate
 msgid "your-project-1234-a1"
 msgstr ""
 
@@ -17952,5 +19949,8 @@ msgstr "zonă zoom"
 msgid "© Layer attribution"
 msgstr "© Atribuire Strat"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
+# sr_Latn]
+#, fuzzy
 msgid "№"
-msgstr ""
+msgstr "№"


### PR DESCRIPTION
### SUMMARY

Backfills untranslated (empty `msgstr`) entries in the **Romanian (ro)** catalog using `scripts/translations/backfill_po.py`, with every other language's translation of the same string as cross-language context.

New entries are marked `#, fuzzy` with a `# Machine-translated via backfill_po.py` attribution for human review. Fuzzy entries **are** served (backend compiles `--use-fuzzy`, frontend uses `po2json --fuzzy`), so the translations reach users on build while remaining reviewable.

Romanian had the largest backlog — it was skipped in the original AI backfill sweep as "already complete" but had ~620 untranslated strings.

Split out from the combined backfill PR (#42099) because this catalog needed a larger canonical-reformatting pass; the bulk of the diff is normalize re-wrapping, not new content.

### TESTING INSTRUCTIONS

QA before opening: **616 entries filled**, 0 placeholder mismatches, `msgfmt -c` clean, 0 existing translations altered (only empty entries filled + canonical re-wrap).

### ADDITIONAL INFORMATION

- [x] Changes UI (translated strings)
