### PR TITLE
fix(sqllab): render each query error once on async fallback

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -355,6 +355,35 @@ describe('ResultSet', () => {
     expect(errorMessages).toHaveLength(errors.length);
   });
 
+  test('deduplicates errors present in both query.errors and query.extra.errors', async () => {
+    // The async fallback path (QueryAutoRefresh) populates both
+    // `query.errors` (via queryFailed) and `query.extra.errors` (via
+    // refreshQueries) with the same errors. ResultSet should render each
+    // error only once, not twice.
+    const duplicatedErrorQuery = {
+      ...failedQueryWithErrors,
+      extra: { errors: failedQueryWithErrors.errors },
+    };
+    const duplicatedErrorState = {
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        queries: {
+          [duplicatedErrorQuery.id]: duplicatedErrorQuery,
+        },
+      },
+    };
+
+    await waitFor(() => {
+      setup(
+        { ...mockedProps, queryId: duplicatedErrorQuery.id },
+        mockStore(duplicatedErrorState),
+      );
+    });
+    const errorMessages = screen.getAllByTestId('error-message');
+    expect(errorMessages).toHaveLength(failedQueryWithErrors.errors.length);
+  });
+
   test('should render a timeout error with a retrial button', async () => {
     await waitFor(() => {
       setup(

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -618,7 +618,22 @@ const ResultSet = ({
   }
 
   if (query.state === QueryState.Failed) {
-    const errors = [...(query.extra?.errors || []), ...(query.errors || [])];
+    // A failed query can carry the same error in both `query.errors` (set by
+    // the queryFailed action) and `query.extra.errors` (set by the async
+    // refresh). When falling back to async polling both get populated with
+    // identical errors, so deduplicate to avoid rendering each error twice.
+    const seenErrors = new Set<string>();
+    const errors = [
+      ...(query.extra?.errors || []),
+      ...(query.errors || []),
+    ].filter(error => {
+      const key = JSON.stringify(error);
+      if (seenErrors.has(key)) {
+        return false;
+      }
+      seenErrors.add(key);
+      return true;
+    });
 
     return (
       <ResultlessStyles>

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -627,7 +627,11 @@ const ResultSet = ({
       ...(query.extra?.errors || []),
       ...(query.errors || []),
     ].filter(error => {
-      const key = JSON.stringify(error);
+      // json-bigint parsing can leave native BigInt values in payloads,
+      // which JSON.stringify rejects; serialize them as strings.
+      const key = JSON.stringify(error, (_, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      );
       if (seenErrors.has(key)) {
         return false;
       }


### PR DESCRIPTION
### SUMMARY

When a SQL Lab query is run asynchronously and fails, its error was rendered **twice** in the results panel. This is the "doubled error messages on SQL Lab fallback" a customer reported.

**Root cause:** on the async polling path a failed query stores the *same* error array in two places in Redux:

- `QueryAutoRefresh` → `refreshQueries` → `REFRESH_QUERIES` reducer populates `query.extra.errors`.
- immediately after, `queryFailed(query, ..., query.extra?.errors)` → `QUERY_FAILED` reducer stores the identical array into `query.errors`.

`ResultSet` rendered the concatenation of both arrays:

```ts
const errors = [...(query.extra?.errors || []), ...(query.errors || [])];
```

so every error rendered twice via `ErrorMessageWithStackTrace`. The synchronous path only sets `query.errors`, which is why it was only doubled "on fallback".

**Fix:** deduplicate the combined list (keyed by `JSON.stringify`) before rendering, so each error shows exactly once while genuinely distinct errors from either source are still preserved. No change to the synchronous path.

### TESTING INSTRUCTIONS

- New Jest test `deduplicates errors present in both query.errors and query.extra.errors` in `ResultSet.test.tsx`.
- Full `ResultSet` suite passes (37/37). Reverting only the fix makes the new test fail with `Expected length: 2 / Received length: 4`, confirming the guard.
- Manual: run an async query in SQL Lab that fails (e.g. bad SQL against an async-enabled DB) and confirm the error now appears once.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [x] Required feature flags: N/A
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API