### PR TITLE
fix(jinja): handle non-JSON body with JSON content-type in get_form_data

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -35,6 +35,7 @@ from flask_appbuilder.security.sqla import models as ab_models
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import _
 from sqlalchemy.exc import NoResultFound
+from werkzeug.exceptions import BadRequest
 
 from superset import appbuilder, dataframe, db, result_set, viz
 from superset.common.db_query_status import QueryStatus
@@ -197,6 +198,27 @@ def loads_request_json(request_json_data: str) -> dict[Any, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def get_request_json_body() -> dict[Any, Any]:
+    """Parse the request body as JSON, coercing failures to ``{}``.
+
+    ``request.is_json`` only inspects the Content-Type header, not whether the
+    body is actually parseable JSON. Callers reaching ``get_form_data`` from a
+    non-HTTP-chart-data context (e.g. an MCP tool call rendering
+    ``filter_values()``) can have a request context whose Content-Type claims
+    JSON but whose body isn't a JSON chart-data payload, which makes Werkzeug
+    raise ``BadRequest`` from ``request.get_json()``. A well-formed but
+    non-object JSON body (e.g. ``null``, a scalar, or an array) is coerced to
+    ``{}`` too, since callers treat the result as a mapping.
+    """
+    if not request.is_json:
+        return {}
+    try:
+        data = request.get_json(cache=True)
+    except BadRequest:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 #: Parameter names `url_for` interprets itself rather than appending to the
 #: query string. Request-supplied query keys matching these must never be
 #: forwarded as `url_for` kwargs.
@@ -345,7 +367,7 @@ def get_form_data(
     form_data: dict[str, Any] = initial_form_data or {}
 
     if has_request_context():
-        json_data = request.get_json(cache=True) if request.is_json else {}
+        json_data = get_request_json_body()
 
         # chart data API requests are JSON
         first_query = (

--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for superset.views.utils module"""
+
+from flask import current_app
+
+from superset.views.utils import get_form_data
+
+
+def test_get_form_data_handles_non_json_body_with_json_content_type() -> None:
+    """get_form_data returns gracefully when Content-Type claims JSON but the
+    body isn't parseable JSON, instead of letting Werkzeug's BadRequest escape.
+
+    This is the shape of the request context an MCP tool call runs in when a
+    chart/dataset SQL template calls the ``filter_values()`` Jinja macro: the
+    Content-Type header says ``application/json`` but the body is not a JSON
+    chart-data payload.
+    """
+    with current_app.test_request_context(
+        data="not-json-at-all", content_type="application/json"
+    ):
+        form_data, slc = get_form_data()
+
+    assert form_data == {}
+    assert slc is None
+
+
+def test_get_form_data_handles_non_dict_json_body() -> None:
+    """get_form_data coerces a well-formed but non-object JSON body to {}.
+
+    ``request.get_json()`` happily returns a scalar or list for valid JSON
+    that isn't a JSON object (e.g. ``null`` or ``42``). Downstream code treats
+    the parsed body as a mapping, so a non-dict result must not leak through.
+    """
+    with current_app.test_request_context(data="42", content_type="application/json"):
+        form_data, slc = get_form_data()
+
+    assert form_data == {}
+    assert slc is None


### PR DESCRIPTION
### SUMMARY
`get_form_data()` crashed with an unhandled `werkzeug.exceptions.BadRequest` whenever it ran inside a request context where the `Content-Type` header claimed JSON but the body wasn't actually parseable JSON. This happens for any caller that reaches `get_form_data()` outside a normal chart-data POST — for example the `filter_values()` / `get_filters()` Jinja macros used in chart and dataset SQL templates, when rendered from a request context that isn't a real chart-data request.

`request.is_json` only inspects the `Content-Type` header; it does not guarantee the body is valid, non-empty JSON. `get_form_data()` already has a helper, `loads_request_json()`, that gracefully falls back to `{}` on a JSON parse failure — but that guard was only applied to the `request.form` / `request.args` fallback paths, not to the primary `request.get_json(cache=True)` call, which is the one that was actually raising.

This PR extracts the JSON-body parsing into a small `get_request_json_body()` helper that catches `BadRequest` and falls back to `{}`, matching the existing `loads_request_json()` behavior.

Internal tracking: SC-114072

### TESTING INSTRUCTIONS
- Added `tests/unit_tests/views/test_utils.py::test_get_form_data_handles_non_json_body_with_json_content_type`, which builds a request context with `Content-Type: application/json` and a non-JSON body, and asserts `get_form_data()` returns `({}, None)` instead of raising.
- `pytest tests/unit_tests/views/test_utils.py tests/unit_tests/jinja_context_test.py -q` — 104 passed.
- Manually reproduced the crash against `master` (`request.get_json(cache=True)` raising `BadRequest`) and confirmed the fix resolves it via `app.test_request_context(data="not-json-at-all", content_type="application/json")`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API