### PR TITLE
docs: update postgresql supported versions policy

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -151,7 +151,7 @@ Superset supports the following database engines/versions:
 
 | Database Engine                           | Supported Versions                       |
 | ----------------------------------------- | ---------------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X, 16.X |
+| [PostgreSQL](https://www.postgresql.org/) | All [currently-supported versions](https://www.postgresql.org/support/versioning/). The highest tested version is defined by the repository's `docker-compose.yaml` and GitHub Actions matrix. |
 | [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                 |
 
 Use the following database drivers and connection strings:

--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -151,7 +151,7 @@ Superset supports the following database engines/versions:
 
 | Database Engine                           | Supported Versions                       |
 | ----------------------------------------- | ---------------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/) | All [currently-supported versions](https://www.postgresql.org/support/versioning/). The highest tested version is defined by the repository's `docker-compose.yaml` and GitHub Actions matrix. |
+| [PostgreSQL](https://www.postgresql.org/) | All [currently-supported versions](https://www.postgresql.org/support/versioning/). The highest tested version is defined by the repository's `docker-compose.yml` and GitHub Actions matrix. |
 | [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                 |
 
 Use the following database drivers and connection strings:

--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -241,10 +241,10 @@ database engine on a separate host or container.
 
 Superset supports the following database engines/versions:
 
-| Database Engine                           | Supported Versions                             |
-| ----------------------------------------- | ---------------------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X, 16.X, 17.X |
-| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                       |
+| Database Engine                           | Supported Versions                                                                                             |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [PostgreSQL](https://www.postgresql.org/) | Regularly tested against PostgreSQL 17 (see docker-compose.yml). Other actively-supported PostgreSQL versions are expected to work but aren't covered by CI. |
+| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                                                                                        |
 
 Use the following database drivers and connection strings:
 

--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -246,6 +246,7 @@ Superset supports the following database engines/versions:
 | [PostgreSQL](https://www.postgresql.org/) | Regularly tested against PostgreSQL 17 (see docker-compose.yml). Other actively-supported PostgreSQL versions are expected to work but aren't covered by CI. |
 | [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                                                                                        |
 
+
 Use the following database drivers and connection strings:
 
 | Database                                  | PyPI package              | Connection String                                                      |


### PR DESCRIPTION
### SUMMARY
Per @sfirke's recommendation in issue #42050, this PR updates the PostgreSQL supported versions documentation to prevent the page from going stale as new versions are released. 

* Replaced the hardcoded version list with a link to the official PostgreSQL support policy.
* Removed the hardcoded maximum version and added a reference to the `docker-compose.yaml` and GitHub Actions matrix as the source of truth for the top-tested version.

### BEFORE/AFTER SCREENSHOTS || ANIMATED GIF
N/A - Documentation text update only.

### TESTING INSTRUCTIONS
Review the modified markdown table in `docs/admin_docs/configuration/configuring-superset.mdx` to ensure the text and formatting are correct.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #42050
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API