### PR TITLE
fix(docs): allow *.run.app in CSP for the Kapa widget backend

### DIFF
--- a/docs/static/.htaccess
+++ b/docs/static/.htaccess
@@ -28,8 +28,9 @@ RewriteRule ^(.*)$ https://superset.apache.org/$1 [R=301,L]
 # - *.googleapis.com, *.google.com, *.gstatic.com: Google Calendar embed, kapa.ai reCAPTCHA - all of these loaded with user consent, following policy laid out in https://privacy.apache.org/faq/committers.html
 # - github.com, *.github.com, *.githubusercontent.com: GitHub user-attachment images in docs (apex github.com serves user-attachments/* assets). Discussed/resolved in this thread: https://issues.apache.org/jira/browse/INFRA-25701?filter=-2 (DPA in place with GitHub)
 # - *.algolia.net, *.algolianet.com: Algolia DocSearch. Approved here: https://privacy.apache.org/faq/committers.html
+# - *.run.app: Google-owned domain (Google Cloud Run) used by the kapa.ai widget backend - only reached after explicit user acceptance when opening the widget, allowable per the policy laid out in https://privacy.apache.org/faq/committers.html
 # See: https://infra.apache.org/tools/csp.html
-SetEnv CSP_PROJECT_DOMAINS "widget.kapa.ai https://*.googleapis.com/ https://*.google.com/ https://*.gstatic.com/ https://github.com/ https://*.github.com/ https://*.githubusercontent.com/ https://*.algolia.net/ https://*.algolianet.com/"
+SetEnv CSP_PROJECT_DOMAINS "widget.kapa.ai https://*.googleapis.com/ https://*.google.com/ https://*.gstatic.com/ https://github.com/ https://*.github.com/ https://*.githubusercontent.com/ https://*.algolia.net/ https://*.algolianet.com/ https://*.run.app/"
 
 # REDIRECTS
 


### PR DESCRIPTION
### SUMMARY
The Kapa widget on superset.apache.org calls a backend hosted on Google Cloud Run (`*.run.app`), which the site's CSP currently blocks, so the widget doesn't work. This adds `https://*.run.app/` to `CSP_PROJECT_DOMAINS` in `docs/static/.htaccess` (the ASF-infra CSP mechanism, see https://infra.apache.org/tools/csp.html).

Per the comment added alongside the other entries: `*.run.app` is a Google-owned domain, and it's only reached after explicit user acceptance when opening the Kapa widget, which keeps it allowable under the ASF privacy policy (https://privacy.apache.org/faq/committers.html), same as the existing `*.google.com` / `*.gstatic.com` entries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CSP header change on the docs site)

### TESTING INSTRUCTIONS
After this deploys to superset.apache.org, open the Kapa "Ask AI" widget, accept the consent prompt, and confirm the chat works with no CSP violations for `*.run.app` in the browser console.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)