### PR TITLE
fix(security): bump pillow from 12.2.0 to 12.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -285,7 +285,7 @@ parsedatetime==2.6
     # via apache-superset (pyproject.toml)
 pgsanity==0.2.9
     # via apache-superset (pyproject.toml)
-pillow==12.2.0
+pillow==12.3.0
     # via apache-superset (pyproject.toml)
 platformdirs==4.3.8
     # via requests-cache

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -665,7 +665,7 @@ pgsanity==0.2.9
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset


### PR DESCRIPTION
### SUMMARY
Bumps `pillow` from 12.2.0 to 12.3.0 to patch 10 known vulnerabilities:

- CVE-2026-54059, CVE-2026-54060, CVE-2026-55379, CVE-2026-55380 (HIGH) — allocation of memory without limits, leading to excessive resource consumption
- CVE-2026-59197, CVE-2026-59205 (HIGH) — out-of-bounds write
- CVE-2026-59198 (HIGH) — out-of-bounds read
- CVE-2026-59200 (HIGH) — resource consumption / denial of service
- CVE-2026-59203 (MEDIUM) — infinite loop
- CVE-2026-55798 (LOW) — improper neutralization leading to command injection

Reviewed the Pillow 12.3.0 release notes: the changes in this range are bug fixes (decompression-bomb checks, integer-overflow and bounds-checking hardening across several format decoders), performance improvements to existing `Image` operations (`filter`, `blend`, `resample`, `getchannel`, `merge`, `putalpha`, `split`, etc.), and removal of non-image `ImageCms` modes. Superset's own Pillow usage (`superset/utils/screenshot_utils.py`, `superset/utils/screenshots.py`, `superset/utils/pdf.py`) only touches the core `PIL.Image` API and does not use `ImageCms`, so no application code changes are required.

`pyproject.toml` already constrains pillow to `>=11.0.0, <13`, so 12.3.0 satisfies the existing range; only the compiled lock files needed updating.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — dependency version bump only, no UI changes.

### TESTING INSTRUCTIONS
- CI: unit and integration test suite
- Manually verify dashboard/chart screenshot generation and PDF export still render correctly, exercising `superset/utils/screenshot_utils.py`, `superset/utils/screenshots.py`, and `superset/utils/pdf.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API