### PR TITLE
fix(security): bump flask to 3.1.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -107,7 +107,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 filelock==3.20.3
     # via -r requirements/base.in
-flask==2.3.3
+flask==3.1.3
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -246,7 +246,7 @@ filelock==3.20.3
     # via
     #   -c requirements/base-constraint.txt
     #   virtualenv
-flask==2.3.3
+flask==3.1.3
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -22,7 +22,8 @@ from random import random
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from flask import Response, escape, url_for
+from flask import Response, url_for
+from markupsafe import escape
 from sqlalchemy import func
 
 from superset import db, security_manager


### PR DESCRIPTION
### SUMMARY
Bumps `flask` from 2.3.3 to 3.1.3 to address CVE-2026-27205 (low severity, use of cache containing sensitive information), which is fixed upstream in Flask 3.1.3.

`pyproject.toml` already declares `flask>=2.2.5, <4.0.0`, but `requirements/base.txt` was locking the resolution to 2.3.3. Verified that none of the pinned flask-* plugins (flask-appbuilder 5.2.2, flask-babel, flask-caching, flask-compress, flask-cors, flask-jwt-extended, flask-limiter, flask-login, flask-migrate, flask-session, flask-sqlalchemy, flask-talisman, flask-wtf) declare an upper bound below Flask 4, so nothing blocks moving the lock to 3.1.3. werkzeug (3.1.6), jinja2 (3.1.6), itsdangerous (2.2.0), click (8.4.2) and blinker (1.9.0) are already pinned at/above the minimums Flask 3.1.3 requires (werkzeug>=3.1.0, jinja2>=3.1.2, itsdangerous>=2.2.0, click>=8.1.3, blinker>=1.9.0), so no companion dependency bumps are needed.

Reviewed the Flask changelog for the full 2.3.3 → 3.1.3 range (3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0, 3.1.1, 3.1.2, 3.1.3). The only breaking change in that range that touches this codebase is Flask 3.0.0 no longer re-exporting `escape`/`Markup` from `markupsafe`; a single test (`tests/integration_tests/dashboard_tests.py`) imported `escape` from `flask`, so that import is updated to come from `markupsafe` directly (identical function, no behavior change). No other breaking changes in the range (removed `_app_ctx_stack`/`_request_ctx_stack` push/pop, `signals_available`, `locked_cached_property`, `SERVER_NAME`/host-matching behavior change in 3.1.0) are used anywhere in `superset/` or `tests/`.

### TESTING INSTRUCTIONS
- CI test suite (unit + integration tests) should pass with `flask==3.1.3`.
- `tests/integration_tests/dashboard_tests.py::DashboardTests::test_get_dashboard` (the only test using `escape` in this file) should continue to pass with `escape` imported from `markupsafe`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: CVE-2026-27205
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
