### PR TITLE
fix(embedded): respect show_filters URL param in standalone report mode

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -566,6 +566,73 @@ describe('DashboardBuilder', () => {
 
     expect(queryByTestId('dashboard-filters-panel')).not.toBeInTheDocument();
   });
+
+  test('should hide the vertical filter bar in report mode (?standalone=3)', () => {
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=3');
+    jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
+      showDashboard: true,
+      missingInitialFilters: [],
+      dashboardFiltersOpen: true,
+      toggleDashboardFiltersOpen: jest.fn(),
+      nativeFiltersEnabled: true,
+    });
+    try {
+      const { getByTestId } = setup();
+      expect(getByTestId('dashboard-filters-panel')).toHaveStyleRule(
+        'display',
+        'none',
+      );
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
+  test('should reveal the vertical filter bar in report mode when embedded ?show_filters=true is set (issue #30630)', () => {
+    // Regression test for #30630: embedded dashboards use ?standalone=3 to hide
+    // the title/tabs/nav, but that also forced isReport=true, which unconditionally
+    // hid the filter bar even when the Embedded SDK's dashboardUiConfig.filters.visible
+    // (mapped to the show_filters URL param) explicitly asked for filters to show.
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=3&show_filters=true');
+    jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
+      showDashboard: true,
+      missingInitialFilters: [],
+      dashboardFiltersOpen: true,
+      toggleDashboardFiltersOpen: jest.fn(),
+      nativeFiltersEnabled: true,
+    });
+    try {
+      const { getByTestId } = setup();
+      expect(getByTestId('dashboard-filters-panel')).not.toHaveStyleRule(
+        'display',
+        'none',
+      );
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
+
+  test('should keep the filter bar hidden in report mode when ?show_filters=false is set', () => {
+    const originalHref = window.location.href;
+    window.history.replaceState({}, '', '/?standalone=3&show_filters=false');
+    jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
+      showDashboard: true,
+      missingInitialFilters: [],
+      dashboardFiltersOpen: true,
+      toggleDashboardFiltersOpen: jest.fn(),
+      nativeFiltersEnabled: true,
+    });
+    try {
+      const { getByTestId } = setup();
+      expect(getByTestId('dashboard-filters-panel')).toHaveStyleRule(
+        'display',
+        'none',
+      );
+    } finally {
+      window.history.replaceState({}, '', originalHref);
+    }
+  });
 });
 
 test('should render ParentSize wrapper with height 100% for tabs', async () => {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -427,6 +427,14 @@ const DashboardBuilder = () => {
       : undefined;
   const standaloneMode = getUrlParam(URL_PARAMS.standalone);
   const isReport = standaloneMode === DashboardStandaloneMode.Report;
+  // Report mode (standalone=3) hides the filter bar by default, since it's used
+  // for one-shot screenshot renders (email reports, thumbnails). Embedded SDK
+  // consumers also use standalone=3 to hide the title/tabs/nav, but may still
+  // want filters visible via dashboardUiConfig.filters.visible, which maps to
+  // the show_filters URL param. An explicit show_filters=true overrides the
+  // report-mode default so the filter bar stays visible.
+  const showFiltersUrlParam = getUrlParam(URL_PARAMS.showFilters);
+  const hideFilterBar = isReport && showFiltersUrlParam !== true;
   const hideDashboardHeader =
     uiConfig.hideTitle ||
     standaloneMode === DashboardStandaloneMode.HideNavAndTitle ||
@@ -528,12 +536,12 @@ const DashboardBuilder = () => {
           filterBarOrientation === FilterBarOrientation.Horizontal && (
             <FilterBar
               orientation={FilterBarOrientation.Horizontal}
-              hidden={isReport}
+              hidden={hideFilterBar}
             />
           )}
       </>
     ),
-    [hideDashboardHeader, showFilterBar, filterBarOrientation, isReport],
+    [hideDashboardHeader, showFilterBar, filterBarOrientation, hideFilterBar],
   );
 
   const renderDraggableContent = useCallback(
@@ -595,7 +603,7 @@ const DashboardBuilder = () => {
       return (
         <FiltersPanel
           width={filterBarWidth}
-          hidden={isReport}
+          hidden={hideFilterBar}
           data-test="dashboard-filters-panel"
         >
           <StickyPanel ref={containerRef} width={filterBarWidth}>
@@ -620,7 +628,7 @@ const DashboardBuilder = () => {
       toggleDashboardFiltersOpen,
       filterBarHeight,
       filterBarOffset,
-      isReport,
+      hideFilterBar,
     ],
   );
 


### PR DESCRIPTION
### SUMMARY
Report mode (`standalone=3`) unconditionally hides the filter bar via `hidden={isReport}` on both the horizontal `FilterBar` and vertical `FiltersPanel`. That's correct for its original purpose (one-shot screenshot renders for scheduled reports/thumbnails), but the Embedded SDK also uses `standalone=3` to hide the title/tabs/nav (its `hideTitle` + `hideTab` config both fold into that same bitmask), and embedded consumers can still ask for filters via `dashboardUiConfig.filters.visible`, which maps to the `show_filters` URL param.

That param was declared in `URL_PARAMS` but never actually wired into `DashboardBuilder`, so it was silently ignored — the filter bar stayed forced-hidden any time `standalone=3` was in play, regardless of `show_filters`.

This introduces `hideFilterBar = isReport && showFiltersUrlParam !== true` so:
- Report mode still hides the filter bar by default (unchanged, backward compatible)
- `show_filters=true` explicitly overrides the report-mode hiding
- `show_filters=false` (or unset) keeps the existing hidden behavior

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this only changes a CSS `display: none` toggle; behavior is covered by unit tests.

### TESTING INSTRUCTIONS
1. Load a dashboard with `?standalone=3` — filter bar should be hidden (unchanged).
2. Load a dashboard with `?standalone=3&show_filters=true` — filter bar should now be visible.
3. Load a dashboard with `?standalone=3&show_filters=false` — filter bar should still be hidden.
4. `npm run test -- DashboardBuilder.test.tsx` in `superset-frontend`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30630
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API