### PR TITLE
fix(label): restore spacing between icon and label text

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Label/Label.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/Label.test.tsx
@@ -55,6 +55,18 @@ test('preserves a custom icon color (antd v6 Tag icon-style regression)', () => 
   });
 });
 
+// Regression: wrapping the icon in a span (see above) stops antd's
+// `> .anticon + span` rule from matching, which had spaced the icon from the
+// label text. Label restores that gap on the content span next to the icon.
+test('keeps a gap between the icon and the label text (#42139)', () => {
+  const { getByText } = render(
+    <Label icon={<Icons.CheckCircleOutlined iconColor="#aabbcc" />}>
+      labeled
+    </Label>,
+  );
+  expect(getByText('labeled')).toHaveStyle({ marginInlineStart: '8px' });
+});
+
 // test stories from the storybook!
 test('renders all the storybook gallery variants', () => {
   const { container } = render(<LabelGallery />);

--- a/superset-frontend/packages/superset-ui-core/src/components/Label/Label.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/Label.test.tsx
@@ -67,6 +67,13 @@ test('keeps a gap between the icon and the label text (#42139)', () => {
   expect(getByText('labeled')).toHaveStyle({ marginInlineStart: '8px' });
 });
 
+// The icon gap must not leak onto icon-less labels: the content spacing is
+// gated on `icon`, so a label without an icon keeps its natural spacing.
+test('does not add the icon gap to an icon-less label (#42139)', () => {
+  const { getByText } = render(<Label>unlabeled</Label>);
+  expect(getByText('unlabeled')).not.toHaveStyle({ marginInlineStart: '8px' });
+});
+
 // test stories from the storybook!
 test('renders all the storybook gallery variants', () => {
   const { container } = render(<LabelGallery />);

--- a/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
@@ -77,6 +77,15 @@ export const Label = forwardRef<HTMLSpanElement, LabelProps>((props, ref) => {
       role={onClick ? 'button' : undefined}
       style={style}
       /*
+       * Ant Design v6's Tag renders the label text in a content span and spaces
+       * it from the icon via the `> .anticon + span` rule. That rule only matches
+       * when the icon is a direct `.anticon` child, which the wrapper span below
+       * breaks, so the gap is restored explicitly on the content span. antd only
+       * renders the content span when an icon is present, so this is a no-op for
+       * icon-less labels.
+       */
+      styles={{ content: { marginInlineStart: theme.sizeUnit * 2 } }}
+      /*
        * Ant Design v6's Tag clones the `icon` element and overrides its inline
        * `style` (see antd/es/tag: cloneElement(icon, { style: mergedStyles.icon })),
        * which would drop the icon's own color/size. Wrapping the icon in a span

--- a/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
@@ -80,11 +80,15 @@ export const Label = forwardRef<HTMLSpanElement, LabelProps>((props, ref) => {
        * Ant Design v6's Tag renders the label text in a content span and spaces
        * it from the icon via the `> .anticon + span` rule. That rule only matches
        * when the icon is a direct `.anticon` child, which the wrapper span below
-       * breaks, so the gap is restored explicitly on the content span. antd only
-       * renders the content span when an icon is present, so this is a no-op for
-       * icon-less labels.
+       * breaks, so the gap is restored explicitly on the content span. Gate it on
+       * `icon` so icon-less labels keep their natural spacing regardless of how
+       * antd renders the content slot.
        */
-      styles={{ content: { marginInlineStart: theme.sizeUnit * 2 } }}
+      styles={
+        icon
+          ? { content: { marginInlineStart: theme.sizeUnit * 2 } }
+          : undefined
+      }
       /*
        * Ant Design v6's Tag clones the `icon` element and overrides its inline
        * `style` (see antd/es/tag: cloneElement(icon, { style: mergedStyles.icon })),


### PR DESCRIPTION
### SUMMARY

The **Draft / Published** status button in the dashboard header lost the space between its status icon and text label, rendering like `⚪Draft` instead of `⚪ Draft`. This is a shared-component regression — it affects every icon `Label` (CachedLabel, DatasetTypeLabel, Timer, etc.), the Draft/Published toggle being the most visible.

**Root cause:** the Ant Design v5→v6 upgrade (#41636) wrapped the `Label`'s icon in a `<span>` so antd v6's `Tag` (which clones the icon element and overwrites its inline `style`) could no longer strip the icon's own color/size. But antd spaces the icon from the label text via the CSS rule `> .anticon + span { margin-inline-start: … }`, which only matches when the icon is a **direct `.anticon` child** of the `Tag`. The wrapper span breaks that adjacency, so the margin is never applied and the gap disappears.

**Fix:** restore the gap explicitly on the `Tag`'s content span via antd's `styles={{ content: { marginInlineStart } }}` semantic API, mirroring the margin antd itself applied. antd only renders the content span when an icon is present, so this is a no-op for icon-less labels (faithful to the original `.anticon + span` semantics). Uses `theme.sizeUnit * 2` (8px) so the spacing tracks the design system.

Fixes #42139

### BEFORE/AFTER

Before: `⚪Draft` (icon flush against text).
After: `⚪ Draft` (leading gap restored).

### TESTING INSTRUCTIONS

- Open a dashboard and check the Draft/Published status button in the header — there should be a normal gap between the status icon and the text.
- `Label` unit tests: added a regression test asserting the label text span carries `marginInlineStart: 8px` when an icon is present. All Label suites pass.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42139
- [x] Changes UI
- [ ] Required feature flags:
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime consideration(s)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
