### PR TITLE
fix(select): exclude null-valued options from "Select all" count

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -945,6 +945,35 @@ test('do not count unselected disabled options in "Select all"', async () => {
   ).toBeInTheDocument();
 });
 
+test('"Select all" does not count null-valued options', async () => {
+  // A falsy-valued option (e.g. <NULL>, value: null) is skipped by
+  // handleSelectAll, so it must not be counted in the "Select all" badge or
+  // the count overstates the selection. Regression test for #40228. Uses a
+  // local options array to stay isolated from tests that mutate OPTIONS.
+  const localOptions = [
+    { label: 'Alpha', value: 1 },
+    { label: 'Bravo', value: 2 },
+  ];
+  render(
+    <Select
+      {...defaultProps}
+      options={[...localOptions, NULL_OPTION]}
+      mode="multiple"
+      maxTagCount={0}
+    />,
+  );
+  await open();
+  // Three options are visible, but the <NULL> option is not bulk-selectable,
+  // so the badge must count only the two real options (would be 3 before fix).
+  await userEvent.click(
+    await screen.findByText(selectAllButtonText(localOptions.length)),
+  );
+  // And Select all selects exactly those two — the null option is skipped.
+  const values = await findAllSelectValues();
+  expect(values.length).toBe(1);
+  expect(values[0]).toHaveTextContent(`+ ${localOptions.length} ...`);
+});
+
 test('"Deselect all" counts all selected options', async () => {
   render(<Select {...defaultProps} allowNewOptions mode="multiple" />);
   await open();

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -311,7 +311,12 @@ const Select = forwardRef(
           const isDisabled = option.disabled;
           const isNew = option.isNewOption;
 
+          // Mirror handleSelectAll, which skips falsy-valued options (e.g. the
+          // <NULL> option whose value is null): they are not bulk-selectable,
+          // so counting them here makes the "Select all" badge overstate what
+          // gets selected.
           if (
+            option.value &&
             (!isDisabled || isSelected) &&
             ((isNew && isSelected) || !isNew)
           ) {


### PR DESCRIPTION
### SUMMARY

In a multi-select (used by dashboard native filters), the **"Select all (N)"**
badge counted every visible option, but `handleSelectAll` skips options whose
value is falsy — e.g. the `<NULL>` option (`value: null`). The result: the badge
could read **"Select all (3)"** while clicking it only selected the two real
values, overstating what Select All actually does (reported in #40228).

The count is computed in `bulkSelectCounts.selectable`
(`superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx`),
which omitted the `option.value` truthiness guard that `handleSelectAll`
already applies. This change adds the same guard so the count reflects the
options that are actually bulk-selectable.

Selection behavior is intentionally unchanged — Select All still does not
select `<NULL>`; only the misleading count is corrected. The `deselectable`
branch is deliberately left as-is because `handleDeselectAll` does clear a
selected null option, so it must keep counting it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: options `[Alpha, Bravo, <NULL>]` → badge shows **"Select all (3)"**, but
clicking it selects only `Alpha` and `Bravo` (2 values).

After: the same options → badge shows **"Select all (2)"**, matching the two
values that Select All actually selects.

### TESTING INSTRUCTIONS

1. Create a dashboard filter (or any multi-select) on a column that contains
   `NULL` values so the dropdown includes a `<NULL>` option.
2. Open the dropdown and note the **"Select all (N)"** count.
   - Before this change: N includes the `<NULL>` option, but clicking Select All
     selects one fewer value.
   - After this change: N excludes the `<NULL>` option and matches the number of
     values actually selected.

Automated coverage: a regression test was added to
`superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx`
(`"Select all" does not count null-valued options`). It fails on `master`
(badge renders `(3)`) and passes with this change. Run it with:

```
cd superset-frontend
npm run test -- packages/superset-ui-core/src/components/Select/Select.test.tsx
```

All 85 tests in that suite pass.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #40228
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API