### PR TITLE
fix(docs): use modern driver package for CrateDB

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -731,6 +731,7 @@ See `superset/mcp_service/PRODUCTION.md` for deployment guides.
 
 ---
 
+- [38358](https://github.com/apache/superset/pull/38358): Switched CrateDB PyPI package from `crate[sqlalchemy]` to `sqlalchemy-cratedb`.
 - [35621](https://github.com/apache/superset/pull/35621): The default hash algorithm has changed from MD5 to SHA-256 for improved security and FedRAMP compliance. This affects cache keys for thumbnails, dashboard digests, chart digests, and filter option names. Existing cached data will be invalidated upon upgrade. To opt out of this change and maintain backward compatibility, set `HASH_ALGORITHM = "md5"` in your `superset_config.py`.
 - [35062](https://github.com/apache/superset/pull/35062): Changed the function signature of `setupExtensions` to `setupCodeOverrides` with options as arguments.
 

--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -3672,7 +3672,7 @@
         "drivers": [
           {
             "name": "crate",
-            "pypi_package": "crate[sqlalchemy]",
+            "pypi_package": "sqlalchemy-cratedb",
             "connection_string": "crate://{host}:{port}",
             "is_recommended": true
           }

--- a/superset/db_engine_specs/crate.py
+++ b/superset/db_engine_specs/crate.py
@@ -49,7 +49,7 @@ class CrateEngineSpec(BaseEngineSpec):
         "drivers": [
             {
                 "name": "crate",
-                "pypi_package": "crate[sqlalchemy]",
+                "pypi_package": "sqlalchemy-cratedb",
                 "connection_string": "crate://{host}:{port}",
                 "is_recommended": True,
             },


### PR DESCRIPTION
### SUMMARY
Adopts #38358 from @amotl. The docs page for CrateDB still pointed at the legacy `crate[sqlalchemy]` driver package in the driver block's `pypi_package` field, a leftover from the `sqlalchemy-cratedb` migration in #29243. The homepage URL and top-level `pypi_packages` list had already been updated elsewhere, so this just fixes the one remaining spot and adds the UPDATING.md line the original PR proposed.

amotl can't enable maintainer edits on the original branch and lost access to the fork, so recycling the change here per the discussion on #38358.

### TESTING INSTRUCTIONS
N/A, docs/metadata only. `ruff`, `black`, and the `db-engine-spec-metadata` pre-commit hook all pass on the change.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
