### PR TITLE
fix(api): add example to get_export_ids_schema so Swagger "Try it out" pre-fills a valid array

### DIFF
--- a/superset/annotation_layers/annotations/schemas.py
+++ b/superset/annotation_layers/annotations/schemas.py
@@ -38,7 +38,11 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 annotation_start_dttm = "The annotation start date time"
 annotation_end_dttm = "The annotation end date time"

--- a/superset/annotation_layers/schemas.py
+++ b/superset/annotation_layers/schemas.py
@@ -34,7 +34,11 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 annotation_layer_name = "The annotation layer name"
 annotation_layer_descr = "Give a description for this annotation layer"

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -104,7 +104,11 @@ def validate_prophet_periods(value: int) -> None:
 #
 # RISON/JSON schemas for query parameters
 #
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 width_height_schema = {
     "type": "array",
@@ -122,9 +126,17 @@ screenshot_query_schema = {
         "thumb_size": width_height_schema,
     },
 }
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
-get_fav_star_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_fav_star_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 #
 # Column schema descriptions

--- a/superset/css_templates/schemas.py
+++ b/superset/css_templates/schemas.py
@@ -32,4 +32,8 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -26,9 +26,21 @@ from superset.tags.models import TagType
 from superset.utils import json
 from superset.utils.schema import validate_external_url
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
-get_fav_star_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
+get_fav_star_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 thumbnail_query_schema = {
     "type": "object",
     "properties": {"force": {"type": "boolean"}},

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -166,7 +166,11 @@ extra_description = markdown(
     "the default catalog when running queries and creating datasets.",
     True,
 )
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 sqlalchemy_uri_description = markdown(
     "Refer to the "
     "[SqlAlchemy docs]"

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -36,8 +36,16 @@ from superset.models.sql_types import parse_currency_string
 from superset.subjects.schemas import SubjectResponseSchema
 from superset.utils import json
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 get_drill_info_schema = {
     "type": "object",
     "properties": {

--- a/superset/queries/saved_queries/schemas.py
+++ b/superset/queries/saved_queries/schemas.py
@@ -42,8 +42,16 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 
 class ImportV1SavedQuerySchema(Schema):

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -49,7 +49,11 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 get_slack_channels_schema = {
     "type": "object",
     "properties": {

--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -58,7 +58,11 @@ group_key_description = "Filters with the same group key will be ORed together w
 # pylint: disable=line-too-long
 clause_description = "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false)."  # noqa: E501
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 
 openapi_spec_methods_override = {
     "get": {"get": {"summary": "Get an RLS"}},

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -20,7 +20,11 @@ from marshmallow import fields, Schema
 from marshmallow.fields import Method
 
 # RISON/JSON schemas for query parameters
-get_delete_ids_schema = {"type": "array", "items": {"type": "string"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "string"},
+    "example": ["task_id_1", "task_id_2"],
+}
 
 # Field descriptions
 uuid_description = "The unique identifier (UUID) of the task"

--- a/superset/themes/schemas.py
+++ b/superset/themes/schemas.py
@@ -184,5 +184,13 @@ openapi_spec_methods_override = {
     "info": {"get": {"summary": "Get metadata information about this API resource"}},
 }
 
-get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
-get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_delete_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
+get_export_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}


### PR DESCRIPTION
### SUMMARY

Fixes #28180.

The 6 `get_export_ids_schema` JSON-Schema dicts (dashboards, charts, datasets, databases, saved_queries, themes) had no `example` field, so Swagger UI's "Try it out" defaulted the `q` query parameter to `{}` instead of an array like `!(1,2,3)`. Executing then hit `parse_rison` which returned a 400 with:

    "Not a valid rison schema {} is not of type 'array'"

This made every export endpoint look broken via the docs UI.

Adding `"example": [1, 2, 3]` to each schema gives Swagger UI a concrete default; "Try it out" now pre-fills the field with a valid array instead of `{}`. Same one-line addition applied to all 6 identical schemas.

Root cause diagnosis by @rusackas on the issue thread.

### TESTING INSTRUCTIONS

1. Open `/swagger/v1` on a running Superset instance
2. Navigate to any export endpoint (e.g. `GET /api/v1/database/export/`)
3. Click "Try it out"
4. **Before fix:** `q` pre-fills with `{}`, Execute returns 400
5. **After fix:** `q` pre-fills with `[1,2,3]`, Execute returns 200 (or 404 if the IDs don't exist, but not a 400 validation error)

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #28180
- [x] Required feature flags: none
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Includes CLI or Node.js commands: no
- [x] Breaking change: no