### PR TITLE
fix(dashboard): make Clear All clear filters that have default values

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -547,7 +547,7 @@ test('Clear All stages filter_select clear without dispatching until Apply', asy
   });
   expect(updateDataMaskSpy).toHaveBeenCalledWith(filterId, {
     id: filterId,
-    filterState: { value: undefined, validateStatus: undefined },
+    filterState: { value: null, validateStatus: undefined },
     extraFormData: {},
   });
   updateDataMaskSpy.mockRestore();
@@ -685,9 +685,92 @@ test('Clear All + Apply only dispatches for filters present in dataMask', async 
   expect(updateDataMaskSpy).toHaveBeenCalledTimes(1);
   expect(updateDataMaskSpy).toHaveBeenCalledWith(idInMask, {
     id: idInMask,
-    filterState: { value: undefined, validateStatus: undefined },
+    filterState: { value: null, validateStatus: undefined },
     extraFormData: {},
   });
+  updateDataMaskSpy.mockRestore();
+});
+
+test('Clear All in horizontal bar does not re-apply default values', async () => {
+  fetchMock.post(
+    'glob:*/api/v1/chart/data',
+    {
+      result: [
+        {
+          data: [{ test_column: 'East' }, { test_column: 'West' }],
+          colnames: ['test_column'],
+          coltypes: [1],
+        },
+      ],
+    },
+    { name: 'horizontal-clear-chart-data' },
+  );
+  const filterId = 'NATIVE_FILTER-horizontal-default';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const filterWithDefault = createFilter({
+    id: filterId,
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'test_column' } }],
+    defaultDataMask: {
+      filterState: { value: ['East'] },
+      extraFormData: {
+        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
+      },
+    },
+    chartsInScope: [18],
+  });
+  const stateHorizontal = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      filterBarOrientation: FilterBarOrientation.Horizontal,
+      metadata: {
+        native_filter_configuration: [filterWithDefault],
+        chart_configuration: {},
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: {
+      [filterId]: createDataMask(filterId, ['East'], {
+        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
+      }),
+    },
+    nativeFilters: {
+      filters: { [filterId]: filterWithDefault },
+      filtersState: {},
+    },
+  };
+
+  render(<FilterBar orientation={FilterBarOrientation.Horizontal} />, {
+    initialState: stateHorizontal,
+    useDnd: true,
+    useRedux: true,
+    useRouter: true,
+  });
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  expect(clearBtn).not.toBeDisabled();
+  await act(async () => {
+    userEvent.click(clearBtn);
+  });
+  // Let the clear-all trigger round-trip through the filter plugin
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  // The staged clear must survive the trigger completing: the default value
+  // must not be re-applied and Apply must stay enabled
+  expect(updateDataMaskSpy).not.toHaveBeenCalled();
+  expect(screen.queryByTitle('East')).not.toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('apply-button'))).not.toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
 
@@ -831,7 +914,7 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
 
   expect(updateDataMaskSpy).toHaveBeenCalledWith(inScopeFilterId, {
     id: inScopeFilterId,
-    filterState: { value: undefined, validateStatus: undefined },
+    filterState: { value: null, validateStatus: undefined },
     extraFormData: {},
   });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -517,22 +517,21 @@ const FilterBar: FC<FiltersBarProps> = ({
       // Only clear in-scope filters
       if (!inScopeFilterIds.has(id)) return;
 
-      // Range filters use [null, null] as the cleared value; others use undefined
-      const clearedValue =
-        filterType === 'filter_range' ? [null, null] : undefined;
+      // Cleared values stage as explicit null ([null, null] for ranges), never
+      // undefined: the select plugin's init effect treats undefined as
+      // "uninitialized" and would re-apply default values once the clear-all
+      // trigger completes.
+      const clearedValue = filterType === 'filter_range' ? [null, null] : null;
       const isRequired = !!filter.controlValues?.enableEmptyFilter;
       if (dataMaskSelected[id]) {
         // Stage the cleared value locally; do NOT dispatch to Redux here.
         // Persistence happens when the user clicks Apply.
         setDataMaskSelected(draft => {
-          if (draft[id].filterState?.value !== undefined) {
-            draft[id].filterState!.value = clearedValue;
-          }
           draft[id].extraFormData = {};
-          if (draft[id].filterState) {
-            draft[id].filterState!.validateStatus = isRequired
-              ? 'error'
-              : undefined;
+          const { filterState } = draft[id];
+          if (filterState) {
+            filterState.value = clearedValue;
+            filterState.validateStatus = isRequired ? 'error' : undefined;
           }
         });
         newClearAllTriggers[id] = true;

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AppSection } from '@superset-ui/core';
+import { AppSection, type ChartProps } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
@@ -441,6 +441,35 @@ describe('RangeFilterPlugin', () => {
           }),
         }),
       );
+    });
+  });
+
+  test('clears a filter still sitting at its default value', () => {
+    const renderWith = (value: [number | null, number | null]) => (
+      <RangeFilterPlugin
+        {...(transformProps({
+          ...rangeProps,
+          filterState: { value },
+        } as unknown as ChartProps) as PluginFilterRangeProps)}
+        setDataMask={setDataMask}
+      />
+    );
+
+    // The filter loads at its default and the user never touches it.
+    const { rerender } = render(renderWith([10, 70]));
+    setDataMask.mockClear();
+
+    // Clear All stages [null, null] for range filters.
+    rerender(renderWith([null, null]));
+
+    expect(setDataMask).toHaveBeenCalledWith({
+      extraFormData: {},
+      filterState: {
+        value: [null, null],
+        label: '',
+        validateStatus: undefined,
+        validateMessage: '',
+      },
     });
   });
 });

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -363,8 +363,14 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
       return;
     }
 
-    // Clear all case
-    if (filterState.value === undefined && !filterState.validateStatus) {
+    // Clear all case. The filter bar stages [null, null] for range filters, so
+    // matching only undefined let a filter still sitting at its default fall
+    // through to the default-restoring branch below.
+    if (
+      (filterState.value === undefined ||
+        isEqualArray(filterState.value, [null, null])) &&
+      !filterState.validateStatus
+    ) {
       setInputValue([null, null]);
       updateDataMaskValue([null, null]);
       return;


### PR DESCRIPTION
### SUMMARY
Clicking "Clear all" did not really clear filters that have a default value configured. The values reappeared right after the click and the Apply button stayed disabled, so there was no way to load the dashboard without those filters.

There turned out to be two independent causes with the same symptom, in two different plugins. Both are fixed here.

**Select filters in the horizontal bar.** `handleClearAll` staged the cleared value as `undefined`, which is the same value the select filter plugin's initialization effect uses to detect an uninitialized filter. The horizontal bar is the only orientation that forwards `clearAllTriggers` into the filter plugins, and consuming the trigger re-runs that initialization effect. Since the staged value was `undefined`, the effect re-applied the configured default (or the first item) and the selection immediately came back, leaving Apply disabled because the selection matched the applied state again. The fix stages an explicit `null` instead, which the plugins already treat as intentionally empty. The vertical bar was not affected.

**Range filters, in both orientations.** The filter bar stages `[null, null]` for a range filter, but the plugin only treated `undefined` as the cleared case. A filter the user had not touched still held its default in local state, so the branch below found the default and the input value equal and wrote the default straight back. The slider and inputs kept their default numbers and Apply stayed disabled, so nothing signalled that the click had been ignored. The fix treats `[null, null]` as cleared alongside `undefined`. A filter the user had already changed took a different branch and behaves the same as before.

This second one is older than the select bug and is not specific to the horizontal bar, but it produces the same user-visible result, so it seemed wrong to fix half the report.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Select filters, horizontal bar.

Before (right after "Clear all": defaults are back and Apply is disabled):

![before](https://files.catbox.moe/jjahp1.png)

After (same click: filters stay cleared and Apply is enabled):

![after](https://files.catbox.moe/mssmdc.png)

For range filters the difference is the same shape: before the fix the slider and both inputs keep the default numbers and Apply stays disabled, after it the bounds clear to the dataset min and max, the inputs empty out, and Apply enables.

### TESTING INSTRUCTIONS
Select filters:

1. Create a dashboard with a chart and three select filters: one with "Filter has default value", one with "Select first filter value by default", and one plain.
2. Set the filter bar orientation to Horizontal and save.
3. Reload the dashboard so the default values populate.
4. Click "Clear all".
5. All three filters should be empty and "Apply" should be enabled; clicking it loads the dashboard without any filters applied.

Range filters:

1. Add a numerical range filter to the dashboard and give it a default range that is narrower than the column's full range.
2. Reload the dashboard and leave the filter alone, so it is still sitting at its default.
3. Click "Clear all".
4. The slider should reset to the column's full range, both inputs should be empty, and "Apply" should be enabled.
5. Repeat with the filter bar in the Vertical orientation, and again after editing the range by hand first. Both should clear.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
