### PR TITLE
refactor: do not cascade to TableColumn

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -33,7 +33,7 @@ filterwarnings =
 #    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
 #    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
-#    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
     error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/commands/dataset/duplicate.py
+++ b/superset/commands/dataset/duplicate.py
@@ -84,7 +84,8 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
         if table.sql:
             table.sql = table.sql.strip().strip(";")
         db.session.add(table)
-        table.columns = [
+
+        columns = [
             TableColumn(
                 column_name=c.column_name,
                 verbose_name=c.verbose_name,
@@ -97,6 +98,9 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
             )
             for c in self._base_model.columns
         ]
+        db.session.add_all(columns)
+        table.columns = columns
+
         table.metrics = [
             SqlMetric(
                 metric_name=m.metric_name,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2021,6 +2021,7 @@ class SqlaTable(
                     type=col["type"],
                     table=self,
                 )
+                db.session.add(new_column)
                 new_column.is_dttm = new_column.is_temporal
                 # Set description from comment field if available
                 if col.get("comment"):

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -961,6 +961,7 @@ class TableColumn(AuditMixinNullable, ImportExportMixin, CertificationMixin, Mod
     table: Mapped["SqlaTable"] = relationship(
         "SqlaTable",
         back_populates="columns",
+        cascade_backrefs=False,
     )
 
     export_fields = [
@@ -1297,6 +1298,7 @@ class SqlaTable(
         TableColumn,
         back_populates="table",
         cascade="all, delete-orphan",
+        cascade_backrefs=False,
         passive_deletes=True,
     )
     metrics: Mapped[list[SqlMetric]] = relationship(

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -135,13 +135,12 @@ def _add_table_metrics(datasource: SqlaTable) -> None:
     if not any(col.column_name == "num_california" for col in columns):
         col_state = str(column("state").compile(db.engine))
         col_num = str(column("num").compile(db.engine))
-        columns.append(
-            TableColumn(
-                column_name="num_california",
-                expression="CASE WHEN %s = 'CA' THEN %s ELSE 0 END"
-                % (col_state, col_num),
-            )
+        column_it = TableColumn(
+            column_name="num_california",
+            expression="CASE WHEN %s = 'CA' THEN %s ELSE 0 END" % (col_state, col_num),
         )
+        db.session.add(column_it)
+        columns.append(column_it)
 
     if not any(col.metric_name == "sum__num" for col in metrics):
         col = str(column("num").compile(db.engine))

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -289,15 +289,18 @@ def virtual_dataset():
         ),
         database=get_example_database(),
     )
-    TableColumn(column_name="col1", type="INTEGER", table=dataset)
-    TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset)
-    TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset)
-    # Different database dialect datetime type is not consistent, so temporarily use varchar  # noqa: E501
-    TableColumn(column_name="col5", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col6", type="INTEGER", table=dataset)
+    columns = [
+        TableColumn(column_name="col1", type="INTEGER", table=dataset),
+        TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset),
+        TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset),
+        # Different database dialect datetime type is not consistent, so temporarily use varchar  # noqa: E501
+        TableColumn(column_name="col5", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col6", type="INTEGER", table=dataset),
+    ]
 
     SqlMetric(metric_name="count", expression="count(*)", table=dataset)
+    db.session.add_all(columns)
     db.session.add(dataset)
     db.session.commit()
 
@@ -329,16 +332,19 @@ def virtual_dataset_with_comments():
         ),
         database=get_example_database(),
     )
-    TableColumn(column_name="col1", type="INTEGER", table=dataset)
-    TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset)
-    TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset)
-    # Different database dialect datetime type is not consistent, so temporarily use varchar  # noqa: E501
-    TableColumn(column_name="col5", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col6", type="INTEGER", table=dataset)
+    columns = [
+        TableColumn(column_name="col1", type="INTEGER", table=dataset),
+        TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset),
+        TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset),
+        # Different database dialect datetime type is not consistent, so temporarily use varchar  # noqa: E501
+        TableColumn(column_name="col5", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col6", type="INTEGER", table=dataset),
+    ]
 
     SqlMetric(metric_name="count", expression="count(*)", table=dataset)
     db.session.add(dataset)
+    db.session.add_all(columns)
     db.session.commit()
 
     yield dataset
@@ -391,20 +397,23 @@ def physical_dataset():
         table_name="physical_dataset",
         database=example_database,
     )
-    TableColumn(column_name="col1", type="INTEGER", table=dataset)
-    TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset)
-    TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col5", type="TIMESTAMP", is_dttm=True, table=dataset)
-    TableColumn(column_name="col6", type="TIMESTAMP", is_dttm=True, table=dataset)
-    TableColumn(
-        column_name="time column with spaces",
-        type="TIMESTAMP",
-        is_dttm=True,
-        table=dataset,
-    )
+    columns = [
+        TableColumn(column_name="col1", type="INTEGER", table=dataset),
+        TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col3", type="DECIMAL(4,2)", table=dataset),
+        TableColumn(column_name="col4", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col5", type="TIMESTAMP", is_dttm=True, table=dataset),
+        TableColumn(column_name="col6", type="TIMESTAMP", is_dttm=True, table=dataset),
+        TableColumn(
+            column_name="time column with spaces",
+            type="TIMESTAMP",
+            is_dttm=True,
+            table=dataset,
+        ),
+    ]
     SqlMetric(metric_name="count", expression="count(*)", table=dataset)
     db.session.add(dataset)
+    db.session.add_all(columns)
     db.session.commit()
 
     yield dataset
@@ -433,11 +442,14 @@ def virtual_dataset_comma_in_column_value():
         ),
         database=get_example_database(),
     )
-    TableColumn(column_name="col1", type="VARCHAR(255)", table=dataset)
-    TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset)
+    columns = [
+        TableColumn(column_name="col1", type="VARCHAR(255)", table=dataset),
+        TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset),
+    ]
 
     SqlMetric(metric_name="count", expression="count(*)", table=dataset)
     db.session.add(dataset)
+    db.session.add_all(columns)
     db.session.commit()
 
     yield dataset

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -121,6 +121,7 @@ class TestDatasetApi(SupersetTestCase):
             extra=extra,
         )
         if columns:
+            db.session.add_all(columns)
             table.columns = columns
         if metrics:
             table.metrics = metrics

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -153,17 +153,17 @@ class TestDatasource(SupersetTestCase):
             "row_limit": 1000,
             "row_offset": 0,
         }
+        columns = [
+            TableColumn(column_name="default_dttm", type="DATETIME", is_dttm=True),
+            TableColumn(column_name="additional_dttm", type="DATETIME", is_dttm=True),
+        ]
+        db.session.add_all(columns)
         table = SqlaTable(
             table_name="dummy_sql_table",
             database=database,
             schema=get_example_default_schema(),
             main_dttm_col="default_dttm",
-            columns=[
-                TableColumn(column_name="default_dttm", type="DATETIME", is_dttm=True),
-                TableColumn(
-                    column_name="additional_dttm", type="DATETIME", is_dttm=True
-                ),
-            ],
+            columns=columns,
             sql=sql,
         )
 
@@ -660,12 +660,13 @@ def test_get_samples_with_incorrect_cc(test_client, login_as_admin, virtual_data
     if get_example_database().backend == "sqlite":
         return
 
-    TableColumn(
+    column = TableColumn(
         column_name="DUMMY CC",
         type="VARCHAR(255)",
         table=virtual_dataset,
         expression="INCORRECT SQL",
     )
+    db.session.add(column)
 
     uri = (
         f"/datasource/samples?datasource_id={virtual_dataset.id}&datasource_type=table"

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import pytest
 
+from superset import db
 from superset.connectors.sqla.models import TableColumn
 from superset.db_engine_specs import load_engine_specs
 from superset.db_engine_specs.base import (
@@ -177,7 +178,7 @@ class SupersetTestCases(SupersetTestCase):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_calculated_column_in_order_by_base_engine_spec(self):
         table = self.get_table(name="birth_names")
-        TableColumn(
+        column = TableColumn(
             column_name="gender_cc",
             type="VARCHAR(255)",
             table=table,
@@ -188,6 +189,7 @@ class SupersetTestCases(SupersetTestCase):
             end
             """,
         )
+        db.session.add(column)
 
         table.database.sqlalchemy_uri = "sqlite://"
         query_obj = {

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -21,6 +21,7 @@ import pytest
 from pandas import DataFrame
 from sqlalchemy import column
 
+from superset import db
 from superset.connectors.sqla.models import TableColumn
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.bigquery import BigQueryEngineSpec
@@ -315,7 +316,7 @@ class TestBigQueryDbEngineSpec(SupersetTestCase):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_calculated_column_in_order_by(self):
         table = self.get_table(name="birth_names")
-        TableColumn(
+        column = TableColumn(
             column_name="gender_cc",
             type="VARCHAR(255)",
             table=table,
@@ -326,6 +327,7 @@ class TestBigQueryDbEngineSpec(SupersetTestCase):
             end
             """,
         )
+        db.session.add(column)
 
         table.database.sqlalchemy_uri = "bigquery://"
         query_obj = {

--- a/tests/integration_tests/db_engine_specs/datastore_tests.py
+++ b/tests/integration_tests/db_engine_specs/datastore_tests.py
@@ -26,6 +26,7 @@ pytest.importorskip("sqlalchemy_datastore")
 
 from sqlalchemy.engine.url import make_url
 
+from superset import db
 from superset.connectors.sqla.models import TableColumn
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.datastore import DatastoreEngineSpec
@@ -240,7 +241,7 @@ class TestDatastoreDbEngineSpec(SupersetTestCase):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_calculated_column_in_order_by(self):
         table = self.get_table(name="birth_names")
-        TableColumn(
+        column = TableColumn(
             column_name="gender_cc",
             type="VARCHAR(255)",
             table=table,
@@ -251,6 +252,7 @@ class TestDatastoreDbEngineSpec(SupersetTestCase):
             end
             """,
         )
+        db.session.add(column)
 
         table.database.sqlalchemy_uri = "datastore://"
         query_obj = {

--- a/tests/integration_tests/fixtures/datasource.py
+++ b/tests/integration_tests/fixtures/datasource.py
@@ -194,6 +194,7 @@ def load_dataset_with_columns() -> Generator[SqlaTable, None, None]:
     column = TableColumn(table_id=dataset.id, column_name="name")
     dataset.columns = [column]
     db.session.add(dataset)
+    db.session.add(column)
     db.session.commit()
     yield dataset
 

--- a/tests/integration_tests/import_export_tests.py
+++ b/tests/integration_tests/import_export_tests.py
@@ -134,7 +134,9 @@ class TestImportExport(SupersetTestCase):
             params=json.dumps(params),
         )
         for col_name in cols_names:
-            table.columns.append(TableColumn(column_name=col_name))
+            column = TableColumn(column_name=col_name)
+            db.session.add(column)
+            table.columns.append(column)
         for metric_name in metric_names:
             table.metrics.append(SqlMetric(metric_name=metric_name, expression=""))
         return table

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -174,7 +174,8 @@ class TestDatabaseModel(SupersetTestCase):
             database=get_example_database(),
         )
         db.session.add(table)
-        TableColumn(
+
+        column = TableColumn(
             column_name="expr",
             expression="case when '{{ current_username() }}' = 'abc' "
             "then 'yes' else 'no' end",
@@ -186,6 +187,7 @@ class TestDatabaseModel(SupersetTestCase):
             expression="count('{{ 'bar_' + time_grain }}')",
             table=table,
         )
+        db.session.add(column)
         db.session.commit()
 
         sqla_query = table.get_sqla_query(**base_query_obj)
@@ -464,20 +466,23 @@ class TestDatabaseModel(SupersetTestCase):
             database=get_example_database(),
             sql="select 123 as intcol, 'abc' as strcol, 'abc' as mycase",
         )
-        TableColumn(column_name="intcol", type="FLOAT", table=table)
-        TableColumn(column_name="oldcol", type="INT", table=table)
-        TableColumn(
-            column_name="expr",
-            expression="case when 1 then 1 else 0 end",
-            type="INT",
-            table=table,
-        )
-        TableColumn(
-            column_name="mycase",
-            expression="case when 1 then 1 else 0 end",
-            type="INT",
-            table=table,
-        )
+        columns = [
+            TableColumn(column_name="intcol", type="FLOAT", table=table),
+            TableColumn(column_name="oldcol", type="INT", table=table),
+            TableColumn(
+                column_name="expr",
+                expression="case when 1 then 1 else 0 end",
+                type="INT",
+                table=table,
+            ),
+            TableColumn(
+                column_name="mycase",
+                expression="case when 1 then 1 else 0 end",
+                type="INT",
+                table=table,
+            ),
+        ]
+        db.session.add_all(columns)
 
         # make sure the columns have been mapped properly
         assert len(table.columns) == 4
@@ -551,8 +556,9 @@ def text_column_table(app_context: AppContext):
         ),
         database=get_example_database(),
     )
-    TableColumn(column_name="foo", type="VARCHAR(255)", table=table)
+    column = TableColumn(column_name="foo", type="VARCHAR(255)", table=table)
     SqlMetric(metric_name="count", expression="count(*)", table=table)
+    db.session.add(column)
     return table
 
 
@@ -725,12 +731,13 @@ def test_should_generate_closed_and_open_time_filter_range(login_as_admin):
         ),
         database=get_example_database(),
     )
-    TableColumn(
+    column = TableColumn(
         column_name="datetime_col",
         type="TIMESTAMP",
         table=table,
         is_dttm=True,
     )
+    db.session.add(column)
     SqlMetric(metric_name="count", expression="count(*)", table=table)
     result_object = table.query(
         {
@@ -1000,18 +1007,20 @@ def test_extra_cache_keys_in_dataset_metrics_and_columns(
     mock_username: Mock,
     mock_user_id: Mock,
 ):
+    columns = [
+        TableColumn(column_name="user", type="VARCHAR(255)"),
+        TableColumn(
+            column_name="username",
+            type="VARCHAR(255)",
+            expression="{{ current_username() }}",
+        ),
+    ]
+    db.session.add_all(columns)
     table = SqlaTable(
         table_name="test_has_no_extra_cache_keys_table",
         sql="SELECT 'abc' as user",
         database=get_example_database(),
-        columns=[
-            TableColumn(column_name="user", type="VARCHAR(255)"),
-            TableColumn(
-                column_name="username",
-                type="VARCHAR(255)",
-                expression="{{ current_username() }}",
-            ),
-        ],
+        columns=columns,
         metrics=[
             SqlMetric(
                 metric_name="variable_profit",
@@ -1111,6 +1120,7 @@ def test__normalize_prequery_result_type(
             type="TIMESTAMP",
         ),
     }
+    db.session.add_all(columns_by_name.values())
 
     normalized = table._normalize_prequery_result_type(
         row,
@@ -1171,6 +1181,7 @@ def test_generic_metric_filtering_without_chart_flag(login_as_admin):
         type="VARCHAR(255)",
         table=table,
     )
+    db.session.add(col)
     table.columns = [col]
 
     metric = SqlMetric(
@@ -1231,6 +1242,7 @@ def test_column_ordering_without_chart_flag(login_as_admin):
 
     col_a = TableColumn(column_name="col_a", type="VARCHAR(255)", table=table)
     col_b = TableColumn(column_name="col_b", type="VARCHAR(255)", table=table)
+    db.session.add_all([col_a, col_b])
     table.columns = [col_a, col_b]
 
     metric_x = SqlMetric(metric_name="metric_x", expression="COUNT(*)", table=table)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

See #40273 .

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Disable `cascade_backrefs` on `TableColumn` because it is deprecated in Airflow 2.
Manually add objects to session that were previously added automatically.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Unit tests:

```
$ SQLALCHEMY_WARN_20=1 python3 -m pytest tests/unit_tests/
```

Integration tests via CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
