### PR TITLE
feat(deps): migrate from backoff to backon (drop-in replacement, zero deps)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     # no bounds for apache-superset-core until we have a stable version
     "apache-superset-core",
-    "backoff>=1.8.0",
+    "backon>=4.4.2",
     # cachetools is used directly by ``superset.db_engine_specs.aws_iam`` (TTLCache).
     # It used to be installed transitively via ``google-auth`` (<2.53), but
     # ``google-auth`` 2.53+ dropped it, so Superset must declare it
@@ -258,7 +258,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = "superset, apache-superset-core, apache-superset-extensions-cli"
-known_third_party = "alembic, apispec, backoff, celery, click, colorama, cron_descriptor, croniter, cryptography, dateutil, deprecation, flask, flask_appbuilder, flask_babel, flask_caching, flask_compress, flask_jwt_extended, flask_login, flask_migrate, flask_sqlalchemy, flask_talisman, flask_testing, flask_wtf, freezegun, geohash, geopy, holidays, humanize, isodate, jinja2, jwt, markdown, markupsafe, marshmallow, marshmallow-union, msgpack, nh3, numpy, pandas, parameterized, parsedatetime, pgsanity, polyline, rison, progress, pyarrow, sqlalchemy_bigquery, pyhive, pyparsing, pytest, pytest_mock, pytz, redis, requests, selenium, setuptools, shillelagh, simplejson, slack, sqlalchemy, sqlalchemy_utils, syntaqlite, typing_extensions, urllib3, werkzeug, wtforms, wtforms_json, yaml"
+known_third_party = "alembic, apispec, backon, celery, click, colorama, cron_descriptor, croniter, cryptography, dateutil, deprecation, flask, flask_appbuilder, flask_babel, flask_caching, flask_compress, flask_jwt_extended, flask_login, flask_migrate, flask_sqlalchemy, flask_talisman, flask_testing, flask_wtf, freezegun, geohash, geopy, holidays, humanize, isodate, jinja2, jwt, markdown, markupsafe, marshmallow, marshmallow-union, msgpack, nh3, numpy, pandas, parameterized, parsedatetime, pgsanity, polyline, rison, progress, pyarrow, sqlalchemy_bigquery, pyhive, pyparsing, pytest, pytest_mock, pytz, redis, requests, selenium, setuptools, shillelagh, simplejson, slack, sqlalchemy, sqlalchemy_utils, syntaqlite, typing_extensions, urllib3, werkzeug, wtforms, wtforms_json, yaml"
 multi_line_output = 3
 order_by_type = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     # no bounds for apache-superset-core until we have a stable version
     "apache-superset-core",
-    "backon>=4.4.5",
+    "backon>=4.4.5,<5",
     # cachetools is used directly by ``superset.db_engine_specs.aws_iam`` (TTLCache).
     # It used to be installed transitively via ``google-auth`` (<2.53), but
     # ``google-auth`` 2.53+ dropped it, so Superset must declare it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     # no bounds for apache-superset-core until we have a stable version
     "apache-superset-core",
-    "backon>=4.4.2",
+    "backon>=4.4.5",
     # cachetools is used directly by ``superset.db_engine_specs.aws_iam`` (TTLCache).
     # It used to be installed transitively via ``google-auth`` (<2.53), but
     # ``google-auth`` 2.53+ dropped it, so Superset must declare it

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ attrs==25.3.0
     #   trio
 babel==2.17.0
     # via flask-babel
-backoff==2.2.1
+backon==4.4.2
     # via apache-superset (pyproject.toml)
 bcrypt==4.3.0
     # via paramiko

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ attrs==25.3.0
     #   trio
 babel==2.17.0
     # via flask-babel
-backon==4.4.2
+backon==4.4.5
     # via apache-superset (pyproject.toml)
 bcrypt==4.3.0
     # via paramiko

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -58,7 +58,7 @@ babel==2.17.0
     # via
     #   -c requirements/base-constraint.txt
     #   flask-babel
-backoff==2.2.1
+backon==4.4.2
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -58,7 +58,7 @@ babel==2.17.0
     # via
     #   -c requirements/base-constraint.txt
     #   flask-babel
-backon==4.4.2
+backon==4.4.5
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset/extensions/storage/persistent_dao.py
+++ b/superset/extensions/storage/persistent_dao.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-import backoff
+import backon
 from flask import current_app
 from flask_babel import gettext as _
 from sqlalchemy import and_, desc, func, LargeBinary
@@ -494,8 +494,8 @@ class ExtensionStorageDAO(BaseDAO[ExtensionStorage]):
     # ── Write (upsert) ────────────────────────────────────────────────────────
 
     @staticmethod
-    @backoff.on_exception(
-        backoff.expo,
+    @backon.on_exception(
+        backon.expo,
         AcquireDistributedLockFailedException,
         factor=0.1,
         base=2,

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Any
 
-import backoff
+import backon
 from flask_appbuilder.api import (
     expose,
     protect,
@@ -238,8 +238,8 @@ class QueryRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.stop_query",
         log_to_statsd=False,
     )
-    @backoff.on_exception(
-        backoff.constant,
+    @backon.on_exception(
+        backon.constant,
         Exception,
         interval=1,
         on_backoff=lambda details: db.session.rollback(),  # pylint: disable=consider-using-transaction

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 from io import IOBase
 from typing import Union
 
-import backoff
+import backon
 from flask import g
 from slack_sdk.errors import (
     BotUserAccessError,
@@ -90,7 +90,7 @@ class SlackNotification(SlackMixin, BaseNotification):  # pylint: disable=too-fe
             return ("pdf", [self._content.pdf])
         return (None, [])
 
-    @backoff.on_exception(backoff.expo, SlackApiError, factor=10, base=2, max_tries=5)
+    @backon.on_exception(backon.expo, SlackApiError, factor=10, base=2, max_tries=5)
     @statsd_gauge("reports.slack.send")
     def send(self) -> None:
         file_type, files = self._get_inline_files()
@@ -138,5 +138,5 @@ class SlackNotification(SlackMixin, BaseNotification):  # pylint: disable=too-fe
             raise NotificationUnprocessableException(str(ex)) from ex
         except SlackClientError as ex:
             # this is the base class for all slack client errors
-            # keep it last so that it doesn't interfere with @backoff
+            # keep it last so that it doesn't interfere with @backon
             raise NotificationUnprocessableException(str(ex)) from ex

--- a/superset/reports/notifications/slackv2.py
+++ b/superset/reports/notifications/slackv2.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Sequence
 from io import IOBase
 from typing import List, Union
 
-import backoff
+import backon
 from flask import g
 from slack_sdk.errors import (
     BotUserAccessError,
@@ -86,8 +86,8 @@ def _give_up_slack_api_retry(ex: Exception) -> bool:
     return bool(error_code and error_code not in _TRANSIENT_SLACK_API_ERROR_CODES)
 
 
-@backoff.on_exception(
-    backoff.expo,
+@backon.on_exception(
+    backon.expo,
     (SlackApiError, SlackClientNotConnectedError),
     factor=10,
     base=2,
@@ -179,5 +179,5 @@ class SlackV2Notification(SlackMixin, BaseNotification):  # pylint: disable=too-
             raise NotificationUnprocessableException(str(ex)) from ex
         except SlackClientError as ex:
             # this is the base class for all slack client errors
-            # keep it last so that it doesn't interfere with @backoff
+            # keep it last so that it doesn't interfere with @backon
             raise NotificationUnprocessableException(str(ex)) from ex

--- a/superset/reports/notifications/webhook.py
+++ b/superset/reports/notifications/webhook.py
@@ -19,7 +19,7 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
-import backoff
+import backon
 import requests
 from flask import current_app
 
@@ -139,8 +139,8 @@ class WebhookNotification(BaseNotification):
         if not is_safe_host(parsed.hostname):
             raise NotificationParamException("Webhook URL target host is not allowed.")
 
-    @backoff.on_exception(
-        backoff.expo,
+    @backon.on_exception(
+        backon.expo,
         NotificationUnprocessableException,
         factor=10,
         base=2,
@@ -149,16 +149,16 @@ class WebhookNotification(BaseNotification):
         # persistently-failing target can stall a worker for minutes per bad
         # URL, starving sequential report dispatch.
         #
-        # backoff (see backoff._sync.retry_exception) samples elapsed at the
-        # start of each attempt and checks it against max_time only after that
-        # attempt fails -- so the giveup decision uses the time measured before
-        # the attempt ran, ignoring the attempt's own duration. With each
-        # request carrying timeout=60, a third attempt can begin past the 120s
-        # mark (its start gated by the prior check, which still saw ~60-70s) and
-        # then run its full 60s before the check trips. The loop therefore makes
-        # 3 attempts: total wall-clock is ~180-210s (180s of requests + up to
-        # ~30s of jitter sleeps: <=10s then <=20s), not 120s. factor is kept at
-        # 10 so legitimately-transient 5xx targets are not abandoned early.
+        # max_time samples elapsed at the start of each attempt and checks
+        # it against max_time only after that attempt fails -- so the giveup
+        # decision uses the time measured before the attempt ran, ignoring
+        # the attempt's own duration. With each request carrying timeout=60,
+        # a third attempt can begin past the 120s mark (its start gated by the
+        # prior check, which still saw ~60-70s) and then run its full 60s
+        # before the check trips. The loop therefore makes 3 attempts: total
+        # wall-clock is ~180-210s (180s of requests + up to ~30s of jitter
+        # sleeps: <=10s then <=20s), not 120s. factor is kept at 10 so
+        # legitimately-transient 5xx targets are not abandoned early.
         max_time=120,
     )
     @statsd_gauge("reports.webhook.send")

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from sys import getsizeof
 from typing import Any, cast, Optional, TYPE_CHECKING, TypeVar, Union
 
-import backoff
+import backon
 import msgpack
 from celery.exceptions import SoftTimeLimitExceeded
 from flask import current_app as app, has_app_context
@@ -132,7 +132,7 @@ def handle_query_error(
     return payload
 
 
-def get_query_backoff_handler(details: dict[Any, Any]) -> None:
+def get_query_retry_handler(details: dict[Any, Any]) -> None:
     stats_logger = app.config["STATS_LOGGER"]
     query_id = details["kwargs"]["query_id"]
     stats_logger.incr(f"error_attempting_orm_query_{details['tries'] - 1}")
@@ -148,11 +148,11 @@ def get_query_giveup_handler(_: Any) -> None:
     stats_logger.incr("error_failed_at_getting_orm_query")
 
 
-@backoff.on_exception(
-    backoff.constant,
+@backon.on_exception(
+    backon.constant,
     SqlLabException,
     interval=1,
-    on_backoff=get_query_backoff_handler,
+    on_backoff=get_query_retry_handler,
     on_giveup=get_query_giveup_handler,
     max_tries=5,
 )

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator, TYPE_CHECKING
 
-import backoff
+import backon
 import jwt
 from flask import current_app as app, url_for
 from marshmallow import EXCLUDE, fields, post_load, Schema, validate
@@ -76,8 +76,8 @@ def generate_code_challenge(code_verifier: str) -> str:
     return code_challenge
 
 
-@backoff.on_exception(
-    backoff.expo,
+@backon.on_exception(
+    backon.expo,
     AcquireDistributedLockFailedException,
     factor=0.1,
     base=2,

--- a/superset/utils/retries.py
+++ b/superset/utils/retries.py
@@ -19,13 +19,13 @@ import logging
 from collections.abc import Generator
 from typing import Any, Callable, Optional
 
-import backoff
+import backon
 
 
 def retry_call(  # pylint: disable=too-many-arguments
     func: Callable[..., Any],
     *args: Any,
-    strategy: Callable[..., Generator[int, None, None]] = backoff.constant,
+    strategy: Callable[..., Generator[int, None, None]] = backon.constant,
     exception: type[Exception] = Exception,
     giveup_log_level: int = logging.WARNING,
     fargs: Optional[list[Any]] = None,
@@ -36,7 +36,7 @@ def retry_call(  # pylint: disable=too-many-arguments
     Retry a given call.
     """
     kwargs["giveup_log_level"] = giveup_log_level
-    decorated = backoff.on_exception(strategy, exception, *args, **kwargs)(func)
+    decorated = backon.on_exception(strategy, exception, *args, **kwargs)(func)
     fargs = fargs or []
     fkwargs = fkwargs or {}
     return decorated(*fargs, **fkwargs)

--- a/tests/unit_tests/reports/notifications/slack_tests.py
+++ b/tests/unit_tests/reports/notifications/slack_tests.py
@@ -48,15 +48,15 @@ from superset.utils.core import HeaderDataType
 
 @pytest.fixture(autouse=True)
 def _skip_backoff_sleep():
-    """Make any @backoff.on_exception retries instant.
+    """Make any @backon.on_exception retries instant.
 
-    SlackV2Notification.send() retries up to 5 times with `backoff.expo(factor=10,
+    SlackV2Notification.send() retries up to 5 times with `backon.expo(factor=10,
     base=2)` — that's ~150s of real sleep on a persistently-failing send. We
     don't care about the wall-clock waits in unit tests; patching `time.sleep`
-    inside backoff's sync runner keeps the assertion semantics (call_count,
-    raised exception type) without the wait.
+    keeps the assertion semantics (call_count, raised exception type) without
+    the wait.
     """
-    with patch("backoff._sync.time.sleep"):
+    with patch("time.sleep"):
         yield
 
 
@@ -817,7 +817,7 @@ def test_v2_send_retries_on_transient_slack_api_error(
     flask_global_mock: MagicMock,
     mock_header_data,
 ) -> None:
-    """`@backoff.on_exception(NotificationUnprocessableException, max_tries=5)`
+    """`@backon.on_exception(NotificationUnprocessableException, max_tries=5)`
     retries the wrapped exception that send() actually raises.
 
     A persistent Slack rate-limit (or any other transient failure that maps to
@@ -846,7 +846,7 @@ def test_v2_send_retries_then_succeeds_on_transient_failure(
     flask_global_mock: MagicMock,
     mock_header_data,
 ) -> None:
-    """The point of switching backoff to NotificationUnprocessableException is
+    """The point of switching to NotificationUnprocessableException is
     that a *transient* failure now retries and the send ultimately succeeds —
     behavior the old (dead) SlackApiError decorator never delivered. Fail twice,
     then succeed: send() must return normally after exactly 3 attempts and still
@@ -937,7 +937,7 @@ def test_v2_send_does_not_retry_param_errors(
     mock_header_data,
 ) -> None:
     """Non-transient errors (config / auth / malformed) are NOT retried — only
-    NotificationUnprocessableException triggers backoff. A
+    NotificationUnprocessableException triggers retry. A
     NotificationParamException-class failure (BotUserAccessError → 422) hits
     the API exactly once and surfaces immediately.
     """
@@ -994,7 +994,7 @@ def test_give_up_slack_api_retry_retries_on_status_code(
     response = _make_slack_response(status_code, data)
     ex = SlackApiError(message="transient", response=response)
 
-    # give_up == False -> the request WILL be retried by backoff.
+    # give_up == False -> the request WILL be retried by backon.
     assert _give_up_slack_api_retry(ex) is False
 
 


### PR DESCRIPTION
### SUMMARY

Migrate from the archived `backoff` library to `backon` — a near-drop-in replacement with zero dependencies and active maintenance.

**Motivation:**
- `backoff` upstream was archived in August 2025 and has Python 3.14+ compatibility issues
- `backon` has zero runtime dependencies (stdlib only)
- Same public API: `@backon.on_exception(backon.expo, ...)`
- Active maintenance (112+ commits, Jul 2026)
- Extra optional features: circuit breaker, hedging, global toggle, testing utilities

**Changes:**
- Replace `backoff>=1.8.0` with `backon>=4.4.5` in pyproject.toml
- Update requirements/*.txt lock files
- Replace `import backoff` with `import backon` in 8 source files
- Replace all `backoff.expo` / `backoff.constant` references with `backon.expo` / `backon.constant`
- Update test patch path from `backoff._sync.time.sleep` to `time.sleep`
- Update isort `known_third_party` config

### TESTING INSTRUCTIONS

1. Run `pip install backon==4.4.5`
2. Run existing unit tests:
   - `pytest tests/unit_tests/reports/notifications/slack_tests.py`
   - `pytest tests/unit_tests/reports/notifications/webhook_tests.py`
   - `pytest tests/unit_tests/utils/oauth2_tests.py`
3. Run `pre-commit run --all-files` to verify lint/formatting

### ADDITIONAL INFORMATION
- [x] Has associated issue: Discussion #42289
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

