### PR TITLE
fix(dashboard): keep refresh_frequency set via the Advanced JSON editor (#42116)

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -57,6 +57,7 @@ jest.mock('./sections/AdvancedSection', () => ({
     <div>
       <span>JSON Metadata</span>
       <textarea
+        aria-label="JSON metadata editor"
         data-test="mock-json-editor"
         value={jsonMetadata}
         onChange={e => onJsonMetadataChange(e.target.value)}
@@ -284,6 +285,19 @@ describe('PropertiesModal', () => {
   });
 
   test('preserves a refresh_frequency edited in the JSON editor on save (#42116)', async () => {
+    // Save (onlyApply: false) PUTs to the API before calling onSubmit, so the
+    // request must be mocked or onSubmit is never reached.
+    const put = jest.spyOn(SupersetCore.SupersetClient, 'put');
+    put.mockResolvedValue({
+      json: {
+        result: {
+          dashboard_title: 'dashboard_title',
+          slug: 'slug',
+          json_metadata: 'json_metadata',
+          editors: 'editors',
+        },
+      },
+    } as any);
     mockedIsFeatureEnabled.mockReturnValue(false);
     const props = createProps();
     const propsWithDashboardInfo = {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -39,6 +40,29 @@ jest.mock('@superset-ui/core', () => ({
     get: () => ['#FFFFFF', '#000000'],
     getDefaultKey: () => 'supersetColors',
   })),
+}));
+
+// Mock the Advanced JSON editor (Ace-based, not drivable in jsdom) with a plain
+// textarea so a direct JSON edit can be simulated. Keeps the "JSON Metadata"
+// label so the existing "should open advance" test still passes.
+jest.mock('./sections/AdvancedSection', () => ({
+  __esModule: true,
+  default: ({
+    jsonMetadata,
+    onJsonMetadataChange,
+  }: {
+    jsonMetadata: string;
+    onJsonMetadataChange: (value: string) => void;
+  }) => (
+    <div>
+      <span>JSON Metadata</span>
+      <textarea
+        data-test="mock-json-editor"
+        value={jsonMetadata}
+        onChange={e => onJsonMetadataChange(e.target.value)}
+      />
+    </div>
+  ),
 }));
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
@@ -257,6 +281,43 @@ describe('PropertiesModal', () => {
       // Check that the Advanced settings section is expanded by looking for its content
       expect(screen.getByText('JSON Metadata')).toBeInTheDocument();
     });
+  });
+
+  test('preserves a refresh_frequency edited in the JSON editor on save (#42116)', async () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+    await screen.findByTestId('dashboard-edit-properties-form');
+
+    // Expand the Advanced settings panel so the (mocked) JSON editor mounts.
+    const advancedHeader = screen
+      .getByText('Advanced settings')
+      .closest('.ant-collapse-header');
+    await userEvent.click(advancedHeader!);
+
+    // Edit refresh_frequency directly in the JSON editor without touching the
+    // Refresh dropdown (the reproduction of #42116).
+    const editor = await screen.findByTestId('mock-json-editor');
+    fireEvent.change(editor, {
+      target: { value: JSON.stringify({ refresh_frequency: 30 }) },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = JSON.parse(props.onSubmit.mock.calls[0][0].jsonMetadata);
+    expect(submitted.refresh_frequency).toBe(30);
   });
 
   test('should close modal', async () => {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -404,6 +404,55 @@ describe('PropertiesModal', () => {
     expect(submitted.refresh_frequency).toBe(0);
   });
 
+  test('propagates a Refresh dropdown-only change into the submitted JSON metadata', async () => {
+    // Selecting a value from the Refresh dropdown without touching the
+    // Advanced JSON editor must still make it into the submitted payload --
+    // handleRefreshFrequencyChange writes the new value into the JSON
+    // metadata object on change (#42116, requested in review).
+    const put = jest.spyOn(SupersetCore.SupersetClient, 'put');
+    put.mockResolvedValue({
+      json: {
+        result: {
+          dashboard_title: 'dashboard_title',
+          slug: 'slug',
+          json_metadata: 'json_metadata',
+          editors: 'editors',
+        },
+      },
+    } as any);
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+    await screen.findByTestId('dashboard-edit-properties-form');
+
+    // mockedJsonMetadata starts at refresh_frequency: 0, so selecting
+    // "1 minute" (60) is a real change coming only from the dropdown.
+    const refreshHeader = screen
+      .getByText('Refresh settings')
+      .closest('.ant-collapse-header');
+    await userEvent.click(refreshHeader!);
+    await userEvent.click(
+      await screen.findByRole('radio', { name: '1 minute' }),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = JSON.parse(props.onSubmit.mock.calls[0][0].jsonMetadata);
+    expect(submitted.refresh_frequency).toBe(60);
+  });
+
   test('should close modal', async () => {
     mockedIsFeatureEnabled.mockImplementation((flag: any) => {
       if (flag === FeatureFlag.TaggingSystem) return true;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -334,6 +334,76 @@ describe('PropertiesModal', () => {
     expect(submitted.refresh_frequency).toBe(30);
   });
 
+  test('preserves an explicit 0 from the JSON editor over a non-zero dropdown value (#42116)', async () => {
+    // A truthy value like 30 can't tell `??` and `||` apart. Only a falsy-but-
+    // explicit `refresh_frequency: 0` in the JSON, combined with a non-zero
+    // Refresh dropdown, catches a regression from `??` back to `||` on
+    // index.tsx, which would let the dropdown's non-zero value win over an
+    // explicit "Don't refresh".
+    const put = jest.spyOn(SupersetCore.SupersetClient, 'put');
+    put.mockResolvedValue({
+      json: {
+        result: {
+          dashboard_title: 'dashboard_title',
+          slug: 'slug',
+          json_metadata: 'json_metadata',
+          editors: 'editors',
+        },
+      },
+    } as any);
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+    // A non-zero refresh_frequency in dashboardInfo so the Refresh dropdown
+    // initializes to a truthy value (dashboardInfo, when passed, is used
+    // directly instead of triggering a fetch -- see the `!currentDashboardInfo`
+    // check in the data-loading effect). handleDashboardData reads the parsed
+    // `metadata` object, not the `json_metadata` string.
+    const nonZeroMetadata = mockedJsonMetadata.replace(
+      '"refresh_frequency": 0',
+      '"refresh_frequency": 30',
+    );
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: nonZeroMetadata,
+        metadata: JSON.parse(nonZeroMetadata),
+      },
+    };
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+    await screen.findByTestId('dashboard-edit-properties-form');
+
+    // Confirm the Refresh dropdown actually picked up the non-zero value.
+    const refreshHeader = screen
+      .getByText('Refresh settings')
+      .closest('.ant-collapse-header');
+    await userEvent.click(refreshHeader!);
+    expect(
+      await screen.findByRole('radio', { name: '30 seconds' }),
+    ).toBeChecked();
+
+    // Edit the JSON editor to explicitly set refresh_frequency to 0 ("Don't
+    // refresh") without touching the Refresh dropdown.
+    const advancedHeader = screen
+      .getByText('Advanced settings')
+      .closest('.ant-collapse-header');
+    await userEvent.click(advancedHeader!);
+    const editor = await screen.findByTestId('mock-json-editor');
+    fireEvent.change(editor, {
+      target: { value: JSON.stringify({ refresh_frequency: 0 }) },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = JSON.parse(props.onSubmit.mock.calls[0][0].jsonMetadata);
+    expect(submitted.refresh_frequency).toBe(0);
+  });
+
   test('should close modal', async () => {
     mockedIsFeatureEnabled.mockImplementation((flag: any) => {
       if (flag === FeatureFlag.TaggingSystem) return true;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -422,11 +422,20 @@ describe('PropertiesModal', () => {
     } as any);
     mockedIsFeatureEnabled.mockReturnValue(false);
     const props = createProps();
+    // dashboardInfo, when passed, is used directly instead of triggering a
+    // fetch (see the `!currentDashboardInfo` check in the data-loading
+    // effect); handleDashboardData reads the parsed `metadata` object, not
+    // the `json_metadata` string, so `metadata` must be parsed here too --
+    // otherwise the seeded JSON has no `refresh_frequency` key at all and
+    // save falls back to the selected 60 through the `?? refreshFrequency`
+    // path regardless of whether the dropdown-to-JSON sync under test
+    // actually runs.
     const propsWithDashboardInfo = {
       ...props,
       dashboardInfo: {
         ...dashboardInfo,
         json_metadata: mockedJsonMetadata,
+        metadata: JSON.parse(mockedJsonMetadata),
       },
     };
     render(<PropertiesModal {...propsWithDashboardInfo} />, {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -343,7 +343,12 @@ const PropertiesModal = ({
         ? resettableCustomLabels
         : false;
     const jsonMetadataObj = getJsonMetadata();
-    jsonMetadataObj.refresh_frequency = refreshFrequency;
+    // A refresh_frequency edited directly in the Advanced JSON editor takes
+    // precedence over the Refresh dropdown state, mirroring how color_scheme is
+    // handled above. Nullish coalescing preserves an explicit 0 ("Don't
+    // refresh") rather than falling through to the dropdown value (#42116).
+    jsonMetadataObj.refresh_frequency =
+      jsonMetadataObj.refresh_frequency ?? refreshFrequency;
     jsonMetadataObj.show_chart_timestamps = Boolean(showChartTimestamps);
     const customLabelColors = jsonMetadataObj.label_colors || {};
     const updatedDashboardMetadata = {
@@ -537,8 +542,14 @@ const PropertiesModal = ({
 
   // Section handlers for extracted components
   const handleThemeChange = (value: any) => setSelectedThemeId(value || null);
-  const handleRefreshFrequencyChange = (value: number) =>
+  const handleRefreshFrequencyChange = (value: number) => {
     setRefreshFrequency(value);
+    // Keep the Advanced JSON editor in sync with the dropdown so the two
+    // sources can't diverge, mirroring onColorSchemeChange (#42116).
+    const jsonMetadataObj = getJsonMetadata();
+    jsonMetadataObj.refresh_frequency = value;
+    setJsonMetadata(jsonStringify(jsonMetadataObj));
+  };
 
   // Helper function for styling section
   const hasCustomLabelsColor = !!Object.keys(

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -238,16 +238,18 @@ const PropertiesModal = ({
     }, handleErrorResponse);
   }, [dashboardId, handleDashboardData]);
 
-  const getJsonMetadata = () => {
+  // Returns undefined (rather than {}) when the editor holds invalid JSON,
+  // so callers can distinguish "empty/no metadata yet" from "user is
+  // mid-edit with unparsable text" and avoid clobbering the latter.
+  const parseJsonMetadata = () => {
     try {
-      const jsonMetadataObj = jsonMetadata?.length
-        ? JSON.parse(jsonMetadata)
-        : {};
-      return jsonMetadataObj;
+      return jsonMetadata?.length ? JSON.parse(jsonMetadata) : {};
     } catch (_) {
-      return {};
+      return undefined;
     }
   };
+
+  const getJsonMetadata = () => parseJsonMetadata() ?? {};
 
   const handleOnChangeEditors = (values: SubjectPickerValue[]) => {
     setEditors(mapPickerValuesToSubjects(values));
@@ -545,8 +547,13 @@ const PropertiesModal = ({
   const handleRefreshFrequencyChange = (value: number) => {
     setRefreshFrequency(value);
     // Keep the Advanced JSON editor in sync with the dropdown so the two
-    // sources can't diverge, mirroring onColorSchemeChange (#42116).
-    const jsonMetadataObj = getJsonMetadata();
+    // sources can't diverge, mirroring onColorSchemeChange (#42116). Skip
+    // this while the editor holds invalid/in-progress JSON so we don't
+    // clobber the user's unfinished edit with a one-field object.
+    const jsonMetadataObj = parseJsonMetadata();
+    if (!jsonMetadataObj) {
+      return;
+    }
     jsonMetadataObj.refresh_frequency = value;
     setJsonMetadata(jsonStringify(jsonMetadataObj));
   };
@@ -591,7 +598,15 @@ const PropertiesModal = ({
           const refreshLimit =
             dashboardInfo?.common?.conf
               ?.SUPERSET_DASHBOARD_PERIODICAL_REFRESH_LIMIT;
-          return validateRefreshFrequency(refreshFrequency, refreshLimit);
+          // A refresh_frequency edited directly in the Advanced JSON editor
+          // takes precedence over the dropdown when saving (see onFinish),
+          // so validate that effective value rather than the dropdown state.
+          const effectiveRefreshFrequency =
+            getJsonMetadata()?.refresh_frequency ?? refreshFrequency;
+          return validateRefreshFrequency(
+            effectiveRefreshFrequency,
+            refreshLimit,
+          );
         },
       },
       {

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -83,11 +83,23 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
                     json.loads(position_json)
                 )
 
-            dashboard = DashboardDAO.update(self._model, self._properties)
-            if self._properties.get("json_metadata"):
+            # ``set_dash_metadata`` merges the incoming metadata against
+            # ``dashboard.params_dict`` (the *stored* ``json_metadata``) to
+            # preserve fields the caller omitted. Routing ``json_metadata``
+            # through the generic attribute update below would overwrite
+            # that stored value before the merge ever sees it, silently
+            # collapsing the merge into a no-op and resetting any omitted
+            # field to its default -- so it is excluded here and applied
+            # exclusively via ``set_dash_metadata``.
+            json_metadata = self._properties.get("json_metadata")
+            dashboard = DashboardDAO.update(
+                self._model,
+                {k: v for k, v in self._properties.items() if k != "json_metadata"},
+            )
+            if json_metadata:
                 DashboardDAO.set_dash_metadata(
                     dashboard,
-                    data=json.loads(self._properties.get("json_metadata", "{}")),
+                    data=json.loads(json_metadata),
                 )
         return dashboard
 

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -408,9 +408,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
             "refresh_frequency": 0,
             "color_scheme": "",
             "label_colors": {},
-            "shared_label_colors": [],
-            "map_label_colors": {},
-            "color_scheme_domain": [],
             "cross_filters_enabled": True,
         }
         for key, default_value in metadata_defaults.items():
@@ -418,6 +415,17 @@ class DashboardDAO(BaseDAO[Dashboard]):
                 md[key] = data[key]
             else:
                 md.setdefault(key, default_value)
+
+        # These are derived from ``color_scheme``/``label_colors`` on the
+        # frontend (see ``applyDashboardLabelsColorOnLoad``) and are always
+        # omitted from the Properties modal's payload, so they must keep
+        # resetting to their default when absent rather than being preserved
+        # -- otherwise a color scheme change made through that modal leaves
+        # stale label-to-color mappings in place instead of triggering
+        # recomputation on next load.
+        md["shared_label_colors"] = data.get("shared_label_colors", [])
+        md["map_label_colors"] = data.get("map_label_colors", {})
+        md["color_scheme_domain"] = data.get("color_scheme_domain", [])
         dashboard.json_metadata = json.dumps(md)
 
     @staticmethod

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -56,6 +56,29 @@ DASHBOARD_CUSTOM_FIELDS = {
     "favorite": ["eq"],
 }
 
+# Keys ``DashboardDAO.set_dash_metadata`` recomputes or overrides itself,
+# rather than passing straight through from the incoming payload: either
+# because they're structurally transformed (positions, filter_scopes,
+# default_filters), reset to a default when absent (color_namespace, the
+# metadata_defaults fields), or always derived and never sent by the
+# frontend (shared_label_colors, map_label_colors, color_scheme_domain).
+# Excluded from the generic merge so that dedicated handling stays
+# authoritative for them.
+_SET_DASH_METADATA_SPECIAL_KEYS = {
+    "positions",
+    "filter_scopes",
+    "default_filters",
+    "color_namespace",
+    "expanded_slices",
+    "refresh_frequency",
+    "color_scheme",
+    "label_colors",
+    "cross_filters_enabled",
+    "shared_label_colors",
+    "map_label_colors",
+    "color_scheme_domain",
+}
+
 
 class DashboardDAO(BaseDAO[Dashboard]):
     base_filter = DashboardAccessFilter
@@ -304,6 +327,17 @@ class DashboardDAO(BaseDAO[Dashboard]):
     ) -> None:
         new_filter_scopes = {}
         md = dashboard.params_dict
+
+        # Merge every incoming metadata key that isn't given dedicated
+        # handling below straight through (e.g. show_chart_timestamps,
+        # stagger_refresh, timed_refresh_immune_slices). Without this, only
+        # the fixed subset of keys this function special-cases would ever
+        # reach ``dashboard.json_metadata`` -- any other field edited via
+        # the Advanced JSON editor would silently revert to its stored
+        # value on save (sadpandajoe, #42142).
+        md.update(
+            {k: v for k, v in data.items() if k not in _SET_DASH_METADATA_SPECIAL_KEYS}
+        )
 
         if (positions := data.get("positions")) is not None:
             # find slices in the position data

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -396,15 +396,28 @@ class DashboardDAO(BaseDAO[Dashboard]):
         else:
             md["color_namespace"] = data.get("color_namespace")
 
-        md["expanded_slices"] = data.get("expanded_slices", {})
-        if "refresh_frequency" in data:
-            md["refresh_frequency"] = data["refresh_frequency"]
-        md["color_scheme"] = data.get("color_scheme", "")
-        md["label_colors"] = data.get("label_colors", {})
-        md["shared_label_colors"] = data.get("shared_label_colors", [])
-        md["map_label_colors"] = data.get("map_label_colors", {})
-        md["color_scheme_domain"] = data.get("color_scheme_domain", [])
-        md["cross_filters_enabled"] = data.get("cross_filters_enabled", True)
+        # Only overwrite these metadata fields when the caller explicitly sends
+        # them. Previously each used ``data.get(key, default)``, which reset a
+        # value to its default whenever it was absent from the payload -- e.g. a
+        # ``refresh_frequency`` set directly in the Advanced JSON editor got
+        # wiped on save. ``setdefault`` still seeds a default for brand-new
+        # dashboards that have never had the key, keeping the shape stable
+        # without clobbering existing values (#42116).
+        metadata_defaults: dict[str, Any] = {
+            "expanded_slices": {},
+            "refresh_frequency": 0,
+            "color_scheme": "",
+            "label_colors": {},
+            "shared_label_colors": [],
+            "map_label_colors": {},
+            "color_scheme_domain": [],
+            "cross_filters_enabled": True,
+        }
+        for key, default_value in metadata_defaults.items():
+            if key in data:
+                md[key] = data[key]
+            else:
+                md.setdefault(key, default_value)
         dashboard.json_metadata = json.dumps(md)
 
     @staticmethod

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1998,7 +1998,13 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         assert model.slug == self.dashboard_data["slug"]
         assert model.position_json == self.dashboard_data["position_json"]
         assert model.css == self.dashboard_data["css"]
-        assert model.json_metadata == self.dashboard_data["json_metadata"]
+        # Compare parsed JSON rather than raw strings: ``set_dash_metadata``
+        # merges against the dashboard's previously stored metadata, so key
+        # insertion order (and therefore serialized key order) is an
+        # implementation detail, not part of the contract being tested.
+        assert json.loads(model.json_metadata) == json.loads(
+            self.dashboard_data["json_metadata"]
+        )
         assert model.published == self.dashboard_data["published"]
         admin_subject = (
             db.session.query(Subject)
@@ -2641,7 +2647,11 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         assert rv.status_code == 200
 
         model = db.session.query(Dashboard).get(dashboard_id)
-        assert model.json_metadata == self.dashboard_data["json_metadata"]
+        # Compare parsed JSON rather than raw strings; see the equivalent
+        # comment in ``test_update_dashboard``.
+        assert json.loads(model.json_metadata) == json.loads(
+            self.dashboard_data["json_metadata"]
+        )
         assert model.dashboard_title == self.dashboard_data["dashboard_title"]
         assert model.slug == self.dashboard_data["slug"]
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2054,6 +2054,52 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         db.session.delete(model)
         db.session.commit()
 
+    def test_update_dashboard_persists_metadata_fields_without_dedicated_handling(
+        self,
+    ):
+        """
+        Dashboard API: ``set_dash_metadata`` only gives dedicated handling to a
+        fixed subset of ``json_metadata`` keys (positions, filter_scopes,
+        refresh_frequency, etc). A field edited via the Advanced JSON editor
+        that isn't in that subset -- e.g. ``show_chart_timestamps``,
+        ``stagger_refresh``, ``timed_refresh_immune_slices`` -- must still be
+        persisted rather than silently dropped on save (see #42142).
+        """
+        admin = self.get_user("admin")
+        dashboard_id = self.insert_dashboard(
+            "title1",
+            "slug1",
+            [admin.id],
+            json_metadata=json.dumps({"refresh_frequency": 60}),
+        ).id
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/dashboard/{dashboard_id}"
+        rv = self.put_assert_metric(
+            uri,
+            {
+                "json_metadata": json.dumps(
+                    {
+                        "refresh_frequency": 60,
+                        "show_chart_timestamps": True,
+                        "stagger_refresh": True,
+                        "stagger_time": 500,
+                        "timed_refresh_immune_slices": [1, 2],
+                    }
+                )
+            },
+            "put",
+        )
+        assert rv.status_code == 200
+        model = db.session.query(Dashboard).get(dashboard_id)
+        saved_metadata = json.loads(model.json_metadata)
+        assert saved_metadata["show_chart_timestamps"] is True
+        assert saved_metadata["stagger_refresh"] is True
+        assert saved_metadata["stagger_time"] == 500
+        assert saved_metadata["timed_refresh_immune_slices"] == [1, 2]
+
+        db.session.delete(model)
+        db.session.commit()
+
     def test_add_dashboard_filters(self):
         """
         Dashboard API: Test that a filter was added

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2010,6 +2010,44 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         db.session.delete(model)
         db.session.commit()
 
+    def test_update_dashboard_preserves_unsent_json_metadata_fields(self):
+        """
+        Dashboard API: a PUT whose ``json_metadata`` omits a field must not
+        reset that field to its default. ``UpdateDashboardCommand`` routes
+        the incoming ``json_metadata`` through ``DashboardDAO.update``'s
+        generic attribute assignment before calling
+        ``DashboardDAO.set_dash_metadata`` -- if that assignment overwrites
+        ``dashboard.json_metadata`` first, the merge in
+        ``set_dash_metadata`` (which reads ``dashboard.params_dict``) has
+        nothing but the new, partial payload to merge against, silently
+        collapsing the merge into a no-op (see #42142).
+        """
+        admin = self.get_user("admin")
+        dashboard_id = self.insert_dashboard(
+            "title1",
+            "slug1",
+            [admin.id],
+            json_metadata=json.dumps(
+                {"refresh_frequency": 60, "cross_filters_enabled": False}
+            ),
+        ).id
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/dashboard/{dashboard_id}"
+        rv = self.put_assert_metric(
+            uri,
+            {"json_metadata": json.dumps({"color_scheme": "d3Category10"})},
+            "put",
+        )
+        assert rv.status_code == 200
+        model = db.session.query(Dashboard).get(dashboard_id)
+        saved_metadata = json.loads(model.json_metadata)
+        assert saved_metadata["refresh_frequency"] == 60
+        assert saved_metadata["cross_filters_enabled"] is False
+        assert saved_metadata["color_scheme"] == "d3Category10"
+
+        db.session.delete(model)
+        db.session.commit()
+
     def test_add_dashboard_filters(self):
         """
         Dashboard API: Test that a filter was added

--- a/tests/integration_tests/dashboards/dao_tests.py
+++ b/tests/integration_tests/dashboards/dao_tests.py
@@ -74,6 +74,46 @@ class TestDashboardDAO(SupersetTestCase):
             db.session.commit()
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    @patch("superset.utils.core.g")
+    @patch("superset.security.manager.g")
+    def test_set_dash_metadata_preserves_unsent_fields(self, mock_sm_g, mock_g):
+        """
+        set_dash_metadata must not reset metadata fields that are absent from the
+        incoming payload, such as a ``refresh_frequency`` edited directly in the
+        Advanced JSON editor (#42116). Fields that are present still override.
+        """
+        mock_g.user = mock_sm_g.user = security_manager.find_user("admin")
+        with self.client.application.test_request_context():
+            dashboard = (
+                db.session.query(Dashboard).filter_by(slug="world_health").first()
+            )
+            original_json_metadata = dashboard.json_metadata
+            try:
+                # Seed an existing refresh_frequency in the stored metadata.
+                metadata = json.loads(dashboard.json_metadata or "{}")
+                metadata["refresh_frequency"] = 60
+                dashboard.json_metadata = json.dumps(metadata)
+                db.session.commit()
+
+                # Payload omits refresh_frequency: it must be preserved, not
+                # reset to 0.
+                DashboardDAO.set_dash_metadata(
+                    dashboard, {"color_scheme": "d3Category10"}
+                )
+                db.session.commit()
+                saved = json.loads(dashboard.json_metadata)
+                assert saved["refresh_frequency"] == 60
+                assert saved["color_scheme"] == "d3Category10"
+
+                # An explicitly-sent value still overrides.
+                DashboardDAO.set_dash_metadata(dashboard, {"refresh_frequency": 30})
+                db.session.commit()
+                assert json.loads(dashboard.json_metadata)["refresh_frequency"] == 30
+            finally:
+                dashboard.json_metadata = original_json_metadata
+                db.session.commit()
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @patch("superset.daos.dashboard.g")
     @patch("superset.security.manager.g")
     def test_copy_dashboard(self, mock_sm_g, mock_g):

--- a/tests/integration_tests/dashboards/dao_tests.py
+++ b/tests/integration_tests/dashboards/dao_tests.py
@@ -89,26 +89,37 @@ class TestDashboardDAO(SupersetTestCase):
             )
             original_json_metadata = dashboard.json_metadata
             try:
-                # Seed an existing refresh_frequency in the stored metadata.
+                # Seed existing values in the stored metadata, including
+                # cross_filters_enabled=False -- its default is True, so this
+                # is the field that actually exercises this PR's change (the
+                # refresh_frequency preservation alone already landed in
+                # #42354).
                 metadata = json.loads(dashboard.json_metadata or "{}")
                 metadata["refresh_frequency"] = 60
+                metadata["cross_filters_enabled"] = False
                 dashboard.json_metadata = json.dumps(metadata)
                 db.session.commit()
 
-                # Payload omits refresh_frequency: it must be preserved, not
-                # reset to 0.
+                # Payload omits refresh_frequency and cross_filters_enabled:
+                # both must be preserved, not reset to their defaults.
                 DashboardDAO.set_dash_metadata(
                     dashboard, {"color_scheme": "d3Category10"}
                 )
                 db.session.commit()
                 saved = json.loads(dashboard.json_metadata)
                 assert saved["refresh_frequency"] == 60
+                assert saved["cross_filters_enabled"] is False
                 assert saved["color_scheme"] == "d3Category10"
 
                 # An explicitly-sent value still overrides.
-                DashboardDAO.set_dash_metadata(dashboard, {"refresh_frequency": 30})
+                DashboardDAO.set_dash_metadata(
+                    dashboard,
+                    {"refresh_frequency": 30, "cross_filters_enabled": True},
+                )
                 db.session.commit()
-                assert json.loads(dashboard.json_metadata)["refresh_frequency"] == 30
+                saved = json.loads(dashboard.json_metadata)
+                assert saved["refresh_frequency"] == 30
+                assert saved["cross_filters_enabled"] is True
             finally:
                 dashboard.json_metadata = original_json_metadata
                 db.session.commit()


### PR DESCRIPTION
### SUMMARY

Fixes #42116: editing `refresh_frequency` in Dashboard Properties → Advanced → JSON metadata resets to `0` on save (a 6.0 → 6.1 regression).

The root cause is in the frontend, not the backend line dosu flagged. In the update path `DashboardDAO.update` sets `json_metadata` first, so in `set_dash_metadata` both `md` and `data` are the *same* incoming JSON, and `data.get("refresh_frequency", 0)` only defaults when the value is genuinely absent from the payload. The value is absent because the **Properties modal drops it**: `handleRefreshFrequencyChange` only updates a separate `refreshFrequency` state (never syncing into the JSON editor), the JSON editor only updates its own text (never syncing back), and on save `onFinish` did `jsonMetadataObj.refresh_frequency = refreshFrequency`, blindly overwriting a value typed into the JSON editor with the stale dropdown state. `color_scheme` right above it already does the correct thing ("json metadata has precedence over selection") — this makes `refresh_frequency` follow the same pattern.

Changes:
- **Frontend (the fix):** on save, a `refresh_frequency` present in the Advanced JSON editor takes precedence over the dropdown (`?? refreshFrequency`, so an explicit `0` is preserved); and a dropdown change now syncs into the JSON editor so the two sources can't diverge — mirroring `onColorSchemeChange`.
- **Backend (hardening, per dosu):** `set_dash_metadata` now only overwrites the eight metadata fields (`refresh_frequency`, `expanded_slices`, `color_scheme`, `label_colors`, …) when they're actually present in the payload, using `setdefault` for brand-new dashboards. This preserves fields on partial `json_metadata` updates instead of resetting them, and keeps the stored shape stable. Verified every existing reader of these keys uses `.get()`/`in` guards, so nothing depends on the old force-default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: set `refresh_frequency` in the Advanced JSON editor, Save → it reverts to `0`.
After: the value is saved and persists.

### TESTING INSTRUCTIONS

1. Open a dashboard → Edit properties → Advanced, and set `"refresh_frequency": 60` in the JSON metadata (without touching the Refresh dropdown). Save, reopen — the value persists.
2. Set the Refresh dropdown to a value and Save — still works (dropdown syncs into the JSON).
3. `pytest tests/integration_tests/dashboards/dao_tests.py -k set_dash_metadata_preserves_unsent_fields`
4. `npm run test -- PropertiesModal.test.tsx`

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42116
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
