### PR TITLE
fix(embedded): stop rejecting guest chart data built from control-specific params keys

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -987,6 +987,57 @@ def _orderby_modified(
     return False
 
 
+#: Chart params keys that hold the metrics a chart renders. Different chart
+#: types store their metrics under control-specific keys (``metric`` for
+#: big number, ``x``/``y``/``size`` for bubble, and so on); a guest requesting
+#: the exact stored value reads nothing beyond what the chart already shows.
+_STORED_METRIC_PARAMS = (
+    "metrics",
+    "metric",
+    "percent_metrics",
+    "secondary_metric",
+    "series_limit_metric",
+    "timeseries_limit_metric",
+    "x",
+    "y",
+    "size",
+)
+
+#: Chart params keys that hold the columns/group-bys a chart renders, across
+#: the control names chart types use for them (``entity``/``series`` for
+#: bubble and world map, ``granularity_sqla`` for the temporal axis, etc.).
+_STORED_COLUMN_PARAMS = (
+    "columns",
+    "groupby",
+    "all_columns",
+    "entity",
+    "series",
+    "series_columns",
+    "x_axis",
+    "granularity_sqla",
+)
+
+
+def _stored_param_values(params: dict[str, Any], keys: tuple[str, ...]) -> set[str]:
+    """
+    Frozen values stored under any of the given chart params keys.
+
+    Scalar-valued controls (``metric``, ``entity``, ...) contribute their single
+    value; list-valued controls contribute each element. Matching stays exact
+    (via ``freeze_value``) — no label or expression equivalence is applied.
+    """
+    values: set[str] = set()
+    for key in keys:
+        value = params.get(key)
+        if value is None or value == "":
+            continue
+        items = value if isinstance(value, (list, tuple)) else [value]
+        values.update(
+            freeze_value(item) for item in items if item is not None and item != ""
+        )
+    return values
+
+
 def _columns_metrics_modified(
     query_context: "QueryContext",
     form_data: dict[str, Any],
@@ -998,19 +1049,20 @@ def _columns_metrics_modified(
     chart exposes. Each requested set must be a subset of the values stored on
     the chart (params and, when present, the stored query context).
     """
-    for key, equivalent in [
-        ("metrics", ["metrics"]),
-        ("columns", ["columns", "groupby"]),
-        ("groupby", ["columns", "groupby"]),
+    for key, stored_params_keys, equivalent in [
+        ("metrics", _STORED_METRIC_PARAMS, ["metrics"]),
+        ("columns", _STORED_COLUMN_PARAMS, ["columns", "groupby"]),
+        ("groupby", _STORED_COLUMN_PARAMS, ["columns", "groupby"]),
     ]:
         requested_values = {freeze_value(value) for value in form_data.get(key) or []}
-        stored_values = {
-            freeze_value(value) for value in stored_chart.params_dict.get(key) or []
-        }
-        # ``form_data`` values are checked against ``params_dict`` alone;
-        # ``query_context`` values are checked below against the fuller set that
-        # also includes the stored query context. This asymmetry is intentional:
-        # each requested source is compared to its corresponding stored source.
+        # Stored params are read across every control name that can hold a
+        # metric or column for some chart type: charts whose query is built
+        # from e.g. ``metric``/``entity``/``groupby`` never store a literal
+        # ``metrics``/``columns`` key, yet their generated payload uses those,
+        # and a guest replaying the chart's own values is not tampering.
+        stored_values = _stored_param_values(
+            stored_chart.params_dict, stored_params_keys
+        )
         if not requested_values.issubset(stored_values):
             return True
 

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -689,7 +689,7 @@ def test_query_context_modified_singular_metric_param(
         "slice_id": 42,
         "metric": "sum__SP_POP_TOTL",
     }
-    query_context.queries = [QueryObject(metrics=["sum__SP_POP_TOTL"])]  # type: ignore
+    query_context.queries = [QueryObject(metrics=["sum__SP_POP_TOTL"])]
     assert not query_context_modified(query_context)
 
 
@@ -716,7 +716,7 @@ def test_query_context_modified_control_specific_column_params(
 
     query_context.form_data = {"slice_id": 42}
     query_context.queries = [
-        QueryObject(  # type: ignore
+        QueryObject(
             columns=["country_name", "region", "year"],
             metrics=[
                 "sum__SP_RUR_TOTL_ZS",
@@ -746,16 +746,16 @@ def test_query_context_modified_novel_values_still_tampered(
     }
     query_context.form_data = {"slice_id": 42}
 
-    query_context.queries = [QueryObject(metrics=["sum__SH_DYN_AIDS"])]  # type: ignore
+    query_context.queries = [QueryObject(metrics=["sum__SH_DYN_AIDS"])]
     assert query_context_modified(query_context)
 
     query_context.queries = [
-        QueryObject(columns=["some_other_column"])  # type: ignore
+        QueryObject(columns=["some_other_column"])
     ]
     assert query_context_modified(query_context)
 
     query_context.queries = [
-        QueryObject(  # type: ignore
+        QueryObject(
             columns=[
                 {"label": "country_code", "sqlExpression": "(select 1)"},
             ],

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -749,9 +749,7 @@ def test_query_context_modified_novel_values_still_tampered(
     query_context.queries = [QueryObject(metrics=["sum__SH_DYN_AIDS"])]
     assert query_context_modified(query_context)
 
-    query_context.queries = [
-        QueryObject(columns=["some_other_column"])
-    ]
+    query_context.queries = [QueryObject(columns=["some_other_column"])]
     assert query_context_modified(query_context)
 
     query_context.queries = [

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -669,6 +669,101 @@ def test_query_context_modified_tampered(
     assert query_context_modified(query_context)
 
 
+def test_query_context_modified_singular_metric_param(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A chart storing its metric under the singular ``metric`` params key (big
+    number, world map, ...) generates a payload with a plural ``metrics`` list;
+    replaying the chart's own metric is not tampering.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "metric": "sum__SP_POP_TOTL",
+        "groupby": [],
+    }
+
+    query_context.form_data = {
+        "slice_id": 42,
+        "metric": "sum__SP_POP_TOTL",
+    }
+    query_context.queries = [QueryObject(metrics=["sum__SP_POP_TOTL"])]  # type: ignore
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_control_specific_column_params(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Charts store their queried columns under control-specific params keys
+    (``entity``/``series`` for bubble, ``groupby`` for most, the temporal
+    column under ``granularity_sqla``); the generated payload carries them in
+    ``columns``, which must not read as tampering.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "entity": "country_name",
+        "series": "region",
+        "granularity_sqla": "year",
+        "x": "sum__SP_RUR_TOTL_ZS",
+        "y": "sum__SP_DYN_LE00_IN",
+        "size": "sum__SP_POP_TOTL",
+    }
+
+    query_context.form_data = {"slice_id": 42}
+    query_context.queries = [
+        QueryObject(  # type: ignore
+            columns=["country_name", "region", "year"],
+            metrics=[
+                "sum__SP_RUR_TOTL_ZS",
+                "sum__SP_DYN_LE00_IN",
+                "sum__SP_POP_TOTL",
+            ],
+        )
+    ]
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_novel_values_still_tampered(
+    mocker: MockerFixture,
+) -> None:
+    """
+    The control-specific params equivalence only authorizes exact stored
+    values: a metric or column the chart does not reference anywhere is still
+    rejected, as is an adhoc expression label-spoofing a stored column.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "metric": "sum__SP_POP_TOTL",
+        "entity": "country_code",
+        "granularity_sqla": "year",
+    }
+    query_context.form_data = {"slice_id": 42}
+
+    query_context.queries = [QueryObject(metrics=["sum__SH_DYN_AIDS"])]  # type: ignore
+    assert query_context_modified(query_context)
+
+    query_context.queries = [
+        QueryObject(columns=["some_other_column"])  # type: ignore
+    ]
+    assert query_context_modified(query_context)
+
+    query_context.queries = [
+        QueryObject(  # type: ignore
+            columns=[
+                {"label": "country_code", "sqlExpression": "(select 1)"},
+            ],
+        )
+    ]
+    assert query_context_modified(query_context)
+
+
 def _native_filter_ctx(
     mocker: MockerFixture,
     queries: list[Any],


### PR DESCRIPTION
### SUMMARY
Embedded guests get a generic 403 (`Guest user cannot modify chart payload`) on any chart persisted without a stored `query_context` — charts created via the REST API and every chart loaded by `load_examples`. The guest tamper check (`_columns_metrics_modified`) compares the requested metrics/columns against only the same-named chart params keys, but chart types store what they query under control-specific keys: `metric` (big number, world map), `entity`/`series`/`x`/`y`/`size` (bubble), `granularity_sqla` (temporal axis), `secondary_metric` (sunburst), plain `groupby` vs the payload's `columns` (even table hits this). The chart's own generated payload reads as tampering.

This is also why `playwright-tests-experimental`'s embedded suite is flaky: the embedded project runs with admin `storageState`, and a cookie race (the `/embedded/<uuid>` response rotates the iframe to an anonymous session while the SDK's parallel csrf/guest-token fetches rewrite the admin cookie) decides whether chart data requests are evaluated as admin (tamper check skipped, 200) or as a real guest (403). The suite only passes when admin wins.

The fix reads the stored side across the control names that can hold a metric or column, keeping exact `freeze_value` matching — only values the chart already references become requestable. No label or expression equivalence is introduced: novel saved metrics, novel columns, adhoc SQL expressions, and label-spoofed adhoc columns replaying a stored column's label are all still rejected (covered by new unit tests).

Verification beyond unit tests: replayed the actual network payloads of all nine `world_health` example charts (captured from the embedded Playwright trace artifacts) through the check — every one was rejected before this change and passes after, while tampered variants of the same payloads stay rejected.

Security model note per `SECURITY.md`: this does not grant any principal a new capability. An embedded guest token holder is entitled to view the data of charts on the dashboard shared with them; the values unlocked here are exactly the ones the stored chart already renders to that guest.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: embedded `world_health` charts show "Data error: Forbidden" for guest-evaluated requests. After: they render.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/security/manager_test.py -k query_context_modified` — includes the new singular-metric, control-specific-columns, and still-tampered cases. Or embed the `world_health` dashboard via the SDK and confirm charts load for a guest token.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)