### PR TITLE
fix(ci): stop concurrency cancellation from bricking required checks on approval-gated PRs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,10 +8,16 @@ on:
     # Possible values: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
     types: [opened, edited, reopened, synchronize]
 
-# cancel previous workflow jobs for PRs
+# Serialize runs per PR without cancelling: the `edited` trigger means a PR
+# opened and then edited has two queued runs for the same head SHA. On
+# first-time-contributor PRs those runs start together when a maintainer
+# approves workflows, and cancel-in-progress lets the older run cancel the
+# newer one — leaving a permanently-cancelled required check on the head SHA
+# that blocks merging until manually re-run. This job takes seconds, so let
+# queued runs complete instead.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   lint-check:

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -2,17 +2,20 @@ name: "Helm: lint and test charts"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - "helm/**"
 
 permissions:
   contents: read
 
-# cancel previous workflow jobs for PRs
+# Serialize runs per PR without cancelling: when a first-time contributor's
+# queued runs are approved together, cancel-in-progress lets an older run
+# cancel a newer one, leaving a permanently-cancelled required check on the
+# head SHA. Queued runs are cheap here, so let them all complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   lint-test:


### PR DESCRIPTION
### SUMMARY

On PR #42114, both required lint checks (`lint-check` from PR Lint and `lint-test` from Helm lint) showed as **cancelled** in the merge box despite green duplicates existing for the same head SHA, blocking an approved PR from merging.

What happened, reconstructed from the check-run/timeline APIs:

1. PR Lint and Helm lint are the **only** two `pull_request` workflows that trigger on the `edited` activity type, so when a PR is opened and its title/description is edited shortly after (which contributors do constantly), each workflow gets **two runs for the same head SHA**.
2. On a first-time contributor's PR, all of those runs sit in `action_required` until a maintainer clicks "Approve and run", which launches them **near-simultaneously**.
3. The per-PR `concurrency` group with `cancel-in-progress: true` then has the duplicate runs cancel each other — and because approval order is arbitrary, the run created *later* can lose the race to the run created *earlier*.
4. GitHub's merge box resolves required checks from the **newest check suite** per check name, so when the newer run is the cancelled one, the PR shows a permanently-cancelled required check. It stays wedged until a maintainer notices and manually re-runs the cancelled run (which is how #42114 was unblocked).

The fix:

- **`pr-lint.yml`**: keep the `edited` trigger (re-linting the title on edit is the point of this workflow), but switch to `cancel-in-progress: false`. The concurrency group still serializes runs per PR; queued duplicates now run to completion instead of cancelling each other. The job takes ~20 seconds, so the runner cost of finishing a redundant run is negligible next to a wedged PR.
- **`superset-helm-lint.yml`**: drop the `edited` trigger entirely — title/body edits cannot change chart contents, and the `helm/**` paths filter already scopes the workflow — and likewise switch to `cancel-in-progress: false` so a multi-push approval race can't strand a cancelled required check either.

Note the same race is theoretically possible on any workflow with `cancel-in-progress: true` when a contributor pushes multiple commits before workflow approval, but the `edited`-triggered same-SHA duplication is what makes these two workflows hit it routinely; this PR scopes the change to them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI behavior)

### TESTING INSTRUCTIONS

- `pre-commit` (check-yaml, zizmor GHA audit, helm-docs) passes on both files.
- Behavior can be observed on any first-time-contributor PR that edits its description after opening: previously each edited-triggered workflow left one cancelled run for the head SHA after workflow approval; with this change all queued runs complete.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)