### PR TITLE
fix(metadata-bar): add max-width to text for proper ellipsis truncation

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
@@ -89,6 +89,7 @@ const StyledItem = styled.div<{
     & .metadata-text {
       color: ${theme.colorTextSecondary};
       min-width: ${TEXT_MIN_WIDTH}px;
+      max-width: ${TEXT_MAX_WIDTH}px;
       overflow: hidden;
       text-overflow: ${collapsed ? 'unset' : 'ellipsis'};
       white-space: nowrap;


### PR DESCRIPTION
## Summary

This PR fixes text overflow in the MetadataBar component where long localized timestamps (e.g. German `Geändert vor 3 Stunden und 42 Minuten`) were being clipped without showing an ellipsis.

## Problem

The `.metadata-text` span in the MetadataBar component had `overflow: hidden` and `text-overflow: ellipsis` set, but lacked an explicit `max-width` constraint. In a flex layout context, `text-overflow: ellipsis` requires a definite width on the element itself to work reliably. Without it, the text was clipped by the parent max-width but the ellipsis was not applied.

## Fix

Added `max-width: 150px` to the `.metadata-text` span. This gives the text element a definite width constraint, ensuring `text-overflow: ellipsis` works properly in the flex layout.

## After
<img width="1920" height="1080" alt="Screenshot from 2026-07-21 13-35-46" src="https://github.com/user-attachments/assets/282a55e2-d879-4f63-8618-880d5f81d56f" />


## Testing

All 21 existing MetadataBar tests pass. The fix is a single CSS property addition with no behavioral changes.

Closes #40460