### PR TITLE
fix: Revert "chore(deps): bump echarts from 5.6.0 to 6.1.0 in /superset-frontend"

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -91,7 +91,7 @@
         "dayjs": "^1.11.21",
         "dom-to-image-more": "^3.10.2",
         "dom-to-pdf": "^0.3.2",
-        "echarts": "^6.1.0",
+        "echarts": "^5.6.0",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.3.6",
         "fuse.js": "^7.5.0",
@@ -19176,13 +19176,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
-      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "6.1.0"
+        "zrender": "5.6.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -43754,9 +43754,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
-      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -176,7 +176,7 @@
     "dayjs": "^1.11.21",
     "dom-to-image-more": "^3.10.2",
     "dom-to-pdf": "^0.3.2",
-    "echarts": "^6.1.0",
+    "echarts": "^5.6.0",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.3.6",
     "fuse.js": "^7.5.0",

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -130,8 +130,11 @@ use([
 // code-split exactly the locales listed here. Keys are Superset locales
 // uppercased (see LANGUAGES in superset/config.py); values point at the
 // echarts bundle, whose naming differs for some locales (Slovenian is
-// langSI, Brazilian Portuguese is langPT-br). Superset locales absent
-// from this map fall back to English.
+// langSI, Brazilian Portuguese is langPT-br). Only locales that echarts
+// 5.6.0 ships a bundle for are listed — Greek (langEL) and Latvian
+// (langLV) were added in echarts 6 and must stay out until this
+// dependency is upgraded again. Superset locales absent from this map
+// fall back to English.
 type EChartsLocaleOption = Parameters<typeof registerLocale>[1];
 
 const LOCALE_LOADERS: Record<
@@ -141,7 +144,6 @@ const LOCALE_LOADERS: Record<
   AR: () => import('echarts/i18n/langAR.js'),
   CS: () => import('echarts/i18n/langCS.js'),
   DE: () => import('echarts/i18n/langDE.js'),
-  EL: () => import('echarts/i18n/langEL.js'),
   EN: () => import('echarts/i18n/langEN.js'),
   ES: () => import('echarts/i18n/langES.js'),
   FA: () => import('echarts/i18n/langFA.js'),
@@ -151,7 +153,6 @@ const LOCALE_LOADERS: Record<
   IT: () => import('echarts/i18n/langIT.js'),
   JA: () => import('echarts/i18n/langJA.js'),
   KO: () => import('echarts/i18n/langKO.js'),
-  LV: () => import('echarts/i18n/langLV.js'),
   NL: () => import('echarts/i18n/langNL.js'),
   PL: () => import('echarts/i18n/langPL.js'),
   RO: () => import('echarts/i18n/langRO.js'),


### PR DESCRIPTION
Reverting the echarts bump due to some echarts (like line chart) being broken. When we bump again, it'll be a larger project where we will probably need to do a migration for the charts. 