### PR TITLE
fix(screenshots): validate cached screenshot image bytes on read and write

### DIFF
--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -85,6 +85,26 @@ class ScreenshotCachePayloadType(TypedDict):
     status: str
 
 
+# Magic bytes for a cheap image sanity check. This is intentionally not a full
+# decode: it's meant to catch 0-byte/corrupt/blank payloads before they're
+# cached or served, not to validate the image is renderable.
+PNG_MAGIC_BYTES = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC_BYTES = b"\xff\xd8\xff"
+
+
+def validate_screenshot_image(image: bytes | None) -> str | None:
+    """Cheaply validate screenshot bytes before they're cached or served.
+
+    :return: None if the bytes look like a usable image, otherwise a short
+        reason ("empty" or "undecodable") suitable for logging.
+    """
+    if not image:
+        return "empty"
+    if not image.startswith((PNG_MAGIC_BYTES, JPEG_MAGIC_BYTES)):
+        return "undecodable"
+    return None
+
+
 class ScreenshotCachePayload:
     def __init__(
         self,
@@ -146,6 +166,13 @@ class ScreenshotCachePayload:
 
     def get_status(self) -> str:
         return self.status.value
+
+    def get_invalid_image_reason(self) -> str | None:
+        """Reason this payload's image should not be served/cached, or None if
+        it passes validation (or it isn't claiming a successful screenshot)."""
+        if self.status != StatusValues.UPDATED:
+            return None
+        return validate_screenshot_image(self._image)
 
     def is_error_cache_ttl_expired(self) -> bool:
         error_cache_ttl = app.config["THUMBNAIL_ERROR_CACHE_TTL"]
@@ -258,6 +285,14 @@ class BaseScreenshot:
             elif isinstance(payload, dict):
                 payload = cast(ScreenshotCachePayloadType, payload)
                 payload = ScreenshotCachePayload.from_dict(payload)
+            if invalid_reason := payload.get_invalid_image_reason():
+                logger.warning(
+                    "Rejecting cached screenshot for %s: %s image payload; "
+                    "treating as a cache miss",
+                    cache_key,
+                    invalid_reason,
+                )
+                return None
             return payload
         logger.info("Failed at getting from cache: %s", cache_key)
         return None
@@ -326,15 +361,24 @@ class BaseScreenshot:
                         image = None
 
                 # Cache the result (success or error) to avoid immediate retries
-                if image:
+                invalid_reason = validate_screenshot_image(image)
+                if image and invalid_reason is None:
                     with event_logger.log_context(
                         f"screenshot.cache.{self.thumbnail_type}"
                     ):
                         cache_payload.update(image)
-                elif cache_payload.status != StatusValues.ERROR:
-                    # Only call error() if not already set — avoids overwriting
-                    # the timestamp recorded when the actual failure occurred above.
-                    cache_payload.error()
+                else:
+                    if invalid_reason:
+                        logger.warning(
+                            "Not caching screenshot result for %s: %s image payload",
+                            cache_key,
+                            invalid_reason,
+                        )
+                    if cache_payload.status != StatusValues.ERROR:
+                        # Only call error() if not already set — avoids overwriting
+                        # the timestamp recorded when the actual failure occurred
+                        # above.
+                        cache_payload.error()
 
                 logger.info("Caching thumbnail: %s", cache_key)
                 self.cache.set(cache_key, cache_payload.to_dict())

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -362,6 +362,10 @@ class BaseScreenshot:
 
                 # Cache the result (success or error) to avoid immediate retries
                 invalid_reason = validate_screenshot_image(image)
+                # `image and` is redundant at runtime (validate_screenshot_image
+                # only returns None for truthy, well-formed bytes) but mypy can't
+                # infer that image is non-None from invalid_reason being None
+                # across the function-call boundary, so it's kept for narrowing.
                 if image and invalid_reason is None:
                     with event_logger.log_context(
                         f"screenshot.cache.{self.thumbnail_type}"

--- a/tests/unit_tests/utils/screenshot_test.py
+++ b/tests/unit_tests/utils/screenshot_test.py
@@ -33,6 +33,10 @@ from superset.utils.screenshots import (
 
 BASE_SCREENSHOT_PATH = "superset.utils.screenshots.BaseScreenshot"
 
+# A minimal valid PNG header, used wherever a test needs bytes that pass
+# ScreenshotCachePayload's image validation.
+FAKE_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+
 
 class MockCache:
     """A class to manage screenshot cache."""
@@ -92,7 +96,7 @@ def test_get_cache_key(app_context, screenshot_obj):
 def test_get_from_cache_key(mocker: MockerFixture, screenshot_obj):
     """get_from_cache_key should always return a ScreenshotCachePayload Object"""
     # backwards compatibility test for retrieving plain bytes
-    fake_bytes = b"fake_screenshot_data"
+    fake_bytes = FAKE_PNG_BYTES
     BaseScreenshot.cache = MockCache()
     BaseScreenshot.cache.set("key", fake_bytes)
     cache_payload = screenshot_obj.get_from_cache_key("key")
@@ -108,10 +112,10 @@ class TestComputeAndCache:
             BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
         )
         get_screenshot = mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"new_image_data"
+            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=FAKE_PNG_BYTES
         )
         resize_image = mocker.patch(
-            BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image_data"
+            BASE_SCREENSHOT_PATH + ".resize_image", return_value=FAKE_PNG_BYTES
         )
         BaseScreenshot.cache = MockCache()
         return {

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -37,6 +37,10 @@ from superset.utils.screenshots import (
 BASE_SCREENSHOT_PATH = "superset.utils.screenshots.BaseScreenshot"
 DISTRIBUTED_LOCK_PATH = "superset.utils.screenshots.DistributedLock"
 
+# A minimal valid PNG header, used wherever a test needs bytes that pass
+# ScreenshotCachePayload's image validation.
+FAKE_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+
 
 class MockCache:
     """A class to manage screenshot cache for testing."""
@@ -83,11 +87,11 @@ class TestCacheOnlyOnSuccess:
         mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         get_screenshot = mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"image_data"
+            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=FAKE_PNG_BYTES
         )
         # Mock resize_image to avoid PIL errors with fake image data
         mocker.patch(
-            BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image_data"
+            BASE_SCREENSHOT_PATH + ".resize_image", return_value=FAKE_PNG_BYTES
         )
         BaseScreenshot.cache = MockCache()
         return get_screenshot
@@ -161,13 +165,15 @@ class TestCacheOnlyOnSuccess:
         screenshot_obj: BaseScreenshot,
         mock_user: MagicMock,
     ) -> None:
-        """Empty bytes from get_screenshot must set ERROR, not leave COMPUTING."""
+        """Empty bytes from get_screenshot must set ERROR, not leave COMPUTING,
+        and must log a WARNING that includes the cache key."""
         mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             return_value=b"",
         )
+        mock_logger = mocker.patch("superset.utils.screenshots.logger")
         BaseScreenshot.cache = MockCache()
 
         screenshot_obj.compute_and_cache(user=mock_user, force=True)
@@ -177,6 +183,43 @@ class TestCacheOnlyOnSuccess:
         assert cached_value is not None
         assert cached_value["status"] == "Error"
         assert cached_value.get("image") is None
+        assert any(
+            cache_key in call.args and "empty" in call.args
+            for call in mock_logger.warning.call_args_list
+        )
+
+    def test_cache_error_status_when_screenshot_returns_garbage_bytes(
+        self,
+        mocker: MockerFixture,
+        screenshot_obj: BaseScreenshot,
+        mock_user: MagicMock,
+    ) -> None:
+        """Non-empty bytes without a valid image header must set ERROR, not be
+        cached as a success, and must log a WARNING that includes the cache key."""
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
+        mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot",
+            return_value=b"this-is-not-a-real-image",
+        )
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".resize_image",
+            return_value=b"this-is-not-a-real-image",
+        )
+        mock_logger = mocker.patch("superset.utils.screenshots.logger")
+        BaseScreenshot.cache = MockCache()
+
+        screenshot_obj.compute_and_cache(user=mock_user, force=True)
+
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is not None
+        assert cached_value["status"] == "Error"
+        assert cached_value.get("image") is None
+        assert any(
+            cache_key in call.args and "undecodable" in call.args
+            for call in mock_logger.warning.call_args_list
+        )
 
     def test_computing_status_written_to_cache_early(
         self,
@@ -197,14 +240,14 @@ class TestCacheOnlyOnSuccess:
                 "Cache should be set to COMPUTING before screenshot starts"
             )
             assert cached_value["status"] == "Computing"
-            return b"image_data"
+            return FAKE_PNG_BYTES
 
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=check_cache_during_screenshot,
         )
         mocker.patch(
-            BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image_data"
+            BASE_SCREENSHOT_PATH + ".resize_image", return_value=FAKE_PNG_BYTES
         )
 
         screenshot_obj.compute_and_cache(user=mock_user, force=True)
@@ -429,11 +472,11 @@ class TestIntegrationCacheBugFix:
         BaseScreenshot.cache.set(cache_key, stale_payload.to_dict())
 
         mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"recovered_image"
+            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=FAKE_PNG_BYTES
         )
         # Mock resize to avoid PIL errors
         mocker.patch(
-            BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image"
+            BASE_SCREENSHOT_PATH + ".resize_image", return_value=FAKE_PNG_BYTES
         )
 
         # Should trigger task because COMPUTING is stale
@@ -482,3 +525,72 @@ class TestIntegrationCacheBugFix:
 
         assert payload._image == old_image
         assert payload.status == StatusValues.COMPUTING
+
+
+class TestReadSideImageValidation:
+    """A cached payload that claims a successful screenshot (status UPDATED)
+    but carries invalid image bytes must be served as a cache miss, not
+    returned to the caller — this is what the dashboard/chart screenshot
+    endpoints call to fetch bytes to serve."""
+
+    def test_zero_byte_image_is_treated_as_cache_miss(
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot
+    ) -> None:
+        mock_logger = mocker.patch("superset.utils.screenshots.logger")
+        BaseScreenshot.cache = MockCache()
+        cache_key = screenshot_obj.get_cache_key()
+        stale_payload = ScreenshotCachePayload(image=b"", status=StatusValues.UPDATED)
+        BaseScreenshot.cache.set(cache_key, stale_payload.to_dict())
+
+        result = screenshot_obj.get_from_cache_key(cache_key)
+
+        assert result is None
+        assert any(
+            cache_key in call.args and "empty" in call.args
+            for call in mock_logger.warning.call_args_list
+        )
+
+    def test_garbage_bytes_image_is_treated_as_cache_miss(
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot
+    ) -> None:
+        mock_logger = mocker.patch("superset.utils.screenshots.logger")
+        BaseScreenshot.cache = MockCache()
+        cache_key = screenshot_obj.get_cache_key()
+        garbage_payload = ScreenshotCachePayload(image=b"not-an-image-at-all")
+        BaseScreenshot.cache.set(cache_key, garbage_payload.to_dict())
+
+        result = screenshot_obj.get_from_cache_key(cache_key)
+
+        assert result is None
+        assert any(
+            cache_key in call.args and "undecodable" in call.args
+            for call in mock_logger.warning.call_args_list
+        )
+
+    def test_valid_image_is_served_normally(
+        self, screenshot_obj: BaseScreenshot
+    ) -> None:
+        BaseScreenshot.cache = MockCache()
+        cache_key = screenshot_obj.get_cache_key()
+        valid_payload = ScreenshotCachePayload(image=FAKE_PNG_BYTES)
+        BaseScreenshot.cache.set(cache_key, valid_payload.to_dict())
+
+        result = screenshot_obj.get_from_cache_key(cache_key)
+
+        assert result is not None
+        assert result.get_image().read() == FAKE_PNG_BYTES
+
+    def test_pending_status_with_no_image_is_not_rejected(
+        self, screenshot_obj: BaseScreenshot
+    ) -> None:
+        """Non-UPDATED statuses (e.g. PENDING/COMPUTING) aren't claiming a
+        successful screenshot, so they should be returned as-is."""
+        BaseScreenshot.cache = MockCache()
+        cache_key = screenshot_obj.get_cache_key()
+        pending_payload = ScreenshotCachePayload(status=StatusValues.PENDING)
+        BaseScreenshot.cache.set(cache_key, pending_payload.to_dict())
+
+        result = screenshot_obj.get_from_cache_key(cache_key)
+
+        assert result is not None
+        assert result.status == StatusValues.PENDING


### PR DESCRIPTION
### SUMMARY
Dashboard/chart screenshot and thumbnail caching (`ScreenshotCachePayload` in `superset/utils/screenshots.py`) had two gaps:

1. **No read-side validation.** `BaseScreenshot.get_from_cache_key()` returned whatever was in the cache as long as a status of `UPDATED` was recorded, even if the stored image was `None`/0-byte or otherwise not a real image. Since the cache key is digest-based, an unchanged dashboard/chart kept serving the same stale/blank entry indefinitely (e.g. a blank PDF download).
2. **Write-side validation was falsy-only.** A prior fix (#41097) set `ERROR` status when the screenshot task produced a falsy (`None`/`b""`) result, but a non-empty, non-image payload (e.g. truncated/corrupt bytes) still passed the `if image:` check and got cached with `UPDATED` status.

This PR adds a shared, cheap validator (`validate_screenshot_image()` — checks non-empty + PNG/JPEG magic-byte header, no full decode) used on both paths:

- **Read side**: `get_from_cache_key()` now rejects a cached payload that claims a successful screenshot (`status == UPDATED`) but fails validation, returning `None` — the same value callers already treat as a cache miss — and logs a `WARNING` with the cache key and the reason (`empty` vs `undecodable`). Because both the dashboard and chart `screenshot`/`thumbnail`/`cache_*` endpoints already call this same shared classmethod, this closes the hole for both resource types without touching `charts/api.py` or `dashboards/api.py`.
- **Write side**: `BaseScreenshot.compute_and_cache()` now runs the same check on the freshly generated image before caching it as a success. If it fails, the payload is marked `ERROR` (consistent with #41097's approach) instead of `UPDATED`, and a `WARNING` with the cache key and reason is logged.

### Scope and known limitation — what this does and does NOT protect against

**This validates image *bytes and headers* only. It deliberately does not inspect image *content*:**

- A **structurally valid but visually blank** capture (e.g. an all-white PNG of an empty dashboard grid) **passes this validation** and will be cached and served.
- A screenshot of **charts stuck on loading spinners** likewise passes — it is a perfectly well-formed PNG.

Preventing those is capture-side responsibility, and is where the readiness/budget work lives (#42253/#42427 positive readiness checks, #42273 no-unguarded-fallback, #42118 tiled wait budget, #42624 report deadline): with those in place, a blank/spinner capture *fails the capture* instead of ever reaching the cache. This PR is the complementary cache-layer guarantee for the class of corruption those fixes can't address: **empty, truncated, or non-image bytes can never be cached as success nor served from cache** — a failure class observed in production (0-byte cached assets) that, with digest-based keys and no TTL eviction in some deployments, previously poisoned an entry indefinitely. A pixel-level blank-image detector would be the durable catch-all for the remaining gap, but that's a separate, heavier change with genuine false-positive risk (legitimately near-empty dashboards) and is intentionally out of scope here.

**Also explicitly not changed:**
- Capture/webdriver logic (`superset/utils/screenshot_utils.py`, `superset/utils/webdriver.py`) — untouched; owned by the readiness/budget PRs above.
- Cache backend, cache keys, and TTLs — unchanged.
- Behavior for correctly-cached images — a valid, non-empty PNG/JPEG payload is served and cached exactly as before; this only changes behavior for payloads that were already broken (empty/corrupt).
- No new config flags — the validation is unconditional, since serving a 0-byte image is never the intended behavior.

### TESTING INSTRUCTIONS
Added unit tests in `tests/unit_tests/utils/test_screenshot_cache_fix.py` and updated fixtures in `tests/unit_tests/utils/screenshot_test.py` (existing tests used non-image placeholder bytes like `b"image_data"` as stand-ins for a "successful" screenshot; these now use a minimal valid PNG header so they still exercise the success path under the new validation):

- Read side: a cached payload with a 0-byte image is served as a cache miss (`None`) with a `WARNING` logged; a payload with non-image garbage bytes is likewise treated as a cache miss; a valid PNG-header payload is served normally; a non-`UPDATED` (e.g. `PENDING`) payload is returned as-is.
- Write side: `compute_and_cache()` with an empty or garbage-bytes screenshot result caches `ERROR` status (never `UPDATED`) and logs a `WARNING` including the cache key and reason.

Run:
```
pytest tests/unit_tests/utils/test_screenshot_cache_fix.py tests/unit_tests/utils/screenshot_test.py -q
```
48 passed. Also ran the broader `tests/unit_tests/utils/ -k screenshot` suite (76 passed); 3 unrelated pre-existing failures in `webdriver_test.py`/`test_screenshot_utils.py` reproduce identically on `master` (playwright-version mismatch in the test environment, unrelated to this change and in files this PR does not touch).

`ruff check` passes on the changed files; `mypy` reports no errors in `superset/utils/screenshots.py`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)