### PR TITLE
fix(dashboard): add cacheKey, dashboardId, and format context to screenshot download error logs

### DIFF
--- a/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.test.ts
+++ b/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.test.ts
@@ -18,6 +18,7 @@
  */
 import { renderHook, act } from '@testing-library/react';
 import { SupersetClient } from '@superset-ui/core';
+import { logging } from '@apache-superset/core/utils';
 import { useDownloadScreenshot } from './useDownloadScreenshot';
 import { DownloadScreenshotFormat } from '../components/menu/DownloadMenuItems/types';
 
@@ -32,6 +33,12 @@ jest.mock('@superset-ui/core', () => ({
       super(message);
       this.status = status;
     }
+  },
+}));
+
+jest.mock('@apache-superset/core/utils', () => ({
+  logging: {
+    error: jest.fn(),
   },
 }));
 
@@ -170,4 +177,47 @@ test('triggers only one download when multiple successful responses race', async
   clickSpy.mockRestore();
   jest.clearAllTimers();
   jest.useRealTimers();
+});
+
+test('logs cacheKey, dashboardId, and format when retries are exhausted', async () => {
+  jest.useFakeTimers();
+  mockPostSuccess();
+  (SupersetClient.get as jest.Mock).mockRejectedValue(notReadyError());
+
+  await triggerDownload();
+
+  // Drive one retry interval at a time so each failed GET has a chance to
+  // resolve and increment the retry counter before the next interval fires.
+  for (let i = 0; i < 31; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      jest.advanceTimersByTime(RETRY_INTERVAL);
+      await flushPromises();
+    });
+  }
+
+  expect(logging.error).toHaveBeenCalledWith('Max retries reached', {
+    cacheKey: CACHE_KEY,
+    dashboardId: DASHBOARD_ID,
+    format: DownloadScreenshotFormat.PNG,
+  });
+
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test('logs dashboardId, format, and the error when the initial screenshot request fails', async () => {
+  const error = new Error('network down');
+  (SupersetClient.post as jest.Mock).mockRejectedValue(error);
+
+  const { result } = renderHook(() => useDownloadScreenshot(DASHBOARD_ID));
+  await act(async () => {
+    result.current(DownloadScreenshotFormat.PDF);
+    await flushPromises();
+  });
+
+  expect(logging.error).toHaveBeenCalledWith(
+    'Failed to trigger dashboard screenshot',
+    { dashboardId: DASHBOARD_ID, format: DownloadScreenshotFormat.PDF, error },
+  );
 });

--- a/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.ts
+++ b/superset-frontend/src/dashboard/hooks/useDownloadScreenshot.ts
@@ -146,7 +146,11 @@ export const useDownloadScreenshot = (
         }
         if (retries >= MAX_RETRIES) {
           stopIntervals('failure');
-          logging.error('Max retries reached');
+          logging.error('Max retries reached', {
+            cacheKey,
+            dashboardId,
+            format,
+          });
           return;
         }
         isFetching = true;
@@ -180,7 +184,11 @@ export const useDownloadScreenshot = (
           fetchImageWithRetry(cacheKey);
         })
         .catch(error => {
-          logging.error(error);
+          logging.error('Failed to trigger dashboard screenshot', {
+            dashboardId,
+            format,
+            error,
+          });
           stopIntervals('failure');
         })
         .finally(() => {


### PR DESCRIPTION
### SUMMARY
`useDownloadScreenshot` polls a screenshot endpoint after triggering a direct dashboard PDF/PNG download, and previously logged terminal failures with no identifying context:
- `logging.error('Max retries reached')` when retry polling was exhausted.
- `logging.error(error)` when the initial trigger request failed.

Neither log call included the cache key, dashboard id, or requested format, making it impossible to correlate a client-side download failure with server-side logs for the same attempt (e.g. cache-key-keyed logs on the screenshot-cache-validation path).

This PR passes that context as structured arguments to `logging.error`, following `console.error(message, ...args)` semantics, so the values remain accessible to any consumer that parses the additional console arguments:
- Retry-exhausted path now logs `logging.error('Max retries reached', { cacheKey, dashboardId, format })`.
- Initial-request-failure path now logs `logging.error('Failed to trigger dashboard screenshot', { dashboardId, format, error })`.

No behavior changes — no new retries, toasts, or timing changes. Purely additive log context.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — logging-only change, no UI impact.

### TESTING INSTRUCTIONS
- Added two unit tests to the existing `useDownloadScreenshot.test.ts` asserting the enriched log calls include the expected fields:
  - `logs cacheKey, dashboardId, and format when retries are exhausted`
  - `logs dashboardId, format, and the error when the initial screenshot request fails`
- Ran `npx jest src/dashboard/hooks/useDownloadScreenshot.test.ts` — all 5 tests pass (3 pre-existing + 2 new).
- Ran `pre-commit run` (prettier, oxlint, custom rules, stylelint, frontend type-checking) on the changed files — all pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API