### PR TITLE
fix(databases): reset import file entry after invalid file error

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -63,6 +63,7 @@ const DATABASE_FETCH_ENDPOINT = 'glob:*/api/v1/database/10';
 const AVAILABLE_DB_ENDPOINT = 'glob:*/api/v1/database/available*';
 const VALIDATE_PARAMS_ENDPOINT = 'glob:*/api/v1/database/validate_parameters*';
 const DATABASE_CONNECT_ENDPOINT = 'glob:*/api/v1/database/';
+const IMPORT_DB_ENDPOINT = 'glob:*/api/v1/database/import/';
 
 const databaseFixture: DatabaseObject = {
   id: 123,
@@ -1599,6 +1600,59 @@ describe('DatabaseModal', () => {
         expect(importDbButton.files?.[0]).toStrictEqual(testFile);
         expect(importDbButton.files?.item(0)).toStrictEqual(testFile);
         expect(importDbButton.files).toHaveLength(1);
+      });
+
+      test('resets the upload entry after an invalid file error', async () => {
+        fetchMock.post(IMPORT_DB_ENDPOINT, {
+          status: 422,
+          body: {
+            errors: [
+              {
+                message:
+                  'Could not find a valid command to import file. Please re-export your file and try importing again',
+                error_type: 'GENERIC_COMMAND_ERROR',
+                level: 'warning',
+                extra: { issue_codes: [] },
+              },
+            ],
+          },
+        });
+
+        // jsdom does not implement scrollIntoView, which the modal calls
+        // once the importing filename renders
+        Element.prototype.scrollIntoView = jest.fn();
+
+        setup();
+
+        await screen.findByTestId('import-database-btn');
+        const fileInput = document.querySelector(
+          'input[type="file"]',
+        ) as HTMLInputElement;
+        // rc-upload spreads e.target.files, so pass a real iterable
+        fireEvent.change(fileInput, {
+          target: {
+            files: [new File([new ArrayBuffer(1)], 'invalid_export.zip')],
+          },
+        });
+
+        await screen.findByText(/could not find a valid command to import/i);
+
+        const uploadItem = document.querySelector('.ant-upload-list-item');
+        expect(uploadItem).toBeInTheDocument();
+        // the spinner must settle rather than spin forever
+        expect(uploadItem).not.toHaveClass('ant-upload-list-item-uploading');
+
+        const removeButton = (uploadItem as HTMLElement).querySelector(
+          'button',
+        ) as HTMLButtonElement;
+        expect(removeButton).toBeInTheDocument();
+        fireEvent.click(removeButton);
+
+        await waitFor(() =>
+          expect(
+            document.querySelector('.ant-upload-list-item'),
+          ).not.toBeInTheDocument(),
+        );
       });
     });
   });

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -2356,6 +2356,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                     id="databaseFile"
                     data-test="database-file-input"
                     accept=".yaml,.json,.yml,.zip"
+                    fileList={fileList}
                     customRequest={() => {}}
                     onChange={onDbImport}
                     onRemove={removeFile}

--- a/superset-frontend/src/features/databases/DatabaseModal/styles.ts
+++ b/superset-frontend/src/features/databases/DatabaseModal/styles.ts
@@ -538,8 +538,4 @@ export const StyledUploadWrapper = styled.div`
   .ant-progress-inner {
     display: none;
   }
-
-  .ant-upload-list-item-card-actions {
-    display: none;
-  }
 `;


### PR DESCRIPTION
### SUMMARY

Uploading an invalid file under "Import database from file" left the modal stuck: the progress spinner spun forever and the trash icon did nothing. Only closing and reopening the modal cleared it.

The `Upload` had no `fileList` prop, so it was uncontrolled — antd rendered its own internal list while React's `fileList` state was updated separately and never displayed. Since `customRequest` is a no-op that never calls `onSuccess`/`onError`, antd's entry stayed at `status: 'uploading'` forever (the spinner), and `removeFile`'s `setFileList` updated state nobody rendered (the dead trash icon). One cause, both symptoms.

Passing `fileList` makes it controlled: `onDbImport` already sets `status: 'done'`, so the spinner settles and the remove icon clears the entry.

Two notes for reviewers:
- `removeFile`'s `return false` looks like the bug but is load-bearing — returning `true` makes antd fire `onChange` → `onDbImport` with the removed file, starting a bogus re-import.
- Also drops a stale `.ant-upload-list-item-card-actions` rule: an antd v4 selector that matches nothing in v6, so it was dead code hiding an icon that should work.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="500" height="893" alt="image" src="https://github.com/user-attachments/assets/ba6e9831-ab3c-4627-9996-eb0973413d47" />
The spinner shows indefinitely and you can't remove the invalid file
After:
<img width="533" height="919" alt="image" src="https://github.com/user-attachments/assets/e62c96bd-1f1a-48be-be72-97279c7a6883" />
Spinner stops and you can remove invalid file with trash icon


### TESTING INSTRUCTIONS

1. Settings > Database Connections > + Database
2. Under "Import database from file", upload a .zip that is not a valid Superset export
3. Error banner appears; the spinner stops and the trash icon removes the entry, letting you retry without closing the modal

Added a regression test that fails on master with `Received: ant-upload-list-item ant-upload-list-item-uploading` — the stuck spinner itself.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No — reported internally
- [ ] Required feature flags: None
- [x] Changes UI — the upload entry in the DB import modal now resets
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No
