### PR TITLE
fix(reports): fail loudly instead of falling back to unguarded screenshot when tiled capture fails

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -563,18 +563,23 @@ class WebDriverPlaywright(WebDriverProxy):
                             log_context=log_context,
                         )
                         if not img:
+                            # _get_screenshot() has no wait/readiness logic at
+                            # all, so falling back to it here would risk
+                            # silently delivering a screenshot of spinners or
+                            # a blank dashboard. Fail the capture loudly
+                            # (report error, thumbnail cache ERROR) instead of
+                            # guessing at a "safer" fallback.
                             logger.warning(
-                                (
-                                    "Tiled screenshot failed, "
-                                    "falling back to standard screenshot"
-                                )
+                                "Tiled screenshot failed for url %s and no "
+                                "safe fallback exists; failing the capture",
+                                url,
                             )
-                            img = WebDriverPlaywright._get_screenshot(
-                                page, element, element_name
+                            raise PlaywrightTimeout(
+                                f"Tiled screenshot failed for url {url}"
                             )
                         logger.debug(
                             "Tiled screenshot result: %d bytes for url: %s",
-                            len(img) if img else 0,
+                            len(img),
                             url,
                         )
                     else:

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -930,10 +930,13 @@ class TestWebDriverPlaywrightErrorHandling:
     @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     @patch("superset.utils.webdriver.take_tiled_screenshot")
-    def test_tiled_screenshot_failure_falls_back_to_standard_screenshot(
+    def test_tiled_screenshot_failure_raises_without_fallback(
         self, mock_take_tiled, mock_logger, mock_browser_manager
     ) -> None:
-        """When take_tiled_screenshot returns None, fall back to standard screenshot."""
+        """When take_tiled_screenshot returns None, fail loudly instead of
+        falling back to an unguarded standard screenshot."""
+        from superset.utils.webdriver import PlaywrightTimeout
+
         mock_user = MagicMock()
         mock_user.username = "test_user"
 
@@ -947,7 +950,8 @@ class TestWebDriverPlaywrightErrorHandling:
         mock_context.new_page.return_value = mock_page
         mock_page.locator.return_value = mock_element
         mock_element.wait_for.return_value = None
-        # page.screenshot is used by _get_screenshot for the "standalone" element
+        # page.screenshot is used by _get_screenshot for the "standalone" element;
+        # it must never be reached by the failure path under test.
         mock_page.screenshot.return_value = b"fallback_screenshot"
 
         def evaluate_side_effect(script):
@@ -983,14 +987,20 @@ class TestWebDriverPlaywrightErrorHandling:
                 mock_auth.return_value = mock_context
 
                 driver = WebDriverPlaywright("chrome")
-                result = driver.get_screenshot(
-                    "http://example.com", "standalone", mock_user
-                )
+                # match= keeps this assertion meaningful even when playwright
+                # is not installed and PlaywrightTimeout aliases bare Exception.
+                with pytest.raises(
+                    PlaywrightTimeout, match="Tiled screenshot failed for url"
+                ):
+                    driver.get_screenshot("http://example.com", "standalone", mock_user)
 
-        assert result == b"fallback_screenshot"
         mock_take_tiled.assert_called_once()
+        mock_page.screenshot.assert_not_called()
+        mock_element.screenshot.assert_not_called()
         mock_logger.warning.assert_any_call(
-            ("Tiled screenshot failed, falling back to standard screenshot"),
+            "Tiled screenshot failed for url %s and no safe fallback "
+            "exists; failing the capture",
+            "http://example.com",
         )
 
 
@@ -1514,10 +1524,13 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
     @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.take_tiled_screenshot")
     @patch("superset.utils.webdriver.app")
-    def test_tiled_fallback_triggered_on_empty_bytes(
+    def test_tiled_empty_bytes_raises_without_fallback(
         self, mock_app, mock_take_tiled, mock_browser_manager
     ):
-        """Tiled fallback fires when take_tiled_screenshot returns b"" (not None)."""
+        """Tiled failure raises when take_tiled_screenshot returns b"" (not None),
+        instead of silently falling through to an unguarded raw capture."""
+        from superset.utils.webdriver import PlaywrightTimeout
+
         mock_user = MagicMock()
         mock_user.username = "test_user"
         mock_app.config = {
@@ -1532,20 +1545,24 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         mock_page.evaluate.side_effect = [25, 6000]
         # Empty bytes — falsy but not None; was silently passed through before the fix
         mock_take_tiled.return_value = b""
-        # _get_screenshot("standalone") calls page.screenshot(full_page=True);
-        # configure that return value so we can assert the fallback was reached
+        # _get_screenshot("standalone") calls page.screenshot(full_page=True); it
+        # must never be reached by the failure path under test.
         mock_page.screenshot.return_value = b"fallback"
 
         with patch.object(WebDriverPlaywright, "auth", return_value=mock_context):
-            result = WebDriverPlaywright("chrome").get_screenshot(
-                "http://example.com", "standalone", mock_user
-            )
+            # match= keeps this assertion meaningful even when playwright
+            # is not installed and PlaywrightTimeout aliases bare Exception.
+            with pytest.raises(
+                PlaywrightTimeout, match="Tiled screenshot failed for url"
+            ):
+                WebDriverPlaywright("chrome").get_screenshot(
+                    "http://example.com", "standalone", mock_user
+                )
 
-        assert result == b"fallback"
         # Tiled path was taken (take_tiled_screenshot was called)
         mock_take_tiled.assert_called_once()
-        # Standard screenshot was called as fallback (full_page=True for "standalone")
-        mock_page.screenshot.assert_called_with(full_page=True)
+        # Standard screenshot must never be called as a fallback
+        mock_page.screenshot.assert_not_called()
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")


### PR DESCRIPTION
### SUMMARY

`WebDriverPlaywright.get_screenshot()` fell back to `_get_screenshot()` — a raw `page.screenshot()`/`element.screenshot()` call with **zero** wait/readiness logic — whenever the tiled capture (`take_tiled_screenshot()`) returned a falsy result (`None` or `b""`). Unlike the tiled path itself or the non-tiled/standard branch in this same method, this fallback never waited for spinners to clear or charts to render, so it could silently deliver a screenshot of loading spinners or a blank dashboard in a report/thumbnail.

This PR removes that fallback. When tiled capture fails for any reason, the method now logs a `WARNING` (a capture/rendering issue, not a system fault — matching the level already used for the other capture-failure paths in this method) and raises `PlaywrightTimeout`, which propagates to a clean report failure the same way the other timeout paths in this method already do.

### BEFORE/AFTER

**Before:**
```python
if not img:
    logger.warning("Tiled screenshot failed, falling back to standard screenshot")
    img = WebDriverPlaywright._get_screenshot(page, element, element_name)
```

**After:**
```python
if not img:
    logger.warning(
        "Tiled screenshot failed for url %s and no safe fallback "
        "exists; failing the report",
        url,
    )
    raise PlaywrightTimeout(f"Tiled screenshot failed for url {url}")
```

### TESTING INSTRUCTIONS

- `tests/unit_tests/utils/webdriver_test.py::TestWebDriverPlaywrightFallback::test_tiled_screenshot_failure_raises_without_fallback` — `take_tiled_screenshot()` returns `None` → asserts `PlaywrightTimeout` is raised, `page.screenshot`/`element.screenshot` are never called, and the `WARNING` log fires with the expected message.
- `tests/unit_tests/utils/webdriver_test.py::TestWebDriverPlaywrightAnimationWaitOrder::test_tiled_empty_bytes_raises_without_fallback` — same assertions for the `b""` (falsy-but-not-`None`) case.
- Ran `pytest tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py` — 59 passed, 1 pre-existing failure unrelated to this change (`test_get_screenshot_handles_playwright_timeout` fails on `master` too, due to a `playwright` package version mismatch with the test's no-arg `PlaywrightTimeout()` construction).
- Ran `pre-commit run --files superset/utils/webdriver.py tests/unit_tests/utils/webdriver_test.py` — all hooks pass (ruff, ruff-format, mypy, pylint).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Not changed (out of scope for this PR):**
- `take_tiled_screenshot()` itself in `screenshot_utils.py`, and the tiling-routing decision (chart-count/height threshold) in `webdriver.py`.
- The non-tiled/standard screenshot branch in `WebDriverPlaywright.get_screenshot()`.
- The Selenium webdriver path (`WebDriverSelenium`).
- Pixel-level/image-content blank-screenshot validation — not built as a backstop here.