### PR TITLE
test(sqla): add the jinja orderby calculated column to the session

### DIFF
--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -214,7 +214,7 @@ class SupersetTestCases(SupersetTestCase):
         SELECT/WHERE/GROUP BY.
         """
         table = self.get_table(name="birth_names")
-        TableColumn(
+        column = TableColumn(
             column_name="gender_cc_jinja",
             type="VARCHAR(255)",
             table=table,
@@ -225,6 +225,7 @@ class SupersetTestCases(SupersetTestCase):
             end
             """,
         )
+        db.session.add(column)
 
         table.database.sqlalchemy_uri = "sqlite://"
         query_obj: QueryObjectDict = {


### PR DESCRIPTION
### SUMMARY
Master CI is red on every Python-Integration DB variant since today: `test_jinja_calculated_column_in_order_by` fails with `assert "'male'" in ' max(gender_cc_jinja) ASC;'`.

Two PRs that were each green collided:
- #41870 added the test, which builds a `TableColumn(table=table)` and relied on backref cascading to keep the column in `table.columns`.
- #42222 (merged later the same day, after #41870's CI ran) set `cascade_backrefs=False` on the TableColumn↔SqlaTable relationship, so the never-added column is lost when the collection is refreshed, and the orderby falls back to the bare column name.

The fix is the same one-liner #42222 applied to the sibling `test_calculated_column_in_order_by_base_engine_spec`: register the column with the session explicitly via `db.session.add(column)`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (test-only change)

### TESTING INSTRUCTIONS
`pytest tests/integration_tests/db_engine_specs/base_engine_spec_tests.py -k order_by` — both order-by calculated-column tests pass; on current master the jinja one fails.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)