### PR TITLE
fix(cache): QueryCacheManager.get() should fail open on cache backend errors

### DIFF
--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -177,7 +177,16 @@ class QueryCacheManager:
         if not key or not _cache[region] or force_query:
             return query_cache
 
-        if cache_value := _cache[region].get(key):
+        try:
+            cache_value = _cache[region].get(key)
+        except Exception as ex:  # pylint: disable=broad-except
+            # A cache backend outage (e.g. Redis connection/timeout errors)
+            # should not surface as an error to the caller: treat it the
+            # same as a cache miss and fall through to querying live data.
+            logger.warning("Error reading cache: %s", error_msg_from_exception(ex))
+            cache_value = None
+
+        if cache_value:
             logger.debug("Cache key: %s", key)
             # Log cache hit for debugging
             logger.debug("CACHE GET - Key: %s, Region: %s", key, region)

--- a/tests/unit_tests/common/test_query_cache_manager.py
+++ b/tests/unit_tests/common/test_query_cache_manager.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock, patch
+
+from superset.common.utils.query_cache_manager import QueryCacheManager
+from superset.constants import CacheRegion
+
+
+class TestQueryCacheManagerGet:
+    def test_get_cache_miss(self):
+        """A regular cache miss returns an empty, non-loaded QueryCacheManager."""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        with patch(
+            "superset.common.utils.query_cache_manager._cache",
+            {CacheRegion.DEFAULT: mock_cache},
+        ):
+            result = QueryCacheManager.get(key="some-key")
+
+        assert result.is_loaded is False
+        assert result.cache_value is None
+
+    def test_get_cache_backend_error_fails_open(self):
+        """
+        If the cache backend raises on read (e.g. a Redis connection or
+        timeout error), QueryCacheManager.get() should not propagate the
+        exception. It should behave exactly like a cache miss so callers
+        fall back to querying live data.
+        """
+        mock_cache = MagicMock()
+        mock_cache.get.side_effect = ConnectionError("connection refused")
+
+        with patch(
+            "superset.common.utils.query_cache_manager._cache",
+            {CacheRegion.DEFAULT: mock_cache},
+        ):
+            result = QueryCacheManager.get(key="some-key")
+
+        miss_result = QueryCacheManager()
+        assert result.is_loaded == miss_result.is_loaded
+        assert result.cache_value == miss_result.cache_value
+        assert result.status == miss_result.status


### PR DESCRIPTION
### SUMMARY
`QueryCacheManager.get()` reads from the configured cache backend with:

```python
if cache_value := _cache[region].get(key):
```

This read is not wrapped in any error handling. If the cache backend (e.g. Redis) raises a connection, timeout, or other backend-specific error on read, the exception propagates all the way up through the chart/dashboard data API (`POST /api/v1/chart/data`) and surfaces as an unhandled 500, instead of gracefully falling back to querying live data — which is exactly what already happens one branch up on a normal cache miss (`if not key or not _cache[region] or force_query: return query_cache`).

In other words: any transient cache backend hiccup — not just a full outage — turns into hard failures for chart and dashboard rendering, even though the data can still be queried live.

This PR wraps the cache read in a try/except, logs the failure at a level appropriate for a potentially noisy/flaky backend, and falls through to the existing cache-miss path so the behavior matches a normal cache miss rather than raising.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend error-handling change, no UI impact.

### TESTING INSTRUCTIONS
- Added `tests/unit_tests/common/test_query_cache_manager.py`:
  - `test_get_cache_miss` — baseline: a normal cache miss returns a non-loaded `QueryCacheManager`.
  - `test_get_cache_backend_error_fails_open` — mocks the cache backend's `.get()` to raise a `ConnectionError`, and asserts `QueryCacheManager.get()` returns the same result as a normal cache miss instead of propagating the exception.
- Manual repro: point `CACHE_CONFIG`/`DATA_CACHE_CONFIG` at a Redis instance, then stop/block Redis while calling `POST /api/v1/chart/data` for a datasource with caching enabled. Before this change: request fails with a 500. After this change: request falls back to querying live data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API