### PR TITLE
feat(i18n): backfill Italian (it) translations (AI-generated, needs review)

### DIFF
--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "A comma separated list of columns that should be parsed as dates"
 msgstr ""
 "Una lista separata da virgole di colonne che dovrebbero "
-"essereinterpretate come date"
+"essere interpretate come date"
 
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr ""
@@ -2538,8 +2538,7 @@ msgstr "Si è verificato un errore nel rendering della visualizzazione: %s"
 
 msgid "An error occurred while saving the semantic view"
 msgstr ""
-"Si è verificato un errore nel caricare nel salvataggio della vista "
-"semantica"
+"Si è verificato un errore durante il salvataggio della vista semantica"
 
 msgid "An error occurred while starring this chart"
 msgstr ""
@@ -4302,7 +4301,7 @@ msgid "Chart type requires a dataset"
 msgstr "Il tipo di grafico richiede un dataset"
 
 msgid "Chart was saved but could not be added to the selected tab."
-msgstr "IL grafico è stato salvato ma non può essere aggiunto al tab selezionato."
+msgstr "Il grafico è stato salvato ma non può essere aggiunto al tab selezionato."
 
 msgid "Chart width"
 msgstr "Larghezza grafico"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -20,40 +20,63 @@ msgstr ""
 "POT-Creation-Date: 2026-06-23 03:46-0700\n"
 "PO-Revision-Date: 2018-02-11 22:26+0200\n"
 "Last-Translator: Raffaele Spangaro <raffa@raffaelespangaro.it>\n"
-"Language-Team: Italiano <>\n"
 "Language: it\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Italiano <>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "A soft-deleted dataset (uuid %(uuid)s) already references this table. "
-"Restore it via POST /api/v1/dataset/%(uuid)s/restore before creating a new "
-"dataset over this table, or use a different table name."
+"Restore it via POST /api/v1/dataset/%(uuid)s/restore before creating a "
+"new dataset over this table, or use a different table name."
 msgstr ""
+"Un dataset eliminato temporaneamente (uuid %(uuid)s) fa già riferimento a"
+" questa tabella. Ripristinalo tramite POST "
+"/api/v1/dataset/%(uuid)s/restore prima di creare un nuovo dataset su "
+"questa tabella, oppure usa un nome di tabella diverso."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "A soft-deleted dataset (uuid %(uuid)s) already references this table. "
-"Restore it via POST /api/v1/dataset/%(uuid)s/restore before uploading, or "
-"upload to a different table name."
+"Restore it via POST /api/v1/dataset/%(uuid)s/restore before uploading, or"
+" upload to a different table name."
 msgstr ""
+"Un dataset eliminato temporaneamente (uuid %(uuid)s) fa già riferimento a"
+" questa tabella. Ripristinalo tramite POST "
+"/api/v1/dataset/%(uuid)s/restore prima di caricare, oppure carica su un "
+"nome di tabella diverso."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "Cannot delete a database whose only remaining datasets are soft-deleted. "
 "Restore them (POST /api/v1/dataset/<uuid>/restore) and delete them "
 "permanently once a purge capability ships, or remove the underlying rows "
 "out-of-band, before deleting the database."
 msgstr ""
+"Impossibile eliminare un database i cui unici dataset rimanenti sono "
+"stati eliminati temporaneamente. Ripristinali (POST "
+"/api/v1/dataset/<uuid>/restore) ed eliminali definitivamente quando sarà "
+"disponibile la funzionalità di eliminazione permanente, oppure rimuovi le"
+" righe sottostanti fuori banda, prima di eliminare il database."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"Dataset cannot be restored because another active dataset already references "
-"the same physical table (same database, catalog, schema, and table name). "
-"Delete the duplicate or rename the table before restoring."
+"Dataset cannot be restored because another active dataset already "
+"references the same physical table (same database, catalog, schema, and "
+"table name). Delete the duplicate or rename the table before restoring."
 msgstr ""
+"Il dataset non può essere ripristinato perché un altro dataset attivo fa "
+"già riferimento alla stessa tabella fisica (stesso database, catalogo, "
+"schema e nome tabella). Elimina il duplicato o rinomina la tabella prima "
+"di ripristinare."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -64,10 +87,10 @@ msgid ""
 "accumulates over different\n"
 "                values. When enabled, the histogram bars represent the "
 "running total of frequencies\n"
-"                up to each bin. This helps you understand how likely it is "
-"to encounter values\n"
-"                below a certain point. Keep in mind that enabling cumulative "
-"doesn't change your\n"
+"                up to each bin. This helps you understand how likely it "
+"is to encounter values\n"
+"                below a certain point. Keep in mind that enabling "
+"cumulative doesn't change your\n"
 "                original data, it just changes the way the histogram is "
 "displayed."
 msgstr ""
@@ -76,8 +99,8 @@ msgstr ""
 "accumulano su valori\n"
 "                diversi. Quando abilitata, le barre dell'istogramma "
 "rappresentano il totale cumulativo delle frequenze\n"
-"                fino a ciascun intervallo. Questo aiuta a capire quanto sia "
-"probabile incontrare valori\n"
+"                fino a ciascun intervallo. Questo aiuta a capire quanto "
+"sia probabile incontrare valori\n"
 "                al di sotto di un certo punto. Tieni presente che "
 "l'abilitazione del cumulativo non modifica i\n"
 "                dati originali, cambia solo il modo in cui viene "
@@ -88,26 +111,26 @@ msgstr ""
 #, fuzzy
 msgid ""
 "\n"
-"                The normalize option transforms the histogram values into "
-"proportions or\n"
+"                The normalize option transforms the histogram values into"
+" proportions or\n"
 "                probabilities by dividing each bin's count by the total "
 "count of data points.\n"
-"                This normalization process ensures that the resulting values "
-"sum up to 1,\n"
-"                enabling a relative comparison of the data's distribution "
-"and providing a\n"
+"                This normalization process ensures that the resulting "
+"values sum up to 1,\n"
+"                enabling a relative comparison of the data's distribution"
+" and providing a\n"
 "                clearer understanding of the proportion of data points "
 "within each bin."
 msgstr ""
 "\n"
-"                L'opzione normalizza trasforma i valori dell'istogramma in "
-"proporzioni o\n"
-"                probabilità dividendo il conteggio di ciascun intervallo per "
-"il totale dei punti dati.\n"
-"                Questo processo di normalizzazione garantisce che la somma "
-"dei valori risultanti sia 1,\n"
-"                consentendo un confronto relativo della distribuzione dei "
-"dati e fornendo una\n"
+"                L'opzione normalizza trasforma i valori dell'istogramma "
+"in proporzioni o\n"
+"                probabilità dividendo il conteggio di ciascun intervallo "
+"per il totale dei punti dati.\n"
+"                Questo processo di normalizzazione garantisce che la "
+"somma dei valori risultanti sia 1,\n"
+"                consentendo un confronto relativo della distribuzione dei"
+" dati e fornendo una\n"
 "                comprensione più chiara della proporzione dei punti dati "
 "all'interno di ciascun intervallo."
 
@@ -122,7 +145,8 @@ msgid ""
 "              "
 msgstr ""
 "\n"
-"                Questo filtro è stato ereditato dal contesto del dashboard.\n"
+"                Questo filtro è stato ereditato dal contesto del "
+"dashboard.\n"
 "                Non verrà salvato durante il salvataggio del grafico.\n"
 "              "
 
@@ -131,15 +155,15 @@ msgstr ""
 #, fuzzy, python-format
 msgid ""
 "\n"
-"            <p>Your report/alert was unable to be generated because of the "
-"following error: %(text)s</p>\n"
+"            <p>Your report/alert was unable to be generated because of "
+"the following error: %(text)s</p>\n"
 "            <p>Please check your dashboard/chart for errors.</p>\n"
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
 "            "
 msgstr ""
 "\n"
-"            <p>Il report/avviso non ha potuto essere generato a causa del "
-"seguente errore: %(text)s</p>\n"
+"            <p>Il report/avviso non ha potuto essere generato a causa del"
+" seguente errore: %(text)s</p>\n"
 "            <p>Si prega di verificare il dashboard/grafico per eventuali "
 "errori.</p>\n"
 "            <p><b><a href=\"%(url)s\">%(call_to_action)s</a></b></p>\n"
@@ -149,8 +173,8 @@ msgid " (excluded)"
 msgstr "(escluso)"
 
 msgid ""
-" Set the opacity to 0 if you do not want to override the color specified in "
-"the GeoJSON"
+" Set the opacity to 0 if you do not want to override the color specified "
+"in the GeoJSON"
 msgstr ""
 " Impostare l'opacità a 0 se non si desidera sovrascrivere il colore "
 "specificato in GeoJSON"
@@ -201,22 +225,24 @@ msgid ""
 "Note\n"
 "                      currently time zones are not supported. If time is "
 "stored\n"
-"                      in epoch format, put `epoch_s` or `epoch_ms`. If no "
-"pattern\n"
+"                      in epoch format, put `epoch_s` or `epoch_ms`. If no"
+" pattern\n"
 "                      is specified we fall back to using the optional "
 "defaults on a per\n"
 "                      database/column name level via the extra parameter."
 msgstr ""
 " standard per garantire che l'ordinamento lessicografico\n"
 "                      coincida con l'ordinamento cronologico. Se il\n"
-"                      formato del timestamp non è conforme allo standard ISO "
-"8601\n"
-"                      sarà necessario definire un'espressione e un tipo per\n"
-"                      trasformare la stringa in una data o timestamp. Nota:\n"
-"                      le zone orarie non sono attualmente supportate. Se il "
-"tempo è memorizzato\n"
-"                      in formato epoch, inserire `epoch_s` o `epoch_ms`. Se "
-"non viene\n"
+"                      formato del timestamp non è conforme allo standard "
+"ISO 8601\n"
+"                      sarà necessario definire un'espressione e un tipo "
+"per\n"
+"                      trasformare la stringa in una data o timestamp. "
+"Nota:\n"
+"                      le zone orarie non sono attualmente supportate. Se "
+"il tempo è memorizzato\n"
+"                      in formato epoch, inserire `epoch_s` o `epoch_ms`. "
+"Se non viene\n"
 "                      specificato alcun pattern, si utilizzano i valori "
 "predefiniti opzionali a livello di\n"
 "                      nome database/colonna tramite il parametro extra."
@@ -324,10 +350,11 @@ msgstr "%(prefix)s %(title)s"
 # sr_Latn]
 #, fuzzy, python-format
 msgid ""
-"%(prefix)sResults truncated to %(row_count)s rows due to memory constraints."
+"%(prefix)sResults truncated to %(row_count)s rows due to memory "
+"constraints."
 msgstr ""
-"%(prefix)sRisultati troncati a %(row_count)s righe a causa di limitazioni di "
-"memoria."
+"%(prefix)sRisultati troncati a %(row_count)s righe a causa di limitazioni"
+" di memoria."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -350,13 +377,15 @@ msgstr "%(rows)d righe restituite"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, de, lv,
 # mi, ro, ru, sl, sr, sr_Latn, uk]
-#, python-format
+#, fuzzy, python-format
 msgid "%(suggestion)s instead of \"%(undefinedParameter)s?\""
 msgid_plural ""
 "%(firstSuggestions)s or %(lastSuggestion)s instead of "
 "\"%(undefinedParameter)s\"?"
-msgstr[0] ""
+msgstr[0] "%(suggestion)s invece di \"%(undefinedParameter)s\"?"
 msgstr[1] ""
+"%(firstSuggestions)s o %(lastSuggestion)s invece di "
+"\"%(undefinedParameter)s\"?"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -468,11 +497,13 @@ msgstr "%s colonna/e"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
 # sr_Latn]
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, ja,
+# sr, sr_Latn]
+#, fuzzy, python-format
 msgid "%s day ago"
 msgid_plural "%s days ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s giorno fa"
+msgstr[1] "%s giorni fa"
 
 #, python-format
 msgid "%s hr ago"
@@ -498,11 +529,11 @@ msgstr "%s elemento/i"
 # es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"%s items could not be tagged because you don’t have edit permissions to all "
-"selected objects."
+"%s items could not be tagged because you don’t have edit permissions to "
+"all selected objects."
 msgstr ""
-"%s elementi non hanno potuto essere etichettati perché non si dispone dei "
-"permessi di modifica per tutti gli oggetti selezionati."
+"%s elementi non hanno potuto essere etichettati perché non si dispone dei"
+" permessi di modifica per tutti gli oggetti selezionati."
 
 #, python-format
 msgid "%s metric"
@@ -826,6 +857,7 @@ msgstr "10 secondi"
 msgid "10/90 percentiles"
 msgstr "percentili 10/90"
 
+#. do-not-translate
 msgid "10000"
 msgstr "10000"
 
@@ -1111,26 +1143,27 @@ msgstr ""
 #, fuzzy
 msgid "A JavaScript function that generates an icon configuration object"
 msgstr ""
-"Una funzione JavaScript che genera un oggetto di configurazione delle icone"
+"Una funzione JavaScript che genera un oggetto di configurazione delle "
+"icone"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy, python-brace-format
 msgid ""
 "A JavaScript object that adheres to the ECharts options specification, "
-"overriding other control options with higher precedence. (i.e. { title: "
-"{ text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: https://"
-"echarts.apache.org/en/option.html. "
+"overriding other control options with higher precedence. (i.e. { title: {"
+" text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). Details: "
+"https://echarts.apache.org/en/option.html. "
 msgstr ""
 "Un oggetto JavaScript conforme alla specifica delle opzioni ECharts, che "
-"sovrascrive le altre opzioni di controllo con priorità più elevata. (ad es. "
-"{ title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). "
+"sovrascrive le altre opzioni di controllo con priorità più elevata. (ad "
+"es. { title: { text: \"My Chart\" }, tooltip: { trigger: \"item\" } }). "
 "Dettagli: https://echarts.apache.org/en/option.html. "
 
 msgid "A comma separated list of columns that should be parsed as dates"
 msgstr ""
-"Una lista separata da virgole di colonne che dovrebbero essereinterpretate "
-"come date"
+"Una lista separata da virgole di colonne che dovrebbero "
+"essereinterpretate come date"
 
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr ""
@@ -1150,34 +1183,36 @@ msgstr "Esiste già un database con lo stesso nome."
 
 msgid "A date is required when using custom date shift"
 msgstr ""
-"Quando si utilizza lo spostamento di data personalizzato, è necessaria una "
-"data"
+"Quando si utilizza lo spostamento di data personalizzato, è necessaria "
+"una data"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "A description for your dashboard"
-msgstr ""
+msgstr "Una descrizione per il tuo dashboard"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-brace-format
 msgid ""
-"A dictionary with column names and their data types if you need to change "
-"the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas library "
-"for supported data types."
+"A dictionary with column names and their data types if you need to change"
+" the defaults. Example: {\"user_id\":\"int\"}. Check Python's Pandas "
+"library for supported data types."
 msgstr ""
-"Un dizionario con nomi di colonne e relativi tipi di dati se è necessario "
-"modificare i valori predefiniti. Esempio: {\"user_id\":\"int\"}. Consulta la "
-"libreria Pandas di Python per i tipi di dati supportati."
+"Un dizionario con nomi di colonne e relativi tipi di dati se è necessario"
+" modificare i valori predefiniti. Esempio: {\"user_id\":\"int\"}. "
+"Consulta la libreria Pandas di Python per i tipi di dati supportati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"A full URL pointing to the location of the built plugin (could be hosted on "
-"a CDN for example)"
+"A full URL pointing to the location of the built plugin (could be hosted "
+"on a CDN for example)"
 msgstr ""
-"Un URL completo che punta alla posizione del plugin compilato (ad esempio "
-"potrebbe essere ospitato su un CDN)"
+"Un URL completo che punta alla posizione del plugin compilato (ad esempio"
+" potrebbe essere ospitato su un CDN)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -1208,8 +1243,8 @@ msgstr ""
 
 msgid "A list of subjects who can view the chart. Searchable by name."
 msgstr ""
-"Un elenco di soggetti che possono visualizzare il grafico. Ricercabile per "
-"nome."
+"Un elenco di soggetti che possono visualizzare il grafico. Ricercabile "
+"per nome."
 
 msgid "A list of tags that have been applied to this chart."
 msgstr "Un elenco di tag che sono stati applicati a questo grafico."
@@ -1226,8 +1261,8 @@ msgstr "Una mappa del mondo, che può indicare i valori in diversi paesi."
 # uk]
 #, fuzzy
 msgid ""
-"A map that takes rendering circles with a variable radius at latitude/"
-"longitude coordinates"
+"A map that takes rendering circles with a variable radius at "
+"latitude/longitude coordinates"
 msgstr ""
 "Una mappa che visualizza cerchi con raggio variabile nelle coordinate di "
 "latitudine/longitudine"
@@ -1235,10 +1270,14 @@ msgstr ""
 msgid "A metric to use for color"
 msgstr "Una metrica da utilizzare come colore"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"A multiplier applied to the point radius. Use this to uniformly scale all "
-"points."
+"A multiplier applied to the point radius. Use this to uniformly scale all"
+" points."
 msgstr ""
+"Un moltiplicatore applicato al raggio del punto. Usalo per scalare "
+"uniformemente tutti i punti."
 
 msgid "A new chart and dashboard will be created."
 msgstr "Saranno creati un nuovo grafico e dashboard."
@@ -1255,12 +1294,12 @@ msgstr "Una nuova dashboard sarà creata."
 #, fuzzy
 msgid ""
 "A polar coordinate chart where the circle is broken into wedges of equal "
-"angle, and the value represented by any wedge is illustrated by its area, "
-"rather than its radius or sweep angle."
+"angle, and the value represented by any wedge is illustrated by its area,"
+" rather than its radius or sweep angle."
 msgstr ""
 "Un grafico a coordinate polari in cui il cerchio è diviso in spicchi di "
-"uguale angolo e il valore rappresentato da ciascuno spicchio è illustrato "
-"dalla sua area, anziché dal suo raggio o angolo di apertura."
+"uguale angolo e il valore rappresentato da ciascuno spicchio è illustrato"
+" dalla sua area, anziché dal suo raggio o angolo di apertura."
 
 msgid "A readable URL for your dashboard"
 msgstr "Una URL leggibile per la dashboard"
@@ -1269,10 +1308,8 @@ msgstr "Una URL leggibile per la dashboard"
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
 # tr, uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"A reference to the [Time] configuration, taking granularity into account"
-msgstr ""
-"Un riferimento alla configurazione [Time], tenendo conto della granularità"
+msgid "A reference to the [Time] configuration, taking granularity into account"
+msgstr "Un riferimento alla configurazione [Time], tenendo conto della granularità"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -1295,8 +1332,8 @@ msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
-"Un insieme di parametri che diventano disponibili nella query utilizzando la "
-"sintassi di template Jinja"
+"Un insieme di parametri che diventano disponibili nella query utilizzando"
+" la sintassi di template Jinja"
 
 msgid "A timeout occurred while executing the query."
 msgstr "Raggiunto timeout nell'eseguire la query."
@@ -1333,8 +1370,8 @@ msgstr ""
 "comprendere\n"
 "          l'effetto cumulativo di valori positivi o negativi introdotti "
 "sequenzialmente.\n"
-"          Questi valori intermedi possono essere basati sul tempo o sulla "
-"categoria."
+"          Questi valori intermedi possono essere basati sul tempo o sulla"
+" categoria."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -1486,7 +1523,8 @@ msgstr "Aggiungi Log"
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Add Query A and Query B identifiers to tooltips to help differentiate series"
+"Add Query A and Query B identifiers to tooltips to help differentiate "
+"series"
 msgstr ""
 "Aggiungi gli identificatori Query A e Query B ai tooltip per aiutare a "
 "differenziare le serie"
@@ -1546,7 +1584,8 @@ msgstr "Aggiungi un altro metodo di notifica"
 
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Aggiungi colonne calcolate al dataset nella modale \"Modifica sorgente dati\""
+"Aggiungi colonne calcolate al dataset nella modale \"Modifica sorgente "
+"dati\""
 
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
 msgstr ""
@@ -1631,18 +1670,19 @@ msgid ""
 "these conditions\n"
 "                    do not impact how the filter is applied to the "
 "dashboard. This is useful\n"
-"                    when you want to improve the query's performance by only "
-"scanning a subset\n"
+"                    when you want to improve the query's performance by "
+"only scanning a subset\n"
 "                    of the underlying data or limit the available values "
 "displayed in the filter."
 msgstr ""
-"Aggiungi clausole di filtro per controllare la query sorgente del filtro,\n"
+"Aggiungi clausole di filtro per controllare la query sorgente del filtro,"
+"\n"
 "                    ma solo nel contesto del completamento automatico, "
 "ovvero queste condizioni\n"
 "                    non influiscono sul modo in cui il filtro viene "
 "applicato al dashboard. Ciò è utile\n"
-"                    quando si desidera migliorare le prestazioni della query "
-"esaminando solo un sottoinsieme\n"
+"                    quando si desidera migliorare le prestazioni della "
+"query esaminando solo un sottoinsieme\n"
 "                    dei dati sottostanti o limitare i valori disponibili "
 "visualizzati nel filtro."
 
@@ -1687,8 +1727,8 @@ msgstr "Aggiungi report"
 # uk, zh, zh_TW]
 msgid "Add required control values to preview chart"
 msgstr ""
-"Aggiungi i valori di controllo richiesti per visualizzare l'anteprima del "
-"grafico"
+"Aggiungi i valori di controllo richiesti per visualizzare l'anteprima del"
+" grafico"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -1776,8 +1816,8 @@ msgid ""
 "Adds color to the chart symbols based on the positive or negative change "
 "from the comparison value."
 msgstr ""
-"Aggiunge colore ai simboli del grafico in base alla variazione positiva o "
-"negativa rispetto al valore di confronto."
+"Aggiunge colore ai simboli del grafico in base alla variazione positiva o"
+" negativa rispetto al valore di confronto."
 
 msgid "Adjust how this database will interact with SQL Lab."
 msgstr "Regolare il modo in cui questo database interagirà con SQL Lab."
@@ -1831,8 +1871,8 @@ msgstr "Dopo"
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"After making the changes, copy the query and paste in the virtual dataset "
-"SQL snippet settings."
+"After making the changes, copy the query and paste in the virtual dataset"
+" SQL snippet settings."
 msgstr ""
 "Dopo aver apportato le modifiche, copia la query e incollala nelle "
 "impostazioni dello snippet SQL del set di dati virtuale."
@@ -1857,33 +1897,33 @@ msgstr "Somma aggregata"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Aggregate function applied to the list of points in each cluster to produce "
-"the cluster label."
+"Aggregate function applied to the list of points in each cluster to "
+"produce the cluster label."
 msgstr ""
-"Funzione di aggregazione applicata all'elenco dei punti in ciascun cluster "
-"per produrre l'etichetta del cluster."
+"Funzione di aggregazione applicata all'elenco dei punti in ciascun "
+"cluster per produrre l'etichetta del cluster."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
 # zh, zh_TW]
 #, fuzzy
 msgid ""
-"Aggregate function to apply when pivoting and computing the total rows and "
-"columns"
+"Aggregate function to apply when pivoting and computing the total rows "
+"and columns"
 msgstr ""
-"Funzione di aggregazione da applicare durante il pivoting e il calcolo delle "
-"righe e colonne totali"
+"Funzione di aggregazione da applicare durante il pivoting e il calcolo "
+"delle righe e colonne totali"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"Aggregates data within the boundary of grid cells and maps the aggregated "
-"values to a dynamic color scale"
+"Aggregates data within the boundary of grid cells and maps the aggregated"
+" values to a dynamic color scale"
 msgstr ""
-"Aggrega i dati all'interno dei limiti delle celle della griglia e mappa i "
-"valori aggregati su una scala di colori dinamica"
+"Aggrega i dati all'interno dei limiti delle celle della griglia e mappa i"
+" valori aggregati su una scala di colori dinamica"
 
 msgid "Aggregation"
 msgstr "Aggregazione"
@@ -1967,11 +2007,10 @@ msgstr "La query di avviso ha restituito più di una colonna."
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
-msgid ""
-"Alert query returned more than one column. %(num_cols)s columns returned"
+msgid "Alert query returned more than one column. %(num_cols)s columns returned"
 msgstr ""
-"La query di avviso ha restituito più di una colonna. %(num_cols)s colonne "
-"restituite"
+"La query di avviso ha restituito più di una colonna. %(num_cols)s colonne"
+" restituite"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -2092,11 +2131,11 @@ msgstr "Permette di modificare i cataloghi"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Allow column names to be changed to case insensitive format, if supported "
-"(e.g. Oracle, Snowflake)."
+"Allow column names to be changed to case insensitive format, if supported"
+" (e.g. Oracle, Snowflake)."
 msgstr ""
-"Consenti la modifica dei nomi delle colonne in formato senza distinzione tra "
-"maiuscole e minuscole, se supportato (ad es. Oracle, Snowflake)."
+"Consenti la modifica dei nomi delle colonne in formato senza distinzione "
+"tra maiuscole e minuscole, se supportato (ad es. Oracle, Snowflake)."
 
 msgid "Allow columns to be rearranged"
 msgstr "Permette di riorganizzare le colonne"
@@ -2118,11 +2157,11 @@ msgstr "Permette linguaggio di manipolazione dei dati"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Allow end user to drag-and-drop column headers to rearrange them. Note their "
-"changes won't persist for the next time they open the chart."
+"Allow end user to drag-and-drop column headers to rearrange them. Note "
+"their changes won't persist for the next time they open the chart."
 msgstr ""
-"Consenti all'utente finale di trascinare le intestazioni delle colonne per "
-"riorganizzarle. Si noti che le modifiche non verranno mantenute alla "
+"Consenti all'utente finale di trascinare le intestazioni delle colonne "
+"per riorganizzarle. Si noti che le modifiche non verranno mantenute alla "
 "prossima apertura del grafico."
 
 msgid "Allow file uploads to database"
@@ -2136,11 +2175,11 @@ msgstr "Permette selezioni del nodo"
 #, fuzzy
 msgid ""
 "Allow the execution of DDL (Data Definition Language: CREATE, DROP, "
-"TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, DELETE, "
-"etc)"
+"TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, "
+"DELETE, etc)"
 msgstr ""
-"Consenti l'esecuzione di DDL (Linguaggio di Definizione dei Dati: CREATE, "
-"DROP, TRUNCATE, ecc.) e DML (Linguaggio di Modifica dei Dati: INSERT, "
+"Consenti l'esecuzione di DDL (Linguaggio di Definizione dei Dati: CREATE,"
+" DROP, TRUNCATE, ecc.) e DML (Linguaggio di Modifica dei Dati: INSERT, "
 "UPDATE, DELETE, ecc.)"
 
 msgid "Allow this database to be explored"
@@ -2176,8 +2215,8 @@ msgid ""
 msgstr ""
 "Noto anche come diagramma a scatola e baffi, questa visualizzazione "
 "confronta le distribuzioni di una metrica correlata in più gruppi. Il "
-"riquadro al centro evidenzia la media, la mediana e i 2 quartili interni. I "
-"baffi attorno a ciascun riquadro visualizzano il minimo, il massimo, "
+"riquadro al centro evidenzia la media, la mediana e i 2 quartili interni."
+" I baffi attorno a ciascun riquadro visualizzano il minimo, il massimo, "
 "l'intervallo e i 2 quartili esterni."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -2202,8 +2241,8 @@ msgstr "Un alert chiamato \"%(name)s\" esiste già"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"An enclosed time range (both start and end) must be specified when using a "
-"Time Comparison."
+"An enclosed time range (both start and end) must be specified when using "
+"a Time Comparison."
 msgstr ""
 "Quando si utilizza un Confronto Temporale, è necessario specificare un "
 "intervallo di tempo chiuso (sia inizio che fine)."
@@ -2213,10 +2252,11 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"An engine must be specified when passing individual parameters to a database."
+"An engine must be specified when passing individual parameters to a "
+"database."
 msgstr ""
-"È necessario specificare un motore quando si passano parametri individuali a "
-"un database."
+"È necessario specificare un motore quando si passano parametri "
+"individuali a un database."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -2253,8 +2293,8 @@ msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
 "administrator."
 msgstr ""
-"Si è verificato un errore nel collassare lo schema di tabelle. Contattare "
-"l'amministratore di sistema."
+"Si è verificato un errore nel collassare lo schema di tabelle. Contattare"
+" l'amministratore di sistema."
 
 #, python-format
 msgid "An error occurred while creating %ss: %s"
@@ -2285,8 +2325,8 @@ msgid ""
 "An error occurred while expanding the table schema. Please contact your "
 "administrator."
 msgstr ""
-"Si è verificato un errore nell'espandere lo schema di tabelle. Contattare "
-"l'amministratore di sistema."
+"Si è verificato un errore nell'espandere lo schema di tabelle. Contattare"
+" l'amministratore di sistema."
 
 #, python-format
 msgid "An error occurred while fetching %s"
@@ -2324,14 +2364,14 @@ msgstr "Si è verificato un errore nel caricare le viste disponibili"
 #, python-format
 msgid "An error occurred while fetching chart editor values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori degli editor del "
-"grafico: %s"
+"Si è verificato un errore durante il recupero dei valori degli editor del"
+" grafico: %s"
 
 #, python-format
 msgid "An error occurred while fetching chart viewer values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori dei visualizzatori "
-"del grafico: %s"
+"Si è verificato un errore durante il recupero dei valori dei "
+"visualizzatori del grafico: %s"
 
 msgid "An error occurred while fetching connections"
 msgstr "Si è verificato un errore nel caricare le connessioni"
@@ -2343,14 +2383,14 @@ msgstr "Errore nel rendering della visualizzazione: %s"
 #, python-format
 msgid "An error occurred while fetching dashboard editor values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori degli editor della "
-"dashboard: %s"
+"Si è verificato un errore durante il recupero dei valori degli editor "
+"della dashboard: %s"
 
 #, python-format
 msgid "An error occurred while fetching dashboard viewer values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori dei visualizzatori "
-"della dashboard: %s"
+"Si è verificato un errore durante il recupero dei valori dei "
+"visualizzatori della dashboard: %s"
 
 msgid "An error occurred while fetching dashboards"
 msgstr "Si è verificato un errore nel caricare le dashboard"
@@ -2364,41 +2404,40 @@ msgstr "Si è verificato un errore durante il recupero delle dashboard: %s"
 #, python-format
 msgid "An error occurred while fetching database related data: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei dati relativi database: %s"
+"Si è verificato un errore durante il recupero dei dati relativi database:"
+" %s"
 
 # Machine-corrected via repair_i18n.py (claude-sonnet-4-6) [restored
 # placeholder]
 #, python-format
 msgid "An error occurred while fetching database values: %s"
-msgstr ""
-"Si è verificato un errore durante il recupero dei valori del database: %s"
+msgstr "Si è verificato un errore durante il recupero dei valori del database: %s"
 
 # Machine-corrected via repair_i18n.py (claude-sonnet-4-6) [restored
 # placeholder]
 #, python-format
 msgid "An error occurred while fetching dataset datasource values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori della sorgente dati "
-"del dataset: %s"
+"Si è verificato un errore durante il recupero dei valori della sorgente "
+"dati del dataset: %s"
 
 #, python-format
 msgid "An error occurred while fetching dataset editor values: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei valori degli editor del "
-"dataset: %s"
+"Si è verificato un errore durante il recupero dei valori degli editor del"
+" dataset: %s"
 
 # Machine-corrected via repair_i18n.py (claude-sonnet-4-6) [restored
 # placeholder]
 #, python-format
 msgid "An error occurred while fetching dataset related data: %s"
 msgstr ""
-"Si è verificato un errore durante il recupero dei dati correlati al dataset: "
-"%s"
+"Si è verificato un errore durante il recupero dei dati correlati al "
+"dataset: %s"
 
 #, python-format
 msgid "An error occurred while fetching editor values: %s"
-msgstr ""
-"Si è verificato un errore durante il recupero dei valori degli editor: %s"
+msgstr "Si è verificato un errore durante il recupero dei valori degli editor: %s"
 
 msgid "An error occurred while fetching function names."
 msgstr "Si è verificato un errore nel caricare i nomi delle funzioni."
@@ -2430,8 +2469,7 @@ msgid "An error occurred while fetching the semantic layer"
 msgstr "Si è verificato un errore nel caricare il livello semantico"
 
 msgid "An error occurred while fetching the semantic view structure"
-msgstr ""
-"Si è verificato un errore nel caricare la struttura della vista semantica"
+msgstr "Si è verificato un errore nel caricare la struttura della vista semantica"
 
 #, python-format
 msgid "An error occurred while fetching theme datasource values: %s"
@@ -2445,7 +2483,8 @@ msgstr "Si è verificato un errore nel caricare i dati di utilizzo"
 #, python-format
 msgid "An error occurred while fetching user values: %s"
 msgstr ""
-"Si è verificato un errore durante lo scaricamento dei valori dell'utente: %s"
+"Si è verificato un errore durante lo scaricamento dei valori dell'utente:"
+" %s"
 
 msgid "An error occurred while formatting SQL"
 msgstr "Si è verificato un errore nel formattare l'SQL"
@@ -2454,14 +2493,19 @@ msgstr "Si è verificato un errore nel formattare l'SQL"
 msgid "An error occurred while importing %s: %s"
 msgstr "Si è verificato un errore durante l'importazione %s: %s"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"An error occurred while loading SQL Lab. This may be caused by a corrupted "
-"query state."
+"An error occurred while loading SQL Lab. This may be caused by a "
+"corrupted query state."
 msgstr ""
+"Si è verificato un errore durante il caricamento di SQL Lab. Ciò potrebbe"
+" essere causato da uno stato di query corrotto."
 
 msgid "An error occurred while loading dashboard information."
 msgstr ""
-"Si è verificato un errore nel caricamento delle informazioni della dashboard."
+"Si è verificato un errore nel caricamento delle informazioni della "
+"dashboard."
 
 msgid "An error occurred while loading the SQL"
 msgstr "Si è verificato un errore nel caricare l'SQL"
@@ -2478,8 +2522,7 @@ msgstr "Errore nel rendering della visualizzazione: %s"
 msgid "An error occurred while refreshing the configuration schema"
 msgstr "Si è verificato un errore nell'aggiornare lo schema di configurazione"
 
-msgid ""
-"An error occurred while removing query. Please contact your administrator."
+msgid "An error occurred while removing query. Please contact your administrator."
 msgstr "Si è verificato un rimuovere la query. Contattare l'amministratore."
 
 msgid ""
@@ -2495,28 +2538,30 @@ msgstr "Si è verificato un errore nel rendering della visualizzazione: %s"
 
 msgid "An error occurred while saving the semantic view"
 msgstr ""
-"Si è verificato un errore nel caricare nel salvataggio della vista semantica"
+"Si è verificato un errore nel caricare nel salvataggio della vista "
+"semantica"
 
 msgid "An error occurred while starring this chart"
 msgstr ""
-"Si è verificato un errore durante l'apposizione della stella a questo grafico"
+"Si è verificato un errore durante l'apposizione della stella a questo "
+"grafico"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"An error occurred while storing your query in the backend. To avoid losing "
-"your changes, please save your query using the \"Save Query\" button."
+"An error occurred while storing your query in the backend. To avoid "
+"losing your changes, please save your query using the \"Save Query\" "
+"button."
 msgstr ""
-"Si è verificato un errore durante il salvataggio della query nel backend. "
-"Per evitare di perdere le modifiche, salvare la query utilizzando il "
+"Si è verificato un errore durante il salvataggio della query nel backend."
+" Per evitare di perdere le modifiche, salvare la query utilizzando il "
 "pulsante \"Salva Query\"."
 
 #, python-format
 msgid "An error occurred while syncing permissions for %s: %s"
-msgstr ""
-"Si è verificato un errore nella sincronizzazione dei permessi per %s: %s"
+msgstr "Si è verificato un errore nella sincronizzazione dei permessi per %s: %s"
 
 msgid "An error occurred while updating the extension."
 msgstr "Si è verificato un errore nell'aggiornamento dell'estensione."
@@ -2528,12 +2573,10 @@ msgid "An error occurred while updating the value."
 msgstr "Errore durante l'aggiornamento del valore."
 
 msgid "An error occurred while upserting the extension."
-msgstr ""
-"Si è verificato un errore nella creazione/aggiornamento dell'estensione."
+msgstr "Si è verificato un errore nella creazione/aggiornamento dell'estensione."
 
 msgid "An error occurred while upserting the value."
-msgstr ""
-"Si è verificato un errore durante l'inserimento/aggiornamento del valore."
+msgstr "Si è verificato un errore durante l'inserimento/aggiornamento del valore."
 
 msgid "An unexpected error occurred"
 msgstr "Si è verificato un errore inatteso"
@@ -2697,8 +2740,8 @@ msgid ""
 "Any color palette selected here will override the colors applied to this "
 "dashboard's individual charts"
 msgstr ""
-"Qualsiasi tavolozza colori selezionata qui sovrascriverà i colori applicati "
-"ai singoli grafici di questo dashboard"
+"Qualsiasi tavolozza colori selezionata qui sovrascriverà i colori "
+"applicati ai singoli grafici di questo dashboard"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -2713,8 +2756,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
-msgid ""
-"Any dashboards using this theme will be automatically dissociated from it."
+msgid "Any dashboards using this theme will be automatically dissociated from it."
 msgstr ""
 "Tutti i dashboard che utilizzano questo tema verranno automaticamente "
 "dissociati da esso."
@@ -2723,11 +2765,10 @@ msgstr ""
 # de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
 # zh_TW]
 #, fuzzy
-msgid ""
-"Any databases that allow connections via SQL Alchemy URIs can be added. "
+msgid "Any databases that allow connections via SQL Alchemy URIs can be added. "
 msgstr ""
-"È possibile aggiungere qualsiasi database che consenta connessioni tramite "
-"URI SQL Alchemy. "
+"È possibile aggiungere qualsiasi database che consenta connessioni "
+"tramite URI SQL Alchemy. "
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
@@ -2737,8 +2778,8 @@ msgid ""
 "Any databases that allow connections via SQL Alchemy URIs can be added. "
 "Learn about how to connect a database driver "
 msgstr ""
-"È possibile aggiungere qualsiasi database che consenta connessioni tramite "
-"URI SQL Alchemy. Scopri come connettere un driver del database "
+"È possibile aggiungere qualsiasi database che consenta connessioni "
+"tramite URI SQL Alchemy. Scopri come connettere un driver del database "
 
 #, python-format
 msgid "Applied cross-filters (%d)"
@@ -2761,22 +2802,24 @@ msgstr "Applicati filtri: %s"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Applied rolling window did not return any data. Please make sure the source "
-"query satisfies the minimum periods defined in the rolling window."
+"Applied rolling window did not return any data. Please make sure the "
+"source query satisfies the minimum periods defined in the rolling window."
 msgstr ""
-"La finestra mobile applicata non ha restituito alcun dato. Assicurati che la "
-"query di origine soddisfi i periodi minimi definiti nella finestra mobile."
+"La finestra mobile applicata non ha restituito alcun dato. Assicurati che"
+" la query di origine soddisfi i periodi minimi definiti nella finestra "
+"mobile."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Applies only when \"Cell bars\" formatting is selected: the background of "
-"the histogram columns is displayed if the \"Show cell bars\" flag is enabled."
+"Applies only when \"Cell bars\" formatting is selected: the background of"
+" the histogram columns is displayed if the \"Show cell bars\" flag is "
+"enabled."
 msgstr ""
-"Si applica solo quando è selezionata la formattazione \"Barre nelle celle\": "
-"lo sfondo delle colonne dell'istogramma viene visualizzato se il flag "
-"\"Mostra barre nelle celle\" è abilitato."
+"Si applica solo quando è selezionata la formattazione \"Barre nelle "
+"celle\": lo sfondo delle colonne dell'istogramma viene visualizzato se il"
+" flag \"Mostra barre nelle celle\" è abilitato."
 
 msgid "Apply"
 msgstr "Applica"
@@ -2811,11 +2854,11 @@ msgstr "Applica formattazione colore condizionale alle colonne numeriche"
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Apply custom CSS to the dashboard. Use class names or element selectors to "
-"target specific components."
+"Apply custom CSS to the dashboard. Use class names or element selectors "
+"to target specific components."
 msgstr ""
-"Applica CSS personalizzato al dashboard. Usa nomi di classe o selettori di "
-"elementi per individuare componenti specifici."
+"Applica CSS personalizzato al dashboard. Usa nomi di classe o selettori "
+"di elementi per individuare componenti specifici."
 
 msgid "Apply filters"
 msgstr "Applica filtri"
@@ -2950,8 +2993,8 @@ msgstr "Sei sicuro di voler sovrascrivere questo set di dati?"
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Are you sure you want to remove the system dark theme? The application will "
-"fall back to the configuration file dark theme."
+"Are you sure you want to remove the system dark theme? The application "
+"will fall back to the configuration file dark theme."
 msgstr ""
 "Sei sicuro di voler rimuovere il tema scuro di sistema? L'applicazione "
 "tornerà al tema scuro del file di configurazione."
@@ -2960,20 +3003,21 @@ msgstr ""
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Are you sure you want to remove the system default theme? The application "
-"will fall back to the configuration file default."
+"Are you sure you want to remove the system default theme? The application"
+" will fall back to the configuration file default."
 msgstr ""
-"Sei sicuro di voler rimuovere il tema predefinito di sistema? L'applicazione "
-"tornerà al valore predefinito del file di configurazione."
+"Sei sicuro di voler rimuovere il tema predefinito di sistema? "
+"L'applicazione tornerà al valore predefinito del file di configurazione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Are you sure you want to revoke this API key? This action cannot be undone."
+"Are you sure you want to revoke this API key? This action cannot be "
+"undone."
 msgstr ""
-"Sei sicuro di voler revocare questa chiave API? Questa azione non può essere "
-"annullata."
+"Sei sicuro di voler revocare questa chiave API? Questa azione non può "
+"essere annullata."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -2997,12 +3041,12 @@ msgstr ""
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"Are you sure you want to set \"%s\" as the system default theme? This will "
-"apply to all users who haven't set a personal preference."
+"Are you sure you want to set \"%s\" as the system default theme? This "
+"will apply to all users who haven't set a personal preference."
 msgstr ""
-"Sei sicuro di voler impostare \"%s\" come tema predefinito di sistema? Verrà "
-"applicato a tutti gli utenti che non hanno impostato una preferenza "
-"personale."
+"Sei sicuro di voler impostare \"%s\" come tema predefinito di sistema? "
+"Verrà applicato a tutti gli utenti che non hanno impostato una preferenza"
+" personale."
 
 msgid "Area"
 msgstr "Area"
@@ -3021,12 +3065,13 @@ msgstr "Opacità grafico ad area"
 # uk]
 #, fuzzy
 msgid ""
-"Area charts are similar to line charts in that they represent variables with "
-"the same scale, but area charts stack the metrics on top of each other."
+"Area charts are similar to line charts in that they represent variables "
+"with the same scale, but area charts stack the metrics on top of each "
+"other."
 msgstr ""
-"I grafici ad area sono simili ai grafici a linee nel senso che rappresentano "
-"variabili con la stessa scala, ma i grafici ad area sovrappongono le "
-"metriche una sull'altra."
+"I grafici ad area sono simili ai grafici a linee nel senso che "
+"rappresentano variabili con la stessa scala, ma i grafici ad area "
+"sovrappongono le metriche una sull'altra."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -3096,7 +3141,8 @@ msgstr "Aggiornamento automatico in pausa (impostato a %s secondi)"
 #, fuzzy, python-format
 msgid "Auto refresh paused - tab inactive (set to %s seconds)"
 msgstr ""
-"Aggiornamento automatico in pausa - scheda inattiva (impostato a %s secondi)"
+"Aggiornamento automatico in pausa - scheda inattiva (impostato a %s "
+"secondi)"
 
 #, python-format
 msgid "Auto refresh set to %s seconds"
@@ -3246,7 +3292,8 @@ msgstr "Grafico a barre"
 
 msgid "Bar Charts are used to show metrics as a series of bars."
 msgstr ""
-"I grafici a barre sono utilizzati per mostrare metriche come serie di barre."
+"I grafici a barre sono utilizzati per mostrare metriche come serie di "
+"barre."
 
 msgid "Bar Values"
 msgstr "Valori barra"
@@ -3268,23 +3315,24 @@ msgstr "Altezza base"
 #, fuzzy
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
 msgstr ""
-"Stile della mappa del livello base. Accetta un URL di stile compatibile con "
-"MapLibre."
+"Stile della mappa del livello base. Accetta un URL di stile compatibile "
+"con MapLibre."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
-"Stile della mappa del livello base. Accetta un URL di stile Mapbox (mapbox://"
-"styles/...)."
+"Stile della mappa del livello base. Accetta un URL di stile Mapbox "
+"(mapbox://styles/...)."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
 msgstr ""
-"Stile della mappa del livello base. Vedere la documentazione di MapLibre: %s"
+"Stile della mappa del livello base. Vedere la documentazione di MapLibre:"
+" %s"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -3303,16 +3351,14 @@ msgstr "Basato su una metrica"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Based on granularity, number of time periods to compare against"
-msgstr ""
-"In base alla granularità, numero di periodi di tempo con cui confrontare"
+msgstr "In base alla granularità, numero di periodi di tempo con cui confrontare"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid "Based on what should series be ordered on the chart and legend"
-msgstr ""
-"In base a cosa le serie devono essere ordinate nel grafico e nella legenda"
+msgstr "In base a cosa le serie devono essere ordinate nel grafico e nella legenda"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -3397,8 +3443,8 @@ msgstr "In basso a sinistra"
 #, fuzzy
 msgid "Bottom margin, in pixels, allowing for more room for axis labels"
 msgstr ""
-"Margine inferiore, in pixel, per consentire più spazio alle etichette degli "
-"assi"
+"Margine inferiore, in pixel, per consentire più spazio alle etichette "
+"degli assi"
 
 msgid "Bottom right"
 msgstr "In basso a destra"
@@ -3414,40 +3460,41 @@ msgstr "Limit"
 #, fuzzy
 msgid ""
 "Bounds for numerical X axis. Not applicable for temporal or categorical "
-"axes. When left empty, the bounds are dynamically defined based on the min/"
-"max of the data. Note that this feature will only expand the axis range. It "
-"won't narrow the data's extent."
+"axes. When left empty, the bounds are dynamically defined based on the "
+"min/max of the data. Note that this feature will only expand the axis "
+"range. It won't narrow the data's extent."
 msgstr ""
 "Limiti per l'asse X numerico. Non applicabile per assi temporali o "
 "categorici. Quando viene lasciato vuoto, i limiti vengono definiti "
 "dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
-"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà l'estensione "
-"dei dati."
+"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Bounds for the X-axis. Selected time merges with min/max date of the data. "
-"When left empty, bounds dynamically defined based on the min/max of the data."
+"Bounds for the X-axis. Selected time merges with min/max date of the "
+"data. When left empty, bounds dynamically defined based on the min/max of"
+" the data."
 msgstr ""
-"Limiti per l'asse X. Il tempo selezionato si unisce alla data min/max dei "
-"dati. Quando viene lasciato vuoto, i limiti vengono definiti dinamicamente "
-"in base al minimo/massimo dei dati."
+"Limiti per l'asse X. Il tempo selezionato si unisce alla data min/max dei"
+" dati. Quando viene lasciato vuoto, i limiti vengono definiti "
+"dinamicamente in base al minimo/massimo dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Bounds for the Y-axis. When left empty, the bounds are dynamically defined "
-"based on the min/max of the data. Note that this feature will only expand "
-"the axis range. It won't narrow the data's extent."
+"Bounds for the Y-axis. When left empty, the bounds are dynamically "
+"defined based on the min/max of the data. Note that this feature will "
+"only expand the axis range. It won't narrow the data's extent."
 msgstr ""
-"Limiti per l'asse Y. Quando viene lasciato vuoto, i limiti vengono definiti "
-"dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
-"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà l'estensione "
-"dei dati."
+"Limiti per l'asse Y. Quando viene lasciato vuoto, i limiti vengono "
+"definiti dinamicamente in base al minimo/massimo dei dati. Si noti che "
+"questa funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -3455,26 +3502,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Bounds for the axis. When left empty, the bounds are dynamically defined "
-"based on the min/max of the data. Note that this feature will only expand "
-"the axis range. It won't narrow the data's extent."
+"based on the min/max of the data. Note that this feature will only expand"
+" the axis range. It won't narrow the data's extent."
 msgstr ""
-"Limiti per l'asse. Quando viene lasciato vuoto, i limiti vengono definiti "
-"dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
-"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà l'estensione "
-"dei dati."
+"Limiti per l'asse. Quando viene lasciato vuoto, i limiti vengono definiti"
+" dinamicamente in base al minimo/massimo dei dati. Si noti che questa "
+"funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
+"l'estensione dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Bounds for the primary Y-axis. When left empty, the bounds are dynamically "
-"defined based on the min/max of the data. Note that this feature will only "
-"expand the axis range. It won't narrow the data's extent."
+"Bounds for the primary Y-axis. When left empty, the bounds are "
+"dynamically defined based on the min/max of the data. Note that this "
+"feature will only expand the axis range. It won't narrow the data's "
+"extent."
 msgstr ""
-"Limiti per l'asse Y primario. Quando viene lasciato vuoto, i limiti vengono "
-"definiti dinamicamente in base al minimo/massimo dei dati. Si noti che "
-"questa funzionalità espanderà solo l'intervallo dell'asse. Non ridurrà "
-"l'estensione dei dati."
+"Limiti per l'asse Y primario. Quando viene lasciato vuoto, i limiti "
+"vengono definiti dinamicamente in base al minimo/massimo dei dati. Si "
+"noti che questa funzionalità espanderà solo l'intervallo dell'asse. Non "
+"ridurrà l'estensione dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -3487,8 +3535,8 @@ msgid ""
 "will only expand\n"
 "                the axis range. It won't narrow the data's extent."
 msgstr ""
-"Limiti per l'asse Y secondario. Funziona solo quando i limiti dell'asse Y "
-"indipendente\n"
+"Limiti per l'asse Y secondario. Funziona solo quando i limiti dell'asse Y"
+" indipendente\n"
 "                sono abilitati. Quando viene lasciato vuoto, i limiti "
 "vengono definiti dinamicamente\n"
 "                in base al minimo/massimo dei dati. Si noti che questa "
@@ -3511,12 +3559,12 @@ msgstr "Seleziona una metrica"
 #, fuzzy
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
-"      This can help viewers understand how each category affects the overall "
-"value."
+"      This can help viewers understand how each category affects the "
+"overall value."
 msgstr ""
 "Suddivide le serie per la categoria specificata in questo controllo.\n"
-"      Questo può aiutare gli utenti a capire come ogni categoria influenza "
-"il valore complessivo."
+"      Questo può aiutare gli utenti a capire come ogni categoria "
+"influenza il valore complessivo."
 
 msgid "Bubble Chart"
 msgstr "Grafico a Bolle"
@@ -3575,16 +3623,16 @@ msgstr "Business"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"By default, each filter loads at most 1000 choices at the initial page load. "
-"Check this box if you have more than 1000 filter values and want to enable "
-"dynamically searching that loads filter values as users type (may add stress "
-"to your database)."
+"By default, each filter loads at most 1000 choices at the initial page "
+"load. Check this box if you have more than 1000 filter values and want to"
+" enable dynamically searching that loads filter values as users type (may"
+" add stress to your database)."
 msgstr ""
-"Per impostazione predefinita, ogni filtro carica al massimo 1000 opzioni al "
-"caricamento iniziale della pagina. Seleziona questa casella se hai più di "
-"1000 valori di filtro e vuoi abilitare la ricerca dinamica che carica i "
-"valori del filtro mentre gli utenti digitano (potrebbe aggiungere carico al "
-"tuo database)."
+"Per impostazione predefinita, ogni filtro carica al massimo 1000 opzioni "
+"al caricamento iniziale della pagina. Seleziona questa casella se hai più"
+" di 1000 valori di filtro e vuoi abilitare la ricerca dinamica che carica"
+" i valori del filtro mentre gli utenti digitano (potrebbe aggiungere "
+"carico al tuo database)."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -3618,6 +3666,11 @@ msgstr "destinatari CC"
 
 msgid "COPY QUERY"
 msgstr "COPIA QUERY"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Copy query"
+msgstr "Copia query"
 
 msgid "CREATE TABLE AS"
 msgstr "Permetti CREATE TABLE AS"
@@ -3657,13 +3710,13 @@ msgstr "CSS applicato al grafico"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"CSS styles may be removed by server-side HTML sanitization. If styles are "
-"not applying, ask your Superset administrator to adjust the HTML "
+"CSS styles may be removed by server-side HTML sanitization. If styles are"
+" not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
 "Gli stili CSS potrebbero essere rimossi dalla sanitizzazione HTML lato "
-"server. Se gli stili non vengono applicati, chiedere all'amministratore di "
-"Superset di modificare la configurazione della sanitizzazione HTML."
+"server. Se gli stili non vengono applicati, chiedere all'amministratore "
+"di Superset di modificare la configurazione della sanitizzazione HTML."
 
 msgid "CSS template"
 msgstr "Template CSS"
@@ -3696,25 +3749,26 @@ msgid "CTAS & CVAS SCHEMA"
 msgstr "SCHEMA CTAS E CVAS"
 
 msgid ""
-"CTAS (create table as select) can only be run with a query where the last "
-"statement is a SELECT. Please make sure your query has a SELECT as its last "
-"statement. Then, try running your query again."
+"CTAS (create table as select) can only be run with a query where the last"
+" statement is a SELECT. Please make sure your query has a SELECT as its "
+"last statement. Then, try running your query again."
 msgstr ""
-"CTAS (create table as select) può essere eseguito solo con una query in cui "
-"l'ultima istruzione è una SELECT. Assicurarsi che la query abbia un SELECT "
-"come ultima istruzione. Quindi, provare a eseguire di nuovo la query."
+"CTAS (create table as select) può essere eseguito solo con una query in "
+"cui l'ultima istruzione è una SELECT. Assicurarsi che la query abbia un "
+"SELECT come ultima istruzione. Quindi, provare a eseguire di nuovo la "
+"query."
 
 msgid "CUSTOM"
 msgstr "PERSONALIZZATO"
 
 msgid ""
 "CVAS (create view as select) can only be run with a query with a single "
-"SELECT statement. Please make sure your query has only a SELECT statement. "
-"Then, try running your query again."
+"SELECT statement. Please make sure your query has only a SELECT "
+"statement. Then, try running your query again."
 msgstr ""
-"CVAS (create view as select) può essere eseguito solo con una query con una "
-"singola istruzione SELECT. Assicurarsi che la query abbia solo un'istruzione "
-"SELECT. Quindi, provare a eseguire di nuovo la query."
+"CVAS (create view as select) può essere eseguito solo con una query con "
+"una singola istruzione SELECT. Assicurarsi che la query abbia solo "
+"un'istruzione SELECT. Quindi, provare a eseguire di nuovo la query."
 
 msgid "CVAS (create view as select) query has more than one statement."
 msgstr "La query CVAS (create view as select) contiene più di una istruzione."
@@ -3739,9 +3793,9 @@ msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
-"Memorizza i dati nella cache separatamente per ogni utente in base ai ruoli "
-"e alle autorizzazioni di accesso ai dati. Se disabilitato, verrà utilizzata "
-"un'unica cache per tutti gli utenti."
+"Memorizza i dati nella cache separatamente per ogni utente in base ai "
+"ruoli e alle autorizzazioni di accesso ai dati. Se disabilitato, verrà "
+"utilizzata un'unica cache per tutti gli utenti."
 
 msgid "Cache timeout"
 msgstr "Timeout della Cache"
@@ -3804,7 +3858,8 @@ msgstr "Calendario a mappa di intensità"
 
 msgid "Can not move top level tab into nested tabs"
 msgstr ""
-"Impossibile spostare la scheda di livello superiore nelle schede nidificate"
+"Impossibile spostare la scheda di livello superiore nelle schede "
+"nidificate"
 
 msgid "Can select multiple values"
 msgstr "Si possono selezionare più valori"
@@ -3844,16 +3899,16 @@ msgstr "Impossibile eliminare i temi di sistema"
 #, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme"
 msgstr ""
-"Impossibile eliminare il tema impostato come tema predefinito o scuro del "
-"sistema"
+"Impossibile eliminare il tema impostato come tema predefinito o scuro del"
+" sistema"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Cannot delete theme that is set as system default or dark theme."
 msgstr ""
-"Impossibile eliminare il tema impostato come tema predefinito o scuro del "
-"sistema."
+"Impossibile eliminare il tema impostato come tema predefinito o scuro del"
+" sistema."
 
 #, python-format
 msgid "Cannot find the table (%s) metadata."
@@ -4032,22 +4087,24 @@ msgstr "Non è permesso modificare una o più di queste dashboard"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Changing the dataset may break the chart if the chart relies on columns or "
-"metadata that does not exist in the target dataset"
+"Changing the dataset may break the chart if the chart relies on columns "
+"or metadata that does not exist in the target dataset"
 msgstr ""
 "La modifica del dataset potrebbe danneggiare il grafico se il grafico "
-"dipende da colonne o metadati che non esistono nel dataset di destinazione"
+"dipende da colonne o metadati che non esistono nel dataset di "
+"destinazione"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Changing these settings will affect all charts using this dataset, including "
-"charts owned by other people."
+"Changing these settings will affect all charts using this dataset, "
+"including charts owned by other people."
 msgstr ""
 "La modifica di queste impostazioni influenzerà tutti i grafici che "
-"utilizzano questo dataset, inclusi i grafici di proprietà di altre persone."
+"utilizzano questo dataset, inclusi i grafici di proprietà di altre "
+"persone."
 
 msgid "Changing this Dashboard is forbidden"
 msgstr "Non è permesso modificare questa dashboard"
@@ -4165,8 +4222,10 @@ msgstr "Ultima Modifica"
 msgid "Chart could not be created."
 msgstr "La tua query non può essere salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Chart could not be restored."
-msgstr ""
+msgstr "Impossibile ripristinare il grafico."
 
 msgid "Chart could not be updated."
 msgstr "La tua query non può essere salvata"
@@ -4194,8 +4253,8 @@ msgstr "Editor del grafico"
 
 msgid "Chart has no query context saved. Please save the chart again."
 msgstr ""
-"Il grafico non ha salvato il contesto della query. Per cortesia salvare il "
-"grafico nuovamente."
+"Il grafico non ha salvato il contesto della query. Per cortesia salvare "
+"il grafico nuovamente."
 
 msgid "Chart height"
 msgstr "Altezza del grafico"
@@ -4243,8 +4302,7 @@ msgid "Chart type requires a dataset"
 msgstr "Il tipo di grafico richiede un dataset"
 
 msgid "Chart was saved but could not be added to the selected tab."
-msgstr ""
-"IL grafico è stato salvato ma non può essere aggiunto al tab selezionato."
+msgstr "IL grafico è stato salvato ma non può essere aggiunto al tab selezionato."
 
 msgid "Chart width"
 msgstr "Larghezza grafico"
@@ -4266,11 +4324,11 @@ msgstr "Controlla ordinamento ascendente"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Check if the Rose Chart should use segment area instead of segment radius "
-"for proportioning"
+"Check if the Rose Chart should use segment area instead of segment radius"
+" for proportioning"
 msgstr ""
-"Verifica se il grafico a rosa deve utilizzare l'area del segmento invece del "
-"raggio del segmento per le proporzioni"
+"Verifica se il grafico a rosa deve utilizzare l'area del segmento invece "
+"del raggio del segmento per le proporzioni"
 
 msgid "Check out this chart in dashboard:"
 msgstr "Rimuovi il grafico dalla dashboard"
@@ -4378,8 +4436,8 @@ msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
-"Scegli i livelli da nascondere da tutti i grafici deck.gl a più livelli in "
-"questo dashboard."
+"Scegli i livelli da nascondere da tutti i grafici deck.gl a più livelli "
+"in questo dashboard."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -4439,19 +4497,20 @@ msgid ""
 "Choose values that should be treated as null. Warning: Hive database "
 "supports only a single value"
 msgstr ""
-"Scegli i valori che devono essere trattati come null. Avviso: il database "
-"Hive supporta solo un singolo valore"
+"Scegli i valori che devono essere trattati come null. Avviso: il database"
+" Hive supporta solo un singolo valore"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"Choose whether a country should be shaded by the metric, or assigned a color "
-"based on a categorical color palette"
+"Choose whether a country should be shaded by the metric, or assigned a "
+"color based on a categorical color palette"
 msgstr ""
-"Scegli se un paese deve essere ombreggiato in base alla metrica, o se gli "
-"deve essere assegnato un colore basato su una palette di colori categorica"
+"Scegli se un paese deve essere ombreggiato in base alla metrica, o se gli"
+" deve essere assegnato un colore basato su una palette di colori "
+"categorica"
 
 msgid "Choose..."
 msgstr "Selezionare..."
@@ -4514,8 +4573,8 @@ msgid ""
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
 "Vista classica di un set di dati a righe e colonne come in un foglio di "
-"calcolo. Usa le tabelle per mostrare una vista dei dati sottostanti o per "
-"visualizzare metriche aggregate."
+"calcolo. Usa le tabelle per mostrare una vista dei dati sottostanti o per"
+" visualizzare metriche aggregate."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -4569,8 +4628,8 @@ msgstr "Cancella la selezione per tornare al tema predefinito del sistema"
 # lv, ru, sr, sr_Latn, uk]
 #, fuzzy
 msgid ""
-"Click on \"Add or edit filters and controls\" option in Settings to create "
-"new dashboard filters"
+"Click on \"Add or edit filters and controls\" option in Settings to "
+"create new dashboard filters"
 msgstr ""
 "Fai clic sull'opzione \"Aggiungi o modifica filtri e controlli\" nelle "
 "Impostazioni per creare nuovi filtri del dashboard"
@@ -4580,11 +4639,11 @@ msgstr ""
 # zh_TW]
 #, fuzzy
 msgid ""
-"Click on \"Create chart\" button in the control panel on the left to preview "
-"a visualization or"
+"Click on \"Create chart\" button in the control panel on the left to "
+"preview a visualization or"
 msgstr ""
-"Fai clic sul pulsante \"Crea grafico\" nel pannello di controllo a sinistra "
-"per visualizzare un'anteprima di una visualizzazione o"
+"Fai clic sul pulsante \"Crea grafico\" nel pannello di controllo a "
+"sinistra per visualizzare un'anteprima di una visualizzazione o"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -4605,11 +4664,11 @@ msgstr "Fai clic sul lucchetto per impedire ulteriori modifiche."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Click this link to switch to an alternate form that allows you to input the "
-"SQLAlchemy URL for this database manually."
+"Click this link to switch to an alternate form that allows you to input "
+"the SQLAlchemy URL for this database manually."
 msgstr ""
-"Fai clic su questo link per passare a un modulo alternativo che consente di "
-"inserire manualmente l'URL SQLAlchemy per questo database."
+"Fai clic su questo link per passare a un modulo alternativo che consente "
+"di inserire manualmente l'URL SQLAlchemy per questo database."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -4619,8 +4678,8 @@ msgid ""
 "Click this link to switch to an alternate form that exposes only the "
 "required fields needed to connect this database."
 msgstr ""
-"Fai clic su questo link per passare a un modulo alternativo che mostra solo "
-"i campi obbligatori necessari per connettere questo database."
+"Fai clic su questo link per passare a un modulo alternativo che mostra "
+"solo i campi obbligatori necessari per connettere questo database."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -4830,7 +4889,8 @@ msgstr "Colore per"
 #, fuzzy
 msgid "Color field must be a hex color (#rrggbb) or 'rgb(r, g, b)'"
 msgstr ""
-"Il campo colore deve essere un colore esadecimale (#rrggbb) o 'rgb(r, g, b)'"
+"Il campo colore deve essere un colore esadecimale (#rrggbb) o 'rgb(r, g, "
+"b)'"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, tr, uk]
@@ -4860,11 +4920,12 @@ msgstr "Schema colore"
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Color will be shaded based the normalized (0% to 100%) value of a given cell "
-"against the other cells in the selected range: "
+"Color will be shaded based the normalized (0% to 100%) value of a given "
+"cell against the other cells in the selected range: "
 msgstr ""
-"Il colore sarà ombreggiato in base al valore normalizzato (da 0% a 100%) di "
-"una determinata cella rispetto alle altre celle nell'intervallo selezionato: "
+"Il colore sarà ombreggiato in base al valore normalizzato (da 0% a 100%) "
+"di una determinata cella rispetto alle altre celle nell'intervallo "
+"selezionato: "
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -4879,10 +4940,11 @@ msgstr "Colonna"
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"Column \"%(column)s\" is not numeric or does not exists in the query results."
+"Column \"%(column)s\" is not numeric or does not exists in the query "
+"results."
 msgstr ""
-"La colonna \"%(column)s\" non è numerica o non esiste nei risultati della "
-"query."
+"La colonna \"%(column)s\" non è numerica o non esiste nei risultati della"
+" query."
 
 msgid "Column Configuration"
 msgstr "Configurazione Colonna"
@@ -4951,11 +5013,11 @@ msgstr "Colonna per 'Raggruppa per'"
 # es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Column to use as the index of the dataframe. If None is given, Index label "
-"is used."
+"Column to use as the index of the dataframe. If None is given, Index "
+"label is used."
 msgstr ""
-"Colonna da utilizzare come indice del dataframe. Se non viene fornito alcun "
-"valore, viene utilizzata l'etichetta Index."
+"Colonna da utilizzare come indice del dataframe. Se non viene fornito "
+"alcun valore, viene utilizzata l'etichetta Index."
 
 msgid "Column type"
 msgstr "Tipo di colonna"
@@ -5059,12 +5121,12 @@ msgstr "Combina metriche"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Comma-separated color picks for the intervals, e.g. 1,2,4. Integers denote "
-"colors from the chosen color scheme and are 1-indexed. Length must be "
-"matching that of interval bounds."
+"Comma-separated color picks for the intervals, e.g. 1,2,4. Integers "
+"denote colors from the chosen color scheme and are 1-indexed. Length must"
+" be matching that of interval bounds."
 msgstr ""
-"Selezioni di colore separate da virgola per gli intervalli, ad es. 1,2,4. I "
-"numeri interi indicano i colori dello schema di colori scelto e sono "
+"Selezioni di colore separate da virgola per gli intervalli, ad es. 1,2,4."
+" I numeri interi indicano i colori dello schema di colori scelto e sono "
 "indicizzati a partire da 1. La lunghezza deve corrispondere a quella dei "
 "limiti degli intervalli."
 
@@ -5073,14 +5135,17 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and 4-5. "
-"Last number should match the value provided for MAX."
+"Comma-separated interval bounds, e.g. 2,4,5 for intervals 0-2, 2-4 and "
+"4-5. Last number should match the value provided for MAX."
 msgstr ""
-"Limiti degli intervalli separati da virgola, ad es. 2,4,5 per gli intervalli "
-"0-2, 2-4 e 4-5. L'ultimo numero deve corrispondere al valore fornito per MAX."
+"Limiti degli intervalli separati da virgola, ad es. 2,4,5 per gli "
+"intervalli 0-2, 2-4 e 4-5. L'ultimo numero deve corrispondere al valore "
+"fornito per MAX."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Common (unit per pixel at zoom 0)"
-msgstr ""
+msgstr "Comune (unità per pixel allo zoom 0)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -5118,24 +5183,25 @@ msgstr "Confronta la stessa metrica riassunta tra più gruppi."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Compares how a metric changes over time between different groups. Each group "
-"is mapped to a row and change over time is visualized bar lengths and color."
+"Compares how a metric changes over time between different groups. Each "
+"group is mapped to a row and change over time is visualized bar lengths "
+"and color."
 msgstr ""
-"Confronta come una metrica cambia nel tempo tra diversi gruppi. Ogni gruppo "
-"è mappato su una riga e il cambiamento nel tempo è visualizzato tramite "
-"lunghezze delle barre e colore."
+"Confronta come una metrica cambia nel tempo tra diversi gruppi. Ogni "
+"gruppo è mappato su una riga e il cambiamento nel tempo è visualizzato "
+"tramite lunghezze delle barre e colore."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Compares metrics between different time periods. Displays time series data "
-"across multiple periods (like weeks or months) to show period-over-period "
-"trends and patterns."
+"Compares metrics between different time periods. Displays time series "
+"data across multiple periods (like weeks or months) to show period-over-"
+"period trends and patterns."
 msgstr ""
 "Confronta le metriche tra diversi periodi di tempo. Visualizza i dati di "
-"serie temporali su più periodi (come settimane o mesi) per mostrare tendenze "
-"e modelli periodo su periodo."
+"serie temporali su più periodi (come settimane o mesi) per mostrare "
+"tendenze e modelli periodo su periodo."
 
 msgid "Comparison"
 msgstr "Confronto"
@@ -5282,8 +5348,7 @@ msgstr "Configura le dimensioni del grafico per ogni livello di zoom"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Configure this dashboard to embed it into an external web application."
-msgstr ""
-"Configura questo pannello per incorporarlo in un'applicazione web esterna."
+msgstr "Configura questo pannello per incorporarlo in un'applicazione web esterna."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -5504,8 +5569,7 @@ msgstr "Copia i dati correnti"
 # de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Copy the identifier of the account you are trying to connect to."
-msgstr ""
-"Copia l'identificatore dell'account a cui stai cercando di connetterti."
+msgstr "Copia l'identificatore dell'account a cui stai cercando di connetterti."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -5571,8 +5635,10 @@ msgstr "Non posso connettermi al server"
 msgid "Could not find viz object"
 msgstr "Impossibile trovare l'oggetto viz"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Could not load SQL Lab"
-msgstr ""
+msgstr "Impossibile caricare SQL Lab"
 
 msgid "Could not load database driver"
 msgstr "Non posso connettermi al server"
@@ -5664,8 +5730,8 @@ msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
-"Crea un dataset per iniziare a visualizzare i tuoi dati come grafico o vai "
-"a\n"
+"Crea un dataset per iniziare a visualizzare i tuoi dati come grafico o "
+"vai a\n"
 "          SQL Lab per interrogare i tuoi dati."
 
 msgid "Create a new Tag"
@@ -5733,8 +5799,7 @@ msgstr "Crimson"
 msgid "Cross-filter column"
 msgstr "Colonna filtro cross"
 
-msgid ""
-"Cross-filter will be applied to all of the charts that use this dataset."
+msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
 "Il filtro cross sarà applicato a tutti i gradici che utilizzano questo "
 "dataset."
@@ -5831,23 +5896,22 @@ msgstr "SQL personalizzato"
 #, fuzzy
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr ""
-"Le metriche SQL ad-hoc personalizzate non sono abilitate per questo set di "
-"dati"
+"Le metriche SQL ad-hoc personalizzate non sono abilitate per questo set "
+"di dati"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
-"I campi SQL personalizzati non possono essere analizzati come una singola "
-"istruzione SQL."
+"I campi SQL personalizzati non possono essere analizzati come una singola"
+" istruzione SQL."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid "Custom SQL fields cannot contain set operations."
-msgstr ""
-"I campi SQL personalizzati non possono contenere operazioni sugli insiemi."
+msgstr "I campi SQL personalizzati non possono contenere operazioni sugli insiemi."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -5875,8 +5939,7 @@ msgstr "Data personalizzata"
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Custom fields not available in aggregated heatmap cells"
-msgstr ""
-"I campi personalizzati non sono disponibili nelle celle heatmap aggregate"
+msgstr "I campi personalizzati non sono disponibili nelle celle heatmap aggregate"
 
 msgid "Custom time filter plugin"
 msgstr "Plugin filtro temporale personalizzato"
@@ -5920,8 +5983,8 @@ msgstr "Personalizza metriche"
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Customize cell titles using Handlebars template syntax. Available variables: "
-"{{rowLabel}}, {{colLabel}}"
+"Customize cell titles using Handlebars template syntax. Available "
+"variables: {{rowLabel}}, {{colLabel}}"
 msgstr ""
 "Personalizza i titoli delle celle usando la sintassi del template "
 "Handlebars. Variabili disponibili: {{rowLabel}}, {{colLabel}}"
@@ -5939,21 +6002,21 @@ msgstr "Personalizza la sorgente dati, i filtri e il layout."
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Customize the label displayed for decreasing values in the chart tooltips "
-"and legend."
+"Customize the label displayed for decreasing values in the chart tooltips"
+" and legend."
 msgstr ""
-"Personalizza l'etichetta visualizzata per i valori decrescenti nei tooltip e "
-"nella legenda del grafico."
+"Personalizza l'etichetta visualizzata per i valori decrescenti nei "
+"tooltip e nella legenda del grafico."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Customize the label displayed for increasing values in the chart tooltips "
-"and legend."
+"Customize the label displayed for increasing values in the chart tooltips"
+" and legend."
 msgstr ""
-"Personalizza l'etichetta visualizzata per i valori crescenti nei tooltip e "
-"nella legenda del grafico."
+"Personalizza l'etichetta visualizzata per i valori crescenti nei tooltip "
+"e nella legenda del grafico."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -5962,8 +6025,8 @@ msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
-"Personalizza l'etichetta visualizzata per i valori totali nei tooltip del "
-"grafico, nella legenda e sull'asse del grafico."
+"Personalizza l'etichetta visualizzata per i valori totali nei tooltip del"
+" grafico, nella legenda e sull'asse del grafico."
 
 msgid "Customize tooltips template"
 msgstr "Personalizza template dei tooltip"
@@ -5982,8 +6045,8 @@ msgstr "Sintassi formato D3: https://github.com/d3/d3-format"
 # uk]
 #, fuzzy
 msgid ""
-"D3 number format for numbers between -1.0 and 1.0, useful when you want to "
-"have different significant digits for small and large numbers"
+"D3 number format for numbers between -1.0 and 1.0, useful when you want "
+"to have different significant digits for small and large numbers"
 msgstr ""
 "Formato numerico D3 per numeri compresi tra -1.0 e 1.0, utile quando si "
 "desidera avere cifre significative diverse per numeri piccoli e grandi"
@@ -6013,6 +6076,7 @@ msgstr "Formato date DD/MM, formato internazionale e europeo"
 msgid "DEC"
 msgstr "DIC"
 
+#. do-not-translate
 msgid "DELETE"
 msgstr "CANCELLA"
 
@@ -6062,8 +6126,7 @@ msgstr "Id Dashboard"
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid "Dashboard [%s] just got created and chart [%s] was added to it"
-msgstr ""
-"La dashboard [%s] è stata appena creata e il grafico [%s] è stato aggiunto"
+msgstr "La dashboard [%s] è stata appena creata e il grafico [%s] è stato aggiunto"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -6152,12 +6215,12 @@ msgid ""
 "chart\n"
 "          filters to have this dashboard filter impact those charts."
 msgstr ""
-"I filtri dell'intervallo temporale del dashboard si applicano alle colonne "
-"temporali definite nella\n"
-"          sezione dei filtri di ogni grafico. Aggiungere colonne temporali "
-"ai filtri del\n"
-"          grafico per fare in modo che questo filtro del dashboard influenzi "
-"quei grafici."
+"I filtri dell'intervallo temporale del dashboard si applicano alle "
+"colonne temporali definite nella\n"
+"          sezione dei filtri di ogni grafico. Aggiungere colonne "
+"temporali ai filtri del\n"
+"          grafico per fare in modo che questo filtro del dashboard "
+"influenzi quei grafici."
 
 msgid "Dashboard title"
 msgstr "Titolo dashboard"
@@ -6210,21 +6273,21 @@ msgstr "Connessioni ai dati"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Data could not be deserialized from the results backend. The storage format "
-"might have changed, rendering the old data stake. You need to re-run the "
-"original query."
+"Data could not be deserialized from the results backend. The storage "
+"format might have changed, rendering the old data stake. You need to re-"
+"run the original query."
 msgstr ""
-"Impossibile deserializzare i dati dal backend dei risultati. Il formato di "
-"archiviazione potrebbe essere cambiato, rendendo i dati precedenti non "
-"validi. È necessario rieseguire la query originale."
+"Impossibile deserializzare i dati dal backend dei risultati. Il formato "
+"di archiviazione potrebbe essere cambiato, rendendo i dati precedenti non"
+" validi. È necessario rieseguire la query originale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Data could not be retrieved from the results backend. You need to re-run the "
-"original query."
+"Data could not be retrieved from the results backend. You need to re-run "
+"the original query."
 msgstr ""
 "Impossibile recuperare i dati dal backend dei risultati. È necessario "
 "rieseguire la query originale."
@@ -6312,8 +6375,8 @@ msgid ""
 "Database driver for importing maybe not installed. Visit the Superset "
 "documentation page for installation instructions: "
 msgstr ""
-"Il driver del database per l'importazione potrebbe non essere installato. "
-"Visita la pagina della documentazione di Superset per le istruzioni di "
+"Il driver del database per l'importazione potrebbe non essere installato."
+" Visita la pagina della documentazione di Superset per le istruzioni di "
 "installazione: "
 
 msgid "Database error"
@@ -6362,8 +6425,7 @@ msgstr "Il riferimento al database non è consentito in un report"
 # es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Database schema is not allowed for csv uploads."
-msgstr ""
-"Lo schema del database non è consentito per il caricamento di file CSV."
+msgstr "Lo schema del database non è consentito per il caricamento di file CSV."
 
 msgid "Database settings updated"
 msgstr "Impostazioni del database aggiornate"
@@ -6384,8 +6446,8 @@ msgstr "Upload di file al database fallito"
 #, fuzzy
 msgid "Database upload file failed, while saving metadata"
 msgstr ""
-"Caricamento del file nel database non riuscito durante il salvataggio dei "
-"metadati"
+"Caricamento del file nel database non riuscito durante il salvataggio dei"
+" metadati"
 
 msgid "Databases"
 msgstr "Basi di dati"
@@ -6412,8 +6474,10 @@ msgstr "La tua query non può essere salvata"
 msgid "Dataset could not be duplicated."
 msgstr "Il dataset non può essere duplicato."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Dataset could not be restored."
-msgstr ""
+msgstr "Impossibile ripristinare il dataset."
 
 msgid "Dataset could not be updated."
 msgstr "La tua query non può essere salvata"
@@ -6495,7 +6559,8 @@ msgstr "Il tipo di sorgente dati non è valido"
 
 msgid "Datasource type is required when datasource_id is given"
 msgstr ""
-"Il tipo di sorgente dati è obbligatorio quando viene indicato datasource_id"
+"Il tipo di sorgente dati è obbligatorio quando viene indicato "
+"datasource_id"
 
 msgid "Datasources"
 msgstr "Sorgenti Dati"
@@ -6513,8 +6578,8 @@ msgid "Date/Time"
 msgstr "Tempo"
 
 msgid ""
-"Datetime column not provided as part table configuration and is required by "
-"this type of chart"
+"Datetime column not provided as part table configuration and is required "
+"by this type of chart"
 msgstr ""
 "la colonna Datetime è necessaria per questo tipo di grafico. Nella "
 "configurazione della tabella però non è stata definita"
@@ -6710,8 +6775,9 @@ msgid ""
 "Default minimal column width in pixels, actual width may still be larger "
 "than this if other columns don't need much space"
 msgstr ""
-"Larghezza minima predefinita della colonna in pixel; la larghezza effettiva "
-"può essere ancora maggiore se le altre colonne non richiedono molto spazio"
+"Larghezza minima predefinita della colonna in pixel; la larghezza "
+"effettiva può essere ancora maggiore se le altre colonne non richiedono "
+"molto spazio"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -6719,8 +6785,8 @@ msgstr ""
 #, fuzzy
 msgid "Default value must be set when \"Filter has default value\" is checked"
 msgstr ""
-"Il valore predefinito deve essere impostato quando è selezionato \"Il filtro "
-"ha un valore predefinito\""
+"Il valore predefinito deve essere impostato quando è selezionato \"Il "
+"filtro ha un valore predefinito\""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -6728,8 +6794,8 @@ msgstr ""
 #, fuzzy
 msgid "Default value must be set when \"Filter value is required\" is checked"
 msgstr ""
-"Il valore predefinito deve essere impostato quando è selezionata \"Il valore "
-"del filtro è obbligatorio\""
+"Il valore predefinito deve essere impostato quando è selezionata \"Il "
+"valore del filtro è obbligatorio\""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
 # es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -6738,8 +6804,9 @@ msgid ""
 "Default value set automatically when \"Select first filter value by "
 "default\" is checked"
 msgstr ""
-"Il valore predefinito viene impostato automaticamente quando è selezionato "
-"\"Seleziona il primo valore del filtro per impostazione predefinita\""
+"Il valore predefinito viene impostato automaticamente quando è "
+"selezionato \"Seleziona il primo valore del filtro per impostazione "
+"predefinita\""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
 # es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
@@ -6749,8 +6816,8 @@ msgid ""
 "Define a function that receives the input and outputs the content for a "
 "tooltip"
 msgstr ""
-"Definire una funzione che riceve l'input e restituisce il contenuto per un "
-"tooltip"
+"Definire una funzione che riceve l'input e restituisce il contenuto per "
+"un tooltip"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -6758,8 +6825,8 @@ msgstr ""
 #, fuzzy
 msgid "Define a function that returns a URL to navigate to when user clicks"
 msgstr ""
-"Definire una funzione che restituisce un URL a cui navigare quando l'utente "
-"fa clic"
+"Definire una funzione che restituisce un URL a cui navigare quando "
+"l'utente fa clic"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -6767,14 +6834,14 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Define a javascript function that receives the data array used in the "
-"visualization and is expected to return a modified version of that array. "
-"This can be used to alter properties of the data, filter, or enrich the "
+"visualization and is expected to return a modified version of that array."
+" This can be used to alter properties of the data, filter, or enrich the "
 "array."
 msgstr ""
 "Definisci una funzione JavaScript che riceve l'array di dati utilizzato "
-"nella visualizzazione e che dovrebbe restituire una versione modificata di "
-"quell'array. Può essere usata per modificare le proprietà dei dati, filtrare "
-"o arricchire l'array."
+"nella visualizzazione e che dovrebbe restituire una versione modificata "
+"di quell'array. Può essere usata per modificare le proprietà dei dati, "
+"filtrare o arricchire l'array."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -6787,23 +6854,24 @@ msgstr "Definisci i punti di interruzione del colore per i dati"
 # zh, zh_TW]
 #, fuzzy
 msgid ""
-"Define contour layers. Isolines represent a collection of line segments that "
-"serparate the area above and below a given threshold. Isobands represent a "
-"collection of polygons that fill the are containing values in a given "
-"threshold range."
+"Define contour layers. Isolines represent a collection of line segments "
+"that serparate the area above and below a given threshold. Isobands "
+"represent a collection of polygons that fill the are containing values in"
+" a given threshold range."
 msgstr ""
 "Definisci i livelli di contorno. Le isolinee rappresentano un insieme di "
 "segmenti di linea che separano l'area al di sopra e al di sotto di una "
 "soglia specificata. Le isobande rappresentano un insieme di poligoni che "
-"riempiono l'area contenente valori in un determinato intervallo di soglia."
+"riempiono l'area contenente valori in un determinato intervallo di "
+"soglia."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Define delivery schedule, timezone, and frequency settings."
 msgstr ""
-"Definisci la pianificazione della consegna, il fuso orario e le impostazioni "
-"di frequenza."
+"Definisci la pianificazione della consegna, il fuso orario e le "
+"impostazioni di frequenza."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -6821,8 +6889,8 @@ msgstr "Definito dalla configurazione di sistema."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Defines a rolling window function to apply, works along with the [Periods] "
-"text box"
+"Defines a rolling window function to apply, works along with the "
+"[Periods] text box"
 msgstr ""
 "Definisce una funzione di finestra mobile da applicare, funziona insieme "
 "alla casella di testo [Periodi]"
@@ -6838,22 +6906,22 @@ msgstr "Definisce la dimensione della griglia in pixel"
 # de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Defines the grouping of entities. Each series is represented by a specific "
-"color in the chart."
+"Defines the grouping of entities. Each series is represented by a "
+"specific color in the chart."
 msgstr ""
-"Definisce il raggruppamento delle entità. Ogni serie è rappresentata da un "
-"colore specifico nel grafico."
+"Definisce il raggruppamento delle entità. Ogni serie è rappresentata da "
+"un colore specifico nel grafico."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Defines the grouping of entities. Each series is shown as a specific color "
-"on the chart and has a legend toggle"
+"Defines the grouping of entities. Each series is shown as a specific "
+"color on the chart and has a legend toggle"
 msgstr ""
-"Definisce il raggruppamento delle entità. Ogni serie viene mostrata con un "
-"colore specifico nel grafico e ha un interruttore di legenda"
+"Definisce il raggruppamento delle entità. Ogni serie viene mostrata con "
+"un colore specifico nel grafico e ha un interruttore di legenda"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -6871,8 +6939,8 @@ msgstr ""
 # uk]
 #, fuzzy
 msgid ""
-"Defines the value that determines the boundary between different regions or "
-"levels in the data "
+"Defines the value that determines the boundary between different regions "
+"or levels in the data "
 msgstr ""
 "Definisce il valore che determina il confine tra le diverse regioni o "
 "livelli nei dati"
@@ -6885,19 +6953,19 @@ msgid ""
 "Defines whether the step should appear at the beginning, middle or end "
 "between two data points"
 msgstr ""
-"Definisce se il gradino deve apparire all'inizio, al centro o alla fine tra "
-"due punti dati"
+"Definisce se il gradino deve apparire all'inizio, al centro o alla fine "
+"tra due punti dati"
 
 msgid "Definition"
 msgstr "Definizione"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]
-#, python-format
+#, fuzzy, python-format
 msgid "Delayed (missed %s refresh)"
 msgid_plural "Delayed (missed %s refreshes)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "In ritardo (%s aggiornamento mancato)"
+msgstr[1] "In ritardo (%s aggiornamenti mancati)"
 
 msgid "Delete"
 msgstr "Cancella"
@@ -7098,8 +7166,8 @@ msgid ""
 "Deleting a tab will remove all content within it and will deactivate any "
 "related alerts or reports. You may still reverse this action with the"
 msgstr ""
-"L'eliminazione di una scheda rimuoverà tutti i contenuti al suo interno e "
-"disattiverà eventuali avvisi o report correlati. Puoi ancora annullare "
+"L'eliminazione di una scheda rimuoverà tutti i contenuti al suo interno e"
+" disattiverà eventuali avvisi o report correlati. Puoi ancora annullare "
 "questa azione con il"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -7165,15 +7233,15 @@ msgstr "Dettagli della certificazione"
 #, fuzzy
 msgid ""
 "Determines how the filter matches values. \"Exact match\" uses the IN "
-"operator (default). ILIKE options enable partial text matching with a free-"
-"text input. Warning: ILIKE queries may be slow on large datasets as they "
-"cannot use indexes effectively."
+"operator (default). ILIKE options enable partial text matching with a "
+"free-text input. Warning: ILIKE queries may be slow on large datasets as "
+"they cannot use indexes effectively."
 msgstr ""
-"Determina come il filtro abbina i valori. \"Corrispondenza esatta\" utilizza "
-"l'operatore IN (predefinito). Le opzioni ILIKE abilitano la corrispondenza "
-"parziale del testo con un input a testo libero. Attenzione: le query ILIKE "
-"potrebbero essere lente su dataset di grandi dimensioni poiché non possono "
-"utilizzare gli indici in modo efficace."
+"Determina come il filtro abbina i valori. \"Corrispondenza esatta\" "
+"utilizza l'operatore IN (predefinito). Le opzioni ILIKE abilitano la "
+"corrispondenza parziale del testo con un input a testo libero. "
+"Attenzione: le query ILIKE potrebbero essere lente su dataset di grandi "
+"dimensioni poiché non possono utilizzare gli indici in modo efficace."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Determina come vengono calcolati baffi e valori anomali."
@@ -7217,9 +7285,9 @@ msgstr "Dimensione"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Dimension column emitted as a cross-filter when a feature is clicked. Other "
-"charts on the dashboard match against this column. If unset, falls back to "
-"the geometry column (legacy behavior, often unmatchable)."
+"Dimension column emitted as a cross-filter when a feature is clicked. "
+"Other charts on the dashboard match against this column. If unset, falls "
+"back to the geometry column (legacy behavior, often unmatchable)."
 msgstr ""
 "Colonna dimensione emessa come filtro incrociato quando si fa clic su un "
 "elemento. Gli altri grafici nel dashboard vengono confrontati con questa "
@@ -7258,14 +7326,14 @@ msgstr "Dimensioni (%s)"
 # zh_TW]
 #, fuzzy
 msgid ""
-"Dimensions contain qualitative values such as names, dates, or geographical "
-"data. Use dimensions to categorize, segment, and reveal the details in your "
-"data. Dimensions affect the level of detail in the view."
+"Dimensions contain qualitative values such as names, dates, or "
+"geographical data. Use dimensions to categorize, segment, and reveal the "
+"details in your data. Dimensions affect the level of detail in the view."
 msgstr ""
 "Le dimensioni contengono valori qualitativi come nomi, date o dati "
 "geografici. Usa le dimensioni per categorizzare, segmentare e rivelare i "
-"dettagli nei tuoi dati. Le dimensioni influenzano il livello di dettaglio "
-"nella visualizzazione."
+"dettagli nei tuoi dati. Le dimensioni influenzano il livello di dettaglio"
+" nella visualizzazione."
 
 msgid "Directed Force Layout"
 msgstr "Disposizione a Forza Diretta"
@@ -7282,11 +7350,12 @@ msgstr "Disabilitare le query di anteprima dei dati di SQL Lab"
 #, fuzzy
 msgid ""
 "Disable data preview when fetching table metadata in SQL Lab.  Useful to "
-"avoid browser performance issues when using  databases with very wide tables."
+"avoid browser performance issues when using  databases with very wide "
+"tables."
 msgstr ""
 "Disabilita l'anteprima dei dati durante il recupero dei metadati delle "
-"tabelle in SQL Lab. Utile per evitare problemi di prestazioni del browser "
-"quando si utilizzano database con tabelle molto ampie."
+"tabelle in SQL Lab. Utile per evitare problemi di prestazioni del browser"
+" quando si utilizzano database con tabelle molto ampie."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -7376,8 +7445,7 @@ msgstr "Mostra totale cumulativo alla fine"
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Display headers for each column at the top of the matrix"
-msgstr ""
-"Mostra intestazioni per ogni colonna nella parte superiore della matrice"
+msgstr "Mostra intestazioni per ogni colonna nella parte superiore della matrice"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -7390,21 +7458,23 @@ msgstr "Mostra etichette per ogni riga sul lato sinistro della matrice"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Display metrics side by side within each column, as opposed to each column "
-"being displayed side by side for each metric."
+"Display metrics side by side within each column, as opposed to each "
+"column being displayed side by side for each metric."
 msgstr ""
-"Mostra le metriche affiancate all'interno di ogni colonna, anziché mostrare "
-"ogni colonna affiancata per ogni metrica."
+"Mostra le metriche affiancate all'interno di ogni colonna, anziché "
+"mostrare ogni colonna affiancata per ogni metrica."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Display percents in the label and tooltip as the percent of the total value, "
-"from the first step of the funnel, or from the previous step in the funnel."
+"Display percents in the label and tooltip as the percent of the total "
+"value, from the first step of the funnel, or from the previous step in "
+"the funnel."
 msgstr ""
 "Mostra le percentuali nell'etichetta e nel tooltip come percentuale del "
-"valore totale, dal primo passo del funnel, o dal passo precedente nel funnel."
+"valore totale, dal primo passo del funnel, o dal passo precedente nel "
+"funnel."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -7432,15 +7502,15 @@ msgstr "Visualizza icona del tipo"
 
 msgid ""
 "Displays connections between entities in a graph structure. Useful for "
-"mapping relationships and showing which nodes are important in a network. "
-"Graph charts can be configured to be force-directed or circulate. If your "
-"data has a geospatial component, try the deck.gl Arc chart."
+"mapping relationships and showing which nodes are important in a network."
+" Graph charts can be configured to be force-directed or circulate. If "
+"your data has a geospatial component, try the deck.gl Arc chart."
 msgstr ""
-"Visualizza le connessioni tra le entità in una struttura grafica. Utile per "
-"mappare le relazioni e mostrare quali nodi sono importanti in una rete. I "
-"grafici a grafo possono essere configurati per essere diretti a forza o a "
-"circolare. Se i dati hanno una componente geospaziale, provare il grafico ad "
-"arco deck.gl."
+"Visualizza le connessioni tra le entità in una struttura grafica. Utile "
+"per mappare le relazioni e mostrare quali nodi sono importanti in una "
+"rete. I grafici a grafo possono essere configurati per essere diretti a "
+"forza o a circolare. Se i dati hanno una componente geospaziale, provare "
+"il grafico ad arco deck.gl."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
@@ -7465,8 +7535,8 @@ msgid ""
 "Divides each category into subcategories based on the values in the "
 "dimension. It can be used to exclude intersections."
 msgstr ""
-"Divide ogni categoria in sottocategorie in base ai valori della dimensione. "
-"Può essere utilizzato per escludere le intersezioni."
+"Divide ogni categoria in sottocategorie in base ai valori della "
+"dimensione. Può essere utilizzato per escludere le intersezioni."
 
 msgid "Do you want a donut or a pie?"
 msgstr "Si desidera una ciambella o una torta?"
@@ -7528,11 +7598,11 @@ msgstr "Scarica sul client"
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"Downloading %(rows)s rows based on the LIMIT configuration. If you want the "
-"entire result set, you need to adjust the LIMIT."
+"Downloading %(rows)s rows based on the LIMIT configuration. If you want "
+"the entire result set, you need to adjust the LIMIT."
 msgstr ""
-"Download di %(rows)s righe in base alla configurazione LIMIT. Se si desidera "
-"l'intero set di risultati, è necessario modificare il LIMIT."
+"Download di %(rows)s righe in base alla configurazione LIMIT. Se si "
+"desidera l'intero set di risultati, è necessario modificare il LIMIT."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -7556,13 +7626,14 @@ msgstr "Trascina e rilascia componenti in questa scheda"
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Drag columns and metrics here to customize tooltip content. Order matters - "
-"items will appear in the same order in tooltips. Click the button to "
+"Drag columns and metrics here to customize tooltip content. Order matters"
+" - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
-"Trascina colonne e metriche qui per personalizzare il contenuto del tooltip. "
-"L'ordine è importante: gli elementi appariranno nello stesso ordine nei "
-"tooltip. Clicca il pulsante per selezionare manualmente colonne e metriche."
+"Trascina colonne e metriche qui per personalizzare il contenuto del "
+"tooltip. L'ordine è importante: gli elementi appariranno nello stesso "
+"ordine nei tooltip. Clicca il pulsante per selezionare manualmente "
+"colonne e metriche."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -7575,8 +7646,7 @@ msgstr "Trascina per riordinare"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Draw a marker on data points. Only applicable for line types."
-msgstr ""
-"Disegna un marcatore sui punti dati. Applicabile solo ai tipi di linea."
+msgstr "Disegna un marcatore sui punti dati. Applicabile solo ai tipi di linea."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -7652,15 +7722,15 @@ msgid ""
 "Drill to detail is disabled because this chart does not group data by "
 "dimension value."
 msgstr ""
-"Il drill to detail è disabilitato perché questo grafico non raggruppa i dati "
-"per valore di dimensione."
+"Il drill to detail è disabilitato perché questo grafico non raggruppa i "
+"dati per valore di dimensione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Drill to detail is disabled for this database. Change the database settings "
-"to enable it."
+"Drill to detail is disabled for this database. Change the database "
+"settings to enable it."
 msgstr ""
 "Il drill to detail è disabilitato per questo database. Modifica le "
 "impostazioni del database per abilitarlo."
@@ -7705,11 +7775,11 @@ msgstr "Nome/i colonna/e duplicati: %(columns)s"
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"Duplicate column/metric labels: %(labels)s. Please make sure all columns and "
-"metrics have a unique label."
+"Duplicate column/metric labels: %(labels)s. Please make sure all columns "
+"and metrics have a unique label."
 msgstr ""
-"Etichette duplicate di colonna/metrica: %(labels)s. Assicurarsi che tutte le "
-"colonne e le metriche abbiano un'etichetta univoca."
+"Etichette duplicate di colonna/metrica: %(labels)s. Assicurarsi che tutte"
+" le colonne e le metriche abbiano un'etichetta univoca."
 
 msgid "Duplicate dataset"
 msgstr "Dataset duplicato"
@@ -7735,36 +7805,39 @@ msgstr "Descrizione"
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Duration (in seconds) of the caching timeout for charts of this database. A "
-"timeout of 0 indicates that the cache never expires, and -1 bypasses the "
-"cache. Note this defaults to the global timeout if undefined."
+"Duration (in seconds) of the caching timeout for charts of this database."
+" A timeout of 0 indicates that the cache never expires, and -1 bypasses "
+"the cache. Note this defaults to the global timeout if undefined."
 msgstr ""
 "Durata (in secondi) del timeout della cache per i grafici di questo "
 "database. Un timeout di 0 indica che la cache non scade mai, mentre -1 "
-"ignora la cache. Si noti che il valore predefinito è il timeout globale se "
-"non definito."
+"ignora la cache. Si noti che il valore predefinito è il timeout globale "
+"se non definito."
 
 msgid ""
-"Duration (in seconds) of the caching timeout for this chart. Set to -1 to "
-"bypass the cache. Note this defaults to the dataset's timeout if undefined."
+"Duration (in seconds) of the caching timeout for this chart. Set to -1 to"
+" bypass the cache. Note this defaults to the dataset's timeout if "
+"undefined."
 msgstr ""
-"Durata (in secondi) per il timeout della cache per questo grafico. Impostare "
-"a -1 per ignorare la cache. Si noti che per impostazione predefinita viene "
-"utilizzato il timeout del dataset."
+"Durata (in secondi) per il timeout della cache per questo grafico. "
+"Impostare a -1 per ignorare la cache. Si noti che per impostazione "
+"predefinita viene utilizzato il timeout del dataset."
 
 msgid ""
-"Duration (in seconds) of the metadata caching timeout for schemas of this "
-"database. If left unset, the cache never expires."
+"Duration (in seconds) of the metadata caching timeout for schemas of this"
+" database. If left unset, the cache never expires."
 msgstr ""
-"Durata (in secondi) del timeout di memorizzazione nella cache dei metadati "
-"per gli schemi del database. Se non viene impostata, la cache non scade mai."
+"Durata (in secondi) del timeout di memorizzazione nella cache dei "
+"metadati per gli schemi del database. Se non viene impostata, la cache "
+"non scade mai."
 
 msgid ""
 "Duration (in seconds) of the metadata caching timeout for tables of this "
 "database. If left unset, the cache never expires. "
 msgstr ""
-"Durata (in secondi) del timeout di memorizzazione nella cache dei metadati "
-"per le tabelle del database. Se non viene impostata, la cache non scade mai."
+"Durata (in secondi) del timeout di memorizzazione nella cache dei "
+"metadati per le tabelle del database. Se non viene impostata, la cache "
+"non scade mai."
 
 msgid "Duration Ms"
 msgstr "Durata ms"
@@ -7825,6 +7898,7 @@ msgstr "Cerca dinamicamente tutti i valori del filtro"
 msgid "Dynamically select grouping columns from a dataset"
 msgstr "Seleziona dinamicamente le colonne di raggruppamento da un set di dati"
 
+#. do-not-translate
 msgid "ECharts"
 msgstr "ECharts"
 
@@ -7834,6 +7908,7 @@ msgstr "ECharts"
 msgid "ECharts Options (JS object literals)"
 msgstr "Opzioni ECharts (letterali oggetto JS)"
 
+#. do-not-translate
 msgid "EMAIL_REPORTS_CTA"
 msgstr "EMAIL_REPORTS_CTA"
 
@@ -7991,15 +8066,14 @@ msgid "Editors"
 msgstr "Editor"
 
 msgid "Editors is a list of subjects who can alter the dashboard."
-msgstr ""
-"Gli editor sono un elenco di soggetti che possono modificare la dashboard."
+msgstr "Gli editor sono un elenco di soggetti che possono modificare la dashboard."
 
 msgid ""
 "Editors is a list of subjects who can alter the dashboard. Searchable by "
 "name."
 msgstr ""
-"Gli editor sono un elenco di soggetti che possono modificare la dashboard. "
-"Ricercabile per nome."
+"Gli editor sono un elenco di soggetti che possono modificare la "
+"dashboard. Ricercabile per nome."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -8115,8 +8189,8 @@ msgstr "Riga vuota"
 #, fuzzy
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr ""
-"Abilita 'Consenti il caricamento di file nel database' nelle impostazioni di "
-"qualsiasi database"
+"Abilita 'Consenti il caricamento di file nel database' nelle impostazioni"
+" di qualsiasi database"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -8200,21 +8274,22 @@ msgstr "Abilita espansione delle righe negli schemi"
 #, fuzzy
 msgid "Enable server side pagination of results (experimental feature)"
 msgstr ""
-"Abilita la paginazione lato server dei risultati (funzionalità sperimentale)"
+"Abilita la paginazione lato server dei risultati (funzionalità "
+"sperimentale)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Enables custom icon configuration via JavaScript"
-msgstr ""
-"Abilita la configurazione personalizzata delle icone tramite JavaScript"
+msgstr "Abilita la configurazione personalizzata delle icone tramite JavaScript"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Enables custom label configuration via JavaScript"
 msgstr ""
-"Abilita la configurazione personalizzata delle etichette tramite JavaScript"
+"Abilita la configurazione personalizzata delle etichette tramite "
+"JavaScript"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
@@ -8233,11 +8308,12 @@ msgstr "Abilita il rendering delle etichette per i punti GeoJSON"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Encountered invalid NULL spatial "
-"entry,                                        please consider filtering "
-"those out"
+"Encountered invalid NULL spatial entry,"
+"                                        please consider filtering those "
+"out"
 msgstr ""
-"È stata rilevata una voce spaziale NULL non valida, si consiglia di filtrarla"
+"È stata rilevata una voce spaziale NULL non valida, si consiglia di "
+"filtrarla"
 
 msgid "Encrypted extra fields"
 msgstr "Ulteriori campi criptati"
@@ -8468,8 +8544,7 @@ msgstr "Errore nell'espressione jinja nella colonna datetime: %(msg)s"
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid "Error in jinja expression in fetch values predicate: %(msg)s"
-msgstr ""
-"Errore nell'espressione jinja nel predicato di recupero valori: %(msg)s"
+msgstr "Errore nell'espressione jinja nel predicato di recupero valori: %(msg)s"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, tr, uk]
@@ -8479,8 +8554,8 @@ msgstr "Errore nell'espressione jinja nell'espressione della metrica: %(msg)s"
 
 msgid "Error loading chart datasources. Filters may not work correctly."
 msgstr ""
-"Errore nel caricare le sorgenti dati del grafico. I filtri potrebbero non "
-"funzionare correttamente."
+"Errore nel caricare le sorgenti dati del grafico. I filtri potrebbero non"
+" funzionare correttamente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -8718,8 +8793,8 @@ msgid ""
 "        Example: '2x+5'"
 msgstr ""
 "Si aspetta una formula con il parametro temporale dipendente 'x'\n"
-"        in millisecondi dall'epoca. mathjs viene utilizzato per valutare le "
-"formule.\n"
+"        in millisecondi dall'epoca. mathjs viene utilizzato per valutare "
+"le formule.\n"
 "        Esempio: '2x+5'"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -8873,14 +8948,14 @@ msgstr "Dati aggiuntivi per JS"
 #, python-brace-format
 msgid ""
 "Extra data to specify table metadata. Currently supports metadata of the "
-"format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\", "
-"\"details\": \"This table is the source of truth.\" }, \"warning_markdown\": "
-"\"This is a warning.\" }`."
+"format: `{ \"certification\": { \"certified_by\": \"Data Platform Team\","
+" \"details\": \"This table is the source of truth.\" }, "
+"\"warning_markdown\": \"This is a warning.\" }`."
 msgstr ""
 "Dati aggiuntivi per specificare i metadati della tabella. Attualmente "
 "supporta metadati nel formato: `{ \"certification\": { \"certified_by\": "
-"\"Data Platform Team\", \"details\": \"This table is the source of truth."
-"\" }, \"warning_markdown\": \"This is a warning.\" }`."
+"\"Data Platform Team\", \"details\": \"This table is the source of "
+"truth.\" }, \"warning_markdown\": \"This is a warning.\" }`."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -8915,6 +8990,11 @@ msgstr "DEB"
 
 msgid "FIT DATA"
 msgstr "FIT DATA"
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: lv]
+#, fuzzy
+msgid "Fit data"
+msgstr "Adatta ai dati"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -9174,11 +9254,11 @@ msgstr "Estensione file non permessa."
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"File handling is not supported in this browser. Please use a modern browser "
-"like Chrome or Edge."
+"File handling is not supported in this browser. Please use a modern "
+"browser like Chrome or Edge."
 msgstr ""
-"La gestione dei file non è supportata in questo browser. Utilizza un browser "
-"moderno come Chrome o Edge."
+"La gestione dei file non è supportata in questo browser. Utilizza un "
+"browser moderno come Chrome o Edge."
 
 msgid "File settings"
 msgstr "Impostazioni file"
@@ -9250,11 +9330,10 @@ msgstr "Valore del filtro"
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
-msgid ""
-"Filter only displays values relevant to selections made in other filters."
+msgid "Filter only displays values relevant to selections made in other filters."
 msgstr ""
-"Il filtro visualizza solo i valori rilevanti per le selezioni effettuate in "
-"altri filtri."
+"Il filtro visualizza solo i valori rilevanti per le selezioni effettuate "
+"in altri filtri."
 
 msgid "Filter options"
 msgstr "Opzioni del filtro"
@@ -9327,20 +9406,21 @@ msgstr "Filtri fuori ambito (%d)"
 #, fuzzy
 msgid ""
 "Filters with the same group key will be ORed together within the group, "
-"while different filter groups will be ANDed together. Undefined group keys "
-"are treated as unique groups, i.e. are not grouped together. For example, if "
-"a table has three filters, of which two are for departments Finance and "
-"Marketing (group key = 'department'), and one refers to the region Europe "
-"(group key = 'region'), the filter clause would apply the filter (department "
-"= 'Finance' OR department = 'Marketing') AND (region = 'Europe')."
+"while different filter groups will be ANDed together. Undefined group "
+"keys are treated as unique groups, i.e. are not grouped together. For "
+"example, if a table has three filters, of which two are for departments "
+"Finance and Marketing (group key = 'department'), and one refers to the "
+"region Europe (group key = 'region'), the filter clause would apply the "
+"filter (department = 'Finance' OR department = 'Marketing') AND (region ="
+" 'Europe')."
 msgstr ""
-"I filtri con la stessa chiave di gruppo verranno uniti con OR all'interno "
-"del gruppo, mentre i diversi gruppi di filtri verranno uniti con AND. Le "
-"chiavi di gruppo non definite vengono trattate come gruppi univoci, ovvero "
-"non vengono raggruppate insieme. Ad esempio, se una tabella ha tre filtri, "
-"di cui due per i reparti Finanza e Marketing (chiave di gruppo = "
-"'department') e uno si riferisce alla regione Europa (chiave di gruppo = "
-"'region'), la clausola di filtro applicherà il filtro (department = "
+"I filtri con la stessa chiave di gruppo verranno uniti con OR all'interno"
+" del gruppo, mentre i diversi gruppi di filtri verranno uniti con AND. Le"
+" chiavi di gruppo non definite vengono trattate come gruppi univoci, "
+"ovvero non vengono raggruppate insieme. Ad esempio, se una tabella ha tre"
+" filtri, di cui due per i reparti Finanza e Marketing (chiave di gruppo ="
+" 'department') e uno si riferisce alla regione Europa (chiave di gruppo ="
+" 'region'), la clausola di filtro applicherà il filtro (department = "
 "'Finance' OR department = 'Marketing') AND (region = 'Europe')."
 
 msgid "Find"
@@ -9380,11 +9460,12 @@ msgstr "Adatta le colonne dinamicamente"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Fix the trend line to the full time range specified in case filtered results "
-"do not include the start or end dates"
+"Fix the trend line to the full time range specified in case filtered "
+"results do not include the start or end dates"
 msgstr ""
-"Fissa la linea di tendenza all'intero intervallo di tempo specificato nel "
-"caso in cui i risultati filtrati non includano le date di inizio o di fine"
+"Fissa la linea di tendenza all'intero intervallo di tempo specificato nel"
+" caso in cui i risultati filtrati non includano le date di inizio o di "
+"fine"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
@@ -9442,8 +9523,8 @@ msgstr "Dimensione font"
 #, fuzzy
 msgid "Font size for axis labels, detail value and other text elements"
 msgstr ""
-"Dimensione carattere per le etichette degli assi, il valore di dettaglio e "
-"altri elementi di testo"
+"Dimensione carattere per le etichette degli assi, il valore di dettaglio "
+"e altri elementi di testo"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -9467,16 +9548,16 @@ msgid ""
 "For Bigquery, Presto and Postgres, shows a button to compute cost before "
 "running a query."
 msgstr ""
-"Per Bigquery, Presto e Postgres, mostra un pulsante per calcolare il costo "
-"prima di eseguire una query."
+"Per Bigquery, Presto e Postgres, mostra un pulsante per calcolare il "
+"costo prima di eseguire una query."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
 # zh_TW]
 #, fuzzy
 msgid ""
-"For Trino, describe full schemas of nested ROW types, expanding them with "
-"dotted paths"
+"For Trino, describe full schemas of nested ROW types, expanding them with"
+" dotted paths"
 msgstr ""
 "Per Trino, descrivi gli schemi completi dei tipi ROW nidificati, "
 "espandendoli con percorsi puntati"
@@ -9496,14 +9577,20 @@ msgid ""
 "For more information about objects are in context in the scope of this "
 "function, refer to the"
 msgstr ""
-"Per ulteriori informazioni sugli oggetti nel contesto di questa funzione, "
-"fare riferimento a"
+"Per ulteriori informazioni sugli oggetti nel contesto di questa funzione,"
+" fare riferimento a"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, tr]
+#, fuzzy
 msgid ""
 "For regular filters, these are the subjects (users, roles, groups) this "
-"filter will be applied to. For base filters, these are the subjects that the "
-"filter DOES NOT apply to, e.g. Admin if admin should see all data."
+"filter will be applied to. For base filters, these are the subjects that "
+"the filter DOES NOT apply to, e.g. Admin if admin should see all data."
 msgstr ""
+"Per i filtri regolari, questi sono i soggetti (utenti, ruoli, gruppi) a "
+"cui verrà applicato questo filtro. Per i filtri di base, questi sono i "
+"soggetti a cui il filtro NON si applica, ad esempio Admin se "
+"l'amministratore deve vedere tutti i dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -9531,11 +9618,11 @@ msgstr "Forza l'interruzione (interrompe l'attività per tutti gli abbonati)"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Force all tables and views to be created in this schema when clicking CTAS "
-"or CVAS in SQL Lab."
+"Force all tables and views to be created in this schema when clicking "
+"CTAS or CVAS in SQL Lab."
 msgstr ""
-"Forza la creazione di tutte le tabelle e le viste in questo schema quando si "
-"fa clic su CTAS o CVAS in SQL Lab."
+"Forza la creazione di tutte le tabelle e le viste in questo schema quando"
+" si fa clic su CTAS o CVAS in SQL Lab."
 
 #, fuzzy
 msgid "Force categorical"
@@ -9582,8 +9669,8 @@ msgstr "Forza aggiornamento lista tabelle"
 #, fuzzy
 msgid "Forces selected Time Grain as the maximum interval for X Axis Labels"
 msgstr ""
-"Forza la granularità temporale selezionata come intervallo massimo per le "
-"etichette dell'asse X"
+"Forza la granularità temporale selezionata come intervallo massimo per le"
+" etichette dell'asse X"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
@@ -9612,7 +9699,8 @@ msgstr "Dati del form non trovati in cache, ritorno ai metadati del grafico"
 #, fuzzy
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr ""
-"Dati del modulo non trovati nella cache, ripristino dei metadati del dataset."
+"Dati del modulo non trovati nella cache, ripristino dei metadati del "
+"dataset."
 
 msgid "Format"
 msgstr "Formato"
@@ -9643,15 +9731,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Format metrics or columns with currency symbols as prefixes or suffixes. "
-"Choose a symbol manually or use 'Auto-detect' to apply the correct symbol "
-"based on the dataset's currency code column. When multiple currencies are "
-"present, formatting falls back to neutral numbers."
+"Choose a symbol manually or use 'Auto-detect' to apply the correct symbol"
+" based on the dataset's currency code column. When multiple currencies "
+"are present, formatting falls back to neutral numbers."
 msgstr ""
 "Formatta le metriche o le colonne con simboli di valuta come prefissi o "
-"suffissi. Scegli un simbolo manualmente o usa 'Rilevamento automatico' per "
-"applicare il simbolo corretto in base alla colonna del codice valuta del "
-"dataset. Quando sono presenti più valute, la formattazione torna a numeri "
-"neutri."
+"suffissi. Scegli un simbolo manualmente o usa 'Rilevamento automatico' "
+"per applicare il simbolo corretto in base alla colonna del codice valuta "
+"del dataset. Quando sono presenti più valute, la formattazione torna a "
+"numeri neutri."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -9745,6 +9833,7 @@ msgstr "Personalizza ulteriormente come visualizzare ogni colonna"
 msgid "Further customize how to display each metric"
 msgstr "Personalizza ulteriormente come visualizzare ogni metrica"
 
+#. do-not-translate
 msgid "GROUP BY"
 msgstr "RAGGRUPPA PER"
 
@@ -9755,12 +9844,12 @@ msgstr "Grafico Gantt"
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Gantt chart visualizes important events over a time span. Every data point "
-"displayed as a separate event along a horizontal line."
+"Gantt chart visualizes important events over a time span. Every data "
+"point displayed as a separate event along a horizontal line."
 msgstr ""
 "Il diagramma di Gantt visualizza gli eventi importanti nel corso di un "
-"periodo di tempo. Ogni punto dati viene visualizzato come un evento separato "
-"lungo una linea orizzontale."
+"periodo di tempo. Ogni punto dati viene visualizzato come un evento "
+"separato lungo una linea orizzontale."
 
 msgid "Gauge Chart"
 msgstr "Grafico a scartamento"
@@ -9828,8 +9917,7 @@ msgstr "Ottieni la data specificata per la festività"
 # es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Give access to multiple catalogs in a single database connection."
-msgstr ""
-"Consenti l'accesso a più cataloghi in un'unica connessione al database."
+msgstr "Consenti l'accesso a più cataloghi in un'unica connessione al database."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -9949,8 +10037,8 @@ msgid ""
 "reached. This prevents incomplete time series data from being displayed."
 msgstr ""
 "Raggruppa le serie rimanenti in una categoria \"Altri\" quando viene "
-"raggiunto il limite delle serie. Questo impedisce la visualizzazione di dati "
-"di serie temporali incompleti."
+"raggiunto il limite delle serie. Questo impedisce la visualizzazione di "
+"dati di serie temporali incompleti."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -10142,14 +10230,14 @@ msgstr "Quanti valori principali selezionare"
 # zh_TW]
 #, fuzzy
 msgid ""
-"How to display time shifts: as individual lines; as the difference between "
-"the main time series and each time shift; as the percentage change; or as "
-"the ratio between series and time shifts."
+"How to display time shifts: as individual lines; as the difference "
+"between the main time series and each time shift; as the percentage "
+"change; or as the ratio between series and time shifts."
 msgstr ""
-"Come visualizzare gli spostamenti temporali: come linee individuali; come "
-"differenza tra la serie temporale principale e ogni spostamento temporale; "
-"come variazione percentuale; o come rapporto tra serie e spostamenti "
-"temporali."
+"Come visualizzare gli spostamenti temporali: come linee individuali; come"
+" differenza tra la serie temporale principale e ogni spostamento "
+"temporale; come variazione percentuale; o come rapporto tra serie e "
+"spostamenti temporali."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -10201,34 +10289,34 @@ msgstr "Id o nodo radice dell'albero"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"If Presto or Trino, all the queries in SQL Lab are going to be executed as "
-"the currently logged on user who must have permission to run them. If Hive "
-"and hive.server2.enable.doAs is enabled, will run the queries as service "
-"account, but impersonate the currently logged on user via "
+"If Presto or Trino, all the queries in SQL Lab are going to be executed "
+"as the currently logged on user who must have permission to run them. If "
+"Hive and hive.server2.enable.doAs is enabled, will run the queries as "
+"service account, but impersonate the currently logged on user via "
 "hive.server2.proxy.user property."
 msgstr ""
-"Se si utilizza Presto o Trino, tutte le query in SQL Lab verranno eseguite "
-"come l'utente attualmente connesso, che deve avere il permesso per "
-"eseguirle. Se è abilitato Hive e hive.server2.enable.doAs, le query verranno "
-"eseguite come account di servizio, ma con la rappresentazione dell'utente "
-"attualmente connesso tramite la proprietà hive.server2.proxy.user."
+"Se si utilizza Presto o Trino, tutte le query in SQL Lab verranno "
+"eseguite come l'utente attualmente connesso, che deve avere il permesso "
+"per eseguirle. Se è abilitato Hive e hive.server2.enable.doAs, le query "
+"verranno eseguite come account di servizio, ma con la rappresentazione "
+"dell'utente attualmente connesso tramite la proprietà "
+"hive.server2.proxy.user."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"If a metric is specified, sorting will be done based on the metric value"
+msgid "If a metric is specified, sorting will be done based on the metric value"
 msgstr ""
-"Se viene specificata una metrica, l'ordinamento verrà effettuato in base al "
-"valore della metrica"
+"Se viene specificata una metrica, l'ordinamento verrà effettuato in base "
+"al valore della metrica"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"If enabled, this control sorts the results/values descending, otherwise it "
-"sorts the results ascending."
+"If enabled, this control sorts the results/values descending, otherwise "
+"it sorts the results ascending."
 msgstr ""
 "Se abilitato, questo controllo ordina i risultati/valori in modo "
 "decrescente, altrimenti ordina i risultati in modo crescente."
@@ -10237,11 +10325,12 @@ msgstr ""
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"If it stays empty, it won't be saved and will be removed from the list. To "
-"remove folders, move metrics and columns to other folders."
+"If it stays empty, it won't be saved and will be removed from the list. "
+"To remove folders, move metrics and columns to other folders."
 msgstr ""
 "Se rimane vuoto, non verrà salvato e verrà rimosso dall'elenco. Per "
-"rimuovere le cartelle, spostare le metriche e le colonne in altre cartelle."
+"rimuovere le cartelle, spostare le metriche e le colonne in altre "
+"cartelle."
 
 msgid "If table already exists"
 msgstr "Se la tabella esiste già"
@@ -10290,10 +10379,8 @@ msgstr "Download dell'immagine non riuscito, aggiorna la pagina e riprova."
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)"
-msgstr ""
-"Impersona l'utente connesso (Presto, Trino, Drill, Hive e Google Sheets)"
+msgid "Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)"
+msgstr "Impersona l'utente connesso (Presto, Trino, Drill, Hive e Google Sheets)"
 
 msgid "Import"
 msgstr "Importa"
@@ -10352,8 +10439,7 @@ msgstr "Importa query"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Import saved query failed for an unknown reason."
-msgstr ""
-"Importazione della query salvata non riuscita per un motivo sconosciuto."
+msgstr "Importazione della query salvata non riuscita per un motivo sconosciuto."
 
 msgid "Import themes"
 msgstr "Importazione temi"
@@ -10562,10 +10648,10 @@ msgstr "Il raggio di intensità è il raggio al quale il peso viene distribuito"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
-msgid ""
-"Intensity is the value multiplied by the weight to obtain the final weight"
+msgid "Intensity is the value multiplied by the weight to obtain the final weight"
 msgstr ""
-"L'intensità è il valore moltiplicato per il peso per ottenere il peso finale"
+"L'intensità è il valore moltiplicato per il peso per ottenere il peso "
+"finale"
 
 msgid "Interval"
 msgstr "Intervallo"
@@ -10589,8 +10675,8 @@ msgstr "Intervalli"
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Invalid Connection String: Expecting String of the form 'ocient://"
-"user:pass@host:port/database'."
+"Invalid Connection String: Expecting String of the form "
+"'ocient://user:pass@host:port/database'."
 msgstr ""
 "Stringa di connessione non valida: è prevista una stringa nella forma "
 "'ocient://user:pass@host:port/database'."
@@ -10633,8 +10719,8 @@ msgstr "Colore non valido"
 # es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Invalid connection string, a valid string usually follows: backend+driver://"
-"user:password@database-host/database-name"
+"Invalid connection string, a valid string usually follows: "
+"backend+driver://user:password@database-host/database-name"
 msgstr ""
 "Stringa di connessione non valida, una stringa valida segue solitamente: "
 "backend+driver://user:password@database-host/database-name"
@@ -10644,13 +10730,15 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Invalid connection string, a valid string usually follows:'DRIVER://"
-"USER:PASSWORD@DB-HOST/DATABASE-NAME'<p>Example:'postgresql://"
-"user:password@your-postgres-db/database'</p>"
+"Invalid connection string, a valid string usually "
+"follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
+"NAME'<p>Example:'postgresql://user:password@your-postgres-"
+"db/database'</p>"
 msgstr ""
 "Stringa di connessione non valida, una stringa valida segue "
 "solitamente:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-"
-"NAME'<p>Esempio:'postgresql://user:password@your-postgres-db/database'</p>"
+"NAME'<p>Esempio:'postgresql://user:password@your-postgres-"
+"db/database'</p>"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -10901,11 +10989,11 @@ msgstr "Problema 1001 - Il database è sotto un carico insolito."
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"It won't be removed even if empty. It won't be shown in chart editing view "
-"if empty."
+"It won't be removed even if empty. It won't be shown in chart editing "
+"view if empty."
 msgstr ""
-"Non verrà rimosso anche se vuoto. Non verrà mostrato nella vista di modifica "
-"del grafico se vuoto."
+"Non verrà rimosso anche se vuoto. Non verrà mostrato nella vista di "
+"modifica del grafico se vuoto."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, fr, ja,
 # lv, ru, sr, sr_Latn, tr, uk]
@@ -10945,15 +11033,15 @@ msgstr "metadati JSON non validi"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"JSON string containing additional connection configuration. This is used to "
-"provide connection information for systems like Hive, Presto and BigQuery "
-"which do not conform to the username:password syntax normally used by "
-"SQLAlchemy."
+"JSON string containing additional connection configuration. This is used "
+"to provide connection information for systems like Hive, Presto and "
+"BigQuery which do not conform to the username:password syntax normally "
+"used by SQLAlchemy."
 msgstr ""
-"Stringa JSON contenente la configurazione di connessione aggiuntiva. Viene "
-"utilizzata per fornire informazioni di connessione per sistemi come Hive, "
-"Presto e BigQuery che non sono conformi alla sintassi username:password "
-"normalmente utilizzata da SQLAlchemy."
+"Stringa JSON contenente la configurazione di connessione aggiuntiva. "
+"Viene utilizzata per fornire informazioni di connessione per sistemi come"
+" Hive, Presto e BigQuery che non sono conformi alla sintassi "
+"username:password normalmente utilizzata da SQLAlchemy."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -11045,8 +11133,8 @@ msgstr "Scorciatoie da tastiera"
 #, fuzzy
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
-"Le chiavi vengono mostrate solo una volta alla creazione. Conservale in modo "
-"sicuro."
+"Le chiavi vengono mostrate solo una volta alla creazione. Conservale in "
+"modo sicuro."
 
 msgid "Kilometers"
 msgstr "Chilometri"
@@ -11098,7 +11186,8 @@ msgstr "Etichetta discendente"
 #, fuzzy
 msgid "Label for the index column. Don't use an existing column name."
 msgstr ""
-"Etichetta per la colonna indice. Non utilizzare un nome di colonna esistente."
+"Etichetta per la colonna indice. Non utilizzare un nome di colonna "
+"esistente."
 
 msgid "Label for your query"
 msgstr "Etichetta per la query"
@@ -11315,8 +11404,8 @@ msgstr "Margine sinistro"
 #, fuzzy
 msgid "Left margin, in pixels, allowing for more room for axis labels"
 msgstr ""
-"Margine sinistro, in pixel, che consente più spazio per le etichette degli "
-"assi"
+"Margine sinistro, in pixel, che consente più spazio per le etichette "
+"degli assi"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -11432,15 +11521,15 @@ msgstr "Limita il numero di righe da mostrare."
 msgid ""
 "Limits the number of series that get displayed. A joined subquery (or an "
 "extra phase where subqueries are not supported) is applied to limit the "
-"number of series that get fetched and rendered. This feature is useful when "
-"grouping by high cardinality column(s) though does increase the query "
-"complexity and cost."
+"number of series that get fetched and rendered. This feature is useful "
+"when grouping by high cardinality column(s) though does increase the "
+"query complexity and cost."
 msgstr ""
-"Limita il numero di serie visualizzate. Viene applicata una sottoquery unita "
-"(o una fase aggiuntiva dove le sottoquery non sono supportate) per limitare "
-"il numero di serie recuperate e renderizzate. Questa funzionalità è utile "
-"quando si raggruppa per colonne ad alta cardinalità, anche se aumenta la "
-"complessità e il costo della query."
+"Limita il numero di serie visualizzate. Viene applicata una sottoquery "
+"unita (o una fase aggiuntiva dove le sottoquery non sono supportate) per "
+"limitare il numero di serie recuperate e renderizzate. Questa "
+"funzionalità è utile quando si raggruppa per colonne ad alta cardinalità,"
+" anche se aumenta la complessità e il costo della query."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
@@ -11467,15 +11556,15 @@ msgstr "Stile Linea"
 # uk]
 #, fuzzy
 msgid ""
-"Line chart is used to visualize measurements taken over a given category. "
-"Line chart is a type of chart which displays information as a series of data "
-"points connected by straight line segments. It is a basic type of chart "
-"common in many fields."
+"Line chart is used to visualize measurements taken over a given category."
+" Line chart is a type of chart which displays information as a series of "
+"data points connected by straight line segments. It is a basic type of "
+"chart common in many fields."
 msgstr ""
-"Il grafico a linee è utilizzato per visualizzare le misurazioni prese su una "
-"determinata categoria. Il grafico a linee è un tipo di grafico che mostra le "
-"informazioni come una serie di punti dati collegati da segmenti di linea "
-"retta. È un tipo di grafico di base comune in molti campi."
+"Il grafico a linee è utilizzato per visualizzare le misurazioni prese su "
+"una determinata categoria. Il grafico a linee è un tipo di grafico che "
+"mostra le informazioni come una serie di punti dati collegati da segmenti"
+" di linea retta. È un tipo di grafico di base comune in molti campi."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -11539,8 +11628,7 @@ msgstr "Elenca Utenti"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "List of extra columns made available in JavaScript functions"
-msgstr ""
-"Elenco delle colonne aggiuntive rese disponibili nelle funzioni JavaScript"
+msgstr "Elenco delle colonne aggiuntive rese disponibili nelle funzioni JavaScript"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -11777,7 +11865,8 @@ msgstr "Rendi l'asse x categoriale"
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Malformed request. slice_id or table_name and db_name arguments are expected"
+"Malformed request. slice_id or table_name and db_name arguments are "
+"expected"
 msgstr ""
 "Richiesta non valida. Sono attesi gli argomenti slice_id o table_name e "
 "db_name"
@@ -11798,8 +11887,9 @@ msgid ""
 "Manage filters and customizations to set scoping, descriptions, and "
 "limitations. Create new elements for better dashboard insights."
 msgstr ""
-"Gestisci filtri e personalizzazioni per impostare l'ambito, le descrizioni e "
-"i limiti. Crea nuovi elementi per una migliore comprensione del dashboard."
+"Gestisci filtri e personalizzazioni per impostare l'ambito, le "
+"descrizioni e i limiti. Crea nuovi elementi per una migliore comprensione"
+" del dashboard."
 
 msgid "Manage your databases"
 msgstr "Gestisci Database"
@@ -11841,8 +11931,8 @@ msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
-"MapLibre è open-source e non richiede alcuna chiave API. Mapbox richiede che "
-"MAPBOX_API_KEY sia configurato sul server."
+"MapLibre è open-source e non richiede alcuna chiave API. Mapbox richiede "
+"che MAPBOX_API_KEY sia configurato sul server."
 
 msgid "Mapbox"
 msgstr "Mapbox"
@@ -11863,8 +11953,7 @@ msgid "Margin"
 msgstr "Margine"
 
 msgid "Mark a column as temporal in \"Edit datasource\" modal"
-msgstr ""
-"Indica la colonna come temporale nella modale \"Modifica sorgente dati\""
+msgstr "Indica la colonna come temporale nella modale \"Modifica sorgente dati\""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -11991,8 +12080,9 @@ msgid ""
 "Maximum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this maximum radius."
 msgstr ""
-"Dimensione massima del raggio del cerchio, in pixel. Al variare del livello "
-"di zoom, questo garantisce che il cerchio rispetti questo raggio massimo."
+"Dimensione massima del raggio del cerchio, in pixel. Al variare del "
+"livello di zoom, questo garantisce che il cerchio rispetti questo raggio "
+"massimo."
 
 msgid "Maximum value"
 msgstr "Valore massimo"
@@ -12032,18 +12122,19 @@ msgid ""
 "Median edge width, the thickest edge will be 4 times thicker than the "
 "thinnest."
 msgstr ""
-"Larghezza mediana del bordo; il bordo più spesso sarà 4 volte più spesso di "
-"quello più sottile."
+"Larghezza mediana del bordo; il bordo più spesso sarà 4 volte più spesso "
+"di quello più sottile."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Median node size, the largest node will be 4 times larger than the smallest"
+"Median node size, the largest node will be 4 times larger than the "
+"smallest"
 msgstr ""
-"Dimensione mediana del nodo; il nodo più grande sarà 4 volte più grande del "
-"più piccolo"
+"Dimensione mediana del nodo; il nodo più grande sarà 4 volte più grande "
+"del più piccolo"
 
 msgid "Median values"
 msgstr "Valori mediani"
@@ -12071,8 +12162,7 @@ msgstr "Velocità di trasferimento memoria in byte - binario (1024B => 1KiB/s)"
 # es, fr, ja, lv, mi, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Memory transfer rate in bytes - decimal (1024B => 1.024kB/s)"
-msgstr ""
-"Velocità di trasferimento memoria in byte - decimale (1024B => 1.024kB/s)"
+msgstr "Velocità di trasferimento memoria in byte - decimale (1024B => 1.024kB/s)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -12110,15 +12200,15 @@ msgstr "Metodo"
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Method to compute the displayed value. \"Overall value\" calculates a single "
-"metric across the entire filtered time period, ideal for non-additive "
-"metrics like ratios, averages, or distinct counts. Other methods operate "
-"over the time series data points."
+"Method to compute the displayed value. \"Overall value\" calculates a "
+"single metric across the entire filtered time period, ideal for non-"
+"additive metrics like ratios, averages, or distinct counts. Other methods"
+" operate over the time series data points."
 msgstr ""
-"Metodo per calcolare il valore visualizzato. \"Valore complessivo\" calcola "
-"una singola metrica sull'intero periodo di tempo filtrato, ideale per "
-"metriche non additive come rapporti, medie o conteggi distinti. Gli altri "
-"metodi operano sui punti dati della serie temporale."
+"Metodo per calcolare il valore visualizzato. \"Valore complessivo\" "
+"calcola una singola metrica sull'intero periodo di tempo filtrato, ideale"
+" per metriche non additive come rapporti, medie o conteggi distinti. Gli "
+"altri metodi operano sui punti dati della serie temporale."
 
 msgid "Metric"
 msgstr "Metrica"
@@ -12253,21 +12343,22 @@ msgid ""
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
-"Metrica utilizzata per definire come vengono ordinate le serie principali se "
-"è presente un limite di serie o celle. Se non definita, si ripristina la "
-"prima metrica (dove appropriato)."
+"Metrica utilizzata per definire come vengono ordinate le serie principali"
+" se è presente un limite di serie o celle. Se non definita, si ripristina"
+" la prima metrica (dove appropriato)."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Metric used to define how the top series are sorted if a series or row limit "
-"is present. If undefined reverts to the first metric (where appropriate)."
+"Metric used to define how the top series are sorted if a series or row "
+"limit is present. If undefined reverts to the first metric (where "
+"appropriate)."
 msgstr ""
-"Metrica utilizzata per definire come vengono ordinate le serie principali se "
-"è presente un limite di serie o righe. Se non definita, si ripristina la "
-"prima metrica (dove appropriato)."
+"Metrica utilizzata per definire come vengono ordinate le serie principali"
+" se è presente un limite di serie o righe. Se non definita, si ripristina"
+" la prima metrica (dove appropriato)."
 
 msgid "Metrics"
 msgstr "Metriche"
@@ -12384,15 +12475,15 @@ msgid ""
 "Minimum radius size of the circle, in pixels. As the zoom level changes, "
 "this insures that the circle respects this minimum radius."
 msgstr ""
-"Dimensione minima del raggio del cerchio, in pixel. Al variare del livello "
-"di zoom, questo garantisce che il cerchio rispetti tale raggio minimo."
+"Dimensione minima del raggio del cerchio, in pixel. Al variare del "
+"livello di zoom, questo garantisce che il cerchio rispetti tale raggio "
+"minimo."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 msgid "Minimum threshold in percentage points for showing labels."
-msgstr ""
-"Soglia minima in punti percentuali per la visualizzazione delle etichette."
+msgstr "Soglia minima in punti percentuali per la visualizzazione delle etichette."
 
 msgid "Minimum value"
 msgstr "Valore minimo"
@@ -12458,11 +12549,11 @@ msgstr "Modificato %s"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
-#, python-format
+#, fuzzy, python-format
 msgid "Modified 1 column in the virtual dataset"
 msgid_plural "Modified %s columns in the virtual dataset"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modificata %s colonna nel dataset virtuale"
+msgstr[1] "Modificate %s colonne nel dataset virtuale"
 
 msgid "Modified by"
 msgstr "Modificato"
@@ -12565,10 +12656,11 @@ msgid "Multiplier"
 msgstr "Moltiplicatore"
 
 msgid ""
-"Must be a chart editor to overwrite this chart. Save as a new chart instead."
+"Must be a chart editor to overwrite this chart. Save as a new chart "
+"instead."
 msgstr ""
-"Devi essere un editor del grafico per sovrascrivere questo grafico. Salvalo "
-"invece come nuovo grafico."
+"Devi essere un editor del grafico per sovrascrivere questo grafico. "
+"Salvalo invece come nuovo grafico."
 
 msgid "Must be unique"
 msgstr "Deve essere unico"
@@ -12600,6 +12692,7 @@ msgstr "Metrica"
 msgid "N/A"
 msgstr "N/A"
 
+#. do-not-translate
 msgid "NOT GROUPED BY"
 msgstr "NON RAGGRUPPATO"
 
@@ -12662,8 +12755,8 @@ msgstr "Nome del database"
 #, fuzzy
 msgid "Name your folder and to edit it later, click on the folder name"
 msgstr ""
-"Assegna un nome alla tua cartella; per modificarla in seguito, clicca sul "
-"nome della cartella"
+"Assegna un nome alla tua cartella; per modificarla in seguito, clicca sul"
+" nome della cartella"
 
 msgid "Native filter column is required"
 msgstr "Colonna filtro nativo obbligatoria"
@@ -12909,8 +13002,8 @@ msgid ""
 "returned, ensure any filters are configured properly and the datasource "
 "contains data for the selected time range."
 msgstr ""
-"Non sono stati restituiti risultati per questa query. Se ci si aspetta che "
-"vengano restituiti risultati, assicurarsi che tutti i filtri siano "
+"Non sono stati restituiti risultati per questa query. Se ci si aspetta "
+"che vengano restituiti risultati, assicurarsi che tutti i filtri siano "
 "configurati correttamente e che la sorgente dati contenga dati per "
 "l'intervallo di tempo selezionato."
 
@@ -12936,13 +13029,13 @@ msgstr "Nessuna metrica salvata trovata"
 
 msgid "No stored results found, you need to re-run your query"
 msgstr ""
-"Nessun risultato memorizzato trovato, è necessario eseguire nuovamente la "
-"query"
+"Nessun risultato memorizzato trovato, è necessario eseguire nuovamente la"
+" query"
 
 msgid "No such column found. To filter on a metric, try the Custom SQL tab."
 msgstr ""
-"Nessuna colonna di questo tipo trovata. Per filtrare in base a una metrica, "
-"provare la scheda SQL Personalizzato."
+"Nessuna colonna di questo tipo trovata. Per filtrare in base a una "
+"metrica, provare la scheda SQL Personalizzato."
 
 msgid "No table columns"
 msgstr "Nessuna colonna di tabella"
@@ -12975,8 +13068,8 @@ msgid ""
 "No validator named %(validator_name)s found (configured for the "
 "%(engine_spec)s engine)"
 msgstr ""
-"Nessun validatore denominato %(validator_name)s trovato (configurato per il "
-"motore %(engine_spec)s)"
+"Nessun validatore denominato %(validator_name)s trovato (configurato per "
+"il motore %(engine_spec)s)"
 
 msgid "Node label position"
 msgstr "Posizione etichetta nodo"
@@ -13134,8 +13227,8 @@ msgid ""
 "               you can enter either only min or max."
 msgstr ""
 "Limiti numerici utilizzati per la codifica dei colori dal rosso al blu.\n"
-"               Inverti i numeri per passare dal blu al rosso. Per ottenere "
-"rosso o blu puro,\n"
+"               Inverti i numeri per passare dal blu al rosso. Per "
+"ottenere rosso o blu puro,\n"
 "               puoi inserire solo il min o il max."
 
 msgid "Number format"
@@ -13182,16 +13275,16 @@ msgid ""
 "Number of periods to compare against. You can use negative numbers to "
 "compare from the beginning of the time range."
 msgstr ""
-"Numero di periodi con cui confrontare. Puoi utilizzare numeri negativi per "
-"confrontare dall'inizio dell'intervallo di tempo."
+"Numero di periodi con cui confrontare. Puoi utilizzare numeri negativi "
+"per confrontare dall'inizio dell'intervallo di tempo."
 
 msgid "Number of periods to ratio against"
 msgstr "Numero di periodi da rapportare"
 
 msgid "Number of rows of file to read. Leave empty (default) to read all rows"
 msgstr ""
-"Numero di righe di file da leggere. Lascia vuoto (impostazione predefinita) "
-"per leggere tutte le righe"
+"Numero di righe di file da leggere. Lascia vuoto (impostazione "
+"predefinita) per leggere tutte le righe"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -13251,6 +13344,7 @@ msgstr "OK"
 msgid "OR"
 msgstr "OPPURE"
 
+#. do-not-translate
 msgid "OVERWRITE"
 msgstr "SOVRASCRITTURA"
 
@@ -13278,12 +13372,13 @@ msgstr "Sulle Dashboard"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"One or many columns to group by. High cardinality groupings should include a "
-"series limit to limit the number of fetched and rendered series."
+"One or many columns to group by. High cardinality groupings should "
+"include a series limit to limit the number of fetched and rendered "
+"series."
 msgstr ""
 "Una o più colonne per il raggruppamento. I raggruppamenti con alta "
-"cardinalità dovrebbero includere un limite di serie per limitare il numero "
-"di serie recuperate e visualizzate."
+"cardinalità dovrebbero includere un limite di serie per limitare il "
+"numero di serie recuperate e visualizzate."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -13377,7 +13472,8 @@ msgstr "Sono ammessi solamente comandi \"SELECT\""
 #, fuzzy
 msgid "Only applies when \"Label Type\" is not set to a percentage."
 msgstr ""
-"Si applica solo quando \"Tipo di etichetta\" non è impostato su percentuale."
+"Si applica solo quando \"Tipo di etichetta\" non è impostato su "
+"percentuale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -13391,8 +13487,7 @@ msgstr ""
 # sr_Latn]
 #, fuzzy
 msgid "Only exact match is available for non-string columns."
-msgstr ""
-"Solo la corrispondenza esatta è disponibile per le colonne non stringa."
+msgstr "Solo la corrispondenza esatta è disponibile per le colonne non stringa."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -13405,11 +13500,11 @@ msgstr "Procedere solo se si ha fiducia nella destinazione o nella sua fonte."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Only show the total value on the stacked chart, and not show on the selected "
-"category"
+"Only show the total value on the stacked chart, and not show on the "
+"selected category"
 msgstr ""
-"Mostra solo il valore totale nel grafico a barre impilate, senza mostrarlo "
-"nella categoria selezionata"
+"Mostra solo il valore totale nel grafico a barre impilate, senza "
+"mostrarlo nella categoria selezionata"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -13440,7 +13535,8 @@ msgstr "Opacità"
 
 msgid "Opacity of Area Chart. Also applies to confidence band."
 msgstr ""
-"Opacità del grafico ad aree. Si applica anche all'intervallo di confidenza."
+"Opacità del grafico ad aree. Si applica anche all'intervallo di "
+"confidenza."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -13457,7 +13553,8 @@ msgstr "Opacità del grafico ad aree."
 #, fuzzy
 msgid "Opacity of bubbles, 0 means completely transparent, 1 means opaque"
 msgstr ""
-"Opacità delle bolle, 0 significa completamente trasparente, 1 significa opaco"
+"Opacità delle bolle, 0 significa completamente trasparente, 1 significa "
+"opaco"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -13472,11 +13569,15 @@ msgstr "Apri il tab Sorgente Dati"
 msgid "Open SQL Lab in a new tab"
 msgstr "Apri SQL Lab in nuova scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Open chart in new tab"
-msgstr ""
+msgstr "Apri il grafico in una nuova scheda"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Open dashboard in new tab"
-msgstr ""
+msgstr "Apri il dashboard in una nuova scheda"
 
 msgid "Open in SQL Lab"
 msgstr "Esponi in SQL Lab"
@@ -13494,11 +13595,11 @@ msgstr "Apri query in SQL Lab"
 msgid ""
 "Operate the database in asynchronous mode, meaning that the queries are "
 "executed on remote workers as opposed to on the web server itself. This "
-"assumes that you have a Celery worker setup as well as a results backend. "
-"Refer to the installation docs for more information."
+"assumes that you have a Celery worker setup as well as a results backend."
+" Refer to the installation docs for more information."
 msgstr ""
-"Gestisce il database in modalità asincrona, il che significa che le query "
-"vengono eseguite su worker remoti anziché sul server web stesso. Questo "
+"Gestisce il database in modalità asincrona, il che significa che le query"
+" vengono eseguite su worker remoti anziché sul server web stesso. Questo "
 "presuppone che sia stato configurato un worker Celery e un backend dei "
 "risultati. Per ulteriori informazioni, consultare la documentazione di "
 "installazione."
@@ -13518,8 +13619,8 @@ msgstr "Operatore non definito per l'aggregatore: %(name)s"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Optional CA_BUNDLE contents to validate HTTPS requests. Only available on "
-"certain database engines."
+"Optional CA_BUNDLE contents to validate HTTPS requests. Only available on"
+" certain database engines."
 msgstr ""
 "Contenuto CA_BUNDLE opzionale per convalidare le richieste HTTPS. "
 "Disponibile solo su alcuni motori di database."
@@ -13572,14 +13673,15 @@ msgstr "Ordinamento"
 # es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Orders the query result that generates the source data for this chart. If a "
-"series or row limit is reached, this determines what data are truncated. If "
-"undefined, defaults to the first metric (where appropriate)."
+"Orders the query result that generates the source data for this chart. If"
+" a series or row limit is reached, this determines what data are "
+"truncated. If undefined, defaults to the first metric (where "
+"appropriate)."
 msgstr ""
 "Ordina il risultato della query che genera i dati sorgente per questo "
-"grafico. Se viene raggiunto un limite di serie o di righe, questo determina "
-"quali dati vengono troncati. Se non definito, viene utilizzata la prima "
-"metrica come predefinita (dove appropriato)."
+"grafico. Se viene raggiunto un limite di serie o di righe, questo "
+"determina quali dati vengono troncati. Se non definito, viene utilizzata "
+"la prima metrica come predefinita (dove appropriato)."
 
 msgid "Orientation"
 msgstr "Orientamento"
@@ -13655,21 +13757,21 @@ msgstr "Sovrapposizione"
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Overlay one or more timeseries from a relative time period. Expects relative "
-"time deltas in natural language (example:  24 hours, 7 days, 52 weeks, 365 "
-"days). Free text is supported."
+"Overlay one or more timeseries from a relative time period. Expects "
+"relative time deltas in natural language (example:  24 hours, 7 days, 52 "
+"weeks, 365 days). Free text is supported."
 msgstr ""
 "Sovrapponi una o più serie temporali da un periodo di tempo relativo. Si "
-"aspetta differenze di tempo relative in linguaggio naturale (esempio:  24 "
-"ore, 7 giorni, 52 settimane, 365 giorni). Il testo libero è supportato."
+"aspetta differenze di tempo relative in linguaggio naturale (esempio:  24"
+" ore, 7 giorni, 52 settimane, 365 giorni). Il testo libero è supportato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Overlay one or more timeseries from a relative time period. Expects relative "
-"time deltas in natural language (example: 24 hours, 7 days, 52 weeks, 365 "
-"days). Free text is supported."
+"Overlay one or more timeseries from a relative time period. Expects "
+"relative time deltas in natural language (example: 24 hours, 7 days, 52 "
+"weeks, 365 days). Free text is supported."
 msgstr ""
 "Sovrapponi una o più serie temporali da un periodo di tempo relativo. Si "
 "aspetta differenze di tempo relative in linguaggio naturale (esempio: 24 "
@@ -13679,18 +13781,18 @@ msgstr ""
 # es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Overlay results from a relative time period. Expects relative time deltas in "
-"natural language (example:  24 hours, 7 days, 52 weeks, 365 days). Free text "
-"is supported. Use \"Inherit range from time filters\" to shift the "
-"comparison time range by the same length as your time range and use "
+"Overlay results from a relative time period. Expects relative time deltas"
+" in natural language (example:  24 hours, 7 days, 52 weeks, 365 days). "
+"Free text is supported. Use \"Inherit range from time filters\" to shift "
+"the comparison time range by the same length as your time range and use "
 "\"Custom\" to set a custom comparison range."
 msgstr ""
 "Sovrapponi i risultati da un periodo di tempo relativo. Si aspetta "
 "differenze di tempo relative in linguaggio naturale (esempio:  24 ore, 7 "
 "giorni, 52 settimane, 365 giorni). Il testo libero è supportato. Usa "
 "\"Eredita intervallo dai filtri temporali\" per spostare l'intervallo di "
-"tempo di comparazione della stessa lunghezza del tuo intervallo temporale e "
-"usa \"Personalizzato\" per impostare un intervallo di comparazione "
+"tempo di comparazione della stessa lunghezza del tuo intervallo temporale"
+" e usa \"Personalizzato\" per impostare un intervallo di comparazione "
 "personalizzato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -13698,11 +13800,11 @@ msgstr ""
 # uk]
 #, fuzzy
 msgid ""
-"Overlays a hexagonal grid on a map, and aggregates data within the boundary "
-"of each cell."
+"Overlays a hexagonal grid on a map, and aggregates data within the "
+"boundary of each cell."
 msgstr ""
-"Sovrappone una griglia esagonale su una mappa e aggrega i dati all'interno "
-"dei confini di ogni cella."
+"Sovrappone una griglia esagonale su una mappa e aggrega i dati "
+"all'interno dei confini di ogni cella."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -13856,8 +13958,8 @@ msgstr "Soglia di partizione"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Partitions whose height to parent height proportions are below this value "
-"are pruned"
+"Partitions whose height to parent height proportions are below this value"
+" are pruned"
 msgstr ""
 "Le partizioni il cui rapporto tra l'altezza e l'altezza del genitore è "
 "inferiore a questo valore vengono rimosse"
@@ -13868,9 +13970,10 @@ msgstr "Password"
 msgid "Password is required"
 msgstr "Password obbligatoria"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid "Password must be at least %(min_length)s characters long."
-msgstr ""
+msgstr "La password deve essere lunga almeno %(min_length)s caratteri."
 
 msgid "Password:"
 msgstr "Password:"
@@ -14087,8 +14190,8 @@ msgid ""
 "Pick one or more columns that should be shown in the annotation. If you "
 "don't select a column all of them will be shown."
 msgstr ""
-"Seleziona una o più colonne da mostrare nell'annotazione. Se non selezioni "
-"una colonna, verranno mostrate tutte."
+"Seleziona una o più colonne da mostrare nell'annotazione. Se non "
+"selezioni una colonna, verranno mostrate tutte."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -14196,31 +14299,31 @@ msgstr "Normale"
 #, fuzzy
 msgid ""
 "Please check your query and confirm that all template parameters are "
-"surround by double braces, for example, \"{{ ds }}\". Then, try running your "
-"query again."
+"surround by double braces, for example, \"{{ ds }}\". Then, try running "
+"your query again."
 msgstr ""
-"Controlla la tua query e conferma che tutti i parametri del modello siano "
-"circondati da doppie parentesi graffe, ad esempio \"{{ ds }}\". Poi, prova a "
-"eseguire di nuovo la query."
+"Controlla la tua query e conferma che tutti i parametri del modello siano"
+" circondati da doppie parentesi graffe, ad esempio \"{{ ds }}\". Poi, "
+"prova a eseguire di nuovo la query."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"Please check your query for syntax errors at or near \"%(syntax_error)s\". "
+"Please check your query for syntax errors at or near "
+"\"%(syntax_error)s\". Then, try running your query again."
+msgstr ""
+"Controlla la tua query per rilevare errori di sintassi in corrispondenza "
+"o vicino a \"%(syntax_error)s\". Poi, prova a eseguire di nuovo la query."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy, python-format
+msgid ""
+"Please check your query for syntax errors near \"%(server_error)s\". "
 "Then, try running your query again."
-msgstr ""
-"Controlla la tua query per rilevare errori di sintassi in corrispondenza o "
-"vicino a \"%(syntax_error)s\". Poi, prova a eseguire di nuovo la query."
-
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
-# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
-# uk, zh, zh_TW]
-#, fuzzy, python-format
-msgid ""
-"Please check your query for syntax errors near \"%(server_error)s\". Then, "
-"try running your query again."
 msgstr ""
 "Controlla la tua query per rilevare errori di sintassi vicino a "
 "\"%(server_error)s\". Poi, prova a eseguire di nuovo la query."
@@ -14229,13 +14332,13 @@ msgstr ""
 # de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Please check your template parameters for syntax errors and make sure they "
-"match across your SQL query and Set Parameters. Then, try running your query "
-"again."
+"Please check your template parameters for syntax errors and make sure "
+"they match across your SQL query and Set Parameters. Then, try running "
+"your query again."
 msgstr ""
 "Controlla i parametri del modello per rilevare errori di sintassi e "
-"assicurati che corrispondano nella tua query SQL e nei Parametri impostati. "
-"Poi, prova a eseguire di nuovo la query."
+"assicurati che corrispondano nella tua query SQL e nei Parametri "
+"impostati. Poi, prova a eseguire di nuovo la query."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -14310,12 +14413,10 @@ msgstr[0] "Contatta l'editor del grafico per assistenza."
 msgstr[1] "Contatta gli editor del grafico per assistenza."
 
 msgid "Please save your chart first, then try creating a new email report."
-msgstr ""
-"Salvare prima il grafico, quindi provare a creare un nuovo report email."
+msgstr "Salvare prima il grafico, quindi provare a creare un nuovo report email."
 
 msgid "Please save your dashboard first, then try creating a new email report."
-msgstr ""
-"Salvare prima la dashboard, quindi provare a creare un nuovo report email."
+msgstr "Salvare prima la dashboard, quindi provare a creare un nuovo report email."
 
 msgid "Please select at least one role or group"
 msgstr "Selezionare almeno un ruolo o gruppo"
@@ -14328,9 +14429,11 @@ msgstr "Seleziona sia un %s che un tipo di grafico per procedere"
 
 #, python-format
 msgid ""
-"Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja macro."
+"Please specify the Dataset ID for the ``%(name)s`` metric in the Jinja "
+"macro."
 msgstr ""
-"Specificare l'ID del dataset per la metrica \"%(name)s\" nella macro Jinja."
+"Specificare l'ID del dataset per la metrica \"%(name)s\" nella macro "
+"Jinja."
 
 msgid "Please use 3 different metric labels"
 msgstr "Seleziona metriche differenti per gli assi destro e sinistro"
@@ -14341,13 +14444,13 @@ msgstr ""
 "destinazione."
 
 msgid ""
-"Plots the individual metrics for each row in the data vertically and links "
-"them together as a line. This chart is useful for comparing multiple metrics "
-"across all of the samples or rows in the data."
+"Plots the individual metrics for each row in the data vertically and "
+"links them together as a line. This chart is useful for comparing "
+"multiple metrics across all of the samples or rows in the data."
 msgstr ""
 "Traccia verticalmente le singole metriche per ogni riga dei dati e le "
-"collega con una linea. Questo grafico è utile per confrontare più metriche "
-"in tutti i campioni o le righe dei dati."
+"collega con una linea. Questo grafico è utile per confrontare più "
+"metriche in tutti i campioni o le righe dei dati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -14389,8 +14492,10 @@ msgstr "Scala del raggio del punto"
 msgid "Point Radius Unit"
 msgstr "Unità del raggio del punto"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Point Radius Units"
-msgstr ""
+msgstr "Unità del raggio del punto"
 
 msgid "Point Size"
 msgstr "Dimensione punto"
@@ -14449,8 +14554,7 @@ msgstr "Porta"
 
 #, python-format
 msgid "Port %(port)s on hostname \"%(hostname)s\" refused the connection."
-msgstr ""
-"La porta %(port)s dell'host \"%(hostname)s\" ha rifiutato la connessione."
+msgstr "La porta %(port)s dell'host \"%(hostname)s\" ha rifiutato la connessione."
 
 msgid "Port out of range 0-65535"
 msgstr "Porta furi dall'intervallo 0-65535"
@@ -14886,14 +14990,15 @@ msgstr "Riduci le tacche dell'asse X"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Reduces the number of X-axis ticks to be rendered. If true, the x-axis will "
-"not overflow and labels may be missing. If false, a minimum width will be "
-"applied to columns and the width may overflow into an horizontal scroll."
+"Reduces the number of X-axis ticks to be rendered. If true, the x-axis "
+"will not overflow and labels may be missing. If false, a minimum width "
+"will be applied to columns and the width may overflow into an horizontal "
+"scroll."
 msgstr ""
-"Riduce il numero di tacche dell'asse X da visualizzare. Se vero, l'asse x "
-"non andrà in overflow e alcune etichette potrebbero mancare. Se falso, verrà "
-"applicata una larghezza minima alle colonne e la larghezza potrebbe andare "
-"in overflow in uno scorrimento orizzontale."
+"Riduce il numero di tacche dell'asse X da visualizzare. Se vero, l'asse x"
+" non andrà in overflow e alcune etichette potrebbero mancare. Se falso, "
+"verrà applicata una larghezza minima alle colonne e la larghezza potrebbe"
+" andare in overflow in uno scorrimento orizzontale."
 
 msgid "Refer to the"
 msgstr "Si riferisce a"
@@ -14974,15 +15079,15 @@ msgstr "Regolare"
 #, fuzzy
 msgid ""
 "Regular filters add where clauses to queries if a user belongs to a role "
-"referenced in the filter, base filters apply filters to all queries except "
-"the roles defined in the filter, and can be used to define what users can "
-"see if no RLS filters within a filter group apply to them."
+"referenced in the filter, base filters apply filters to all queries "
+"except the roles defined in the filter, and can be used to define what "
+"users can see if no RLS filters within a filter group apply to them."
 msgstr ""
 "I filtri normali aggiungono clausole WHERE alle query se un utente "
-"appartiene a un ruolo referenziato nel filtro; i filtri di base applicano "
-"filtri a tutte le query tranne i ruoli definiti nel filtro, e possono essere "
-"utilizzati per definire cosa possono vedere gli utenti se nessun filtro RLS "
-"all'interno di un gruppo di filtri si applica a loro."
+"appartiene a un ruolo referenziato nel filtro; i filtri di base applicano"
+" filtri a tutte le query tranne i ruoli definiti nel filtro, e possono "
+"essere utilizzati per definire cosa possono vedere gli utenti se nessun "
+"filtro RLS all'interno di un gruppo di filtri si applica a loro."
 
 msgid "Relational"
 msgstr "Relazionale"
@@ -15018,8 +15123,10 @@ msgstr "Quantità relativa"
 msgid "Reload"
 msgstr "Ricarica"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Reload SQL Lab"
-msgstr ""
+msgstr "Ricarica SQL Lab"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -15076,11 +15183,12 @@ msgstr "Visualizza le colonne in formato HTML"
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Renders table cells as HTML when applicable. For example, HTML <a> tags will "
-"be rendered as hyperlinks."
+"Renders table cells as HTML when applicable. For example, HTML <a> tags "
+"will be rendered as hyperlinks."
 msgstr ""
-"Visualizza le celle della tabella come HTML quando applicabile. Ad esempio, "
-"i tag HTML <a> verranno visualizzati come collegamenti ipertestuali."
+"Visualizza le celle della tabella come HTML quando applicabile. Ad "
+"esempio, i tag HTML <a> verranno visualizzati come collegamenti "
+"ipertestuali."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -15157,15 +15265,15 @@ msgstr ""
 #, fuzzy
 msgid "Report Schedule is still working, refusing to re-compute."
 msgstr ""
-"La pianificazione del report è ancora in esecuzione, rifiuto di ricalcolare."
+"La pianificazione del report è ancora in esecuzione, rifiuto di "
+"ricalcolare."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Report Schedule log prune failed."
-msgstr ""
-"Eliminazione del registro della pianificazione del report non riuscita."
+msgstr "Eliminazione del registro della pianificazione del report non riuscita."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -15210,8 +15318,10 @@ msgstr "Il report è attivo"
 msgid "Report name"
 msgstr "Nome Completo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Report not yet run"
-msgstr ""
+msgstr "Report non ancora eseguito"
 
 msgid "Report schedule client error"
 msgstr "Segnala un errore del client di pianificazione"
@@ -15299,9 +15409,10 @@ msgstr "I valori di controllo obbligatori sono stati rimossi"
 msgid "Resample"
 msgstr "Ricampiona"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid "Resample method '%(method)s' is not supported."
-msgstr ""
+msgstr "Il metodo di ricampionamento '%(method)s' non è supportato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -15357,8 +15468,8 @@ msgstr "La risorsa non è stata trovata."
 
 msgid "Resource was removed before editorship could be verified"
 msgstr ""
-"La risorsa è stata rimossa prima che fosse possibile verificare il permesso "
-"di modifica"
+"La risorsa è stata rimossa prima che fosse possibile verificare il "
+"permesso di modifica"
 
 msgid "Restore filter"
 msgstr "Reimposta filtro"
@@ -15386,7 +15497,8 @@ msgstr "Il backend dei risultati non è configurato."
 #, fuzzy
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr ""
-"Il backend dei risultati necessario per le query asincrone non è configurato."
+"Il backend dei risultati necessario per le query asincrone non è "
+"configurato."
 
 msgid "Resume auto-refresh"
 msgstr "Riattiva l'aggiornamento automatico"
@@ -15544,23 +15656,24 @@ msgstr "Sicurezza a livello di riga"
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Row Limit: percentages are calculated based on the subset of data retrieved, "
-"respecting the row limit. All Records: Percentages are calculated based on "
-"the total dataset, ignoring the row limit."
+"Row Limit: percentages are calculated based on the subset of data "
+"retrieved, respecting the row limit. All Records: Percentages are "
+"calculated based on the total dataset, ignoring the row limit."
 msgstr ""
-"Limite di righe: le percentuali vengono calcolate in base al sottoinsieme di "
-"dati recuperati, rispettando il limite di righe. Tutti i record: le "
-"percentuali vengono calcolate in base al dataset totale, ignorando il limite "
-"di righe."
+"Limite di righe: le percentuali vengono calcolate in base al sottoinsieme"
+" di dati recuperati, rispettando il limite di righe. Tutti i record: le "
+"percentuali vengono calcolate in base al dataset totale, ignorando il "
+"limite di righe."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Row containing the headers to use as column names (0 is first line of data)."
+"Row containing the headers to use as column names (0 is first line of "
+"data)."
 msgstr ""
-"Riga contenente le intestazioni da utilizzare come nomi di colonna (0 è la "
-"prima riga di dati)."
+"Riga contenente le intestazioni da utilizzare come nomi di colonna (0 è "
+"la prima riga di dati)."
 
 msgid "Row height"
 msgstr "Altezza riga"
@@ -15687,13 +15800,13 @@ msgstr "SQL Lab"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"SQL Lab cannot authorise a statement that could not be fully parsed. Qualify "
-"tables explicitly and avoid dynamic SQL inside stored-procedure or vendor-"
-"specific calls."
+"SQL Lab cannot authorise a statement that could not be fully parsed. "
+"Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
+"or vendor-specific calls."
 msgstr ""
 "SQL Lab non può autorizzare un'istruzione che non è stata completamente "
-"analizzata. Qualificare esplicitamente le tabelle ed evitare SQL dinamico "
-"nelle stored procedure o nelle chiamate specifiche del vendor."
+"analizzata. Qualificare esplicitamente le tabelle ed evitare SQL dinamico"
+" nelle stored procedure o nelle chiamate specifiche del vendor."
 
 msgid "SQL Lab queries"
 msgstr "SQL Lab query"
@@ -15707,18 +15820,19 @@ msgid ""
 "Currently, you are using %(currentUsage)s KB out of %(maxStorage)d KB "
 "storage space.\n"
 "To keep SQL Lab from crashing, please delete some query tabs.\n"
-"You can re-access these queries by using the Save feature before you delete "
-"the tab.\n"
+"You can re-access these queries by using the Save feature before you "
+"delete the tab.\n"
 "Note that you will need to close other SQL Lab windows before you do this."
 msgstr ""
-"SQL Lab utilizza la memoria locale del browser per memorizzare le query e i "
-"risultati.\n"
+"SQL Lab utilizza la memoria locale del browser per memorizzare le query e"
+" i risultati.\n"
 "Attualmente stai utilizzando %(currentUsage)s KB su %(maxStorage)d KB di "
 "spazio di archiviazione.\n"
 "Per evitare che SQL Lab vada in crash, elimina alcune schede di query.\n"
-"Puoi accedere nuovamente a queste query utilizzando la funzione Salva prima "
-"di eliminare la scheda.\n"
-"Tieni presente che dovrai chiudere altre finestre di SQL Lab prima di farlo."
+"Puoi accedere nuovamente a queste query utilizzando la funzione Salva "
+"prima di eliminare la scheda.\n"
+"Tieni presente che dovrai chiudere altre finestre di SQL Lab prima di "
+"farlo."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
@@ -15963,7 +16077,8 @@ msgstr "Scala e Sposta"
 #, fuzzy
 msgid "Scale factor applied to metric-driven line widths"
 msgstr ""
-"Fattore di scala applicato alle larghezze delle linee basate sulle metriche"
+"Fattore di scala applicato alle larghezze delle linee basate sulle "
+"metriche"
 
 msgid "Scale only"
 msgstr "Scala solamente"
@@ -15991,8 +16106,9 @@ msgid ""
 "connected in order. It shows a statistical relationship between two "
 "variables."
 msgstr ""
-"Il grafico a dispersione ha l'asse orizzontale in unità lineari e i punti "
-"sono collegati in ordine. Mostra una relazione statistica tra due variabili."
+"Il grafico a dispersione ha l'asse orizzontale in unità lineari e i punti"
+" sono collegati in ordine. Mostra una relazione statistica tra due "
+"variabili."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -16070,7 +16186,8 @@ msgstr "Larghezza screenshot"
 #, fuzzy, python-format
 msgid "Screenshot width must be between %(min)spx and %(max)spx"
 msgstr ""
-"La larghezza dello screenshot deve essere compresa tra %(min)spx e %(max)spx"
+"La larghezza dello screenshot deve essere compresa tra %(min)spx e "
+"%(max)spx"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -16294,8 +16411,8 @@ msgstr "Seleziona una metrica da visualizzare sull'asse destro"
 # zh_TW]
 #, fuzzy
 msgid ""
-"Select a metric to display. You can use an aggregation function on a column "
-"or write custom SQL to create a metric."
+"Select a metric to display. You can use an aggregation function on a "
+"column or write custom SQL to create a metric."
 msgstr ""
 "Seleziona una metrica da visualizzare. Puoi utilizzare una funzione di "
 "aggregazione su una colonna o scrivere SQL personalizzato per creare una "
@@ -16338,11 +16455,12 @@ msgstr "Seleziona un tema"
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Select a time grain for the visualization. The grain is the time interval "
-"represented by a single point on the chart."
+"Select a time grain for the visualization. The grain is the time interval"
+" represented by a single point on the chart."
 msgstr ""
-"Seleziona una granularità temporale per la visualizzazione. La granularità è "
-"l'intervallo di tempo rappresentato da un singolo punto sul grafico."
+"Seleziona una granularità temporale per la visualizzazione. La "
+"granularità è l'intervallo di tempo rappresentato da un singolo punto sul"
+" grafico."
 
 msgid "Select a visualization type"
 msgstr "Seleziona un tipo di visualizzazione"
@@ -16429,13 +16547,13 @@ msgstr "Seleziona database"
 # zh_TW]
 #, fuzzy
 msgid ""
-"Select databases require additional fields to be completed in the Advanced "
-"tab to successfully connect the database. Learn what requirements your "
-"databases has "
+"Select databases require additional fields to be completed in the "
+"Advanced tab to successfully connect the database. Learn what "
+"requirements your databases has "
 msgstr ""
-"Alcuni database selezionati richiedono la compilazione di campi aggiuntivi "
-"nella scheda Avanzate per connettersi correttamente al database. Scopri i "
-"requisiti del tuo database "
+"Alcuni database selezionati richiedono la compilazione di campi "
+"aggiuntivi nella scheda Avanzate per connettersi correttamente al "
+"database. Scopri i requisiti del tuo database "
 
 msgid "Select dataset source"
 msgstr "Seleziona sorgente dataset"
@@ -16488,18 +16606,18 @@ msgstr "Seleziona gruppi"
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Select layers in the order you want them stacked. First selected appears at "
-"the bottom.Layers let you combine multiple visualizations on one map. Each "
-"layer is a saved deck.gl chart (like scatter plots, polygons, or arcs) that "
-"displays different data or insights. Stack them to reveal patterns and "
-"relationships across your data."
+"Select layers in the order you want them stacked. First selected appears "
+"at the bottom.Layers let you combine multiple visualizations on one map. "
+"Each layer is a saved deck.gl chart (like scatter plots, polygons, or "
+"arcs) that displays different data or insights. Stack them to reveal "
+"patterns and relationships across your data."
 msgstr ""
-"Seleziona i livelli nell'ordine in cui vuoi che siano sovrapposti. Il primo "
-"selezionato appare in basso. I livelli consentono di combinare più "
+"Seleziona i livelli nell'ordine in cui vuoi che siano sovrapposti. Il "
+"primo selezionato appare in basso. I livelli consentono di combinare più "
 "visualizzazioni su una mappa. Ogni livello è un grafico deck.gl salvato "
 "(come grafici a dispersione, poligoni o archi) che mostra dati o "
-"informazioni diversi. Sovrapponili per rivelare schemi e relazioni nei tuoi "
-"dati."
+"informazioni diversi. Sovrapponili per rivelare schemi e relazioni nei "
+"tuoi dati."
 
 msgid "Select layers to hide"
 msgstr "Seleziona livelli da nascondere"
@@ -16513,27 +16631,27 @@ msgstr "Seleziona nome oggetto"
 #, fuzzy
 msgid ""
 "Select one or many metrics to display, that will be displayed in the "
-"percentages of total. Percentage metrics will be calculated only from data "
-"within the row limit. You can use an aggregation function on a column or "
-"write custom SQL to create a percentage metric."
+"percentages of total. Percentage metrics will be calculated only from "
+"data within the row limit. You can use an aggregation function on a "
+"column or write custom SQL to create a percentage metric."
 msgstr ""
 "Seleziona una o più metriche da visualizzare, che verranno mostrate come "
-"percentuali del totale. Le metriche percentuali saranno calcolate solo dai "
-"dati entro il limite di righe. Puoi utilizzare una funzione di aggregazione "
-"su una colonna o scrivere SQL personalizzato per creare una metrica "
-"percentuale."
+"percentuali del totale. Le metriche percentuali saranno calcolate solo "
+"dai dati entro il limite di righe. Puoi utilizzare una funzione di "
+"aggregazione su una colonna o scrivere SQL personalizzato per creare una "
+"metrica percentuale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Select one or many metrics to display. You can use an aggregation function "
-"on a column or write custom SQL to create a metric."
+"Select one or many metrics to display. You can use an aggregation "
+"function on a column or write custom SQL to create a metric."
 msgstr ""
-"Seleziona una o più metriche da visualizzare. Puoi utilizzare una funzione "
-"di aggregazione su una colonna o scrivere SQL personalizzato per creare una "
-"metrica."
+"Seleziona una o più metriche da visualizzare. Puoi utilizzare una "
+"funzione di aggregazione su una colonna o scrivere SQL personalizzato per"
+" creare una metrica."
 
 msgid "Select operator"
 msgstr "Seleziona operatore"
@@ -16588,8 +16706,8 @@ msgid ""
 msgstr ""
 "Seleziona la forma per il calcolo dei valori. \"FIXED\" imposta tutti i "
 "livelli di zoom alla stessa dimensione. \"LINEAR\" aumenta le dimensioni "
-"linearmente in base alla pendenza specificata. \"EXP\" aumenta le dimensioni "
-"esponenzialmente in base all'esponente specificato"
+"linearmente in base alla pendenza specificata. \"EXP\" aumenta le "
+"dimensioni esponenzialmente in base all'esponente specificato"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -16614,26 +16732,26 @@ msgstr "Seleziona il Livello di Annotazione che vorresti usare."
 msgid ""
 "Select the charts to which you want to apply cross-filters in this "
 "dashboard. Deselecting a chart will exclude it from being filtered when "
-"applying cross-filters from any chart on the dashboard. You can select \"All "
-"charts\" to apply cross-filters to all charts that use the same dataset or "
-"contain the same column name in the dashboard."
+"applying cross-filters from any chart on the dashboard. You can select "
+"\"All charts\" to apply cross-filters to all charts that use the same "
+"dataset or contain the same column name in the dashboard."
 msgstr ""
 "Seleziona i grafici a cui vuoi applicare i filtri incrociati in questa "
-"dashboard. La deselezione di un grafico lo escluderà dal filtraggio quando "
-"si applicano filtri incrociati da qualsiasi grafico nella dashboard. Puoi "
-"selezionare \"Tutti i grafici\" per applicare filtri incrociati a tutti i "
-"grafici che utilizzano lo stesso dataset o contengono lo stesso nome di "
-"colonna nella dashboard."
+"dashboard. La deselezione di un grafico lo escluderà dal filtraggio "
+"quando si applicano filtri incrociati da qualsiasi grafico nella "
+"dashboard. Puoi selezionare \"Tutti i grafici\" per applicare filtri "
+"incrociati a tutti i grafici che utilizzano lo stesso dataset o "
+"contengono lo stesso nome di colonna nella dashboard."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Select the charts to which you want to apply cross-filters when interacting "
-"with this chart. You can select \"All charts\" to apply filters to all "
-"charts that use the same dataset or contain the same column name in the "
-"dashboard."
+"Select the charts to which you want to apply cross-filters when "
+"interacting with this chart. You can select \"All charts\" to apply "
+"filters to all charts that use the same dataset or contain the same "
+"column name in the dashboard."
 msgstr ""
 "Seleziona i grafici a cui vuoi applicare i filtri incrociati quando "
 "interagisci con questo grafico. Puoi selezionare \"Tutti i grafici\" per "
@@ -16661,17 +16779,17 @@ msgstr ""
 #, fuzzy
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
-"Seleziona il colore utilizzato per i valori che indicano una diminuzione nel "
-"grafico."
+"Seleziona il colore utilizzato per i valori che indicano una diminuzione "
+"nel grafico."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Select the column containing currency codes such as USD, EUR, GBP, etc. Used "
-"when building charts when 'Auto-detect' currency formatting is enabled. If "
-"this column is not set or if a chart metric contains multiple currencies, "
-"charts will fall back to neutral numeric formatting."
+"Select the column containing currency codes such as USD, EUR, GBP, etc. "
+"Used when building charts when 'Auto-detect' currency formatting is "
+"enabled. If this column is not set or if a chart metric contains multiple"
+" currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
 "Seleziona la colonna contenente i codici valuta come USD, EUR, GBP, ecc. "
 "Utilizzata durante la creazione di grafici quando è abilitata la "
@@ -16689,19 +16807,19 @@ msgstr "Seleziona la colonna geojson"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Select the map tile provider. MapLibre is open-source and requires no API "
-"key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
+"Select the map tile provider. MapLibre is open-source and requires no API"
+" key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
 "Seleziona il provider di tile per la mappa. MapLibre è open-source e non "
-"richiede una chiave API. Mapbox richiede che MAPBOX_API_KEY sia configurato "
-"in Superset."
+"richiede una chiave API. Mapbox richiede che MAPBOX_API_KEY sia "
+"configurato in Superset."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Select the metric used to determine which color breakpoint range each path "
-"falls into."
+"Select the metric used to determine which color breakpoint range each "
+"path falls into."
 msgstr ""
 "Seleziona la metrica utilizzata per determinare in quale intervallo di "
 "colore rientra ciascun percorso."
@@ -16723,19 +16841,20 @@ msgid ""
 "Select values in highlighted field(s) in the control panel. Then run the "
 "query by clicking on the %s button."
 msgstr ""
-"Seleziona i valori nei campi evidenziati nel pannello di controllo. Quindi "
-"esegui la query facendo clic sul pulsante %s."
+"Seleziona i valori nei campi evidenziati nel pannello di controllo. "
+"Quindi esegui la query facendo clic sul pulsante %s."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Select which time grains are available in the filter control. This is a UI "
-"allow list only and does not add extra conditions to the underlying queries."
+"Select which time grains are available in the filter control. This is a "
+"UI allow list only and does not add extra conditions to the underlying "
+"queries."
 msgstr ""
-"Seleziona quali granularità temporali sono disponibili nel controllo filtro. "
-"Questa è solo una lista consentita dell'interfaccia utente e non aggiunge "
-"condizioni aggiuntive alle query sottostanti."
+"Seleziona quali granularità temporali sono disponibili nel controllo "
+"filtro. Questa è solo una lista consentita dell'interfaccia utente e non "
+"aggiunge condizioni aggiuntive alle query sottostanti."
 
 msgid "Selected"
 msgstr "Selezionati"
@@ -17002,8 +17121,8 @@ msgstr "Imposta la frequenza di aggiornamento automatico per questo pannello."
 # ja, lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Set the automatic refresh frequency for this dashboard. The dashboard will "
-"reload its data at the specified interval."
+"Set the automatic refresh frequency for this dashboard. The dashboard "
+"will reload its data at the specified interval."
 msgstr ""
 "Imposta la frequenza di aggiornamento automatico per questo pannello. Il "
 "pannello ricaricherà i dati all'intervallo specificato."
@@ -17021,14 +17140,14 @@ msgstr "Configura i dettagli di base, come nome e descrizione."
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Sets the default temporal column for this dataset. Automatically selected as "
-"the time column when building charts that require a time dimension and used "
-"in dashboard level time filters."
+"Sets the default temporal column for this dataset. Automatically selected"
+" as the time column when building charts that require a time dimension "
+"and used in dashboard level time filters."
 msgstr ""
 "Imposta la colonna temporale predefinita per questo dataset. Viene "
-"selezionata automaticamente come colonna temporale durante la creazione di "
-"grafici che richiedono una dimensione temporale e viene utilizzata nei "
-"filtri temporali a livello di pannello."
+"selezionata automaticamente come colonna temporale durante la creazione "
+"di grafici che richiedono una dimensione temporale e viene utilizzata nei"
+" filtri temporali a livello di pannello."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -17036,12 +17155,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
-"        represented by one ring with the innermost circle as the top of the "
-"hierarchy."
+"        represented by one ring with the innermost circle as the top of "
+"the hierarchy."
 msgstr ""
 "Imposta i livelli di gerarchia del grafico. Ogni livello è\n"
-"        rappresentato da un anello con il cerchio più interno come vertice "
-"della gerarchia."
+"        rappresentato da un anello con il cerchio più interno come "
+"vertice della gerarchia."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -17107,8 +17226,8 @@ msgstr "La descrizione breve deve essere univoca per questo livello"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Should daily seasonality be applied. An integer value will specify Fourier "
-"order of seasonality."
+"Should daily seasonality be applied. An integer value will specify "
+"Fourier order of seasonality."
 msgstr ""
 "Specifica se applicare la stagionalità giornaliera. Un valore intero "
 "specificherà l'ordine di Fourier della stagionalità."
@@ -17118,8 +17237,8 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Should weekly seasonality be applied. An integer value will specify Fourier "
-"order of seasonality."
+"Should weekly seasonality be applied. An integer value will specify "
+"Fourier order of seasonality."
 msgstr ""
 "Specifica se applicare la stagionalità settimanale. Un valore intero "
 "specificherà l'ordine di Fourier della stagionalità."
@@ -17129,8 +17248,8 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Should yearly seasonality be applied. An integer value will specify Fourier "
-"order of seasonality."
+"Should yearly seasonality be applied. An integer value will specify "
+"Fourier order of seasonality."
 msgstr ""
 "Specifica se applicare la stagionalità annuale. Un valore intero "
 "specificherà l'ordine di Fourier della stagionalità."
@@ -17223,8 +17342,8 @@ msgstr "Mostra asse Y"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Show Y-axis on the sparkline. Will display the manually set min/max if set "
-"or min/max values in the data otherwise."
+"Show Y-axis on the sparkline. Will display the manually set min/max if "
+"set or min/max values in the data otherwise."
 msgstr ""
 "Mostra l'asse Y sul grafico sparkline. Visualizzerà i valori min/max "
 "impostati manualmente se impostati, altrimenti i valori min/max nei dati."
@@ -17275,8 +17394,8 @@ msgid "Show entries per page"
 msgstr "Mostra elementi per pagina"
 
 msgid ""
-"Show hierarchical relationships of data, with the value represented by area, "
-"showing proportion and contribution to the whole."
+"Show hierarchical relationships of data, with the value represented by "
+"area, showing proportion and contribution to the whole."
 msgstr ""
 "Mostra le relazioni gerarchiche dei dati, con il valore rappresentato "
 "dall'area, mostrando la proporzione e il contributo all'insieme."
@@ -17391,8 +17510,8 @@ msgstr "Mostra totale"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Show total aggregations of selected metrics. Note that row limit does not "
-"apply to the result."
+"Show total aggregations of selected metrics. Note that row limit does not"
+" apply to the result."
 msgstr ""
 "Mostra le aggregazioni totali delle metriche selezionate. Si noti che il "
 "limite di righe non si applica al risultato."
@@ -17405,12 +17524,13 @@ msgstr "Mostra valori"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Showcases a single metric front-and-center. Big number is best used to call "
-"attention to a KPI or the one thing you want your audience to focus on."
+"Showcases a single metric front-and-center. Big number is best used to "
+"call attention to a KPI or the one thing you want your audience to focus "
+"on."
 msgstr ""
-"Mette in evidenza una singola metrica al centro. Il numero grande è ideale "
-"per attirare l'attenzione su un KPI o sull'elemento su cui si desidera che "
-"il pubblico si concentri."
+"Mette in evidenza una singola metrica al centro. Il numero grande è "
+"ideale per attirare l'attenzione su un KPI o sull'elemento su cui si "
+"desidera che il pubblico si concentri."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -17418,20 +17538,21 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Showcases a single number accompanied by a simple line chart, to call "
-"attention to an important metric along with its change over time or other "
-"dimension."
+"attention to an important metric along with its change over time or other"
+" dimension."
 msgstr ""
-"Mette in evidenza un singolo numero accompagnato da un semplice grafico a "
-"linee, per attirare l'attenzione su una metrica importante insieme alla sua "
-"variazione nel tempo o in un'altra dimensione."
+"Mette in evidenza un singolo numero accompagnato da un semplice grafico a"
+" linee, per attirare l'attenzione su una metrica importante insieme alla "
+"sua variazione nel tempo o in un'altra dimensione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Showcases how a metric changes as the funnel progresses. This classic chart "
-"is useful for visualizing drop-off between stages in a pipeline or lifecycle."
+"Showcases how a metric changes as the funnel progresses. This classic "
+"chart is useful for visualizing drop-off between stages in a pipeline or "
+"lifecycle."
 msgstr ""
 "Mostra come una metrica cambia man mano che l'imbuto progredisce. Questo "
 "grafico classico è utile per visualizzare il calo tra le fasi di una "
@@ -17442,20 +17563,20 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Showcases the flow or link between categories using thickness of chords. The "
-"value and corresponding thickness can be different for each side."
+"Showcases the flow or link between categories using thickness of chords. "
+"The value and corresponding thickness can be different for each side."
 msgstr ""
 "Mostra il flusso o il collegamento tra categorie utilizzando lo spessore "
-"delle corde. Il valore e lo spessore corrispondente possono essere diversi "
-"per ciascun lato."
+"delle corde. Il valore e lo spessore corrispondente possono essere "
+"diversi per ciascun lato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Showcases the progress of a single metric against a given target. The higher "
-"the fill, the closer the metric is to the target."
+"Showcases the progress of a single metric against a given target. The "
+"higher the fill, the closer the metric is to the target."
 msgstr ""
 "Mostra il progresso di una singola metrica rispetto a un obiettivo dato. "
 "Maggiore è il riempimento, più la metrica è vicina all'obiettivo."
@@ -17545,7 +17666,8 @@ msgstr "Dimensione dei simboli dei bordi"
 #, fuzzy
 msgid "Size of marker. Also applies to forecast observations."
 msgstr ""
-"Dimensione del marcatore. Si applica anche alle osservazioni di previsione."
+"Dimensione del marcatore. Si applica anche alle osservazioni di "
+"previsione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -17613,11 +17735,12 @@ msgstr "Linea Smussata"
 # uk]
 #, fuzzy
 msgid ""
-"Smooth-line is a variation of the line chart. Without angles and hard edges, "
-"Smooth-line sometimes looks smarter and more professional."
+"Smooth-line is a variation of the line chart. Without angles and hard "
+"edges, Smooth-line sometimes looks smarter and more professional."
 msgstr ""
-"La linea smussata è una variante del grafico a linee. Senza angoli e bordi "
-"netti, la linea smussata appare a volte più elegante e professionale."
+"La linea smussata è una variante del grafico a linee. Senza angoli e "
+"bordi netti, la linea smussata appare a volte più elegante e "
+"professionale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -17631,15 +17754,16 @@ msgstr "Pieno"
 #, fuzzy
 msgid "Some groups could not be resolved and are shown as IDs."
 msgstr ""
-"Alcuni gruppi non hanno potuto essere risolti e vengono visualizzati come ID."
+"Alcuni gruppi non hanno potuto essere risolti e vengono visualizzati come"
+" ID."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid "Some permissions could not be resolved and are shown as IDs."
 msgstr ""
-"Alcune autorizzazioni non hanno potuto essere risolte e vengono visualizzate "
-"come ID."
+"Alcune autorizzazioni non hanno potuto essere risolte e vengono "
+"visualizzate come ID."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -17656,15 +17780,14 @@ msgstr "Alcuni profili non esistono"
 # lv, ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "Something went wrong while saving the user info"
-msgstr ""
-"Si è verificato un errore durante il salvataggio delle informazioni utente"
+msgstr "Si è verificato un errore durante il salvataggio delle informazioni utente"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Something went wrong with embedded authentication. Check the dev console for "
-"details."
+"Something went wrong with embedded authentication. Check the dev console "
+"for details."
 msgstr ""
 "Si è verificato un errore con l'autenticazione incorporata. Controlla la "
 "console di sviluppo per i dettagli."
@@ -17676,8 +17799,7 @@ msgstr "Qualcosa è andato storto."
 
 #, python-format
 msgid "Sorry there was an error fetching database information: %s"
-msgstr ""
-"Si è verificato un errore nel reperire le informazioni del database: %s"
+msgstr "Si è verificato un errore nel reperire le informazioni del database: %s"
 
 msgid "Sorry there was an error fetching saved charts: "
 msgstr "Si è verificato un errore nel reperire i grafici salvati: "
@@ -17791,13 +17913,13 @@ msgstr "Ordina query per"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Sort results by series name in ascending order. When combined with \"Sort by "
-"metric\", this acts as a tiebreaker for equal metric values. Adding this "
-"sort may reduce query performance on some databases."
+"Sort results by series name in ascending order. When combined with \"Sort"
+" by metric\", this acts as a tiebreaker for equal metric values. Adding "
+"this sort may reduce query performance on some databases."
 msgstr ""
-"Ordina i risultati per nome della serie in ordine crescente. Se combinato "
-"con \"Ordina per metrica\", funge da criterio di spareggio per valori di "
-"metrica uguali. L'aggiunta di questo ordinamento potrebbe ridurre le "
+"Ordina i risultati per nome della serie in ordine crescente. Se combinato"
+" con \"Ordina per metrica\", funge da criterio di spareggio per valori di"
+" metrica uguali. L'aggiunta di questo ordinamento potrebbe ridurre le "
 "prestazioni delle query su alcuni database."
 
 msgid "Sort rows by"
@@ -17865,8 +17987,8 @@ msgid ""
 "estimation, and Dremio for syntax changes, among others."
 msgstr ""
 "Specificare la versione del database. Viene utilizzata con Presto per la "
-"stima dei costi delle query e con Dremio per le modifiche alla sintassi, tra "
-"le altre cose."
+"stima dei costi delle query e con Dremio per le modifiche alla sintassi, "
+"tra le altre cose."
 
 #, fuzzy
 msgid "Split number"
@@ -17980,10 +18102,11 @@ msgstr "L'asse Y inizia da 0"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Start y-axis at zero. Uncheck to start y-axis at minimum value in the data."
+"Start y-axis at zero. Uncheck to start y-axis at minimum value in the "
+"data."
 msgstr ""
-"Inizia l'asse y da zero. Deseleziona per iniziare l'asse y dal valore minimo "
-"nei dati."
+"Inizia l'asse y da zero. Deseleziona per iniziare l'asse y dal valore "
+"minimo nei dati."
 
 msgid "Started"
 msgstr "Iniziato"
@@ -18029,15 +18152,16 @@ msgstr "Linea a gradini"
 # uk]
 #, fuzzy
 msgid ""
-"Stepped-line graph (also called step chart) is a variation of line chart but "
-"with the line forming a series of steps between data points. A step chart "
-"can be useful when you want to show the changes that occur at irregular "
-"intervals."
+"Stepped-line graph (also called step chart) is a variation of line chart "
+"but with the line forming a series of steps between data points. A step "
+"chart can be useful when you want to show the changes that occur at "
+"irregular intervals."
 msgstr ""
-"Il grafico a linee a gradini (detto anche grafico a scalini) è una variante "
-"del grafico a linee in cui la linea forma una serie di gradini tra i punti "
-"dati. Un grafico a scalini può essere utile quando si desidera mostrare le "
-"variazioni che si verificano a intervalli irregolari."
+"Il grafico a linee a gradini (detto anche grafico a scalini) è una "
+"variante del grafico a linee in cui la linea forma una serie di gradini "
+"tra i punti dati. Un grafico a scalini può essere utile quando si "
+"desidera mostrare le variazioni che si verificano a intervalli "
+"irregolari."
 
 msgid "Stop"
 msgstr "Stop"
@@ -18070,8 +18194,10 @@ msgstr "Strade"
 msgid "Streets (Carto)"
 msgstr "Strade (Carto)"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Streets (OSM)"
-msgstr ""
+msgstr "Strade (OSM)"
 
 msgid "Strength to pull the graph toward center"
 msgstr "Forza per tirare il grafico verso il centro"
@@ -18096,8 +18222,7 @@ msgstr "Strutturale"
 # sr_Latn]
 #, fuzzy
 msgid "Structure is managed by the upstream semantic layer and is read-only."
-msgstr ""
-"La struttura è gestita dal livello semantico a monte ed è di sola lettura."
+msgstr "La struttura è gestita dal livello semantico a monte ed è di sola lettura."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -18107,7 +18232,8 @@ msgstr "Stile"
 
 msgid "Style the ends of the progress bar with a round cap"
 msgstr ""
-"Acconcia le estremità della barra di avanzamento con un cappuccio arrotondato"
+"Acconcia le estremità della barra di avanzamento con un cappuccio "
+"arrotondato"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, uk]
@@ -18268,12 +18394,13 @@ msgstr "Scambia righe e colonne"
 # uk]
 #, fuzzy
 msgid ""
-"Swiss army knife for visualizing data. Choose between step, line, scatter, "
-"and bar charts. This viz type has many customization options as well."
+"Swiss army knife for visualizing data. Choose between step, line, "
+"scatter, and bar charts. This viz type has many customization options as "
+"well."
 msgstr ""
-"Coltellino svizzero per la visualizzazione dei dati. Scegli tra grafici a "
-"gradini, a linee, a dispersione e a barre. Questo tipo di visualizzazione "
-"offre anche molte opzioni di personalizzazione."
+"Coltellino svizzero per la visualizzazione dei dati. Scegli tra grafici a"
+" gradini, a linee, a dispersione e a barre. Questo tipo di "
+"visualizzazione offre anche molte opzioni di personalizzazione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -18332,10 +18459,10 @@ msgstr "Sintassi"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
-msgid ""
-"Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
+msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
 msgstr ""
-"Errore di sintassi: %(qualifier)s input \"%(input)s\" atteso \"%(expected)s"
+"Errore di sintassi: %(qualifier)s input \"%(input)s\" atteso "
+"\"%(expected)s"
 
 msgid "System"
 msgstr "Sistema"
@@ -18364,6 +18491,7 @@ msgstr "Tema predefinito di sistema rimosso"
 msgid "TABLES"
 msgstr "TABELLE"
 
+#. do-not-translate
 #, fuzzy
 msgid "TEMPORAL_RANGE"
 msgstr "è temporale"
@@ -18423,12 +18551,12 @@ msgstr ""
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Table already exists. You can change your 'if table already exists' strategy "
-"to append or replace or provide a different Table Name to use."
+"Table already exists. You can change your 'if table already exists' "
+"strategy to append or replace or provide a different Table Name to use."
 msgstr ""
-"La tabella esiste già. È possibile modificare la strategia 'se la tabella "
-"esiste già' in aggiungi o sostituisci, oppure fornire un nome di tabella "
-"diverso da utilizzare."
+"La tabella esiste già. È possibile modificare la strategia 'se la tabella"
+" esiste già' in aggiungi o sostituisci, oppure fornire un nome di tabella"
+" diverso da utilizzare."
 
 msgid "Table cache timeout"
 msgstr "Timeout cache tabella"
@@ -18562,8 +18690,8 @@ msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
-"L'attività non è interrompibile. L'attività è in corso ma non ha registrato "
-"un gestore di interruzione."
+"L'attività non è interrompibile. L'attività è in corso ma non ha "
+"registrato un gestore di interruzione."
 
 msgid "Task parameters are invalid."
 msgstr "Parametri dell'attività non validi."
@@ -18588,8 +18716,8 @@ msgid ""
 "substitution): {{row}}, {{column}}, {{rowLabel}}, {{columnLabel}}"
 msgstr ""
 "Modello per i titoli delle celle. Utilizza la sintassi dei modelli "
-"Handlebars (una popolare libreria di template che usa le doppie parentesi "
-"graffe per la sostituzione delle variabili): {{row}}, {{column}}, "
+"Handlebars (una popolare libreria di template che usa le doppie parentesi"
+" graffe per la sostituzione delle variabili): {{row}}, {{column}}, "
 "{{rowLabel}}, {{columnLabel}}"
 
 msgid "Template parameters"
@@ -18612,11 +18740,11 @@ msgstr "Elaborazione del modello non riuscita: %(ex)s"
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Templated link, it's possible to include {{ metric }} or other values coming "
-"from the controls."
+"Templated link, it's possible to include {{ metric }} or other values "
+"coming from the controls."
 msgstr ""
-"Collegamento basato su modello, è possibile includere {{ metric }} o altri "
-"valori provenienti dai controlli."
+"Collegamento basato su modello, è possibile includere {{ metric }} o "
+"altri valori provenienti dai controlli."
 
 msgid "Temporal X-Axis"
 msgstr "Asse Y temporale"
@@ -18626,12 +18754,13 @@ msgstr "Asse Y temporale"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Terminate running queries when browser window closed or navigated to another "
-"page. Available for Presto, Hive, MySQL, Postgres and Snowflake databases."
+"Terminate running queries when browser window closed or navigated to "
+"another page. Available for Presto, Hive, MySQL, Postgres and Snowflake "
+"databases."
 msgstr ""
-"Termina le query in esecuzione quando la finestra del browser viene chiusa o "
-"si naviga verso un'altra pagina. Disponibile per i database Presto, Hive, "
-"MySQL, Postgres e Snowflake."
+"Termina le query in esecuzione quando la finestra del browser viene "
+"chiusa o si naviga verso un'altra pagina. Disponibile per i database "
+"Presto, Hive, MySQL, Postgres e Snowflake."
 
 msgid "Test connection"
 msgstr "Testa la Connessione"
@@ -18674,16 +18803,16 @@ msgid "The API response from %s does not match the IDatabaseTable interface."
 msgstr "La risposta API da %s non corrisponde all'interfaccia IDatabaseTable."
 
 msgid ""
-"The CSS for individual dashboards can be altered here, or in the dashboard "
-"view where changes are immediately visible"
+"The CSS for individual dashboards can be altered here, or in the "
+"dashboard view where changes are immediately visible"
 msgstr ""
 "Il CSS di ogni singola dashboard può essere modificato qui, oppure nella "
 "vista della dashboard dove i cambiamenti sono visibili immediatamente"
 
 msgid ""
 "The CTAS (create table as select) doesn't have a SELECT statement at the "
-"end. Please make sure your query has a SELECT as its last statement. Then, "
-"try running your query again."
+"end. Please make sure your query has a SELECT as its last statement. "
+"Then, try running your query again."
 msgstr ""
 "Il CTAS (crea tabella come select) non ha un comando SELECT alla fine. "
 "Assicurarsi che la query abbia un SELECT come ultima istruzione. Quindi, "
@@ -18700,44 +18829,49 @@ msgstr ""
 # sr_Latn]
 #, fuzzy
 msgid ""
-"The Global Task Framework is not enabled. Please contact your administrator "
-"to enable the GLOBAL_TASK_FRAMEWORK feature flag."
+"The Global Task Framework is not enabled. Please contact your "
+"administrator to enable the GLOBAL_TASK_FRAMEWORK feature flag."
 msgstr ""
-"Il Global Task Framework non è abilitato. Contatta il tuo amministratore per "
-"abilitare il flag di funzionalità GLOBAL_TASK_FRAMEWORK."
+"Il Global Task Framework non è abilitato. Contatta il tuo amministratore "
+"per abilitare il flag di funzionalità GLOBAL_TASK_FRAMEWORK."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True in "
-"your feature flags to use @task. See https://superset.apache.org/docs/"
-"configuration/async-queries-celery for configuration details."
+"The Global Task Framework is not enabled. Set GLOBAL_TASK_FRAMEWORK=True "
+"in your feature flags to use @task. See "
+"https://superset.apache.org/docs/configuration/async-queries-celery for "
+"configuration details."
 msgstr ""
-"Il Global Task Framework non è abilitato. Imposta GLOBAL_TASK_FRAMEWORK=True "
-"nei flag di funzionalità per utilizzare @task. Consulta https://"
-"superset.apache.org/docs/configuration/async-queries-celery per i dettagli "
-"di configurazione."
+"Il Global Task Framework non è abilitato. Imposta "
+"GLOBAL_TASK_FRAMEWORK=True nei flag di funzionalità per utilizzare @task."
+" Consulta https://superset.apache.org/docs/configuration/async-queries-"
+"celery per i dettagli di configurazione."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "The SSH server host key could not be verified against the expected key."
 msgstr ""
+"Impossibile verificare la chiave host del server SSH rispetto alla chiave"
+" prevista."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The Sankey chart visually tracks the movement and transformation of values "
-"across\n"
+"The Sankey chart visually tracks the movement and transformation of "
+"values across\n"
 "          system stages. Nodes represent stages, connected by links "
 "depicting value flow. Node\n"
 "          height corresponds to the visualized metric, providing a clear "
 "representation of\n"
 "          value distribution and transformation."
 msgstr ""
-"Il diagramma di Sankey traccia visivamente il movimento e la trasformazione "
-"dei valori attraverso\n"
-"          le fasi del sistema. I nodi rappresentano le fasi, collegati da "
-"link che illustrano il flusso di valori. L'altezza\n"
+"Il diagramma di Sankey traccia visivamente il movimento e la "
+"trasformazione dei valori attraverso\n"
+"          le fasi del sistema. I nodi rappresentano le fasi, collegati da"
+" link che illustrano il flusso di valori. L'altezza\n"
 "          del nodo corrisponde alla metrica visualizzata, fornendo una "
 "rappresentazione chiara della\n"
 "          distribuzione e trasformazione dei valori."
@@ -18760,12 +18894,12 @@ msgstr "L'asse X non è nell'elenco dei filtri"
 # ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The X-axis is not on the filters list which will prevent it from being used "
-"in time range filters in dashboards. Would you like to add it to the filters "
-"list?"
+"The X-axis is not on the filters list which will prevent it from being "
+"used in time range filters in dashboards. Would you like to add it to the"
+" filters list?"
 msgstr ""
-"L'asse X non è nell'elenco dei filtri, il che impedirà il suo utilizzo nei "
-"filtri per intervallo di tempo nei dashboard. Desideri aggiungerlo "
+"L'asse X non è nell'elenco dei filtri, il che impedirà il suo utilizzo "
+"nei filtri per intervallo di tempo nei dashboard. Desideri aggiungerlo "
 "all'elenco dei filtri?"
 
 msgid "The annotation has been saved"
@@ -18785,16 +18919,21 @@ msgstr "Il colore di sfondo dei grafici."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The category of source nodes used to assign colors. If a node is associated "
-"with more than one category, only the first will be used."
+"The category of source nodes used to assign colors. If a node is "
+"associated with more than one category, only the first will be used."
 msgstr ""
-"La categoria dei nodi sorgente utilizzata per assegnare i colori. Se un nodo "
-"è associato a più di una categoria, verrà utilizzata solo la prima."
+"La categoria dei nodi sorgente utilizzata per assegnare i colori. Se un "
+"nodo è associato a più di una categoria, verrà utilizzata solo la prima."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"The chart this report targets was deleted. Restore the chart, or update the "
-"report to point at an active chart."
+"The chart this report targets was deleted. Restore the chart, or update "
+"the report to point at an active chart."
 msgstr ""
+"Il grafico a cui fa riferimento questo report è stato eliminato. "
+"Ripristina il grafico o aggiorna il report per puntarlo a un grafico "
+"attivo."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -18804,20 +18943,21 @@ msgstr "Il grafico è ancora in caricamento. Attendi un momento e riprova."
 
 msgid ""
 "The classic. Great for showing how much of a company each investor gets, "
-"what demographics follow your blog, or what portion of the budget goes to "
-"the military industrial complex.\n"
+"what demographics follow your blog, or what portion of the budget goes to"
+" the military industrial complex.\n"
 "\n"
-"        Pie charts can be difficult to interpret precisely. If clarity of "
-"relative proportion is important, consider using a bar or other chart type "
-"instead."
+"        Pie charts can be difficult to interpret precisely. If clarity of"
+" relative proportion is important, consider using a bar or other chart "
+"type instead."
 msgstr ""
 "Il classico. Ottimo per mostrare quanto di un'azienda ottiene ogni "
-"investitore, quali dati demografici seguono il tuo blog o quale parte del "
-"budget va al complesso industriale militare.\n"
+"investitore, quali dati demografici seguono il tuo blog o quale parte del"
+" budget va al complesso industriale militare.\n"
 "\n"
 "        I grafici a torta possono essere difficili da interpretare con "
-"precisione. Se la chiarezza della proporzione relativa è importante, prendi "
-"in considerazione l'utilizzo di un grafico a barre o di un altro tipo."
+"precisione. Se la chiarezza della proporzione relativa è importante, "
+"prendi in considerazione l'utilizzo di un grafico a barre o di un altro "
+"tipo."
 
 msgid "The color for points and clusters in RGB"
 msgstr "Il colore dei punti e dei cluster in RGB"
@@ -18866,12 +19006,12 @@ msgstr ""
 # es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The colors of this chart might be overridden by custom label colors of the "
-"related dashboard.\n"
+"The colors of this chart might be overridden by custom label colors of "
+"the related dashboard.\n"
 "    Check the JSON metadata in the Advanced settings."
 msgstr ""
-"I colori di questo grafico potrebbero essere sovrascritti dai colori delle "
-"etichette personalizzate del dashboard correlato.\n"
+"I colori di questo grafico potrebbero essere sovrascritti dai colori "
+"delle etichette personalizzate del dashboard correlato.\n"
 "    Controlla i metadati JSON nelle impostazioni Avanzate."
 
 msgid "The column header label"
@@ -18906,10 +19046,15 @@ msgstr ""
 msgid "The dashboard has been saved"
 msgstr "La dashboard è stata salvata"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "The dashboard this report targets was deleted. Restore the dashboard, or "
 "update the report to point at an active dashboard."
 msgstr ""
+"Il dashboard a cui fa riferimento questo report è stato eliminato. "
+"Ripristina il dashboard o aggiorna il report per puntarlo a un dashboard "
+"attivo."
 
 msgid "The data source seems to have been deleted"
 msgstr "La sorgente dati sembra essere stata cancellata"
@@ -18942,7 +19087,8 @@ msgstr "Il database ha restituito un errore inatteso."
 
 msgid "The database that was used to generate this query could not be found"
 msgstr ""
-"Impossibile trovare il database che è stato usato per generare questa query."
+"Impossibile trovare il database che è stato usato per generare questa "
+"query."
 
 msgid "The database was deleted."
 msgstr "Il database è stato cancellato."
@@ -18956,14 +19102,12 @@ msgstr "Database non trovato."
 msgid "The dataset associated with this chart no longer exists"
 msgstr "Il dataset associato a questo grafico non esiste più"
 
-msgid ""
-"The dataset column/metric that returns the values on your chart's x-axis."
+msgid "The dataset column/metric that returns the values on your chart's x-axis."
 msgstr ""
 "La colonna/metrica del dataset che restituisce i valori sull'asse X del "
 "grafico."
 
-msgid ""
-"The dataset column/metric that returns the values on your chart's y-axis."
+msgid "The dataset column/metric that returns the values on your chart's y-axis."
 msgstr ""
 "La colonna/metrica del dataset che restituisce i valori sull'asse Y del "
 "grafico."
@@ -18973,12 +19117,14 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The dataset columns will be automatically synced\n"
-"              based on the changes in your SQL query. If your changes don't\n"
+"              based on the changes in your SQL query. If your changes "
+"don't\n"
 "              impact the column definitions, you might want to skip this "
 "step."
 msgstr ""
 "Le colonne del dataset verranno sincronizzate automaticamente\n"
-"              in base alle modifiche nella query SQL. Se le modifiche non\n"
+"              in base alle modifiche nella query SQL. Se le modifiche non"
+"\n"
 "              influiscono sulle definizioni delle colonne, è possibile "
 "saltare questo passaggio."
 
@@ -18994,7 +19140,8 @@ msgid ""
 "                in undesirable ways."
 msgstr ""
 "La configurazione del dataset esposta qui\n"
-"                influisce su tutti i grafici che utilizzano questo dataset.\n"
+"                influisce su tutti i grafici che utilizzano questo "
+"dataset.\n"
 "                Tenere presente che la modifica delle impostazioni\n"
 "                qui potrebbe influire su altri grafici\n"
 "                in modi indesiderati."
@@ -19012,23 +19159,21 @@ msgid "The datasource is too large to query."
 msgstr "La sorgente dati è troppo grande per la query."
 
 msgid "The default catalog that should be used for the connection."
-msgstr ""
-"Il catalogo predefinito che dovrebbe essere utilizzato per la connessione."
+msgstr "Il catalogo predefinito che dovrebbe essere utilizzato per la connessione."
 
 msgid "The default schema that should be used for the connection."
-msgstr ""
-"Lo schema predefinito che dovrebbe essere utilizzato per la connessione."
+msgstr "Lo schema predefinito che dovrebbe essere utilizzato per la connessione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The description can be displayed as widget headers in the dashboard view. "
-"Supports markdown."
+"The description can be displayed as widget headers in the dashboard view."
+" Supports markdown."
 msgstr ""
-"La descrizione può essere visualizzata come intestazione dei widget nella "
-"vista del dashboard. Supporta il markdown."
+"La descrizione può essere visualizzata come intestazione dei widget nella"
+" vista del dashboard. Supporta il markdown."
 
 msgid "The display name of your dashboard"
 msgstr "Il nome da visualizzare per la dashboard"
@@ -19040,8 +19185,8 @@ msgid "The distance between cells, in pixels"
 msgstr "La distanza tra le celle, in pixel"
 
 msgid ""
-"The duration of time in seconds before the cache is invalidated. Set to -1 "
-"to bypass the cache."
+"The duration of time in seconds before the cache is invalidated. Set to "
+"-1 to bypass the cache."
 msgstr ""
 "Intervallo di tempo, in secondi, prima che la cache venga invalidata. "
 "Impostare a -1 per ignorare la cache."
@@ -19073,13 +19218,13 @@ msgstr "L'estensione %(id)s non può essere caricata."
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The extent of the map on application start. FIT DATA automatically sets the "
-"extent so that all data points are included in the viewport. CUSTOM allows "
-"users to define the extent manually."
+"The extent of the map on application start. FIT DATA automatically sets "
+"the extent so that all data points are included in the viewport. CUSTOM "
+"allows users to define the extent manually."
 msgstr ""
 "L'estensione della mappa all'avvio dell'applicazione. FIT DATA imposta "
-"automaticamente l'estensione in modo che tutti i punti dati siano inclusi "
-"nel viewport. CUSTOM consente agli utenti di definire l'estensione "
+"automaticamente l'estensione in modo che tutti i punti dati siano inclusi"
+" nel viewport. CUSTOM consente agli utenti di definire l'estensione "
 "manualmente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
@@ -19103,11 +19248,12 @@ msgstr ""
 # sr_Latn]
 #, fuzzy
 msgid ""
-"The following fields contain sensitive information that was masked during "
-"export. Please provide the values to import this database."
+"The following fields contain sensitive information that was masked during"
+" export. Please provide the values to import this database."
 msgstr ""
-"I seguenti campi contengono informazioni sensibili che sono state mascherate "
-"durante l'esportazione. Fornire i valori per importare questo database."
+"I seguenti campi contengono informazioni sensibili che sono state "
+"mascherate durante l'esportazione. Fornire i valori per importare questo "
+"database."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -19118,8 +19264,8 @@ msgid ""
 "preventing the dashboard\n"
 "                    from rendering: %s"
 msgstr ""
-"I seguenti filtri hanno l'opzione 'Seleziona il primo valore del filtro per "
-"impostazione predefinita'\n"
+"I seguenti filtri hanno l'opzione 'Seleziona il primo valore del filtro "
+"per impostazione predefinita'\n"
 "                    attivata e non è stato possibile caricarli, il che "
 "impedisce al dashboard\n"
 "                    di essere visualizzato: %s"
@@ -19147,8 +19293,7 @@ msgstr "Il gruppo è stato aggiornato."
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "The height of the current zoom level to compute all heights from"
-msgstr ""
-"L'altezza del livello di zoom corrente da cui calcolare tutte le altezze"
+msgstr "L'altezza del livello di zoom corrente da cui calcolare tutte le altezze"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -19157,15 +19302,15 @@ msgid ""
 "The histogram chart displays the distribution of a dataset by\n"
 "          representing the frequency or count of values within different "
 "ranges or bins.\n"
-"          It helps visualize patterns, clusters, and outliers in the data "
-"and provides\n"
+"          It helps visualize patterns, clusters, and outliers in the data"
+" and provides\n"
 "          insights into its shape, central tendency, and spread."
 msgstr ""
 "Il grafico a istogramma visualizza la distribuzione di un dataset\n"
-"          rappresentando la frequenza o il conteggio dei valori all'interno "
-"di diversi intervalli o bin.\n"
-"          Aiuta a visualizzare pattern, cluster e valori anomali nei dati e "
-"fornisce\n"
+"          rappresentando la frequenza o il conteggio dei valori "
+"all'interno di diversi intervalli o bin.\n"
+"          Aiuta a visualizzare pattern, cluster e valori anomali nei dati"
+" e fornisce\n"
 "          informazioni sulla sua forma, tendenza centrale e dispersione."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -19183,16 +19328,15 @@ msgid ""
 "The host \"%(hostname)s\" might be down, and can't be reached on port "
 "%(port)s."
 msgstr ""
-"L'host \"%(hostname)s\" potrebbe essere inattivo e non raggiungibile sulla "
-"porta %(port)s."
+"L'host \"%(hostname)s\" potrebbe essere inattivo e non raggiungibile "
+"sulla porta %(port)s."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "The host might be down, and can't be reached on the provided port."
-msgstr ""
-"L'host potrebbe essere inattivo e non raggiungibile sulla porta fornita."
+msgstr "L'host potrebbe essere inattivo e non raggiungibile sulla porta fornita."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
@@ -19219,19 +19363,20 @@ msgstr "L'id del grafico attivo"
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The image URL of the icon to display for GeoJSON points. Note that the image "
-"URL must conform to the content security policy (CSP) in order to load "
-"correctly."
+"The image URL of the icon to display for GeoJSON points. Note that the "
+"image URL must conform to the content security policy (CSP) in order to "
+"load correctly."
 msgstr ""
-"L'URL dell'immagine dell'icona da visualizzare per i punti GeoJSON. Tenere "
-"presente che l'URL dell'immagine deve essere conforme alla politica di "
-"sicurezza dei contenuti (CSP) per caricarsi correttamente."
+"L'URL dell'immagine dell'icona da visualizzare per i punti GeoJSON. "
+"Tenere presente che l'URL dell'immagine deve essere conforme alla "
+"politica di sicurezza dei contenuti (CSP) per caricarsi correttamente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The initial level (depth) of the tree. If set as -1 all nodes are expanded."
+"The initial level (depth) of the tree. If set as -1 all nodes are "
+"expanded."
 msgstr ""
 "Il livello iniziale (profondità) dell'albero. Se impostato a -1, tutti i "
 "nodi sono espansi."
@@ -19251,8 +19396,8 @@ msgstr "Il limite inferiore dell'intervallo di soglia dell'Isoband"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The maximum number of subdivisions of each group; lower values are pruned "
-"first"
+"The maximum number of subdivisions of each group; lower values are pruned"
+" first"
 msgstr ""
 "Il numero massimo di suddivisioni di ciascun gruppo; i valori più bassi "
 "vengono eliminati per primi"
@@ -19280,8 +19425,8 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy, python-brace-format
 msgid ""
-"The metadata_params in Extra field is not configured correctly. The key %"
-"{key}s is invalid."
+"The metadata_params in Extra field is not configured correctly. The key "
+"%{key}s is invalid."
 msgstr ""
 "Il parametro metadata_params nel campo Extra non è configurato "
 "correttamente. La chiave %{key}s non è valida."
@@ -19291,7 +19436,8 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The metadata_params object gets unpacked into the sqlalchemy.MetaData call."
+"The metadata_params object gets unpacked into the sqlalchemy.MetaData "
+"call."
 msgstr ""
 "L'oggetto metadata_params viene decompresso nella chiamata "
 "sqlalchemy.MetaData."
@@ -19301,10 +19447,11 @@ msgstr ""
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The minimum number of rolling periods required to show a value. For instance "
-"if you do a cumulative sum on 7 days you may want your \"Min Period\" to be "
-"7, so that all data points shown are the total of 7 periods. This will hide "
-"the \"ramp up\" taking place over the first 7 periods"
+"The minimum number of rolling periods required to show a value. For "
+"instance if you do a cumulative sum on 7 days you may want your \"Min "
+"Period\" to be 7, so that all data points shown are the total of 7 "
+"periods. This will hide the \"ramp up\" taking place over the first 7 "
+"periods"
 msgstr ""
 "Il numero minimo di periodi di scorrimento necessari per visualizzare un "
 "valore. Ad esempio, se si esegue una somma cumulativa su 7 giorni, si "
@@ -19316,8 +19463,8 @@ msgstr ""
 # es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The minimum value of metrics. It is an optional configuration. If not set, "
-"it will be the minimum value of the data"
+"The minimum value of metrics. It is an optional configuration. If not "
+"set, it will be the minimum value of the data"
 msgstr ""
 "Il valore minimo delle metriche. È una configurazione opzionale. Se non "
 "impostato, sarà il valore minimo dei dati"
@@ -19355,11 +19502,11 @@ msgstr "Il numero di bin per l'istogramma"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The number of hours, negative or positive, to shift the time column. This "
-"can be used to move UTC time to local time."
+"The number of hours, negative or positive, to shift the time column. This"
+" can be used to move UTC time to local time."
 msgstr ""
-"Il numero di ore, negative o positive, per spostare la colonna temporale. "
-"Può essere utilizzato per convertire l'ora UTC in ora locale."
+"Il numero di ore, negative o positive, per spostare la colonna temporale."
+" Può essere utilizzato per convertire l'ora UTC in ora locale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ru, sr, sr_Latn, tr, uk]
@@ -19370,14 +19517,14 @@ msgstr "Il numero di risultati visualizzati è limitato a %(rows)d."
 #, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
 msgstr ""
-"Il numero di righe visualizzate è limitato a %(rows)d dall'elenco a discesa."
+"Il numero di righe visualizzate è limitato a %(rows)d dall'elenco a "
+"discesa."
 
 #, python-format
-msgid ""
-"The number of rows displayed is limited to %(rows)d by the limit dropdown."
+msgid "The number of rows displayed is limited to %(rows)d by the limit dropdown."
 msgstr ""
-"Il numero di righe visualizzate è limitato a %(rows)d dall'elenco a discesa "
-"del limite."
+"Il numero di righe visualizzate è limitato a %(rows)d dall'elenco a "
+"discesa del limite."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19388,8 +19535,8 @@ msgstr "Il numero di righe visualizzate è limitato a %(rows)d dalla query"
 
 #, python-format
 msgid ""
-"The number of rows displayed is limited to %(rows)d by the query and limit "
-"dropdown."
+"The number of rows displayed is limited to %(rows)d by the query and "
+"limit dropdown."
 msgstr ""
 "Il numero di righe visualizzate è limitato a %(rows)d dalla query e "
 "dall'elenco a discesa del limite."
@@ -19406,20 +19553,18 @@ msgstr "L'oggetto non esiste nel database specificato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
-#, python-format
+#, fuzzy, python-format
 msgid "The parameter %(parameters)s in your query is undefined."
-msgid_plural ""
-"The following parameters in your query are undefined: %(parameters)s."
-msgstr[0] ""
-msgstr[1] ""
+msgid_plural "The following parameters in your query are undefined: %(parameters)s."
+msgstr[0] "Il parametro %(parameters)s nella tua query non è definito."
+msgstr[1] "I seguenti parametri nella tua query non sono definiti: %(parameters)s."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid "The password provided for username \"%(username)s\" is incorrect."
-msgstr ""
-"La password fornita per il nome utente \"%(username)s\" non è corretta."
+msgstr "La password fornita per il nome utente \"%(username)s\" non è corretta."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19441,14 +19586,14 @@ msgstr "Il ripristino della password è avvenuto con successo"
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the charts. Please note that the \"Secure Extra\" and "
-"\"Certificate\" sections of the database configuration are not present in "
-"export files, and should be added manually after the import if they are "
+"\"Certificate\" sections of the database configuration are not present in"
+" export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
 "Le password per i database elencati di seguito sono necessarie per "
 "importarli insieme ai grafici. Si noti che le sezioni \"Secure Extra\" e "
-"\"Certificate\" della configurazione del database non sono presenti nei file "
-"di esportazione e dovrebbero essere aggiunte manualmente dopo "
+"\"Certificate\" della configurazione del database non sono presenti nei "
+"file di esportazione e dovrebbero essere aggiunte manualmente dopo "
 "l'importazione, se necessario."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -19458,15 +19603,15 @@ msgstr ""
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the dashboards. Please note that the \"Secure Extra\" and "
-"\"Certificate\" sections of the database configuration are not present in "
-"export files, and should be added manually after the import if they are "
+"\"Certificate\" sections of the database configuration are not present in"
+" export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
 "Le password per i database elencati di seguito sono necessarie per "
-"importarli insieme alle dashboard. Si noti che le sezioni \"Secure Extra\" e "
-"\"Certificate\" della configurazione del database non sono presenti nei file "
-"di esportazione e dovrebbero essere aggiunte manualmente dopo "
-"l'importazione, se necessario."
+"importarli insieme alle dashboard. Si noti che le sezioni \"Secure "
+"Extra\" e \"Certificate\" della configurazione del database non sono "
+"presenti nei file di esportazione e dovrebbero essere aggiunte "
+"manualmente dopo l'importazione, se necessario."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk,
@@ -19475,14 +19620,14 @@ msgstr ""
 msgid ""
 "The passwords for the databases below are needed in order to import them "
 "together with the datasets. Please note that the \"Secure Extra\" and "
-"\"Certificate\" sections of the database configuration are not present in "
-"export files, and should be added manually after the import if they are "
+"\"Certificate\" sections of the database configuration are not present in"
+" export files, and should be added manually after the import if they are "
 "needed."
 msgstr ""
 "Le password per i database elencati di seguito sono necessarie per "
 "importarli insieme ai dataset. Si noti che le sezioni \"Secure Extra\" e "
-"\"Certificate\" della configurazione del database non sono presenti nei file "
-"di esportazione e dovrebbero essere aggiunte manualmente dopo "
+"\"Certificate\" della configurazione del database non sono presenti nei "
+"file di esportazione e dovrebbero essere aggiunte manualmente dopo "
 "l'importazione, se necessario."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
@@ -19491,22 +19636,21 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The passwords for the databases below are needed in order to import them "
-"together with the saved queries. Please note that the \"Secure Extra\" and "
-"\"Certificate\" sections of the database configuration are not present in "
-"export files, and should be added manually after the import if they are "
-"needed."
+"together with the saved queries. Please note that the \"Secure Extra\" "
+"and \"Certificate\" sections of the database configuration are not "
+"present in export files, and should be added manually after the import if"
+" they are needed."
 msgstr ""
 "Le password per i database elencati di seguito sono necessarie per "
 "importarli insieme alle query salvate. Si noti che le sezioni \"Secure "
 "Extra\" e \"Certificate\" della configurazione del database non sono "
-"presenti nei file di esportazione e dovrebbero essere aggiunte manualmente "
-"dopo l'importazione, se necessario."
+"presenti nei file di esportazione e dovrebbero essere aggiunte "
+"manualmente dopo l'importazione, se necessario."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
-msgid ""
-"The passwords for the databases below are needed in order to import them."
+msgid "The passwords for the databases below are needed in order to import them."
 msgstr ""
 "Le password per i database elencati di seguito sono necessarie per "
 "importarli."
@@ -19525,14 +19669,14 @@ msgstr "Il modello del formato del timestamp. Per le stringhe usa "
 msgid ""
 "The periodicity over which to pivot time. Users can provide\n"
 "            \"Pandas\" offset alias.\n"
-"            Click on the info bubble for more details on accepted \"freq\" "
-"expressions."
+"            Click on the info bubble for more details on accepted "
+"\"freq\" expressions."
 msgstr ""
 "La periodicità su cui effettuare il pivot del tempo. Gli utenti possono "
 "fornire\n"
 "            un alias di offset \"Pandas\".\n"
-"            Fare clic sulla bolla informativa per ulteriori dettagli sulle "
-"espressioni \"freq\" accettate."
+"            Fare clic sulla bolla informativa per ulteriori dettagli "
+"sulle espressioni \"freq\" accettate."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19546,13 +19690,13 @@ msgstr "Il raggio in pixel"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The pointer to a physical table (or view). Keep in mind that the chart is "
-"associated to this Superset logical table, and this logical table points the "
-"physical table referenced here."
+"The pointer to a physical table (or view). Keep in mind that the chart is"
+" associated to this Superset logical table, and this logical table points"
+" the physical table referenced here."
 msgstr ""
-"Il puntatore a una tabella fisica (o vista). Tenere presente che il grafico "
-"è associato a questa tabella logica di Superset, e questa tabella logica "
-"punta alla tabella fisica a cui si fa riferimento qui."
+"Il puntatore a una tabella fisica (o vista). Tenere presente che il "
+"grafico è associato a questa tabella logica di Superset, e questa tabella"
+" logica punta alla tabella fisica a cui si fa riferimento qui."
 
 msgid "The port is closed."
 msgstr "La porta è chiusa."
@@ -19588,8 +19732,8 @@ msgstr "La query associata ai risultati è stata eliminata."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The query associated with these results could not be found. You need to re-"
-"run the original query."
+"The query associated with these results could not be found. You need to "
+"re-run the original query."
 msgstr ""
 "La query associata a questi risultati non è stata trovata. È necessario "
 "rieseguire la query originale."
@@ -19608,12 +19752,12 @@ msgstr "La query non può essere caricata"
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"The query estimation was killed after %(sqllab_timeout)s seconds. It might "
-"be too complex, or the database might be under heavy load."
+"The query estimation was killed after %(sqllab_timeout)s seconds. It "
+"might be too complex, or the database might be under heavy load."
 msgstr ""
 "La stima della query è stata interrotta dopo %(sqllab_timeout)s secondi. "
-"Potrebbe essere troppo complessa, o il database potrebbe essere sotto carico "
-"elevato."
+"Potrebbe essere troppo complessa, o il database potrebbe essere sotto "
+"carico elevato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19637,17 +19781,18 @@ msgid ""
 "The query was killed after %(sqllab_timeout)s seconds. It might be too "
 "complex, or the database might be under heavy load."
 msgstr ""
-"La query è stata interrotta dopo %(sqllab_timeout)s secondi. Potrebbe essere "
-"troppo complessa, o il database potrebbe essere sotto carico elevato."
+"La query è stata interrotta dopo %(sqllab_timeout)s secondi. Potrebbe "
+"essere troppo complessa, o il database potrebbe essere sotto carico "
+"elevato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The radius (in pixels) the algorithm uses to define a cluster. Choose 0 to "
-"turn off clustering, but beware that a large number of points (>1000) will "
-"cause lag."
+"The radius (in pixels) the algorithm uses to define a cluster. Choose 0 "
+"to turn off clustering, but beware that a large number of points (>1000) "
+"will cause lag."
 msgstr ""
 "Il raggio (in pixel) che l'algoritmo utilizza per definire un cluster. "
 "Scegliere 0 per disattivare il clustering, ma attenzione che un numero "
@@ -19658,18 +19803,23 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The radius of individual points (ones that are not in a cluster). Either a "
-"numerical column or `Auto`, which scales the point based on the largest "
-"cluster"
+"The radius of individual points (ones that are not in a cluster). Either "
+"a numerical column or `Auto`, which scales the point based on the largest"
+" cluster"
 msgstr ""
-"Il raggio dei punti individuali (quelli che non si trovano in un cluster). "
-"Una colonna numerica oppure `Auto`, che ridimensiona il punto in base al "
-"cluster più grande"
+"Il raggio dei punti individuali (quelli che non si trovano in un "
+"cluster). Una colonna numerica oppure `Auto`, che ridimensiona il punto "
+"in base al cluster più grande"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
 "The radius of point features, in the units specified below. The final "
 "rendered size is this value multiplied by Point Radius Scale."
 msgstr ""
+"Il raggio delle feature puntuali, nelle unità specificate di seguito. La "
+"dimensione finale renderizzata è questo valore moltiplicato per la Scala "
+"del raggio del punto."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19688,8 +19838,9 @@ msgstr "Il report verrà inviato alla tua email a"
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The result of this query must be a value capable of numeric interpretation "
-"e.g. 1, 1.0, or \"1\" (compatible with Python's float() function)."
+"The result of this query must be a value capable of numeric "
+"interpretation e.g. 1, 1.0, or \"1\" (compatible with Python's float() "
+"function)."
 msgstr ""
 "Il risultato di questa query deve essere un valore interpretabile "
 "numericamente, ad esempio 1, 1.0, o \"1\" (compatibile con la funzione "
@@ -19713,11 +19864,11 @@ msgstr "Il backend dei risultati non dispone più dei dati dalla query."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The results stored in the backend were stored in a different format, and no "
-"longer can be deserialized."
+"The results stored in the backend were stored in a different format, and "
+"no longer can be deserialized."
 msgstr ""
-"I risultati memorizzati nel backend sono stati salvati in un formato diverso "
-"e non possono più essere deserializzati."
+"I risultati memorizzati nel backend sono stati salvati in un formato "
+"diverso e non possono più essere deserializzati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19725,8 +19876,8 @@ msgstr ""
 #, fuzzy
 msgid "The rich tooltip shows a list of all series for that point in time"
 msgstr ""
-"Il tooltip avanzato mostra un elenco di tutte le serie per quel punto nel "
-"tempo"
+"Il tooltip avanzato mostra un elenco di tutte le serie per quel punto nel"
+" tempo"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, uk]
@@ -19747,29 +19898,30 @@ msgstr "Il profilo è stato aggiornato."
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"The row limit set for the chart was reached. The chart may show partial data."
+"The row limit set for the chart was reached. The chart may show partial "
+"data."
 msgstr ""
-"È stato raggiunto il limite di righe impostato per il grafico. Il grafico "
-"potrebbe mostrare dati parziali."
+"È stato raggiunto il limite di righe impostato per il grafico. Il grafico"
+" potrebbe mostrare dati parziali."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"The schema \"%(schema)s\" does not exist. A valid schema must be used to run "
-"this query."
+"The schema \"%(schema)s\" does not exist. A valid schema must be used to "
+"run this query."
 msgstr ""
-"Lo schema \"%(schema)s\" non esiste. Per eseguire questa query è necessario "
-"utilizzare uno schema valido."
+"Lo schema \"%(schema)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare uno schema valido."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"The schema \"%(schema_name)s\" does not exist. A valid schema must be used "
-"to run this query."
+"The schema \"%(schema_name)s\" does not exist. A valid schema must be "
+"used to run this query."
 msgstr ""
 "Lo schema \"%(schema_name)s\" non esiste. Per eseguire questa query è "
 "necessario utilizzare uno schema valido."
@@ -19827,19 +19979,19 @@ msgstr "Lo schema del payload inviato non è corretto."
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"The table \"%(table)s\" does not exist. A valid table must be used to run "
-"this query."
+"The table \"%(table)s\" does not exist. A valid table must be used to run"
+" this query."
 msgstr ""
-"La tabella \"%(table)s\" non esiste. Per eseguire questa query è necessario "
-"utilizzare una tabella valida."
+"La tabella \"%(table)s\" non esiste. Per eseguire questa query è "
+"necessario utilizzare una tabella valida."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"The table \"%(table_name)s\" does not exist. A valid table must be used to "
-"run this query."
+"The table \"%(table_name)s\" does not exist. A valid table must be used "
+"to run this query."
 msgstr ""
 "La tabella \"%(table_name)s\" non esiste. Per eseguire questa query è "
 "necessario utilizzare una tabella valida."
@@ -19855,38 +20007,38 @@ msgstr "La tabella è stata eliminata o rinominata nel database."
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The time column for the visualization. Note that you can define arbitrary "
-"expression that return a DATETIME column in the table. Also note that the "
-"filter below is applied against this column or expression"
+"The time column for the visualization. Note that you can define arbitrary"
+" expression that return a DATETIME column in the table. Also note that "
+"the filter below is applied against this column or expression"
 msgstr ""
 "La colonna temporale per la visualizzazione. Si noti che è possibile "
-"definire espressioni arbitrarie che restituiscono una colonna DATETIME nella "
-"tabella. Si noti inoltre che il filtro sottostante viene applicato a questa "
-"colonna o espressione"
+"definire espressioni arbitrarie che restituiscono una colonna DATETIME "
+"nella tabella. Si noti inoltre che il filtro sottostante viene applicato "
+"a questa colonna o espressione"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"The time granularity for the visualization. Note that you can type and use "
-"simple natural language as in `10 seconds`, `1 day` or `56 weeks`"
+"The time granularity for the visualization. Note that you can type and "
+"use simple natural language as in `10 seconds`, `1 day` or `56 weeks`"
 msgstr ""
 "La granularità temporale per la visualizzazione. Si noti che è possibile "
-"digitare e utilizzare un linguaggio naturale semplice come `10 seconds`, `1 "
-"day` o `56 weeks`"
+"digitare e utilizzare un linguaggio naturale semplice come `10 seconds`, "
+"`1 day` o `56 weeks`"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"The time granularity for the visualization. Note that you can type and use "
-"simple natural language as in `10 seconds`,`1 day` or `56 weeks`"
+"The time granularity for the visualization. Note that you can type and "
+"use simple natural language as in `10 seconds`,`1 day` or `56 weeks`"
 msgstr ""
 "La granularità temporale per la visualizzazione. Si noti che è possibile "
-"digitare e utilizzare un linguaggio naturale semplice come `10 seconds`,`1 "
-"day` o `56 weeks`"
+"digitare e utilizzare un linguaggio naturale semplice come `10 "
+"seconds`,`1 day` o `56 weeks`"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -19894,9 +20046,9 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The time granularity for the visualization. This applies a date "
-"transformation to alter your time column and defines a new time granularity. "
-"The options here are defined on a per database engine basis in the Superset "
-"source code."
+"transformation to alter your time column and defines a new time "
+"granularity. The options here are defined on a per database engine basis "
+"in the Superset source code."
 msgstr ""
 "La granularità temporale per la visualizzazione. Viene applicata una "
 "trasformazione della data per modificare la colonna temporale e viene "
@@ -19909,20 +20061,21 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The time range for the visualization. All relative times, e.g. \"Last "
-"month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using "
-"the server's local time (sans timezone). All tooltips and placeholder times "
-"are expressed in UTC (sans timezone). The timestamps are then evaluated by "
-"the database using the engine's local timezone. Note one can explicitly set "
-"the timezone per the ISO 8601 format if specifying either the start and/or "
-"end time."
+"month\", \"Last 7 days\", \"now\", etc. are evaluated on the server using"
+" the server's local time (sans timezone). All tooltips and placeholder "
+"times are expressed in UTC (sans timezone). The timestamps are then "
+"evaluated by the database using the engine's local timezone. Note one can"
+" explicitly set the timezone per the ISO 8601 format if specifying either"
+" the start and/or end time."
 msgstr ""
-"L'intervallo di tempo per la visualizzazione. Tutti i tempi relativi, ad es. "
-"\"Ultimo mese\", \"Ultimi 7 giorni\", \"ora\", ecc. vengono calcolati sul "
-"server utilizzando l'ora locale del server (senza fuso orario). Tutti i "
-"tooltip e i tempi segnaposto sono espressi in UTC (senza fuso orario). I "
-"timestamp vengono quindi elaborati dal database utilizzando il fuso orario "
-"locale del motore. Si noti che è possibile impostare esplicitamente il fuso "
-"orario nel formato ISO 8601 se si specifica l'ora di inizio e/o di fine."
+"L'intervallo di tempo per la visualizzazione. Tutti i tempi relativi, ad "
+"es. \"Ultimo mese\", \"Ultimi 7 giorni\", \"ora\", ecc. vengono calcolati"
+" sul server utilizzando l'ora locale del server (senza fuso orario). "
+"Tutti i tooltip e i tempi segnaposto sono espressi in UTC (senza fuso "
+"orario). I timestamp vengono quindi elaborati dal database utilizzando il"
+" fuso orario locale del motore. Si noti che è possibile impostare "
+"esplicitamente il fuso orario nel formato ISO 8601 se si specifica l'ora "
+"di inizio e/o di fine."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19932,8 +20085,8 @@ msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
-"L'unità di tempo per ogni blocco. Dovrebbe essere un'unità più piccola di "
-"domain_granularity. Dovrebbe essere maggiore o uguale a Time Grain"
+"L'unità di tempo per ogni blocco. Dovrebbe essere un'unità più piccola di"
+" domain_granularity. Dovrebbe essere maggiore o uguale a Time Grain"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19956,10 +20109,14 @@ msgstr "Unità di misura per la dimensione dell'icona"
 msgid "The unit for label size"
 msgstr "Unità di misura per la dimensione dell'etichetta"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid ""
-"The unit for point radius. Use \"pixels\" for consistent screen-space sizing "
-"regardless of zoom level."
+"The unit for point radius. Use \"pixels\" for consistent screen-space "
+"sizing regardless of zoom level."
 msgstr ""
+"L'unità per il raggio del punto. Usa \"pixel\" per una dimensione "
+"uniforme nello spazio schermo indipendentemente dal livello di zoom."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -19985,18 +20142,17 @@ msgstr "L'utente è stato aggiornato."
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
-msgid ""
-"The user/password combination is not valid (Incorrect password for user)."
+msgid "The user/password combination is not valid (Incorrect password for user)."
 msgstr ""
-"La combinazione utente/password non è valida (password errata per l'utente)."
+"La combinazione utente/password non è valida (password errata per "
+"l'utente)."
 
 #, python-format
 msgid "The username \"%(username)s\" does not exist."
 msgstr "L'utente \"%(username)s\" non esiste."
 
 msgid "The username provided when connecting to a database is not valid."
-msgstr ""
-"Il nome utente fornito durante la connessione a un database non è valido."
+msgstr "Il nome utente fornito durante la connessione a un database non è valido."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -20027,7 +20183,8 @@ msgstr "Lo spessore delle Isoline in pixel"
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "The width of the current zoom level to compute all widths from"
 msgstr ""
-"La larghezza del livello di zoom corrente da cui calcolare tutte le larghezze"
+"La larghezza del livello di zoom corrente da cui calcolare tutte le "
+"larghezze"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -20041,11 +20198,11 @@ msgstr "Lo spessore delle linee"
 # sr_Latn]
 #, fuzzy
 msgid ""
-"The width of the lines as either a fixed value or variable width based on a "
-"metric."
+"The width of the lines as either a fixed value or variable width based on"
+" a metric."
 msgstr ""
-"La larghezza delle linee come valore fisso o larghezza variabile basata su "
-"una metrica."
+"La larghezza delle linee come valore fisso o larghezza variabile basata "
+"su una metrica."
 
 msgid "Theme"
 msgstr "Tema"
@@ -20102,8 +20259,8 @@ msgstr "Ci sono modifiche non salvate."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"There is a syntax error in the SQL query. Perhaps there was a misspelling or "
-"a typo."
+"There is a syntax error in the SQL query. Perhaps there was a misspelling"
+" or a typo."
 msgstr ""
 "C'è un errore di sintassi nella query SQL. Forse c'è stato un errore "
 "ortografico o un refuso."
@@ -20116,8 +20273,8 @@ msgstr "Al momento non ci sono informazioni da visualizzare."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"There is no chart definition associated with this component, could it have "
-"been deleted?"
+"There is no chart definition associated with this component, could it "
+"have been deleted?"
 msgstr ""
 "Non esiste una definizione di grafico associata a questo componente, "
 "potrebbe essere stata eliminata?"
@@ -20127,8 +20284,8 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"There is not enough space for this component. Try decreasing its width, or "
-"increasing the destination width."
+"There is not enough space for this component. Try decreasing its width, "
+"or increasing the destination width."
 msgstr ""
 "Non c'è abbastanza spazio per questo componente. Prova a ridurne la "
 "larghezza o ad aumentare la larghezza della destinazione."
@@ -20198,8 +20355,8 @@ msgstr "Si è verificato un errore nel caricare le schede della dashboard"
 #, fuzzy, python-format
 msgid "There was an error saving the favorite status: %s"
 msgstr ""
-"Si è verificato un errore durante il salvataggio dello stato dei preferiti: "
-"%s"
+"Si è verificato un errore durante il salvataggio dello stato dei "
+"preferiti: %s"
 
 msgid "There was an error updating the group. Please, try again."
 msgstr "Si è verificato un errore nell'aggiornare il gruppo. Riprovare."
@@ -20240,8 +20397,7 @@ msgstr "Si è verificato un errore nel cancellare %s: %s"
 
 #, python-format
 msgid "There was an issue deleting registration for user: %s"
-msgstr ""
-"Si è verificato un errore nel cancellare la registrazione per l'utente: %s"
+msgstr "Si è verificato un errore nel cancellare la registrazione per l'utente: %s"
 
 #, python-format
 msgid "There was an issue deleting rules: %s"
@@ -20257,8 +20413,7 @@ msgstr "Si è verificato un errore nel cancellare i %s selezionati: %s"
 
 #, python-format
 msgid "There was an issue deleting the selected annotations: %s"
-msgstr ""
-"Si è verificato un errore nel cancellare le annotazioni selezionate: %s"
+msgstr "Si è verificato un errore nel cancellare le annotazioni selezionate: %s"
 
 #, python-format
 msgid "There was an issue deleting the selected charts: %s"
@@ -20326,8 +20481,8 @@ msgstr "Si è verificato un errore nel caricare i report."
 #, fuzzy
 msgid "There was an issue fetching the favorite status of this dashboard."
 msgstr ""
-"Si è verificato un problema durante il recupero dello stato dei preferiti di "
-"questa dashboard."
+"Si è verificato un problema durante il recupero dello stato dei preferiti"
+" di questa dashboard."
 
 #, python-format
 msgid "There was an issue fetching your chart: %s"
@@ -20348,8 +20503,8 @@ msgstr "Si è verificato un errore nel caricare le query salvate: %s"
 #, python-format
 msgid "There was an issue previewing the selected query %s"
 msgstr ""
-"Si è verificato un errore nel visualizzare in anteprima la query selezionata "
-"%s"
+"Si è verificato un errore nel visualizzare in anteprima la query "
+"selezionata %s"
 
 #, python-format
 msgid "There was an issue previewing the selected query. %s"
@@ -20365,13 +20520,13 @@ msgstr "Questi sono i set di dati a cui verrà applicato questo filtro."
 
 msgid ""
 "This JSON object is generated dynamically when clicking the save or "
-"overwrite button in the dashboard view. It is exposed here for reference and "
-"for power users who may want to alter specific parameters."
+"overwrite button in the dashboard view. It is exposed here for reference "
+"and for power users who may want to alter specific parameters."
 msgstr ""
-"Questo oggetto JSON è generato in maniera dinamica al clic sul pulsante di "
-"salvataggio o sovrascrittura nella vista dashboard. Il JSON è esposto qui "
-"come riferimento e per gli utenti esperti che vogliono modificare parametri "
-"specifici."
+"Questo oggetto JSON è generato in maniera dinamica al clic sul pulsante "
+"di salvataggio o sovrascrittura nella vista dashboard. Il JSON è esposto "
+"qui come riferimento e per gli utenti esperti che vogliono modificare "
+"parametri specifici."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20439,16 +20594,16 @@ msgid ""
 "This can be either an IP address (e.g. 127.0.0.1) or a domain name (e.g. "
 "mydatabase.com)."
 msgstr ""
-"Può essere un indirizzo IP (ad es. 127.0.0.1) o un nome di dominio (ad es. "
-"mydatabase.com)."
+"Può essere un indirizzo IP (ad es. 127.0.0.1) o un nome di dominio (ad "
+"es. mydatabase.com)."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
 # zh_TW]
 #, fuzzy
 msgid ""
-"This chart applies cross-filters to charts whose datasets contain columns "
-"with the same name."
+"This chart applies cross-filters to charts whose datasets contain columns"
+" with the same name."
 msgstr ""
 "Questo grafico applica filtri incrociati ai grafici i cui set di dati "
 "contengono colonne con lo stesso nome."
@@ -20474,7 +20629,8 @@ msgstr ""
 #, fuzzy
 msgid "This chart is managed externally, and can't be edited in Superset"
 msgstr ""
-"Questo grafico è gestito esternamente e non può essere modificato in Superset"
+"Questo grafico è gestito esternamente e non può essere modificato in "
+"Superset"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20482,8 +20638,8 @@ msgstr ""
 #, fuzzy
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
-"Questo grafico potrebbe essere incompatibile con il filtro (i set di dati "
-"non corrispondono)"
+"Questo grafico potrebbe essere incompatibile con il filtro (i set di dati"
+" non corrispondono)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -20506,8 +20662,7 @@ msgstr "Questa colonna potrebbe essere incompatibile con l'attuale %s"
 # uk]
 #, fuzzy
 msgid "This column might be incompatible with current dataset"
-msgstr ""
-"Questa colonna potrebbe essere incompatibile con il set di dati corrente"
+msgstr "Questa colonna potrebbe essere incompatibile con il set di dati corrente"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20520,22 +20675,22 @@ msgstr "Questa colonna deve contenere informazioni di data/ora."
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This control filters the whole chart based on the selected time range. All "
-"relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. are "
-"evaluated on the server using the server's local time (sans timezone). All "
-"tooltips and placeholder times are expressed in UTC (sans timezone). The "
-"timestamps are then evaluated by the database using the engine's local "
-"timezone. Note one can explicitly set the timezone per the ISO 8601 format "
-"if specifying either the start and/or end time."
+"This control filters the whole chart based on the selected time range. "
+"All relative times, e.g. \"Last month\", \"Last 7 days\", \"now\", etc. "
+"are evaluated on the server using the server's local time (sans "
+"timezone). All tooltips and placeholder times are expressed in UTC (sans "
+"timezone). The timestamps are then evaluated by the database using the "
+"engine's local timezone. Note one can explicitly set the timezone per the"
+" ISO 8601 format if specifying either the start and/or end time."
 msgstr ""
 "Questo controllo filtra l'intero grafico in base all'intervallo di tempo "
 "selezionato. Tutti i tempi relativi, ad es. \"Ultimo mese\", \"Ultimi 7 "
 "giorni\", \"adesso\", ecc. vengono valutati sul server utilizzando l'ora "
 "locale del server (senza fuso orario). Tutti i tooltip e i segnaposto "
-"temporali sono espressi in UTC (senza fuso orario). I timestamp vengono poi "
-"valutati dal database utilizzando il fuso orario locale del motore. Si noti "
-"che è possibile impostare esplicitamente il fuso orario nel formato ISO 8601 "
-"specificando l'ora di inizio e/o di fine."
+"temporali sono espressi in UTC (senza fuso orario). I timestamp vengono "
+"poi valutati dal database utilizzando il fuso orario locale del motore. "
+"Si noti che è possibile impostare esplicitamente il fuso orario nel "
+"formato ISO 8601 specificando l'ora di inizio e/o di fine."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20547,8 +20702,8 @@ msgid ""
 "annotation data."
 msgstr ""
 "Questo controlla se il campo \"time_range\" dalla vista corrente\n"
-"                  debba essere trasmesso al grafico contenente i dati delle "
-"annotazioni."
+"                  debba essere trasmesso al grafico contenente i dati "
+"delle annotazioni."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20561,8 +20716,8 @@ msgid ""
 msgstr ""
 "Questo controlla se il campo della granularità temporale dalla vista "
 "corrente\n"
-"                  debba essere trasmesso al grafico contenente i dati delle "
-"annotazioni."
+"                  debba essere trasmesso al grafico contenente i dati "
+"delle annotazioni."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20578,13 +20733,13 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"This dashboard is not published which means it will not show up in the list "
-"of dashboards. Favorite it to see it there or access it by using the URL "
-"directly."
+"This dashboard is not published which means it will not show up in the "
+"list of dashboards. Favorite it to see it there or access it by using the"
+" URL directly."
 msgstr ""
 "Questa dashboard non è pubblicata, il che significa che non apparirà "
-"nell'elenco delle dashboard. Aggiungila ai preferiti per vederla lì oppure "
-"accedi direttamente tramite URL."
+"nell'elenco delle dashboard. Aggiungila ai preferiti per vederla lì "
+"oppure accedi direttamente tramite URL."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20623,11 +20778,11 @@ msgstr "Questa dashboard è pubblicata. Clicca per renderla una bozza."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"This dashboard is ready to embed. In your application, pass the following id "
-"to the SDK:"
+"This dashboard is ready to embed. In your application, pass the following"
+" id to the SDK:"
 msgstr ""
-"Questa dashboard è pronta per essere incorporata. Nella tua applicazione, "
-"passa il seguente ID all'SDK:"
+"Questa dashboard è pronta per essere incorporata. Nella tua applicazione,"
+" passa il seguente ID all'SDK:"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -20640,8 +20795,8 @@ msgstr "Questa dashboard è stata salvata con successo."
 # ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This database does not allow for DDL/DML, but the query mutates data. Please "
-"contact your administrator for more assistance."
+"This database does not allow for DDL/DML, but the query mutates data. "
+"Please contact your administrator for more assistance."
 msgstr ""
 "Questo database non consente operazioni DDL/DML, ma la query modifica i "
 "dati. Contatta il tuo amministratore per ulteriore assistenza."
@@ -20663,20 +20818,22 @@ msgid ""
 "This database table does not contain any data. Please select a different "
 "table."
 msgstr ""
-"Questa tabella del database non contiene dati. Seleziona una tabella diversa."
+"Questa tabella del database non contiene dati. Seleziona una tabella "
+"diversa."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"This database uses OAuth2 for authentication. Please click the link above to "
-"grant Apache Superset permission to access the data. Your personal access "
-"token will be stored encrypted and used only for queries run by you."
+"This database uses OAuth2 for authentication. Please click the link above"
+" to grant Apache Superset permission to access the data. Your personal "
+"access token will be stored encrypted and used only for queries run by "
+"you."
 msgstr ""
 "Questo database utilizza OAuth2 per l'autenticazione. Fai clic sul link "
-"sopra per concedere ad Apache Superset il permesso di accedere ai dati. Il "
-"tuo token di accesso personale verrà memorizzato in forma crittografata e "
-"utilizzato solo per le query eseguite da te."
+"sopra per concedere ad Apache Superset il permesso di accedere ai dati. "
+"Il tuo token di accesso personale verrà memorizzato in forma "
+"crittografata e utilizzato solo per le query eseguite da te."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20698,9 +20855,9 @@ msgstr "Questo definisce l'elemento da tracciare sul grafico"
 # lv, ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This email is already associated with an account. Please choose another one."
-msgstr ""
-"Questo indirizzo email è già associato a un account. Sceglierne un altro."
+"This email is already associated with an account. Please choose another "
+"one."
+msgstr "Questo indirizzo email è già associato a un account. Sceglierne un altro."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -20715,23 +20872,23 @@ msgstr ""
 # uk]
 #, fuzzy
 msgid ""
-"This field is used as a unique identifier to attach the calculated dimension "
-"to charts. It is also used as the alias in the SQL query."
+"This field is used as a unique identifier to attach the calculated "
+"dimension to charts. It is also used as the alias in the SQL query."
 msgstr ""
-"Questo campo viene utilizzato come identificatore univoco per collegare la "
-"dimensione calcolata ai grafici. Viene anche utilizzato come alias nella "
-"query SQL."
+"Questo campo viene utilizzato come identificatore univoco per collegare "
+"la dimensione calcolata ai grafici. Viene anche utilizzato come alias "
+"nella query SQL."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"This field is used as a unique identifier to attach the metric to charts. It "
-"is also used as the alias in the SQL query."
+"This field is used as a unique identifier to attach the metric to charts."
+" It is also used as the alias in the SQL query."
 msgstr ""
-"Questo campo viene utilizzato come identificatore univoco per associare la "
-"metrica ai grafici. Viene utilizzato anche come alias nella query SQL."
+"Questo campo viene utilizzato come identificatore univoco per associare "
+"la metrica ai grafici. Viene utilizzato anche come alias nella query SQL."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, uk]
@@ -20767,32 +20924,32 @@ msgstr "Questa cartella supporta solo metriche"
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"This functionality is disabled in your environment for security reasons."
+msgid "This functionality is disabled in your environment for security reasons."
 msgstr ""
-"Questa funzionalità è disabilitata nel tuo ambiente per motivi di sicurezza."
+"Questa funzionalità è disabilitata nel tuo ambiente per motivi di "
+"sicurezza."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This is a default columns folder. Its name cannot be changed or removed. It "
-"can stay empty but will only accept column items."
+"This is a default columns folder. Its name cannot be changed or removed. "
+"It can stay empty but will only accept column items."
 msgstr ""
-"Questa è la cartella predefinita per le colonne. Il suo nome non può essere "
-"modificato o rimosso. Può rimanere vuota ma accetterà solo elementi di tipo "
-"colonna."
+"Questa è la cartella predefinita per le colonne. Il suo nome non può "
+"essere modificato o rimosso. Può rimanere vuota ma accetterà solo "
+"elementi di tipo colonna."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This is a default metrics folder. Its name cannot be changed or removed. It "
-"can stay empty but will only accept metric items."
+"This is a default metrics folder. Its name cannot be changed or removed. "
+"It can stay empty but will only accept metric items."
 msgstr ""
-"Questa è la cartella predefinita per le metriche. Il suo nome non può essere "
-"modificato o rimosso. Può rimanere vuota ma accetterà solo elementi di tipo "
-"metrica."
+"Questa è la cartella predefinita per le metriche. Il suo nome non può "
+"essere modificato o rimosso. Può rimanere vuota ma accetterà solo "
+"elementi di tipo metrica."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -20811,17 +20968,18 @@ msgstr "Questo è un messaggio di errore personalizzato per b"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"This is the condition that will be added to the WHERE clause. For example, "
-"to only return rows for a particular client, you might define a regular "
-"filter with the clause `client_id = 9`. To display no rows unless a user "
-"belongs to a RLS filter role, a base filter can be created with the clause "
-"`1 = 0` (always false)."
+"This is the condition that will be added to the WHERE clause. For "
+"example, to only return rows for a particular client, you might define a "
+"regular filter with the clause `client_id = 9`. To display no rows unless"
+" a user belongs to a RLS filter role, a base filter can be created with "
+"the clause `1 = 0` (always false)."
 msgstr ""
-"Questa è la condizione che verrà aggiunta alla clausola WHERE. Ad esempio, "
-"per restituire solo le righe di un determinato cliente, è possibile definire "
-"un filtro normale con la clausola `client_id = 9`. Per non visualizzare "
-"alcuna riga a meno che un utente non appartenga a un ruolo di filtro RLS, è "
-"possibile creare un filtro base con la clausola `1 = 0` (sempre falso)."
+"Questa è la condizione che verrà aggiunta alla clausola WHERE. Ad "
+"esempio, per restituire solo le righe di un determinato cliente, è "
+"possibile definire un filtro normale con la clausola `client_id = 9`. Per"
+" non visualizzare alcuna riga a meno che un utente non appartenga a un "
+"ruolo di filtro RLS, è possibile creare un filtro base con la clausola `1"
+" = 0` (sempre falso)."
 
 msgid "This is the default dark theme"
 msgstr "Questo è il tema scuro predefinito"
@@ -20841,22 +20999,23 @@ msgstr "Questo è il tema chiaro predefinito"
 #, fuzzy
 msgid "This is the only time you will see this key. Store it securely."
 msgstr ""
-"Questa è l'unica volta che vedrai questa chiave. Conservala in modo sicuro."
+"Questa è l'unica volta che vedrai questa chiave. Conservala in modo "
+"sicuro."
 
 msgid ""
-"This json object describes the positioning of the widgets in the dashboard. "
-"It is dynamically generated when adjusting the widgets size and positions by "
-"using drag & drop in the dashboard view"
+"This json object describes the positioning of the widgets in the "
+"dashboard. It is dynamically generated when adjusting the widgets size "
+"and positions by using drag & drop in the dashboard view"
 msgstr ""
 "L'oggetto JSON descrive la posizione dei vari widget nella dashboard. È "
-"generato automaticamente nel momento in cui se ne cambia la posizione e la "
-"dimensione usando la funzione di drag & drop nella vista della dashboard. "
+"generato automaticamente nel momento in cui se ne cambia la posizione e "
+"la dimensione usando la funzione di drag & drop nella vista della "
+"dashboard. "
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
 #, fuzzy
 msgid "This link cannot be followed because its address is unsafe."
-msgstr ""
-"Impossibile seguire questo collegamento perché l'indirizzo non è sicuro."
+msgstr "Impossibile seguire questo collegamento perché l'indirizzo non è sicuro."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -20865,8 +21024,8 @@ msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
-"Questo collegamento ti porterà a un sito web esterno. Non possiamo garantire "
-"la sicurezza delle destinazioni esterne."
+"Questo collegamento ti porterà a un sito web esterno. Non possiamo "
+"garantire la sicurezza delle destinazioni esterne."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20879,10 +21038,10 @@ msgstr "Questo componente markdown contiene un errore."
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"This markdown component has an error. Please revert your recent changes."
+msgid "This markdown component has an error. Please revert your recent changes."
 msgstr ""
-"Questo componente markdown contiene un errore. Annulla le modifiche recenti."
+"Questo componente markdown contiene un errore. Annulla le modifiche "
+"recenti."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -20923,14 +21082,16 @@ msgstr "Questa opzione è stata disabilitata dall'amministratore."
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This page is intended to be embedded in an iframe, but it looks like that is "
-"not the case."
+"This page is intended to be embedded in an iframe, but it looks like that"
+" is not the case."
 msgstr ""
-"Questa pagina è destinata a essere incorporata in un iframe, ma sembra che "
-"non sia così."
+"Questa pagina è destinata a essere incorporata in un iframe, ma sembra "
+"che non sia così."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "This password is too common; please choose a less guessable one."
-msgstr ""
+msgstr "Questa password è troppo comune; scegline una più difficile da indovinare."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -20965,13 +21126,13 @@ msgstr "Questa sezione contiene errori di validazione"
 # uk]
 #, fuzzy
 msgid ""
-"This session has encountered an interruption, and some controls may not work "
-"as intended. If you are the developer of this app, please check that the "
-"guest token is being generated correctly."
+"This session has encountered an interruption, and some controls may not "
+"work as intended. If you are the developer of this app, please check that"
+" the guest token is being generated correctly."
 msgstr ""
-"Questa sessione ha subito un'interruzione e alcuni controlli potrebbero non "
-"funzionare come previsto. Se sei lo sviluppatore di questa app, verifica che "
-"il token ospite venga generato correttamente."
+"Questa sessione ha subito un'interruzione e alcuni controlli potrebbero "
+"non funzionare come previsto. Se sei lo sviluppatore di questa app, "
+"verifica che il token ospite venga generato correttamente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -20985,11 +21146,11 @@ msgstr "Questa tabella ha già un dataset"
 # zh_TW]
 #, fuzzy
 msgid ""
-"This table already has a dataset associated with it. You can only associate "
-"one dataset with a table.\n"
+"This table already has a dataset associated with it. You can only "
+"associate one dataset with a table.\n"
 msgstr ""
-"Questa tabella ha già un dataset associato. È possibile associare un solo "
-"dataset a una tabella.\n"
+"Questa tabella ha già un dataset associato. È possibile associare un solo"
+" dataset a una tabella.\n"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -21042,14 +21203,14 @@ msgstr "Questo interromperà (arresterà) il task per tutti i %s iscritti."
 # es, fa, fr, ja, lv, mi, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"This will be applied to the whole table. Arrows (↑ and ↓) will be added to "
-"main columns for increase and decrease. Basic conditional formatting can be "
-"overwritten by conditional formatting below."
+"This will be applied to the whole table. Arrows (↑ and ↓) will be added "
+"to main columns for increase and decrease. Basic conditional formatting "
+"can be overwritten by conditional formatting below."
 msgstr ""
-"Verrà applicato all'intera tabella. Le frecce (↑ e ↓) verranno aggiunte alle "
-"colonne principali per indicare aumento e diminuzione. La formattazione "
-"condizionale di base può essere sovrascritta dalla formattazione "
-"condizionale sottostante."
+"Verrà applicato all'intera tabella. Le frecce (↑ e ↓) verranno aggiunte "
+"alle colonne principali per indicare aumento e diminuzione. La "
+"formattazione condizionale di base può essere sovrascritta dalla "
+"formattazione condizionale sottostante."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -21058,8 +21219,7 @@ msgid "This will cancel the task."
 msgstr "Questo annullerà il task."
 
 msgid "This will remove your current embed configuration."
-msgstr ""
-"In questo modo verrà rimossa la configurazione di incorporamento corrente."
+msgstr "In questo modo verrà rimossa la configurazione di incorporamento corrente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
@@ -21352,8 +21512,8 @@ msgid ""
 "Timeout configured (%s seconds) but no abort handler defined. Task will "
 "continue running past the timeout."
 msgstr ""
-"Timeout configurato (%s secondi) ma nessun gestore di interruzione definito. "
-"L'attività continuerà a essere eseguita oltre il timeout."
+"Timeout configurato (%s secondi) ma nessun gestore di interruzione "
+"definito. L'attività continuerà a essere eseguita oltre il timeout."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -21397,24 +21557,25 @@ msgstr "Titolo o Slug"
 #, fuzzy
 msgid ""
 "To begin using your Google Sheets, you need to create a database first. "
-"Databases are used as a way to identify your data so that it can be queried "
-"and visualized. This database will hold all of your individual Google Sheets "
-"you choose to connect here."
+"Databases are used as a way to identify your data so that it can be "
+"queried and visualized. This database will hold all of your individual "
+"Google Sheets you choose to connect here."
 msgstr ""
 "Per iniziare a utilizzare i tuoi Google Sheets, devi prima creare un "
-"database. I database vengono utilizzati come metodo per identificare i tuoi "
-"dati in modo che possano essere interrogati e visualizzati. Questo database "
-"conterrà tutti i singoli Google Sheets che sceglierai di collegare qui."
+"database. I database vengono utilizzati come metodo per identificare i "
+"tuoi dati in modo che possano essere interrogati e visualizzati. Questo "
+"database conterrà tutti i singoli Google Sheets che sceglierai di "
+"collegare qui."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"To enable multiple column sorting, hold down the ⇧ Shift key while clicking "
-"the column header."
+"To enable multiple column sorting, hold down the ⇧ Shift key while "
+"clicking the column header."
 msgstr ""
-"Per abilitare l'ordinamento per più colonne, tieni premuto il tasto ⇧ Shift "
-"mentre fai clic sull'intestazione della colonna."
+"Per abilitare l'ordinamento per più colonne, tieni premuto il tasto ⇧ "
+"Shift mentre fai clic sull'intestazione della colonna."
 
 msgid "To filter on a metric, use Custom SQL tab."
 msgstr "Per filtrare una metrica, utilizzare una scheda SQL Personalizzato"
@@ -21428,17 +21589,23 @@ msgstr "ottenere una URL leggibile per la tua dashboard"
 msgid "Token Request URI"
 msgstr "URI Richiesta Token"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
-"Too many sub-slices requested. The maximum allowed is %(max)s, but %(count)s "
-"were requested."
+"Too many sub-slices requested. The maximum allowed is %(max)s, but "
+"%(count)s were requested."
 msgstr ""
+"Sono stati richiesti troppi sotto-grafici. Il massimo consentito è "
+"%(max)s, ma ne sono stati richiesti %(count)s."
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
 "Too many time comparisons requested. The maximum allowed is %(max)s, but "
 "%(count)s were requested."
 msgstr ""
+"Sono stati richiesti troppi confronti temporali. Il massimo consentito è "
+"%(max)s, ma ne sono stati richiesti %(count)s."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, uk]
@@ -21609,8 +21776,8 @@ msgstr "Tronca Asse X"
 # de, es, fr, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Truncate X Axis. Can be overridden by specifying a min or max bound. Only "
-"applicable for numerical X axis."
+"Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
+" applicable for numerical X axis."
 msgstr ""
 "Tronca l'asse X. Può essere ignorato specificando un limite minimo o "
 "massimo. Applicabile solo per l'asse X numerico."
@@ -21624,7 +21791,8 @@ msgstr "Tronca Asse Y"
 #, fuzzy
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
 msgstr ""
-"Tronca l'asse Y. Può essere ignorato specificando un limite minimo o massimo."
+"Tronca l'asse Y. Può essere ignorato specificando un limite minimo o "
+"massimo."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -21637,18 +21805,16 @@ msgstr "Tronca le celle lunghe alla \"larghezza minima\" impostata sopra"
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"Truncates the specified date to the accuracy specified by the date unit."
-msgstr ""
-"Tronca la data specificata alla precisione specificata dall'unità di data."
+msgid "Truncates the specified date to the accuracy specified by the date unit."
+msgstr "Tronca la data specificata alla precisione specificata dall'unità di data."
 
 msgid "Trust this URL and don't ask again"
 msgstr "Considera questo URL affidabile e non chiedere di nuovo"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
-"Prova ad applicare filtri diversi o ad assicurarti che la tua sorgente dati "
-"disponga di dati"
+"Prova ad applicare filtri diversi o ad assicurarti che la tua sorgente "
+"dati disponga di dati"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -21771,22 +21937,23 @@ msgstr "Impossibile connettersi al database \"%(database)s\"."
 # uk]
 #, fuzzy
 msgid ""
-"Unable to connect. Verify that the following roles are set on the service "
-"account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", \"BigQuery "
-"Job User\" and the following permissions are set "
+"Unable to connect. Verify that the following roles are set on the service"
+" account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", "
+"\"BigQuery Job User\" and the following permissions are set "
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
 "Impossibile connettersi. Verifica che i seguenti ruoli siano impostati "
 "sull'account di servizio: \"BigQuery Data Viewer\", \"BigQuery Metadata "
-"Viewer\", \"BigQuery Job User\" e che i seguenti permessi siano impostati: "
-"\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
+"Viewer\", \"BigQuery Job User\" e che i seguenti permessi siano "
+"impostati: \"bigquery.readsessions.create\", "
+"\"bigquery.readsessions.getData\""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, fuzzy
 msgid ""
-"Unable to connect. Verify that the following roles are set on the service "
-"account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
+"Unable to connect. Verify that the following roles are set on the service"
+" account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
 "Impossibile connettersi. Verifica che i seguenti ruoli siano impostati "
@@ -21803,9 +21970,9 @@ msgid ""
 "Unable to create report: User email address is required but not found. "
 "Please ensure your user profile has a valid email address."
 msgstr ""
-"Impossibile creare il report: l'indirizzo email dell'utente è obbligatorio "
-"ma non è stato trovato. Assicurati che il tuo profilo utente abbia un "
-"indirizzo email valido."
+"Impossibile creare il report: l'indirizzo email dell'utente è "
+"obbligatorio ma non è stato trovato. Assicurati che il tuo profilo utente"
+" abbia un indirizzo email valido."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -21826,8 +21993,8 @@ msgstr "Impossibile codificare il valore"
 #, fuzzy
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
-"Impossibile recuperare le viste semantiche. Controlla la configurazione del "
-"livello."
+"Impossibile recuperare le viste semantiche. Controlla la configurazione "
+"del livello."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -21858,8 +22025,8 @@ msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
 msgstr ""
-"Impossibile caricare le colonne per la tabella selezionata. Seleziona una "
-"tabella diversa."
+"Impossibile caricare le colonne per la tabella selezionata. Seleziona una"
+" tabella diversa."
 
 msgid "Unable to load dashboard"
 msgstr "Impossibile caricare dashboard"
@@ -21869,34 +22036,35 @@ msgstr "Impossibile caricare dashboard"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Unable to migrate query editor state to backend. Superset will retry later. "
-"Please contact your administrator if this problem persists."
+"Unable to migrate query editor state to backend. Superset will retry "
+"later. Please contact your administrator if this problem persists."
 msgstr ""
 "Impossibile migrare lo stato dell'editor di query nel backend. Superset "
-"riproverà più tardi. Contatta il tuo amministratore se il problema persiste."
+"riproverà più tardi. Contatta il tuo amministratore se il problema "
+"persiste."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Unable to migrate query state to backend. Superset will retry later. Please "
-"contact your administrator if this problem persists."
-msgstr ""
-"Impossibile migrare lo stato della query nel backend. Superset riproverà più "
-"tardi. Contatta il tuo amministratore se il problema persiste."
-
-# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
-# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
-# uk, zh, zh_TW]
-#, fuzzy
-msgid ""
-"Unable to migrate table schema state to backend. Superset will retry later. "
+"Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
 msgstr ""
+"Impossibile migrare lo stato della query nel backend. Superset riproverà "
+"più tardi. Contatta il tuo amministratore se il problema persiste."
+
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
+# de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
+# uk, zh, zh_TW]
+#, fuzzy
+msgid ""
+"Unable to migrate table schema state to backend. Superset will retry "
+"later. Please contact your administrator if this problem persists."
+msgstr ""
 "Impossibile migrare lo stato dello schema della tabella nel backend. "
-"Superset riproverà più tardi. Contatta il tuo amministratore se il problema "
-"persiste."
+"Superset riproverà più tardi. Contatta il tuo amministratore se il "
+"problema persiste."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fa, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -21967,8 +22135,7 @@ msgstr "Errore imprevisto"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Unexpected error occurred, please check your logs for details"
-msgstr ""
-"Si è verificato un errore imprevisto, controlla i tuoi log per i dettagli"
+msgstr "Si è verificato un errore imprevisto, controlla i tuoi log per i dettagli"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh, zh_TW]
@@ -22255,8 +22422,9 @@ msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
-"Usa la sintassi Handlebars per creare tooltip personalizzati. Le variabili "
-"disponibili si basano sulla selezione del contenuto del tooltip sopra."
+"Usa la sintassi Handlebars per creare tooltip personalizzati. Le "
+"variabili disponibili si basano sulla selezione del contenuto del tooltip"
+" sopra."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22302,8 +22470,8 @@ msgid ""
 msgstr ""
 "Usa un altro grafico esistente come sorgente per annotazioni e "
 "sovrapposizioni.\n"
-"          Il tuo grafico deve essere uno di questi tipi di visualizzazione: "
-"[%s]"
+"          Il tuo grafico deve essere uno di questi tipi di "
+"visualizzazione: [%s]"
 
 msgid "Use automatic color"
 msgstr "Colore automatico"
@@ -22318,8 +22486,8 @@ msgstr "condividi query"
 #, fuzzy
 msgid "Use date formatting even when metric value is not a timestamp"
 msgstr ""
-"Usa la formattazione della data anche quando il valore della metrica non è "
-"un timestamp"
+"Usa la formattazione della data anche quando il valore della metrica non "
+"è un timestamp"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, tr, uk]
@@ -22376,8 +22544,8 @@ msgstr "Usa questo per definire un colore statico per tutti i cerchi"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Used internally to identify the plugin. Should be set to the package name "
-"from the pluginʼs package.json"
+"Used internally to identify the plugin. Should be set to the package name"
+" from the pluginʼs package.json"
 msgstr ""
 "Usato internamente per identificare il plugin. Deve essere impostato sul "
 "nome del pacchetto dal package.json del plugin"
@@ -22388,15 +22556,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Used to summarize a set of data by grouping together multiple statistics "
-"along two axes. Examples: Sales numbers by region and month, tasks by status "
-"and assignee, active users by age and location. Not the most visually "
-"stunning visualization, but highly informative and versatile."
+"along two axes. Examples: Sales numbers by region and month, tasks by "
+"status and assignee, active users by age and location. Not the most "
+"visually stunning visualization, but highly informative and versatile."
 msgstr ""
-"Utilizzato per riepilogare un insieme di dati raggruppando più statistiche "
-"lungo due assi. Esempi: numeri di vendita per regione e mese, attività per "
-"stato e assegnatario, utenti attivi per età e posizione. Non è la "
-"visualizzazione più spettacolare dal punto di vista visivo, ma è molto "
-"informativa e versatile."
+"Utilizzato per riepilogare un insieme di dati raggruppando più "
+"statistiche lungo due assi. Esempi: numeri di vendita per regione e mese,"
+" attività per stato e assegnatario, utenti attivi per età e posizione. "
+"Non è la visualizzazione più spettacolare dal punto di vista visivo, ma è"
+" molto informativa e versatile."
 
 msgid "User"
 msgstr "Utente"
@@ -22418,15 +22586,16 @@ msgstr "Info utente"
 #, fuzzy
 msgid "User must select a value before applying the chart customization"
 msgstr ""
-"L'utente deve selezionare un valore prima di applicare la personalizzazione "
-"del grafico"
+"L'utente deve selezionare un valore prima di applicare la "
+"personalizzazione del grafico"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid "User must select a value before applying the customization"
 msgstr ""
-"L'utente deve selezionare un valore prima di applicare la personalizzazione"
+"L'utente deve selezionare un valore prima di applicare la "
+"personalizzazione"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
@@ -22458,16 +22627,16 @@ msgstr "Utenti"
 #, fuzzy
 msgid "Users are not allowed to set a search path for security reasons."
 msgstr ""
-"Per motivi di sicurezza, agli utenti non è consentito impostare un percorso "
-"di ricerca."
+"Per motivi di sicurezza, agli utenti non è consentito impostare un "
+"percorso di ricerca."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk, zh,
 # zh_TW]
 #, fuzzy
 msgid ""
-"Uses Gaussian Kernel Density Estimation to visualize spatial distribution of "
-"data"
+"Uses Gaussian Kernel Density Estimation to visualize spatial distribution"
+" of data"
 msgstr ""
 "Utilizza la stima della densità del kernel gaussiano per visualizzare la "
 "distribuzione spaziale dei dati"
@@ -22477,13 +22646,13 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Uses a gauge to showcase progress of a metric towards a target. The position "
-"of the dial represents the progress and the terminal value in the gauge "
-"represents the target value."
+"Uses a gauge to showcase progress of a metric towards a target. The "
+"position of the dial represents the progress and the terminal value in "
+"the gauge represents the target value."
 msgstr ""
-"Utilizza un indicatore per mostrare l'avanzamento di una metrica verso un "
-"obiettivo. La posizione del quadrante rappresenta il progresso e il valore "
-"finale nell'indicatore rappresenta il valore obiettivo."
+"Utilizza un indicatore per mostrare l'avanzamento di una metrica verso un"
+" obiettivo. La posizione del quadrante rappresenta il progresso e il "
+"valore finale nell'indicatore rappresenta il valore obiettivo."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22491,14 +22660,14 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Uses circles to visualize the flow of data through different stages of a "
-"system. Hover over individual paths in the visualization to understand the "
-"stages a value took. Useful for multi-stage, multi-group visualizing funnels "
-"and pipelines."
+"system. Hover over individual paths in the visualization to understand "
+"the stages a value took. Useful for multi-stage, multi-group visualizing "
+"funnels and pipelines."
 msgstr ""
 "Utilizza cerchi per visualizzare il flusso di dati attraverso le diverse "
 "fasi di un sistema. Passa il mouse sui singoli percorsi nella "
-"visualizzazione per comprendere le fasi attraversate da un valore. Utile per "
-"la visualizzazione di imbuti e pipeline a più fasi e gruppi."
+"visualizzazione per comprendere le fasi attraversate da un valore. Utile "
+"per la visualizzazione di imbuti e pipeline a più fasi e gruppi."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -22598,22 +22767,21 @@ msgstr "Valori dipendenti su"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, fr,
 # ja, lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
-msgid ""
-"Values less than this percentage will be grouped into the Other category."
+msgid "Values less than this percentage will be grouped into the Other category."
 msgstr ""
-"I valori inferiori a questa percentuale verranno raggruppati nella categoria "
-"Altro."
+"I valori inferiori a questa percentuale verranno raggruppati nella "
+"categoria Altro."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"Values selected in other filters will affect the filter options to only show "
-"relevant values"
+"Values selected in other filters will affect the filter options to only "
+"show relevant values"
 msgstr ""
-"I valori selezionati in altri filtri influenzeranno le opzioni del filtro "
-"per mostrare solo i valori rilevanti"
+"I valori selezionati in altri filtri influenzeranno le opzioni del filtro"
+" per mostrare solo i valori rilevanti"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22676,13 +22844,14 @@ msgid "Viewers"
 msgstr "Visualizzatori"
 
 msgid ""
-"Viewers is a list of subjects who can view the dashboard. If no viewers are "
-"defined, the dashboard is accessible to all users with appropriate "
+"Viewers is a list of subjects who can view the dashboard. If no viewers "
+"are defined, the dashboard is accessible to all users with appropriate "
 "datasource permissions."
 msgstr ""
 "I visualizzatori sono un elenco di soggetti che possono visualizzare la "
-"dashboard. Se non sono definiti visualizzatori, la dashboard è accessibile a "
-"tutti gli utenti con autorizzazioni appropriate sulla fonte dati."
+"dashboard. Se non sono definiti visualizzatori, la dashboard è "
+"accessibile a tutti gli utenti con autorizzazioni appropriate sulla fonte"
+" dati."
 
 #, fuzzy
 msgid "Viewport"
@@ -22734,56 +22903,58 @@ msgstr "Tipo di Visualizzazione"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Visualize a parallel set of metrics across multiple groups. Each group is "
-"visualized using its own line of points and each metric is represented as an "
-"edge in the chart."
+"Visualize a parallel set of metrics across multiple groups. Each group is"
+" visualized using its own line of points and each metric is represented "
+"as an edge in the chart."
 msgstr ""
-"Visualizza un insieme parallelo di metriche su più gruppi. Ogni gruppo viene "
-"visualizzato con la propria linea di punti e ogni metrica è rappresentata "
-"come un arco nel grafico."
+"Visualizza un insieme parallelo di metriche su più gruppi. Ogni gruppo "
+"viene visualizzato con la propria linea di punti e ogni metrica è "
+"rappresentata come un arco nel grafico."
 
 msgid ""
 "Visualize a related metric across pairs of groups. Heatmaps excel at "
-"showcasing the correlation or strength between two groups. Color is used to "
-"emphasize the strength of the link between each pair of groups."
+"showcasing the correlation or strength between two groups. Color is used "
+"to emphasize the strength of the link between each pair of groups."
 msgstr ""
-"Visualizza una metrica correlata tra coppie di gruppi. Le mappe di intensità "
-"eccellono nel mostrare la correlazione o la forza tra due gruppi. Il colore "
-"è usato per enfatizzare la forza del legame tra ogni coppia di gruppi."
+"Visualizza una metrica correlata tra coppie di gruppi. Le mappe di "
+"intensità eccellono nel mostrare la correlazione o la forza tra due "
+"gruppi. Il colore è usato per enfatizzare la forza del legame tra ogni "
+"coppia di gruppi."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"Visualize geospatial data like 3D buildings, landscapes, or objects in grid "
-"view."
+"Visualize geospatial data like 3D buildings, landscapes, or objects in "
+"grid view."
 msgstr ""
-"Visualizza dati geospaziali come edifici 3D, paesaggi o oggetti in vista a "
-"griglia."
+"Visualizza dati geospaziali come edifici 3D, paesaggi o oggetti in vista "
+"a griglia."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Visualize multiple levels of hierarchy using a familiar tree-like structure."
+"Visualize multiple levels of hierarchy using a familiar tree-like "
+"structure."
 msgstr ""
-"Visualizza più livelli di gerarchia utilizzando una familiare struttura ad "
-"albero."
+"Visualizza più livelli di gerarchia utilizzando una familiare struttura "
+"ad albero."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk]
 #, fuzzy
 msgid ""
-"Visualize two different series using the same x-axis. Note that both series "
-"can be visualized with a different chart type (e.g. 1 using bars and 1 using "
-"a line)."
+"Visualize two different series using the same x-axis. Note that both "
+"series can be visualized with a different chart type (e.g. 1 using bars "
+"and 1 using a line)."
 msgstr ""
 "Visualizza due serie diverse utilizzando lo stesso asse x. Si noti che "
-"entrambe le serie possono essere visualizzate con un tipo di grafico diverso "
-"(ad es. una con barre e una con una linea)."
+"entrambe le serie possono essere visualizzate con un tipo di grafico "
+"diverso (ad es. una con barre e una con una linea)."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22791,12 +22962,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Visualizes a metric across three dimensions of data in a single chart (X "
-"axis, Y axis, and bubble size). Bubbles from the same group can be showcased "
-"using bubble color."
+"axis, Y axis, and bubble size). Bubbles from the same group can be "
+"showcased using bubble color."
 msgstr ""
-"Visualizza una metrica su tre dimensioni di dati in un unico grafico (asse "
-"X, asse Y e dimensione della bolla). Le bolle dello stesso gruppo possono "
-"essere mostrate usando il colore della bolla."
+"Visualizza una metrica su tre dimensioni di dati in un unico grafico "
+"(asse X, asse Y e dimensione della bolla). Le bolle dello stesso gruppo "
+"possono essere mostrate usando il colore della bolla."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22810,26 +22981,26 @@ msgstr "Visualizza su una mappa i punti collegati che formano un percorso."
 # uk]
 #, fuzzy
 msgid ""
-"Visualizes geographic areas from your data as polygons on a Mapbox rendered "
-"map. Polygons can be colored using a metric."
+"Visualizes geographic areas from your data as polygons on a Mapbox "
+"rendered map. Polygons can be colored using a metric."
 msgstr ""
 "Visualizza le aree geografiche dei tuoi dati come poligoni su una mappa "
-"renderizzata da Mapbox. I poligoni possono essere colorati utilizzando una "
-"metrica."
+"renderizzata da Mapbox. I poligoni possono essere colorati utilizzando "
+"una metrica."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Visualizes how a metric has changed over a time using a color scale and a "
-"calendar view. Gray values are used to indicate missing values and the "
+"Visualizes how a metric has changed over a time using a color scale and a"
+" calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
-"Visualizza come una metrica è cambiata nel tempo utilizzando una scala di "
-"colori e una vista calendario. I valori grigi vengono utilizzati per "
-"indicare i valori mancanti e la scala di colori lineare viene utilizzata per "
-"codificare la grandezza del valore di ogni giorno."
+"Visualizza come una metrica è cambiata nel tempo utilizzando una scala di"
+" colori e una vista calendario. I valori grigi vengono utilizzati per "
+"indicare i valori mancanti e la scala di colori lineare viene utilizzata "
+"per codificare la grandezza del valore di ogni giorno."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22841,22 +23012,23 @@ msgid ""
 "subdivision's value is elevated when you hover over the corresponding "
 "geographic boundary."
 msgstr ""
-"Visualizza come una singola metrica varia nelle principali suddivisioni di "
-"un paese (stati, province, ecc.) su una mappa coropletica. Il valore di ogni "
-"suddivisione viene evidenziato quando si passa il mouse sul confine "
-"geografico corrispondente."
+"Visualizza come una singola metrica varia nelle principali suddivisioni "
+"di un paese (stati, province, ecc.) su una mappa coropletica. Il valore "
+"di ogni suddivisione viene evidenziato quando si passa il mouse sul "
+"confine geografico corrispondente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Visualizes many different time-series objects in a single chart. This chart "
-"is being deprecated and we recommend using the Time-series Chart instead."
+"Visualizes many different time-series objects in a single chart. This "
+"chart is being deprecated and we recommend using the Time-series Chart "
+"instead."
 msgstr ""
 "Visualizza molti oggetti di serie temporali diversi in un unico grafico. "
-"Questo grafico è in fase di deprecazione e si consiglia di utilizzare invece "
-"il grafico delle serie temporali."
+"Questo grafico è in fase di deprecazione e si consiglia di utilizzare "
+"invece il grafico delle serie temporali."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22881,9 +23053,11 @@ msgstr "Tipo"
 msgid "WED"
 msgstr "MER"
 
+#. do-not-translate
 msgid "WFS"
 msgstr ""
 
+#. do-not-translate
 msgid "WMS"
 msgstr ""
 
@@ -22934,8 +23108,8 @@ msgstr "Attenzione!"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Warning! Changing the dataset may break the chart if the metadata does not "
-"exist."
+"Warning! Changing the dataset may break the chart if the metadata does "
+"not exist."
 msgstr ""
 "Attenzione! La modifica del dataset potrebbe danneggiare il grafico se i "
 "metadati non esistono."
@@ -22977,7 +23151,8 @@ msgstr "Stiamo elaborando la tua query"
 #, fuzzy, python-format
 msgid "We can't seem to resolve column \"%(column)s\" at line %(location)s."
 msgstr ""
-"Non è possibile risolvere la colonna \"%(column)s\" alla riga %(location)s."
+"Non è possibile risolvere la colonna \"%(column)s\" alla riga "
+"%(location)s."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -22991,7 +23166,8 @@ msgstr "Non è possibile risolvere la colonna \"%(column_name)s\""
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"We can't seem to resolve the column \"%(column_name)s\" at line %(location)s."
+"We can't seem to resolve the column \"%(column_name)s\" at line "
+"%(location)s."
 msgstr ""
 "Non è possibile risolvere la colonna \"%(column_name)s\" alla riga "
 "%(location)s."
@@ -23014,7 +23190,8 @@ msgstr "Impossibile attivare o disattivare questo report."
 # uk]
 #, fuzzy
 msgid ""
-"We were unable to carry over any controls when switching to this new dataset."
+"We were unable to carry over any controls when switching to this new "
+"dataset."
 msgstr ""
 "Non è stato possibile trasferire alcun controllo durante il passaggio a "
 "questo nuovo dataset."
@@ -23024,11 +23201,11 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy, python-format
 msgid ""
-"We were unable to connect to your database named \"%(database)s\". Please "
-"verify your database name and try again."
+"We were unable to connect to your database named \"%(database)s\". Please"
+" verify your database name and try again."
 msgstr ""
-"Impossibile connettersi al database denominato \"%(database)s\". Verifica il "
-"nome del database e riprova."
+"Impossibile connettersi al database denominato \"%(database)s\". Verifica"
+" il nome del database e riprova."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23076,31 +23253,31 @@ msgstr "Peso"
 
 #, python-format
 msgid ""
-"We’re having trouble loading these results. Queries are set to timeout after "
-"%s second."
+"We’re having trouble loading these results. Queries are set to timeout "
+"after %s second."
 msgid_plural ""
-"We’re having trouble loading these results. Queries are set to timeout after "
-"%s seconds."
+"We’re having trouble loading these results. Queries are set to timeout "
+"after %s seconds."
 msgstr[0] ""
-"Stiamo riscontrando problemi nel caricamento di questi risultati. Le query "
-"sono impostate per il timeout dopo %s secondo."
+"Stiamo riscontrando problemi nel caricamento di questi risultati. Le "
+"query sono impostate per il timeout dopo %s secondo."
 msgstr[1] ""
-"Stiamo riscontrando problemi nel caricamento di questi risultati. Le query "
-"sono impostate per il timeout dopo %s secondi."
+"Stiamo riscontrando problemi nel caricamento di questi risultati. Le "
+"query sono impostate per il timeout dopo %s secondi."
 
 #, python-format
 msgid ""
-"We’re having trouble loading this visualization. Queries are set to timeout "
-"after %s second."
+"We’re having trouble loading this visualization. Queries are set to "
+"timeout after %s second."
 msgid_plural ""
-"We’re having trouble loading this visualization. Queries are set to timeout "
-"after %s seconds."
+"We’re having trouble loading this visualization. Queries are set to "
+"timeout after %s seconds."
 msgstr[0] ""
-"Stiamo riscontrando problemi nel caricamento della visualizzazione. Le query "
-"sono impostate per il timeout dopo %s secondo."
+"Stiamo riscontrando problemi nel caricamento della visualizzazione. Le "
+"query sono impostate per il timeout dopo %s secondo."
 msgstr[1] ""
-"Stiamo riscontrando problemi nel caricamento della visualizzazione. Le query "
-"sono impostate per il timeout dopo %s secondi."
+"Stiamo riscontrando problemi nel caricamento della visualizzazione. Le "
+"query sono impostate per il timeout dopo %s secondi."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -23129,11 +23306,11 @@ msgstr "Cosa deve succedere se la tabella esiste già"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"When `Calculation type` is set to \"Percentage change\", the Y Axis Format "
-"is forced to `.1%`"
+"When `Calculation type` is set to \"Percentage change\", the Y Axis "
+"Format is forced to `.1%`"
 msgstr ""
-"Quando il `Tipo di calcolo` è impostato su \"Variazione percentuale\", il "
-"Formato dell'asse Y è forzato a `.1%`"
+"Quando il `Tipo di calcolo` è impostato su \"Variazione percentuale\", il"
+" Formato dell'asse Y è forzato a `.1%`"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23141,8 +23318,8 @@ msgstr ""
 #, fuzzy
 msgid "When a secondary metric is provided, a linear color scale is used."
 msgstr ""
-"Quando viene fornita una metrica secondaria, viene utilizzata una scala di "
-"colori lineare."
+"Quando viene fornita una metrica secondaria, viene utilizzata una scala "
+"di colori lineare."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23158,8 +23335,8 @@ msgid ""
 "When enabled, the axis will display labels for the minimum and maximum "
 "values of your data"
 msgstr ""
-"Se abilitato, l'asse mostrerà le etichette per i valori minimi e massimi dei "
-"tuoi dati"
+"Se abilitato, l'asse mostrerà le etichette per i valori minimi e massimi "
+"dei tuoi dati"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23174,25 +23351,24 @@ msgstr ""
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"When only a primary metric is provided, a categorical color scale is used."
+msgid "When only a primary metric is provided, a categorical color scale is used."
 msgstr ""
-"Quando viene fornita solo una metrica primaria, viene utilizzata una scala "
-"di colori categoriale."
+"Quando viene fornita solo una metrica primaria, viene utilizzata una "
+"scala di colori categoriale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"When specifying SQL, the datasource acts as a view. Superset will use this "
-"statement as a subquery while grouping and filtering on the generated parent "
-"queries.If changes are made to your SQL query, columns in your dataset will "
-"be synced when saving the dataset."
+"When specifying SQL, the datasource acts as a view. Superset will use "
+"this statement as a subquery while grouping and filtering on the "
+"generated parent queries.If changes are made to your SQL query, columns "
+"in your dataset will be synced when saving the dataset."
 msgstr ""
 "Quando si specifica SQL, la sorgente dati funge da vista. Superset "
-"utilizzerà questa istruzione come sottoquery durante il raggruppamento e il "
-"filtraggio delle query padre generate. Se vengono apportate modifiche alla "
-"query SQL, le colonne nel dataset verranno sincronizzate durante il "
+"utilizzerà questa istruzione come sottoquery durante il raggruppamento e "
+"il filtraggio delle query padre generate. Se vengono apportate modifiche "
+"alla query SQL, le colonne nel dataset verranno sincronizzate durante il "
 "salvataggio del dataset."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, cs, de,
@@ -23200,18 +23376,18 @@ msgstr ""
 # zh, zh_TW]
 #, fuzzy
 msgid ""
-"When the secondary temporal columns are filtered, apply the same filter to "
-"the main datetime column."
+"When the secondary temporal columns are filtered, apply the same filter "
+"to the main datetime column."
 msgstr ""
-"Quando le colonne temporali secondarie vengono filtrate, applica lo stesso "
-"filtro alla colonna datetime principale."
+"Quando le colonne temporali secondarie vengono filtrate, applica lo "
+"stesso filtro alla colonna datetime principale."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, es,
 # fa, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"When unchecked, colors from the selected color scheme will be used for time "
-"shifted series"
+"When unchecked, colors from the selected color scheme will be used for "
+"time shifted series"
 msgstr ""
 "Se deselezionato, verranno utilizzati i colori dello schema colori "
 "selezionato per le serie con spostamento temporale"
@@ -23221,18 +23397,19 @@ msgstr ""
 # zh, zh_TW]
 #, fuzzy
 msgid ""
-"When using \"Autocomplete filters\", this can be used to improve performance "
-"of the query fetching the values. Use this option to apply a predicate "
-"(WHERE clause) to the query selecting the distinct values from the table. "
-"Typically the intent would be to limit the scan by applying a relative time "
-"filter on a partitioned or indexed time-related field."
+"When using \"Autocomplete filters\", this can be used to improve "
+"performance of the query fetching the values. Use this option to apply a "
+"predicate (WHERE clause) to the query selecting the distinct values from "
+"the table. Typically the intent would be to limit the scan by applying a "
+"relative time filter on a partitioned or indexed time-related field."
 msgstr ""
 "Quando si utilizzano i \"Filtri di completamento automatico\", questa "
 "opzione può essere usata per migliorare le prestazioni della query che "
 "recupera i valori. Utilizza questa opzione per applicare un predicato "
-"(clausola WHERE) alla query che seleziona i valori distinti dalla tabella. "
-"In genere, l'intento è limitare la scansione applicando un filtro temporale "
-"relativo su un campo temporale partizionato o indicizzato."
+"(clausola WHERE) alla query che seleziona i valori distinti dalla "
+"tabella. In genere, l'intento è limitare la scansione applicando un "
+"filtro temporale relativo su un campo temporale partizionato o "
+"indicizzato."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, ko, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
@@ -23256,8 +23433,8 @@ msgstr ""
 # sr_Latn]
 #, fuzzy
 msgid ""
-"When using this option, default value can't be set. Using this option may "
-"impact the load times for your dashboard."
+"When using this option, default value can't be set. Using this option may"
+" impact the load times for your dashboard."
 msgstr ""
 "Quando si utilizza questa opzione, non è possibile impostare un valore "
 "predefinito. L'utilizzo di questa opzione può influire sui tempi di "
@@ -23267,20 +23444,17 @@ msgstr ""
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
-msgid ""
-"Whether the progress bar overlaps when there are multiple groups of data"
-msgstr ""
-"Se la barra di avanzamento si sovrappone quando ci sono più gruppi di dati"
+msgid "Whether the progress bar overlaps when there are multiple groups of data"
+msgstr "Se la barra di avanzamento si sovrappone quando ci sono più gruppi di dati"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"Whether to align background charts with both positive and negative values at "
-"0"
-msgstr ""
-"Se allineare i grafici di sfondo con valori sia positivi che negativi a 0"
+"Whether to align background charts with both positive and negative values"
+" at 0"
+msgstr "Se allineare i grafici di sfondo con valori sia positivi che negativi a 0"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23288,7 +23462,8 @@ msgstr ""
 #, fuzzy
 msgid "Whether to align positive and negative values in cell bar chart at 0"
 msgstr ""
-"Se allineare i valori positivi e negativi nel grafico a barre della cella a 0"
+"Se allineare i valori positivi e negativi nel grafico a barre della cella"
+" a 0"
 
 msgid "Whether to always show the annotation label"
 msgstr "Se mostrare sempre l'etichetta dell'annotazione"
@@ -23314,22 +23489,24 @@ msgstr ""
 # uk, zh, zh_TW]
 msgid "Whether to colorize numeric values by if they are positive or negative"
 msgstr ""
-"Se colorare i valori numerici in base al fatto che siano positivi o negativi"
+"Se colorare i valori numerici in base al fatto che siano positivi o "
+"negativi"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 msgid ""
-"Whether to colorize numeric values by whether they are positive or negative"
+"Whether to colorize numeric values by whether they are positive or "
+"negative"
 msgstr ""
-"Se colorare i valori numerici in base al fatto che siano positivi o negativi"
+"Se colorare i valori numerici in base al fatto che siano positivi o "
+"negativi"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Whether to display a bar chart background in table columns"
-msgstr ""
-"Se visualizzare uno sfondo a grafico a barre nelle colonne della tabella"
+msgstr "Se visualizzare uno sfondo a grafico a barre nelle colonne della tabella"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23467,8 +23644,7 @@ msgstr "Se includere la percentuale nel tooltip."
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "Whether to include the time granularity as defined in the time section"
-msgstr ""
-"Se includere la granularità temporale come definita nella sezione tempo"
+msgstr "Se includere la granularità temporale come definita nella sezione tempo"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23491,11 +23667,12 @@ msgstr "Se mostrare come grafico Nightingale"
 # es, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"Whether to show extra controls or not. Extra controls include things like "
-"making multiBar charts stacked or side by side."
+"Whether to show extra controls or not. Extra controls include things like"
+" making multiBar charts stacked or side by side."
 msgstr ""
-"Se mostrare o meno i controlli aggiuntivi. I controlli aggiuntivi includono "
-"opzioni come rendere i grafici a più barre impilati o affiancati."
+"Se mostrare o meno i controlli aggiuntivi. I controlli aggiuntivi "
+"includono opzioni come rendere i grafici a più barre impilati o "
+"affiancati."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23545,7 +23722,8 @@ msgstr ""
 
 msgid "Whether to sort tooltip by the selected metric in descending order."
 msgstr ""
-"Se ordinare il tooltip secondo la metrica selezionata in ordine discendente."
+"Se ordinare il tooltip secondo la metrica selezionata in ordine "
+"discendente."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -23717,6 +23895,7 @@ msgstr "Asse X"
 msgid "X-scale interval"
 msgstr "Intervallo scala X"
 
+#. do-not-translate
 msgid "XYZ"
 msgstr ""
 
@@ -23844,8 +24023,9 @@ msgstr "Stai modificando una query dal dataset virtuale "
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"You are importing one or more charts that already exist. Overwriting might "
-"cause you to lose some of your work. Are you sure you want to overwrite?"
+"You are importing one or more charts that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
 msgstr ""
 "Stai importando uno o più grafici che esistono già. La sovrascrittura "
 "potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
@@ -23882,8 +24062,9 @@ msgstr ""
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"You are importing one or more datasets that already exist. Overwriting might "
-"cause you to lose some of your work. Are you sure you want to overwrite?"
+"You are importing one or more datasets that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
 msgstr ""
 "Stai importando uno o più dataset che esistono già. La sovrascrittura "
 "potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
@@ -23894,49 +24075,51 @@ msgstr ""
 # zh_TW]
 #, fuzzy
 msgid ""
-"You are importing one or more saved queries that already exist. Overwriting "
-"might cause you to lose some of your work. Are you sure you want to "
-"overwrite?"
+"You are importing one or more saved queries that already exist. "
+"Overwriting might cause you to lose some of your work. Are you sure you "
+"want to overwrite?"
 msgstr ""
-"Stai importando una o più query salvate che esistono già. La sovrascrittura "
-"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
-"sovrascrivere?"
+"Stai importando una o più query salvate che esistono già. La "
+"sovrascrittura potrebbe causare la perdita di parte del tuo lavoro. Sei "
+"sicuro di voler sovrascrivere?"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"You are importing one or more themes that already exist. Overwriting might "
-"cause you to lose some of your work. Are you sure you want to overwrite?"
+"You are importing one or more themes that already exist. Overwriting "
+"might cause you to lose some of your work. Are you sure you want to "
+"overwrite?"
 msgstr ""
-"Stai importando uno o più temi che esistono già. La sovrascrittura potrebbe "
-"causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
+"Stai importando uno o più temi che esistono già. La sovrascrittura "
+"potrebbe causare la perdita di parte del tuo lavoro. Sei sicuro di voler "
 "sovrascrivere?"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"You are viewing this chart in a dashboard context with labels shared across "
-"multiple charts.\n"
+"You are viewing this chart in a dashboard context with labels shared "
+"across multiple charts.\n"
 "        The color scheme selection is disabled."
 msgstr ""
-"Stai visualizzando questo grafico in un contesto di dashboard con etichette "
-"condivise tra più grafici.\n"
+"Stai visualizzando questo grafico in un contesto di dashboard con "
+"etichette condivise tra più grafici.\n"
 "        La selezione dello schema colori è disabilitata."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, fuzzy
 msgid ""
-"You are viewing this chart in the context of a dashboard that is directly "
-"affecting its colors.\n"
-"        To edit the color scheme, open this chart outside of the dashboard."
-msgstr ""
-"Stai visualizzando questo grafico nel contesto di un dashboard che influenza "
-"direttamente i suoi colori.\n"
-"        Per modificare lo schema colori, apri questo grafico al di fuori del "
+"You are viewing this chart in the context of a dashboard that is directly"
+" affecting its colors.\n"
+"        To edit the color scheme, open this chart outside of the "
 "dashboard."
+msgstr ""
+"Stai visualizzando questo grafico nel contesto di un dashboard che "
+"influenza direttamente i suoi colori.\n"
+"        Per modificare lo schema colori, apri questo grafico al di fuori "
+"del dashboard."
 
 msgid "You can"
 msgstr "È possibile"
@@ -23970,23 +24153,24 @@ msgstr ""
 msgid ""
 "You can choose to display all charts that you have access to or only the "
 "ones you own.\n"
-"              Your filter selection will be saved and remain active until "
-"you choose to change it."
+"              Your filter selection will be saved and remain active until"
+" you choose to change it."
 msgstr ""
 "Puoi scegliere di visualizzare tutti i grafici a cui hai accesso o solo "
 "quelli di tua proprietà.\n"
-"              La selezione del filtro verrà salvata e rimarrà attiva finché "
-"non decidi di cambiarla."
+"              La selezione del filtro verrà salvata e rimarrà attiva "
+"finché non decidi di cambiarla."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"You can create a new chart or use existing ones from the panel on the right"
+"You can create a new chart or use existing ones from the panel on the "
+"right"
 msgstr ""
-"Puoi creare un nuovo grafico o utilizzare quelli esistenti dal pannello a "
-"destra"
+"Puoi creare un nuovo grafico o utilizzare quelli esistenti dal pannello a"
+" destra"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -24012,8 +24196,8 @@ msgid ""
 "You cannot delete the last temporal filter as it's used for time range "
 "filters in dashboards."
 msgstr ""
-"Non puoi eliminare l'ultimo filtro temporale poiché viene utilizzato per i "
-"filtri dell'intervallo di tempo nei dashboard."
+"Non puoi eliminare l'ultimo filtro temporale poiché viene utilizzato per "
+"i filtri dell'intervallo di tempo nei dashboard."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -24021,8 +24205,8 @@ msgstr ""
 #, fuzzy
 msgid "You cannot use 45° tick layout along with the time range filter"
 msgstr ""
-"Non è possibile utilizzare il layout di graduazione a 45° insieme al filtro "
-"dell'intervallo di tempo"
+"Non è possibile utilizzare il layout di graduazione a 45° insieme al "
+"filtro dell'intervallo di tempo"
 
 #, python-format
 msgid "You do not have permission to edit this %s"
@@ -24046,8 +24230,10 @@ msgstr "Non hai i permessi per accedere alla/e sorgente/i dati: %(name)s."
 msgid "You do not have sufficient permissions to edit the chart"
 msgstr "Non si hanno i permessi sufficienti per modificare il grafico"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "You don't have access to one or more of the referenced datasources."
-msgstr ""
+msgstr "Non hai accesso a una o più delle sorgenti dati a cui si fa riferimento."
 
 msgid "You don't have access to this chart."
 msgstr "Non si ha accesso a questo grafico."
@@ -24123,31 +24309,33 @@ msgstr "Hai delle modifiche non salvate."
 # uk]
 #, fuzzy, python-format
 msgid ""
-"You have used all %(historyLength)s undo slots and will not be able to fully "
-"undo subsequent actions. You may save your current state to reset the "
-"history."
+"You have used all %(historyLength)s undo slots and will not be able to "
+"fully undo subsequent actions. You may save your current state to reset "
+"the history."
 msgstr ""
-"Hai utilizzato tutti i %(historyLength)s slot di annullamento e non sarai in "
-"grado di annullare completamente le azioni successive. Puoi salvare il tuo "
-"stato attuale per reimpostare la cronologia."
+"Hai utilizzato tutti i %(historyLength)s slot di annullamento e non sarai"
+" in grado di annullare completamente le azioni successive. Puoi salvare "
+"il tuo stato attuale per reimpostare la cronologia."
 
 #, python-format
 msgid ""
-"You must be a %s editor in order to edit. Please reach out to a %s editor to "
-"request modifications or edit access."
+"You must be a %s editor in order to edit. Please reach out to a %s editor"
+" to request modifications or edit access."
 msgstr ""
-"Devi essere un editor di %s per poter modificare. Contatta un editor di %s "
-"per richiedere modifiche o accesso in modifica."
+"Devi essere un editor di %s per poter modificare. Contatta un editor di "
+"%s per richiedere modifiche o accesso in modifica."
 
 msgid ""
-"You must be a dataset editor in order to edit. Please reach out to a dataset "
-"editor to request modifications or edit access."
+"You must be a dataset editor in order to edit. Please reach out to a "
+"dataset editor to request modifications or edit access."
 msgstr ""
-"Devi essere un editor del dataset per poter modificare. Contatta un editor "
-"del dataset per richiedere modifiche o accesso in modifica."
+"Devi essere un editor del dataset per poter modificare. Contatta un "
+"editor del dataset per richiedere modifiche o accesso in modifica."
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja, tr]
+#, fuzzy
 msgid "You must change your password before continuing."
-msgstr ""
+msgstr "Devi cambiare la password prima di continuare."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -24163,11 +24351,14 @@ msgstr "Devi scegliere un nome per il nuovo dashboard"
 msgid "You must run the query successfully first"
 msgstr "Devi prima eseguire la query con successo"
 
-#, python-format
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy, python-format
 msgid ""
-"You need access to the following tables: %(tables)s, 'all_database_access' "
-"or 'all_datasource_access' permission"
+"You need access to the following tables: %(tables)s, "
+"'all_database_access' or 'all_datasource_access' permission"
 msgstr ""
+"Hai bisogno dell'accesso alle seguenti tabelle: %(tables)s, del permesso "
+"'all_database_access' o 'all_datasource_access'"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -24180,12 +24371,13 @@ msgstr "Devi"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"You updated the values in the control panel, but the chart was not updated "
-"automatically. Run the query by clicking on the \"Update chart\" button or"
+"You updated the values in the control panel, but the chart was not "
+"updated automatically. Run the query by clicking on the \"Update chart\" "
+"button or"
 msgstr ""
-"Hai aggiornato i valori nel pannello di controllo, ma il grafico non è stato "
-"aggiornato automaticamente. Esegui la query facendo clic sul pulsante "
-"\"Aggiorna grafico\" o"
+"Hai aggiornato i valori nel pannello di controllo, ma il grafico non è "
+"stato aggiornato automaticamente. Esegui la query facendo clic sul "
+"pulsante \"Aggiorna grafico\" o"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -24194,8 +24386,8 @@ msgid ""
 "You'll be removed from this task. It will continue running for %s other "
 "subscriber(s)."
 msgstr ""
-"Verrai rimosso da questa attività. Continuerà a essere eseguita per %s altro/"
-"i abbonato/i."
+"Verrai rimosso da questa attività. Continuerà a essere eseguita per %s "
+"altro/i abbonato/i."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -24246,7 +24438,8 @@ msgstr "Il tuo dashboard è vicino al limite di dimensione."
 #, fuzzy
 msgid "Your dashboard is too large. Please reduce its size before saving it."
 msgstr ""
-"Il tuo dashboard è troppo grande. Riduci le sue dimensioni prima di salvarlo."
+"Il tuo dashboard è troppo grande. Riduci le sue dimensioni prima di "
+"salvarlo."
 
 msgid "Your query could not be saved"
 msgstr "La tua query non può essere salvata"
@@ -24265,8 +24458,8 @@ msgid ""
 "Your query has been scheduled. To see details of your query, navigate to "
 "Saved queries"
 msgstr ""
-"La tua query è stata pianificata. Per visualizzare i dettagli della query, "
-"vai a Query salvate"
+"La tua query è stata pianificata. Per visualizzare i dettagli della "
+"query, vai a Query salvate"
 
 msgid "Your query was not properly saved"
 msgstr "La query non è stata salvata correttamente"
@@ -24280,8 +24473,10 @@ msgstr "La tua query è stata salvata"
 msgid "Your report could not be deleted"
 msgstr "Il report non può essere cancellato"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "Your session has ended. Please sign in again."
-msgstr ""
+msgstr "La tua sessione è terminata. Effettua nuovamente l'accesso."
 
 msgid "Your user information"
 msgstr "Informazioni utenza"
@@ -24329,8 +24524,7 @@ msgstr "[ dashboard senza titolo ]"
 # tr, uk, zh, zh_TW]
 #, fuzzy
 msgid "[Longitude] and [Latitude] columns must be present in [Group By]"
-msgstr ""
-"Le colonne [Longitude] e [Latitude] devono essere presenti in [Group By]"
+msgstr "Le colonne [Longitude] e [Latitude] devono essere presenti in [Group By]"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr, sr_Latn,
@@ -24371,12 +24565,12 @@ msgstr "[desc]"
 #, fuzzy
 msgid ""
 "[optional] this secondary metric is used to define the color as a ratio "
-"against the primary metric. When omitted, the color is categorical and based "
-"on labels"
+"against the primary metric. When omitted, the color is categorical and "
+"based on labels"
 msgstr ""
 "[opzionale] questa metrica secondaria viene utilizzata per definire il "
-"colore come rapporto rispetto alla metrica primaria. Se omessa, il colore è "
-"categorico e basato sulle etichette"
+"colore come rapporto rispetto alla metrica primaria. Se omessa, il colore"
+" è categorico e basato sulle etichette"
 
 msgid "[untitled customization]"
 msgstr "[personalizzazione senza nome]"
@@ -24408,21 +24602,20 @@ msgstr "`confidence_interval` deve essere compreso tra 0 e 1 (esclusi)"
 #, fuzzy
 msgid ""
 "`count` is COUNT(*) if a group by is used. Numerical columns will be "
-"aggregated with the aggregator. Non-numerical columns will be used to label "
-"points. Leave empty to get a count of points in each cluster."
+"aggregated with the aggregator. Non-numerical columns will be used to "
+"label points. Leave empty to get a count of points in each cluster."
 msgstr ""
 "`count` è COUNT(*) se viene utilizzato un raggruppamento. Le colonne "
 "numeriche verranno aggregate con l'aggregatore. Le colonne non numeriche "
-"verranno utilizzate per etichettare i punti. Lascia vuoto per ottenere un "
-"conteggio dei punti in ogni cluster."
+"verranno utilizzate per etichettare i punti. Lascia vuoto per ottenere un"
+" conteggio dei punti in ogni cluster."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
 #, fuzzy
 msgid "`operation` property of post processing object undefined"
-msgstr ""
-"La proprietà `operation` dell'oggetto di post-elaborazione non è definita"
+msgstr "La proprietà `operation` dell'oggetto di post-elaborazione non è definita"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
 #, fuzzy, python-format
@@ -24463,8 +24656,10 @@ msgstr "`row_offset` deve essere maggiore o uguale a 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` deve essere maggiore o uguale a 0"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "`window` must be between 1 and 10000"
-msgstr ""
+msgstr "`window` deve essere compreso tra 1 e 10000"
 
 msgid "a few seconds"
 msgstr "pochi secondi"
@@ -24521,8 +24716,10 @@ msgstr "annotazione"
 msgid "annotation_layer"
 msgstr "livello_annotazione"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "apple"
-msgstr ""
+msgstr "mela"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -24551,8 +24748,10 @@ msgstr "sfondo"
 msgid "background color"
 msgstr "colore sfondo"
 
+# Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
+#, fuzzy
 msgid "banana"
-msgstr ""
+msgstr "banana"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, ja, lv, mi, nl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
@@ -24583,6 +24782,7 @@ msgstr "tra {down} e {up} {name}"
 msgid "bfill"
 msgstr "bfill"
 
+#. do-not-translate
 msgid "bolt"
 msgstr ""
 
@@ -24705,6 +24905,7 @@ msgstr "crea un nuovo grafico"
 msgid "create dataset from SQL query"
 msgstr "crea dataset dalla query SQL"
 
+#. do-not-translate
 msgid "crontab"
 msgstr "crontab"
 
@@ -24806,6 +25007,7 @@ msgstr "deck.gl Arco"
 msgid "deck.gl Contour"
 msgstr "deck.gl Contour"
 
+#. do-not-translate
 msgid "deck.gl Geojson"
 msgstr ""
 
@@ -24885,6 +25087,7 @@ msgstr "dialect+driver://username:password@host:port/database"
 msgid "documentation"
 msgstr "documentazione"
 
+#. do-not-translate
 msgid "dttm"
 msgstr "dttm"
 
@@ -24993,6 +25196,7 @@ msgstr "elementi per pagina"
 msgid "error"
 msgstr "errore"
 
+#. do-not-translate
 msgid "error_message"
 msgstr "error_message"
 
@@ -25141,8 +25345,8 @@ msgid ""
 "is expected to be a Mapbox/OSM URL (eg. mapbox://styles/...) or a tile "
 "server URL (eg. tile://http...)"
 msgstr ""
-"dovrebbe essere un URL Mapbox/OSM (ad es. mapbox://styles/...) o un URL di "
-"server di tile (ad es. tile://http...)"
+"dovrebbe essere un URL Mapbox/OSM (ad es. mapbox://styles/...) o un URL "
+"di server di tile (ad es. tile://http...)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
@@ -25165,23 +25369,23 @@ msgstr "è falso"
 # es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"is linked to %s charts that appear on %s dashboards and users have %s SQL "
-"Lab tabs using this database open. Are you sure you want to continue? "
+"is linked to %s charts that appear on %s dashboards and users have %s SQL"
+" Lab tabs using this database open. Are you sure you want to continue? "
 "Deleting the database will break those objects."
 msgstr ""
-"è collegato a %s grafici che appaiono su %s dashboard e gli utenti hanno %s "
-"schede SQL Lab che utilizzano questo database aperte. Sei sicuro di voler "
-"continuare? L'eliminazione del database danneggerà quegli oggetti."
+"è collegato a %s grafici che appaiono su %s dashboard e gli utenti hanno "
+"%s schede SQL Lab che utilizzano questo database aperte. Sei sicuro di "
+"voler continuare? L'eliminazione del database danneggerà quegli oggetti."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sl, sr, sr_Latn, tr, uk]
 #, fuzzy, python-format
 msgid ""
-"is linked to %s charts that appear on %s dashboards. Are you sure you want "
-"to continue? Deleting the dataset will break those objects."
+"is linked to %s charts that appear on %s dashboards. Are you sure you "
+"want to continue? Deleting the dataset will break those objects."
 msgstr ""
-"è collegato a %s grafici che appaiono su %s dashboard. Sei sicuro di voler "
-"continuare? L'eliminazione del dataset danneggerà quegli oggetti."
+"è collegato a %s grafici che appaiono su %s dashboard. Sei sicuro di "
+"voler continuare? L'eliminazione del dataset danneggerà quegli oggetti."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ca, cs, de,
 # es, fr, ja, lv, mi, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -25342,8 +25546,8 @@ msgstr "nativeFilters[%(idx)s].filterValues deve essere una lista"
 # sr_Latn]
 #, fuzzy, python-format
 msgid ""
-"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on the "
-"dashboard"
+"nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' does not exist on "
+"the dashboard"
 msgstr ""
 "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' non esiste nella "
 "dashboard"
@@ -25352,8 +25556,7 @@ msgstr ""
 # sr_Latn]
 #, fuzzy, python-format
 msgid "nativeFilters[%(idx)s].nativeFilterId must be a non-empty string"
-msgstr ""
-"nativeFilters[%(idx)s].nativeFilterId deve essere una stringa non vuota"
+msgstr "nativeFilters[%(idx)s].nativeFilterId deve essere una stringa non vuota"
 
 msgid "no SQL validator is configured"
 msgstr "non è configurato alcun validatore SQL"
@@ -25423,15 +25626,19 @@ msgstr "soprattutto"
 msgid "p-value precision"
 msgstr "precisione p-value"
 
+#. do-not-translate
 msgid "p1"
 msgstr ""
 
+#. do-not-translate
 msgid "p5"
 msgstr ""
 
+#. do-not-translate
 msgid "p95"
 msgstr ""
 
+#. do-not-translate
 msgid "p99"
 msgstr ""
 
@@ -25443,15 +25650,16 @@ msgstr "in attesa"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"percentiles must be a list or tuple with two numeric values, of which the "
-"first is lower than the second value"
+"percentiles must be a list or tuple with two numeric values, of which the"
+" first is lower than the second value"
 msgstr ""
-"i percentili devono essere una lista o una tupla con due valori numerici, di "
-"cui il primo è inferiore al secondo valore"
+"i percentili devono essere una lista o una tupla con due valori numerici,"
+" di cui il primo è inferiore al secondo valore"
 
 msgid "permalink state not found"
 msgstr "Stato del permalink non trovato"
 
+#. do-not-translate
 msgid "pivoted_xlsx"
 msgstr "pivoted_xlsx"
 
@@ -25537,6 +25745,7 @@ msgstr "in esecuzione"
 msgid "save"
 msgstr "salva"
 
+#. do-not-translate
 msgid "schema1,schema2"
 msgstr ""
 
@@ -25554,13 +25763,15 @@ msgstr "serie"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"series: Treat each series independently; overall: All series use the same "
-"scale; change: Show changes compared to the first data point in each series"
+"series: Treat each series independently; overall: All series use the same"
+" scale; change: Show changes compared to the first data point in each "
+"series"
 msgstr ""
-"serie: Tratta ogni serie indipendentemente; generale: Tutte le serie usano "
-"la stessa scala; variazione: Mostra le variazioni rispetto al primo punto "
-"dati di ogni serie"
+"serie: Tratta ogni serie indipendentemente; generale: Tutte le serie "
+"usano la stessa scala; variazione: Mostra le variazioni rispetto al primo"
+" punto dati di ogni serie"
 
+#. do-not-translate
 msgid "sql"
 msgstr ""
 
@@ -25586,10 +25797,12 @@ msgstr "sfalsato"
 msgid "std"
 msgstr "std"
 
+#. do-not-translate
 #, fuzzy
 msgid "step-after"
 msgstr "Cerca / Filtra"
 
+#. do-not-translate
 msgid "step-before"
 msgstr ""
 
@@ -25621,6 +25834,7 @@ msgstr "successo"
 msgid "sum"
 msgstr "somma"
 
+#. do-not-translate
 msgid "superset.example.com"
 msgstr ""
 
@@ -25695,8 +25909,8 @@ msgstr "aggiornato"
 # uk, zh, zh_TW]
 #, fuzzy
 msgid ""
-"upper percentile must be greater than 0 and less than 100. Must be higher "
-"than lower percentile."
+"upper percentile must be greater than 0 and less than 100. Must be higher"
+" than lower percentile."
 msgstr ""
 "il percentile superiore deve essere maggiore di 0 e minore di 100. Deve "
 "essere superiore al percentile inferiore."
@@ -25780,6 +25994,7 @@ msgstr "y: i valori sono normalizzati all'interno di ogni riga"
 msgid "year"
 msgstr "anno"
 
+#. do-not-translate
 msgid "your-project-1234-a1"
 msgstr ""
 


### PR DESCRIPTION
### SUMMARY

Backfills untranslated (empty `msgstr`) entries in the **Italian (it)** catalog using `scripts/translations/backfill_po.py`, with every other language's translation of the same string as cross-language context.

New entries are marked `#, fuzzy` with a `# Machine-translated via backfill_po.py` attribution for human review. Fuzzy entries **are** served (backend compiles `--use-fuzzy`, frontend uses `po2json --fuzzy`), so the translations reach users on build while remaining reviewable.

Fills new user-facing strings added since the last sweep.

Split out from the combined backfill PR (#42099) because this catalog needed a larger canonical-reformatting pass; the bulk of the diff is normalize re-wrapping, not new content.

### TESTING INSTRUCTIONS

QA before opening: **40 entries filled**, 0 placeholder mismatches, `msgfmt -c` clean, 0 existing translations altered (only empty entries filled + canonical re-wrap).

### ADDITIONAL INFORMATION

- [x] Changes UI (translated strings)
