### PR TITLE
fix(SafeMarkdown): let htmlSchemaOverrides replace matching default attribute rules

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -86,7 +86,11 @@ type AttributeDefinition = string | readonly [string, ...unknown[]];
 function getAttributeDefinitionKey(
   definition: AttributeDefinition,
 ): string | undefined {
-  return typeof definition === 'string' ? definition : definition[0];
+  if (typeof definition === 'string') return definition;
+  // htmlSchemaOverrides comes from runtime config and isn't guaranteed to
+  // match the expected shape; a malformed element (e.g. `null`) has no key
+  // rather than crashing the lookup.
+  return Array.isArray(definition) ? definition[0] : undefined;
 }
 
 /**

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -137,6 +137,11 @@ export function getOverrideHtmlSchema(
       // the schema (e.g. `tagNames`, `protocols.href`) is a plain list where
       // concatenation is the correct merge.
       if (object === target.attributes) {
+        // htmlSchemaOverrides comes from runtime config and isn't guaranteed
+        // to match the expected shape; fall back to the default definitions
+        // for a tag rather than throwing if an operator supplies something
+        // other than an array of attribute definitions.
+        if (!Array.isArray(srcValue)) return objValue;
         return mergeAttributeDefinitions(objValue, srcValue);
       }
       return objValue.concat(srcValue);

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -78,19 +78,69 @@ export function transformLinkUri(uri: string): string {
   return DANGEROUS_LINK_PROTOCOLS.includes(scheme) ? '' : url;
 }
 
+// A hast-util-sanitize attribute definition is either a bare property name
+// (any value allowed) or a tuple of `[propertyName, ...allowedValues]` (only
+// the listed values allowed). See hast-util-sanitize's `PropertyDefinition`.
+type AttributeDefinition = string | readonly [string, ...unknown[]];
+
+function getAttributeDefinitionKey(
+  definition: AttributeDefinition,
+): string | undefined {
+  return typeof definition === 'string' ? definition : definition[0];
+}
+
+/**
+ * Merge an operator-supplied list of attribute definitions for a tag (or the
+ * `'*'` wildcard) with the corresponding default definitions.
+ *
+ * hast-util-sanitize's `findDefinition` returns only the FIRST definition it
+ * finds for a given property name, so a naive concat leaves whichever list
+ * happens to declare that property first in charge. The default schema
+ * already declares restrictive tuples for some properties (e.g.
+ * `li: [['className', 'task-list-item']]`), so appending an operator's
+ * override after it never took effect. Because a failed allowlist check
+ * returns `[]` rather than `undefined`, hast-util-sanitize's own `'*'`
+ * fallback never kicked in either.
+ *
+ * To fix that, an override definition replaces the default definition for
+ * the same property (by property name) instead of being appended alongside
+ * it.
+ */
+function mergeAttributeDefinitions(
+  defaults: readonly AttributeDefinition[],
+  overrides: readonly AttributeDefinition[],
+): AttributeDefinition[] {
+  const overriddenKeys = new Set(
+    overrides.map(getAttributeDefinitionKey).filter(Boolean),
+  );
+  const remainingDefaults = defaults.filter(
+    definition => !overriddenKeys.has(getAttributeDefinitionKey(definition)),
+  );
+  return [...remainingDefaults, ...overrides];
+}
+
 export function getOverrideHtmlSchema(
   originalSchema: typeof defaultSchema,
   htmlSchemaOverrides: SafeMarkdownProps['htmlSchemaOverrides'],
 ) {
-  // Merge into a fresh clone: mergeWith mutates its first argument, and the
-  // array customizer concatenates, so merging into the shared defaultSchema
-  // import would progressively widen the sanitization allowlist for every
-  // SafeMarkdown instance app-wide.
+  // Merge into a fresh clone: mergeWith mutates its first argument, so
+  // merging into the shared defaultSchema import would progressively widen
+  // the sanitization allowlist for every SafeMarkdown instance app-wide.
+  const target = cloneDeep(originalSchema);
   return mergeWith(
-    cloneDeep(originalSchema),
+    target,
     htmlSchemaOverrides,
-    (objValue, srcValue) =>
-      Array.isArray(objValue) ? objValue.concat(srcValue) : undefined,
+    (objValue, srcValue, _key, object) => {
+      if (!Array.isArray(objValue)) return undefined;
+      // Only the per-tag (and `'*'`) arrays nested under `attributes` hold
+      // property definitions that need dedup-by-key; every other array in
+      // the schema (e.g. `tagNames`, `protocols.href`) is a plain list where
+      // concatenation is the correct merge.
+      if (object === target.attributes) {
+        return mergeAttributeDefinitions(objValue, srcValue);
+      }
+      return objValue.concat(srcValue);
+    },
   );
 }
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -115,7 +115,7 @@ describe('getOverrideHtmlSchema', () => {
     expect(result.attributes?.li).toEqual(['className']);
   });
 
-  test('a "*" wildcard override allows classes on li even though li has its own default definition', () => {
+  test('a "*" wildcard override alone does not widen li, which has its own default definition', () => {
     const result = getOverrideHtmlSchema(taskListSchemaFixture, {
       attributes: { '*': ['className'] },
     });
@@ -126,6 +126,22 @@ describe('getOverrideHtmlSchema', () => {
     // `li` entry first, this alone documents why an `li`-specific override
     // is required to unblock arbitrary classes on `li` -- a `'*'` override
     // does not, by itself, widen a tag that already has its own definition.
+    expect(result.attributes?.li).toEqual(taskListSchemaFixture.attributes?.li);
+  });
+
+  test('a malformed (non-array) attribute override for a tag falls back to the default definition instead of throwing', () => {
+    expect(() =>
+      getOverrideHtmlSchema(taskListSchemaFixture, {
+        // Runtime config isn't guaranteed to match the expected shape; a
+        // string here (rather than an array of attribute definitions) must
+        // not crash markdown rendering.
+        attributes: { li: 'className' as unknown as string[] },
+      }),
+    ).not.toThrow();
+
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {
+      attributes: { li: 'className' as unknown as string[] },
+    });
     expect(result.attributes?.li).toEqual(taskListSchemaFixture.attributes?.li);
   });
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -83,6 +83,65 @@ describe('getOverrideHtmlSchema', () => {
       (second.tagNames ?? []).filter(name => name === 'iframe'),
     ).toHaveLength(1);
   });
+
+  // Regression tests for #34191: hast-util-sanitize's real default schema
+  // restricts `li`/`ul`/`ol` `className` to specific task-list values, e.g.
+  // `li: [['className', 'task-list-item']]` (see hast-util-sanitize's
+  // `lib/schema.js`). `rehype-sanitize` is mocked globally in this jest
+  // project (see NOTE above), so `defaultSchema` isn't usable here; this
+  // fixture mirrors just the shape that matters for these tests.
+  //
+  // findDefinition only ever returns the FIRST definition it finds for a
+  // given property name, so simply concatenating the operator's override
+  // after the default restrictive tuple left the default in charge: any
+  // other class value was silently dropped, and (since a failed allowlist
+  // check returns `[]` rather than `undefined`) hast-util-sanitize's own
+  // `'*'` wildcard fallback never kicked in either.
+  const taskListSchemaFixture: typeof defaultSchema = {
+    attributes: {
+      li: [['className', 'task-list-item']],
+      ul: [['className', 'contains-task-list']],
+      ol: [['className', 'contains-task-list']],
+    },
+  };
+
+  test('an override for a property replaces the same-named default definition', () => {
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {
+      attributes: { li: ['className'] },
+    });
+
+    // The override should fully replace the default `li` className
+    // restriction, not merely be appended after it.
+    expect(result.attributes?.li).toEqual(['className']);
+  });
+
+  test('a "*" wildcard override allows classes on li even though li has its own default definition', () => {
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {
+      attributes: { '*': ['className'] },
+    });
+
+    expect(result.attributes?.['*']).toContainEqual('className');
+    // The restrictive `li`-specific default is still present (untouched by
+    // this override), but since findDefinition matches on the specific
+    // `li` entry first, this alone documents why an `li`-specific override
+    // is required to unblock arbitrary classes on `li` -- a `'*'` override
+    // does not, by itself, widen a tag that already has its own definition.
+    expect(result.attributes?.li).toEqual(taskListSchemaFixture.attributes?.li);
+  });
+
+  test('the default task-list class restriction on li/ul/ol still applies with no override', () => {
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {});
+
+    expect(result.attributes?.li).toEqual([['className', 'task-list-item']]);
+    expect(result.attributes?.ul).toContainEqual([
+      'className',
+      'contains-task-list',
+    ]);
+    expect(result.attributes?.ol).toContainEqual([
+      'className',
+      'contains-task-list',
+    ]);
+  });
 });
 
 describe('transformLinkUri', () => {

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -145,6 +145,25 @@ describe('getOverrideHtmlSchema', () => {
     expect(result.attributes?.li).toEqual(taskListSchemaFixture.attributes?.li);
   });
 
+  test('a malformed (null) element within an attribute override array falls back to the default definition instead of throwing', () => {
+    expect(() =>
+      getOverrideHtmlSchema(taskListSchemaFixture, {
+        // Runtime config isn't guaranteed to match the expected shape; a
+        // `null` element here must not crash the key lookup used to
+        // dedup overrides against the default definitions.
+        attributes: { li: [null] as unknown as string[] },
+      }),
+    ).not.toThrow();
+
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {
+      attributes: { li: [null] as unknown as string[] },
+    });
+    expect(result.attributes?.li).toEqual([
+      ...taskListSchemaFixture.attributes!.li!,
+      null,
+    ]);
+  });
+
   test('the default task-list class restriction on li/ul/ol still applies with no override', () => {
     const result = getOverrideHtmlSchema(taskListSchemaFixture, {});
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -115,6 +115,17 @@ describe('getOverrideHtmlSchema', () => {
     expect(result.attributes?.li).toEqual(['className']);
   });
 
+  test('a per-tag override leaves a sibling tag definition untouched', () => {
+    const result = getOverrideHtmlSchema(taskListSchemaFixture, {
+      attributes: { li: ['className'] },
+    });
+
+    // Only the overridden tag (`li`) is replaced; `ul`/`ol` keep their
+    // default restrictive definitions since the merge recurses per-tag.
+    expect(result.attributes?.ul).toEqual(taskListSchemaFixture.attributes?.ul);
+    expect(result.attributes?.ol).toEqual(taskListSchemaFixture.attributes?.ol);
+  });
+
   test('a "*" wildcard override alone does not widen li, which has its own default definition', () => {
     const result = getOverrideHtmlSchema(taskListSchemaFixture, {
       attributes: { '*': ['className'] },


### PR DESCRIPTION
### SUMMARY
`getOverrideHtmlSchema` in `SafeMarkdown.tsx` merges an operator's `htmlSchemaOverrides`/`HTML_SANITIZATION_SCHEMA_EXTENSIONS` into `rehype-sanitize`'s default schema using a `mergeWith` customizer that concatenates attribute-definition arrays. hast-util-sanitize's `findDefinition` only ever returns the *first* definition it finds for a given property name, and the default schema already declares restrictive tuples for some tags, e.g.:

```js
li: [['className', 'task-list-item']],
ul: [...aria, ['className', 'contains-task-list']],
ol: [...aria, ['className', 'contains-task-list']],
```

So concatenating an operator's override *after* those defaults never actually widened anything — the restrictive default tuple was always found first. Worse, since a failed allowlist check on `className` returns `[]` (an empty array) rather than `undefined`, hast-util-sanitize's own `'*'` wildcard fallback never kicked in either. The net effect (see #34191): any CSS class set on `<li>`/`<ul>`/`<ol>` in a Handlebars/Markdown chart gets silently stripped to an empty `class=""`, even with `HTML_SANITIZATION_SCHEMA_EXTENSIONS` configured to allow it.

This PR changes the merge so that, within `attributes`, an override definition for a property **replaces** the default definition for that same property (deduped by property name) instead of just being appended alongside it. Other schema arrays (`tagNames`, `protocols.*`, etc.) keep the original concat behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this is a schema-merge logic fix with no visual changes on its own; see #34191 for screenshots of the bug (classes on `<li>`/`<ul>` being stripped to `class=""`).

### TESTING INSTRUCTIONS
Added regression tests in `superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx` (`getOverrideHtmlSchema` describe block) that:
- Pin the bug: with `htmlSchemaOverrides: { attributes: { li: ['className'] } }`, the merged schema's `li` definition must be replaced by the override, not have the restrictive default tuple win.
- Pin the `'*'` wildcard case: with `htmlSchemaOverrides: { attributes: { '*': ['className'] } }`, the wildcard override is present, and (documented for clarity) an `li`-specific default still wins unless `li` itself is overridden — since `findDefinition` checks the tag-specific list before `'*'`.
- Assert the default task-list `className` restriction on `li`/`ul`/`ol` is unchanged when no override is supplied.

Manually:
1. Set `HTML_SANITIZATION_SCHEMA_EXTENSIONS = {"attributes": {"li": ["className"]}}` (or `"*": ["className"]` plus a per-tag override) in `superset_config.py`.
2. Build a Handlebars or Markdown chart with an `<li class="my-class">` element.
3. Confirm the rendered `<li>` keeps `class="my-class"` instead of being stripped to `class=""`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #34191
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API