### PR TITLE
fix(sqllab): merge databases state instead of replacing in SET_DATABASES reducer

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.ts
@@ -698,4 +698,48 @@ describe('sqlLabReducer', () => {
       expect(newState.queries.abcd.state).toBe(QueryState.Success);
     });
   });
+
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+  describe('SET_DATABASES', () => {
+    test('should merge databases instead of replacing', () => {
+      const db1 = { id: 1, database_name: 'db1', allow_run_async: false, extra: '{}' };
+      const db2 = { id: 2, database_name: 'db2', allow_run_async: false, extra: '{}' };
+      const db3 = { id: 3, database_name: 'db3', allow_run_async: false, extra: '{}' };
+
+      let state = sqlLabReducer(initialState, {
+        type: actions.SET_DATABASES,
+        databases: [db1, db2],
+      });
+      expect(Object.keys(state.databases)).toHaveLength(2);
+      expect(state.databases[1].database_name).toBe('db1');
+      expect(state.databases[2].database_name).toBe('db2');
+
+      state = sqlLabReducer(state, {
+        type: actions.SET_DATABASES,
+        databases: [db2, db3],
+      });
+      expect(Object.keys(state.databases)).toHaveLength(3);
+      expect(state.databases[1].database_name).toBe('db1');
+      expect(state.databases[2].database_name).toBe('db2');
+      expect(state.databases[3].database_name).toBe('db3');
+    });
+
+    test('should overwrite existing database entries with updated data', () => {
+      const db1 = { id: 1, database_name: 'db1', allow_run_async: false, extra: '{}' };
+      const db1Updated = { id: 1, database_name: 'db1_renamed', allow_run_async: true, extra: '{}' };
+
+      let state = sqlLabReducer(initialState, {
+        type: actions.SET_DATABASES,
+        databases: [db1],
+      });
+      expect(state.databases[1].database_name).toBe('db1');
+
+      state = sqlLabReducer(state, {
+        type: actions.SET_DATABASES,
+        databases: [db1Updated],
+      });
+      expect(state.databases[1].database_name).toBe('db1_renamed');
+      expect(state.databases[1].allow_run_async).toBe(true);
+    });
+  });
 });

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -729,7 +729,7 @@ export default function sqlLabReducer(
           extra_json: JSON.parse(db.extra || ''),
         };
       });
-      return { ...state, databases };
+      return { ...state, databases: { ...state.databases, ...databases } };
     },
     [actions.REFRESH_QUERIES]() {
       let newQueries = { ...state.queries };


### PR DESCRIPTION
### SUMMARY

Fixes #41245

The `SET_DATABASES` reducer was **replacing** the entire `databases` state object with only the newly fetched results. When SQL Lab initializes, it fetches databases via the API (default `page_size=20` from FAB), and the reducer would overwrite the full databases map with just those 20 results. This caused the "database not found" warning for any saved tab referencing a database outside the first page of results.

The fix changes the reducer to **merge** new databases into the existing state, preserving any previously loaded database entries. This is a one-line change:

```diff
- return { ...state, databases };
+ return { ...state, databases: { ...state.databases, ...databases } };
```

### AFTER Testing Video:
[Screencast from 2026-07-18 18-07-11.webm](https://github.com/user-attachments/assets/9f4831ab-827d-4eea-9c5a-19ad45430c26)



### TESTING INSTRUCTIONS

1. Create a Superset instance with >20 databases
2. Save a SQL Lab tab with a database whose ID is not in the first 20 results
3. Reload SQL Lab — the "database not found" warning should no longer appear
4. Run the new unit tests: `npx jest src/SqlLab/reducers/sqlLab.test.ts`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #41245
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API