### PR TITLE
fix(explore): render stopped state when a chart query is cancelled

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.test.tsx
+++ b/superset-frontend/src/components/Chart/Chart.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import '@testing-library/jest-dom';
 import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
 import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
@@ -85,4 +85,23 @@ test('shows loading spinner for client-side errors without errors array when dat
 
   expect(screen.getByRole('status')).toBeInTheDocument();
   expect(screen.queryByText(/Some client-side error/)).not.toBeInTheDocument();
+});
+
+test('shows the stop message and a re-run affordance when the query was stopped', () => {
+  const onQuery = jest.fn();
+  render(
+    <Chart
+      {...baseProps}
+      chartStatus="stopped"
+      chartAlert="Updating chart was stopped"
+      onQuery={onQuery}
+    />,
+  );
+
+  expect(screen.getByText('Updating chart was stopped')).toBeInTheDocument();
+
+  const rerun = screen.getByText('click here');
+  fireEvent.click(rerun);
+  fireEvent.keyDown(rerun, { key: 'Enter' });
+  expect(onQuery).toHaveBeenCalledTimes(2);
 });

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -440,6 +440,30 @@ function Chart({
     );
   }
 
+  if (chartStatus === 'stopped') {
+    return (
+      <EmptyState
+        size="large"
+        title={chartAlert || t('Updating chart was stopped')}
+        description={
+          <span>
+            {t('Run a new query using the "Update chart" button or')}{' '}
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={onQuery}
+              onKeyDown={handleKeyboardActivation(() => onQuery?.())}
+            >
+              {t('click here')}
+            </span>
+            .
+          </span>
+        }
+        image="chart.svg"
+      />
+    );
+  }
+
   if (errorMessage && ensureIsArray(queriesResponse).length === 0) {
     return (
       <EmptyState


### PR DESCRIPTION
### SUMMARY

Clicking **Stop** while a chart query runs in Explore left the chart area blank with no message. The Stop logic was correct — the request aborts, `chartUpdateStopped` dispatches, and the reducer sets `chartStatus: 'stopped'` with the alert `Updating chart was stopped` — but `Chart.tsx` had no render branch for `'stopped'`. It only handled `'failed'`, and the "ready to go" empty state is gated on `!chartAlert`, so every branch declined and the container rendered nothing.

This adds an informational `EmptyState` for the stopped status that surfaces the existing alert and offers a re-run affordance, mirroring the neighboring "Your chart is ready to go!" state.

Scope note: this fixes the synchronous (non-GAQ) flow. Under `GLOBAL_ASYNC_QUERIES` the abort is a no-op once the job is polling, so `'stopped'` is never set and this branch never renders — that is tracked separately.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: Stop → chart area goes blank, no message.
After: Stop → "Updating chart was stopped" with a link to re-run.

<img width="1644" height="878" alt="image" src="https://github.com/user-attachments/assets/0ace6e93-67d3-4c9a-b27d-6aa0eaef1a7b" />


### TESTING INSTRUCTIONS

1. Create a dataset whose query runs for a few seconds (e.g. a virtual dataset `SELECT pg_sleep(20)`).
2. Build a chart on it and trigger a refresh (click the `Cached` badge).
3. Click **Stop** while it loads.
4. The chart area shows "Updating chart was stopped" and a re-run link, instead of blank space.

Unit test added in `Chart.test.tsx`; `npm run test -- Chart.test.tsx`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: No — internal tracker
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API