### PR TITLE
fix(semantic-layers): guard unsupported raw-row actions

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -49,7 +49,7 @@ const waitForRender = (overrides: Record<string, any> = {}) =>
   waitFor(() => setup(overrides));
 
 const SAMPLES_ENDPOINT =
-  'end:/datasource/samples?force=false&datasource_type=table&datasource_id=7&per_page=50&page=1';
+  'glob:*/datasource/samples?force=false&datasource_type=table&datasource_id=7&per_page=50&page=1*';
 
 const DATASET_ENDPOINT = 'glob:*/api/v1/dataset/*';
 
@@ -147,6 +147,7 @@ const fetchWithPaginatedData = () => {
 afterEach(() => {
   fetchMock.clearHistory().removeRoutes();
   supersetGetCache.clear();
+  jest.restoreAllMocks();
 });
 
 test('should render', async () => {
@@ -212,16 +213,35 @@ test('should render the metadata bar', async () => {
 });
 
 test('should render the error', async () => {
-  jest
+  const postSpy = jest
     .spyOn(SupersetClient, 'post')
     .mockRejectedValue(new Error('Something went wrong'));
   await waitForRender();
+  expect(await screen.findByRole('alert')).toBeVisible();
+  expect(screen.getByText('Failed to load drill-to-detail rows')).toBeVisible();
   expect(screen.getByText('Error: Something went wrong')).toBeInTheDocument();
+  expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Copy')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Reload')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Download' }),
+  ).not.toBeInTheDocument();
+  postSpy.mockRestore();
 });
 
 describe('download actions', () => {
-  const renderWithDownloadPermission = () =>
-    render(
+  const renderWithDownloadPermission = () => {
+    jest.spyOn(SupersetClient, 'post').mockResolvedValue({
+      json: {
+        result: {
+          total_count: 3,
+          data: [{ year: 1996, na_sales: 11.27, eu_sales: 8.89 }],
+          colnames: ['year', 'na_sales', 'eu_sales'],
+          coltypes: [0, 0, 0],
+        },
+      },
+    } as never);
+    return render(
       <DrillDetailPane
         initialFilters={[]}
         formData={chart.form_data as unknown as QueryFormData}
@@ -235,6 +255,7 @@ describe('download actions', () => {
         },
       },
     );
+  };
 
   const clickDownloadItem = async (label: string) => {
     await userEvent.click(

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -42,6 +42,7 @@ import BooleanCell from '@superset-ui/core/components/Table/cell-renderers/Boole
 import NullCell from '@superset-ui/core/components/Table/cell-renderers/NullCell';
 import TimeCell from '@superset-ui/core/components/Table/cell-renderers/TimeCell';
 import { EmptyState, Loading } from '@superset-ui/core/components';
+import { Alert } from '@apache-superset/core/components';
 import { getDatasourceSamples } from 'src/components/Chart/chartAction';
 import Table, {
   ColumnsType,
@@ -360,15 +361,19 @@ export default function DrillDetailPane({
 
   let tableContent = null;
   if (responseError) {
-    // Render error if page download failed
     tableContent = (
-      <pre
+      <div
         css={css`
           margin-top: ${theme.sizeUnit * 4}px;
         `}
       >
-        {responseError}
-      </pre>
+        <Alert
+          type="error"
+          showIcon
+          message={t('Failed to load drill-to-detail rows')}
+          description={responseError}
+        />
+      </div>
     );
   } else if (bootstrapping) {
     // Render loading if first page hasn't loaded
@@ -409,8 +414,8 @@ export default function DrillDetailPane({
 
   return (
     <>
-      {!bootstrapping && metadataBarComponent}
-      {!bootstrapping && (
+      {!bootstrapping && !responseError && metadataBarComponent}
+      {!bootstrapping && !responseError && (
         <TableControls
           filters={filters}
           setFilters={setFilters}

--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/index.tsx
@@ -50,6 +50,7 @@ const DISABLED_REASONS = {
   DATABASE: t(
     'Drill to detail is disabled for this database. Change the database settings to enable it.',
   ),
+  DATASOURCE: t('Drill to detail is not available for this datasource type'),
   NO_AGGREGATIONS: t(
     'Drill to detail is disabled because this chart does not group data by dimension value.',
   ),
@@ -116,6 +117,14 @@ export const useDrillDetailMenuItems = ({
       datasources[formData.datasource]?.database?.disable_drill_to_detail,
   );
 
+  const datasourceSupportsDrillToDetail = useSelector<
+    RootState,
+    boolean | undefined
+  >(
+    ({ datasources }) =>
+      datasources[formData.datasource]?.supports_drill_to_detail,
+  );
+
   const openModal = useCallback(
     (filters: BinaryQueryObjectFilterClause[], event: MouseEvent) => {
       onClick(event);
@@ -158,7 +167,10 @@ export const useDrillDetailMenuItems = ({
 
   let drillDisabled;
   let drillByDisabled;
-  if (drillToDetailDisabled) {
+  if (datasourceSupportsDrillToDetail === false) {
+    drillDisabled = DISABLED_REASONS.DATASOURCE;
+    drillByDisabled = DISABLED_REASONS.DATASOURCE;
+  } else if (drillToDetailDisabled) {
     drillDisabled = DISABLED_REASONS.DATABASE;
     drillByDisabled = DISABLED_REASONS.DATABASE;
   } else if (handlesDimensionContextMenu) {

--- a/superset-frontend/src/components/Chart/useDrillDetailMenuItems/useDrillDetailMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/useDrillDetailMenuItems/useDrillDetailMenuItems.test.tsx
@@ -444,3 +444,47 @@ test('context menu renders <NULL> for null dimension values', async () => {
   await expectDrillToDetailByEnabled();
   await expectDrillToDetailByDimension(filterNull);
 });
+
+const buildStateWithUnsupportedDatasource = () => {
+  const baseState = getMockStoreWithNativeFilters().getState();
+  const datasourceKey = defaultFormData.datasource as string;
+  return {
+    ...baseState,
+    datasources: {
+      ...baseState.datasources,
+      [datasourceKey]: {
+        ...baseState.datasources[datasourceKey],
+        supports_drill_to_detail: false,
+      },
+    },
+  };
+};
+
+test('dropdown keeps unsupported drill visible and disabled', async () => {
+  cleanup();
+  render(<MockRenderChart formData={defaultFormData} />, {
+    useRouter: true,
+    useRedux: true,
+    initialState: buildStateWithUnsupportedDatasource(),
+  });
+
+  await expectDrillToDetailDisabled(
+    'Drill to detail is not available for this datasource type',
+  );
+  await expectNoDrillToDetailBy();
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('context menu disables both unsupported detail actions', async () => {
+  cleanup();
+  render(<MockRenderChart formData={defaultFormData} isContextMenu />, {
+    useRouter: true,
+    useRedux: true,
+    initialState: buildStateWithUnsupportedDatasource(),
+  });
+
+  const reason = 'Drill to detail is not available for this datasource type';
+  await expectDrillToDetailDisabled(reason);
+  await expectDrillToDetailByDisabled(reason);
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -232,6 +232,8 @@ export type Datasource = Dataset & {
   // Populated by the dashboard datasets API alongside ``type``; declared here
   // so callers can rely on structural typing instead of casting.
   datasource_type?: DatasourceType;
+  supports_samples?: boolean;
+  supports_drill_to_detail?: boolean;
 };
 export type DatasourcesState = {
   [key: string]: Datasource;

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -244,25 +244,37 @@ export const DataTablesPane = ({
     }
   }, [resultsTabFallback]);
 
+  const showSamplesTab = datasource?.supports_samples !== false;
+
+  useEffect(() => {
+    if (!showSamplesTab && activeTabKey === ResultTypes.Samples) {
+      setActiveTabKey(ResultTypes.Results);
+    }
+  }, [activeTabKey, showSamplesTab]);
+
   const tabItems = [
     ...queryResultsPanes,
-    {
-      key: ResultTypes.Samples,
-      label: t('Samples'),
-      children: (
-        <StyledDiv>
-          <SamplesPane
-            datasource={datasource}
-            queryFormData={queryFormData}
-            queryForce={queryForce}
-            isRequest={isRequest.samples}
-            setForceQuery={setForceQuery}
-            isVisible={ResultTypes.Samples === activeTabKey}
-            canDownload={canDownload}
-          />
-        </StyledDiv>
-      ),
-    },
+    ...(showSamplesTab
+      ? [
+          {
+            key: ResultTypes.Samples,
+            label: t('Samples'),
+            children: (
+              <StyledDiv>
+                <SamplesPane
+                  datasource={datasource}
+                  queryFormData={queryFormData}
+                  queryForce={queryForce}
+                  isRequest={isRequest.samples}
+                  setForceQuery={setForceQuery}
+                  isVisible={ResultTypes.Samples === activeTabKey}
+                  canDownload={canDownload}
+                />
+              </StyledDiv>
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -21,6 +21,7 @@ import { t } from '@apache-superset/core/translation';
 import { ensureIsArray } from '@superset-ui/core';
 import { datasetLabelLower } from 'src/features/semanticLayers/label';
 import { styled } from '@apache-superset/core/theme';
+import { Alert } from '@apache-superset/core/components';
 import { EmptyState, Loading } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
 import { GridTable } from 'src/components/GridTable';
@@ -35,7 +36,7 @@ import {
 import { TableControls, ROW_LIMIT_OPTIONS } from './DataTableControls';
 import { SamplesPaneProps } from '../types';
 
-const Error = styled.pre`
+const ErrorAlertWrapper = styled.div`
   margin-top: ${({ theme }) => `${theme.sizeUnit * 4}px`};
 `;
 
@@ -140,22 +141,14 @@ export const SamplesPane = ({
 
   if (responseError) {
     return (
-      <>
-        <TableControls
-          data={data}
-          columnNames={colnames}
-          columnTypes={coltypes}
-          rowcount={rowcount}
-          datasourceId={datasourceId}
-          onInputChange={handleInputChange}
-          isLoading={isLoading}
-          canDownload={canDownload}
-          rowLimit={rowLimit}
-          rowLimitOptions={ROW_LIMIT_OPTIONS}
-          onRowLimitChange={handleRowLimitChange}
+      <ErrorAlertWrapper>
+        <Alert
+          type="error"
+          showIcon
+          message={t('Failed to load samples')}
+          description={responseError}
         />
-        <Error>{responseError}</Error>
-      </>
+      </ErrorAlertWrapper>
     );
   }
 

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -27,13 +27,14 @@ import {
   QueryData,
 } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
+import { Alert } from '@apache-superset/core/components';
 import { EmptyState, Loading } from '@superset-ui/core/components';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ResultsPaneProps, QueryResultInterface } from '../types';
 import { SingleQueryResultPane } from './SingleQueryResultPane';
-import { TableControls, ROW_LIMIT_OPTIONS } from './DataTableControls';
+import { ROW_LIMIT_OPTIONS } from './DataTableControls';
 
-const Error = styled.pre`
+const ErrorAlertWrapper = styled.div`
   margin-top: ${({ theme }) => `${theme.sizeUnit * 4}px`};
 `;
 
@@ -77,8 +78,6 @@ export const useResultsPane = ({
   const [responseError, setResponseError] = useState<string>('');
   const queryCount = metadata?.queryObjectCount ?? 1;
   const isQueryCountDynamic = metadata?.dynamicQueryObjectCount;
-
-  const noOpInputChange = useCallback(() => {}, []);
 
   // Never exceed the chart's own row_limit
   const effectiveRowLimit = Math.min(rowLimit, chartRowLimit);
@@ -188,19 +187,14 @@ export const useResultsPane = ({
 
   if (responseError) {
     const err = (
-      <>
-        <TableControls
-          data={[]}
-          columnNames={[]}
-          columnTypes={[]}
-          rowcount={0}
-          datasourceId={queryFormData.datasource}
-          onInputChange={noOpInputChange}
-          isLoading={false}
-          canDownload={canDownload}
+      <ErrorAlertWrapper>
+        <Alert
+          type="error"
+          showIcon
+          message={t('Failed to load results')}
+          description={responseError}
         />
-        <Error>{responseError}</Error>
-      </>
+      </ErrorAlertWrapper>
     );
     return Array(queryCount).fill(err);
   }

--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -19,7 +19,12 @@
 import fetchMock from 'fetch-mock';
 import { FeatureFlag } from '@superset-ui/core';
 import * as copyUtils from 'src/utils/copy';
-import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { setItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import { DataTablesPane } from '..';
@@ -65,6 +70,19 @@ describe('DataTablesPane', () => {
   });
 
   test('Should show tabs: View results', async () => {
+    fetchMock.post(
+      'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A0%7D',
+      {
+        result: [
+          {
+            data: [],
+            colnames: [],
+            coltypes: [],
+            rowcount: 0,
+          },
+        ],
+      },
+    );
     const props = createDataTablesPaneProps(0);
     render(<DataTablesPane {...props} />, {
       useRedux: true,
@@ -78,15 +96,76 @@ describe('DataTablesPane', () => {
   });
 
   test('Should show tabs: View samples', async () => {
+    fetchMock.post(
+      'end:/datasource/samples?force=false&datasource_type=table&datasource_id=34&per_page=100&page=1',
+      {
+        result: {
+          data: [],
+          colnames: [],
+          coltypes: [],
+          rowcount: 0,
+        },
+      },
+    );
     const props = createDataTablesPaneProps(0);
     render(<DataTablesPane {...props} />, {
       useRedux: true,
     });
     userEvent.click(screen.getByText('Samples'));
     expect(
-      await screen.findByText('0 rows', undefined, { timeout: 5000 }),
+      await screen.findByText('No samples were returned for this dataset'),
     ).toBeVisible();
     expect(await screen.findByLabelText('Collapse data panel')).toBeVisible();
+  });
+
+  test('Hides Samples only when the datasource explicitly opts out', async () => {
+    const props = createDataTablesPaneProps(0);
+    render(
+      <DataTablesPane
+        {...props}
+        datasource={{ ...props.datasource, supports_samples: false }}
+      />,
+      { useRedux: true },
+    );
+
+    expect(await screen.findByText('Results')).toBeVisible();
+    expect(screen.queryByText('Samples')).not.toBeInTheDocument();
+  });
+
+  test('Falls back to rendered Results after Samples becomes unavailable', async () => {
+    const props = createDataTablesPaneProps(0);
+    const { rerender } = render(<DataTablesPane {...props} />, {
+      useRedux: true,
+    });
+
+    userEvent.click(screen.getByLabelText('Expand data panel'));
+    userEvent.click(await screen.findByText('Samples'));
+    rerender(
+      <DataTablesPane
+        {...props}
+        datasource={{ ...props.datasource, supports_samples: false }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('Samples')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText('Results')).toBeVisible();
+    expect(screen.getByLabelText('Collapse data panel')).toBeVisible();
+  });
+
+  test('Shows only an accessible alert when Results loading fails', async () => {
+    fetchMock.post('glob:*/api/v1/chart/data*', 500);
+    const props = createDataTablesPaneProps(999);
+    render(<DataTablesPane {...props} />, { useRedux: true });
+
+    userEvent.click(screen.getByText('Results'));
+    expect(await screen.findByRole('alert')).toBeVisible();
+    expect(await screen.findByText('Failed to load results')).toBeVisible();
+    expect(screen.queryByLabelText('Copy')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Reload')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    fetchMock.clearHistory().removeRoutes();
   });
 
   test('Should copy data table content correctly', async () => {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import fetchMock from 'fetch-mock';
-import { render, waitFor } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { SamplesPane } from '../components';
 import { createSamplesPaneProps } from './fixture';
@@ -88,7 +88,12 @@ describe('SamplesPane', () => {
       useRedux: true,
     });
 
+    expect(await screen.findByRole('alert')).toBeVisible();
+    expect(await findByText('Failed to load samples')).toBeVisible();
     expect(await findByText('Error: Bad request')).toBeVisible();
+    expect(screen.queryByLabelText('Copy')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Reload')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
   });
 
   test('force query, render', async () => {

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -74,6 +74,8 @@ export type Datasource = Dataset & {
   schema?: string;
   is_sqllab_view?: boolean;
   extra?: string | object;
+  supports_samples?: boolean;
+  supports_drill_to_detail?: boolean;
 };
 
 export interface ExplorePageInitialData {

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -230,6 +230,10 @@ def _get_drill_detail(
     # todo(yongjie): Remove this function,
     #  when determining whether samples should be applied to the time filter.
     datasource = _get_datasource(query_context, query_obj)
+    if getattr(datasource, "supports_drill_to_detail", True) is False:
+        raise QueryObjectValidationError(
+            _("Drill to detail is not available for this datasource type")
+        )
     query_obj = copy.copy(query_obj)
     query_obj.is_timeseries = False
     query_obj.metrics = None

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -193,6 +193,11 @@ class BaseDatasource(
     # Only some datasources support Row Level Security
     is_rls_supported: bool = False
 
+    # Raw-row operations are supported by SQL-backed datasources by default.
+    # The capabilities remain independent so datasource types can override either one.
+    supports_samples: bool = True
+    supports_drill_to_detail: bool = True
+
     @property
     def name(self) -> str:
         # can be a Column or a property pointing to one
@@ -485,6 +490,8 @@ class BaseDatasource(
             "order_by_choices": self.order_by_choices,
             "verbose_map": self.verbose_map,
             "select_star": self.select_star,
+            "supports_samples": self.supports_samples,
+            "supports_drill_to_detail": self.supports_drill_to_detail,
         }
 
     def data_for_slices(  # pylint: disable=too-many-locals  # noqa: C901

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -200,6 +200,10 @@ class SemanticView(AuditMixinNullable, Model):
 
     __tablename__ = "semantic_views"
 
+    # Semantic views expose governed dimensions and metrics rather than raw rows.
+    supports_samples: bool = False
+    supports_drill_to_detail: bool = False
+
     # Use integer as the primary key for cross-database auto-increment
     # compatibility (sa.Identity() is not supported in MySQL or SQLite).
     # The uuid column is a secondary unique identifier used in URLs and perms.
@@ -424,6 +428,8 @@ class SemanticView(AuditMixinNullable, Model):
             "filter_select_enabled": True,
             "sql": None,
             "select_star": None,
+            "supports_samples": self.supports_samples,
+            "supports_drill_to_detail": self.supports_drill_to_detail,
             "editors": [],
             "description": self.description,
             "table_name": self.name,

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -338,6 +338,8 @@ class ExplorableData(TypedDict, total=False):
     extra: str | None
     always_filter_main_dttm: bool
     normalize_columns: bool
+    supports_samples: bool
+    supports_drill_to_detail: bool
 
 
 VizData: TypeAlias = list[Any] | dict[Any, Any] | None

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -202,6 +202,19 @@ class Datasource(BaseSupersetView):
             payload = SamplesPayloadSchema().load(request.json)
         except ValidationError as err:
             return json_error_response(err.messages, status=400)
+
+        datasource_class = DatasourceDAO.sources.get(
+            DatasourceType(params["datasource_type"])
+        )
+        if (
+            datasource_class is not None
+            and getattr(datasource_class, "supports_samples", True) is False
+        ):
+            return json_error_response(
+                _("Samples are not available for this datasource type"),
+                status=400,
+            )
+
         dashboard_id = None
         if security_manager.is_guest_user():
             if not params["dashboard_id"]:

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -28,9 +28,11 @@ from zipfile import ZipFile
 import pytest
 from flask import g, Response
 from flask.ctx import AppContext
+from flask.testing import FlaskClient
 
 from superset.charts.data.api import ChartDataRestApi
 from superset.commands.chart.data.get_data_command import ChartDataCommand
+from superset.commands.chart.exceptions import ChartDataQueryFailedError
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.constants import CACHE_DISABLED_TIMEOUT
@@ -162,6 +164,32 @@ class BaseTestChartDataApi(SupersetTestCase):
             if target_column and original_groupby_value is not False:
                 target_column.groupby = original_groupby_value
                 db.session.commit()
+
+
+@mock.patch("superset.charts.data.api.ChartDataCommand")
+@mock.patch.object(ChartDataRestApi, "_create_query_context_from_form")
+def test_drill_detail_query_failure_maps_to_400(
+    create_query_context: mock.MagicMock,
+    chart_data_command: mock.MagicMock,
+    test_client: FlaskClient,
+    login_as_admin: None,
+) -> None:
+    """Chart data API maps the canonical drill failure to HTTP 400."""
+    query_context: mock.MagicMock = create_query_context.return_value
+    query_context.get_cache_timeout.return_value = CACHE_DISABLED_TIMEOUT
+    query_context.result_format = ChartDataResultFormat.JSON
+    query_context.result_type = ChartDataResultType.DRILL_DETAIL
+    chart_data_command.return_value.run.side_effect = ChartDataQueryFailedError(
+        "Drill to detail is not available for this datasource type"
+    )
+
+    response: Response = test_client.post(CHART_DATA_URI, json={})
+
+    assert response.status_code == 400
+    assert (
+        response.json["message"]
+        == "Drill to detail is not available for this datasource type"
+    )
 
 
 @pytest.mark.chart_data_flow

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -22,7 +22,8 @@ from unittest import mock
 
 import pytest
 import rison
-from flask import current_app
+from flask import current_app, Response
+from flask.testing import FlaskClient
 from sqlalchemy import text
 
 from superset import db, security_manager as sm
@@ -638,7 +639,6 @@ def test_get_samples(test_client, login_as_admin, virtual_dataset):
         region=CacheRegion.DATA,
     )
     assert not rv2.json["result"]["is_cached"]
-
     # 3. data precision
     assert "colnames" in rv2.json["result"]
     assert "coltypes" in rv2.json["result"]
@@ -654,6 +654,22 @@ def test_get_samples(test_client, login_as_admin, virtual_dataset):
     eager_samples["col3"] = eager_samples["col3"].apply(float)
     eager_samples = eager_samples.to_dict(orient="records")
     assert eager_samples == rv2.json["result"]["data"]
+
+
+def test_get_samples_rejects_semantic_view(
+    test_client: FlaskClient,
+    login_as_admin: None,
+) -> None:
+    """Datasource API returns the canonical error for semantic views."""
+    response: Response = test_client.post(
+        "/datasource/samples?datasource_id=1&datasource_type=semantic_view",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert response.json == {
+        "error": "Samples are not available for this datasource type"
+    }
 
 
 def test_get_samples_with_incorrect_cc(test_client, login_as_admin, virtual_dataset):

--- a/tests/unit_tests/common/test_query_actions_drill_detail.py
+++ b/tests/unit_tests/common/test_query_actions_drill_detail.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.common.query_actions import _get_drill_detail
+from superset.exceptions import QueryObjectValidationError
+
+
+def test_get_drill_detail_rejects_unsupported_datasource_before_query() -> None:
+    """Reject unsupported detail requests before executing the query."""
+    datasource: MagicMock = MagicMock()
+    datasource.supports_drill_to_detail = False
+
+    with (
+        patch(
+            "superset.common.query_actions._get_datasource",
+            return_value=datasource,
+        ),
+        patch("superset.common.query_actions._get_full") as get_full,
+        pytest.raises(
+            QueryObjectValidationError,
+            match="^Drill to detail is not available for this datasource type$",
+        ),
+    ):
+        _get_drill_detail(MagicMock(), MagicMock())
+
+    get_full.assert_not_called()
+
+
+def test_get_drill_detail_preserves_omitted_capability_behavior() -> None:
+    """Preserve detail queries for datasource implementations without the field."""
+    datasource: MagicMock = MagicMock(spec=["columns"])
+    column: MagicMock = MagicMock()
+    column.column_name = "id"
+    datasource.columns = [column]
+    query_object: MagicMock = MagicMock()
+    expected: dict[str, list[object]] = {"data": []}
+
+    with (
+        patch(
+            "superset.common.query_actions._get_datasource",
+            return_value=datasource,
+        ),
+        patch(
+            "superset.common.query_actions._get_full",
+            return_value=expected,
+        ) as get_full,
+    ):
+        assert _get_drill_detail(MagicMock(), query_object) is expected
+
+    get_full.assert_called_once()

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -1001,6 +1001,8 @@ def test_sqla_table_data_includes_currency_code_column(mocker: MockerFixture) ->
     data = table.data
     assert data["currency_code_column"] == "currency_code"
     assert data["main_dttm_col"] == "ds"
+    assert data["supports_samples"] is True
+    assert data["supports_drill_to_detail"] is True
 
 
 def test_sqla_table_link_escapes_url(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -653,6 +653,14 @@ def test_semantic_view_data(
         assert data["table_name"] == "Orders View"
         assert data["datasource_name"] == "Orders View"
         assert data["offset"] == 0
+        assert data["supports_samples"] is False
+        assert data["supports_drill_to_detail"] is False
+
+
+def test_semantic_view_raw_row_capabilities_are_disabled() -> None:
+    """Semantic views opt out of both independent raw-row capabilities."""
+    assert SemanticView.supports_samples is False
+    assert SemanticView.supports_drill_to_detail is False
 
 
 @pytest.fixture

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -268,6 +268,60 @@ def test_save_always_checks_editorship_even_without_editors_field(
     mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
 
 
+@patch("superset.views.datasource.views._", lambda message: message)
+@patch("superset.views.datasource.views.get_samples")
+@patch("superset.views.datasource.views.json_error_response")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+def test_samples_rejects_unsupported_datasource_before_query(
+    mock_security_manager: MagicMock,
+    mock_json_error_response: MagicMock,
+    mock_get_samples: MagicMock,
+) -> None:
+    """Reject unsupported Samples requests before constructing a query."""
+    from flask import Flask
+
+    mock_security_manager.is_guest_user.return_value = False
+    mock_json_error_response.return_value = "error-response"
+
+    with Flask(__name__).test_request_context(
+        "/datasource/samples?datasource_type=semantic_view&datasource_id=1",
+        method="POST",
+        json={},
+    ):
+        result: str = _get_view_func("samples")(_view_self())
+
+    assert result == "error-response"
+    mock_json_error_response.assert_called_once_with(
+        "Samples are not available for this datasource type",
+        status=400,
+    )
+    mock_get_samples.assert_not_called()
+
+
+@patch("superset.views.datasource.views.get_samples")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+def test_samples_preserves_supported_datasource_behavior(
+    mock_security_manager: MagicMock,
+    mock_get_samples: MagicMock,
+) -> None:
+    """Continue to fetch Samples when a datasource does not opt out."""
+    from flask import Flask
+
+    mock_security_manager.is_guest_user.return_value = False
+    mock_get_samples.return_value = {"rows": []}
+    view = _view_self()
+
+    with Flask(__name__).test_request_context(
+        "/datasource/samples?datasource_type=query&datasource_id=1",
+        method="POST",
+        json={},
+    ):
+        _get_view_func("samples")(view)
+
+    mock_get_samples.assert_called_once()
+    view.json_response.assert_called_once_with({"result": {"rows": []}})
+
+
 @patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
 @patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
 def test_save_non_editor_with_editors_field_is_rejected(


### PR DESCRIPTION
### SUMMARY

Adds explicit datasource capabilities for Samples and Drill to Detail, with SQL-backed datasources enabled by default and semantic views opted out.

The Explore and chart UI now hide or disable unsupported raw-row actions, while backend endpoints reject direct unsupported requests with clear 400 responses. Existing datasource implementations that do not expose the capability fields retain their prior behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not included. The visible change is that Samples and Drill to Detail controls are unavailable for semantic views.

### TESTING INSTRUCTIONS

1. Open a SQL-backed dataset in Explore and confirm Samples remains available.
2. Open a semantic view in Explore and confirm the Samples tab is not shown.
3. Open a chart backed by a semantic view and confirm Drill to Detail is unavailable.
4. Send direct Samples or Drill to Detail requests for a semantic view and confirm they return HTTP 400 with the capability-specific error.

Automated verification:
- `pre-commit run --all-files`
- 132 focused backend tests passed.
- 4 focused frontend suites passed (39 passed, 1 skipped).
- A broader backend integration selection had 169 passes and 73 skips; 9 cache-dependent tests could not run because local Redis at localhost:6379 was unavailable.

### ADDITIONAL INFORMATION

- [x] Has associated issue: SC-107949
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API