### PR TITLE
fix(plugin-chart-echarts): clarify Tooltip sort by metric description for stacked charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -279,7 +279,7 @@ const tooltipSortByMetricControl: ControlSetItem = {
     renderTrigger: true,
     default: false,
     description: t(
-      'Whether to sort tooltip by the selected metric in descending order.',
+      'Whether to sort tooltip by the selected metric in descending order. On stacked charts, values are shown in ascending order.',
     ),
     visibility: ({ controls }: ControlPanelsContainerProps) =>
       Boolean(controls?.rich_tooltip?.value),


### PR DESCRIPTION
### SUMMARY

The "Tooltip sort by metric" control (`tooltipSortByMetric`) describes itself as sorting the tooltip "in descending order", but on **stacked** charts the tooltip actually displays in **ascending** order.

Why: `extractTooltipKeys` (`utils/series.ts`) does sort descending (`b - a`), but the Timeseries tooltip formatter (`Timeseries/transformProps.ts`) then runs `rows.reverse()` whenever the chart is stacked — introduced in #23392 so stacked tooltips read top-of-stack first. The reverse runs unconditionally, so it also inverts the sort-by-metric ordering. Non-stacked charts (and the Mixed Chart, whose formatter has no such reverse) display descending as documented.

This PR updates the control's description text in the UI to accurately describe both behaviors:

> Whether to sort tooltip by the selected metric in descending order. On stacked charts, values are shown in ascending order.

No sorting behavior is changed. An alternative would be to skip the `rows.reverse()` when `tooltipSortByMetric` is enabled so the ordering is consistently descending, but that changes rendered behavior for existing users, so this PR just makes the description honest. Happy to follow up with the behavior change if preferred.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — one-line change to the control's info-tooltip text.

### TESTING INSTRUCTIONS

Open a stacked Bar/Area chart, enable Rich tooltip, and hover the "Tooltip sort by metric" checkbox's info icon — the description now notes the ascending order on stacked charts.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
