### PR TITLE
fix(database): capture result metadata after fetch

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -860,9 +860,10 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
 
                 # Fetch results from last statement if requested
                 if fetch_last_result and i == len(script.statements) - 1:
-                    # Capture cursor.description while it's still valid
-                    description = cursor.description
                     rows = self.db_engine_spec.fetch_data(cursor)
+                    # Some asynchronous DB-API drivers expose placeholder metadata
+                    # until fetching waits for the operation to finish.
+                    description = cursor.description
                 else:
                     # Consume results without storing
                     cursor.fetchall()

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1826,10 +1826,10 @@ def test_get_df_captures_description_after_fetch(mocker: MockerFixture) -> None:
     database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
 
     cursor = mocker.MagicMock()
-    placeholder_description = [
+    placeholder_description: list[tuple[str, str, None, None, None, None, None]] = [
         ("Result", "STRING", None, None, None, None, None),
     ]
-    result_description = [
+    result_description: list[tuple[str, str, None, None, None, None, None]] = [
         ("value", "BIGINT", None, None, None, None, None),
     ]
     cursor.description = placeholder_description

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1815,6 +1815,50 @@ def test_execute_sql_preserves_line_comments_single_statement(
     assert "/*" not in executed_sql
 
 
+def test_get_df_captures_description_after_fetch(mocker: MockerFixture) -> None:
+    """Fetch asynchronous results before capturing their final column metadata.
+
+    Some asynchronous DB-API drivers (e.g. Spark Thrift) expose placeholder
+    ``cursor.description`` until a fetch call waits for the operation to finish.
+    Capturing ``description`` after ``fetch_data`` ensures the real column
+    metadata is used.
+    """
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+
+    cursor = mocker.MagicMock()
+    placeholder_description = [
+        ("Result", "STRING", None, None, None, None, None),
+    ]
+    result_description = [
+        ("value", "BIGINT", None, None, None, None, None),
+    ]
+    cursor.description = placeholder_description
+
+    conn = mocker.MagicMock()
+    conn.cursor.return_value = cursor
+    get_raw_connection = mocker.patch.object(database, "get_raw_connection")
+    get_raw_connection.return_value.__enter__.return_value = conn
+    mocker.patch.object(database.db_engine_spec, "execute")
+
+    def fetch_data(_: object) -> list[tuple[int]]:
+        cursor.description = result_description
+        return [(1,)]
+
+    mocker.patch.object(
+        database.db_engine_spec,
+        "fetch_data",
+        side_effect=fetch_data,
+    )
+
+    _, rows, description = database._execute_sql_with_mutation_and_logging(
+        "SELECT 1",
+        fetch_last_result=True,
+    )
+
+    assert rows == [(1,)]
+    assert description == result_description
+
+
 def test_post_process_df_non_zero_based_index() -> None:
     """
     post_process_df must not raise when the DataFrame index doesn't contain 0


### PR DESCRIPTION
### SUMMARY

`Database._execute_sql_with_mutation_and_logging` captured `cursor.description` **before** calling `db_engine_spec.fetch_data(cursor)`. Some asynchronous DB-API drivers — notably Spark Thrift — expose *placeholder* column metadata (a single `Result` column of type `STRING`) until a fetch call waits for the async operation to complete. As a result, charts and queries executed against such databases received incorrect column names and types.

This moves the `description = cursor.description` capture to run **after** `fetch_data`, so the real column metadata is read once the operation has resolved.

Two properties are preserved:

- The capture stays inside the `with self.get_raw_connection() as conn:` block, so the Databricks fix from #34906 (which required reading `description` before the connection closes) is not regressed.
- This aligns with `BaseEngineSpec.fetch_data`, which already reads `cursor.description` *after* `cursor.fetchall()`.

Per DB-API 2.0, `cursor.description` remains valid after `execute` until the next `execute`, and fetching does not reset it, so this reordering is safe for synchronous drivers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (backend-only change). Behaviorally, on affected async engines:

- **Before:** result columns show placeholder metadata (single `Result` column, type `STRING`).
- **After:** result columns show the query's actual names and types.

### TESTING INSTRUCTIONS

Added `tests/unit_tests/models/core_test.py::test_get_df_captures_description_after_fetch`, which simulates an async cursor whose `description` transitions from a placeholder to the real metadata during `fetch_data`, and asserts the captured description reflects the post-fetch value. The test fails under the previous before-fetch ordering and passes with this change.

```
pytest tests/unit_tests/models/core_test.py -k captures_description_after_fetch
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API