### PR TITLE
feat(timeseries): percent-change rebasing with a draggable baseline

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -90,7 +90,9 @@ export default function EchartsTimeseries({
       series?: { data?: SeriesDataPoint[] }[];
     };
     const baseSeries = (option.series ?? []).map(s =>
-      Array.isArray(s.data) ? (s.data as SeriesDataPoint[]) : [],
+      Array.isArray(s.data)
+        ? (s.data.filter(Array.isArray) as SeriesDataPoint[])
+        : [],
     );
     const xs = Array.from(
       new Set(baseSeries.flat().map(([x]) => Number(x))),
@@ -119,11 +121,10 @@ export default function EchartsTimeseries({
         graphic: [
           {
             id: 'percent-change-baseline',
-            type: 'rect',
+            // only group elements support children in the graphic API
+            type: 'group',
             x: px - 4,
             y: gridRect.top,
-            shape: { width: 8, height: gridRect.height },
-            style: { fill: theme.colorFillQuaternary },
             cursor: 'ew-resize',
             draggable: true,
             z: 100,
@@ -142,9 +143,12 @@ export default function EchartsTimeseries({
             children: [
               {
                 type: 'rect',
-                left: 'center',
-                top: 0,
-                shape: { width: 2, height: gridRect.height },
+                shape: { x: 0, y: 0, width: 8, height: gridRect.height },
+                style: { fill: 'rgba(0, 0, 0, 0.02)' },
+              },
+              {
+                type: 'rect',
+                shape: { x: 3, y: 0, width: 2, height: gridRect.height },
                 style: { fill: theme.colorTextSecondary },
               },
             ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -27,6 +27,7 @@ import {
   LegendState,
   ensureIsArray,
 } from '@superset-ui/core';
+import { useTheme } from '@apache-superset/core/theme';
 import type {
   ECElementEvent,
   ViewRootGroup,
@@ -68,6 +69,7 @@ export default function EchartsTimeseries({
   onLegendScroll,
 }: TimeseriesChartTransformedProps) {
   const { stack } = formData;
+  const theme = useTheme();
   const echartRef = useRef<EchartsHandler | null>(null);
   // eslint-disable-next-line no-param-reassign
   refs.echartRef = echartRef;
@@ -121,7 +123,7 @@ export default function EchartsTimeseries({
             x: px - 4,
             y: gridRect.top,
             shape: { width: 8, height: gridRect.height },
-            style: { fill: 'rgba(0, 0, 0, 0.02)' },
+            style: { fill: theme.colorFillQuaternary },
             cursor: 'ew-resize',
             draggable: true,
             z: 100,
@@ -143,7 +145,7 @@ export default function EchartsTimeseries({
                 left: 'center',
                 top: 0,
                 shape: { width: 2, height: gridRect.height },
-                style: { fill: '#666' },
+                style: { fill: theme.colorTextSecondary },
               },
             ],
           },
@@ -157,7 +159,7 @@ export default function EchartsTimeseries({
         graphic: [{ id: 'percent-change-baseline', $action: 'remove' }],
       });
     };
-  }, [rebaseEnabled, echartOptions, width, height]);
+  }, [rebaseEnabled, echartOptions, width, height, theme]);
   const extraControlRef = useRef<HTMLDivElement>(null);
   const [extraControlHeight, setExtraControlHeight] = useState(0);
   useEffect(() => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -127,7 +127,31 @@ export default function EchartsTimeseries({
     };
 
     const drawHandle = () => {
-      const gridRect = { top: 0, height: chart.getHeight() };
+      // Cap the handle to the plot area so it doesn't run through the
+      // legend above or the axis labels below.
+      let gridRect = { top: 0, height: chart.getHeight() };
+      try {
+        const rect = (
+          chart as unknown as {
+            getModel: () => {
+              getComponent: (
+                type: string,
+                index: number,
+              ) => {
+                coordinateSystem: {
+                  getRect: () => { y: number; height: number };
+                };
+              };
+            };
+          }
+        )
+          .getModel()
+          .getComponent('grid', 0)
+          .coordinateSystem.getRect();
+        gridRect = { top: rect.y, height: rect.height };
+      } catch {
+        // fall back to the full chart height
+      }
       let px: number;
       try {
         [px] = [chart.convertToPixel({ xAxisIndex: 0 }, baselineX) as number];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -35,6 +35,11 @@ import type GlobalModel from 'echarts/types/src/model/Global';
 import type ComponentModel from 'echarts/types/src/model/Component';
 import { EchartsHandler, EventHandlers } from '../types';
 import Echart from '../components/Echart';
+import {
+  rebaseSeriesData,
+  snapToNearestX,
+  SeriesDataPoint,
+} from './percentChange';
 import { OrientationType, TimeseriesChartTransformedProps } from './types';
 import { formatSeriesName } from '../utils/series';
 import { ExtraControls } from '../components/ExtraControls';
@@ -67,6 +72,92 @@ export default function EchartsTimeseries({
   // eslint-disable-next-line no-param-reassign
   refs.echartRef = echartRef;
   const clickTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Draggable percent-change baseline: when the rebase view is active, a
+  // vertical line is drawn on the plot; dragging it re-indexes every series
+  // to the hovered point via the composable rebase, entirely client-side.
+  const rebaseEnabled = Boolean(
+    (formData as { rebasePercentChange?: boolean }).rebasePercentChange,
+  );
+  useEffect(() => {
+    if (!rebaseEnabled) return undefined;
+    const chart = echartRef.current?.getEchartInstance?.();
+    if (!chart) return undefined;
+
+    const option = chart.getOption() as {
+      series?: { data?: SeriesDataPoint[] }[];
+    };
+    const baseSeries = (option.series ?? []).map(s =>
+      Array.isArray(s.data) ? (s.data as SeriesDataPoint[]) : [],
+    );
+    const xs = Array.from(
+      new Set(baseSeries.flat().map(([x]) => Number(x))),
+    ).sort((a, b) => a - b);
+    if (xs.length === 0) return undefined;
+    let baselineX = xs[0];
+
+    const applyBaseline = (newX: number) => {
+      baselineX = newX;
+      chart.setOption({
+        series: baseSeries.map(data => ({
+          data: rebaseSeriesData(data, newX),
+        })),
+      });
+    };
+
+    const drawHandle = () => {
+      const gridRect = { top: 0, height: chart.getHeight() };
+      let px: number;
+      try {
+        [px] = [chart.convertToPixel({ xAxisIndex: 0 }, baselineX) as number];
+      } catch {
+        return;
+      }
+      chart.setOption({
+        graphic: [
+          {
+            id: 'percent-change-baseline',
+            type: 'rect',
+            x: px - 4,
+            y: gridRect.top,
+            shape: { width: 8, height: gridRect.height },
+            style: { fill: 'rgba(0, 0, 0, 0.02)' },
+            cursor: 'ew-resize',
+            draggable: true,
+            z: 100,
+            ondrag(this: { x: number; y: number }) {
+              this.y = gridRect.top;
+              const dataX = chart.convertFromPixel(
+                { xAxisIndex: 0 },
+                this.x + 4,
+              ) as number;
+              const snapped = snapToNearestX(xs, dataX);
+              if (snapped !== undefined && snapped !== baselineX) {
+                applyBaseline(snapped);
+              }
+            },
+            ondragend: () => drawHandle(),
+            children: [
+              {
+                type: 'rect',
+                left: 'center',
+                top: 0,
+                shape: { width: 2, height: gridRect.height },
+                style: { fill: '#666' },
+              },
+            ],
+          },
+        ],
+      });
+    };
+    drawHandle();
+
+    return () => {
+      chart.setOption({
+        graphic: [{ id: 'percent-change-baseline', $action: 'remove' }],
+      });
+    };
+  }, [rebaseEnabled, echartOptions, width, height]);
   const extraControlRef = useRef<HTMLDivElement>(null);
   const [extraControlHeight, setExtraControlHeight] = useState(0);
   useEffect(() => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -81,6 +81,10 @@ export default function EchartsTimeseries({
   const rebaseEnabled = Boolean(
     (formData as { rebasePercentChange?: boolean }).rebasePercentChange,
   );
+  // Persists the dragged baseline across effect reruns (e.g. resizes or
+  // other option changes) so those don't silently snap it back to the
+  // first point.
+  const baselineXRef = useRef<number | string | null>(null);
   useEffect(() => {
     if (!rebaseEnabled) return undefined;
     const chart = echartRef.current?.getEchartInstance?.();
@@ -94,14 +98,27 @@ export default function EchartsTimeseries({
         ? (s.data.filter(Array.isArray) as SeriesDataPoint[])
         : [],
     );
-    const xs = Array.from(
-      new Set(baseSeries.flat().map(([x]) => Number(x))),
-    ).sort((a, b) => a - b);
+    // Preserve the axis' native x type: numeric for time/value axes,
+    // string for category axes (coercing categories with Number() would
+    // turn them into NaN and break snapping/positioning below).
+    const xs = Array.from(new Set(baseSeries.flat().map(([x]) => x)));
     if (xs.length === 0) return undefined;
-    let baselineX = xs[0];
+    if (typeof xs[0] === 'number') {
+      (xs as number[]).sort((a, b) => a - b);
+    }
+    let baselineX =
+      baselineXRef.current !== null && xs.includes(baselineXRef.current)
+        ? baselineXRef.current
+        : xs[0];
+    baselineXRef.current = baselineX;
+    // Coalesces drag updates to at most one setOption per animation
+    // frame; rebasing every series on every raw pointer-move event
+    // can stutter on large charts.
+    let dragFrame: ReturnType<typeof requestAnimationFrame> | null = null;
 
-    const applyBaseline = (newX: number) => {
+    const applyBaseline = (newX: number | string) => {
       baselineX = newX;
+      baselineXRef.current = newX;
       chart.setOption({
         series: baseSeries.map(data => ({
           data: rebaseSeriesData(data, newX),
@@ -133,11 +150,15 @@ export default function EchartsTimeseries({
               const dataX = chart.convertFromPixel(
                 { xAxisIndex: 0 },
                 this.x + 4,
-              ) as number;
-              const snapped = snapToNearestX(xs, dataX);
-              if (snapped !== undefined && snapped !== baselineX) {
-                applyBaseline(snapped);
-              }
+              ) as number | string;
+              if (dragFrame !== null) return;
+              dragFrame = requestAnimationFrame(() => {
+                dragFrame = null;
+                const snapped = snapToNearestX(xs, dataX);
+                if (snapped !== undefined && snapped !== baselineX) {
+                  applyBaseline(snapped);
+                }
+              });
             },
             ondragend: () => drawHandle(),
             children: [
@@ -159,6 +180,9 @@ export default function EchartsTimeseries({
     drawHandle();
 
     return () => {
+      if (dragFrame !== null) {
+        cancelAnimationFrame(dragFrame);
+      }
       chart.setOption({
         graphic: [{ id: 'percent-change-baseline', $action: 'remove' }],
       });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -144,7 +144,7 @@ export default function EchartsTimeseries({
               {
                 type: 'rect',
                 shape: { x: 0, y: 0, width: 8, height: gridRect.height },
-                style: { fill: 'rgba(0, 0, 0, 0.02)' },
+                style: { fill: theme.colorFillSecondary },
               },
               {
                 type: 'rect',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -108,6 +108,22 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'rebase_percent_change',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Percent change'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Rebase each series to its percent change from a baseline ' +
+                  'point, like the legacy Time-series Percent Change chart. ' +
+                  'Drag the vertical baseline on the chart to re-index.',
+              ),
+            },
+          },
+        ],
+        [
+          {
             name: 'markerEnabled',
             config: {
               type: 'CheckboxControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/percentChange.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/percentChange.ts
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { DataRecord } from '@superset-ui/core';
+
+/**
+ * Rebases every non-x column of a timeseries result to its percent change
+ * from that column's first non-null value, restoring the view the legacy
+ * nvd3 "Time-series Percent Change" chart computed in the renderer:
+ * y' = y / y0 - 1. Columns whose baseline is 0 (or missing) yield nulls
+ * since a percent change from zero is undefined.
+ */
+export function rebaseToPercentChange(
+  records: DataRecord[],
+  xAxis: string,
+): DataRecord[] {
+  const baselines: Record<string, number> = {};
+  records.forEach(record => {
+    Object.entries(record).forEach(([key, value]) => {
+      if (
+        key !== xAxis &&
+        !(key in baselines) &&
+        typeof value === 'number' &&
+        !Number.isNaN(value)
+      ) {
+        baselines[key] = value;
+      }
+    });
+  });
+
+  return records.map(record => {
+    const rebased: DataRecord = { [xAxis]: record[xAxis] };
+    Object.entries(record).forEach(([key, value]) => {
+      if (key === xAxis) return;
+      const baseline = baselines[key];
+      rebased[key] =
+        typeof value === 'number' &&
+        !Number.isNaN(value) &&
+        baseline !== undefined &&
+        baseline !== 0
+          ? value / baseline - 1
+          : null;
+    });
+    return rebased;
+  });
+}
+
+export type SeriesDataPoint = [number | string, number | null];
+
+/**
+ * Re-indexes already-rebased series data to a new baseline x. Because
+ * percent-change rebasing is composable, v' = (1 + v) / (1 + vk) - 1
+ * derives the new view directly from the currently displayed values,
+ * where vk is the series value at the nearest x at or before the new
+ * baseline (falling back to the first non-null point).
+ */
+export function rebaseSeriesData(
+  data: SeriesDataPoint[],
+  baselineX: number | string,
+): SeriesDataPoint[] {
+  // the non-null point with the largest x at or before the baseline,
+  // falling back to the first non-null point
+  let baselineValue: number | null = null;
+  data.forEach(([x, y]) => {
+    if (y == null) return;
+    if (x <= baselineX || baselineValue === null) {
+      baselineValue = y;
+    }
+  });
+  if (baselineValue === null || baselineValue === -1) {
+    return data.map(([x]) => [x, null]);
+  }
+  const divisor = 1 + baselineValue;
+  return data.map(([x, y]) => [x, y == null ? null : (1 + y) / divisor - 1]);
+}
+
+/** Snaps a dragged x position to the nearest available data x. */
+export function snapToNearestX(
+  xs: number[],
+  target: number,
+): number | undefined {
+  if (xs.length === 0) return undefined;
+  return xs.reduce((best, x) =>
+    Math.abs(x - target) < Math.abs(best - target) ? x : best,
+  );
+}

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/percentChange.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/percentChange.ts
@@ -89,13 +89,25 @@ export function rebaseSeriesData(
   return data.map(([x, y]) => [x, y == null ? null : (1 + y) / divisor - 1]);
 }
 
-/** Snaps a dragged x position to the nearest available data x. */
+/**
+ * Snaps a dragged x position to the nearest available data x. Time/value
+ * axes report a continuous pixel-derived number, so the nearest point is
+ * found by numeric distance. Category axes report the exact category
+ * value already snapped by ECharts; there's no numeric scale to measure
+ * distance against, so it's only validated against the known x values
+ * (falling back to the first one if the pixel landed outside the axis).
+ */
 export function snapToNearestX(
-  xs: number[],
-  target: number,
-): number | undefined {
+  xs: (number | string)[],
+  target: number | string,
+): number | string | undefined {
   if (xs.length === 0) return undefined;
-  return xs.reduce((best, x) =>
+  if (typeof target === 'string') {
+    return xs.includes(target) ? target : xs[0];
+  }
+  const numericXs = xs.filter((x): x is number => typeof x === 'number');
+  if (numericXs.length === 0) return undefined;
+  return numericXs.reduce((best, x) =>
     Math.abs(x - target) < Math.abs(best - target) ? x : best,
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -18,6 +18,7 @@
  */
 /* eslint-disable camelcase */
 import { invert } from 'lodash-es';
+import { rebaseToPercentChange } from './percentChange';
 import { t } from '@apache-superset/core/translation';
 import {
   AnnotationLayer,
@@ -290,7 +291,7 @@ export default function transformProps(
     return { ...acc, [entry[0]]: entry[1] };
   }, {});
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
-  const rebasedData = rebaseForecastDatum(data, verboseMap);
+  const forecastRebasedData = rebaseForecastDatum(data, verboseMap);
   let xAxisLabel = getXAxisLabel(chartProps.rawFormData) as string;
   if (
     isPhysicalColumn(chartProps.rawFormData?.x_axis) &&
@@ -298,6 +299,16 @@ export default function transformProps(
   ) {
     xAxisLabel = verboseMap[xAxisLabel];
   }
+  // Restores the legacy nvd3 "Time-series Percent Change" view: every series
+  // rebased client-side to its percent change from the first point. The
+  // baseline can be re-indexed interactively via the draggable line the
+  // chart component installs.
+  const rebasePercentChange = Boolean(
+    (formData as { rebasePercentChange?: boolean }).rebasePercentChange,
+  );
+  const rebasedData = rebasePercentChange
+    ? rebaseToPercentChange(forecastRebasedData, xAxisLabel)
+    : forecastRebasedData;
   const isHorizontal = orientation === OrientationType.Horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,
@@ -349,7 +360,9 @@ export default function transformProps(
   const isAreaExpand = stack === StackControlsValue.Expand;
   const series: SeriesOption[] = [];
 
-  const forcePercentFormatter = Boolean(contributionMode || isAreaExpand);
+  const forcePercentFormatter = Boolean(
+    contributionMode || isAreaExpand || rebasePercentChange,
+  );
   const percentFormatter = forcePercentFormatter
     ? getPercentFormatter(yAxisFormat)
     : getPercentFormatter(NumberFormats.PERCENT_2_POINT);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/percentChange.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/percentChange.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  rebaseToPercentChange,
+  rebaseSeriesData,
+  snapToNearestX,
+} from '../../src/Timeseries/percentChange';
+
+test('rebases each column to percent change from its first value', () => {
+  const rebased = rebaseToPercentChange(
+    [
+      { __timestamp: 1, a: 100, b: 50 },
+      { __timestamp: 2, a: 150, b: 25 },
+      { __timestamp: 3, a: 200, b: null },
+    ],
+    '__timestamp',
+  );
+  expect(rebased).toEqual([
+    { __timestamp: 1, a: 0, b: 0 },
+    { __timestamp: 2, a: 0.5, b: -0.5 },
+    { __timestamp: 3, a: 1, b: null },
+  ]);
+});
+
+test('skips leading nulls when picking the baseline', () => {
+  const rebased = rebaseToPercentChange(
+    [
+      { __timestamp: 1, a: null },
+      { __timestamp: 2, a: 40 },
+      { __timestamp: 3, a: 60 },
+    ],
+    '__timestamp',
+  );
+  expect(rebased[1].a).toBe(0);
+  expect(rebased[2].a).toBeCloseTo(0.5);
+});
+
+test('yields nulls when the baseline is zero', () => {
+  const rebased = rebaseToPercentChange(
+    [
+      { __timestamp: 1, a: 0 },
+      { __timestamp: 2, a: 10 },
+    ],
+    '__timestamp',
+  );
+  expect(rebased.map(r => r.a)).toEqual([null, null]);
+});
+
+test('re-indexing displayed data matches rebasing raw data to that point', () => {
+  // raw 100, 150, 200 rebased to first point: 0, 0.5, 1
+  const displayed: [number, number][] = [
+    [1, 0],
+    [2, 0.5],
+    [3, 1],
+  ];
+  // re-index to x=2 (raw 150): 100/150-1, 0, 200/150-1
+  const reindexed = rebaseSeriesData(displayed, 2);
+  expect(reindexed[0][1]).toBeCloseTo(100 / 150 - 1);
+  expect(reindexed[1][1]).toBeCloseTo(0);
+  expect(reindexed[2][1]).toBeCloseTo(200 / 150 - 1);
+});
+
+test('re-indexing to the current baseline is a no-op', () => {
+  const displayed: [number, number][] = [
+    [1, 0],
+    [2, 0.5],
+  ];
+  expect(rebaseSeriesData(displayed, 1)).toEqual(displayed);
+});
+
+test('snaps to the nearest available x', () => {
+  expect(snapToNearestX([10, 20, 30], 24)).toBe(20);
+  expect(snapToNearestX([10, 20, 30], 26)).toBe(30);
+  expect(snapToNearestX([], 5)).toBeUndefined();
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/percentChange.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/percentChange.test.ts
@@ -89,3 +89,10 @@ test('snaps to the nearest available x', () => {
   expect(snapToNearestX([10, 20, 30], 26)).toBe(30);
   expect(snapToNearestX([], 5)).toBeUndefined();
 });
+
+test('validates a category-axis x instead of coercing it to a number', () => {
+  // category axes report their exact (already-snapped) value on drag
+  expect(snapToNearestX(['a', 'b', 'c'], 'b')).toBe('b');
+  // a pixel that landed outside the axis falls back to the first category
+  expect(snapToNearestX(['a', 'b', 'c'], 'unknown')).toBe('a');
+});

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -392,6 +392,13 @@ class MigrateCompareChart(TimeseriesChart):
     source_viz_type = "compare"
     target_viz_type = "echarts_timeseries_line"
 
+    def _pre_action(self) -> None:
+        super()._pre_action()
+        # Restore the percent-change view the nvd3 renderer computed
+        # client-side; the ECharts line chart rebases series when this
+        # flag is set and offers a draggable baseline to re-index.
+        self.data["rebase_percent_change"] = True
+
 
 class MigrateAreaChart(TimeseriesChart):
     source_viz_type = "area"

--- a/tests/unit_tests/migrations/viz/nvd3_compare_chart_to_echarts_test.py
+++ b/tests/unit_tests/migrations/viz/nvd3_compare_chart_to_echarts_test.py
@@ -30,6 +30,8 @@ SOURCE_FORM_DATA: dict[str, Any] = {
 TARGET_FORM_DATA: dict[str, Any] = {
     "form_data_bak": SOURCE_FORM_DATA,
     "viz_type": "echarts_timeseries_line",
+    # the percent-change view the nvd3 renderer computed client-side
+    "rebase_percent_change": True,
 }
 
 


### PR DESCRIPTION
### SUMMARY
Stacked on #41714. Restores the functionality lost when saved "Time-series Percent Change" (`compare`) charts were migrated to the ECharts line chart — including the draggable baseline the nvd3 `cumulativeLineChart` was known for.

A new **Percent change** control on the Line chart rebases every series client-side to its percent change from the first point (`y / y0 − 1`, computed in `transformProps` exactly where the nvd3 renderer used to do it), and joins the existing `forcePercentFormatter` path so the y-axis and tooltips format as percentages automatically. A draggable vertical baseline is installed on the plot (ECharts `graphic` + `convertFromPixel`, snapped to the nearest data point); dragging re-indexes every series via the composable rebase identity `(1+v)/(1+vk) − 1`, so re-indexing needs no re-query and no raw-data retention.

`MigrateCompareChart` now sets the flag, so migrated compare charts come out rendering their percent-change view rather than degrading to a plain line chart — resolving the `form_data_bak`-fragility concern, since the intent is materialized in live form data.

### TESTING INSTRUCTIONS
- `npx jest plugins/plugin-chart-echarts/test/Timeseries/percentChange.test.ts` — rebase math incl. baseline-zero, leading nulls, and the composability identity.
- `pytest tests/unit_tests/migrations/viz/nvd3_compare_chart_to_echarts_test.py` — migration sets the flag.
- Manual: Line chart on `birth_names` (`sum__num` by state), tick **Percent change**, then drag the vertical baseline across the plot.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)