### PR TITLE
test(core): pin dashboard save-error toast mapping for non-JSON 403 responses

### DIFF
--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -336,3 +336,29 @@ test('getErrorText', async () => {
     ),
   ).toEqual('Sorry, an unknown error occurred.');
 });
+
+test('getErrorText for a non-JSON 403 response', async () => {
+  // A 403 originating outside Superset (reverse proxy, WAF, SSO gateway)
+  // carries an HTML or plain-text body instead of the API's JSON
+  // `{"message": "Forbidden"}`, so it must fall back to the generic
+  // status-derived text rather than the permission-denied copy.
+  const proxyForbidden = new Response(
+    '<html><head><title>403 Forbidden</title></head><body>Forbidden</body></html>',
+    {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: { 'Content-Type': 'text/html' },
+    },
+  );
+  expect(await getErrorText(proxyForbidden, 'dashboard')).toEqual(
+    'Sorry, there was an error saving this dashboard: Forbidden',
+  );
+
+  const supersetForbidden = new Response(
+    JSON.stringify({ message: 'Forbidden' }),
+    { status: 403, statusText: 'FORBIDDEN' },
+  );
+  expect(await getErrorText(supersetForbidden, 'dashboard')).toEqual(
+    'You do not have permission to edit this dashboard',
+  );
+});

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -372,6 +372,73 @@ describe('dashboardState actions', () => {
         { event: 'dashboard_properties_changed' },
       );
     });
+
+    // The save-error toast mapping lives inline in `onError`, not behind
+    // `getErrorText`, so these exercise the thunk itself. A 403 whose body is
+    // the API's `{"message": "Forbidden"}` shape must surface the
+    // permission-denied copy, while a 403 from outside Superset (reverse proxy,
+    // WAF, SSO gateway) carries a non-JSON body and must fall back to the
+    // generic status-derived toast. See #42239.
+    const findDangerToast = (dispatch: jest.Mock) =>
+      dispatch.mock.calls
+        .map(call => call[0])
+        .find(
+          action =>
+            action?.type === ADD_TOAST &&
+            action.payload.toastType === ToastType.Danger,
+        );
+
+    test('maps a non-JSON 403 save failure to the generic error toast', async () => {
+      const { getState, dispatch } = setup();
+      putStub.mockRestore();
+      putStub = jest.spyOn(SupersetClient, 'put').mockRejectedValue(
+        new Response(
+          '<html><head><title>403 Forbidden</title></head><body>Forbidden</body></html>',
+          {
+            status: 403,
+            statusText: 'Forbidden',
+            headers: { 'Content-Type': 'text/html' },
+          },
+        ),
+      );
+
+      const thunk = saveDashboardRequest(
+        newDashboardData,
+        192,
+        SAVE_TYPE_OVERWRITE,
+      );
+      await thunk(dispatch, getState);
+
+      await waitFor(() =>
+        expect(findDangerToast(dispatch)?.payload.text).toBe(
+          'Sorry, there was an error saving this dashboard: Forbidden',
+        ),
+      );
+    });
+
+    test('maps a Superset JSON 403 save failure to the permission-denied toast', async () => {
+      const { getState, dispatch } = setup();
+      putStub.mockRestore();
+      putStub = jest.spyOn(SupersetClient, 'put').mockRejectedValue(
+        new Response(JSON.stringify({ message: 'Forbidden' }), {
+          status: 403,
+          statusText: 'FORBIDDEN',
+        }),
+      );
+
+      const thunk = saveDashboardRequest(
+        newDashboardData,
+        192,
+        SAVE_TYPE_OVERWRITE,
+      );
+      await thunk(dispatch, getState);
+
+      await waitFor(() =>
+        expect(findDangerToast(dispatch)?.payload.text).toBe(
+          'You do not have permission to edit this dashboard',
+        ),
+      );
+    });
   });
 
   test('fetchCharts returns a Promise that resolves after all refreshes', async () => {


### PR DESCRIPTION
### SUMMARY

Issue #42239 reports an Admin getting `Sorry, there was an error saving this dashboard: Forbidden` when resizing a chart and saving. Assessing whether that can be a Superset permission bug:

- The backend already proves an Admin `PUT /api/v1/dashboard/{id}` with `position_json` succeeds (`test_update_dashboard` in `tests/integration_tests/dashboards/api_tests.py`).
- A 403 produced by Superset's own permission layer has the JSON body `{"message": "Forbidden"}`, which `getErrorText` maps to the distinct toast `You do not have permission to edit this dashboard` (already covered).
- The toast in the report (`...: Forbidden`) is only reachable when the 403 body is **not** that JSON shape, i.e. an HTML/plain-text response from something in front of Superset (reverse proxy, WAF, SSO gateway), where `getClientErrorObject` falls back to the status-code lookup.

That third mapping was untested. This adds a green test pinning both 403 shapes to their respective toasts, so the generic `: Forbidden` toast remains a reliable signal that the rejection originated outside Superset. If either mapping ever regresses, this catches the diagnostic drifting.

No production code changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, test only.

### TESTING INSTRUCTIONS

```
cd superset-frontend
npm run test -- packages/superset-ui-core/test/query/getClientErrorObject.test.ts
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Refs #42239
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)