### PR TITLE
fix(db_engine_specs): stop filtering out Postgres schemas prefixed with pg

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -794,6 +794,28 @@ WHERE datistemplate = false;
             }
 
     @classmethod
+    def get_schema_names(cls, inspector: Inspector) -> set[str]:
+        """
+        Return all schema names, excluding actual Postgres system schemas.
+
+        SQLAlchemy's Postgres dialect filters out system schemas with the
+        query ``nspname NOT LIKE 'pg_%'``. Since ``_`` is a single-character
+        wildcard in SQL ``LIKE`` patterns, this unintentionally excludes any
+        user-defined schema that merely starts with ``pg`` followed by any
+        other character (e.g. ``pgsql``, ``pgstats``), not only the actual
+        Postgres system schemas, which are always prefixed with the literal
+        string ``pg_`` (e.g. ``pg_catalog``, ``pg_toast``).
+        """
+        with inspector.engine.connect() as conn:
+            return {
+                name
+                for (name,) in conn.execute(
+                    text("SELECT nspname FROM pg_namespace ORDER BY nspname")
+                )
+                if not name.startswith("pg_")
+            }
+
+    @classmethod
     def get_table_names(
         cls, database: Database, inspector: PGInspector, schema: str | None
     ) -> set[str]:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -806,6 +806,9 @@ WHERE datistemplate = false;
         other character (e.g. ``pgsql``, ``pgstats``), not only the
         ``pg_``-prefixed system schemas. Matching on the literal ``pg_``
         prefix instead keeps those user-defined schemas.
+
+        TODO: drop this override once sqlalchemy/sqlalchemy#13471 is merged
+        and released, and SQLAlchemy is bumped past that version.
         """
         with inspector.engine.connect() as conn:
             return {

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -796,15 +796,16 @@ WHERE datistemplate = false;
     @classmethod
     def get_schema_names(cls, inspector: Inspector) -> set[str]:
         """
-        Return all schema names, excluding actual Postgres system schemas.
+        Return all schema names, excluding the ``pg_``-prefixed Postgres
+        system schemas (e.g. ``pg_catalog``, ``pg_toast``).
 
         SQLAlchemy's Postgres dialect filters out system schemas with the
         query ``nspname NOT LIKE 'pg_%'``. Since ``_`` is a single-character
         wildcard in SQL ``LIKE`` patterns, this unintentionally excludes any
         user-defined schema that merely starts with ``pg`` followed by any
-        other character (e.g. ``pgsql``, ``pgstats``), not only the actual
-        Postgres system schemas, which are always prefixed with the literal
-        string ``pg_`` (e.g. ``pg_catalog``, ``pg_toast``).
+        other character (e.g. ``pgsql``, ``pgstats``), not only the
+        ``pg_``-prefixed system schemas. Matching on the literal ``pg_``
+        prefix instead keeps those user-defined schemas.
         """
         with inspector.engine.connect() as conn:
             return {

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -403,3 +403,33 @@ def test_interval_type_mutator() -> None:
     assert mutator(True) is None
     assert mutator([1, 2, 3]) is None
     assert mutator({"days": 1}) is None
+
+
+def test_get_schema_names_excludes_only_actual_system_schemas(
+    mocker: MockerFixture,
+) -> None:
+    """
+    DB Eng Specs (postgres): Test ``get_schema_names``
+
+    User-defined schemas that merely start with ``pg`` (but are not
+    actual Postgres system schemas, which always start with the literal
+    ``pg_``) must not be filtered out. See SIP/issue #30678.
+    """
+    inspector = mocker.MagicMock()
+    inspector.engine.connect().__enter__().execute.return_value = [
+        ("public",),
+        ("pgsql",),
+        ("pgstats",),
+        ("pg_catalog",),
+        ("pg_toast",),
+        ("information_schema",),
+    ]
+
+    schemas = spec.get_schema_names(inspector)
+
+    assert schemas == {
+        "public",
+        "pgsql",
+        "pgstats",
+        "information_schema",
+    }

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -413,7 +413,7 @@ def test_get_schema_names_excludes_only_actual_system_schemas(
 
     User-defined schemas that merely start with ``pg`` (but are not
     actual Postgres system schemas, which always start with the literal
-    ``pg_``) must not be filtered out. See SIP/issue #30678.
+    ``pg_``) must not be filtered out. See issue #30678.
     """
     inspector = mocker.MagicMock()
     inspector.engine.connect().__enter__().execute.return_value = [


### PR DESCRIPTION
### SUMMARY
Fixes a bug where Postgres schemas whose names start with `pg` (but aren't real system schemas), like `pgsql` or `pgstats`, silently disappeared from the schema list in Superset (SQL Lab schema dropdown, dataset creation, etc).

The root cause is in SQLAlchemy's Postgres dialect, not Superset's own filtering: `get_schema_names` excludes system schemas with the query `nspname NOT LIKE 'pg_%'`. In SQL `LIKE` patterns, `_` matches any single character, so this pattern actually matches `pg` + any one character + anything, not just the literal `pg_` prefix used by real Postgres system schemas (`pg_catalog`, `pg_toast`, etc). As a result, any user-created schema starting with `pg` followed by one more character gets silently dropped.

This adds an override of `get_schema_names` in `PostgresBaseEngineSpec` that queries `pg_namespace` directly and filters with a plain Python `str.startswith("pg_")` check, which only excludes schemas with the real literal prefix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (backend-only fix)

### TESTING INSTRUCTIONS
- Added `test_get_schema_names_excludes_only_actual_system_schemas` in `tests/unit_tests/db_engine_specs/test_postgres.py`, which pins the bug: it asserts that schemas like `pgsql` and `pgstats` are kept while actual system schemas (`pg_catalog`, `pg_toast`) are excluded. This test fails without the fix and passes with it.
- To verify manually: create a Postgres schema named e.g. `pgsql` or `pgfoo`, then check that it now shows up in the SQL Lab schema dropdown / dataset creation flow.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30678
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API