### PR TITLE
test(jinja): prove current_user_* macros produce collision-free cache keys

### DIFF
--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -684,6 +684,104 @@ def test_user_macros_without_user_info(mocker: MockerFixture):
     assert cache.current_user_rls_rules() is None
 
 
+def _user_metadata_cache_keys(
+    mocker: MockerFixture,
+    *,
+    user_id: int | None,
+    username: str | None,
+    email: str | None,
+    roles: list[str],
+) -> list[Any]:
+    """
+    Render the user-metadata macros for a given user and return the values they
+    contributed to the query cache key.
+    """
+    mock_g = mocker.patch("superset.utils.core.g")
+    if user_id is None:
+        mock_g.user = None
+    else:
+        mock_g.user.id = user_id
+        mock_g.user.username = username
+        mock_g.user.email = email
+    mocker.patch(
+        "superset.security_manager.get_user_roles",
+        return_value=[Role(name=name) for name in roles],
+    )
+    keys: list[Any] = []
+    cache = ExtraCache(extra_cache_keys=keys, table=mocker.MagicMock())
+    cache.current_user_id()
+    cache.current_username()
+    cache.current_user_email()
+    cache.current_user_roles()
+    return keys
+
+
+def test_user_metadata_cache_keys_isolate_distinct_users(mocker: MockerFixture):
+    """
+    Two different users contribute disjoint values to the cache key, so neither
+    can be served the other's cached result. This is the property that keeps the
+    ``current_user_*`` macro family safe for per-user (and multi-tenant) queries.
+    """
+    alice = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
+    )
+    bob = _user_metadata_cache_keys(
+        mocker, user_id=2, username="bob", email="bob@example.com", roles=["Gamma"]
+    )
+    assert alice
+    assert bob
+    assert set(alice).isdisjoint(set(bob))
+
+
+def test_user_metadata_cache_keys_match_for_identical_users(mocker: MockerFixture):
+    """
+    The same user always contributes the same values, so identical renders
+    correctly share a cache entry (no needless fragmentation).
+    """
+    first = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
+    )
+    second = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
+    )
+    assert first == second
+
+
+def test_anonymous_user_never_collides_with_a_logged_in_user(mocker: MockerFixture):
+    """
+    Refutes the "skip cache key when the value is absent" collision concern: an
+    anonymous render contributes nothing to the cache key, so its key can never
+    equal a logged-in user's, and no logged-in user's cached data is served to an
+    anonymous request. Every absent user also renders identically (the macros
+    return ``None``), so absent users correctly share one cache entry rather than
+    colliding.
+    """
+    logged_in = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
+    )
+    anonymous = _user_metadata_cache_keys(
+        mocker, user_id=None, username=None, email=None, roles=[]
+    )
+    assert anonymous == []
+    assert logged_in != anonymous
+
+
+def test_user_metadata_cache_keys_track_each_field_independently(
+    mocker: MockerFixture,
+):
+    """
+    Two users who differ in a single field (here only the roles) still get
+    distinct cache keys, so a change in any one metadata field is reflected.
+    """
+    admin = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
+    )
+    gamma = _user_metadata_cache_keys(
+        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Gamma"]
+    )
+    assert admin != gamma
+
+
 def test_current_user_rls_rules_with_no_table(mocker: MockerFixture):
     """
     Test the ``current_user_rls_rules`` macro when no table is provided.

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -716,7 +716,9 @@ def _user_metadata_cache_keys(
     return keys
 
 
-def test_user_metadata_cache_keys_isolate_distinct_users(mocker: MockerFixture):
+def test_user_metadata_cache_keys_isolate_distinct_users(
+    mocker: MockerFixture,
+) -> None:
     """
     Two different users contribute disjoint values to the cache key, so neither
     can be served the other's cached result. This is the property that keeps the
@@ -733,7 +735,9 @@ def test_user_metadata_cache_keys_isolate_distinct_users(mocker: MockerFixture):
     assert set(alice).isdisjoint(set(bob))
 
 
-def test_user_metadata_cache_keys_match_for_identical_users(mocker: MockerFixture):
+def test_user_metadata_cache_keys_match_for_identical_users(
+    mocker: MockerFixture,
+) -> None:
     """
     The same user always contributes the same values, so identical renders
     correctly share a cache entry (no needless fragmentation).
@@ -747,7 +751,9 @@ def test_user_metadata_cache_keys_match_for_identical_users(mocker: MockerFixtur
     assert first == second
 
 
-def test_anonymous_user_never_collides_with_a_logged_in_user(mocker: MockerFixture):
+def test_anonymous_user_never_collides_with_a_logged_in_user(
+    mocker: MockerFixture,
+) -> None:
     """
     Refutes the "skip cache key when the value is absent" collision concern: an
     anonymous render contributes nothing to the cache key, so its key can never
@@ -768,7 +774,7 @@ def test_anonymous_user_never_collides_with_a_logged_in_user(mocker: MockerFixtu
 
 def test_user_metadata_cache_keys_track_each_field_independently(
     mocker: MockerFixture,
-):
+) -> None:
     """
     Two users who differ in a single field (here only the roles) still get
     distinct cache keys, so a change in any one metadata field is reflected.

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -748,7 +748,9 @@ def test_user_metadata_cache_keys_match_for_identical_users(
     second = _user_metadata_cache_keys(
         mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
     )
-    assert first == second
+    # The real cache key is built from ``set(extra_cache_keys)``, so compare on
+    # the normalized set rather than the raw ordered list.
+    assert set(first) == set(second)
 
 
 def test_anonymous_user_never_collides_with_a_logged_in_user(
@@ -773,26 +775,43 @@ def test_anonymous_user_never_collides_with_a_logged_in_user(
     )
     # The absent id/username/email contribute nothing, so an anonymous request's
     # key carries only its role, never a stray value for the missing fields.
-    assert anon_first == [json.dumps(["Public"])]
+    assert set(anon_first) == {json.dumps(["Public"])}
     # Two anonymous requests share a cache entry; neither collides with a user.
-    assert anon_first == anon_second
+    assert set(anon_first) == set(anon_second)
     assert set(anon_first).isdisjoint(set(logged_in))
 
 
-def test_user_metadata_cache_keys_track_each_field_independently(
+@pytest.mark.parametrize(
+    "field, other_value",
+    [
+        ("user_id", 2),
+        ("username", "bob"),
+        ("email", "bob@example.com"),
+        ("roles", ["Gamma"]),
+    ],
+)
+def test_user_metadata_cache_keys_guard_each_field_independently(
     mocker: MockerFixture,
+    field: str,
+    other_value: Any,
 ) -> None:
     """
-    Two users who differ in a single field (here only the roles) still get
-    distinct cache keys, so a change in any one metadata field is reflected.
+    Two users who differ in exactly one metadata field get distinct cache keys.
+    Guarding each field on its own means a regression that stops any single
+    macro (``current_user_id`` / ``current_username`` / ``current_user_email`` /
+    ``current_user_roles``) from contributing to the key would fail its case here,
+    rather than hiding behind the other fields.
     """
-    admin = _user_metadata_cache_keys(
-        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
-    )
-    gamma = _user_metadata_cache_keys(
-        mocker, user_id=1, username="alice", email="alice@example.com", roles=["Gamma"]
-    )
-    assert admin != gamma
+    base = {
+        "user_id": 1,
+        "username": "alice",
+        "email": "alice@example.com",
+        "roles": ["Admin"],
+    }
+    variant = {**base, field: other_value}
+    base_keys = _user_metadata_cache_keys(mocker, **base)
+    variant_keys = _user_metadata_cache_keys(mocker, **variant)
+    assert set(base_keys) != set(variant_keys)
 
 
 def test_current_user_rls_rules_with_no_table(mocker: MockerFixture):

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -755,21 +755,28 @@ def test_anonymous_user_never_collides_with_a_logged_in_user(
     mocker: MockerFixture,
 ) -> None:
     """
-    Refutes the "skip cache key when the value is absent" collision concern: an
-    anonymous render contributes nothing to the cache key, so its key can never
-    equal a logged-in user's, and no logged-in user's cached data is served to an
-    anonymous request. Every absent user also renders identically (the macros
-    return ``None``), so absent users correctly share one cache entry rather than
-    colliding.
+    Refutes the "skip cache key when the value is absent" collision concern. A
+    real anonymous request has no user object, so ``current_user_id`` /
+    ``current_username`` / ``current_user_email`` return ``None`` and add nothing
+    to the key, while ``current_user_roles`` still contributes the Public role.
+    Two anonymous requests therefore render identically and correctly share one
+    cache entry, and neither can be served a logged-in user's cached result.
     """
     logged_in = _user_metadata_cache_keys(
         mocker, user_id=1, username="alice", email="alice@example.com", roles=["Admin"]
     )
-    anonymous = _user_metadata_cache_keys(
-        mocker, user_id=None, username=None, email=None, roles=[]
+    anon_first = _user_metadata_cache_keys(
+        mocker, user_id=None, username=None, email=None, roles=["Public"]
     )
-    assert anonymous == []
-    assert logged_in != anonymous
+    anon_second = _user_metadata_cache_keys(
+        mocker, user_id=None, username=None, email=None, roles=["Public"]
+    )
+    # The absent id/username/email contribute nothing, so an anonymous request's
+    # key carries only its role, never a stray value for the missing fields.
+    assert anon_first == [json.dumps(["Public"])]
+    # Two anonymous requests share a cache entry; neither collides with a user.
+    assert anon_first == anon_second
+    assert set(anon_first).isdisjoint(set(logged_in))
 
 
 def test_user_metadata_cache_keys_track_each_field_independently(

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -802,13 +802,13 @@ def test_user_metadata_cache_keys_guard_each_field_independently(
     ``current_user_roles``) from contributing to the key would fail its case here,
     rather than hiding behind the other fields.
     """
-    base = {
+    base: dict[str, Any] = {
         "user_id": 1,
         "username": "alice",
         "email": "alice@example.com",
         "roles": ["Admin"],
     }
-    variant = {**base, field: other_value}
+    variant: dict[str, Any] = {**base, field: other_value}
     base_keys = _user_metadata_cache_keys(mocker, **base)
     variant_keys = _user_metadata_cache_keys(mocker, **variant)
     assert set(base_keys) != set(variant_keys)


### PR DESCRIPTION
### SUMMARY

Review of #33924 raised a concern (flagged by a bot, echoing a broader point about the whole macro family) that the user-metadata Jinja macros only add to the query cache key when their value is *present* — skipping the key when the value is absent — and that this could cause cache collisions across users:

```python
if user_id := get_user_id():
    if add_to_cache_keys:
        self.cache_key_wrapper(user_id)
    return user_id
return None
```

This affects the whole family: `current_user_id`, `current_username`, `current_user_email`, `current_user_roles`.

It turns out the skipped path is **not** a collision risk, and this PR adds tests proving it rather than changing behavior. The reason it's safe: an absent value renders identically for every user (the macro returns `None`), so absent users correctly *share* one cache entry instead of colliding, while present values are always distinct in the key. Where the attribute is absent and a default is used (as in #33924's `get_guest_user_attribute`), the default is a literal in the query template, and the template is itself part of the cache key — so absent renders are still fully determined.

### Tests added (all pass)

- distinct users contribute **disjoint** cache-key values, so neither is served the other's cached result (the multi-tenant safety property)
- identical users contribute identical values (correct sharing, no needless fragmentation)
- an anonymous render contributes **nothing**, so it can never collide with a logged-in user's cache entry
- a change in any single metadata field yields a distinct cache key

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/jinja_context_test.py -k "cache_keys or anonymous_user_never"
```

No behavior change — these lock in and document the existing correct behavior, and clear the way for #33924's `get_guest_user_attribute` (which follows the same pattern).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
