### PR TITLE
fix(plugin-chart-echarts): stop clobbering echarts builtin locales with empty objects

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -63,7 +63,7 @@ import {
   MarkAreaComponent,
   MarkLineComponent,
 } from 'echarts/components';
-import { LabelLayout } from 'echarts/features';
+import { LabelLayout, LegacyGridContainLabel } from 'echarts/features';
 import {
   EchartsHandler,
   EchartsProps,
@@ -72,6 +72,7 @@ import {
 } from '../types';
 import { DEFAULT_LOCALE } from '../constants';
 import { mergeEchartsThemeOverrides } from '../utils/themeOverrides';
+import { loadLocale } from './echartsLocale';
 
 // Define this interface here to avoid creating a dependency back to superset-frontend,
 // TODO: to move the type to @superset-ui/core
@@ -119,79 +120,10 @@ use([
   TitleComponent,
   VisualMapComponent,
   LabelLayout,
+  // Superset chart options rely on `grid.containLabel`, which echarts 6
+  // ignores (clipping axis labels) unless this legacy feature is registered.
+  LegacyGridContainLabel,
 ]);
-
-// Explicit per-locale imports rather than a template-literal dynamic
-// import: a computed import makes bundlers build a "context module" over
-// echarts/i18n, and resolving that directory through the echarts package's
-// `exports` map fails intermittently in webpack incremental builds
-// ("Package path ./i18n is exported ... but no valid target file was
-// found"). A static map is also the only thing that lets bundlers
-// code-split exactly the locales listed here. Keys are Superset locales
-// uppercased (see LANGUAGES in superset/config.py); values point at the
-// echarts bundle, whose naming differs for some locales (Slovenian is
-// langSI, Brazilian Portuguese is langPT-br). Superset locales absent
-// from this map fall back to English.
-//
-// The "-obj" suffix is required and must not be dropped. echarts ships two
-// UMD builds per locale: langXX.js self-registers under echarts' own key and
-// exports nothing, while langXX-obj.js exports the locale object. Importing
-// the plain langXX.js yields an empty object, and registering that erases the
-// locale's `time` section, so every time-axis label crashes echarts'
-// formatTime with "Cannot read properties of null" — it evaluates
-// `month[u - 1]` eagerly for every template, even "{yyyy}". Registering the
-// object ourselves is also what lets Superset locale keys that differ from
-// echarts' own (SL -> SI, PT_BR -> PT-br) resolve at init time.
-type EChartsLocaleOption = Parameters<typeof registerLocale>[1];
-
-const LOCALE_LOADERS: Record<
-  string,
-  () => Promise<{ default: EChartsLocaleOption }>
-> = {
-  AR: () => import('echarts/i18n/langAR-obj.js'),
-  CS: () => import('echarts/i18n/langCS-obj.js'),
-  DE: () => import('echarts/i18n/langDE-obj.js'),
-  EL: () => import('echarts/i18n/langEL-obj.js'),
-  EN: () => import('echarts/i18n/langEN-obj.js'),
-  ES: () => import('echarts/i18n/langES-obj.js'),
-  FA: () => import('echarts/i18n/langFA-obj.js'),
-  FI: () => import('echarts/i18n/langFI-obj.js'),
-  FR: () => import('echarts/i18n/langFR-obj.js'),
-  HU: () => import('echarts/i18n/langHU-obj.js'),
-  IT: () => import('echarts/i18n/langIT-obj.js'),
-  JA: () => import('echarts/i18n/langJA-obj.js'),
-  KO: () => import('echarts/i18n/langKO-obj.js'),
-  LV: () => import('echarts/i18n/langLV-obj.js'),
-  NL: () => import('echarts/i18n/langNL-obj.js'),
-  PL: () => import('echarts/i18n/langPL-obj.js'),
-  RO: () => import('echarts/i18n/langRO-obj.js'),
-  PT_BR: () => import('echarts/i18n/langPT-br-obj.js'),
-  RU: () => import('echarts/i18n/langRU-obj.js'),
-  SL: () => import('echarts/i18n/langSI-obj.js'),
-  SV: () => import('echarts/i18n/langSV-obj.js'),
-  TH: () => import('echarts/i18n/langTH-obj.js'),
-  TR: () => import('echarts/i18n/langTR-obj.js'),
-  UK: () => import('echarts/i18n/langUK-obj.js'),
-  VI: () => import('echarts/i18n/langVI-obj.js'),
-  ZH: () => import('echarts/i18n/langZH-obj.js'),
-};
-
-const loadLocale = async (locale: string) => {
-  const loader = LOCALE_LOADERS[locale];
-  if (!loader) {
-    // Locale not supported in ECharts
-    return undefined;
-  }
-  try {
-    const localeObj = (await loader()).default;
-    // registerLocale replaces any built-in entry under the same key, so a
-    // partial object would leave echarts formatting against missing data.
-    // Fall back to the built-in locale instead of registering a broken one.
-    return localeObj?.time ? localeObj : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 // Report/thumbnail screenshots use standalone="true" (charts) or 3 (reports);
 // live embeds use 1/2 and keep animation. See superset/utils/screenshots.py.

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/echartsLocale.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/echartsLocale.ts
@@ -94,7 +94,11 @@ export const loadLocale = async (
     // Depending on the module system, the locale object is either the
     // module's default export or the module namespace itself.
     const localeObj = mod.default ?? (mod as unknown as EChartsLocaleOption);
-    if (localeObj && Object.keys(localeObj).length > 0) {
+    // registerLocale replaces any builtin entry under the same key, and
+    // `time` is the section whose absence crashes every time-axis chart, so
+    // a locale without it (an empty or partial bundle) must not be
+    // registered. Fall back to the builtin locale instead.
+    if (localeObj?.time) {
       return localeObj;
     }
   } catch {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/echartsLocale.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/echartsLocale.ts
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { registerLocale } from 'echarts/core';
+
+export type EChartsLocaleOption = Parameters<typeof registerLocale>[1];
+
+// Import the `lang*-obj.js` locale bundles, NOT the plain `lang*.js` ones.
+// The plain files are side-effect UMD modules: they call
+// `registerLocale` against `require('echarts/lib/echarts')` — a second,
+// separate echarts instance from the treeshaken `echarts/core` the app
+// uses — and export nothing. Under webpack's CommonJS interop that gives
+// `.default === {}`, and registering that empty object under a builtin
+// locale name ('EN'/'ZH') wipes out the builtin definitions: every
+// time-axis chart then crashes in echarts' time formatter reading
+// `time.month` from the empty locale. The `-obj` variants export the
+// locale object itself, with no side effects and no duplicate echarts.
+//
+// Explicit per-locale imports rather than a template-literal dynamic
+// import: a computed import makes bundlers build a "context module" over
+// echarts/i18n, and resolving that directory through the echarts package's
+// `exports` map fails intermittently in webpack incremental builds
+// ("Package path ./i18n is exported ... but no valid target file was
+// found"). A static map is also the only thing that lets bundlers
+// code-split exactly the locales listed here. Keys are Superset locales
+// uppercased (see LANGUAGES in superset/config.py); values point at the
+// echarts bundle, whose naming differs for some locales (Slovenian is
+// langSI, Brazilian Portuguese is langPT-br). Superset locales absent
+// from this map fall back to English.
+export const LOCALE_LOADERS: Record<
+  string,
+  () => Promise<{ default: EChartsLocaleOption }>
+> = {
+  AR: () => import('echarts/i18n/langAR-obj.js'),
+  CS: () => import('echarts/i18n/langCS-obj.js'),
+  DE: () => import('echarts/i18n/langDE-obj.js'),
+  EL: () => import('echarts/i18n/langEL-obj.js'),
+  EN: () => import('echarts/i18n/langEN-obj.js'),
+  ES: () => import('echarts/i18n/langES-obj.js'),
+  FA: () => import('echarts/i18n/langFA-obj.js'),
+  FI: () => import('echarts/i18n/langFI-obj.js'),
+  FR: () => import('echarts/i18n/langFR-obj.js'),
+  HU: () => import('echarts/i18n/langHU-obj.js'),
+  IT: () => import('echarts/i18n/langIT-obj.js'),
+  JA: () => import('echarts/i18n/langJA-obj.js'),
+  KO: () => import('echarts/i18n/langKO-obj.js'),
+  LV: () => import('echarts/i18n/langLV-obj.js'),
+  NL: () => import('echarts/i18n/langNL-obj.js'),
+  PL: () => import('echarts/i18n/langPL-obj.js'),
+  RO: () => import('echarts/i18n/langRO-obj.js'),
+  PT_BR: () => import('echarts/i18n/langPT-br-obj.js'),
+  RU: () => import('echarts/i18n/langRU-obj.js'),
+  SL: () => import('echarts/i18n/langSI-obj.js'),
+  SV: () => import('echarts/i18n/langSV-obj.js'),
+  TH: () => import('echarts/i18n/langTH-obj.js'),
+  TR: () => import('echarts/i18n/langTR-obj.js'),
+  UK: () => import('echarts/i18n/langUK-obj.js'),
+  VI: () => import('echarts/i18n/langVI-obj.js'),
+  ZH: () => import('echarts/i18n/langZH-obj.js'),
+};
+
+/**
+ * Resolve the ECharts locale object for a Superset locale, or undefined
+ * when the locale is unsupported or the bundle yields no usable content.
+ * Returning undefined makes the caller skip `registerLocale`, so echarts
+ * keeps its builtin locale definitions instead of having them overwritten
+ * by an empty object.
+ */
+export const loadLocale = async (
+  locale: string,
+): Promise<EChartsLocaleOption | undefined> => {
+  const loader = LOCALE_LOADERS[locale];
+  if (!loader) {
+    // Locale not supported in ECharts
+    return undefined;
+  }
+  try {
+    const mod = await loader();
+    // Depending on the module system, the locale object is either the
+    // module's default export or the module namespace itself.
+    const localeObj = mod.default ?? (mod as unknown as EChartsLocaleOption);
+    if (localeObj && Object.keys(localeObj).length > 0) {
+      return localeObj;
+    }
+  } catch {
+    // fall through to the builtin locale
+  }
+  return undefined;
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/test/components/echartsLocale.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/components/echartsLocale.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { init, use, registerLocale } from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { SVGRenderer } from 'echarts/renderers';
+import { GridComponent } from 'echarts/components';
+import { LOCALE_LOADERS, loadLocale } from '../../src/components/echartsLocale';
+
+type LocaleWithTime = {
+  time?: { month?: string[]; dayOfWeek?: string[] };
+};
+
+test('loadLocale returns undefined for locales echarts does not ship', async () => {
+  expect(await loadLocale('XX')).toBeUndefined();
+});
+
+test.each(Object.keys(LOCALE_LOADERS))(
+  'locale %s loads a locale object with time names',
+  async localeKey => {
+    const localeObj = (await loadLocale(localeKey)) as LocaleWithTime;
+    // A locale object without content would clobber echarts' builtin
+    // locales when registered; missing `time` names crash every
+    // time-axis chart inside echarts' time formatter (see #42314
+    // discussion — "Cannot read properties of null (reading '0')").
+    expect(localeObj).toBeDefined();
+    expect(localeObj.time?.month).toHaveLength(12);
+    expect(localeObj.time?.dayOfWeek).toHaveLength(7);
+  },
+);
+
+test('registering the loaded EN locale keeps time-axis charts rendering', async () => {
+  use([SVGRenderer, LineChart, GridComponent]);
+  const localeObj = await loadLocale('EN');
+  expect(localeObj).toBeDefined();
+  registerLocale('EN', localeObj!);
+
+  const chart = init(null, null, {
+    renderer: 'svg',
+    ssr: true,
+    width: 400,
+    height: 300,
+    locale: 'EN',
+  });
+  chart.setOption(
+    {
+      xAxis: { type: 'time' },
+      yAxis: { type: 'value' },
+      series: [
+        {
+          type: 'line',
+          data: [
+            [new Date(1965, 0, 1).getTime(), 100],
+            [new Date(1985, 0, 1).getTime(), 200],
+            [new Date(2005, 0, 1).getTime(), 150],
+          ],
+        },
+      ],
+    },
+    { notMerge: true, lazyUpdate: false },
+  );
+  expect(chart.renderToSVGString()).toContain('<svg');
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/components/echartsLocale.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/components/echartsLocale.test.ts
@@ -57,22 +57,26 @@ test('registering the loaded EN locale keeps time-axis charts rendering', async 
     height: 300,
     locale: 'EN',
   });
-  chart.setOption(
-    {
-      xAxis: { type: 'time' },
-      yAxis: { type: 'value' },
-      series: [
-        {
-          type: 'line',
-          data: [
-            [new Date(1965, 0, 1).getTime(), 100],
-            [new Date(1985, 0, 1).getTime(), 200],
-            [new Date(2005, 0, 1).getTime(), 150],
-          ],
-        },
-      ],
-    },
-    { notMerge: true, lazyUpdate: false },
-  );
-  expect(chart.renderToSVGString()).toContain('<svg');
+  try {
+    chart.setOption(
+      {
+        xAxis: { type: 'time' },
+        yAxis: { type: 'value' },
+        series: [
+          {
+            type: 'line',
+            data: [
+              [new Date(1965, 0, 1).getTime(), 100],
+              [new Date(1985, 0, 1).getTime(), 200],
+              [new Date(2005, 0, 1).getTime(), 150],
+            ],
+          },
+        ],
+      },
+      { notMerge: true, lazyUpdate: false },
+    );
+    expect(chart.renderToSVGString()).toContain('<svg');
+  } finally {
+    chart.dispose();
+  }
 });


### PR DESCRIPTION
### SUMMARY

Line charts (and every other time-axis chart) are broken on `master`, crashing with `TypeError: Cannot read properties of null (reading '0')` while rendering. The working theory was the echarts 6 bump (#40264), and #42314 proposes reverting it, but the crash is actually coming from our locale loading.

The locale loaders in `Echart.tsx` import echarts' `i18n/lang*.js` bundles. Those are side-effect UMD files: they call `registerLocale` against a *second* echarts instance (`require('echarts/lib/echarts')`) and export nothing, so webpack's CommonJS interop hands us `.default === {}`. We then call `registerLocale('EN', {})`, which overwrites echarts' builtin EN locale with an empty object. The next time a time axis formats a label, echarts reads `time.month` from that empty locale and throws. This became reachable when #42055 pointed the dynamic import at a path that actually resolves; the old `echarts/lib/i18n/...` path isn't in the echarts `exports` map, so the import always failed and we silently fell back to the builtin locale.

Worth noting: reverting the bump wouldn't fix `master`. I verified echarts 5.6.0 crashes the same way once an empty EN locale is registered, so #42314 alone would leave line charts broken.

The fix:
- Import the `lang*-obj.js` variants instead. They export the locale object itself, have no side effects, and drop the duplicated echarts lib bundle from every locale chunk.
- Guard `registerLocale` against content-free locale objects so the builtins can't get wiped again.
- Register `LegacyGridContainLabel`, since echarts 6 otherwise ignores `grid.containLabel` (which most of our chart options set) and clips axis labels.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: any time-axis ECharts viz in Explore shows "An error occurred while rendering the visualization: TypeError: Cannot read properties of null (reading '0')". After: renders normally.

### TESTING INSTRUCTIONS

Open a Line Chart on `birth_names` (x-axis `ds`) on `master` to see the crash, then on this branch to see it render. New unit tests in `echartsLocale.test.ts` cover the loaders (every locale must yield real `time` content) and render a time-axis chart end to end with the loaded EN locale registered. I also verified line, bar, area, scatter, smooth, step, mixed timeseries, big number w/ trendline, and pie in a browser against this branch.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)