### PR TITLE
fix(jinja): handle UndefinedError from virtual dataset templates

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -54,7 +54,7 @@ from flask_appbuilder.models.decorators import renders
 from flask_appbuilder.models.mixins import AuditMixin
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import get_locale, lazy_gettext as _
-from jinja2.exceptions import TemplateError
+from jinja2.exceptions import TemplateError, UndefinedError
 from markupsafe import escape, Markup
 from pandas import DateOffset
 from sqlalchemy import and_, Column, or_, UniqueConstraint
@@ -2775,6 +2775,16 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if template_processor:
             try:
                 sql = template_processor.process_template(sql)
+            except UndefinedError as ex:
+                # Raised when a template references an undefined value, e.g.
+                # indexing into an empty list returned by `filter_values()`
+                # when no dashboard filter is active for that column.
+                raise QueryObjectValidationError(
+                    _(
+                        "Virtual dataset template error: %(msg)s",
+                        msg=str(ex),
+                    )
+                ) from ex
             except (TemplateError, SupersetSyntaxErrorException) as ex:
                 # Extract error message from different exception types
                 if isinstance(ex, TemplateError):

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -38,7 +38,7 @@ from superset.connectors.sqla.models import (
     SqlMetric,
     TableColumn,
 )
-from superset.exceptions import SupersetTemplateException
+from superset.exceptions import QueryObjectValidationError, SupersetTemplateException
 from superset.jinja_context import (
     dataset_macro,
     ExtraCache,
@@ -2111,3 +2111,31 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
 )
 def test_extra_cache_regex(sql: str, expected: bool) -> None:
     assert bool(ExtraCache.regex.search(sql)) is expected
+
+
+def test_get_rendered_sql_filter_values_index_error_on_empty_list() -> None:
+    """
+    A virtual dataset template that indexes into ``filter_values()`` (e.g.
+    ``filter_values('col')[0]``) raises a Jinja ``UndefinedError`` when no
+    dashboard filter is active for that column, since the call returns an
+    empty list. ``get_rendered_sql`` must surface this as a
+    ``QueryObjectValidationError`` instead of letting the raw
+    ``UndefinedError`` propagate as an unhandled 500.
+    """
+    database = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="virtual_t",
+        sql=(
+            "SELECT col FROM t WHERE col = "
+            """{{ "'" + filter_values('col')[0] + "'" }}"""
+        ),
+    )
+    processor = get_template_processor(database=database, table=table)
+
+    with pytest.raises(
+        QueryObjectValidationError,
+        match="list object has no element 0",
+    ):
+        table.get_rendered_sql(processor)

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -2118,9 +2118,10 @@ def test_get_rendered_sql_filter_values_index_error_on_empty_list() -> None:
     A virtual dataset template that indexes into ``filter_values()`` (e.g.
     ``filter_values('col')[0]``) raises a Jinja ``UndefinedError`` when no
     dashboard filter is active for that column, since the call returns an
-    empty list. ``get_rendered_sql`` must surface this as a
-    ``QueryObjectValidationError`` instead of letting the raw
-    ``UndefinedError`` propagate as an unhandled 500.
+    empty list. ``get_rendered_sql`` must surface this with the dedicated
+    "Virtual dataset template error" message rather than the generic
+    "Error while rendering virtual dataset query" message used for other
+    template errors.
     """
     database = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
     table = SqlaTable(
@@ -2136,6 +2137,6 @@ def test_get_rendered_sql_filter_values_index_error_on_empty_list() -> None:
 
     with pytest.raises(
         QueryObjectValidationError,
-        match="list object has no element 0",
+        match=r"Virtual dataset template error: list object has no element 0",
     ):
         table.get_rendered_sql(processor)


### PR DESCRIPTION
### SUMMARY
Virtual dataset SQL templates that index into `filter_values()` (e.g. `filter_values('col')[0]`) can raise a Jinja `UndefinedError` when no dashboard filter is active for that column. This gives that error a dedicated, more specific validation message instead of the generic template-rendering error message it was previously grouped under.

### PROBLEM
When a virtual dataset's SQL template does something like:

```sql
WHERE col = {{ "'" + filter_values('col')[0] + "'" }}
```

and there are no active dashboard filters for `col`, `filter_values('col')` returns an empty list, and operating on the resulting undefined value (e.g. concatenating it into a string, a common pattern for quoting filter values in SQL) raises `jinja2.exceptions.UndefinedError` (e.g. `list object has no element 0`) during Jinja rendering.

`get_rendered_sql()` in `superset/models/helpers.py` already caught this via a broader `except (TemplateError, SupersetSyntaxErrorException)` clause, since `UndefinedError` is a subclass of `TemplateError` — so it was not surfacing as a raw 500. However, it was reported with the same generic message used for unrelated template syntax errors ("Error while rendering virtual dataset query: ..."), which doesn't make it obvious to the dashboard/chart owner that the root cause is a template referencing a value (like an unset filter) that isn't available.

### FIX
Added an explicit `except UndefinedError` branch in `get_rendered_sql()`, ordered before the existing `except (TemplateError, SupersetSyntaxErrorException)` branch, that re-raises as `QueryObjectValidationError` with a dedicated message: `"Virtual dataset template error: %(msg)s"`, using the original exception's message.

Note: other call sites of `template_processor.process_template()` in `superset/models/helpers.py` (e.g. `_process_sql_expression`, `get_timestamp_expression`, `convert_tbl_column_to_sqla_col`) are not wrapped in equivalent error handling and could still raise `UndefinedError` unhandled for adhoc SQL expressions. That's out of scope for this PR, which is narrowly focused on the virtual dataset SQL template path.

### TESTING INSTRUCTIONS
- Added a regression test in `tests/unit_tests/jinja_context_test.py` that builds a virtual dataset whose SQL template indexes into `filter_values('col')[0]` with no active filters, and asserts that `get_rendered_sql()` raises `QueryObjectValidationError` with the new "Virtual dataset template error" message. Verified the test fails against the pre-fix code (with the old generic message) and passes with the fix.
- Ran `pytest tests/unit_tests/jinja_context_test.py tests/unit_tests/models/helpers_test.py` locally — all tests pass.
- Ran `ruff check`, `ruff format --check`, `pylint`, and `mypy` on the changed files.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API