### PR TITLE
refactor: engine enforce SQLAlchemy 2.0

### DIFF
--- a/scripts/benchmark_migration.py
+++ b/scripts/benchmark_migration.py
@@ -93,7 +93,7 @@ def find_models(module: ModuleType) -> list[type[Model]]:  # noqa: C901
     # where the current model is out-of-sync with the existing table after a
     # downgrade
     sqlalchemy_uri = current_app.config["SQLALCHEMY_DATABASE_URI"]
-    engine = create_engine(sqlalchemy_uri)
+    engine = create_engine(sqlalchemy_uri, future=True)
     Base = automap_base()  # noqa: N806
     Base.prepare(engine, reflect=True)
     seen = set()

--- a/superset/cli/test_db.py
+++ b/superset/cli/test_db.py
@@ -280,7 +280,7 @@ def test_sqlalchemy_dialect(
     """
     Test the SQLAlchemy dialect, making sure it supports everything Superset needs.
     """
-    engine = create_engine(sqlalchemy_uri, **engine_kwargs)
+    engine = create_engine(sqlalchemy_uri, future=True, **engine_kwargs)
     dialect = engine.dialect
 
     console.print("[bold]Checking functions used by the inspector...")

--- a/superset/cli/test_db.py
+++ b/superset/cli/test_db.py
@@ -280,7 +280,10 @@ def test_sqlalchemy_dialect(
     """
     Test the SQLAlchemy dialect, making sure it supports everything Superset needs.
     """
-    engine = create_engine(sqlalchemy_uri, future=True, **engine_kwargs)
+    if "future" not in engine_kwargs:
+        engine_kwargs["future"] = True
+
+    engine = create_engine(sqlalchemy_uri, **engine_kwargs)
     dialect = engine.dialect
 
     console.print("[bold]Checking functions used by the inspector...")

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -389,6 +389,7 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
                     }
                 }
             },
+            future=True,
         )
         conn = engine.connect()
         idx = 0

--- a/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
@@ -68,37 +68,33 @@ class Database(Base):
 
 
 def replace(source, target):
-    bind = op.get_bind()
-    session = db.Session(bind=bind)
+    with db.Session(bind=op.get_bind()) as session:
+        with session.begin():
+            query = (
+                session.query(Slice, Database)
+                .join(Table, Slice.datasource_id == Table.id)
+                .join(Database, Table.database_id == Database.id)
+                .filter(Slice.datasource_type == "table")
+                .all()
+            )
 
-    query = (
-        session.query(Slice, Database)
-        .join(Table, Slice.datasource_id == Table.id)
-        .join(Database, Table.database_id == Database.id)
-        .filter(Slice.datasource_type == "table")
-        .all()
-    )
+            for slc, database in query:
+                try:
+                    engine = create_engine(database.sqlalchemy_uri, future=True)
 
-    for slc, database in query:
-        try:
-            engine = create_engine(database.sqlalchemy_uri, future=True)
+                    if engine.dialect.identifier_preparer._double_percents:
+                        params = json.loads(slc.params)
 
-            if engine.dialect.identifier_preparer._double_percents:
-                params = json.loads(slc.params)
+                        if "adhoc_filters" in params:
+                            for filt in params["adhoc_filters"]:
+                                if "sqlExpression" in filt:
+                                    filt["sqlExpression"] = filt[
+                                        "sqlExpression"
+                                    ].replace(source, target)
 
-                if "adhoc_filters" in params:
-                    for filt in params["adhoc_filters"]:
-                        if "sqlExpression" in filt:
-                            filt["sqlExpression"] = filt["sqlExpression"].replace(
-                                source, target
-                            )
-
-                    slc.params = json.dumps(params, sort_keys=True)
-        except Exception:  # noqa: S110
-            pass
-
-    session.commit()
-    session.close()
+                            slc.params = json.dumps(params, sort_keys=True)
+                except Exception:  # noqa: S110
+                    pass
 
 
 def upgrade():

--- a/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
@@ -81,7 +81,7 @@ def replace(source, target):
 
     for slc, database in query:
         try:
-            engine = create_engine(database.sqlalchemy_uri)
+            engine = create_engine(database.sqlalchemy_uri, future=True)
 
             if engine.dialect.identifier_preparer._double_percents:
                 params = json.loads(slc.params)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -644,7 +644,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
                 if cached := _ENGINE_CACHE.get(cache_key):
                     return cached
         try:
-            engine = create_engine(sqlalchemy_url, **engine_kwargs)
+            engine = create_engine(sqlalchemy_url, future=True, **engine_kwargs)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
         if cache_key is not None:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -644,7 +644,9 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
                 if cached := _ENGINE_CACHE.get(cache_key):
                     return cached
         try:
-            engine = create_engine(sqlalchemy_url, future=True, **engine_kwargs)
+            if "future" not in engine_kwargs:
+                engine_kwargs["future"] = True
+            engine = create_engine(sqlalchemy_url, **engine_kwargs)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
         if cache_key is not None:

--- a/tests/integration_tests/dao/conftest.py
+++ b/tests/integration_tests/dao/conftest.py
@@ -80,6 +80,7 @@ def app_context(app: Flask) -> Generator[Session, None, None]:
         "sqlite:///:memory:",
         poolclass=StaticPool,
         connect_args={"check_same_thread": False},
+        future=True,
     )
 
     # Create session bound to in-memory database

--- a/tests/integration_tests/fixtures/datasource.py
+++ b/tests/integration_tests/fixtures/datasource.py
@@ -173,7 +173,9 @@ def get_datasource_post() -> dict[str, Any]:
 
 @pytest.fixture
 def load_dataset_with_columns() -> Generator[SqlaTable, None, None]:
-    engine = create_engine(app.config["SQLALCHEMY_DATABASE_URI"], echo=True)
+    engine = create_engine(
+        app.config["SQLALCHEMY_DATABASE_URI"], echo=True, future=True
+    )
     meta = MetaData()
 
     students = Table(

--- a/tests/integration_tests/migrations/composite_pk_association_tables__tests.py
+++ b/tests/integration_tests/migrations/composite_pk_association_tables__tests.py
@@ -55,7 +55,7 @@ def post_upgrade_engine() -> sa.engine.Engine:
     NULLs — with ``nullable=False`` here, ``test_fk_columns_not_null``
     would pass trivially rather than because the migration promoted
     anything."""
-    engine = sa.create_engine("sqlite:///:memory:")
+    engine = sa.create_engine("sqlite:///:memory:", future=True)
     md = sa.MetaData()
     for t in AFFECTED_TABLES:
         nullable = t.name in TABLES_WITH_NULLABLE_FKS

--- a/tests/integration_tests/migrations/composite_pk_association_tables__tests.py
+++ b/tests/integration_tests/migrations/composite_pk_association_tables__tests.py
@@ -72,7 +72,7 @@ def post_upgrade_engine() -> sa.engine.Engine:
 
     # Apply the migration's upgrade() against this engine via Alembic's
     # MigrationContext, patching the migration module's ``op`` reference.
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         ops = Operations(ctx)
         original_op = _migration.op

--- a/tests/integration_tests/migrations/composite_pk_round_trip__tests.py
+++ b/tests/integration_tests/migrations/composite_pk_round_trip__tests.py
@@ -90,7 +90,7 @@ def _run_with_alembic_context(engine: sa.engine.Engine, fn) -> None:
     migration module's ``op`` to point at this context so its
     ``op.get_bind()`` and ``op.batch_alter_table`` calls execute against
     the in-memory engine."""
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
         ops = Operations(ctx)
         original_op = _migration.op

--- a/tests/integration_tests/migrations/composite_pk_round_trip__tests.py
+++ b/tests/integration_tests/migrations/composite_pk_round_trip__tests.py
@@ -112,7 +112,7 @@ def test_round_trip_against_in_memory_sqlite() -> None:
       documented intentional asymmetry.)
     - Post-re-upgrade idempotency: shape matches the first post-upgrade.
     """
-    engine = sa.create_engine("sqlite:///:memory:")
+    engine = sa.create_engine("sqlite:///:memory:", future=True)
     _build_pre_migration_schema(engine)
 
     _run_with_alembic_context(engine, _migration.upgrade)
@@ -169,7 +169,7 @@ def test_upgrade_scrubs_null_fks_and_duplicates() -> None:
     the upgrade, and asserts exactly the distinct non-NULL pairs survive
     (the composite PK could not even be created otherwise).
     """
-    engine = sa.create_engine("sqlite:///:memory:")
+    engine = sa.create_engine("sqlite:///:memory:", future=True)
     _build_pre_migration_schema(engine)
 
     md = sa.MetaData()

--- a/tests/unit_tests/charts/test_filters.py
+++ b/tests/unit_tests/charts/test_filters.py
@@ -60,7 +60,8 @@ def test_chart_filter_scopes_guest_to_token_dashboards(mocker: MockerFixture) ->
 
     compiled: str = str(
         captured["clause"].compile(
-            create_engine("sqlite://"), compile_kwargs={"literal_binds": True}
+            create_engine("sqlite://", future=True),
+            compile_kwargs={"literal_binds": True},
         )
     )
     assert "EXISTS" in compiled  # scoped via the m2m dashboards relationship

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -43,7 +43,7 @@ def get_session(mocker: MockerFixture) -> Callable[[], Session]:
     """
     Create an in-memory SQLite db.session.to test models.
     """
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
 
     def get_session():
         Session_ = sessionmaker(bind=engine)  # pylint: disable=invalid-name  # noqa: N806

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -270,7 +270,7 @@ def test_query_datasources_by_permissions(mocker: MockerFixture) -> None:
     """
     db = mocker.patch("superset.connectors.sqla.models.db")
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     database = Database(database_name="my_db", id=1)
     sqla_table = SqlaTable(
         table_name="my_sqla_table",
@@ -293,7 +293,7 @@ def test_query_datasources_by_permissions_with_catalog_schema(
     """
     db = mocker.patch("superset.connectors.sqla.models.db")
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     database = Database(database_name="my_db", id=1)
     sqla_table = SqlaTable(
         table_name="my_sqla_table",
@@ -947,7 +947,7 @@ def test_get_sqla_table_quoting_for_cross_catalog(
     from sqlalchemy import create_engine, select
 
     # Create a Postgres-like engine to test proper quoting
-    engine = create_engine("postgresql://user:pass@host/db")
+    engine = create_engine("postgresql://user:pass@host/db", future=True)
 
     # Mock database with cross-catalog support and proper quote_identifier
     database = mocker.MagicMock()
@@ -984,7 +984,7 @@ def test_get_sqla_table_without_cross_catalog_ignores_catalog(
     from sqlalchemy import create_engine, select
 
     # Create a PostgreSQL engine (doesn't support cross-catalog queries)
-    engine = create_engine("postgresql://user:pass@localhost/db")
+    engine = create_engine("postgresql://user:pass@localhost/db", future=True)
 
     # Mock database without cross-catalog support
     database = mocker.MagicMock()
@@ -1018,7 +1018,7 @@ def test_quoted_name_prevents_double_quoting(mocker: MockerFixture) -> None:
     """
     from sqlalchemy import create_engine, select
 
-    engine = create_engine("postgresql://user:pass@host/db")
+    engine = create_engine("postgresql://user:pass@host/db", future=True)
 
     # Mock database
     database = mocker.MagicMock()

--- a/tests/unit_tests/databases/filters_test.py
+++ b/tests/unit_tests/databases/filters_test.py
@@ -63,7 +63,7 @@ def test_database_filter_full_db_access(mocker: MockerFixture) -> None:
     mocker.patch("flask.current_app.config", {"EXTRA_DYNAMIC_QUERY_FILTERS": False})
     mocker.patch.object(security_manager, "can_access_all_databases", return_value=True)
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     Session = sessionmaker(bind=engine)  # noqa: N806
     session = Session()
     query = session.query(Database)
@@ -105,7 +105,7 @@ def test_database_filter(mocker: MockerFixture) -> None:
         ],
     )
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     Session = sessionmaker(bind=engine)  # noqa: N806
     session = Session()
     query = session.query(Database)

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -225,6 +225,7 @@ def test_validate_parameters_catalog(
                 }
             }
         },
+        future=True,
     )
 
 
@@ -298,6 +299,7 @@ def test_validate_parameters_catalog_and_credentials(
                 }
             }
         },
+        future=True,
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_sqlite.py
+++ b/tests/unit_tests/db_engine_specs/test_sqlite.py
@@ -120,7 +120,7 @@ def test_convert_dttm(
 def test_time_grain_expressions(dttm: str, grain: str, expected: str) -> None:  # noqa: F811
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     with engine.begin() as connection:
         connection.execute(text("CREATE TABLE t (dttm DATETIME)"))
         connection.execute(text("INSERT INTO t VALUES (:dttm)"), {"dttm": dttm})

--- a/tests/unit_tests/extensions/test_sqlalchemy.py
+++ b/tests/unit_tests/extensions/test_sqlalchemy.py
@@ -136,7 +136,7 @@ def test_superset(mocker: MockerFixture, app_context: None, table1: None) -> Non
     g.user.is_anonymous = False
 
     try:
-        engine = create_engine("superset://")
+        engine = create_engine("superset://", future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
@@ -177,7 +177,7 @@ def test_superset_limit(mocker: MockerFixture, app_context: None, table1: None) 
     g.user.is_anonymous = False
 
     try:
-        engine = create_engine("superset://")
+        engine = create_engine("superset://", future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
@@ -212,7 +212,7 @@ def test_superset_joins(
     g.user.is_anonymous = False
 
     try:
-        engine = create_engine("superset://")
+        engine = create_engine("superset://", future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
@@ -256,7 +256,7 @@ def test_dml(
     g.user.is_anonymous = False
 
     try:
-        engine = create_engine("superset://")
+        engine = create_engine("superset://", future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
@@ -328,7 +328,7 @@ def test_security_manager(
     )
 
     try:
-        engine = create_engine("superset://")
+        engine = create_engine("superset://", future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")
@@ -362,7 +362,7 @@ def test_allowed_dbs(mocker: MockerFixture, app_context: None, table1: None) -> 
     g.user.is_anonymous = False
 
     try:
-        engine = create_engine("superset://", allowed_dbs=["database1"])
+        engine = create_engine("superset://", allowed_dbs=["database1"], future=True)
     except Exception as e:
         # Skip test if superset:// dialect can't be loaded (common in Docker)
         pytest.skip(f"Superset dialect not available: {e}")

--- a/tests/unit_tests/migrations/composite_pk_association_tables_test.py
+++ b/tests/unit_tests/migrations/composite_pk_association_tables_test.py
@@ -103,7 +103,7 @@ def _build_in_memory_schema(
             primary_key=True,
         ),
     )
-    engine = sa.create_engine("sqlite:///:memory:")
+    engine = sa.create_engine("sqlite:///:memory:", future=True)
     metadata.create_all(engine)
     # Seed parent rows so the FK constraints can be satisfied.
     # Identifiers come from the AFFECTED_TABLES test parameter list, not user input.

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_dashboards.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_dashboards.py
@@ -76,7 +76,7 @@ def engine() -> Engine:
     on ``slug`` is included so SQLite's no-op branch can be asserted
     against the post-migration state.
     """
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite:///:memory:", future=True)
     md = MetaData()
     table = Table(
         TABLE_NAME,

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_slices.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_slices.py
@@ -64,7 +64,7 @@ def engine() -> Engine:
     ``deleted_at`` and its index, so only the columns that participate in
     the test are seeded.
     """
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite:///:memory:", future=True)
     md = MetaData()
     Table(
         TABLE_NAME,

--- a/tests/unit_tests/migrations/test_add_deleted_at_to_tables.py
+++ b/tests/unit_tests/migrations/test_add_deleted_at_to_tables.py
@@ -64,7 +64,7 @@ def engine() -> Engine:
     ``deleted_at`` and its index, so only the columns that participate in
     the test are seeded.
     """
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite:///:memory:", future=True)
     md = MetaData()
     Table(
         TABLE_NAME,

--- a/tests/unit_tests/migrations/test_strip_metricsqlexpressions_from_ag_grid_params.py
+++ b/tests/unit_tests/migrations/test_strip_metricsqlexpressions_from_ag_grid_params.py
@@ -73,7 +73,7 @@ def _contaminated_query_context() -> str:
 
 @pytest.fixture
 def engine():
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite:///:memory:", future=True)
     migration.Base.metadata.create_all(engine)
     return engine
 

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -581,6 +581,7 @@ def test_get_sqla_engine(mocker: MockerFixture) -> None:
     create_engine.assert_called_with(
         make_url("trino:///"),
         connect_args={"source": "Apache Superset"},
+        future=True,
     )
 
 
@@ -701,6 +702,7 @@ def test_get_sqla_engine_user_impersonation(mocker: MockerFixture) -> None:
     create_engine.assert_called_with(
         make_url("trino:///"),
         connect_args={"user": "alice", "source": "Apache Superset"},
+        future=True,
     )
 
 
@@ -756,6 +758,7 @@ def test_get_sqla_engine_user_impersonation_email(mocker: MockerFixture) -> None
     create_engine.assert_called_with(
         make_url("trino:///"),
         connect_args={"user": "alice.doe", "source": "Apache Superset"},
+        future=True,
     )
 
 
@@ -1268,7 +1271,7 @@ def test_get_schema_access_for_file_upload() -> None:
     try:
         from sqlalchemy import create_engine
 
-        create_engine("gsheets://")
+        create_engine("gsheets://", future=True)
     except Exception:
         pytest.skip("gsheets:// dialect not available (Shillelagh not installed)")
 
@@ -2023,6 +2026,7 @@ def test_prequery_listener_mutation_race_deterministic(
 
     def patched_create_engine(url: Any, **kwargs: Any) -> Any:
         kwargs["creator"] = parking_creator
+        kwargs["future"] = True
         return real_create_engine(url, **kwargs)
 
     mocker.patch(

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -52,6 +52,7 @@ def database(mocker: MockerFixture, session: Session) -> Database:
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
+        future=True,
     )
     database = Database(database_name="db", sqlalchemy_uri="sqlite://")
 
@@ -123,6 +124,7 @@ def test_values_for_column_passes_catalog_and_schema(
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
+        future=True,
     )
     database = Database(database_name="db", sqlalchemy_uri="sqlite://")
 
@@ -183,6 +185,7 @@ def test_values_for_column_passes_none_catalog_and_schema(
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
+        future=True,
     )
     database = Database(database_name="db", sqlalchemy_uri="sqlite://")
 

--- a/tests/unit_tests/models/owner_association_tables_test.py
+++ b/tests/unit_tests/models/owner_association_tables_test.py
@@ -60,7 +60,7 @@ def _create_standalone(table: sa.Table) -> sa.engine.Engine:
     real ``Table`` object can be created without its parent tables while its
     primary-key constraint remains fully enforced.
     """
-    engine = sa.create_engine("sqlite:///:memory:")
+    engine = sa.create_engine("sqlite:///:memory:", future=True)
     table.create(engine)
     return engine
 

--- a/tests/unit_tests/security/exclude_users_filter_test.py
+++ b/tests/unit_tests/security/exclude_users_filter_test.py
@@ -44,7 +44,7 @@ def test_exclude_users_filter_no_exclusions(mocker: MockerFixture) -> None:
         mock_current_app,
     )
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     Session = sessionmaker(bind=engine)  # noqa: N806
     session = Session()
     query = session.query(User)

--- a/tests/unit_tests/utils/filters_test.py
+++ b/tests/unit_tests/utils/filters_test.py
@@ -50,7 +50,7 @@ def test_get_dataset_access_filters(mocker: MockerFixture) -> None:
     )
 
     clause = get_dataset_access_filters(SqlaTable)
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     compiled_query = clause.compile(engine, compile_kwargs={"literal_binds": True})
     assert str(compiled_query) == (
         "dbs.id IN (1, 3) "
@@ -117,7 +117,7 @@ def test_guest_embedded_dashboard_filter_uuid_resources(
     # structure (an EXISTS against embedded_dashboards.uuid) rather than the value.
     clause = guest_embedded_dashboard_filter()
     assert clause is not None
-    compiled = str(clause.compile(create_engine("sqlite://")))
+    compiled = str(clause.compile(create_engine("sqlite://", future=True)))
     assert "EXISTS" in compiled
     assert "embedded_dashboards" in compiled
     assert "uuid" in compiled
@@ -139,7 +139,8 @@ def test_guest_embedded_dashboard_filter_int_resources(
     assert clause is not None
     compiled = str(
         clause.compile(
-            create_engine("sqlite://"), compile_kwargs={"literal_binds": True}
+            create_engine("sqlite://", future=True),
+            compile_kwargs={"literal_binds": True},
         )
     )
     assert "dashboards.id IN (5, 7)" in compiled
@@ -165,7 +166,7 @@ def test_guest_embedded_dashboard_filter_mixed_uuid_and_int_ids(
     assert clause is not None
     # uuid column is BINARY(16), so compile without literal_binds and assert
     # structure: an EXISTS on embedded_dashboards OR a dashboards.id filter.
-    compiled = str(clause.compile(create_engine("sqlite://")))
+    compiled = str(clause.compile(create_engine("sqlite://", future=True)))
     assert "embedded_dashboards" in compiled
     assert "dashboards.id IN" in compiled
     assert " OR " in compiled

--- a/tests/unit_tests/utils/pandas_sqlalchemy_compat_test.py
+++ b/tests/unit_tests/utils/pandas_sqlalchemy_compat_test.py
@@ -35,7 +35,7 @@ def test_to_sql_accepts_sqlalchemy_engine_and_dtypes() -> None:
     """
     restore_pandas_sqlalchemy_support()
 
-    engine = create_engine("sqlite://")
+    engine = create_engine("sqlite://", future=True)
     df = pd.DataFrame(
         {
             "name": ["a", "b"],

--- a/tests/unit_tests/versioning/test_listener.py
+++ b/tests/unit_tests/versioning/test_listener.py
@@ -41,7 +41,7 @@ class LifecycleRow(Base):
 @pytest.fixture
 def lifecycle_session() -> Iterator[Session]:
     """Yield an isolated SQLAlchemy session backed by in-memory SQLite."""
-    engine = sa.create_engine("sqlite://")
+    engine = sa.create_engine("sqlite://", future=True)
     Base.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
     try:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

See #40273 .

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

After all warnings about `Engine` transactions incompatible with the SQLAlchemy 2.0 API have been converted to errors, this PR goes a step further.
`create_engine()` is now called with `future=True` everywhere so that only the SQLAlchemy 2.0 API is allowed with `Engine` transactions.
Wherever we perform assertions on `Engine` mocks in unit tests, we have to temporarily modify those assertions with the `future` flag in order to pass.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Unit tests:

```
SQLALCHEMY_WARN_20=1 python3 -m pytest tests/unit_tests/
```

Integration tests via CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
