### PR TITLE
fix(models): purge_oauth2_tokens filters on wrong column

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1446,7 +1446,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
         scope or in the endpoints.
         """
         db.session.query(DatabaseUserOAuth2Tokens).filter(
-            DatabaseUserOAuth2Tokens.id == self.id
+            DatabaseUserOAuth2Tokens.database_id == self.id
         ).delete()
 
     def execute(

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1375,6 +1375,85 @@ def test_purge_oauth2_tokens(session: Session) -> None:
     assert database.name == "my_oauth2_db"
 
 
+def test_purge_oauth2_tokens_scoped_by_database_id(session: Session) -> None:
+    """
+    Ensure `purge_oauth2_tokens` filters by ``database_id``, not by the
+    token-table primary key.
+
+    The existing ``test_purge_oauth2_tokens`` case inserts a single token per
+    database in an empty schema, so token PKs and database PKs align 1:1 by
+    coincidence. This regression test inserts several tokens on ``database1``
+    first so token PKs advance past 1, then creates ``database2`` and purges
+    it. All of ``database1``'s tokens must remain untouched.
+    """
+    from flask_appbuilder.security.sqla.models import Role, User  # noqa: F401
+
+    from superset.models.core import Database, DatabaseUserOAuth2Tokens
+
+    Database.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+
+    user = User(
+        first_name="Alice",
+        last_name="Doe",
+        email="adoe2@example.org",
+        username="adoe2",
+    )
+    session.add(user)
+    session.flush()
+
+    database1 = Database(database_name="db1_pk_drift", sqlalchemy_uri="sqlite://")
+    session.add(database1)
+    session.flush()
+
+    # Insert several tokens on database1 so token PKs advance past 1 and drift
+    # away from any single database PK.
+    for i in range(5):
+        session.add(
+            DatabaseUserOAuth2Tokens(
+                user_id=user.id,
+                database_id=database1.id,
+                access_token=f"db1_access_{i}",  # noqa: S106
+                access_token_expiration=datetime(2023, 1, 1),
+                refresh_token=f"db1_refresh_{i}",  # noqa: S106
+            )
+        )
+    session.flush()
+
+    database2 = Database(database_name="db2_pk_drift", sqlalchemy_uri="sqlite://")
+    session.add(database2)
+    session.flush()
+
+    assert (
+        session.query(DatabaseUserOAuth2Tokens)
+        .filter_by(database_id=database1.id)
+        .count()
+        == 5
+    )
+    assert (
+        session.query(DatabaseUserOAuth2Tokens)
+        .filter_by(database_id=database2.id)
+        .count()
+        == 0
+    )
+
+    # Purging database2 must not touch database1's tokens, even though one
+    # of database1's token PKs will collide with database2's PK.
+    database2.purge_oauth2_tokens()
+
+    assert (
+        session.query(DatabaseUserOAuth2Tokens)
+        .filter_by(database_id=database1.id)
+        .count()
+        == 5
+    )
+    assert (
+        session.query(DatabaseUserOAuth2Tokens)
+        .filter_by(database_id=database2.id)
+        .count()
+        == 0
+    )
+
+
 def test_compile_sqla_query_no_optimization(query: Select) -> None:
     """
     Test the `compile_sqla_query` method.

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -1453,6 +1453,17 @@ def test_purge_oauth2_tokens_scoped_by_database_id(session: Session) -> None:
         == 0
     )
 
+    # Purging database1 must delete all of its tokens. Filtering by the
+    # token PK instead of `database_id` would delete at most one row here.
+    database1.purge_oauth2_tokens()
+
+    assert (
+        session.query(DatabaseUserOAuth2Tokens)
+        .filter_by(database_id=database1.id)
+        .count()
+        == 0
+    )
+
 
 def test_compile_sqla_query_no_optimization(query: Select) -> None:
     """


### PR DESCRIPTION
### SUMMARY

`Database.purge_oauth2_tokens()` at `superset/models/core.py:1440` filters the `database_user_oauth2_tokens` table by the token-table primary key against the `Database` primary key, instead of by the `database_id` foreign key. Because token PKs and database PKs are independent auto-increment sequences, the delete removes the row whose token PK happens to equal `self.id` rather than the tokens actually associated with this database.

The existing unit test at `tests/unit_tests/models/core_test.py::test_purge_oauth2_tokens` happens to pass because it inserts one database and one token per database in an empty schema, so PK=1 aligns with PK=1 by coincidence. Any scenario where the token PK and database PK diverge (the normal state once more than one token has ever existed) leaves the wrong rows deleted and the intended rows in place.

The one-line fix scopes the filter by `database_id`:

```diff
- db.session.query(DatabaseUserOAuth2Tokens).filter(
-     DatabaseUserOAuth2Tokens.id == self.id
- ).delete()
+ db.session.query(DatabaseUserOAuth2Tokens).filter(
+     DatabaseUserOAuth2Tokens.database_id == self.id
+ ).delete()
```

This matches:
- the docstring ("Delete all OAuth2 tokens associated with this database"),
- the FK declared on the model (`database_id = Column(Integer, ForeignKey("dbs.id", ondelete="CASCADE"))`), and
- the migration that introduced the table (`2024-03-20_16-02_678eefb4ab44_add_access_token_table.py`, which declares `sa.PrimaryKeyConstraint("id")` on its own independent SERIAL sequence).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — internal ORM filter change, no UI.

### TESTING INSTRUCTIONS

Added `test_purge_oauth2_tokens_scoped_by_database_id` alongside the existing test. It inserts several tokens on `database1` first (so token PKs advance past 1), then creates `database2`, then purges `database2`. The current filter would delete one of `database1`'s tokens; the fix leaves them all in place.

```bash
pytest tests/unit_tests/models/core_test.py -k purge_oauth2 -v
```

Both `test_purge_oauth2_tokens` (existing) and `test_purge_oauth2_tokens_scoped_by_database_id` (new) pass with the fix. The new test fails on unpatched `master`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Discussed privately with the Superset Security team; opening here as a correctness fix per their request.
