### PR TITLE
chore: SQLAlchemy User cascade backref warnings are irrelevant

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -36,11 +36,9 @@ filterwarnings =
     error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
-    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
     error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
-#    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
+    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
     error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
     error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
     error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
     error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
-#    error:"User" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

See #40273 .

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR addresses the warnings thrown by SQLAlchemy 1.4 because the `User` and `Role` models do not explicit declare `cascade_backrefs=False` in agreement with SQLAlchemy 2.0.
For completeness, the respective warning/error type is removed from `pytest.ini` although there is no code change:

*   The `cascade_backrefs` parameter is _not_ set to `False` in the `User` and `Role` models they are in the Flask Appbuilder library and not part of the codebase.
    My IDE tells me that, within Flask Appbuilder, there is only [one location](https://github.com/dpgaspar/Flask-AppBuilder/blob/55a5ab67348b3249a78e9bbbf817e320c20b81dd/flask_appbuilder/security/sqla/apis/user/api.py#L126) where a `User` object is created (and not queried from the database). 
    This `User` object is explicitly added to the SQLAlchemy session [a few lines later](https://github.com/dpgaspar/Flask-AppBuilder/blob/55a5ab67348b3249a78e9bbbf817e320c20b81dd/flask_appbuilder/security/sqla/apis/user/api.py#L167).
    So Flask Appbuilder should not block the next step of activating the `Session` object `future` flag.
*   I manually checked the 110 or so call sites in the Superset codebase.
    `User` plays a hybrid role of (i) being the DTO corresponding to the user relation in the database, and (ii) representing the user in the IAM of Flask.
    From what I see, in the SQLAlchemy case, `User` is already explicitly added to the SQLAlchemy session, sometimes indirectly via `UserDAO.create()`.
    In the Flask case, it is most often passed to the `override_user` context manager, and does not have to be persisted.
*   I completely removed the warning/error class from `pytest.ini`, similarly to #41977 and #41982.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Because the code has not been altered, and no new warnings are converted to errors, we do not expect any tests to fail.
This is not a problem because the [official documentation](https://docs.sqlalchemy.org/en/14/errors.html#object-is-being-merged-into-a-session-along-the-backref-cascade) suggests the alternative of setting `Session.future`, which is the next step in the roadmap anyways. #40273 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
