### PR TITLE
fix(chat): prevent main content reload when toggling chat panel

### DIFF
--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -189,6 +189,7 @@ const AppContent = ({
         flex: 1;
         min-height: 0;
         overflow: hidden;
+        justify-content: center;
 
         /*
          * Splitter.Panel is not a flex container by default, so flex:1 on
@@ -233,7 +234,8 @@ const App = () => {
     () =>
       createHtmlPortalNode({
         attributes: {
-          style: 'display: flex; flex-direction: column; flex: 1 1 auto;',
+          style:
+            'display: flex; flex-direction: column; flex: 1 1 auto; height: 100%; min-height: 0;',
         },
       }),
     [],

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -165,7 +165,13 @@ const AppContent = ({
     CHAT_PANEL_DEFAULT_WIDTH,
   );
 
-  const layoutContent = <OutPortal node={layoutPortalNode} />;
+  const layoutContent = (
+    <Layout css={isPanelOpen ? layoutCss : undefined}>
+      <Layout.Content css={isPanelOpen ? contentCss : pageScrollContentCss}>
+        <OutPortal node={layoutPortalNode} />
+      </Layout.Content>
+    </Layout>
+  );
 
   const content = isPanelOpen ? (
     <Splitter
@@ -227,11 +233,7 @@ const App = () => {
       <LocationPathnameLogger />
       <RootContextProviders>
         <InPortal node={layoutPortalNode}>
-          <Layout css={layoutCss}>
-            <Layout.Content css={contentCss}>
-              <RouteSwitch />
-            </Layout.Content>
-          </Layout>
+          <RouteSwitch />
         </InPortal>
         <AppContent />
         <ToastContainer />

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -225,7 +225,19 @@ const AppContent = ({
 };
 
 const App = () => {
-  const layoutPortalNode = useMemo(() => createHtmlPortalNode(), []);
+  // OutPortal renders this node's bare DOM element in place of <RouteSwitch />.
+  // Pages (e.g. SqlLab) rely on `flex: 1 1 auto` to stretch inside
+  // Layout.Content, which only works if their direct parent is a flex
+  // container; without this the portal's unstyled div collapses to 0 height.
+  const layoutPortalNode = useMemo(
+    () =>
+      createHtmlPortalNode({
+        attributes: {
+          style: 'display: flex; flex-direction: column; flex: 1 1 auto;',
+        },
+      }),
+    [],
+  );
 
   return (
     <Router basename={applicationRoot()}>

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useMemo } from 'react';
 import {
   BrowserRouter as Router,
   Switch,
@@ -24,6 +24,12 @@ import {
   Redirect,
   useLocation,
 } from 'react-router-dom';
+import {
+  createHtmlPortalNode,
+  InPortal,
+  OutPortal,
+  type HtmlPortalNode,
+} from 'react-reverse-portal';
 import { bindActionCreators } from 'redux';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { Flex, Layout, Loading } from '@superset-ui/core/components';
@@ -141,7 +147,11 @@ const pageScrollContentCss = css`
 
 // Renders the app shell and picks the scroll model: in chat panel mode <Layout>
 // sits in a Splitter beside the chat panel; otherwise the page scrolls normally.
-const AppContent = () => {
+const AppContent = ({
+  layoutPortalNode,
+}: {
+  layoutPortalNode: HtmlPortalNode;
+}) => {
   const isAuthenticated =
     isUser(bootstrapData.user) && !bootstrapData.user.isAnonymous;
   const chatExtensionsEnabled =
@@ -155,13 +165,7 @@ const AppContent = () => {
     CHAT_PANEL_DEFAULT_WIDTH,
   );
 
-  const layoutContent = (
-    <Layout css={isPanelOpen ? layoutCss : undefined}>
-      <Layout.Content css={isPanelOpen ? contentCss : pageScrollContentCss}>
-        <RouteSwitch />
-      </Layout.Content>
-    </Layout>
-  );
+  const layoutContent = <OutPortal node={layoutPortalNode} />;
 
   const content = isPanelOpen ? (
     <Splitter
@@ -214,15 +218,26 @@ const AppContent = () => {
   );
 };
 
-const App = () => (
-  <Router basename={applicationRoot()}>
-    <ScrollToTop />
-    <LocationPathnameLogger />
-    <RootContextProviders>
-      <AppContent />
-      <ToastContainer />
-    </RootContextProviders>
-  </Router>
-);
+const App = () => {
+  const layoutPortalNode = useMemo(() => createHtmlPortalNode(), []);
+
+  return (
+    <Router basename={applicationRoot()}>
+      <ScrollToTop />
+      <LocationPathnameLogger />
+      <RootContextProviders>
+        <InPortal node={layoutPortalNode}>
+          <Layout css={layoutCss}>
+            <Layout.Content css={contentCss}>
+              <RouteSwitch />
+            </Layout.Content>
+          </Layout>
+        </InPortal>
+        <AppContent />
+        <ToastContainer />
+      </RootContextProviders>
+    </Router>
+  );
+};
 
 export default App;

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -235,7 +235,7 @@ const App = () => {
         <InPortal node={layoutPortalNode}>
           <RouteSwitch />
         </InPortal>
-        <AppContent />
+        <AppContent layoutPortalNode={layoutPortalNode} />
         <ToastContainer />
       </RootContextProviders>
     </Router>


### PR DESCRIPTION
### SUMMARY
When the chat panel is opened/closed in panel mode, `AppContent` conditionally wraps the main `<Layout>` tree in a `<Splitter>` alongside the chat panel. Because this JSX was inlined and recreated in a different position in the tree depending on `isPanelOpen`, React unmounted and remounted the entire route content (dashboards, Explore, SQL Lab, etc.) on every toggle — causing a visible reload of whatever page the user was on.

This PR uses `react-reverse-portal` to fix it: the `<Layout>`/route tree is now rendered once via `<InPortal>` at the top level of `<App>`, and `AppContent` renders it through `<OutPortal>` in both the inline and `Splitter`-wrapped branches. Since the portal keeps the underlying React subtree mounted regardless of where the `OutPortal` is placed, moving it in and out of the `Splitter` no longer triggers a remount.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/9926760c-882d-4698-a356-d32773b7a94b

After:

https://github.com/user-attachments/assets/504643b6-3b28-403d-ab66-2fea2c9ba2c1

### TESTING INSTRUCTIONS
1. Enable the chat extension feature flag and open any page (e.g. a dashboard or Explore).
2. Open the chat panel in panel mode, then close it, repeatedly.
3. Confirm the main content area no longer reloads/flickers/resets state (e.g. scroll position, unsaved form state, in-progress chart render) when toggling.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
