### PR TITLE
fix(native-filters): keep filter value input caret at inline start

### DIFF
--- a/superset-frontend/src/chartCustomizations/components/common.ts
+++ b/superset-frontend/src/chartCustomizations/components/common.ts
@@ -25,6 +25,13 @@ export const RESPONSIVE_WIDTH = 0;
 export const FilterPluginStyle = styled.div<PluginFilterStylesProps>`
   min-height: ${({ height }) => height}px;
   width: ${({ width }) => (width === RESPONSIVE_WIDTH ? '100%' : `${width}px`)};
+  /* Filter value controls (Input / InputNumber / the Select search field) */
+  /* resolve 'text-align' by inheritance. Pin the wrapper to the inline start */
+  /* so the caret and typed text stay at the inline-start edge even when a */
+  /* centered 'text-align' is inherited from an ancestor (e.g. a host-app */
+  /* theme or css-in-js override). 'start' is the CSS default, so this is a */
+  /* no-op unless a centered value is inherited, and it is RTL-safe. */
+  text-align: start;
 `;
 
 export const StyledFormItem = styled(FormItem)`

--- a/superset-frontend/src/filters/components/common.test.tsx
+++ b/superset-frontend/src/filters/components/common.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from 'spec/helpers/testing-library';
+
+import { FilterPluginStyle } from 'src/filters/components/common';
+import { FilterPluginStyle as ChartCustomizationsFilterPluginStyle } from 'src/chartCustomizations/components/common';
+
+test('FilterPluginStyle pins the filter value control wrapper to the inline start', () => {
+  // Keeps the caret and typed text at the inline-start edge even when a
+  // centered `text-align` is inherited from an ancestor. Guards against
+  // regressing the wrapper-level rule back to a centered/absent value.
+  const { container } = render(<FilterPluginStyle height={100} width={100} />);
+  expect(container.firstChild).toHaveStyleRule('text-align', 'start');
+});
+
+test('chartCustomizations FilterPluginStyle stays in sync with the inline-start rule', () => {
+  const { container } = render(
+    <ChartCustomizationsFilterPluginStyle height={100} width={100} />,
+  );
+  expect(container.firstChild).toHaveStyleRule('text-align', 'start');
+});

--- a/superset-frontend/src/filters/components/common.ts
+++ b/superset-frontend/src/filters/components/common.ts
@@ -25,6 +25,13 @@ export const RESPONSIVE_WIDTH = 0;
 export const FilterPluginStyle = styled.div<PluginFilterStylesProps>`
   min-height: ${({ height }) => height}px;
   width: ${({ width }) => (width === RESPONSIVE_WIDTH ? '100%' : `${width}px`)};
+  /* Filter value controls (Input / InputNumber / the Select search field) */
+  /* resolve 'text-align' by inheritance. Pin the wrapper to the inline start */
+  /* so the caret and typed text stay at the inline-start edge even when a */
+  /* centered 'text-align' is inherited from an ancestor (e.g. a host-app */
+  /* theme or css-in-js override). 'start' is the CSS default, so this is a */
+  /* no-op unless a centered value is inherited, and it is RTL-safe. */
+  text-align: start;
 `;
 
 export const StyledFormItem = styled(FormItem)`


### PR DESCRIPTION
### SUMMARY

Native filter **value** controls (multi-select and the other value plugins) share the `FilterPluginStyle` wrapper. Their search `<input>` resolves `text-align` by inheritance, so when a centered `text-align` is inherited from an ancestor, the caret and typed text render centered instead of at the inline start.

This pins the shared wrapper to `text-align: start` (the CSS default) so the caret/typed text stay at the inline start regardless of any centered value inherited from an ancestor (e.g. a host application's theme or css-in-js layer). It is a no-op unless such a value is inherited, and it is RTL-safe.

Note: the pinned Ant Design (6.5.1) does **not** set `text-align: center` on `.ant-select-content` itself — verified across antd 6.0.0–6.5.1, where the only `text-align: center` in the Select style layer is on `.ant-select-clear`. So this is intentionally a wrapper-level guard rather than an override of an upstream rule; an earlier iteration's nested `.ant-select-content` override (which targeted a rule not present upstream) has been dropped per review.

The same wrapper is duplicated in `chartCustomizations/components/common.ts`; both copies are kept in sync.

Supersedes #42266 (same fix, reworked to address review feedback) — thanks to the reviewers there.

### TESTING INSTRUCTIONS

- Unit: `npx jest src/filters/components/common.test.tsx` — asserts both `FilterPluginStyle` copies expose `text-align: start`.
- Manual: add a native filter of type **Value** (multi-select) to a dashboard and click into the input; the caret and placeholder/typed text should sit at the inline start.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
