### PR TITLE
fix(mysql): resolve wire-protocol column types and mutate rows from immutable results

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1236,6 +1236,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 )
             }
             if column_mutators:
+                data = list(data)
                 indexes = {row[0]: idx for idx, row in enumerate(description)}
                 for row_idx, row in enumerate(data):
                     new_row = list(row)

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -238,6 +238,48 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
             LONGTEXT(),
             GenericDataType.STRING,
         ),
+        # wire-protocol FIELD_TYPE names emitted by `get_datatype`, seen on
+        # SQL Lab and virtual dataset columns instead of DDL type names
+        (
+            re.compile(r"^var_string", re.IGNORECASE),
+            types.String(),
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile(r"^newdecimal", re.IGNORECASE),
+            DECIMAL(),
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile(r"^tiny$", re.IGNORECASE),
+            TINYINT(),
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile(r"^short$", re.IGNORECASE),
+            types.SmallInteger(),
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile(r"^blob$", re.IGNORECASE),
+            types.String(),
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile(r"^year$", re.IGNORECASE),
+            types.Integer(),
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile(r"^enum\b", re.IGNORECASE),
+            types.String(),
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile(r"^set\b", re.IGNORECASE),
+            types.String(),
+            GenericDataType.STRING,
+        ),
     )
     column_type_mutators: dict[types.TypeEngine, Callable[[Any], Any]] = {
         DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -70,6 +70,15 @@ from tests.unit_tests.fixtures.common import dttm  # noqa: F401
         ("DATETIME", types.DateTime, None, GenericDataType.TEMPORAL, True),
         ("TIMESTAMP", types.TIMESTAMP, None, GenericDataType.TEMPORAL, True),
         ("TIME", types.Time, None, GenericDataType.TEMPORAL, True),
+        # Wire-protocol names
+        ("VAR_STRING", types.String, None, GenericDataType.STRING, False),
+        ("NEWDECIMAL", DECIMAL, None, GenericDataType.NUMERIC, False),
+        ("TINY", TINYINT, None, GenericDataType.NUMERIC, False),
+        ("SHORT", types.SmallInteger, None, GenericDataType.NUMERIC, False),
+        ("BLOB", types.String, None, GenericDataType.STRING, False),
+        ("YEAR", types.Integer, None, GenericDataType.NUMERIC, False),
+        ("ENUM", types.String, None, GenericDataType.STRING, False),
+        ("SET", types.String, None, GenericDataType.STRING, False),
     ],
 )
 def test_get_column_spec(
@@ -82,6 +91,19 @@ def test_get_column_spec(
     from superset.db_engine_specs.mysql import MySQLEngineSpec as spec  # noqa: N813
 
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
+
+
+def test_fetch_data_mutates_decimal_rows_in_tuple_results() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec as spec  # noqa: N813
+
+    newdecimal, var_string = 246, 253
+    cursor = Mock()
+    cursor.description = [("amount", newdecimal), ("label", var_string)]
+    cursor.fetchall.return_value = (("10.50", "Ships"), ("22.30", "Planes"))
+
+    data = spec.fetch_data(cursor)
+
+    assert data == [(Decimal("10.50"), "Ships"), (Decimal("22.30"), "Planes")]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

Columns of MySQL virtual datasets (created from SQL Lab queries) showed a "?" type icon in the chart panel instead of ABC/#, which also hid type-dependent controls such as X-Axis Sort By.

Physical datasets get column types from the SQLAlchemy inspector as DDL names (`VARCHAR(100)`, `DECIMAL(15,2)`), which match `MySQLEngineSpec.column_type_mappings`. Virtual dataset columns instead get their type from the driver's cursor description via `get_datatype`, which returns the raw wire-protocol `FIELD_TYPE` constant names (`VAR_STRING` for VARCHAR, `NEWDECIMAL` for DECIMAL, `TINY` for TINYINT, `BLOB` for TEXT, and so on). None of those names matched any mapping regex, so `type_generic` resolved to `None`.

This PR adds mappings for the 8 wire-protocol names that had no match: `VAR_STRING`, `NEWDECIMAL`, `TINY`, `SHORT`, `BLOB`, `YEAR`, `ENUM` and `SET`. Regexes are anchored so they don't collide with existing DDL patterns (`^tiny$` vs `^tinytext`), and `^enum\b`/`^set\b` also cover the DDL forms (`ENUM('a','b')`), which were equally unresolved.

Fixing the type resolution exposed a second, latent bug: MySQL registers a `column_type_mutators` entry that converts DECIMAL string values to Python `Decimal`, keyed on the resolved column type. It had never fired because `NEWDECIMAL` never resolved. Once it did, `BaseEngineSpec.fetch_data` crashed with `TypeError: 'tuple' object does not support item assignment`, because the mutation loop assigns rows back into the `fetchall()` result and mysqlclient returns a tuple of rows (psycopg2 returns a list, which is why the same code works for Postgres). Fixed by copying the result into a list before mutating.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1581" height="784" alt="Screenshot 2026-07-18 at 12 59 02" src="https://github.com/user-attachments/assets/63ac1ace-a257-4bf4-92eb-9a1948707fd4" />

After:
<img width="1497" height="837" alt="Screenshot 2026-07-18 at 12 59 27" src="https://github.com/user-attachments/assets/c31907a7-2392-43bd-a2c8-c2a4e77ed06c" />


### TESTING INSTRUCTIONS
1. Start a MySQL instance and create a table exercising the affected types:
   ```sql
   CREATE TABLE sample_data (
     id INT AUTO_INCREMENT PRIMARY KEY,
     label VARCHAR(100),
     amount DECIMAL(15, 2)
   );
   INSERT INTO sample_data (label, amount) VALUES ('Ships', 10.50), ('Planes', 22.30);
2. Connect the MySQL database to Superset.
3. In SQL Lab, run SELECT * FROM sample_data and use "Save or Overwrite Dataset" to save it as a new (virtual) dataset.
4. Create a chart from that dataset.
5. Verify label shows the string indicator, amount and id show the numeric indicator, and the chart renders data instead of a type error.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
