### PR TITLE
fix(ag-grid-table): avoid ambiguous build query import

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -58,7 +58,7 @@ export function getQueryMode(formData: TableChartFormData) {
   return hasRawColumns ? QueryMode.Raw : QueryMode.Aggregate;
 }
 
-export const buildQuery: BuildQuery<TableChartFormData> = (
+export const buildQueryUncached: BuildQuery<TableChartFormData> = (
   formData: TableChartFormData,
   options,
 ) => {
@@ -782,7 +782,7 @@ export const cachedBuildQuery = (): BuildQuery<TableChartFormData> => {
   };
 
   return (formData, options) =>
-    buildQuery(
+    buildQueryUncached(
       { ...formData },
       {
         extras: { cachedChanges },

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 import { AdhocColumn, QueryMode, VizType } from '@superset-ui/core';
-import buildQuery, {
-  buildQuery as buildQueryUncached,
-} from '../src/buildQuery';
+import buildQuery, { buildQueryUncached } from '../src/buildQuery';
 import { TableChartFormData } from '../src/types';
 
 const basicFormData: TableChartFormData = {


### PR DESCRIPTION
### SUMMARY

Rename the uncached AG Grid build-query export to `buildQueryUncached` and update its internal caller and tests.

Commit `10ff47070211f24877a7ed8744c1157e881d402f` introduced a named `buildQuery` export alongside the module's existing default export. Consumers imported the default export with the same local name, causing Oxlint's `import/no-named-as-default` rule to fail. The distinct export name removes that ambiguity without changing runtime behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this change has no UI impact.

### TESTING INSTRUCTIONS

- `npm run lint`
- `npx jest plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts --runTestsByPath --maxWorkers=2 --silent` (82 tests)
- Targeted builds for core, chart controls, and AG Grid packages
- `pre-commit run --files superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts`
- `git diff --check`

`pre-commit run --all-files` was also run. Patch-relevant hooks passed, but the repository-wide run is not clean on this checkout because of unrelated baseline failures in backend mypy/Ruff checks, missing docs-local ESLint dependencies, and missing generated frontend declaration outputs.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
