### PR TITLE
fix(sql-lab): dedupe doubled error message on query failure

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -355,6 +355,41 @@ describe('ResultSet', () => {
     expect(errorMessages).toHaveLength(errors.length);
   });
 
+  test('should not duplicate errors present in both errors and extra.errors', async () => {
+    // Async query failures populate `extra.errors` (from the poll payload) and
+    // `errors` (from the queryFailed action) with the same error object; the
+    // failure message should still be rendered only once.
+    const error = {
+      message: 'Something went wrong',
+      error_type: 'TEST_ERROR',
+      level: 'error',
+      extra: null,
+    };
+    const duplicatedErrorQuery = {
+      ...failedQueryWithErrors,
+      errors: [error],
+      extra: { errors: [error] },
+    };
+    const duplicatedErrorState = {
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        queries: {
+          [duplicatedErrorQuery.id]: duplicatedErrorQuery,
+        },
+      },
+    };
+
+    await waitFor(() => {
+      setup(
+        { ...mockedProps, queryId: duplicatedErrorQuery.id },
+        mockStore(duplicatedErrorState),
+      );
+    });
+    const errorMessages = screen.getAllByTestId('error-message');
+    expect(errorMessages).toHaveLength(1);
+  });
+
   test('should render a timeout error with a retrial button', async () => {
     await waitFor(() => {
       setup(

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -30,7 +30,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
 import { useHistory } from 'react-router-dom';
-import { pick } from 'lodash-es';
+import { isEqual, pick, uniqWith } from 'lodash-es';
 import {
   Button,
   ButtonGroup,
@@ -618,7 +618,13 @@ const ResultSet = ({
   }
 
   if (query.state === QueryState.Failed) {
-    const errors = [...(query.extra?.errors || []), ...(query.errors || [])];
+    // `query.extra.errors` (from the async poll payload) and `query.errors`
+    // (from the queryFailed action) can hold the same error, so dedupe to
+    // avoid rendering the failure message twice.
+    const errors = uniqWith(
+      [...(query.extra?.errors || []), ...(query.errors || [])],
+      isEqual,
+    );
 
     return (
       <ResultlessStyles>


### PR DESCRIPTION
### SUMMARY

When a SQL Lab query fails, the error message was rendered **twice** in the results panel.

**Root cause:** For asynchronous query failures, the same error ends up in two places on the query object:

- `superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx:115` dispatches `refreshQueries(...)`, and the `REFRESH_QUERIES` reducer (`superset-frontend/src/SqlLab/reducers/sqlLab.ts:760`) merges the poll payload — including `extra.errors` — into the query.
- Immediately after, the same component dispatches `queryFailed(query, ..., query.extra?.errors)` (`QueryAutoRefresh/index.tsx:123`), and the `QUERY_FAILED` reducer (`reducers/sqlLab.ts:450`) stores that same array as `query.errors`.

`ResultSet` then rendered the concatenation of both arrays at `superset-frontend/src/SqlLab/components/ResultSet/index.tsx:621`:

```ts
const errors = [...(query.extra?.errors || []), ...(query.errors || [])];
```

Because `query.extra.errors` and `query.errors` hold the identical error, each error was rendered twice by the `errors.map(...)` below it.

**Fix:** Deduplicate the concatenated array with `uniqWith(..., isEqual)` so an error present in both sources is shown exactly once. This is the single render site that covers both the sync and async failure paths, so it also guards against any future double-source.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Skipped — behavior is covered by a unit test._

### TESTING INSTRUCTIONS

1. Run an async (`allow_run_async`) SQL Lab query that fails (e.g. reference a non-existent column).
2. Before: the database error is displayed twice. After: it is displayed once.

Automated: `superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx` adds a test asserting a single `error-message` when the same error is present in both `errors` and `extra.errors`. The test fails on the unpatched code (renders 2) and passes with the fix.

```
Tests:       37 passed, 37 total
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes sc-114990
https://app.shortcut.com/preset/story/114990
