### PR TITLE
feat(ci): install helm-docs directly instead of using whole brew setup (backport #41629)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,19 +28,18 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Enable brew and helm-docs
-        # Add brew to the path - see https://github.com/actions/runner-images/issues/6283
-        run: |
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY" >>"${GITHUB_ENV}"
-          brew install norwoodj/tap/helm-docs
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
+
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
### SUMMARY

Backports #41629 to the `6.1` branch.

The `pre-commit` workflow on `6.1` started failing partway through the day, even though it had been green that same morning and no repo change caused it. Comparing the two `6.1` push runs pinpoints the trigger:

| | passed (earlier) | failed (later) |
|---|---|---|
| GitHub `ubuntu-24.04` runner image | `20260705.232.1` | `20260714.240.1` |
| `Skipping norwoodj/tap ... not trusted` warning | present | present |
| result | `Installing helm-docs`, `Pouring ... bottle` → **success** | `Broken pipe` → **failure** |

**Root cause: a GitHub runner-image upgrade**, not a Homebrew tap-trust change. The `Skipping norwoodj/tap because it is not trusted` warning appears in *both* runs (including the passing one) and is not the cause — brew installed `helm-docs` fine on the older image. On the newer image (`20260714.240.1`), the same `brew install norwoodj/tap/helm-docs` command dies with `Broken pipe` before it can pour the bottle:

```
==> Tapping norwoodj/tap
##[warning]Skipping norwoodj/tap because it is not trusted. Run `brew trust norwoodj/tap` to trust it.
##[error]Broken pipe
```

This broke all pre-commit jobs (`current`/`previous`/`next`) on `6.1` and every PR based on it, before any hook runs. `master` was unaffected by the image bump because #41629 had already replaced the brew step with a direct `go install` — but that fix was never backported to `6.1`.

This change mirrors #41629: it removes the fragile pre-installed-brew dependency and installs `helm-docs` via `go install` instead.

### BEFORE/AFTER

**Before:** `Enable brew and helm-docs` step runs `brew install norwoodj/tap/helm-docs` → fails with `Broken pipe` on the newer runner image.

**After:** `Setup Go` + `Install helm-docs` (`go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2`), independent of the runner's pre-installed brew.

### TESTING INSTRUCTIONS

CI on this PR exercises the change: the `pre-commit` workflow should install `helm-docs` via Go and pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Backport of #41629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)