### PR TITLE
fix(charts): use chart name in CSV/XLSX/zip export filenames

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 from datetime import datetime
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -496,6 +497,12 @@ class ChartDataRestApi(ChartRestApi):
                 )
 
             export_filename = filename or self._get_default_export_filename(form_data)
+            # `generate_download_headers` always appends the format extension,
+            # so strip a matching one here to avoid doubled extensions (e.g.
+            # "chart.csv.csv") if the caller already included it.
+            export_filename = re.sub(
+                r"\.(csv|xlsx|zip)$", "", export_filename, flags=re.IGNORECASE
+            )
 
             if len(result["queries"]) == 1:
                 # return single query results

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -495,13 +495,19 @@ class ChartDataRestApi(ChartRestApi):
                     result, form_data, filename=filename, expected_rows=expected_rows
                 )
 
+            export_filename = filename or self._get_default_export_filename(form_data)
+
             if len(result["queries"]) == 1:
                 # return single query results
                 data = result["queries"][0]["data"]
                 if is_csv_format:
-                    return CsvResponse(data, headers=generate_download_headers("csv"))
+                    return CsvResponse(
+                        data, headers=generate_download_headers("csv", export_filename)
+                    )
 
-                return XlsxResponse(data, headers=generate_download_headers("xlsx"))
+                return XlsxResponse(
+                    data, headers=generate_download_headers("xlsx", export_filename)
+                )
 
             # return multi-query results bundled as a zip file
             def _process_data(query_data: Any) -> Any:
@@ -519,7 +525,7 @@ class ChartDataRestApi(ChartRestApi):
             }
             return Response(
                 create_zip(files),
-                headers=generate_download_headers("zip"),
+                headers=generate_download_headers("zip", export_filename),
                 mimetype="application/zip",
             )
 
@@ -544,6 +550,26 @@ class ChartDataRestApi(ChartRestApi):
             return resp
 
         return self.response_400(message=f"Unsupported result_format: {result_format}")
+
+    @staticmethod
+    def _get_default_export_filename(form_data: dict[str, Any] | None) -> str:
+        """
+        Build a fallback export filename (without extension) from the chart's
+        name so downloaded files are easy to identify, instead of the
+        generic timestamp-only default used by ``generate_download_headers``.
+
+        Used whenever the client hasn't supplied an explicit filename, by
+        both the streaming and non-streaming chart data export responses.
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        chart_name = "export"
+
+        if form_data and form_data.get("slice_name"):
+            chart_name = form_data["slice_name"]
+        elif form_data and form_data.get("viz_type"):
+            chart_name = form_data["viz_type"]
+
+        return secure_filename(f"superset_{chart_name}_{timestamp}")
 
     def _log_is_cached(
         self,
@@ -709,16 +735,7 @@ class ChartDataRestApi(ChartRestApi):
 
         # Use filename from frontend if provided, otherwise generate one
         if not filename:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            chart_name = "export"
-
-            if form_data and form_data.get("slice_name"):
-                chart_name = form_data["slice_name"]
-            elif form_data and form_data.get("viz_type"):
-                chart_name = form_data["viz_type"]
-
-            # Sanitize chart name for filename
-            filename = secure_filename(f"superset_{chart_name}_{timestamp}.csv")
+            filename = f"{self._get_default_export_filename(form_data)}.csv"
         else:
             # Sanitize the client-provided filename before placing it in the
             # Content-Disposition header to avoid header/path injection.

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from flask import Flask, g
 
@@ -236,3 +236,95 @@ def test_extract_export_filename_preserves_normal_name() -> None:
 def test_extract_export_filename_all_special_falls_back_to_none() -> None:
     """A name with no usable characters becomes None (generated downstream)."""
     assert _extract_filename("***") is None
+
+
+def test_send_chart_response_uses_chart_name_for_csv_filename() -> None:
+    """
+    Regression test: the non-streaming CSV export branch of
+    _send_chart_response must include the chart's name in the
+    Content-Disposition header, not just a bare timestamp, mirroring the
+    streaming CSV export path.
+    """
+    from superset.charts.data.api import ChartDataRestApi
+    from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+
+    query_context = MagicMock()
+    query_context.result_type = ChartDataResultType.FULL
+    query_context.result_format = ChartDataResultFormat.CSV
+
+    result = {
+        "query_context": query_context,
+        "queries": [{"data": "col_a,col_b\n1,2\n"}],
+    }
+
+    api = ChartDataRestApi()
+    with (
+        patch("superset.charts.data.api.security_manager") as mock_security_manager,
+        patch("superset.charts.data.api.is_feature_enabled", return_value=False),
+    ):
+        mock_security_manager.can_access.return_value = True
+        response = api._send_chart_response(
+            result, form_data={"slice_name": "My Chart", "row_limit": 10}
+        )
+
+    content_disposition = response.headers["Content-Disposition"]
+    assert "My_Chart" in content_disposition
+
+
+def test_send_chart_response_uses_chart_name_for_xlsx_filename() -> None:
+    """Same regression as above, for the XLSX export branch."""
+    from superset.charts.data.api import ChartDataRestApi
+    from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+
+    query_context = MagicMock()
+    query_context.result_type = ChartDataResultType.FULL
+    query_context.result_format = ChartDataResultFormat.XLSX
+
+    result = {
+        "query_context": query_context,
+        "queries": [{"data": b"fake-xlsx-bytes"}],
+    }
+
+    api = ChartDataRestApi()
+    with (
+        patch("superset.charts.data.api.security_manager") as mock_security_manager,
+        patch("superset.charts.data.api.is_feature_enabled", return_value=False),
+    ):
+        mock_security_manager.can_access.return_value = True
+        response = api._send_chart_response(
+            result, form_data={"slice_name": "My Chart", "row_limit": 10}
+        )
+
+    content_disposition = response.headers["Content-Disposition"]
+    assert "My_Chart" in content_disposition
+
+
+def test_send_chart_response_uses_chart_name_for_zip_filename() -> None:
+    """Same regression as above, for the multi-query zip export branch."""
+    from superset.charts.data.api import ChartDataRestApi
+    from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+
+    query_context = MagicMock()
+    query_context.result_type = ChartDataResultType.FULL
+    query_context.result_format = ChartDataResultFormat.CSV
+
+    result = {
+        "query_context": query_context,
+        "queries": [
+            {"data": "col_a\n1\n"},
+            {"data": "col_a\n2\n"},
+        ],
+    }
+
+    api = ChartDataRestApi()
+    with (
+        patch("superset.charts.data.api.security_manager") as mock_security_manager,
+        patch("superset.charts.data.api.is_feature_enabled", return_value=False),
+    ):
+        mock_security_manager.can_access.return_value = True
+        response = api._send_chart_response(
+            result, form_data={"slice_name": "My Chart", "row_limit": 10}
+        )
+
+    content_disposition = response.headers["Content-Disposition"]
+    assert "My_Chart" in content_disposition

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -328,3 +328,38 @@ def test_send_chart_response_uses_chart_name_for_zip_filename() -> None:
 
     content_disposition = response.headers["Content-Disposition"]
     assert "My_Chart" in content_disposition
+
+
+def test_send_chart_response_does_not_double_extension_for_csv_filename() -> None:
+    """
+    Regression test: a client-supplied filename that already includes the
+    ``.csv`` extension must not be doubled (e.g. ``export.csv.csv``) by the
+    non-streaming CSV export branch of _send_chart_response.
+    """
+    from superset.charts.data.api import ChartDataRestApi
+    from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+
+    query_context = MagicMock()
+    query_context.result_type = ChartDataResultType.FULL
+    query_context.result_format = ChartDataResultFormat.CSV
+
+    result = {
+        "query_context": query_context,
+        "queries": [{"data": "col_a,col_b\n1,2\n"}],
+    }
+
+    api = ChartDataRestApi()
+    with (
+        patch("superset.charts.data.api.security_manager") as mock_security_manager,
+        patch("superset.charts.data.api.is_feature_enabled", return_value=False),
+    ):
+        mock_security_manager.can_access.return_value = True
+        response = api._send_chart_response(
+            result,
+            form_data={"row_limit": 10},
+            filename="my_export.csv",
+        )
+
+    content_disposition = response.headers["Content-Disposition"]
+    assert "my_export.csv.csv" not in content_disposition
+    assert "my_export.csv" in content_disposition


### PR DESCRIPTION
### SUMMARY
Chart data exports (CSV/XLSX/zip) from `/api/v1/chart/data` were always
named with a bare timestamp (e.g. `20260127_160233.csv`), even though the
endpoint already extracts a sanitized `filename` from the request. Only
the large-dataset *streaming* CSV path honored that filename (and its
chart-name-based fallback); the regular non-streaming CSV, XLSX, and
multi-query zip branches in `_send_chart_response` called
`generate_download_headers()` with no filename at all, dropping it on the
floor.

This PR:
- Passes the extracted `filename` through to `generate_download_headers()`
  in the CSV, XLSX, and zip branches.
- When no filename is supplied, falls back to the same chart-name +
  timestamp default already used by the streaming CSV path (extracted into
  a shared `_get_default_export_filename` helper to avoid duplicating that
  logic).
- Report/email attachments already use the report name, so this change is
  scoped to the chart data export endpoints only.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (backend header change only)

### TESTING INSTRUCTIONS
1. Open any saved chart in Explore.
2. Use Download → Export to CSV (or Excel).
3. Confirm the downloaded filename starts with the chart's name instead of
   just a timestamp.

Also see the added unit tests in
`tests/unit_tests/charts/test_chart_data_api.py`, which pin the bug by
asserting the `Content-Disposition` header contains the chart name for
the CSV, XLSX, and zip export branches.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #37487
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
