### PR TITLE
refactor(tags): align ExportTagsCommand with ExportModelsCommand

### DIFF
--- a/superset/commands/chart/export.py
+++ b/superset/commands/chart/export.py
@@ -110,4 +110,4 @@ class ExportChartsCommand(ExportModelsCommand):
             and feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM")
         ):
             chart_id = model.id
-            yield from ExportTagsCommand().export(chart_ids=[chart_id])
+            yield from ExportTagsCommand(chart_ids=[chart_id]).run()

--- a/superset/commands/chart/export.py
+++ b/superset/commands/chart/export.py
@@ -91,6 +91,21 @@ class ExportChartsCommand(ExportModelsCommand):
     def enable_tag_export(cls) -> None:
         cls._include_tags = True
 
+    def run(self) -> Iterator[tuple[str, Callable[[], str]]]:
+        yield from super().run()
+
+        # Tags are exported once for all requested charts (rather than per
+        # chart in `_export`) so a multi-chart export doesn't lose tags to
+        # the parent's per-file-name de-duplication of `tags.yaml`.
+        if (
+            self.export_related
+            and ExportChartsCommand._include_tags
+            and feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM")
+        ):
+            yield from ExportTagsCommand(
+                chart_ids=[model.id for model in self._models]
+            ).run()
+
     @staticmethod
     def _export(
         model: Slice, export_related: bool = True
@@ -102,12 +117,3 @@ class ExportChartsCommand(ExportModelsCommand):
 
         if model.table and export_related:
             yield from ExportDatasetsCommand([model.table.id]).run()
-
-        # Check if the calling class is ExportDashboardCommands
-        if (
-            export_related
-            and ExportChartsCommand._include_tags
-            and feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM")
-        ):
-            chart_id = model.id
-            yield from ExportTagsCommand(chart_ids=[chart_id]).run()

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -393,9 +393,9 @@ class ExportDashboardsCommand(ExportModelsCommand):
             yield from command.run()
             command.enable_tag_export()
             if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
-                yield from ExportTagsCommand.export(
+                yield from ExportTagsCommand(
                     dashboard_ids=dashboard_ids, chart_ids=chart_ids
-                )
+                ).run()
 
             # Export related theme
             if model.theme:

--- a/superset/commands/export/assets.py
+++ b/superset/commands/export/assets.py
@@ -70,12 +70,10 @@ class ExportAssetsCommand(BaseCommand):
             elif command == ExportChartsCommand:
                 chart_ids = ids
 
-        # FIXME: It would probably be better to align the tags export
-        # command with the other export commands
-        yield from ExportTagsCommand.export(
+        yield from ExportTagsCommand(
             dashboard_ids=dashboard_ids,
             chart_ids=chart_ids,
-        )
+        ).run()
 
     def validate(self) -> None:
         pass

--- a/superset/commands/tag/export.py
+++ b/superset/commands/tag/export.py
@@ -42,11 +42,9 @@ class ExportTagsCommand(ExportModelsCommand):
         dashboard_ids: Optional[Union[int, List[Union[int, str]]]] = None,
         chart_ids: Optional[Union[int, List[Union[int, str]]]] = None,
     ):
-        self.model_ids = model_ids or []
-        self.export_related = export_related
+        super().__init__(model_ids=model_ids or [], export_related=export_related)
         self.dashboard_ids = dashboard_ids
         self.chart_ids = chart_ids
-        self._models = []
 
     def run(self) -> Iterator[tuple[str, Callable[[], str]]]:
         if not feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
@@ -54,13 +52,11 @@ class ExportTagsCommand(ExportModelsCommand):
 
         yield (
             ExportTagsCommand._file_name(),
-            lambda: ExportTagsCommand._file_content(
-                self.dashboard_ids, self.chart_ids
-            ),
+            lambda: ExportTagsCommand._file_content(self.dashboard_ids, self.chart_ids),
         )
 
     @staticmethod
-    def _file_name() -> str:
+    def _file_name(model: Any = None) -> str:
         return "tags.yaml"
 
     @staticmethod

--- a/superset/commands/tag/export.py
+++ b/superset/commands/tag/export.py
@@ -23,33 +23,56 @@ from collections.abc import Iterator
 import yaml
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
+from superset.daos.tag import TagDAO
 from superset.extensions import feature_flag_manager
 from superset.tags.models import TagType
+from superset.commands.export.models import ExportModelsCommand
 from superset.commands.tag.exceptions import TagNotFoundError
 
 
-# pylint: disable=too-few-public-methods
-class ExportTagsCommand:
+class ExportTagsCommand(ExportModelsCommand):
+    dao = TagDAO
     not_found = TagNotFoundError
+
+    def __init__(
+        self,
+        model_ids: Optional[list[int]] = None,
+        export_related: bool = True,
+        *,
+        dashboard_ids: Optional[Union[int, List[Union[int, str]]]] = None,
+        chart_ids: Optional[Union[int, List[Union[int, str]]]] = None,
+    ):
+        self.model_ids = model_ids or []
+        self.export_related = export_related
+        self.dashboard_ids = dashboard_ids
+        self.chart_ids = chart_ids
+        self._models = []
+
+    def run(self) -> Iterator[tuple[str, Callable[[], str]]]:
+        if not feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
+            return
+
+        yield (
+            ExportTagsCommand._file_name(),
+            lambda: ExportTagsCommand._file_content(
+                self.dashboard_ids, self.chart_ids
+            ),
+        )
 
     @staticmethod
     def _file_name() -> str:
-        # Use the model to determine the filename
         return "tags.yaml"
 
     @staticmethod
     def _merge_tags(
         dashboard_tags: List[dict[str, Any]], chart_tags: List[dict[str, Any]]
     ) -> List[dict[str, Any]]:
-        # Create a dictionary to prevent duplicates based on tag name
         tags_dict = {tag["tag_name"]: tag for tag in dashboard_tags}
 
-        # Add chart tags, preserving unique tag names
         for tag in chart_tags:
             if tag["tag_name"] not in tags_dict:
                 tags_dict[tag["tag_name"]] = tag
 
-        # Return merged tags as a list
         return list(tags_dict.values())
 
     @staticmethod
@@ -62,13 +85,9 @@ class ExportTagsCommand:
         dashboard_tags = []
         chart_tags = []
 
-        # Fetch dashboard tags if provided
         if dashboard_ids:
-            # Ensure dashboard_ids is a list
             if isinstance(dashboard_ids, int):
-                dashboard_ids = [
-                    dashboard_ids
-                ]  # Convert single int to list for consistency
+                dashboard_ids = [dashboard_ids]
 
             dashboards = [
                 dashboard
@@ -88,11 +107,9 @@ class ExportTagsCommand:
                 ]
                 dashboard_tags.extend(filtered_tags)
 
-        # Fetch chart tags if provided
         if chart_ids:
-            # Ensure chart_ids is a list
             if isinstance(chart_ids, int):
-                chart_ids = [chart_ids]  # Convert single int to list for consistency
+                chart_ids = [chart_ids]
 
             charts = [
                 chart
@@ -109,11 +126,9 @@ class ExportTagsCommand:
                 ]
                 chart_tags.extend(filtered_tags)
 
-        # Merge the tags from both dashboards and charts
         merged_tags = ExportTagsCommand._merge_tags(dashboard_tags, chart_tags)
         payload["tags"].extend(merged_tags)
 
-        # Convert to YAML format
         file_content = yaml.safe_dump(payload, sort_keys=False)
         return file_content
 

--- a/superset/commands/tag/export.py
+++ b/superset/commands/tag/export.py
@@ -52,12 +52,12 @@ class ExportTagsCommand(ExportModelsCommand):
 
         self.validate()
 
-        dashboard_ids: list[int] = (
+        dashboard_ids: list[Union[int, str]] = (
             [self.dashboard_ids]
             if isinstance(self.dashboard_ids, int)
             else list(self.dashboard_ids or [])
         )
-        chart_ids: list[int] = (
+        chart_ids: list[Union[int, str]] = (
             [self.chart_ids]
             if isinstance(self.chart_ids, int)
             else list(self.chart_ids or [])

--- a/superset/commands/tag/export.py
+++ b/superset/commands/tag/export.py
@@ -25,7 +25,7 @@ from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
 from superset.daos.tag import TagDAO
 from superset.extensions import feature_flag_manager
-from superset.tags.models import TagType
+from superset.tags.models import ObjectType, TagType
 from superset.commands.export.models import ExportModelsCommand
 from superset.commands.tag.exceptions import TagNotFoundError
 
@@ -50,9 +50,35 @@ class ExportTagsCommand(ExportModelsCommand):
         if not feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
             return
 
+        self.validate()
+
+        dashboard_ids: list[int] = (
+            [self.dashboard_ids]
+            if isinstance(self.dashboard_ids, int)
+            else list(self.dashboard_ids or [])
+        )
+        chart_ids: list[int] = (
+            [self.chart_ids]
+            if isinstance(self.chart_ids, int)
+            else list(self.chart_ids or [])
+        )
+
+        if self.model_ids:
+            for tag in self._models:
+                for tagged_object in tag.objects:
+                    if tagged_object.object_type == ObjectType.dashboard:
+                        dashboard_ids.append(tagged_object.object_id)
+                    elif tagged_object.object_type == ObjectType.chart:
+                        chart_ids.append(tagged_object.object_id)
+
+        dashboard_ids = list(set(dashboard_ids))
+        chart_ids = list(set(chart_ids))
+
         yield (
             ExportTagsCommand._file_name(),
-            lambda: ExportTagsCommand._file_content(self.dashboard_ids, self.chart_ids),
+            lambda: ExportTagsCommand._file_content(
+                dashboard_ids or None, chart_ids or None
+            ),
         )
 
     @staticmethod
@@ -127,16 +153,3 @@ class ExportTagsCommand(ExportModelsCommand):
 
         file_content = yaml.safe_dump(payload, sort_keys=False)
         return file_content
-
-    @staticmethod
-    def export(
-        dashboard_ids: Optional[Union[int, List[Union[int, str]]]] = None,
-        chart_ids: Optional[Union[int, List[Union[int, str]]]] = None,
-    ) -> Iterator[tuple[str, Callable[[], str]]]:
-        if not feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
-            return
-
-        yield (
-            ExportTagsCommand._file_name(),
-            lambda: ExportTagsCommand._file_content(dashboard_ids, chart_ids),
-        )

--- a/superset/commands/tag/export.py
+++ b/superset/commands/tag/export.py
@@ -71,8 +71,8 @@ class ExportTagsCommand(ExportModelsCommand):
                     elif tagged_object.object_type == ObjectType.chart:
                         chart_ids.append(tagged_object.object_id)
 
-        dashboard_ids = list(set(dashboard_ids))
-        chart_ids = list(set(chart_ids))
+        dashboard_ids = list(dict.fromkeys(dashboard_ids))
+        chart_ids = list(dict.fromkeys(chart_ids))
 
         yield (
             ExportTagsCommand._file_name(),

--- a/tests/unit_tests/commands/export_test.py
+++ b/tests/unit_tests/commands/export_test.py
@@ -102,10 +102,10 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ]
 
     ExportTagsCommand = mocker.patch(  # noqa: N806
-        "superset.commands.export.assets.ExportTagsCommand.export"
+        "superset.commands.export.assets.ExportTagsCommand"
     )
 
-    ExportTagsCommand.return_value = [
+    ExportTagsCommand.return_value.run.return_value = [
         ("tags.yaml", lambda: "<TAGS CONTENTS>"),
     ]
 


### PR DESCRIPTION
## Summary

Closes #40766

`ExportTagsCommand` was the only export command that did not extend `ExportModelsCommand`. It was a standalone class with all `@staticmethod` methods and a custom `export()` classmethod interface, requiring special-case handling in `ExportAssetsCommand` and callers.

This refactoring makes `ExportTagsCommand` extend `ExportModelsCommand`, bringing it in line with the rest of the export command architecture.

## Changes

- **`superset/commands/tag/export.py`**: `ExportTagsCommand` now extends `ExportModelsCommand` with `dao = TagDAO` and `not_found = TagNotFoundError`. Overrides `run()` to handle tag-specific export logic. `__init__` accepts both `model_ids`/`export_related` (for consistency with parent) and `dashboard_ids`/`chart_ids` (for the tag-specific interface). The static `export()` method is removed; all callers use `run()`. Dashboard/chart ids are de-duplicated with `dict.fromkeys()` (not `set()`) so `tags.yaml` ordering stays stable across repeated exports.

- **`superset/commands/export/assets.py`**: Updated to use `ExportTagsCommand(...).run()` instead of `ExportTagsCommand.export(...)`. Removed the FIXME comment about aligning the tags export command.

- **`superset/commands/chart/export.py`**: `ExportChartsCommand.run()` is now overridden to export tags once for all requested charts, aggregated after `super().run()`, instead of once per chart from inside `_export()` — a per-chart call meant only the first chart's `tags.yaml` survived the parent's per-filename de-dup on a multi-chart export.

- **`superset/commands/dashboard/export.py`**: Updated to use `ExportTagsCommand(...).run()` instead of `ExportTagsCommand.export(...)`.

- **`tests/unit_tests/commands/export_test.py`**: Updated mock to match new `run()` interface.

## Testing

### Unit Tests

```bash
pytest tests/unit_tests/commands/export_test.py -v
```

### Backend Tests

```bash
pytest tests/unit_tests/commands/ -v -k export
```

### Manual Testing

1. Enable `TAGGING_SYSTEM` feature flag in `superset_config.py`
2. Create a dashboard with tags and a chart with tags
3. Export dashboards via API: `GET /api/v1/dashboard/export/?q=(ids:)`
4. Verify the exported zip contains `tags.yaml` with merged tags from both dashboards and charts
5. Export charts individually and verify tags are included
6. Run the full asset export and verify all files are correct

### Regression Check

- Verify that importing the exported bundle recreates all tags correctly
- Verify that tag deduplication works (same tag name on dashboard and chart appears once)

