### PR TITLE
fix(docker): isolate tagged images from host packages

### DIFF
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -28,8 +28,10 @@ x-superset-image: &superset-image apachesuperset.docker.scarf.sh/apache/superset
 x-superset-volumes:
   &superset-volumes # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
   - ./docker:/app/docker
-  - ./superset-core:/app/superset-core
   - superset_home:/app/superset_home
+x-superset-environment: &superset-environment
+  # Tagged images must use their bundled packages rather than host bind mounts.
+  DEV_MODE: "false"
 
 services:
   redis:
@@ -58,6 +60,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    environment: *superset-environment
     image: *superset-image
     container_name: superset_app
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
@@ -79,6 +82,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    environment: *superset-environment
     depends_on:
       db:
         condition: service_started
@@ -98,6 +102,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    environment: *superset-environment
     restart: unless-stopped
     depends_on:
       superset-init:
@@ -120,6 +125,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    environment: *superset-environment
     restart: unless-stopped
     depends_on:
       superset-init:

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -39,6 +39,7 @@ RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({403, 429})
 PATTERNS = {
     "python": [
         r"^\.github/workflows/.*python",
+        r"^docker-compose-image-tag\.yml$",
         r"^tests/",
         r"^superset/",
         r"^scripts/",

--- a/tests/unit_tests/docker_compose_image_tag_test.py
+++ b/tests/unit_tests/docker_compose_image_tag_test.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pathlib import Path
+
+import yaml
+
+
+def test_image_tag_services_use_bundled_packages() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    compose = yaml.safe_load(
+        (repository_root / "docker-compose-image-tag.yml").read_text(),
+    )
+    image = compose["x-superset-image"]
+    image_services = [
+        service
+        for service in compose["services"].values()
+        if service.get("image") == image
+    ]
+
+    assert image_services
+    assert all(
+        service.get("environment", {}).get("DEV_MODE") == "false"
+        for service in image_services
+    )
+    assert all(
+        all(
+            not isinstance(volume, str) or ":/app/superset-core" not in volume
+            for volume in service.get("volumes", [])
+        )
+        for service in image_services
+    )

--- a/tests/unit_tests/scripts/change_detector_test.py
+++ b/tests/unit_tests/scripts/change_detector_test.py
@@ -94,3 +94,10 @@ def test_fetch_gives_up_after_max_retries() -> None:
             change_detector.fetch_files_github_api("http://api")
 
     assert urlopen_mock.call_count == change_detector.MAX_RETRIES
+
+
+def test_image_tag_compose_changes_trigger_python_tests() -> None:
+    assert change_detector.detect_changes(
+        ["docker-compose-image-tag.yml"],
+        change_detector.PATTERNS["python"],
+    )


### PR DESCRIPTION
### SUMMARY

Fix the master-only tagged-image Compose sanity check after Python 3.10 support
was removed in #42045.

`docker-compose-image-tag.yml` inherited `DEV_MODE=true` and bind-mounted the
current `superset-core` over the published `latest-dev` image's editable
package. That made the Python 3.10.20 image attempt to install current source,
which requires Python 3.11, and failed master run
https://github.com/apache/superset/actions/runs/29754426258.

Tagged-image services now use their bundled packages by forcing
`DEV_MODE=false` and removing the host core mount. The regression test covers
every service using the tagged Superset image, and the change detector routes
this Compose file through Python unit tests so future Compose-only pull
requests run that coverage.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; CI and Docker Compose configuration only.

### TESTING INSTRUCTIONS

```bash
PYTHONPATH=. pytest -q --noconftest \
  tests/unit_tests/scripts/change_detector_test.py \
  tests/unit_tests/docker_compose_image_tag_test.py

docker compose -f docker-compose-image-tag.yml config --quiet
pre-commit run
```

The two focused test files pass (6 tests), the resolved Compose configuration
has four tagged-image services with `DEV_MODE=false` and no
`/app/superset-core` mount, and every applicable staged-file pre-commit hook
passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
