### PR TITLE
fix: Added PostgreSQL 17.X to the supported database versions table in configuration docs

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -149,10 +149,10 @@ database engine on a separate host or container.
 
 Superset supports the following database engines/versions:
 
-| Database Engine                           | Supported Versions                       |
-| ----------------------------------------- | ---------------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X, 16.X |
-| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                 |
+| Database Engine                           | Supported Versions                             |
+| ----------------------------------------- | ---------------------------------------------- |
+| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X, 16.X, 17.X |
+| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                       |
 
 Use the following database drivers and connection strings:
 


### PR DESCRIPTION
Fixes #42050

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
One line change to enumerate support for PostgreSQL 17 in the config docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Added PostgreSQL 17.X to the supported database versions table in configuring-superset.mdx, since docker-compose.yml, docker-compose-light.yml, docker-compose-non-dev.yml, and all CI workflows use postgres:17/postgres:17-alpine. Left 10.X-16.X in place since there's no repo evidence they no longer work; that lower-bound question remains open for maintainers to decide.

**How this was tested:** `test()`