### PR TITLE
fix(ci): diff pre-commit changed files against the live base branch tip

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -81,7 +81,6 @@ jobs:
         id: changed_files
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
@@ -95,7 +94,15 @@ jobs:
           # Resolve the commit to diff against.
           base=""
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            base="${BASE_SHA}"
+            # HEAD is the PR merge commit, so its first parent is the current
+            # tip of the base branch. github.event.pull_request.base.sha is
+            # NOT that: GitHub freezes it at PR creation, so on a long-lived
+            # PR it points at the original branch point and the diff picks up
+            # all of the base branch's churn since then — thousands of paths,
+            # enough for the CHANGED_FILES env var below to exceed the
+            # kernel's per-variable size limit and kill the step with
+            # "Argument list too long" before bash even starts.
+            base="$(git rev-parse HEAD^1 2>/dev/null || true)"
           elif [ -n "${BEFORE_SHA:-}" ] && \
                [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
             base="${BEFORE_SHA}"
@@ -113,6 +120,15 @@ jobs:
 
           # Files present in HEAD that changed since the base (drop deletions).
           files="$(git diff --name-only --diff-filter=ACMRT "${base}...HEAD")"
+
+          # Env vars have a hard per-variable size limit (E2BIG at step
+          # start). A PR that legitimately touches thousands of files is
+          # better served by --all-files anyway.
+          if [ "$(printf '%s' "${files}" | wc -c)" -gt 100000 ]; then
+            echo "::notice::Changed-file list too large to pass via env; falling back to --all-files."
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ -z "${files}" ]; then
             echo "mode=none" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### SUMMARY

The pre-commit workflow's changed-files detection diffs against `github.event.pull_request.base.sha`, which GitHub **freezes at PR creation**. On a long-lived PR the diff therefore runs from the original branch point to the merge ref (which contains *current* master), sweeping in all of master's churn since the branch was cut.

This has two failure modes, both observed on #41127 (branched before the antd v6 upgrade and the i18n catalog canonicalization landed):

1. Silent over-linting: pre-commit runs on hundreds/thousands of files the PR never touched.
2. Hard failure: once the file list crosses the kernel's per-env-var limit (`MAX_ARG_STRLEN`, 128KiB), the runner cannot even start bash for the step — it dies with `An error occurred trying to start process '/usr/bin/bash' ... Argument list too long` and no hook output. Re-runs replay the same frozen payload, so the job can never go green again; the only workaround is closing and reopening the PR.

The fix:

- For `pull_request` events, diff against `HEAD^1` instead. The checkout is the PR **merge commit**, so its first parent *is* the current base-branch tip, and the three-dot diff yields exactly the PR's own files regardless of how old the branch is. The existing fail-closed guard (fall back to `--all-files` when the base can't be resolved) is kept and covers the no-merge-commit edge.
- Cap the computed list at 100KB (safely under the 128KiB limit): a PR that legitimately touches thousands of files now degrades to an `--all-files` sweep instead of an unstartable step.

`push`/`schedule` behavior is unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI behavior)

### TESTING INSTRUCTIONS

- `check-yaml` and `zizmor` pre-commit hooks pass on the workflow file.
- Behavior is observable on any PR whose branch point predates a large master change: previously the changed-files list contained all of master's intervening churn; with this change it contains only the PR's files. The failing case is reproducible on #41127 prior to its close/reopen.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)