### PR TITLE
fix: guard potential null derefs and remove dead branches

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -318,7 +318,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             # another temporal filter. A new filter based on the value of
             # the granularity will be added later in the code.
             # In practice, this is replacing the previous default temporal filter.
-            if is_adhoc_column(filter_to_remove):  # type: ignore
+            if filter_to_remove and is_adhoc_column(filter_to_remove):  # type: ignore
                 filter_to_remove = filter_to_remove.get("sqlExpression")
 
             if filter_to_remove:

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -206,11 +206,9 @@ class QueryCacheManager:
                 )
                 query_cache.status = QueryStatus.SUCCESS
                 query_cache.is_loaded = True
-                query_cache.is_cached = cache_value is not None
+                query_cache.is_cached = True
                 query_cache.sql_rowcount = cache_value.get("sql_rowcount", None)
-                query_cache.cache_dttm = (
-                    cache_value["dttm"] if cache_value is not None else None
-                )
+                query_cache.cache_dttm = cache_value["dttm"]
                 query_cache.queried_dttm = cache_value.get(
                     "queried_dttm", cache_value.get("dttm")
                 )

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -534,6 +534,7 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         ],
     ) -> list[SupersetError]:
         errors: list[SupersetError] = []
+        connect_args: dict[str, Any] = {}
         if extra := json.loads(properties.get("extra")):  # type: ignore
             engine_params = extra.get("engine_params", {})
             connect_args = engine_params.get("connect_args", {})

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -1229,6 +1229,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         all_columns: list[ResultSetColumnType] = []
         expanded_columns = []
         current_array_level = None
+        unnested_rows: dict[int, int] = defaultdict(int)
         while to_process:
             column, level = to_process.popleft()
             if column["column_name"] not in [
@@ -1242,7 +1243,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             # added by the first. every time we change a level in the nested arrays
             # we reinitialize this.
             if level != current_array_level:
-                unnested_rows: dict[int, int] = defaultdict(int)
+                unnested_rows = defaultdict(int)
                 current_array_level = level
 
             name = column["column_name"]


### PR DESCRIPTION
### SUMMARY
Small robustness/cleanup pass in a few backend paths surfaced by static analysis:

- **databricks** `validate_parameters`: `connect_args` was only bound inside the `if extra := json.loads(...)` block, so an empty `extra` raised `UnboundLocalError` at `connect_args.get("http_path")`. Now initialized to `{}` up front.
- **query_cache_manager**: inside the `if cache_value := ...` block `cache_value` is always truthy, so `is_cached = cache_value is not None` and the `else None` branch of `cache_dttm` were redundant/dead. Simplified.
- **query_context_factory**: made the None-safety of `filter_to_remove` explicit before `is_adhoc_column`.
- **presto** `expand_data`: `unnested_rows` was only assigned inside a conditional; initialized before the loop so it's always bound.

### TESTING INSTRUCTIONS
No behavior change except the databricks fix (empty `extra` no longer raises). Covered by existing db_engine_specs and query-context unit tests.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: No
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No