### PR TITLE
fix(chart): render chart error stack trace in monospace in dark mode

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -18,12 +18,21 @@
  */
 import { ReactNode } from 'react';
 import { t } from '@apache-superset/core/translation';
+import { styled } from '@apache-superset/core/theme';
 import { ErrorSource, SupersetError } from '@superset-ui/core';
 import { Typography } from '@superset-ui/core/components';
 import { getErrorMessageComponentRegistry } from './getErrorMessageComponentRegistry';
 import { ErrorAlert } from './ErrorAlert';
 
 const DEFAULT_TITLE = t('Unexpected error');
+
+// Render the stack trace in the monospace font in both light and dark mode.
+// Set font-family explicitly from the theme token (as SQL Lab does) rather
+// than relying on the browser/antd default styling for `pre`, which is
+// cascade-order dependent and can fall back to the UI font in dark mode.
+const StackTrace = styled.pre`
+  font-family: ${({ theme }) => theme.fontFamilyCode};
+`;
 
 type Props = {
   title?: string;
@@ -90,7 +99,7 @@ export function ErrorMessageWithStackTrace({
           </Typography.Link>
         )}
         <br />
-        {stackTrace && <pre>{stackTrace}</pre>}
+        {stackTrace && <StackTrace>{stackTrace}</StackTrace>}
       </>
     ) : undefined);
 


### PR DESCRIPTION
### SUMMARY

Error messages shown inside charts — standalone charts and charts embedded in dashboards — rendered their stack-trace / error detail in the default UI font (Lato) in **dark mode**, instead of the monospace font used in light mode. SQL Lab error messages were unaffected.

**Root cause:** `ErrorMessageWithStackTrace` (the shared error component used by both SQL Lab's `ResultSet` and charts via `ChartErrorMessage`) rendered the stack trace in a bare `<pre>` with no explicit `font-family`, relying on the browser/antd default styling for the element. That default is cascade-order dependent: when the dark theme's style tags are (re)injected, the UI font-family reset wins over the inherited monospace, so the chart error text dropped to the UI font. SQL Lab was unaffected because it sets the monospace family explicitly on the element (`MonospaceDiv`, `font-family: theme.fontFamilyCode`), which always wins regardless of injection order.

**Fix:** Render the stack trace in a `styled.pre` that sets `font-family` from `theme.fontFamilyCode` directly on the element — the shared theme token, mirroring SQL Lab's `MonospaceDiv` and the existing `TaskStackTracePopover`. Because the family is now set on the element from the theme token, it resolves to monospace in both light and dark mode. This is the single shared error path, so SQL Lab and chart error rendering stay consistent.

### BEFORE/AFTER

Before: chart error stack traces rendered in the UI font (Lato) in dark mode.
After: chart error stack traces render in the monospace font (`theme.fontFamilyCode`) in both light and dark mode.

### TESTING INSTRUCTIONS

1. Switch to dark mode.
2. Trigger a chart error (e.g. a chart whose query errors) in a standalone chart and in a dashboard.
3. Expand the error detail / stack trace and confirm it renders in the monospace font, matching light mode and SQL Lab.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [x] Required feature flags: n/a
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API