### PR TITLE
fix(views): remove stray space in @deprecated new_target log message

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -193,7 +193,7 @@ def deprecated(
                     eol_version,
                 ]
                 if new_target:
-                    message += " . Use the following API endpoint instead: %s"
+                    message += ". Use the following API endpoint instead: %s"
                     logger_args.append(new_target)
                 logger.warning(message, *logger_args)
             return f(self, *args, **kwargs)

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -296,3 +296,22 @@ def test_deprecated_logs_warning_exactly_once() -> None:
     # separate positional arg rather than being interpolated into the
     # message template string itself.
     assert "5.0.0" in mock_logger.warning.call_args[0]
+
+
+def test_deprecated_new_target_message_has_no_stray_space() -> None:
+    from superset.views.base import BaseSupersetView, deprecated
+
+    @deprecated(eol_version="5.0.0", new_target="/api/v1/chart/data")
+    def endpoint(self: BaseSupersetView) -> None:
+        return None
+
+    view = MagicMock(spec=BaseSupersetView)
+    view.__class__.__name__ = "Superset"
+
+    with patch("superset.views.base.logger") as mock_logger:
+        endpoint(view)
+
+    template, *args = mock_logger.warning.call_args[0]
+    formatted = template % tuple(args)
+    assert "5.0.0. Use the following API endpoint instead" in formatted
+    assert "5.0.0 . Use" not in formatted


### PR DESCRIPTION
**Decisions made that were not in the instructions**
None.

## What was the warning?

Production logs show `Superset.explore_json This API endpoint is deprecated and will be removed in version 5.0.0` — emitted by the shared `@deprecated()` decorator in `superset/views/base.py`, used across several endpoints in `superset/views/core.py` (`explore_json`, `explore_json_data`, `warm_up_cache`, etc).

## What changed

When a `@deprecated()` call site sets `new_target`, the message concatenation left a stray space before the period:

```
"...will be removed in version 5.0.0 . Use the following API endpoint instead: /api/v1/chart/data"
```

instead of the intended:

```
"...will be removed in version 5.0.0. Use the following API endpoint instead: /api/v1/chart/data"
```

One-character fix: `" . Use..."` → `". Use..."` in `superset/views/base.py`. Added a regression test (`test_deprecated_new_target_message_has_no_stray_space`) asserting the formatted message has no stray space before the period.

## No-behavior-change note

This only touches the deprecation warning's log message text. It does not change the deprecated endpoint's behavior, routing, permissions, or the `@deprecated()` decorator's once-per-process warning semantics. The `explore_json` endpoint itself remains deprecated and unchanged — it's an intentional, architectural deprecation and out of scope here. Note #41714 is a separate in-flight effort to remove the legacy `explore_json`/`viz.py` pipeline entirely; this PR is just a stopgap message-hygiene fix for current production logs in the meantime.

## Test plan

- `tests/unit_tests/views/test_base.py` — added `test_deprecated_new_target_message_has_no_stray_space`; ran the full file (32 tests) locally, all pass.
- `ruff check` / `ruff format --check` clean.
- Full `pre-commit run` clean (mypy, ruff, pylint, etc.).