### PR TITLE
fix(dataset): disable duplicate button when name is empty

### DIFF
--- a/superset-frontend/src/features/datasets/DuplicateDatasetModal.test.tsx
+++ b/superset-frontend/src/features/datasets/DuplicateDatasetModal.test.tsx
@@ -207,6 +207,21 @@ test('pressing Enter key triggers duplicate action', async () => {
   });
 });
 
+test('pressing Enter with empty input does not trigger duplicate action', async () => {
+  const onHide = jest.fn();
+  const onDuplicate = jest.fn();
+
+  renderModal(mockDataset, onHide, onDuplicate);
+
+  const input = await screen.findByTestId('duplicate-modal-input');
+
+  // Press Enter without typing a name
+  await userEvent.type(input, '{enter}');
+
+  // onPressEnter should not bypass the disabled state
+  expect(onDuplicate).not.toHaveBeenCalled();
+});
+
 test('modal closes when onHide is called', async () => {
   const onHide = jest.fn();
   const onDuplicate = jest.fn();

--- a/superset-frontend/src/features/datasets/DuplicateDatasetModal.test.tsx
+++ b/superset-frontend/src/features/datasets/DuplicateDatasetModal.test.tsx
@@ -106,6 +106,19 @@ test('modal opens when dataset is provided', async () => {
   ).toBeInTheDocument();
 });
 
+test('duplicate button is disabled when modal first opens', async () => {
+  const onHide = jest.fn();
+  const onDuplicate = jest.fn();
+
+  renderModal(mockDataset, onHide, onDuplicate);
+
+  const duplicateButton = await screen.findByRole('button', {
+    name: /duplicate/i,
+  });
+
+  expect(duplicateButton).toBeDisabled();
+});
+
 test('modal does not open when dataset is null', () => {
   const onHide = jest.fn();
   const onDuplicate = jest.fn();

--- a/superset-frontend/src/features/datasets/DuplicateDatasetModal.tsx
+++ b/superset-frontend/src/features/datasets/DuplicateDatasetModal.tsx
@@ -34,7 +34,7 @@ const DuplicateDatasetModal: FunctionComponent<DuplicateDatasetModalProps> = ({
   onDuplicate,
 }) => {
   const [show, setShow] = useState<boolean>(false);
-  const [disableSave, setDisableSave] = useState<boolean>(false);
+  const [disableSave, setDisableSave] = useState<boolean>(true);
   const [newDuplicateDatasetName, setNewDuplicateDatasetName] =
     useState<string>('');
 
@@ -50,6 +50,7 @@ const DuplicateDatasetModal: FunctionComponent<DuplicateDatasetModalProps> = ({
 
   useEffect(() => {
     setNewDuplicateDatasetName('');
+    setDisableSave(true);
     setShow(dataset !== null);
   }, [dataset]);
 

--- a/superset-frontend/src/features/datasets/DuplicateDatasetModal.tsx
+++ b/superset-frontend/src/features/datasets/DuplicateDatasetModal.tsx
@@ -45,6 +45,9 @@ const DuplicateDatasetModal: FunctionComponent<DuplicateDatasetModalProps> = ({
   };
 
   const duplicateDataset = () => {
+    if (disableSave) {
+      return;
+    }
     onDuplicate(newDuplicateDatasetName);
   };
 


### PR DESCRIPTION
Fixes #40405 

## Summary

This PR fixes an issue where the **Duplicate** button is enabled when the Duplicate Dataset modal is first opened, even though the dataset name is empty.

## Root Cause

`disableSave` was initialized to `false`, and the modal's `useEffect` reset the dataset name but did not reset the disabled state. As a result, the Duplicate button could remain enabled with an empty input.

## Changes

- Initialize `disableSave` to `true`
- Reset `disableSave` inside `useEffect` whenever the modal opens
- Add a regression test to verify the Duplicate button is disabled on initial render

## Testing

Executed:

```bash
npm test -- src/features/datasets/DuplicateDatasetModal.test.tsx
```

Result:

- Test Suites: 1 passed
- Tests: 10 passed