### PR TITLE
refactor: set cascade_backrefs=False for SavedQuery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,7 +30,7 @@ filterwarnings =
     always::sqlalchemy.exc.RemovedIn20Warning
     error:Passing a string to Connection.execute\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
     error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
-#    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -500,13 +500,25 @@ class SavedQuery(
     template_parameters = Column(Text)
     user = relationship(
         security_manager.user_model,
-        backref=backref("saved_queries", cascade="all, delete-orphan"),
+        backref=backref(
+            "saved_queries",
+            cascade="all, delete-orphan",
+            # SQLAlchemy 2.0 behavior: assigning `saved_query.user` no longer
+            # cascades the SavedQuery into the User's session; callers must
+            # add objects to a session explicitly.
+            cascade_backrefs=False,
+        ),
         foreign_keys=[user_id],
     )
     database = relationship(
         "Database",
         foreign_keys=[db_id],
-        backref=backref("saved_queries", cascade="all, delete-orphan"),
+        backref=backref(
+            "saved_queries",
+            cascade="all, delete-orphan",
+            # SQLAlchemy 2.0 behavior: see `user` above.
+            cascade_backrefs=False,
+        ),
     )
     rows = Column(Integer, nullable=True)
     last_run = Column(DateTime, nullable=True)


### PR DESCRIPTION
See #40273

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enable errors for the `"SavedQuery" object is being merged into a Session along the backref cascade path` RemovedIn20Warning, and adopt the SQLAlchemy 2.0 behavior for both SavedQuery backrefs (`User.saved_queries` and `Database.saved_queries`).

Constructing `SavedQuery(database=...)` or `SavedQuery(user=...)` no longer implicitly merges the new object into the parent's session. All code paths that persist saved queries already call `session.add()` explicitly, so no call sites needed changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)