### PR TITLE
fix(dashboard): offer Exit edit mode when there is nothing to discard

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -522,12 +522,15 @@ test('should disable both buttons when no actions available', () => {
   expect(onRedo).not.toHaveBeenCalled();
 });
 
-test('should render the "Discard" button as disabled', () => {
+test('should render an enabled "Exit edit mode" button when there are no unsaved changes', () => {
   setup(editableState);
-  expect(screen.getByRole('button', { name: /discard/i })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /exit edit mode/i })).toBeEnabled();
+  expect(
+    screen.queryByRole('button', { name: /discard/i }),
+  ).not.toBeInTheDocument();
 });
 
-test('should enable the "Discard" button when there are unsaved changes', () => {
+test('should render an enabled "Discard" button when there are unsaved changes', () => {
   const unsavedState = {
     ...editableState,
     dashboardState: {
@@ -537,6 +540,9 @@ test('should enable the "Discard" button when there are unsaved changes', () => 
   };
   setup(unsavedState);
   expect(screen.getByRole('button', { name: /discard/i })).toBeEnabled();
+  expect(
+    screen.queryByRole('button', { name: /exit edit mode/i }),
+  ).not.toBeInTheDocument();
 });
 
 test('should render the "Save" button as disabled', () => {

--- a/superset-frontend/src/dashboard/components/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/index.tsx
@@ -722,13 +722,14 @@ const Header = (): JSX.Element => {
                 <Button
                   css={discardBtnStyle}
                   buttonSize="small"
-                  disabled={!hasUnsavedChanges}
                   onClick={discardChanges}
                   buttonStyle="secondary"
                   data-test="discard-changes-button"
-                  aria-label={t('Discard')}
+                  aria-label={
+                    hasUnsavedChanges ? t('Discard') : t('Exit edit mode')
+                  }
                 >
-                  {t('Discard')}
+                  {hasUnsavedChanges ? t('Discard') : t('Exit edit mode')}
                 </Button>
                 <Button
                   css={saveBtnStyle}


### PR DESCRIPTION
### SUMMARY
Follow-up to #40832, which disabled the Discard button when a dashboard edit session has no unsaved changes. That fixed the misleading affordance (Discard had nothing to discard), but as @sadpandajoe noted on that PR, it left the edit-mode toolbar with no way back to view mode on a pristine session: Save and Discard are both disabled, and the "..." menu has no exit item, so the only escape is a page refresh or navigating away.

This keeps the button always enabled, and swaps the label based on state: **Discard** when there are unsaved changes, **Exit edit mode** when there are none. The click handler is identical in both cases (drops the `?edit` param and returns to view mode), so the label always describes what actually happens.

If @yousoph / @kasiazjc would rather see a different treatment (a separate exit control, different wording, etc.), happy to iterate. This is meant as the smallest change that removes the dead end.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: on a pristine edit session, Discard is disabled and there is no toolbar path back to view mode.
After: the same button reads "Exit edit mode" and is clickable; with unsaved changes it reads "Discard" exactly as before.

### TESTING INSTRUCTIONS
1. Open any dashboard and click **Edit dashboard**.
2. Without changing anything, confirm the secondary button reads **Exit edit mode** and is enabled; clicking it returns to view mode.
3. Re-enter edit mode and make a change (drag a chart, rename). Confirm the button now reads **Discard** and discards on click.
4. Undo/redo and Save behavior are unchanged.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)