### PR TITLE
test(sql): prove Oracle GROUP BY stays explicit for virtual-dataset charts

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -473,6 +473,35 @@ def test_format_oracle_group_by_keeps_explicit_expressions() -> None:
     assert not any(item.isdigit() for item in group_by_items)
 
 
+def test_format_oracle_group_by_keeps_explicit_expressions_subquery() -> None:
+    """
+    Test that formatting an Oracle chart query doesn't rewrite ``GROUP BY``
+    to ordinals when the aggregated column comes from a virtual dataset
+    subquery.
+
+    This mirrors the query shape SQLAlchemy generates for a bar chart with a
+    dimension and a ``COUNT(*)`` metric on a virtual dataset, which is the
+    reproduction reported in
+    https://github.com/apache/superset/issues/28327 (``ORA-00979: not a
+    GROUP BY expression``). Fixed by the same sqlglot upgrade that resolved
+    https://github.com/apache/superset/issues/35414.
+    """
+    sql = (
+        "SELECT bar AS bar, COUNT(*) AS count "
+        "FROM (SELECT 'foo' AS bar FROM dual) AS virtual_table "
+        "GROUP BY bar"
+    )
+    formatted = SQLStatement(sql, engine="oracle").format()
+
+    group_by_clause = formatted.split("GROUP BY")[1]
+    group_by_items = [
+        line.strip().rstrip(",") for line in group_by_clause.strip().splitlines()
+    ]
+    assert group_by_items == ["bar"]
+    # no item should have been replaced by a positional reference
+    assert not any(item.isdigit() for item in group_by_items)
+
+
 def test_split_no_dialect() -> None:
     """
     Test the statement split when the engine has no corresponding dialect.


### PR DESCRIPTION
### SUMMARY

Test-only PR — closes #28327.

Issue #28327 reported that Superset generates `GROUP BY 1` (positional/ordinal) SQL for Oracle charts and filters, which fails with `ORA-00979: not a GROUP BY expression` since Oracle doesn't support positional `GROUP BY`. The clearest reproduction on the thread (from `6.0.0rc4`) was: save `SELECT 'foo' AS bar FROM dual` as a dataset, then build a bar chart with `BAR` as the dimension and `COUNT(*)` as the metric.

This turned out to be the same root cause already diagnosed and fixed for #35414: `sqlglot < 27.21.0` rewrote `GROUP BY` expressions that matched aliased projections (exactly what SQLAlchemy emits for chart queries) into ordinals when generating Oracle SQL. `master` currently pins `sqlglot==30.12.0` (`requirements/base.txt`), which contains the upstream fix, and #41834 already added a regression test for the general case.

This PR adds a second regression test covering the specific query shape from #28327's reproduction: a virtual-dataset subquery (`SELECT ... FROM (SELECT 'foo' AS bar FROM dual) AS virtual_table GROUP BY bar`) with a `COUNT(*)` aggregate, using the Oracle dialect. I verified it passes on current `master`:

```
tests/unit_tests/sql/parse_tests.py::test_format_oracle_group_by_keeps_explicit_expressions_subquery PASSED
```

No production code changes — the fix already landed via the sqlglot dependency bump. This just pins the specific #28327 scenario so a future sqlglot downgrade or Oracle-dialect regression doesn't silently reintroduce `ORA-00979`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only)

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/sql/parse_tests.py::test_format_oracle_group_by_keeps_explicit_expressions_subquery -x -q
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #28327
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API