### PR TITLE
fix(explore): resolve now/today anchors to local time, not UTC

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -630,6 +630,12 @@ Added a new combined datasource list endpoint at `GET /api/v1/datasource/` to se
 - Semantic views are included only when the `SEMANTIC_LAYERS` feature flag is enabled.
 - The endpoint enforces strict `order_column` validation and returns `400` for invalid sort columns.
 
+### Custom time range "Now"/"Today" anchors resolve in local time
+
+Custom time ranges that use the "Now" or "Today" anchor (for the Start, End, or the relative anchor itself) previously resolved that anchor in UTC before formatting it into a naive datetime string, which was then re-parsed elsewhere as local time. For users outside UTC, this made the resolved anchor drift by their browser's UTC offset. "Now"/"Today" now resolve directly in local time, matching the later local re-parse.
+
+Charts and dashboards using these anchors will compute a different (correct) timestamp after upgrading; if a chart's filters or drill-downs were tuned to compensate for the old offset, review them after upgrading.
+
 ## 6.1.0
 
 ### ClickHouse minimum driver version bump

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/dateParser.test.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/dateParser.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { dttmToDayjs } from 'src/explore/components/controls/DateFilterControl/utils/dateParser';
+
+// jest.config.js pins TZ to America/New_York (UTC-4 in June) for all unit
+// tests, giving these assertions a fixed, non-zero UTC offset to catch
+// UTC/local mix-ups against.
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('dttmToDayjs("now") resolves to the current local time, not UTC', () => {
+  jest.useFakeTimers();
+  // Midnight UTC on June 3rd is 8pm the previous day in America/New_York
+  // (UTC-4 during summer time).
+  jest.setSystemTime(new Date('2024-06-03T00:00:00Z'));
+
+  const result = dttmToDayjs('now');
+
+  // dttmToDayjs's fallback branch (`extendedDayjs(dttm)`) re-parses a naive
+  // "YYYY-MM-DDTHH:mm:ss" string -- the format produced when "now" gets
+  // resolved and formatted elsewhere in this module -- as local wall-clock
+  // time. For that round trip to reproduce the actual current moment,
+  // resolving "now" must also use local wall-clock time rather than UTC.
+  expect(result.format('YYYY-MM-DD HH:mm:ss')).toEqual('2024-06-02 20:00:00');
+});
+
+test('dttmToDayjs("today") resolves to local midnight, not UTC midnight', () => {
+  jest.useFakeTimers();
+  // 2am UTC on June 3rd is still June 2nd, 10pm, in America/New_York.
+  jest.setSystemTime(new Date('2024-06-03T02:00:00Z'));
+
+  const result = dttmToDayjs('today');
+
+  expect(result.format('YYYY-MM-DD HH:mm:ss')).toEqual('2024-06-02 00:00:00');
+});

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateParser.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateParser.ts
@@ -40,11 +40,18 @@ export const ISO8601_AND_CONSTANT = RegExp(
 const SPECIFIC_MODE = ['specific', 'today', 'now'];
 
 export const dttmToDayjs = (dttm: string): Dayjs => {
+  // "now"/"today" are later formatted (see dttmToString) into a naive
+  // "YYYY-MM-DDTHH:mm:ss" string with no UTC offset, and that string is
+  // re-parsed elsewhere as local time (the `extendedDayjs(dttm)` fallback
+  // below). Resolving these constants in UTC rather than local time would
+  // make that round trip drift by the browser's UTC offset, which is what
+  // caused the "Now" anchor to display and query the wrong wall-clock time
+  // for users outside UTC.
   if (dttm === 'now') {
-    return extendedDayjs().utc().startOf('second');
+    return extendedDayjs().startOf('second');
   }
   if (dttm === 'today') {
-    return extendedDayjs().utc().startOf('day');
+    return extendedDayjs().startOf('day');
   }
   return extendedDayjs(dttm);
 };


### PR DESCRIPTION
### SUMMARY
The custom time range's "Now"/"Midnight" options resolve through `dttmToDayjs`, which forced `now`/`today` into UTC before formatting them into a naive datetime string with no offset. That same naive string gets re-parsed elsewhere in the module as local time, so switching from "Now" to a specific date/time (or from "Anchor to: Now" to a specific anchor) drifted by the browser's UTC offset. That's the mismatch several users reported on #30627: the resolved value is off by their timezone offset instead of reflecting the actual current moment.

This drops the forced `.utc()` call so `now`/`today` resolve in local time, matching the naive string's later local re-parse.

I added a test first (`dateParser.test.ts`) pinning the bug with a fixed non-UTC timezone before making the fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, this is a data/logic fix, not a visual change.

### TESTING INSTRUCTIONS
`npm run test -- dateParser.test.ts` from `superset-frontend/`. Both new tests fail against the old `.utc()`-forced code and pass after the fix.

Manually: with a browser timezone other than UTC, pick a custom time range, set Start to "Now", then switch it to "Specific Date/Time". The date/time picker should now show the actual current local time instead of one offset by your UTC difference.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30627
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API