### PR TITLE
fix(components): restore icon/text spacing in Label

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/index.tsx
@@ -82,6 +82,9 @@ export const Label = forwardRef<HTMLSpanElement, LabelProps>((props, ref) => {
        * which would drop the icon's own color/size. Wrapping the icon in a span
        * lets Tag override the (empty) wrapper style while the real icon keeps its
        * own inline styling.
+       *
+       * The wrapper also breaks Tag's own icon/text spacing rule
+       * (`> .anticon + span`), so the equivalent gap is re-applied here.
        */
       icon={
         icon ? (
@@ -89,6 +92,7 @@ export const Label = forwardRef<HTMLSpanElement, LabelProps>((props, ref) => {
             css={css`
               display: inline-flex;
               align-items: center;
+              ${children ? `margin-inline-end: ${theme.paddingXS}px;` : ''}
             `}
           >
             {icon}


### PR DESCRIPTION
### SUMMARY
The antd v6 upgrade (#41636) wrapped `Label`'s icon in a plain `<span>` so that antd Tag's `cloneElement` style override wouldn't clobber the icon's own inline styling. A side effect: antd Tag spaces its icon from the tag text via the CSS rule `> .anticon + span { margin-inline-start: ... }`, and the wrapper span no longer matches that selector — so every `Label` rendered with an `icon` lost the gap between the icon and the text (visible in the Explore `Timer` and `CachedLabel` pills, among others).

This re-applies the equivalent gap (`margin-inline-end: ${theme.paddingXS}px`, mirroring antd's own icon/text spacing) on the wrapper span, only when the label has children — fixing all icon'd Labels at the component root rather than patching individual call sites.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![before](https://raw.githubusercontent.com/rusackas/superset/assets/label-icon-spacing/before.png)

After:

![after](https://raw.githubusercontent.com/rusackas/superset/assets/label-icon-spacing/after.png)

### TESTING INSTRUCTIONS
1. Open any chart in Explore and run a query.
2. Look at the status pills under the chart (row count / cached / timer).
3. The clock and cached icons should have a small gap before the text instead of sitting flush against it.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)