### PR TITLE
fix(clickhouse): retry adhoc column type probe with comment-safe SQL

### DIFF
--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -161,6 +161,21 @@ def get_columns_description(
             db_engine_spec.execute(cursor, mutated_query, database)
             result = db_engine_spec.fetch_data(cursor, limit=limit)
             result_set = SupersetResultSet(result, cursor.description, db_engine_spec)
+            if not result_set.columns and (
+                retry_sql := db_engine_spec.get_column_description_retry_sql(
+                    mutated_query
+                )
+            ):
+                # Some drivers (e.g. clickhouse-connect) fail to populate
+                # cursor.description for a legitimate zero-row metadata probe
+                # once SQL_QUERY_MUTATOR has added leading comments. Retry
+                # once with a comment-safe wrapped query -- see
+                # get_column_description_retry_sql -- before giving up.
+                db_engine_spec.execute(cursor, retry_sql, database)
+                result = db_engine_spec.fetch_data(cursor, limit=limit)
+                result_set = SupersetResultSet(
+                    result, cursor.description, db_engine_spec
+                )
             return result_set.columns
     except Exception as ex:
         raise SupersetGenericDBErrorException(message=str(ex)) from ex

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -2353,6 +2353,36 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         return 1
 
+    @classmethod
+    def get_column_description_retry_sql(cls, sql: str) -> str | None:
+        """
+        Build a comment-safe fallback query for ``get_columns_description`` to
+        retry with when a zero-row metadata probe unexpectedly comes back with
+        an empty ``cursor.description``.
+
+        Some DB-API drivers only run their own "empty result" metadata
+        fallback -- used to populate ``cursor.description`` when a query
+        legitimately returns zero rows -- when the executed SQL text starts
+        with ``SELECT``/``WITH``. ``SQL_QUERY_MUTATOR`` can prepend comments
+        (e.g. query attribution) ahead of the ``SELECT`` keyword, which
+        defeats that startswith check on those drivers even though the query
+        itself is valid.
+
+        Engine specs affected by this can override this hook to wrap the
+        already-mutated SQL passed in so that the outer statement always
+        starts with a bare ``SELECT``. The original SQL -- including any
+        comments added by ``SQL_QUERY_MUTATOR`` -- is preserved verbatim, so
+        no mutation/audit behavior is lost, and the wrapped query still
+        returns zero rows.
+
+        Returning ``None`` (the default) means the engine doesn't support or
+        need this retry.
+
+        :param sql: The already limited and mutated SQL that was executed
+        :return: A comment-safe SQL string to retry with, or ``None``
+        """
+        return None
+
     @staticmethod
     def pyodbc_rows_to_tuples(data: list[Any]) -> list[tuple[Any, ...]]:
         """

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -531,3 +531,15 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
         if schema:
             uri = uri.set(database=parse.quote(schema, safe=""))
         return uri, connect_args
+
+    @classmethod
+    def get_column_description_retry_sql(cls, sql: str) -> str | None:
+        # clickhouse-connect's cursor only backfills `cursor.description` for
+        # a zero-row result -- e.g. the `WHERE false` probe used to detect an
+        # adhoc column's type without scanning any rows -- when the operation
+        # string starts with SELECT/WITH after stripping whitespace. Leading
+        # SQL comments inserted by SQL_QUERY_MUTATOR (e.g. query attribution)
+        # defeat that check, so wrap the untouched, already-mutated SQL in a
+        # bare outer SELECT to satisfy it without altering or dropping any of
+        # the mutator's comments.
+        return f"SELECT * FROM (\n{sql}\n) AS __superset_type_probe LIMIT 0"  # noqa: S608

--- a/tests/unit_tests/connectors/sqla/utils_test.py
+++ b/tests/unit_tests/connectors/sqla/utils_test.py
@@ -171,6 +171,103 @@ def test_get_virtual_table_metadata_zero_row_query(
     assert [col["column_name"] for col in columns] == ["id", "name", "event_date"]
 
 
+def test_get_columns_description_retries_with_comment_safe_sql_when_empty(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression test for SC-114843: when the mutated query comes back with an
+    empty cursor.description (e.g. clickhouse-connect 0.14.1 failing to
+    backfill metadata for a comment-prefixed, zero-row query), and the engine
+    spec provides a comment-safe retry query via
+    ``get_column_description_retry_sql``, ``get_columns_description`` must
+    retry once with that query rather than giving up.
+    """
+    database = mocker.MagicMock()
+    cursor = mocker.MagicMock()
+
+    retry_sql = (
+        "SELECT * FROM (\n-- comment\nSELECT 1\n) AS __superset_type_probe LIMIT 0"
+    )
+    db_engine_spec = mocker.MagicMock()
+    db_engine_spec.get_column_description_retry_sql.return_value = retry_sql
+
+    database.get_raw_connection.return_value.__enter__.return_value.cursor.return_value = cursor  # noqa: E501
+    database.db_engine_spec = db_engine_spec
+    database.apply_limit_to_sql.return_value = "SELECT 1 WHERE false"
+    database.mutate_sql_based_on_config.return_value = (
+        "-- comment\nSELECT 1 WHERE false"
+    )
+
+    # First SupersetResultSet() (empty) has no columns; second (after retry)
+    # does.
+    empty_result_set = mocker.MagicMock(columns=[])
+    real_result_set = mocker.MagicMock(columns=[{"name": "Duration"}])
+    mocker.patch(
+        "superset.connectors.sqla.utils.SupersetResultSet",
+        side_effect=[empty_result_set, real_result_set],
+    )
+
+    columns = get_columns_description(
+        database, "catalog", "schema", "SELECT 1 WHERE false"
+    )
+
+    assert columns == [{"name": "Duration"}]
+    db_engine_spec.get_column_description_retry_sql.assert_called_once_with(
+        "-- comment\nSELECT 1 WHERE false"
+    )
+    # The original mutated (comment-prefixed) query is executed directly
+    # once, and then -- because the first metadata result came back empty --
+    # db_engine_spec.execute() is invoked a second time with the
+    # comment-safe retry query.
+    assert cursor.execute.call_count == 1
+    assert cursor.execute.call_args_list[0].args[0] == (
+        "-- comment\nSELECT 1 WHERE false"
+    )
+    assert db_engine_spec.execute.call_count == 2
+    assert db_engine_spec.execute.call_args_list[0].args[:2] == (
+        cursor,
+        "-- comment\nSELECT 1 WHERE false",
+    )
+    assert db_engine_spec.execute.call_args_list[1].args[:2] == (cursor, retry_sql)
+
+
+def test_get_columns_description_no_retry_when_engine_has_no_hook(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Engines that don't opt into ``get_column_description_retry_sql`` (i.e.
+    the default ``None`` from BaseEngineSpec) must not have their behavior
+    changed by this fix, even when a query legitimately returns zero
+    columns.
+    """
+    database = mocker.MagicMock()
+    cursor = mocker.MagicMock()
+    cursor.description = []
+
+    result_set = mocker.MagicMock(columns=[])
+    db_engine_spec = mocker.MagicMock()
+    db_engine_spec.get_column_description_retry_sql.return_value = None
+
+    database.get_raw_connection.return_value.__enter__.return_value.cursor.return_value = cursor  # noqa: E501
+    database.db_engine_spec = db_engine_spec
+    database.apply_limit_to_sql.return_value = "SELECT * FROM table"
+    database.mutate_sql_based_on_config.return_value = "SELECT * FROM table"
+
+    mocker.patch(
+        "superset.connectors.sqla.utils.SupersetResultSet", return_value=result_set
+    )
+
+    columns = get_columns_description(
+        database, "catalog", "schema", "SELECT * FROM table"
+    )
+
+    assert columns == []
+    assert cursor.execute.call_count == 1, (
+        "no retry should be attempted when the engine spec has no comment-safe "
+        "retry query to offer"
+    )
+
+
 def test_get_virtual_table_metadata(mocker: MockerFixture) -> None:
     """
     Test the `get_virtual_table_metadata` function.

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -253,3 +253,53 @@ def test_adjust_engine_params_fully_qualified(
 
     uri = spec.adjust_engine_params(url, {}, None, schema)[0]
     assert str(uri) == expected_result
+
+
+def test_get_column_description_retry_sql_preserves_comments_and_zero_rows() -> None:
+    """
+    Regression test for SC-114843.
+
+    clickhouse-connect's cursor only backfills cursor.description for a
+    zero-row result when the operation string starts with SELECT/WITH after
+    stripping whitespace. SQL_QUERY_MUTATOR-inserted leading comments (e.g.
+    query hash / workspace attribution) defeat that check. The retry SQL
+    built by ``get_column_description_retry_sql`` must wrap the *exact*
+    mutated SQL -- including all of its comments -- in a bare outer SELECT,
+    without dropping or reordering anything, and without introducing a
+    real-row probe.
+    """
+    from superset.db_engine_specs.clickhouse import ClickHouseConnectEngineSpec
+
+    mutated_sql = (
+        "-- query hash: abc123\n"
+        "-- workspace_slug: acme-corp\n"
+        "SELECT arrayElement(tags, 1) AS tag\n"
+        "FROM events\n"
+        "WHERE false\n"
+        "LIMIT 1\n"
+        "-- query hash: abc123"
+    )
+
+    retry_sql = ClickHouseConnectEngineSpec.get_column_description_retry_sql(
+        mutated_sql
+    )
+
+    assert retry_sql is not None
+    assert retry_sql.strip().upper().startswith("SELECT")
+    # every line of the original mutated SQL -- comments included -- must
+    # survive verbatim
+    for line in mutated_sql.splitlines():
+        assert line in retry_sql
+    assert "where false" in retry_sql.lower()
+    assert retry_sql.strip().lower().endswith("limit 0")
+
+
+def test_base_engine_spec_has_no_column_description_retry_by_default() -> None:
+    """
+    The comment-safe retry is opt-in: engines that don't override
+    ``get_column_description_retry_sql`` must keep returning ``None`` so
+    ``get_columns_description`` never retries for them.
+    """
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    assert BaseEngineSpec.get_column_description_retry_sql("SELECT 1") is None

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -19,7 +19,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
+import re
 from contextlib import contextmanager
 from typing import Any, cast, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -2715,6 +2717,220 @@ def test_adhoc_column_to_sqla_skips_probe_when_not_forced(
         _, generic_type = table.adhoc_column_to_sqla(adhoc_col)
 
     assert generic_type is None
+
+
+class _FakeClickHouseConnectCursor:
+    """
+    Mimics clickhouse-connect 0.14.1's ``cursor.py``: the empty-result
+    metadata fallback -- which backfills ``cursor.description`` for a
+    legitimate zero-row result -- only runs when the executed operation
+    string starts with ``SELECT``/``WITH`` after stripping whitespace. A
+    leading SQL comment (e.g. from SQL_QUERY_MUTATOR) defeats that check.
+    """
+
+    def __init__(self, real_description: list[tuple[object, ...]]) -> None:
+        self._real_description = real_description
+        self.description: list[tuple[object, ...]] | None = None
+        self.arraysize = 0
+        self.executed: list[str] = []
+
+    def execute(self, operation: str, *args: object, **kwargs: object) -> None:
+        self.executed.append(operation)
+        if operation.strip().upper().startswith(("SELECT", "WITH")):
+            self.description = self._real_description
+        else:
+            self.description = []
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return []
+
+
+def _mutate_with_attribution_comments(sql_: str, is_split: bool = False) -> str:
+    """
+    Mirrors a typical SQL_QUERY_MUTATOR: leading query-hash/workspace
+    attribution comments plus a trailing query-hash comment.
+    """
+    return (
+        "-- query hash: abc123\n"
+        "-- workspace_slug: acme-corp\n"
+        f"{sql_}\n"
+        "-- query hash: abc123"
+    )
+
+
+def _run_probe_with_real_cursor(
+    database: Database,
+    adhoc_col: AdhocColumn,
+    mocker: MockerFixture,
+    *,
+    with_comment_safe_retry: bool,
+) -> _FakeClickHouseConnectCursor:
+    """
+    Exercise the real ``get_columns_description`` (not mocked out, unlike
+    ``_run_probe``) against a fake cursor that reproduces clickhouse-connect
+    0.14.1's comment-sensitive empty-result metadata fallback, with a mutator
+    that adds leading and trailing SQL comments like Preset's
+    SQL_QUERY_MUTATOR does.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.db_engine_specs.clickhouse import ClickHouseConnectEngineSpec
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a", type="INTEGER")],
+    )
+
+    real_description: list[tuple[object, ...]] = [
+        ("Duration", "Float64", None, None, None, None, None)
+    ]
+    cursor = _FakeClickHouseConnectCursor(real_description)
+
+    @contextmanager
+    def mock_get_raw_connection(catalog=None, schema=None, **kwargs):
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+        yield connection
+
+    spec_cls = database.db_engine_spec
+    mocker.patch.object(database, "get_raw_connection", new=mock_get_raw_connection)
+    mocker.patch.object(
+        database,
+        "mutate_sql_based_on_config",
+        new=_mutate_with_attribution_comments,
+    )
+
+    patches: list[Any] = [
+        patch.object(spec_cls, "type_probe_needs_row", False),
+    ]
+    if with_comment_safe_retry:
+        patches.append(
+            patch.object(
+                spec_cls,
+                "get_column_description_retry_sql",
+                new=classmethod(
+                    lambda cls, sql: (
+                        ClickHouseConnectEngineSpec.get_column_description_retry_sql(
+                            sql
+                        )
+                    )
+                ),
+            )
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        table.adhoc_column_to_sqla(adhoc_col)
+
+    return cursor
+
+
+@pytest.mark.parametrize(
+    "adhoc_col",
+    [
+        pytest.param(
+            {
+                "sqlExpression": "round(a / 50) * 50 / 1000",
+                "label": "Duration",
+                "columnType": "BASE_AXIS",
+                "timeGrain": "P1D",
+            },
+            id="simple_expression",
+        ),
+        pytest.param(
+            {
+                "sqlExpression": "arrayElement(splitByChar(',', 'a,b,c'), 1)",
+                "label": "Duration",
+                "columnType": "BASE_AXIS",
+                "timeGrain": "P1D",
+            },
+            id="array_syntax_expression",
+        ),
+    ],
+)
+def test_adhoc_column_type_probe_survives_query_mutator_comments_on_clickhouse(
+    database: Database,
+    mocker: MockerFixture,
+    adhoc_col: AdhocColumn,
+) -> None:
+    """
+    Regression test for SC-114843.
+
+    clickhouse-connect 0.14.1 only backfills ``cursor.description`` for a
+    zero-row result when the executed operation string starts with
+    SELECT/WITH after stripping whitespace. SQL_QUERY_MUTATOR prepends
+    query-attribution comments (query hash, workspace_slug) ahead of the
+    SELECT keyword and appends a trailing query-hash comment, which used to
+    make adhoc_column_to_sqla's WHERE FALSE type probe come back with an
+    empty cursor.description and raise ColumnNotFoundException at
+    superset/connectors/sqla/models.py:~1705 -- even though the underlying
+    expression is completely valid and zero rows are read.
+
+    The fix (ClickHouseConnectEngineSpec.get_column_description_retry_sql)
+    must resolve this WITHOUT falling back to a real-row probe, which would
+    reintroduce ClickHouse's max_rows_to_read failures on huge tables.
+    """
+    cursor = _run_probe_with_real_cursor(
+        database, adhoc_col, mocker, with_comment_safe_retry=True
+    )
+
+    # One or more comment-prefixed attempts (which the fake driver -- like
+    # the real one -- can't read metadata from), followed by the
+    # comment-safe wrapped retry as the last execution.
+    assert len(cursor.executed) >= 2
+    *earlier_attempts, retry = cursor.executed
+
+    for attempt in earlier_attempts:
+        assert "query hash" in attempt, "mutator comments must be applied"
+        assert not attempt.strip().upper().startswith(("SELECT", "WITH")), (
+            "prior attempts should still be comment-prefixed, reproducing the bug"
+        )
+
+    assert retry.strip().upper().startswith("SELECT"), (
+        "retry must start with a bare SELECT so clickhouse-connect's "
+        "empty-result fallback triggers"
+    )
+    assert "-- query hash: abc123" in retry, (
+        "retry must preserve the mutator's comments verbatim -- no security/"
+        "audit information should be dropped"
+    )
+    assert "-- workspace_slug: acme-corp" in retry
+    # apply_limit_to_sql reformats the query (via sqlglot), so WHERE and its
+    # condition can land on separate lines -- match loosely on whitespace.
+    always_false_pattern = re.compile(r"where\s+(false|0\s*=\s*1)", re.IGNORECASE)
+    assert always_false_pattern.search(retry), (
+        f"retry must still be a zero-row probe (WHERE false), got: {retry}"
+    )
+    assert retry.strip().lower().endswith("limit 0"), (
+        f"outer wrapper must also guarantee zero rows, got: {retry}"
+    )
+
+
+def test_adhoc_column_type_probe_raises_without_comment_safe_retry_hook(
+    database: Database,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Companion negative-control for SC-114843: confirms the failure mode this
+    fix addresses. Without an engine-spec hook to retry with a comment-safe
+    query, a comment-mutated zero-row probe against a clickhouse-connect-like
+    driver raises ColumnNotFoundException, exactly as it did before this fix.
+    """
+    from superset.exceptions import ColumnNotFoundException
+
+    adhoc_col: AdhocColumn = {
+        "sqlExpression": "round(a / 50) * 50 / 1000",
+        "label": "Duration",
+        "columnType": "BASE_AXIS",
+        "timeGrain": "P1D",
+    }
+
+    with pytest.raises(ColumnNotFoundException):
+        _run_probe_with_real_cursor(
+            database, adhoc_col, mocker, with_comment_safe_retry=False
+        )
 
 
 def _normalize_df_datasource(column: object) -> MagicMock:


### PR DESCRIPTION
### SUMMARY

Fixes a regression where **ClickHouse adhoc SQL-expression charts fail with `ColumnNotFoundException`** whenever a deployment's `SQL_QUERY_MUTATOR` prepends SQL comments (e.g. query attribution/hashing) ahead of the `SELECT` keyword.

**Root cause:** `adhoc_column_to_sqla` probes an adhoc column's type with a zero-row `WHERE false` query so it never scans real data (this zero-row probe pattern was introduced by #42052, which fixed the physical time filter being dropped for expression axes). clickhouse-connect's DB-API cursor only backfills `cursor.description` for a legitimate zero-row result when the *executed operation string* starts with `SELECT`/`WITH` after stripping whitespace. When `SQL_QUERY_MUTATOR` adds leading comments ahead of `SELECT` (a common and supported customization point, used for query attribution/auditing), that `startswith` check silently fails even though the query is entirely valid and reads zero rows — so `cursor.description` comes back empty, `get_columns_description()` returns no columns, and `adhoc_column_to_sqla` raises `ColumnNotFoundException`.

**Why upgrading clickhouse-connect is not sufficient:** we already carry a clickhouse-connect 0.8.8 → 1.5.0 upgrade (the latest release as of this fix), which was necessary to resolve unrelated, older probe issues. That upgrade does **not** fix this bug — the comment-sensitivity in clickhouse-connect's empty-result metadata fallback is a `startswith` check on the raw operation string and is present in every clickhouse-connect release we've tested through 1.5.0. There is no version bump that resolves this without either (a) never prepending comments before `SELECT` (not viable — that behavior is a supported customization point via `SQL_QUERY_MUTATOR`, used by deployments for query attribution/auditing) or (b) reworking the probe to read real rows (not viable — see below).

**Fix:** add a narrow, opt-in `BaseEngineSpec.get_column_description_retry_sql(sql)` hook. `get_columns_description()` calls it **only** when the first probe legitimately comes back with an empty `cursor.description` (i.e. the retry path never fires for the common case where the probe succeeds). The default implementation returns `None`, so all engines other than ClickHouse are completely unaffected.

`ClickHouseConnectEngineSpec` implements the hook by wrapping the **already-mutated** SQL — comments included, unmodified, unreordered — in a bare outer `SELECT * FROM (\n{sql}\n) AS __superset_type_probe LIMIT 0`. The outer statement satisfies clickhouse-connect's `startswith` check, while the inner query (with all of `SQL_QUERY_MUTATOR`'s comments intact) still executes and still returns zero rows. This deliberately does **not**:
- switch to a real-row probe (e.g. `LIMIT 1`) — that would reintroduce ClickHouse `max_rows_to_read` / resource-limit failures on huge tables, which is the reason the zero-row probe pattern from #42052 exists in the first place;
- drop, reorder, or bypass anything `SQL_QUERY_MUTATOR` added — the retry query is the *exact* mutated SQL, wrapped, so query attribution/auditing comments always reach ClickHouse for both the initial attempt and the retry.

### SECURITY / AUDIT RATIONALE

This change is deliberately narrow in scope because `SQL_QUERY_MUTATOR` output is frequently relied on for query attribution and audit trails:

- The retry SQL is built by wrapping the **verbatim** mutated SQL string; no comment, hint, or clause added by `SQL_QUERY_MUTATOR` is stripped, reordered, or altered.
- There is no new code path that bypasses `SQL_QUERY_MUTATOR` — the retry query is derived from its output, not from the pre-mutation SQL.
- The hook is opt-in per engine spec (default `None`) and only triggers after a real probe attempt returns zero columns, so it cannot be used to skip or short-circuit the normal mutation/execution flow for any engine, including ClickHouse's first attempt.
- No new SQL injection surface: `get_column_description_retry_sql` only wraps a string Superset already built and was about to execute; it does not incorporate any additional user input.

### BEFORE/AFTER

**Before:** an adhoc SQL-expression column/metric on a ClickHouse dataset (e.g. `round(a / 50) * 50 / 1000`, or an expression using ClickHouse array functions) fails to render with `ColumnNotFoundException` as soon as the deployment's `SQL_QUERY_MUTATOR` adds a leading comment to queries.

**After:** the same chart renders correctly. The physical time filter/predicate added by #42052 remains present on the query. No real rows are scanned during the type probe (zero-row/no-scan probing is preserved, so `max_rows_to_read`-style limits on huge ClickHouse tables are not re-triggered).

### TESTING INSTRUCTIONS

Local end-to-end validation (2026-07-22) against a ClickHouse datasource with a `SQL_QUERY_MUTATOR` that prepends/appends attribution comments:
- An adhoc SQL-expression chart (simple arithmetic expression and a ClickHouse array-function expression) returns data correctly.
- The physical timestamp predicate from the original query remains present on the executed SQL (i.e. this fix doesn't regress #42052).
- No `ColumnNotFoundException` is raised for either expression shape.
- Zero-row/no-scan probing behavior is preserved — the retry query still executes as `... LIMIT 0` over the mutated SQL, so no real ClickHouse table scan occurs during type probing.

Automated tests added/exercised in this PR:
- `tests/unit_tests/connectors/sqla/utils_test.py` — `get_columns_description` retries once with the engine-provided comment-safe SQL when the first probe comes back with an empty `cursor.description`, and does **not** retry for engines that don't opt in (default `None` hook).
- `tests/unit_tests/db_engine_specs/test_clickhouse.py` — `ClickHouseConnectEngineSpec.get_column_description_retry_sql` preserves every line of the mutated SQL (including leading/trailing comments) verbatim, still contains the zero-row predicate, and still ends in `LIMIT 0`; `BaseEngineSpec.get_column_description_retry_sql` defaults to `None`.
- `tests/unit_tests/models/helpers_test.py` — end-to-end `adhoc_column_to_sqla` regression coverage against a fake cursor that reproduces clickhouse-connect's comment-sensitive empty-result fallback, with a mutator that adds both leading *and* trailing comments (mirroring real `SQL_QUERY_MUTATOR` usage): covers both a simple arithmetic expression and a ClickHouse array-syntax expression, plus a negative-control test confirming `ColumnNotFoundException` is still raised when an engine spec doesn't provide the retry hook.

Run locally with:
```
pytest tests/unit_tests/connectors/sqla/utils_test.py tests/unit_tests/db_engine_specs/test_clickhouse.py tests/unit_tests/models/helpers_test.py
```

### RISK

Low, and scoped to ClickHouse:
- The new `BaseEngineSpec` hook defaults to `None` for every engine; behavior for all non-ClickHouse engines is unchanged (the retry branch in `get_columns_description` is unreachable for them).
- For ClickHouse, the retry only fires when the initial probe already came back with zero columns (i.e. the pre-existing failure case) — engines/queries that already worked continue to take the exact same code path as before.
- No SQL mutator bypass and no change to `SQL_QUERY_MUTATOR` semantics (see Security/Audit Rationale above).

### ROLLBACK

Revert this commit. `BaseEngineSpec.get_column_description_retry_sql` and its ClickHouse override are additive and self-contained (no migrations, no config changes, no feature flag), so reverting fully restores prior behavior with no follow-up cleanup required.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Related:**
- Original related regression: #42052 (fix(charts): preserve time filter for expression axes) — introduced the zero-row `WHERE false` type-probe pattern this fix builds on.
- Internal tracking: SC-114843 (sc-107759, sc-113850 related; **sc-113851 is a separate, unrelated issue**).
- Private validated backport: preset-io/superset-private#997
- Prior (necessary but insufficient) dependency bump: preset-io/superset-shell#4521 (clickhouse-connect 0.8.8 → 1.5.0)
