### PR TITLE
fix(plugin-chart-echarts): import the -obj locale build so time axes render

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -135,36 +135,46 @@ use([
 // (langLV) were added in echarts 6 and must stay out until this
 // dependency is upgraded again. Superset locales absent from this map
 // fall back to English.
+//
+// The "-obj" suffix is required and must not be dropped. echarts ships two
+// UMD builds per locale: langXX.js self-registers under echarts' own key and
+// exports nothing, while langXX-obj.js exports the locale object. Importing
+// the plain langXX.js yields an empty object, and registering that erases the
+// locale's `time` section, so every time-axis label crashes echarts'
+// formatTime with "Cannot read properties of null" — it evaluates
+// `month[u - 1]` eagerly for every template, even "{yyyy}". Registering the
+// object ourselves is also what lets Superset locale keys that differ from
+// echarts' own (SL -> SI, PT_BR -> PT-br) resolve at init time.
 type EChartsLocaleOption = Parameters<typeof registerLocale>[1];
 
 const LOCALE_LOADERS: Record<
   string,
   () => Promise<{ default: EChartsLocaleOption }>
 > = {
-  AR: () => import('echarts/i18n/langAR.js'),
-  CS: () => import('echarts/i18n/langCS.js'),
-  DE: () => import('echarts/i18n/langDE.js'),
-  EN: () => import('echarts/i18n/langEN.js'),
-  ES: () => import('echarts/i18n/langES.js'),
-  FA: () => import('echarts/i18n/langFA.js'),
-  FI: () => import('echarts/i18n/langFI.js'),
-  FR: () => import('echarts/i18n/langFR.js'),
-  HU: () => import('echarts/i18n/langHU.js'),
-  IT: () => import('echarts/i18n/langIT.js'),
-  JA: () => import('echarts/i18n/langJA.js'),
-  KO: () => import('echarts/i18n/langKO.js'),
-  NL: () => import('echarts/i18n/langNL.js'),
-  PL: () => import('echarts/i18n/langPL.js'),
-  RO: () => import('echarts/i18n/langRO.js'),
-  PT_BR: () => import('echarts/i18n/langPT-br.js'),
-  RU: () => import('echarts/i18n/langRU.js'),
-  SL: () => import('echarts/i18n/langSI.js'),
-  SV: () => import('echarts/i18n/langSV.js'),
-  TH: () => import('echarts/i18n/langTH.js'),
-  TR: () => import('echarts/i18n/langTR.js'),
-  UK: () => import('echarts/i18n/langUK.js'),
-  VI: () => import('echarts/i18n/langVI.js'),
-  ZH: () => import('echarts/i18n/langZH.js'),
+  AR: () => import('echarts/i18n/langAR-obj.js'),
+  CS: () => import('echarts/i18n/langCS-obj.js'),
+  DE: () => import('echarts/i18n/langDE-obj.js'),
+  EN: () => import('echarts/i18n/langEN-obj.js'),
+  ES: () => import('echarts/i18n/langES-obj.js'),
+  FA: () => import('echarts/i18n/langFA-obj.js'),
+  FI: () => import('echarts/i18n/langFI-obj.js'),
+  FR: () => import('echarts/i18n/langFR-obj.js'),
+  HU: () => import('echarts/i18n/langHU-obj.js'),
+  IT: () => import('echarts/i18n/langIT-obj.js'),
+  JA: () => import('echarts/i18n/langJA-obj.js'),
+  KO: () => import('echarts/i18n/langKO-obj.js'),
+  NL: () => import('echarts/i18n/langNL-obj.js'),
+  PL: () => import('echarts/i18n/langPL-obj.js'),
+  RO: () => import('echarts/i18n/langRO-obj.js'),
+  PT_BR: () => import('echarts/i18n/langPT-br-obj.js'),
+  RU: () => import('echarts/i18n/langRU-obj.js'),
+  SL: () => import('echarts/i18n/langSI-obj.js'),
+  SV: () => import('echarts/i18n/langSV-obj.js'),
+  TH: () => import('echarts/i18n/langTH-obj.js'),
+  TR: () => import('echarts/i18n/langTR-obj.js'),
+  UK: () => import('echarts/i18n/langUK-obj.js'),
+  VI: () => import('echarts/i18n/langVI-obj.js'),
+  ZH: () => import('echarts/i18n/langZH-obj.js'),
 };
 
 const loadLocale = async (locale: string) => {
@@ -174,7 +184,11 @@ const loadLocale = async (locale: string) => {
     return undefined;
   }
   try {
-    return (await loader()).default;
+    const localeObj = (await loader()).default;
+    // registerLocale replaces any built-in entry under the same key, so a
+    // partial object would leave echarts formatting against missing data.
+    // Fall back to the built-in locale instead of registering a broken one.
+    return localeObj?.time ? localeObj : undefined;
   } catch {
     return undefined;
   }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
@@ -190,3 +190,20 @@ test('does not restore when the new option reshapes dataZoom', async () => {
   );
   expect(dataZoomCalls).toHaveLength(0);
 });
+
+test('registers a locale object complete enough to format time axis labels', async () => {
+  // echarts ships two UMD builds per locale: langXX.js self-registers and
+  // exports nothing, langXX-obj.js exports the locale object. Importing the
+  // former yields {}, and registering that shadows the built-in locale, so
+  // formatTime blows up on every time-axis label -- it eagerly evaluates
+  // month[u - 1] for any template, even '{yyyy}'. Pin the working shape.
+  const { registerLocale } = jest.requireMock('echarts/core');
+  registerLocale.mockClear();
+
+  renderEchart({ xAxis: {}, series: [] });
+
+  await waitFor(() => expect(registerLocale).toHaveBeenCalled());
+  const [localeKey, localeObj] = registerLocale.mock.calls.at(-1);
+  expect(localeKey).toBe('EN');
+  expect(localeObj?.time?.month).toHaveLength(12);
+});


### PR DESCRIPTION
### SUMMARY

Every chart with a temporal x-axis (line, area, bar, ...) throws
`TypeError: Cannot read properties of null (reading '0')` while rendering axis labels.

echarts ships **two** UMD builds per locale:

| file | behaviour |
|---|---|
| `echarts/i18n/langEN.js` | self-registers under echarts' own key, **exports nothing** |
| `echarts/i18n/langEN-obj.js` | **exports** the locale object |

`Echart.tsx` imported the first one, so `(await loader()).default` was `{}` — empty, but
truthy, so it passed the `if (localeObj)` guard and got handed to `registerLocale('EN', {})`.
That call overwrote the complete locale the very same module had just self-registered,
leaving the registered locale with no `time` section.

echarts' `formatTime` builds its result as a chained `.replace()`, and replacement
arguments are evaluated **eagerly** — it reads `month[u - 1]` even when the template is
just `{yyyy}`. With `time` missing, `month` is `null` and every single axis label throws.

The fix switches all 24 loaders to the `-obj.js` build, and additionally refuses to register
a locale object that has no `time` section, so a future bad import degrades to echarts'
built-in locale instead of crashing the chart.

This also stops dragging the full `echarts` bundle in: the `langXX.js` CJS branch does
`require('echarts/lib/echarts')`, which defeats the tree-shaken `echarts/core` setup this
plugin uses. The `-obj` factory takes only `exports`. (Improvement expected, not measured.)

#### Regression origin

`echarts/lib/i18n/lang${locale}` (a real ESM module with a full `export default`) was
swapped for `echarts/i18n/lang${locale}.js` in #42055, and that path was then carried
forward into the static `LOCALE_LOADERS` map in #42154. The defect is independent of the
echarts major version — 5.6.0 and 6.1.0 both ship the same two i18n flavours.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- N/A - the "before" is a chart that fails to render at all -->

### TESTING INSTRUCTIONS

1. Open any chart with a temporal x-axis (e.g. a line chart from the sample data).
2. Before this change the chart fails to render and the console shows
   `Cannot read properties of null (reading '0')` from echarts' `formatTime`.
   After this change the chart renders with formatted time axis labels.
3. Repeat with a non-English locale to confirm localized labels still work.

Automated:

```
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts
```

A new test in `test/components/Echart.test.tsx` asserts the object handed to
`registerLocale` actually carries a 12-entry `time.month`, which fails against the
previous import path.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
