### PR TITLE
feat(mcp): per-resource token scopes with user-permission intersection

### DIFF
--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -400,7 +400,7 @@ Once enabled, each user manages their own keys from their profile page:
 1. Open the user menu (top-right) and click **Info** to navigate to the User Info page
 2. Expand the **API Keys** section
 3. Click **+ API Key**
-4. Enter a name and (optionally) an expiration date
+4. Enter a name and optionally select resource scopes
 5. Copy the generated token — it is shown only once
 
 Only users with the `can_read` and `can_write` permissions on `ApiKey` (granted by default to Admins) can manage API keys.
@@ -414,6 +414,18 @@ Authorization: Bearer <your-api-key>
 ```
 
 This works for all REST API endpoints and the MCP server. The request is executed with the permissions of the user who created the key.
+
+#### API Key Scopes
+
+The creation dialog can restrict an API key to MCP resource actions such as
+`superset:dashboard:read` or `superset:chart:write`. A scope is an additional
+restriction: it never grants a permission that the creating user does not
+already have through Superset RBAC. Write scopes also cover update and delete
+operations for that resource; `superset:sqllab:write` covers SQL execution.
+
+Keys created without scopes retain legacy RBAC-only behavior. The scoped-key
+restrictions described here are enforced by the MCP server; regular REST API
+routes continue to apply their existing Superset RBAC checks.
 
 #### Use Cases
 

--- a/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
@@ -27,8 +27,14 @@ import {
   Input,
   Button,
   Modal,
+  Select,
 } from '@superset-ui/core/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
+import {
+  API_KEY_SCOPE_OPTIONS,
+  getApiKeyScopesHelpText,
+  serializeApiKeyScopes,
+} from './apiKeyScopes';
 
 interface ApiKeyCreateModalProps {
   show: boolean;
@@ -38,6 +44,7 @@ interface ApiKeyCreateModalProps {
 
 interface FormValues {
   name: string;
+  scopes?: string[];
 }
 
 export function ApiKeyCreateModal({
@@ -62,9 +69,13 @@ export function ApiKeyCreateModal({
 
   const handleFormSubmit = async (values: FormValues) => {
     try {
+      const scopes = serializeApiKeyScopes(values.scopes);
       const response = await SupersetClient.post({
         endpoint: '/api/v1/security/api_keys/',
-        jsonPayload: values,
+        jsonPayload: {
+          name: values.name,
+          ...(scopes && { scopes }),
+        },
       });
       const key = response.json?.result?.key;
       if (!key) {
@@ -168,6 +179,22 @@ export function ApiKeyCreateModal({
         <Input
           name="name"
           placeholder={t('e.g., CI/CD Pipeline, Analytics Script')}
+        />
+      </FormItem>
+      <FormItem
+        name="scopes"
+        label={t('Scopes')}
+        help={getApiKeyScopesHelpText()}
+      >
+        <Select
+          name="scopes"
+          mode="multiple"
+          allowClear
+          showSearch
+          options={API_KEY_SCOPE_OPTIONS}
+          placeholder={t('Select resource scopes (optional)')}
+          data-test="api-key-scopes-select"
+          getPopupContainer={trigger => trigger.closest('.ant-modal-container')}
         />
       </FormItem>
     </FormModal>

--- a/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
@@ -183,7 +183,7 @@ export function ApiKeyCreateModal({
       </FormItem>
       <FormItem
         name="scopes"
-        label={t('Scopes')}
+        label={t('MCP scopes')}
         help={getApiKeyScopesHelpText()}
       >
         <Select
@@ -192,9 +192,11 @@ export function ApiKeyCreateModal({
           allowClear
           showSearch
           options={API_KEY_SCOPE_OPTIONS}
-          placeholder={t('Select resource scopes (optional)')}
+          placeholder={t('Select MCP resource scopes (optional)')}
           data-test="api-key-scopes-select"
-          getPopupContainer={trigger => trigger.closest('.ant-modal-container')}
+          getPopupContainer={(trigger: HTMLElement) =>
+            trigger.closest<HTMLElement>('.ant-modal-container')
+          }
         />
       </FormItem>
     </FormModal>

--- a/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
@@ -196,7 +196,7 @@ export function ApiKeyCreateModal({
           placeholder={t('Select MCP resource scopes (optional)')}
           data-test="api-key-scopes-select"
           getPopupContainer={(trigger: HTMLElement) =>
-            trigger.closest<HTMLElement>('.ant-modal-container')
+            trigger.closest<HTMLElement>('.ant-modal-container') ?? trigger
           }
         />
       </FormItem>

--- a/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyCreateModal.tsx
@@ -30,6 +30,7 @@ import {
   Select,
 } from '@superset-ui/core/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
+import copyTextToClipboard from 'src/utils/copy';
 import {
   API_KEY_SCOPE_OPTIONS,
   getApiKeyScopesHelpText,
@@ -94,7 +95,7 @@ export function ApiKeyCreateModal({
       return;
     }
     try {
-      await navigator.clipboard.writeText(createdKey);
+      await copyTextToClipboard(() => Promise.resolve(createdKey));
       setCopied(true);
       if (copyTimerRef.current) {
         clearTimeout(copyTimerRef.current);

--- a/superset-frontend/src/features/apiKeys/ApiKeyList.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyList.tsx
@@ -163,6 +163,19 @@ export function ApiKeyList() {
       render: (_: unknown, record: ApiKey) => getStatusBadge(record),
     },
     {
+      title: t('Scopes'),
+      dataIndex: 'scopes',
+      key: 'scopes',
+      render: (scopes: string | null) =>
+        scopes ? (
+          <Tooltip title={scopes}>
+            <Tag>{t('%s scoped', scopes.split(',').length)}</Tag>
+          </Tooltip>
+        ) : (
+          <Tag>{t('RBAC only')}</Tag>
+        ),
+    },
+    {
       title: t('Actions'),
       key: 'actions',
       render: (_: unknown, record: ApiKey) => (

--- a/superset-frontend/src/features/apiKeys/ApiKeyList.tsx
+++ b/superset-frontend/src/features/apiKeys/ApiKeyList.tsx
@@ -163,13 +163,13 @@ export function ApiKeyList() {
       render: (_: unknown, record: ApiKey) => getStatusBadge(record),
     },
     {
-      title: t('Scopes'),
+      title: t('MCP scopes'),
       dataIndex: 'scopes',
       key: 'scopes',
       render: (scopes: string | null) =>
         scopes ? (
           <Tooltip title={scopes}>
-            <Tag>{t('%s scoped', scopes.split(',').length)}</Tag>
+            <Tag>{t('%s MCP scopes', scopes.split(',').length)}</Tag>
           </Tooltip>
         ) : (
           <Tag>{t('RBAC only')}</Tag>

--- a/superset-frontend/src/features/apiKeys/apiKeyScopes.test.ts
+++ b/superset-frontend/src/features/apiKeys/apiKeyScopes.test.ts
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { API_KEY_SCOPE_OPTIONS, serializeApiKeyScopes } from './apiKeyScopes';
+import {
+  API_KEY_SCOPE_OPTIONS,
+  getApiKeyScopesHelpText,
+  serializeApiKeyScopes,
+} from './apiKeyScopes';
 
 test('offers read and write scopes for every supported resource', () => {
   expect(API_KEY_SCOPE_OPTIONS).toHaveLength(32);
@@ -36,4 +40,11 @@ test('serializes selected scopes for the FAB API', () => {
   ).toBe('superset:dashboard:read,superset:chart:write');
   expect(serializeApiKeyScopes([])).toBeUndefined();
   expect(serializeApiKeyScopes()).toBeUndefined();
+});
+
+test('explains that scopes apply to MCP rather than REST APIs', () => {
+  expect(getApiKeyScopesHelpText()).toContain('MCP resources');
+  expect(getApiKeyScopesHelpText()).toContain(
+    'do not restrict REST API requests',
+  );
 });

--- a/superset-frontend/src/features/apiKeys/apiKeyScopes.test.ts
+++ b/superset-frontend/src/features/apiKeys/apiKeyScopes.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { API_KEY_SCOPE_OPTIONS, serializeApiKeyScopes } from './apiKeyScopes';
+
+test('offers read and write scopes for every supported resource', () => {
+  expect(API_KEY_SCOPE_OPTIONS).toHaveLength(32);
+  expect(API_KEY_SCOPE_OPTIONS).toContainEqual({
+    label: 'superset:dashboard:read',
+    value: 'superset:dashboard:read',
+  });
+  expect(API_KEY_SCOPE_OPTIONS).toContainEqual({
+    label: 'superset:sqllab:write',
+    value: 'superset:sqllab:write',
+  });
+});
+
+test('serializes selected scopes for the FAB API', () => {
+  expect(
+    serializeApiKeyScopes(['superset:dashboard:read', 'superset:chart:write']),
+  ).toBe('superset:dashboard:read,superset:chart:write');
+  expect(serializeApiKeyScopes([])).toBeUndefined();
+  expect(serializeApiKeyScopes()).toBeUndefined();
+});

--- a/superset-frontend/src/features/apiKeys/apiKeyScopes.ts
+++ b/superset-frontend/src/features/apiKeys/apiKeyScopes.ts
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@apache-superset/core/translation';
+
+const API_KEY_SCOPE_RESOURCES = [
+  'annotation',
+  'chart',
+  'dashboard',
+  'database',
+  'dataset',
+  'explore',
+  'query',
+  'report',
+  'role',
+  'rls',
+  'savedquery',
+  'sqllab',
+  'tag',
+  'task',
+  'theme',
+  'user',
+] as const;
+
+const API_KEY_SCOPE_ACTIONS = ['read', 'write'] as const;
+
+export const API_KEY_SCOPE_OPTIONS = API_KEY_SCOPE_RESOURCES.flatMap(resource =>
+  API_KEY_SCOPE_ACTIONS.map(action => {
+    const value = `superset:${resource}:${action}`;
+    return { label: value, value };
+  }),
+);
+
+export const serializeApiKeyScopes = (scopes?: string[]) =>
+  scopes?.length ? scopes.join(',') : undefined;
+
+export const getApiKeyScopesHelpText = () =>
+  t(
+    'Limit this key to selected resources and actions. Leave empty for legacy RBAC-only behavior. Scopes never grant permissions the user does not already have.',
+  );

--- a/superset-frontend/src/features/apiKeys/apiKeyScopes.ts
+++ b/superset-frontend/src/features/apiKeys/apiKeyScopes.ts
@@ -51,5 +51,5 @@ export const serializeApiKeyScopes = (scopes?: string[]) =>
 
 export const getApiKeyScopesHelpText = () =>
   t(
-    'Limit this key to selected resources and actions. Leave empty for legacy RBAC-only behavior. Scopes never grant permissions the user does not already have.',
+    'Limit which MCP resources and actions this key can access. These scopes do not restrict REST API requests and never grant permissions the user does not already have. Leave empty for legacy RBAC-only behavior.',
   );

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -68,6 +68,11 @@ from superset.mcp_service.session_scope import _mcp_session_token
 from superset.mcp_service.utils.error_sanitization import (
     sanitize_for_log as _sanitize_for_log,
 )
+from superset.security.api_key_scopes import (
+    get_resource_scope,
+    METHOD_PERMISSION_SCOPE_ACTION,
+    RESOURCE_SCOPE_NAME as RESOURCE_SCOPE_NAME,
+)
 from superset.security.guest_token import GuestUser
 
 if TYPE_CHECKING:
@@ -126,46 +131,8 @@ class MCPNoAuthSourceError(ValueError):
 # is a privileged, write-class operation and therefore requires the write
 # scope. When introducing a new method permission, add it here.
 _METHOD_TO_REQUIRED_SCOPE = {
-    "read": "superset:read",
-    # "get" is the read-class permission FAB registers on its security API
-    # views (User/Role) — those views have no can_read, so tools targeting
-    # them declare method_permission_name="get".
-    "get": "superset:read",
-    "write": "superset:write",
-    "delete": "superset:write",
-    # SQL execution (execute_sql, get_chart_sql) runs arbitrary queries and is
-    # treated as a write-class privileged operation for scope purposes.
-    "execute_sql_query": "superset:write",
-}
-
-# Maps a tool's ``class_permission_name`` to the resource segment of its
-# per-resource scope string (``superset:<resource>:<action>``).
-#
-# This is an explicit map rather than a ``class_permission_name.lower()``
-# transform because a naive lowercase breaks for "Row Level Security" (which
-# contains spaces) and produces awkward names for "ReportSchedule" and
-# "SQLLab". Keep this in sync with the ``class_permission_name`` values
-# declared by MCP tools (grep for ``class_permission_name=`` under
-# ``superset/mcp_service``). A resource missing from this map simply has no
-# per-resource scope — tokens must then rely on the flat
-# ``_METHOD_TO_REQUIRED_SCOPE`` scopes (see ``_token_scope_allows``).
-RESOURCE_SCOPE_NAME: dict[str, str] = {
-    "Annotation": "annotation",
-    "Chart": "chart",
-    "Dashboard": "dashboard",
-    "Database": "database",
-    "Dataset": "dataset",
-    "Explore": "explore",
-    "Query": "query",
-    "ReportSchedule": "report",
-    "Role": "role",
-    "Row Level Security": "rls",
-    "SavedQuery": "savedquery",
-    "SQLLab": "sqllab",
-    "Tag": "tag",
-    "Task": "task",
-    "Theme": "theme",
-    "User": "user",
+    method: f"superset:{action}"
+    for method, action in METHOD_PERMISSION_SCOPE_ACTION.items()
 }
 
 
@@ -179,12 +146,7 @@ def _required_resource_scope(
     the flat ``_METHOD_TO_REQUIRED_SCOPE`` fallback still applies in that case
     (see ``_token_scope_allows``).
     """
-    resource = RESOURCE_SCOPE_NAME.get(class_permission_name)
-    action = _METHOD_TO_REQUIRED_SCOPE.get(method_permission_name)
-    if resource is None or action is None:
-        return None
-    action_slug = action.rsplit(":", 1)[-1]
-    return f"superset:{resource}:{action_slug}"
+    return get_resource_scope(class_permission_name, method_permission_name)
 
 
 def _get_token_scopes() -> set[str] | None:

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -164,8 +164,13 @@ def _get_token_scopes() -> set[str] | None:
 
     try:
         access_token = get_access_token()
-    except Exception:  # noqa: BLE001 - no JWT context for this request
-        return None
+    except Exception:  # noqa: BLE001 - fail closed on token-context errors
+        logger.exception("Unable to resolve MCP access-token scopes")
+        # ``None`` means that no scoped credential was presented and enables
+        # legacy RBAC-only behavior. An empty set instead makes every scope
+        # check fail, so an unexpected context error cannot erase restrictions
+        # carried by a credential.
+        return set()
 
     if access_token is None:
         return None
@@ -389,8 +394,13 @@ def check_tool_permission(  # noqa: C901
                 )
             return False
 
+        method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")
+        class_permission_name = getattr(func, CLASS_PERMISSION_ATTR, None)
+
+        # Token capabilities and user RBAC are independent restrictions.
+        # Disabling RBAC must not discard scopes explicitly carried by a key.
         if not current_app.config.get("MCP_RBAC_ENABLED", True):
-            return True
+            return _token_scope_allows(method_permission_name, class_permission_name)
 
         if not hasattr(g, "user") or not g.user:
             if log_denial:
@@ -403,8 +413,6 @@ def check_tool_permission(  # noqa: C901
                 )
             return False
 
-        method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")
-        class_permission_name = getattr(func, CLASS_PERMISSION_ATTR, None)
         if not class_permission_name:
             # No RBAC configured for this tool; allow by default. This is a
             # supported configuration (a protected tool may intentionally
@@ -508,7 +516,7 @@ def is_tool_visible_to_current_user(tool: Any) -> bool:
             return False
 
         if not current_app.config.get("MCP_RBAC_ENABLED", True):
-            return True
+            return check_tool_permission(tool_func, log_denial=False)
 
         from superset.mcp_service.privacy import (
             tool_requires_data_model_metadata_access,
@@ -520,10 +528,6 @@ def is_tool_visible_to_current_user(tool: Any) -> bool:
             and not user_can_view_data_model_metadata()
         ):
             return False
-
-        class_permission_name = getattr(tool_func, CLASS_PERMISSION_ATTR, None)
-        if not class_permission_name:
-            return True
 
         return check_tool_permission(tool_func, log_denial=False)
 

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -138,6 +138,54 @@ _METHOD_TO_REQUIRED_SCOPE = {
     "execute_sql_query": "superset:write",
 }
 
+# Maps a tool's ``class_permission_name`` to the resource segment of its
+# per-resource scope string (``superset:<resource>:<action>``).
+#
+# This is an explicit map rather than a ``class_permission_name.lower()``
+# transform because a naive lowercase breaks for "Row Level Security" (which
+# contains spaces) and produces awkward names for "ReportSchedule" and
+# "SQLLab". Keep this in sync with the ``class_permission_name`` values
+# declared by MCP tools (grep for ``class_permission_name=`` under
+# ``superset/mcp_service``). A resource missing from this map simply has no
+# per-resource scope — tokens must then rely on the flat
+# ``_METHOD_TO_REQUIRED_SCOPE`` scopes (see ``_token_scope_allows``).
+RESOURCE_SCOPE_NAME: dict[str, str] = {
+    "Annotation": "annotation",
+    "Chart": "chart",
+    "Dashboard": "dashboard",
+    "Database": "database",
+    "Dataset": "dataset",
+    "Explore": "explore",
+    "Query": "query",
+    "ReportSchedule": "report",
+    "Role": "role",
+    "Row Level Security": "rls",
+    "SavedQuery": "savedquery",
+    "SQLLab": "sqllab",
+    "Tag": "tag",
+    "Task": "task",
+    "Theme": "theme",
+    "User": "user",
+}
+
+
+def _required_resource_scope(
+    class_permission_name: str, method_permission_name: str
+) -> str | None:
+    """Compute the ``superset:<resource>:<action>`` scope string for a tool.
+
+    Returns None if either the resource or the action isn't mapped — callers
+    must treat that as "no per-resource scope available," not as a grant;
+    the flat ``_METHOD_TO_REQUIRED_SCOPE`` fallback still applies in that case
+    (see ``_token_scope_allows``).
+    """
+    resource = RESOURCE_SCOPE_NAME.get(class_permission_name)
+    action = _METHOD_TO_REQUIRED_SCOPE.get(method_permission_name)
+    if resource is None or action is None:
+        return None
+    action_slug = action.rsplit(":", 1)[-1]
+    return f"superset:{resource}:{action_slug}"
+
 
 def _get_token_scopes() -> set[str] | None:
     """Return the set of scopes on the current JWT access token, or None.
@@ -167,12 +215,21 @@ def _get_token_scopes() -> set[str] | None:
     return {str(s) for s in scopes}
 
 
-def _token_scope_allows(method_permission_name: str) -> bool:
+def _token_scope_allows(
+    method_permission_name: str, class_permission_name: str | None = None
+) -> bool:
     """Return whether the current token's scopes permit the given method.
 
     Back-compat: returns True (allow) when the token carries no scopes or there
     is no JWT context, so deployments not using scopes keep RBAC-only behavior.
     Only when the token advertises scopes is the mapped required scope enforced.
+
+    The per-resource scope (``superset:<resource>:<action>``, derived via
+    ``_required_resource_scope``) is an ALTERNATIVE grant path alongside the
+    flat method scope: a token carrying either the flat scope
+    (e.g. ``superset:read``) or the matching per-resource scope
+    (e.g. ``superset:dashboard:read``) is allowed, so already-issued
+    flat-scoped tokens keep working unchanged.
     """
     token_scopes = _get_token_scopes()
     if token_scopes is None:
@@ -190,7 +247,15 @@ def _token_scope_allows(method_permission_name: str) -> bool:
             method_permission_name,
         )
         return False
-    return required_scope in token_scopes
+    if required_scope in token_scopes:
+        return True
+    if class_permission_name is not None:
+        resource_scope = _required_resource_scope(
+            class_permission_name, method_permission_name
+        )
+        if resource_scope is not None and resource_scope in token_scopes:
+            return True
+    return False
 
 
 class MCPPermissionDeniedError(PermissionError):
@@ -234,12 +299,16 @@ def _log_scope_denial(
     cyclomatic complexity in check.
     """
     required_scope = _METHOD_TO_REQUIRED_SCOPE.get(method_permission_name)
+    resource_scope = _required_resource_scope(
+        class_permission_name, method_permission_name
+    )
+    scope_desc = resource_scope or required_scope
     if log_denial:
         logger.warning(
             "Scope denied for user %s: token lacks required scope "
             "'%s' for %s on %s (tool: %s)",
             _sanitize_for_log(g.user.username),
-            required_scope,
+            scope_desc,
             permission_str,
             class_permission_name,
             func.__name__,
@@ -248,7 +317,7 @@ def _log_scope_denial(
         logger.debug(
             "Tool hidden for user %s: token lacks required scope '%s' (tool: %s)",
             _sanitize_for_log(g.user.username),
-            required_scope,
+            scope_desc,
             func.__name__,
         )
 
@@ -399,7 +468,9 @@ def check_tool_permission(  # noqa: C901
         # advertises scopes. Tokens/deployments that don't use scopes (API keys,
         # scope-less JWTs, dev-mode) fall through to RBAC-only behavior — see
         # ``_token_scope_allows``.
-        if has_permission and not _token_scope_allows(method_permission_name):
+        if has_permission and not _token_scope_allows(
+            method_permission_name, class_permission_name
+        ):
             _log_scope_denial(
                 func,
                 method_permission_name,

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -403,6 +403,7 @@ def check_tool_permission(  # noqa: C901
                 )
             return False
 
+        method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")
         class_permission_name = getattr(func, CLASS_PERMISSION_ATTR, None)
         if not class_permission_name:
             # No RBAC configured for this tool; allow by default. This is a
@@ -417,9 +418,17 @@ def check_tool_permission(  # noqa: C901
                     "class_permission_name; allowing access without an RBAC check",
                     func.__name__,
                 )
+            if not _token_scope_allows(method_permission_name):
+                if log_denial:
+                    logger.warning(
+                        "Scope denied for permission-less tool %s: token lacks "
+                        "flat scope for method %s",
+                        func.__name__,
+                        method_permission_name,
+                    )
+                return False
             return True
 
-        method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")
         permission_str = f"{PERMISSION_PREFIX}{method_permission_name}"
 
         has_permission = security_manager.can_access(

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -264,7 +264,11 @@ def _log_scope_denial(
     resource_scope = _required_resource_scope(
         class_permission_name, method_permission_name
     )
-    scope_desc = resource_scope or required_scope
+    scope_desc = (
+        resource_scope
+        or required_scope
+        or f"unmapped method permission '{method_permission_name}'"
+    )
     if log_denial:
         logger.warning(
             "Scope denied for user %s: token lacks required scope "

--- a/superset/mcp_service/composite_token_verifier.py
+++ b/superset/mcp_service/composite_token_verifier.py
@@ -113,15 +113,19 @@ class CompositeTokenVerifier(TokenVerifier):
             )
         self._api_key_prefixes = tuple(valid)
 
-    def _validate_api_key_sync(self, token: str) -> str | None:
-        """Validate an API key against FAB and return the user's username.
+    def _validate_api_key_sync(self, token: str) -> tuple[str, list[str]] | None:
+        """Validate an API key against FAB and return (username, scopes).
 
         Runs synchronously inside a thread executor. Pushes a fresh Flask
         app context so that FAB's SecurityManager can access the database.
 
-        Returns the username on success, or ``None`` if the key is invalid,
-        FAB does not support ``validate_api_key``, or an unexpected error
-        occurs (fail closed).
+        ``scopes`` is the key's own ``ApiKey.scopes`` column, parsed from
+        FAB's comma-separated string storage format into a list (empty list
+        if the key has no scopes set, matching the "no scopes advertised"
+        convention used elsewhere in this module and in ``auth.py``).
+
+        Returns ``None`` if the key is invalid, FAB does not support
+        ``validate_api_key``, or an unexpected error occurs (fail closed).
         """
         if self._app is None:
             return None
@@ -135,12 +139,21 @@ class CompositeTokenVerifier(TokenVerifier):
                     )
                     return None
                 user = sm.validate_api_key(token)
-                username = user.username if user else None
-                # Unbind the local reference so this frame no longer points at
-                # the raw token (defense-in-depth). Python does not zero the
-                # underlying string memory on rebind.
-                token = ""  # noqa: S105
-                return username
+                if user is None:
+                    return None
+                username = user.username
+                scopes_str = (
+                    sm.get_api_key_scopes(token)
+                    if hasattr(sm, "get_api_key_scopes")
+                    else None
+                )
+                scopes = (
+                    [s.strip() for s in scopes_str.split(",") if s.strip()]
+                    if scopes_str
+                    else []
+                )
+                token = ""  # noqa: S105 -- unbind raw token, defense-in-depth
+                return username, scopes
         except Exception:  # noqa: BLE001 — catch-all: DB errors, FAB internals, etc.
             logger.warning(
                 "API key transport validation failed unexpectedly; rejecting token",
@@ -168,21 +181,26 @@ class CompositeTokenVerifier(TokenVerifier):
         if any(token.startswith(prefix) for prefix in self._api_key_prefixes):
             if self._app is not None:
                 loop = asyncio.get_running_loop()
-                username = await loop.run_in_executor(
+                result = await loop.run_in_executor(
                     None, self._validate_api_key_sync, token
                 )
-                if username is None:
+                if result is None:
                     logger.debug(
                         "API key rejected at transport layer (invalid or expired)"
                     )
                     return None
+                username, key_scopes = result
                 logger.debug(
                     "API key validated at transport layer for user=%s", username
                 )
                 return AccessToken(
                     token=token,
                     client_id="api_key",
-                    scopes=list(self.required_scopes or []),
+                    # Prefer the key's own scopes over verifier-global
+                    # required_scopes. Empty list = no scopes set = "no scopes
+                    # advertised" back-compat per auth.py's
+                    # _get_token_scopes()/_token_scope_allows().
+                    scopes=key_scopes or list(self.required_scopes or []),
                     claims={
                         API_KEY_PASSTHROUGH_CLAIM: True,
                         API_KEY_VALIDATED_USERNAME_CLAIM: username,
@@ -190,10 +208,11 @@ class CompositeTokenVerifier(TokenVerifier):
                 )
 
             # No app configured: fall back to prefix-only pass-through so
-            # ``_resolve_user_from_api_key`` handles DB validation.
-            # NOTE: ``MCP_REQUIRED_SCOPES`` is intentionally not enforced for
-            # API-key auth — FAB API keys do not carry scopes. Authorization is
-            # enforced downstream via ``check_tool_permission`` (RBAC).
+            # ``_resolve_user_from_api_key`` handles DB validation. Without an
+            # app there is no DB access here, so the key's own ApiKey.scopes
+            # cannot be read — the verifier-global required_scopes are used
+            # instead. Authorization is still enforced downstream via
+            # ``check_tool_permission`` (RBAC).
             logger.debug("API key token detected (prefix match), passing through")
             return AccessToken(
                 token=token,

--- a/superset/mcp_service/composite_token_verifier.py
+++ b/superset/mcp_service/composite_token_verifier.py
@@ -196,11 +196,10 @@ class CompositeTokenVerifier(TokenVerifier):
                 return AccessToken(
                     token=token,
                     client_id="api_key",
-                    # Prefer the key's own scopes over verifier-global
-                    # required_scopes. Empty list = no scopes set = "no scopes
-                    # advertised" back-compat per auth.py's
-                    # _get_token_scopes()/_token_scope_allows().
-                    scopes=key_scopes or list(self.required_scopes or []),
+                    # Preserve the key's own scopes exactly. An empty list
+                    # means "no scopes advertised" and therefore retains the
+                    # RBAC-only behavior for existing unscoped API keys.
+                    scopes=key_scopes,
                     claims={
                         API_KEY_PASSTHROUGH_CLAIM: True,
                         API_KEY_VALIDATED_USERNAME_CLAIM: username,

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -653,10 +653,9 @@ def _build_composite_verifier(
     if api_key_enabled:
         if required_scopes := app.config.get("MCP_REQUIRED_SCOPES", []):
             logger.warning(
-                "MCP_REQUIRED_SCOPES is configured but API key tokens bypass "
-                "scope enforcement. API key holders gain access regardless of "
-                "MCP_REQUIRED_SCOPES=%r. Enforce per-key authorization via FAB "
-                "roles/RBAC instead.",
+                "MCP_REQUIRED_SCOPES=%r is configured, but API key tokens use "
+                "the scopes stored on each key instead. Unscoped API keys "
+                "retain legacy RBAC-only behavior.",
                 required_scopes,
             )
         raw_prefixes: str | Sequence[str] = app.config.get(

--- a/superset/mcp_service/system/tool/get_schema.py
+++ b/superset/mcp_service/system/tool/get_schema.py
@@ -30,7 +30,7 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
-from superset.mcp_service.auth import MCPPermissionDeniedError
+from superset.mcp_service.auth import _token_scope_allows, MCPPermissionDeniedError
 from superset.mcp_service.common.schema_discovery import (
     CHART_DEFAULT_COLUMNS,
     CHART_SEARCH_COLUMNS,
@@ -237,6 +237,7 @@ async def get_schema(
 
         if current_app.config.get("MCP_RBAC_ENABLED", True) and not (
             security_manager.can_access("can_read", class_permission)
+            and _token_scope_allows("read", class_permission)
         ):
             user_str = getattr(getattr(g, "user", None), "username", None)
             logger.warning(

--- a/superset/mcp_service/system/tool/get_schema.py
+++ b/superset/mcp_service/system/tool/get_schema.py
@@ -235,10 +235,10 @@ async def get_schema(
 
         from superset import security_manager
 
-        if current_app.config.get("MCP_RBAC_ENABLED", True) and not (
-            security_manager.can_access("can_read", class_permission)
-            and _token_scope_allows("read", class_permission)
-        ):
+        rbac_allows = not current_app.config.get(
+            "MCP_RBAC_ENABLED", True
+        ) or security_manager.can_access("can_read", class_permission)
+        if not (rbac_allows and _token_scope_allows("read", class_permission)):
             user_str = getattr(getattr(g, "user", None), "username", None)
             logger.warning(
                 "get_schema RBAC denied: user=%s type=%s view=%s",

--- a/superset/security/api_key_scopes.py
+++ b/superset/security/api_key_scopes.py
@@ -23,6 +23,7 @@ METHOD_PERMISSION_SCOPE_ACTION: dict[str, str] = {
     "read": "read",
     "get": "read",
     "write": "write",
+    "update": "write",
     "delete": "write",
     "execute_sql_query": "write",
 }

--- a/superset/security/api_key_scopes.py
+++ b/superset/security/api_key_scopes.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Canonical resource and action mappings for scoped API keys."""
+
+# Map FAB method permissions used by MCP tools to the coarser actions supported
+# by API-key scopes. Keep this explicit so an unknown permission fails closed.
+METHOD_PERMISSION_SCOPE_ACTION: dict[str, str] = {
+    "read": "read",
+    "get": "read",
+    "write": "write",
+    "delete": "write",
+    "execute_sql_query": "write",
+}
+
+# Map MCP/FAB class permission names to stable public resource slugs. These
+# cannot be derived by lowercasing because several names contain spaces or use
+# public spellings that differ from their internal class names.
+RESOURCE_SCOPE_NAME: dict[str, str] = {
+    "Annotation": "annotation",
+    "Chart": "chart",
+    "Dashboard": "dashboard",
+    "Database": "database",
+    "Dataset": "dataset",
+    "Explore": "explore",
+    "Query": "query",
+    "ReportSchedule": "report",
+    "Role": "role",
+    "Row Level Security": "rls",
+    "SavedQuery": "savedquery",
+    "SQLLab": "sqllab",
+    "Tag": "tag",
+    "Task": "task",
+    "Theme": "theme",
+    "User": "user",
+}
+
+RESOURCE_SCOPE_CLASS: dict[str, str] = {
+    resource: class_name for class_name, resource in RESOURCE_SCOPE_NAME.items()
+}
+RESOURCE_SCOPE_ACTIONS: frozenset[str] = frozenset(
+    METHOD_PERMISSION_SCOPE_ACTION.values()
+)
+
+
+def get_resource_scope(
+    class_permission_name: str, method_permission_name: str
+) -> str | None:
+    """Return the resource scope required by a FAB class/method permission."""
+    resource = RESOURCE_SCOPE_NAME.get(class_permission_name)
+    action = METHOD_PERMISSION_SCOPE_ACTION.get(method_permission_name)
+    if resource is None or action is None:
+        return None
+    return f"superset:{resource}:{action}"

--- a/superset/security/api_key_scopes.py
+++ b/superset/security/api_key_scopes.py
@@ -56,6 +56,14 @@ RESOURCE_SCOPE_CLASS: dict[str, str] = {
 RESOURCE_SCOPE_ACTIONS: frozenset[str] = frozenset(
     METHOD_PERMISSION_SCOPE_ACTION.values()
 )
+SCOPE_ACTION_METHOD_PERMISSIONS: dict[str, tuple[str, ...]] = {
+    action: tuple(
+        method
+        for method, mapped_action in METHOD_PERMISSION_SCOPE_ACTION.items()
+        if mapped_action == action
+    )
+    for action in RESOURCE_SCOPE_ACTIONS
+}
 
 
 def get_resource_scope(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5006,7 +5006,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                     f"Requested scope '{scope}' exceeds the issuing user's "
                     "own permissions"
                 )
-            if len(parts) == 2 and parts[0] == "superset" and is_admin:
+            if (
+                len(parts) == 2
+                and parts[0] == "superset"
+                and parts[1] in RESOURCE_SCOPE_ACTIONS
+                and is_admin
+            ):
                 continue
             raise ValueError(
                 f"Requested scope '{scope}' is not a recognized "

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4976,9 +4976,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if not scopes:
             return
         # pylint: disable-next=import-outside-toplevel
-        from superset.mcp_service.auth import RESOURCE_SCOPE_NAME
+        from superset.security.api_key_scopes import (
+            RESOURCE_SCOPE_ACTIONS,
+            RESOURCE_SCOPE_CLASS,
+        )
 
-        resource_for_slug = {slug: name for name, slug in RESOURCE_SCOPE_NAME.items()}
         is_admin = any(role.name == "Admin" for role in getattr(user, "roles", []))
         for raw_scope in scopes.split(","):
             scope = raw_scope.strip()
@@ -4987,14 +4989,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             parts = scope.split(":")
             if len(parts) == 3 and parts[0] == "superset":
                 _, resource_slug, action = parts
-                class_permission_name = resource_for_slug.get(resource_slug)
+                class_permission_name = RESOURCE_SCOPE_CLASS.get(resource_slug)
                 if class_permission_name is None:
                     raise ValueError(
                         f"Requested scope '{scope}' names an unrecognized "
                         f"resource '{resource_slug}'"
                     )
-                method = "read" if action == "read" else "write"
-                if self._has_view_access(user, f"can_{method}", class_permission_name):
+                if action not in RESOURCE_SCOPE_ACTIONS:
+                    raise ValueError(
+                        f"Requested scope '{scope}' names an unrecognized "
+                        f"action '{action}'"
+                    )
+                if self._has_view_access(user, f"can_{action}", class_permission_name):
                     continue
                 raise ValueError(
                     f"Requested scope '{scope}' exceeds the issuing user's "

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4994,7 +4994,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                         f"resource '{resource_slug}'"
                     )
                 method = "read" if action == "read" else "write"
-                if self.can_access(f"can_{method}", class_permission_name):
+                if self._has_view_access(user, f"can_{method}", class_permission_name):
                     continue
                 raise ValueError(
                     f"Requested scope '{scope}' exceeds the issuing user's "

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -17,6 +17,7 @@
 # pylint: disable=too-many-lines
 """A set of constants and methods to manage permissions and security"""
 
+import datetime
 import logging
 import re
 import time
@@ -4924,6 +4925,105 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         audience = self._get_guest_token_jwt_audience()
         return self.pyjwt_for_guest_token.decode(
             raw_token, secret, algorithms=[algo], audience=audience
+        )
+
+    def get_api_key_scopes(self, api_key_string: str) -> Optional[str]:
+        """Return the ``scopes`` value for a validated API key.
+
+        FAB's ``validate_api_key`` resolves the matching ``ApiKey`` row
+        internally (by lookup hash) but only returns the associated
+        ``User`` — the row's ``scopes`` column is otherwise unreachable by
+        callers. This repeats the same cheap, indexed lookup so MCP's
+        ``CompositeTokenVerifier`` can propagate per-key scopes instead of
+        silently falling back to verifier-global scopes. Call only after
+        ``validate_api_key`` has already succeeded for this token — this
+        method does not itself verify the key hash or active status.
+        """
+        lookup = self._compute_lookup_hash(api_key_string)  # type: ignore[attr-defined]
+        api_key = (
+            self.session.query(self.api_key_model)  # type: ignore[attr-defined]
+            .filter(self.api_key_model.lookup_hash == lookup)
+            .one_or_none()
+        )
+        return api_key.scopes if api_key else None
+
+    def _validate_requested_api_key_scopes(
+        self, user: Any, scopes: Optional[str]
+    ) -> None:
+        """Raise if ``scopes`` would grant a user more than their own RBAC.
+
+        Enforces the "intersection, never broader" rule confirmed for this
+        feature: a user must never be able to mint a token scoped beyond
+        what their own role already permits, even if they hand-author the
+        scopes string themselves at issuance time.
+
+        Per-resource scopes (``superset:<resource>:<action>``) are checked
+        against the user's actual ``can_<method>`` RBAC grant for that
+        resource. Flat scopes (``superset:read``/``superset:write``, the
+        pre-per-resource form) can only be self-issued by Admins — a flat
+        scope grants a method across every resource, and there's no single
+        RBAC check that soundly proves a non-Admin has that for "every
+        resource," so it's rejected for anyone else rather than guessed at.
+        Unrecognized scope strings are rejected outright (fail closed).
+
+        NOTE: this only prevents the request from being honored; it does
+        not (yet) produce a clean 400 response, since FAB's ``ApiKeyApi``
+        has no validation hook this can plug into without replacing the API
+        registration entirely. Raising here surfaces as a 500 via FAB's
+        ``@safe`` decorator until that's addressed — tracked as a known
+        follow-up, not silently accepted.
+        """
+        if not scopes:
+            return
+        # pylint: disable-next=import-outside-toplevel
+        from superset.mcp_service.auth import RESOURCE_SCOPE_NAME
+
+        resource_for_slug = {slug: name for name, slug in RESOURCE_SCOPE_NAME.items()}
+        is_admin = any(role.name == "Admin" for role in getattr(user, "roles", []))
+        for raw_scope in scopes.split(","):
+            scope = raw_scope.strip()
+            if not scope:
+                continue
+            parts = scope.split(":")
+            if len(parts) == 3 and parts[0] == "superset":
+                _, resource_slug, action = parts
+                class_permission_name = resource_for_slug.get(resource_slug)
+                if class_permission_name is None:
+                    raise ValueError(
+                        f"Requested scope '{scope}' names an unrecognized "
+                        f"resource '{resource_slug}'"
+                    )
+                method = "read" if action == "read" else "write"
+                if self.can_access(f"can_{method}", class_permission_name):
+                    continue
+                raise ValueError(
+                    f"Requested scope '{scope}' exceeds the issuing user's "
+                    "own permissions"
+                )
+            if len(parts) == 2 and parts[0] == "superset" and is_admin:
+                continue
+            raise ValueError(
+                f"Requested scope '{scope}' is not a recognized "
+                "superset:<resource>:<action> scope, or requires Admin to "
+                "self-issue as a flat scope"
+            )
+
+    def create_api_key(
+        self,
+        user: Any,
+        name: str,
+        scopes: Optional[str] = None,
+        expires_on: Optional[datetime.datetime] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Create a new API key, enforcing the scope-intersection rule.
+
+        Thin wrapper around FAB's ``SecurityManager.create_api_key`` — see
+        ``_validate_requested_api_key_scopes`` for the actual check. FAB's
+        base implementation is otherwise unchanged.
+        """
+        self._validate_requested_api_key_scopes(user, scopes)
+        return super().create_api_key(  # type: ignore[misc]
+            user=user, name=name, scopes=scopes, expires_on=expires_on
         )
 
     @staticmethod

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4979,9 +4979,13 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.security.api_key_scopes import (
             RESOURCE_SCOPE_ACTIONS,
             RESOURCE_SCOPE_CLASS,
+            SCOPE_ACTION_METHOD_PERMISSIONS,
         )
 
-        is_admin = any(role.name == "Admin" for role in getattr(user, "roles", []))
+        admin_role_name = get_conf()["AUTH_ROLE_ADMIN"]
+        is_admin = any(
+            role.name == admin_role_name for role in getattr(user, "roles", [])
+        )
         for raw_scope in scopes.split(","):
             scope = raw_scope.strip()
             if not scope:
@@ -5000,7 +5004,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                         f"Requested scope '{scope}' names an unrecognized "
                         f"action '{action}'"
                     )
-                if self._has_view_access(user, f"can_{action}", class_permission_name):
+                if any(
+                    self._has_view_access(user, f"can_{method}", class_permission_name)
+                    for method in SCOPE_ACTION_METHOD_PERMISSIONS[action]
+                ):
                     continue
                 raise ValueError(
                     f"Requested scope '{scope}' exceeds the issuing user's "

--- a/tests/integration_tests/queries/saved_queries/api_tests.py
+++ b/tests/integration_tests/queries/saved_queries/api_tests.py
@@ -18,7 +18,6 @@
 # isort:skip_file
 """Unit tests for Superset"""
 
-from datetime import datetime
 from io import BytesIO
 from typing import Optional
 from unittest.mock import Mock, patch
@@ -606,7 +605,10 @@ class TestSavedQueryApi(SupersetTestCase):
             db.session.query(SavedQuery).filter(SavedQuery.label == "label1").all()[0]
         )
         self.login(ADMIN_USERNAME)
-        with freeze_time(datetime.now()):
+        # Freeze relative to the persisted timestamp so database-specific
+        # timestamp precision cannot make the humanized value age into the
+        # next bucket while the request is being handled.
+        with freeze_time(saved_query.changed_on):
             uri = f"api/v1/saved_query/{saved_query.id}"
             rv = self.get_assert_metric(uri, "get")
             assert rv.status_code == 200

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -66,7 +66,7 @@ def mock_auth():
 
 
 @pytest.fixture(autouse=True)
-def allow_data_model_metadata():
+def allow_data_model_metadata():  # noqa: PT004
     """Keep the standalone get_schema suite in the unrestricted default path."""
     with patch.object(
         get_schema_module,
@@ -606,3 +606,21 @@ class TestGetSchemaPermissionMap:
         factories = set(get_schema_module._SCHEMA_CORE_FACTORIES.keys())
         perms = set(get_schema_module._MODEL_TYPE_CLASS_PERMISSION.keys())
         assert factories == perms
+
+    @pytest.mark.asyncio
+    async def test_resource_scope_is_enforced(self, app, mcp_server):
+        """RBAC access alone cannot bypass a scoped token's resource limit."""
+        with (
+            patch.dict(app.config, {"MCP_RBAC_ENABLED": True}),
+            patch("superset.security_manager.can_access", return_value=True),
+            patch.object(
+                get_schema_module, "_token_scope_allows", return_value=False
+            ) as scope_allows,
+        ):
+            async with Client(mcp_server) as client:
+                with pytest.raises(ToolError, match="Permission denied"):
+                    await client.call_tool(
+                        "get_schema", {"request": {"model_type": "chart"}}
+                    )
+
+        scope_allows.assert_called_once_with("read", "Chart")

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -624,3 +624,22 @@ class TestGetSchemaPermissionMap:
                     )
 
         scope_allows.assert_called_once_with("read", "Chart")
+
+    @pytest.mark.asyncio
+    async def test_resource_scope_is_enforced_when_rbac_disabled(self, app, mcp_server):
+        """The RBAC feature flag does not disable credential scopes."""
+        with (
+            patch.dict(app.config, {"MCP_RBAC_ENABLED": False}),
+            patch("superset.security_manager.can_access") as can_access,
+            patch.object(
+                get_schema_module, "_token_scope_allows", return_value=False
+            ) as scope_allows,
+        ):
+            async with Client(mcp_server) as client:
+                with pytest.raises(ToolError, match="Permission denied"):
+                    await client.call_tool(
+                        "get_schema", {"request": {"model_type": "chart"}}
+                    )
+
+        can_access.assert_not_called()
+        scope_allows.assert_called_once_with("read", "Chart")

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -23,12 +23,14 @@ import pytest
 from flask import g
 
 from superset.mcp_service.auth import (
+    _required_resource_scope,
     check_tool_permission,
     CLASS_PERMISSION_ATTR,
     is_tool_visible_to_current_user,
     MCPPermissionDeniedError,
     METHOD_PERMISSION_ATTR,
     PERMISSION_PREFIX,
+    RESOURCE_SCOPE_NAME,
 )
 
 
@@ -478,6 +480,102 @@ def test_scope_execute_sql_query_requires_write_scope(app_context) -> None:
             assert check_tool_permission(func) is False
         with _patch_token_scopes(["superset:write"]):
             assert check_tool_permission(func) is True
+
+
+# -- Per-resource scopes (superset:<resource>:<action>) --
+
+
+def test_required_resource_scope_special_names() -> None:
+    """The explicit resource map handles names a naive lower() would break:
+    'Row Level Security' (spaces) and 'ReportSchedule'/'SQLLab' (misnames)."""
+    assert _required_resource_scope("Row Level Security", "read") == "superset:rls:read"
+    assert _required_resource_scope("ReportSchedule", "write") == (
+        "superset:report:write"
+    )
+    assert _required_resource_scope("SQLLab", "execute_sql_query") == (
+        "superset:sqllab:write"
+    )
+
+
+def test_required_resource_scope_unmapped_returns_none() -> None:
+    """An unmapped resource or method yields None (no per-resource scope),
+    which callers must NOT treat as a grant."""
+    assert _required_resource_scope("NotAResource", "read") is None
+    assert _required_resource_scope("Chart", "not_a_method") is None
+
+
+def test_resource_scope_name_covers_all_tool_resource_classes() -> None:
+    """RESOURCE_SCOPE_NAME must cover every class_permission_name declared by
+    MCP tools. If a new resource class is added, add it to the map."""
+    assert set(RESOURCE_SCOPE_NAME.keys()) == {
+        "Annotation",
+        "Chart",
+        "Dashboard",
+        "Database",
+        "Dataset",
+        "Explore",
+        "Query",
+        "ReportSchedule",
+        "Role",
+        "Row Level Security",
+        "SavedQuery",
+        "SQLLab",
+        "Tag",
+        "Task",
+        "Theme",
+        "User",
+    }
+
+
+def test_per_resource_scope_grants_matching_tool(app_context) -> None:
+    """A token scoped ONLY to superset:chart:write (no flat superset:write)
+    still grants a Chart/write tool via the per-resource grant path."""
+    g.user = MagicMock(username="editor")
+    func = _make_tool_func(class_perm="Chart", method_perm="write")
+
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with (
+        patch("superset.mcp_service.auth.security_manager", mock_sm),
+        _patch_token_scopes(["superset:chart:write"]),
+    ):
+        result = check_tool_permission(func)
+
+    assert result is True
+
+
+def test_per_resource_scope_does_not_leak_across_resources(app_context) -> None:
+    """A token scoped to superset:chart:write does NOT grant a Dashboard/write
+    tool (resource isolation)."""
+    g.user = MagicMock(username="editor")
+    func = _make_tool_func(class_perm="Dashboard", method_perm="write")
+
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with (
+        patch("superset.mcp_service.auth.security_manager", mock_sm),
+        _patch_token_scopes(["superset:chart:write"]),
+    ):
+        result = check_tool_permission(func)
+
+    assert result is False
+
+
+def test_per_resource_scope_enforces_action(app_context) -> None:
+    """A token scoped to superset:chart:read does NOT grant a Chart/write tool
+    (action still enforced within the resource)."""
+    g.user = MagicMock(username="editor")
+    func = _make_tool_func(class_perm="Chart", method_perm="write")
+
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with (
+        patch("superset.mcp_service.auth.security_manager", mock_sm),
+        _patch_token_scopes(["superset:chart:read"]),
+    ):
+        result = check_tool_permission(func)
+
+    assert result is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -495,6 +495,7 @@ def test_required_resource_scope_special_names() -> None:
     assert _required_resource_scope("SQLLab", "execute_sql_query") == (
         "superset:sqllab:write"
     )
+    assert _required_resource_scope("Chart", "update") == "superset:chart:write"
 
 
 def test_required_resource_scope_unmapped_returns_none() -> None:

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -449,7 +449,9 @@ def test_scope_read_denied_when_token_lacks_read_scope(app_context) -> None:
     assert result is False
 
 
-def test_scope_denies_unmapped_method_for_scoped_token(app_context) -> None:
+def test_scope_denies_unmapped_method_for_scoped_token(
+    app_context, caplog: pytest.LogCaptureFixture
+) -> None:
     """A scoped token presented for a method permission that is NOT in the
     scope map fails closed (denied), even when RBAC grants, so an unmapped
     custom permission cannot silently bypass scope enforcement."""
@@ -465,6 +467,8 @@ def test_scope_denies_unmapped_method_for_scoped_token(app_context) -> None:
         result = check_tool_permission(func)
 
     assert result is False
+    assert "unmapped method permission 'some_custom_perm'" in caplog.text
+    assert "required scope 'None'" not in caplog.text
 
 
 def test_scope_execute_sql_query_requires_write_scope(app_context) -> None:

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -110,6 +110,17 @@ def test_check_tool_permission_no_class_permission_allows(app_context) -> None:
     assert check_tool_permission(func) is True
 
 
+def test_scoped_token_constrains_permissionless_tool(app_context) -> None:
+    """Resource-only scopes do not grant permission-less tools."""
+    g.user = MagicMock(username="admin")
+    func = _make_tool_func()
+
+    with _patch_token_scopes(["superset:dashboard:read"]):
+        assert check_tool_permission(func) is False
+    with _patch_token_scopes(["superset:read"]):
+        assert check_tool_permission(func) is True
+
+
 def test_check_tool_permission_no_user_denies(app_context) -> None:
     """If no g.user, permission check should deny."""
     g.user = None

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -183,6 +183,19 @@ def test_check_tool_permission_disabled_via_config(app_context, app) -> None:
         app.config["MCP_RBAC_ENABLED"] = True
 
 
+def test_disabled_rbac_still_enforces_token_scopes(app_context, app) -> None:
+    """Disabling user RBAC does not disable credential restrictions."""
+    func = _make_tool_func(class_perm="Chart", method_perm="write")
+    app.config["MCP_RBAC_ENABLED"] = False
+    try:
+        with _patch_token_scopes(["superset:dashboard:read"]):
+            assert check_tool_permission(func) is False
+        with _patch_token_scopes(["superset:chart:write"]):
+            assert check_tool_permission(func) is True
+    finally:
+        app.config["MCP_RBAC_ENABLED"] = True
+
+
 # -- Permission constants --
 
 
@@ -300,6 +313,19 @@ def test_visibility_public_tool_no_class_permission(app_context) -> None:
     tool = MagicMock()
     tool.fn = func
     assert is_tool_visible_to_current_user(tool) is True
+
+
+def test_visibility_hides_permissionless_tool_from_resource_scoped_token(
+    app_context,
+) -> None:
+    """Permission-less tools require a flat scope in tools/list too."""
+    g.user = MagicMock(username="viewer")
+    tool = _make_mock_tool(fn=_make_tool_func())
+
+    with _patch_token_scopes(["superset:dashboard:read"]):
+        assert is_tool_visible_to_current_user(tool) is False
+    with _patch_token_scopes(["superset:read"]):
+        assert is_tool_visible_to_current_user(tool) is True
 
 
 def test_visibility_allowed_tool(app_context) -> None:
@@ -442,6 +468,23 @@ def test_scope_falls_back_to_rbac_when_no_jwt_context(app_context) -> None:
         result = check_tool_permission(func)
 
     assert result is True
+
+
+def test_scope_context_error_fails_closed(app_context) -> None:
+    """An unexpected token lookup failure cannot erase token restrictions."""
+    g.user = MagicMock(username="editor")
+    func = _make_tool_func(class_perm="Chart", method_perm="read")
+
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with (
+        patch("superset.mcp_service.auth.security_manager", mock_sm),
+        patch(
+            "fastmcp.server.dependencies.get_access_token",
+            side_effect=TypeError("invalid token context"),
+        ),
+    ):
+        assert check_tool_permission(func) is False
 
 
 def test_scope_read_denied_when_token_lacks_read_scope(app_context) -> None:

--- a/tests/unit_tests/mcp_service/test_composite_token_verifier.py
+++ b/tests/unit_tests/mcp_service/test_composite_token_verifier.py
@@ -233,13 +233,22 @@ async def test_api_key_passthrough_propagates_required_scopes() -> None:
 # -- Transport-layer DB validation (app configured) --
 
 
-def _make_app_with_api_key(username: str | None) -> MagicMock:
-    """Return a mock Flask app whose SecurityManager validates to ``username``."""
+def _make_app_with_api_key(
+    username: str | None, scopes: str | None = None
+) -> MagicMock:
+    """Return a mock Flask app whose SecurityManager validates to ``username``.
+
+    ``scopes`` is what ``get_api_key_scopes`` returns (FAB stores scopes as a
+    comma-separated string, or None). It must be configured explicitly — an
+    unconfigured MagicMock return value would raise on ``.split(",")`` inside
+    the verifier's broad except-block and silently read as a rejected key.
+    """
     mock_user = MagicMock()
     mock_user.username = username
 
     mock_sm = MagicMock()
     mock_sm.validate_api_key = MagicMock(return_value=mock_user if username else None)
+    mock_sm.get_api_key_scopes = MagicMock(return_value=scopes)
 
     mock_app = MagicMock()
     mock_app.app_context.return_value.__enter__ = MagicMock(return_value=None)
@@ -262,6 +271,43 @@ async def test_transport_validation_valid_key_returns_access_token() -> None:
     assert result.client_id == "api_key"
     assert result.claims.get(API_KEY_PASSTHROUGH_CLAIM) is True
     assert result.claims.get(API_KEY_VALIDATED_USERNAME_CLAIM) == "alice"
+
+
+@pytest.mark.asyncio
+async def test_transport_validation_uses_keys_own_scopes() -> None:
+    """A key with its own ApiKey.scopes carries them on the AccessToken,
+    parsed from FAB's comma-separated storage format."""
+    mock_app = _make_app_with_api_key(
+        "alice", scopes="superset:dashboard:read, superset:chart:read"
+    )
+    verifier = CompositeTokenVerifier(
+        jwt_verifier=None, api_key_prefixes=["sst_"], app=mock_app
+    )
+
+    result = await verifier.verify_token("sst_valid_key")
+
+    assert result is not None
+    assert result.scopes == ["superset:dashboard:read", "superset:chart:read"]
+
+
+@pytest.mark.asyncio
+async def test_transport_validation_no_key_scopes_falls_back_to_required() -> None:
+    """A key without its own scopes falls back to the verifier-global
+    required_scopes (back-compat: "no scopes advertised")."""
+    mock_app = _make_app_with_api_key("alice", scopes=None)
+    jwt_verifier = MagicMock()
+    jwt_verifier.required_scopes = ["superset:read"]
+    jwt_verifier.verify_token = AsyncMock()
+
+    verifier = CompositeTokenVerifier(
+        jwt_verifier=jwt_verifier, api_key_prefixes=["sst_"], app=mock_app
+    )
+
+    result = await verifier.verify_token("sst_valid_key")
+
+    assert result is not None
+    assert result.scopes == list(verifier.required_scopes)
+    assert result.scopes == ["superset:read"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/test_composite_token_verifier.py
+++ b/tests/unit_tests/mcp_service/test_composite_token_verifier.py
@@ -291,9 +291,8 @@ async def test_transport_validation_uses_keys_own_scopes() -> None:
 
 
 @pytest.mark.asyncio
-async def test_transport_validation_no_key_scopes_falls_back_to_required() -> None:
-    """A key without its own scopes falls back to the verifier-global
-    required_scopes (back-compat: "no scopes advertised")."""
+async def test_transport_validation_no_key_scopes_remains_unscoped() -> None:
+    """A key without scopes remains unscoped despite global JWT requirements."""
     mock_app = _make_app_with_api_key("alice", scopes=None)
     jwt_verifier = MagicMock()
     jwt_verifier.required_scopes = ["superset:read"]
@@ -306,8 +305,7 @@ async def test_transport_validation_no_key_scopes_falls_back_to_required() -> No
     result = await verifier.verify_token("sst_valid_key")
 
     assert result is not None
-    assert result.scopes == list(verifier.required_scopes)
-    assert result.scopes == ["superset:read"]
+    assert result.scopes == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for API key scope validation in SupersetSecurityManager.
+
+Covers the "intersection, never broader" rule: a user must not be able to
+mint an API key scoped beyond what their own RBAC already permits.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.extensions import appbuilder
+from superset.security.manager import SupersetSecurityManager
+
+
+def _make_user(*role_names: str) -> MagicMock:
+    """Build a mock user whose roles carry the given names."""
+    user = MagicMock()
+    roles = []
+    for role_name in role_names:
+        role = MagicMock()
+        role.name = role_name
+        roles.append(role)
+    user.roles = roles
+    return user
+
+
+@pytest.fixture
+def sm(app_context: None) -> SupersetSecurityManager:
+    return SupersetSecurityManager(appbuilder)
+
+
+def test_no_scopes_is_a_noop(sm: SupersetSecurityManager) -> None:
+    """No scopes requested: nothing to validate, no RBAC lookups."""
+    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._validate_requested_api_key_scopes(_make_user("Gamma"), None)
+    sm._validate_requested_api_key_scopes(_make_user("Gamma"), "")
+    sm.can_access.assert_not_called()
+
+
+def test_per_resource_scope_allowed_when_user_has_permission(
+    sm: SupersetSecurityManager,
+) -> None:
+    """A per-resource scope the user's RBAC covers is allowed, and is checked
+    against the matching can_<method> grant."""
+    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
+    sm._validate_requested_api_key_scopes(
+        _make_user("Gamma"), "superset:dashboard:read"
+    )
+    sm.can_access.assert_called_once_with("can_read", "Dashboard")
+
+
+def test_per_resource_scope_rejected_when_user_lacks_permission(
+    sm: SupersetSecurityManager,
+) -> None:
+    """A per-resource scope beyond the user's RBAC is rejected."""
+    sm.can_access = MagicMock(return_value=False)  # type: ignore[method-assign]
+    with pytest.raises(ValueError, match="exceeds the issuing user's own"):
+        sm._validate_requested_api_key_scopes(
+            _make_user("Gamma"), "superset:dashboard:write"
+        )
+
+
+@pytest.mark.parametrize("action", ["delete", "update"])
+def test_non_read_actions_map_to_can_write(
+    sm: SupersetSecurityManager, action: str
+) -> None:
+    """Non-read actions check can_write — matching the current RBAC
+    granularity, which has no separate can_delete/can_update on resources."""
+    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
+    sm._validate_requested_api_key_scopes(
+        _make_user("Gamma"), f"superset:chart:{action}"
+    )
+    sm.can_access.assert_called_once_with("can_write", "Chart")
+
+
+def test_unrecognized_resource_slug_rejected_without_rbac_lookup(
+    sm: SupersetSecurityManager,
+) -> None:
+    """An unknown resource slug is rejected outright (fail closed) and never
+    consults RBAC."""
+    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    with pytest.raises(ValueError, match="unrecognized resource"):
+        sm._validate_requested_api_key_scopes(
+            _make_user("Admin"), "superset:notathing:read"
+        )
+    sm.can_access.assert_not_called()
+
+
+def test_flat_scope_allowed_for_admin(sm: SupersetSecurityManager) -> None:
+    """A flat scope (superset:write) may be self-issued by an Admin, with no
+    per-resource RBAC lookups."""
+    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._validate_requested_api_key_scopes(_make_user("Admin"), "superset:write")
+    sm.can_access.assert_not_called()
+
+
+def test_flat_scope_rejected_for_non_admin(sm: SupersetSecurityManager) -> None:
+    """A flat scope grants a method across every resource; non-Admins cannot
+    self-issue it."""
+    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    with pytest.raises(ValueError, match="requires Admin"):
+        sm._validate_requested_api_key_scopes(_make_user("Gamma"), "superset:write")
+
+
+def test_any_failing_scope_rejects_the_whole_request(
+    sm: SupersetSecurityManager,
+) -> None:
+    """With multiple comma-separated scopes, one failure rejects the request
+    even when other scopes are individually allowed."""
+    sm.can_access = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda perm, view: view == "Chart"
+    )
+    with pytest.raises(ValueError, match="exceeds the issuing user's own"):
+        sm._validate_requested_api_key_scopes(
+            _make_user("Gamma"),
+            "superset:chart:read, superset:dashboard:write",
+        )
+
+
+def test_create_api_key_rejects_before_delegating_to_fab(
+    sm: SupersetSecurityManager,
+) -> None:
+    """create_api_key validates scopes BEFORE calling FAB's implementation:
+    a rejected request never reaches FAB."""
+    sm.can_access = MagicMock(return_value=False)  # type: ignore[method-assign]
+    with patch(
+        "flask_appbuilder.security.sqla.manager.SecurityManager.create_api_key"
+    ) as fab_create:
+        with pytest.raises(ValueError, match="exceeds the issuing user's own"):
+            sm.create_api_key(
+                user=_make_user("Gamma"),
+                name="my key",
+                scopes="superset:dashboard:write",
+            )
+        fab_create.assert_not_called()
+
+
+def test_create_api_key_delegates_to_fab_on_success(
+    sm: SupersetSecurityManager,
+) -> None:
+    """A validated request is delegated to FAB's create_api_key unchanged."""
+    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
+    user = _make_user("Gamma")
+    with patch(
+        "flask_appbuilder.security.sqla.manager.SecurityManager.create_api_key",
+        return_value={"key": "sst_secret"},
+    ) as fab_create:
+        result = sm.create_api_key(
+            user=user,
+            name="my key",
+            scopes="superset:dashboard:read",
+        )
+        fab_create.assert_called_once_with(
+            user=user, name="my key", scopes="superset:dashboard:read", expires_on=None
+        )
+    assert result == {"key": "sst_secret"}

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -76,16 +76,17 @@ def test_per_resource_scope_rejected_when_user_lacks_permission(
         )
 
 
-@pytest.mark.parametrize("action", ["delete", "update"])
-def test_non_read_actions_map_to_can_write(
+@pytest.mark.parametrize("action", ["delete", "update", "garbage"])
+def test_unrecognized_actions_are_rejected(
     sm: SupersetSecurityManager, action: str
 ) -> None:
-    """Non-read actions check can_write — matching the current RBAC
-    granularity, which has no separate can_delete/can_update on resources."""
-    sm._has_view_access = MagicMock(return_value=True)
-    user = _make_user("Gamma")
-    sm._validate_requested_api_key_scopes(user, f"superset:chart:{action}")
-    sm._has_view_access.assert_called_once_with(user, "can_write", "Chart")
+    """Actions that runtime enforcement cannot consume are rejected."""
+    sm._has_view_access = MagicMock()
+    with pytest.raises(ValueError, match="unrecognized action"):
+        sm._validate_requested_api_key_scopes(
+            _make_user("Gamma"), f"superset:chart:{action}"
+        )
+    sm._has_view_access.assert_not_called()
 
 
 def test_unrecognized_resource_slug_rejected_without_rbac_lookup(

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -76,6 +76,42 @@ def test_per_resource_scope_rejected_when_user_lacks_permission(
         )
 
 
+@pytest.mark.parametrize(
+    ("scope", "registered_permission"),
+    [
+        ("superset:user:read", "can_get"),
+        ("superset:role:read", "can_get"),
+        ("superset:sqllab:write", "can_execute_sql_query"),
+    ],
+)
+def test_scope_issuance_uses_runtime_method_mapping(
+    sm: SupersetSecurityManager, scope: str, registered_permission: str
+) -> None:
+    """Issuance accepts the FAB method permission used by runtime tools."""
+    user = _make_user("Gamma")
+    sm._has_view_access = MagicMock(
+        side_effect=lambda _user, permission, _view: permission == registered_permission
+    )
+
+    sm._validate_requested_api_key_scopes(user, scope)
+
+    assert any(
+        call.args[1] == registered_permission
+        for call in sm._has_view_access.call_args_list
+    )
+
+
+def test_custom_admin_role_can_issue_flat_scope(
+    sm: SupersetSecurityManager,
+) -> None:
+    """Flat-scope issuance honors AUTH_ROLE_ADMIN rather than a fixed name."""
+    with patch("superset.security.manager.get_conf") as get_conf:
+        get_conf.return_value = {"AUTH_ROLE_ADMIN": "PlatformAdmin"}
+        sm._validate_requested_api_key_scopes(
+            _make_user("PlatformAdmin"), "superset:write"
+        )
+
+
 @pytest.mark.parametrize("action", ["delete", "update", "garbage"])
 def test_unrecognized_actions_are_rejected(
     sm: SupersetSecurityManager, action: str

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -21,11 +21,17 @@ Covers the "intersection, never broader" rule: a user must not be able to
 mint an API key scoped beyond what their own RBAC already permits.
 """
 
+import re
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from superset.extensions import appbuilder
+from superset.security.api_key_scopes import (
+    RESOURCE_SCOPE_ACTIONS,
+    RESOURCE_SCOPE_CLASS,
+)
 from superset.security.manager import SupersetSecurityManager
 
 
@@ -44,6 +50,33 @@ def _make_user(*role_names: str) -> MagicMock:
 @pytest.fixture
 def sm(app_context: None) -> SupersetSecurityManager:
     return SupersetSecurityManager(appbuilder)
+
+
+def test_frontend_scope_catalog_matches_backend_contract() -> None:
+    """Keep the UI picker aligned with the canonical enforcement vocabulary."""
+    frontend_catalog = (
+        Path(__file__).parents[3]
+        / "superset-frontend/src/features/apiKeys/apiKeyScopes.ts"
+    ).read_text()
+    resources_source = re.search(
+        r"const API_KEY_SCOPE_RESOURCES = \[(.*?)\] as const;",
+        frontend_catalog,
+        re.DOTALL,
+    )
+    actions_source = re.search(
+        r"const API_KEY_SCOPE_ACTIONS = \[(.*?)\] as const;",
+        frontend_catalog,
+        re.DOTALL,
+    )
+
+    assert resources_source is not None
+    assert actions_source is not None
+    assert set(re.findall(r"'([^']+)'", resources_source.group(1))) == set(
+        RESOURCE_SCOPE_CLASS
+    )
+    assert set(re.findall(r"'([^']+)'", actions_source.group(1))) == set(
+        RESOURCE_SCOPE_ACTIONS
+    )
 
 
 def test_no_scopes_is_a_noop(sm: SupersetSecurityManager) -> None:

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -110,6 +110,16 @@ def test_flat_scope_allowed_for_admin(sm: SupersetSecurityManager) -> None:
     sm._has_view_access.assert_not_called()
 
 
+def test_unrecognized_flat_scope_rejected_for_admin(
+    sm: SupersetSecurityManager,
+) -> None:
+    """Admins cannot mint undefined flat scopes."""
+    sm._has_view_access = MagicMock()
+    with pytest.raises(ValueError, match="not a recognized"):
+        sm._validate_requested_api_key_scopes(_make_user("Admin"), "superset:garbage")
+    sm._has_view_access.assert_not_called()
+
+
 def test_flat_scope_rejected_for_non_admin(sm: SupersetSecurityManager) -> None:
     """A flat scope grants a method across every resource; non-Admins cannot
     self-issue it."""

--- a/tests/unit_tests/security/test_api_key_scopes.py
+++ b/tests/unit_tests/security/test_api_key_scopes.py
@@ -48,10 +48,10 @@ def sm(app_context: None) -> SupersetSecurityManager:
 
 def test_no_scopes_is_a_noop(sm: SupersetSecurityManager) -> None:
     """No scopes requested: nothing to validate, no RBAC lookups."""
-    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock()
     sm._validate_requested_api_key_scopes(_make_user("Gamma"), None)
     sm._validate_requested_api_key_scopes(_make_user("Gamma"), "")
-    sm.can_access.assert_not_called()
+    sm._has_view_access.assert_not_called()
 
 
 def test_per_resource_scope_allowed_when_user_has_permission(
@@ -59,18 +59,17 @@ def test_per_resource_scope_allowed_when_user_has_permission(
 ) -> None:
     """A per-resource scope the user's RBAC covers is allowed, and is checked
     against the matching can_<method> grant."""
-    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
-    sm._validate_requested_api_key_scopes(
-        _make_user("Gamma"), "superset:dashboard:read"
-    )
-    sm.can_access.assert_called_once_with("can_read", "Dashboard")
+    sm._has_view_access = MagicMock(return_value=True)
+    user = _make_user("Gamma")
+    sm._validate_requested_api_key_scopes(user, "superset:dashboard:read")
+    sm._has_view_access.assert_called_once_with(user, "can_read", "Dashboard")
 
 
 def test_per_resource_scope_rejected_when_user_lacks_permission(
     sm: SupersetSecurityManager,
 ) -> None:
     """A per-resource scope beyond the user's RBAC is rejected."""
-    sm.can_access = MagicMock(return_value=False)  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock(return_value=False)
     with pytest.raises(ValueError, match="exceeds the issuing user's own"):
         sm._validate_requested_api_key_scopes(
             _make_user("Gamma"), "superset:dashboard:write"
@@ -83,11 +82,10 @@ def test_non_read_actions_map_to_can_write(
 ) -> None:
     """Non-read actions check can_write — matching the current RBAC
     granularity, which has no separate can_delete/can_update on resources."""
-    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
-    sm._validate_requested_api_key_scopes(
-        _make_user("Gamma"), f"superset:chart:{action}"
-    )
-    sm.can_access.assert_called_once_with("can_write", "Chart")
+    sm._has_view_access = MagicMock(return_value=True)
+    user = _make_user("Gamma")
+    sm._validate_requested_api_key_scopes(user, f"superset:chart:{action}")
+    sm._has_view_access.assert_called_once_with(user, "can_write", "Chart")
 
 
 def test_unrecognized_resource_slug_rejected_without_rbac_lookup(
@@ -95,26 +93,26 @@ def test_unrecognized_resource_slug_rejected_without_rbac_lookup(
 ) -> None:
     """An unknown resource slug is rejected outright (fail closed) and never
     consults RBAC."""
-    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock()
     with pytest.raises(ValueError, match="unrecognized resource"):
         sm._validate_requested_api_key_scopes(
             _make_user("Admin"), "superset:notathing:read"
         )
-    sm.can_access.assert_not_called()
+    sm._has_view_access.assert_not_called()
 
 
 def test_flat_scope_allowed_for_admin(sm: SupersetSecurityManager) -> None:
     """A flat scope (superset:write) may be self-issued by an Admin, with no
     per-resource RBAC lookups."""
-    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock()
     sm._validate_requested_api_key_scopes(_make_user("Admin"), "superset:write")
-    sm.can_access.assert_not_called()
+    sm._has_view_access.assert_not_called()
 
 
 def test_flat_scope_rejected_for_non_admin(sm: SupersetSecurityManager) -> None:
     """A flat scope grants a method across every resource; non-Admins cannot
     self-issue it."""
-    sm.can_access = MagicMock()  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock()
     with pytest.raises(ValueError, match="requires Admin"):
         sm._validate_requested_api_key_scopes(_make_user("Gamma"), "superset:write")
 
@@ -124,8 +122,8 @@ def test_any_failing_scope_rejects_the_whole_request(
 ) -> None:
     """With multiple comma-separated scopes, one failure rejects the request
     even when other scopes are individually allowed."""
-    sm.can_access = MagicMock(  # type: ignore[method-assign]
-        side_effect=lambda perm, view: view == "Chart"
+    sm._has_view_access = MagicMock(
+        side_effect=lambda user, perm, view: view == "Chart"
     )
     with pytest.raises(ValueError, match="exceeds the issuing user's own"):
         sm._validate_requested_api_key_scopes(
@@ -139,7 +137,7 @@ def test_create_api_key_rejects_before_delegating_to_fab(
 ) -> None:
     """create_api_key validates scopes BEFORE calling FAB's implementation:
     a rejected request never reaches FAB."""
-    sm.can_access = MagicMock(return_value=False)  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock(return_value=False)
     with patch(
         "flask_appbuilder.security.sqla.manager.SecurityManager.create_api_key"
     ) as fab_create:
@@ -156,7 +154,7 @@ def test_create_api_key_delegates_to_fab_on_success(
     sm: SupersetSecurityManager,
 ) -> None:
     """A validated request is delegated to FAB's create_api_key unchanged."""
-    sm.can_access = MagicMock(return_value=True)  # type: ignore[method-assign]
+    sm._has_view_access = MagicMock(return_value=True)
     user = _make_user("Gamma")
     with patch(
         "flask_appbuilder.security.sqla.manager.SecurityManager.create_api_key",


### PR DESCRIPTION
### SUMMARY
Adds per-resource token scopes (`superset:<resource>:<action>`, e.g. `superset:dashboard:read`) to the MCP service, and wires the already-existing (but previously inert) FAB `ApiKey.scopes` column into enforcement. Follows up on the flat `superset:read`/`superset:write` scope enforcement shipped in #40653, and piggybacks on SIP-202 (#37971) rather than a new SIP.

Four pieces:

1. **API keys now carry their own scopes.** `CompositeTokenVerifier` previously stamped API-key tokens with the verifier-global `required_scopes` instead of the key's own `ApiKey.scopes` column (which FAB persists but nothing ever read back). `_validate_api_key_sync` now returns `(username, scopes)` via a new `SupersetSecurityManager.get_api_key_scopes()` lookup, and `verify_token` puts the key's own scopes on the `AccessToken`. Keys with no scopes fall back to the previous behavior ("no scopes advertised" → RBAC-only, fully back-compat).

2. **Per-resource scope checks in the MCP auth layer.** `_token_scope_allows()` accepts the tool's `class_permission_name` and grants access if the token carries either the flat method scope (`superset:write`) **or** the matching per-resource scope (`superset:chart:write`). Resources map to scope slugs via an explicit `RESOURCE_SCOPE_NAME` dict (16 entries) rather than a naive `.lower()` transform, which breaks for `"Row Level Security"` (spaces) and misnames `ReportSchedule`/`SQLLab`. Already-issued flat-scoped tokens keep working unchanged; unmapped resources/methods stay fail-closed.

3. **Issuance-time intersection validation.** `SupersetSecurityManager.create_api_key()` now validates requested scopes against the issuing user's own RBAC before delegating to FAB: a user can never mint a key scoped beyond what their own role permits. Per-resource scopes are checked against the user's `can_read`/`can_write` grant for that resource; flat scopes are Admin-only to self-issue; unrecognized scope strings are rejected (fail closed).

4. **Scope picker UI.** The API-key creation modal offers the supported per-resource read/write scopes, serializes the selections for FAB, explains that scopes only restrict existing RBAC, and the key list indicates scoped versus legacy RBAC-only keys.

Design decisions and known limitations:
- The scope **action** reuses the existing `method_permission_name` vocabulary (`read`/`write`, with `delete`/`execute_sql_query` treated as write-class), matching the current RBAC granularity. A finer `create/read/update/delete/execute` action taxonomy requires a `scope_action` parameter on the `@tool` decorator in the separate `superset-core` package — deliberately out of scope here.
- Scope-validation rejections at issuance currently surface as HTTP 500 (via FAB's `@safe`) rather than a clean 400, because FAB's `ApiKeyApi` has no validation hook to plug into. Tracked as a follow-up; noted in the validator's docstring.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The existing API-key creation modal now includes an optional searchable multi-select for resource scopes, and the API-key list shows whether each key is scoped or RBAC-only.

### TESTING INSTRUCTIONS
```bash
pytest tests/unit_tests/mcp_service/test_auth_rbac.py \
       tests/unit_tests/mcp_service/test_composite_token_verifier.py \
       tests/unit_tests/security/test_api_key_scopes.py

cd superset-frontend
yarn test apiKeyScopes.test.ts --runInBand
```
Manual verification: with `FAB_API_KEY_ENABLED=True` and MCP auth configured, create an API key with `scopes="superset:dashboard:read"` (as a user who can read dashboards); calling MCP with that key allows `list_dashboards`/`get_dashboard_info` but denies chart tools and all write tools. Creating a key with a scope the user's role doesn't grant (or a flat `superset:write` as a non-Admin) is rejected. Keys created without scopes behave exactly as before (RBAC-only).

### ADDITIONAL INFORMATION
- [x] Has associated issue: SIP-202 ([#37971](https://github.com/apache/superset/issues/37971)); follows the initial MCP scope work in [#40653](https://github.com/apache/superset/pull/40653)
- [x] Required feature flags/configuration: `FAB_API_KEY_ENABLED=True` exposes API-key management; MCP API-key authentication must also be enabled (`MCP_API_KEY_ENABLED=True`, or its default fallback to `FAB_API_KEY_ENABLED`). `MCP_RBAC_ENABLED=True` remains the recommended setting. No new feature flag is introduced by this PR.
- [x] Changes UI: adds the optional MCP scope picker and scope status to API-key management
- [ ] Includes DB Migration: **No.** This uses FAB's existing `ApiKey.scopes` column; no schema change is included. (SIP-59 migration approval is not applicable.)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible — N/A
  - [ ] Confirm DB migration upgrade and downgrade tested — N/A
  - [ ] Runtime estimates and downtime expectations provided — N/A; no migration or expected downtime
- [x] Introduces new feature or API: adds MCP per-resource scope issuance, propagation, enforcement, and UI selection; it does not add a new REST endpoint
- [ ] Removes existing feature or API: **No.** Legacy unscoped API keys retain RBAC-only behavior, and existing flat MCP scopes remain supported.




<img width="1724" height="965" alt="Screenshot 2026-08-17 at 5 05 25 PM" src="https://github.com/user-attachments/assets/95d1c088-f70a-4e14-8fbb-f898f53bedf2" />
<img width="1719" height="956" alt="Screenshot 2026-08-17 at 5 05 16 PM" src="https://github.com/user-attachments/assets/d8e0fe07-baa8-47b7-8292-e1b503d28b95" />
<img width="1723" height="953" alt="Screenshot 2026-08-17 at 5 05 07 PM" src="https://github.com/user-attachments/assets/46070546-5517-4505-b579-2c1a46d1ffeb" />
<img width="1730" height="950" alt="Screenshot 2026-08-17 at 5 04 52 PM" src="https://github.com/user-attachments/assets/edab70ba-466f-4461-9088-d2862cbc07a4" />
<img width="1724" height="967" alt="Screenshot 2026-08-17 at 5 04 33 PM" src="https://github.com/user-attachments/assets/863bcd67-9617-43ef-9912-b2f8f83c2d26" />
