### PR TITLE
fix(native-filters): keep filter value input caret left-aligned

### DIFF
--- a/superset-frontend/src/filters/components/common.ts
+++ b/superset-frontend/src/filters/components/common.ts
@@ -25,6 +25,22 @@ export const RESPONSIVE_WIDTH = 0;
 export const FilterPluginStyle = styled.div<PluginFilterStylesProps>`
   min-height: ${({ height }) => height}px;
   width: ${({ width }) => (width === RESPONSIVE_WIDTH ? '100%' : `${width}px`)};
+  /* Input / InputNumber filter value controls resolve text-align by */
+  /* inheritance, so pin them to the inline start to keep the caret and typed */
+  /* text at the left edge. */
+  text-align: start;
+
+  /* antd v6 sets 'text-align: center' directly on '.ant-select-content' for */
+  /* multiple-mode Selects (its selector '.ant-select-multiple */
+  /* .ant-select-content' has specificity 0,2,0). The Select search input */
+  /* lives inside '.ant-select-content' and inherits that value, so the caret */
+  /* and typed text render centered. A value inherited from this wrapper */
+  /* cannot beat a rule that targets '.ant-select-content' directly, so */
+  /* override the element itself: this wrapper class plus the two antd classes */
+  /* give specificity 0,3,0, which wins without !important. RTL-safe. */
+  .ant-select .ant-select-content {
+    text-align: start;
+  }
 `;
 
 export const StyledFormItem = styled(FormItem)`


### PR DESCRIPTION
### SUMMARY

When clicking into a dashboard native-filter **value** control (e.g. a multi-select filter), the caret and the placeholder/typed text render **centered** instead of left-aligned.

This is a regression from the Ant Design v6 upgrade. antd v6 emits `text-align: center` directly on `.ant-select-multiple .ant-select-content` (its own css-in-js). The Select search `<input>` lives inside `.ant-select-content` and resolves `text-align` by inheritance, so the caret/text inherit the centered value.

**Fix:** in the shared `FilterPluginStyle` wrapper used by all native filter value plugins, pin `text-align: start` and override `.ant-select .ant-select-content` directly. Overriding the element itself is required because a value inherited from an ancestor cannot beat a rule that targets `.ant-select-content` directly. The override's specificity (wrapper class + two antd classes = `0,3,0`) beats antd's `.ant-select-multiple .ant-select-content` (`0,2,0`) without `!important`. `start` is the CSS default, so this is a no-op except where antd leaked the centered alignment, and it's RTL-safe.

Scoped to native filter value controls (Select, Range, Time, TimeColumn, TimeGrain) — no app-wide blast radius.

### TESTING INSTRUCTIONS

1. Add a native filter of type **Value** (multi-select) to a dashboard.
2. Click into the filter's input.
3. The caret and placeholder/typed text should be left-aligned (inline start), not centered.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [x] Required feature flags: n/a
- [x] Changes UI
