### PR TITLE
refactor: set cascade_backrefs=False for Query

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -29,7 +29,7 @@ filterwarnings =
     ignore
     always::sqlalchemy.exc.RemovedIn20Warning
     error:Passing a string to Connection.execute\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
-#    error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -190,7 +190,14 @@ class Query(
     database = relationship(
         "Database",
         foreign_keys=[database_id],
-        backref=backref("queries", cascade="all, delete-orphan"),
+        backref=backref(
+            "queries",
+            cascade="all, delete-orphan",
+            # SQLAlchemy 2.0 behavior: assigning `query.database` no longer
+            # cascades the Query into the Database's session; callers must
+            # add objects to a session explicitly.
+            cascade_backrefs=False,
+        ),
     )
     user = relationship(security_manager.user_model, foreign_keys=[user_id])
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3703,7 +3703,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 client_id=shortid()[:10],
                 user_id=get_user_id(),
             )
-            self.session.expunge(query)
+            # This ephemeral Query must never be persisted; with
+            # cascade_backrefs=False it is not added to the session in the
+            # first place, so only expunge if something else added it.
+            if query in self.session:
+                self.session.expunge(query)
 
         if database and table or query:
             if query:


### PR DESCRIPTION
See #40273

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enable errors for the `"Query" object is being merged into a Session along the backref cascade path` RemovedIn20Warning, and fix the code that relied on the reverse cascade.

- `Database.queries` backref now sets `cascade_backrefs=False`, which is the SQLAlchemy 2.0 behavior: constructing `Query(database=...)` no longer implicitly merges the new object into the Database's session. All code paths that persist queries already call `session.add()` explicitly.
- `SupersetSecurityManager.raise_for_access` builds an ephemeral `Query` for access checks and unconditionally expunged it from the session. Since the object is no longer implicitly merged, the expunge is now guarded, matching the existing pattern in `Database.resolve_default_schema`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)