### PR TITLE
chore(reports): log Playwright screenshot lifecycle stages

### DIFF
--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -21,6 +21,7 @@ import logging
 from datetime import datetime
 from enum import Enum
 from io import BytesIO
+from time import monotonic
 from typing import cast, TYPE_CHECKING, TypedDict
 
 from flask import current_app as app
@@ -308,24 +309,64 @@ class BaseScreenshot:
                 cache_payload.computing()
                 self.cache.set(cache_key, cache_payload.to_dict())
                 image = None
+                lifecycle_started = monotonic()
                 # Assuming all sorts of things can go wrong with Selenium
                 try:
-                    logger.info("trying to generate screenshot")
+                    logger.info(
+                        "Screenshot lifecycle stage started: stage=capture "
+                        "elapsed=0.00s context=%s",
+                        cache_key,
+                    )
                     with event_logger.log_context(
                         f"screenshot.compute.{self.thumbnail_type}"
                     ):
-                        image = self.get_screenshot(user=user, window_size=window_size)
+                        image = self.get_screenshot(
+                            user=user,
+                            window_size=window_size,
+                            log_context=cache_key,
+                        )
+                    logger.info(
+                        "Screenshot lifecycle stage completed: stage=capture "
+                        "elapsed=%.2fs context=%s",
+                        monotonic() - lifecycle_started,
+                        cache_key,
+                    )
                 except Exception as ex:  # pylint: disable=broad-except
                     logger.warning(
-                        "Failed at generating thumbnail %s", ex, exc_info=True
+                        "Failed at generating thumbnail during stage=capture "
+                        "elapsed=%.2fs context=%s: %s",
+                        monotonic() - lifecycle_started,
+                        cache_key,
+                        ex,
+                        exc_info=True,
                     )
                     cache_payload.error()
                 if image and window_size != thumb_size:
+                    resize_started = monotonic()
                     try:
+                        logger.info(
+                            "Screenshot lifecycle stage started: stage=resize "
+                            "elapsed=%.2fs context=%s",
+                            resize_started - lifecycle_started,
+                            cache_key,
+                        )
                         image = self.resize_image(image, thumb_size=thumb_size)
+                        logger.info(
+                            "Screenshot lifecycle stage completed: stage=resize "
+                            "stage_elapsed=%.2fs elapsed=%.2fs context=%s",
+                            monotonic() - resize_started,
+                            monotonic() - lifecycle_started,
+                            cache_key,
+                        )
                     except Exception as ex:  # pylint: disable=broad-except
                         logger.warning(
-                            "Failed at resizing thumbnail %s", ex, exc_info=True
+                            "Failed at resizing thumbnail during stage=resize "
+                            "stage_elapsed=%.2fs elapsed=%.2fs context=%s: %s",
+                            monotonic() - resize_started,
+                            monotonic() - lifecycle_started,
+                            cache_key,
+                            ex,
+                            exc_info=True,
                         )
                         cache_payload.error()
                         image = None
@@ -341,10 +382,21 @@ class BaseScreenshot:
                     # the timestamp recorded when the actual failure occurred above.
                     cache_payload.error()
 
-                logger.info("Caching thumbnail: %s", cache_key)
+                cache_started = monotonic()
+                logger.info(
+                    "Screenshot lifecycle stage started: stage=cache "
+                    "elapsed=%.2fs context=%s",
+                    cache_started - lifecycle_started,
+                    cache_key,
+                )
                 self.cache.set(cache_key, cache_payload.to_dict())
                 logger.info(
-                    "Updated thumbnail cache; Status: %s", cache_payload.get_status()
+                    "Screenshot lifecycle stage completed: stage=cache "
+                    "stage_elapsed=%.2fs elapsed=%.2fs status=%s context=%s",
+                    monotonic() - cache_started,
+                    monotonic() - lifecycle_started,
+                    cache_payload.get_status(),
+                    cache_key,
                 )
         except LockAlreadyHeldException:
             logger.info(

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -21,7 +21,7 @@ import atexit
 import logging
 from abc import ABC, abstractmethod
 from enum import Enum
-from time import sleep
+from time import monotonic, sleep
 from typing import Any, TYPE_CHECKING
 
 from flask import current_app as app
@@ -291,25 +291,91 @@ class WebDriverPlaywright(WebDriverProxy):
             )
             return None
 
+        overall_started = monotonic()
+        stage_started = overall_started
+        current_stage = "initialization"
+        stage_failed = False
+        context_suffix = f" context={log_context}" if log_context else ""
+
+        def begin_stage(stage: str) -> None:
+            nonlocal current_stage, stage_failed, stage_started
+            timestamp = monotonic()
+            if not stage_failed:
+                logger.info(
+                    "Playwright screenshot stage completed: stage=%s "
+                    "stage_elapsed=%.2fs total_elapsed=%.2fs%s",
+                    current_stage,
+                    timestamp - stage_started,
+                    timestamp - overall_started,
+                    context_suffix,
+                )
+            current_stage = stage
+            stage_failed = False
+            stage_started = timestamp
+            logger.info(
+                "Playwright screenshot stage started: stage=%s "
+                "total_elapsed=%.2fs%s",
+                current_stage,
+                timestamp - overall_started,
+                context_suffix,
+            )
+
+        def log_stage_exception() -> None:
+            nonlocal stage_failed
+            stage_failed = True
+            timestamp = monotonic()
+            logger.warning(
+                "Playwright screenshot failed: stage=%s stage_elapsed=%.2fs "
+                "total_elapsed=%.2fs%s",
+                current_stage,
+                timestamp - stage_started,
+                timestamp - overall_started,
+                context_suffix,
+                exc_info=True,
+            )
+
         browser_args = app.config["WEBDRIVER_OPTION_ARGS"]
-        browser = _browser_manager.get_browser(browser_args)
+        begin_stage("browser_acquisition")
+        try:
+            browser = _browser_manager.get_browser(browser_args)
+        except Exception:
+            log_stage_exception()
+            raise
         pixel_density = app.config["WEBDRIVER_WINDOW"].get("pixel_density", 1)
         viewport_height = self._window[1]
         viewport_width = self._window[0]
-        context = browser.new_context(
-            bypass_csp=True,
-            viewport={
-                "height": viewport_height,
-                "width": viewport_width,
-            },
-            device_scale_factor=pixel_density,
-        )
-        context.set_default_timeout(app.config["SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT"])
+        begin_stage("browser_context_creation")
+        try:
+            context = browser.new_context(
+                bypass_csp=True,
+                viewport={
+                    "height": viewport_height,
+                    "width": viewport_width,
+                },
+                device_scale_factor=pixel_density,
+            )
+            context.set_default_timeout(
+                app.config["SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT"]
+            )
+        except Exception:
+            log_stage_exception()
+            raise
         if user:
-            self.auth(user, context)
-        page = context.new_page()
+            begin_stage("machine_authentication")
+            try:
+                self.auth(user, context)
+            except Exception:
+                log_stage_exception()
+                raise
+        begin_stage("page_creation")
+        try:
+            page = context.new_page()
+        except Exception:
+            log_stage_exception()
+            raise
         img: bytes | None = None
         try:
+            begin_stage("navigation")
             try:
                 page.goto(
                     url,
@@ -327,6 +393,7 @@ class WebDriverPlaywright(WebDriverProxy):
             page.wait_for_timeout(selenium_headstart * 1000)
             element: Locator
             try:
+                begin_stage("dashboard_element_discovery")
                 try:
                     # page didn't load
                     logger.debug(
@@ -338,6 +405,7 @@ class WebDriverPlaywright(WebDriverProxy):
                     logger.exception("Timed out requesting url %s", url)
                     raise
 
+                begin_stage("chart_container_discovery")
                 try:
                     # chart containers didn't render
                     logger.debug("Wait for chart containers to draw at url: %s", url)
@@ -363,6 +431,7 @@ class WebDriverPlaywright(WebDriverProxy):
                             unexpected_errors,
                         )
                 # Detect large dashboards and use tiled screenshots if enabled
+                begin_stage("tiling_decision")
                 tiled_enabled = app.config.get("SCREENSHOT_TILED_ENABLED", False)
 
                 if tiled_enabled:
@@ -410,6 +479,7 @@ class WebDriverPlaywright(WebDriverProxy):
                         page.set_viewport_size(
                             {"height": tile_height, "width": viewport_width}
                         )
+                        begin_stage("tiled_readiness_and_capture")
                         img = take_tiled_screenshot(
                             page,
                             element_name,
@@ -444,6 +514,7 @@ class WebDriverPlaywright(WebDriverProxy):
                         )
                         # Standard screenshot captures the full element including
                         # below-the-fold content, so wait for all spinners globally.
+                        begin_stage("readiness")
                         try:
                             logger.debug(
                                 "Waiting for all spinners to clear at url: %s "
@@ -476,6 +547,7 @@ class WebDriverPlaywright(WebDriverProxy):
                             url,
                             user.username if user else "None",
                         )
+                        begin_stage("capture")
                         img = WebDriverPlaywright._get_screenshot(
                             page, element, element_name
                         )
@@ -492,6 +564,7 @@ class WebDriverPlaywright(WebDriverProxy):
                     )
                     # Standard screenshot captures the full element including
                     # below-the-fold content, so wait for all spinners globally.
+                    begin_stage("readiness")
                     try:
                         logger.debug(
                             "Waiting for all spinners to clear at url: %s "
@@ -523,6 +596,7 @@ class WebDriverPlaywright(WebDriverProxy):
                         url,
                         user.username if user else "None",
                     )
+                    begin_stage("capture")
                     img = WebDriverPlaywright._get_screenshot(
                         page, element, element_name
                     )
@@ -535,11 +609,35 @@ class WebDriverPlaywright(WebDriverProxy):
             except PlaywrightTimeout:
                 raise
             except PlaywrightError:
+                stage_failed = True
+                timestamp = monotonic()
                 logger.exception(
-                    "Encountered an unexpected error when requesting url %s", url
+                    "Encountered an unexpected Playwright error: stage=%s "
+                    "stage_elapsed=%.2fs total_elapsed=%.2fs%s",
+                    current_stage,
+                    timestamp - stage_started,
+                    timestamp - overall_started,
+                    context_suffix,
                 )
+        except Exception:
+            log_stage_exception()
+            raise
         finally:
-            context.close()
+            begin_stage("browser_context_close")
+            try:
+                context.close()
+            except Exception:
+                log_stage_exception()
+                raise
+            timestamp = monotonic()
+            logger.info(
+                "Playwright screenshot stage completed: stage=%s "
+                "stage_elapsed=%.2fs total_elapsed=%.2fs%s",
+                current_stage,
+                timestamp - stage_started,
+                timestamp - overall_started,
+                context_suffix,
+            )
         return img
 
 

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -313,8 +313,7 @@ class WebDriverPlaywright(WebDriverProxy):
             stage_failed = False
             stage_started = timestamp
             logger.info(
-                "Playwright screenshot stage started: stage=%s "
-                "total_elapsed=%.2fs%s",
+                "Playwright screenshot stage started: stage=%s total_elapsed=%.2fs%s",
                 current_stage,
                 timestamp - overall_started,
                 context_suffix,

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -651,7 +651,11 @@ def test_playwright_screenshot_emits_correlated_stage_markers(
 def test_playwright_screenshot_exception_logs_current_stage_and_elapsed(
     mock_app, mock_logger, mock_browser_manager
 ):
-    mock_app.config = {"WEBDRIVER_OPTION_ARGS": []}
+    mock_app.config = {
+        "WEBDRIVER_OPTION_ARGS": [],
+        "SCREENSHOT_LOCATE_WAIT": 10,
+        "SCREENSHOT_LOAD_WAIT": 10,
+    }
     error = RuntimeError("browser unavailable")
     mock_browser_manager.get_browser.side_effect = error
 
@@ -1133,9 +1137,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         assert "animation_wait" in call_order
         spinner_idx = call_order.index("spinner_wait")
         anim_idx = call_order.index("animation_wait")
-        assert (
-            spinner_idx < anim_idx
-        ), "spinner wait must precede animation wait in non-tiled path"
+        assert spinner_idx < anim_idx, (
+            "spinner wait must precede animation wait in non-tiled path"
+        )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1225,9 +1229,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
             for call in mock_page.wait_for_timeout.call_args_list
             if call[0][0] == 2 * 1000
         ]
-        assert (
-            animation_waits == []
-        ), "No global 2s animation wait_for_timeout should fire on the tiled path"
+        assert animation_waits == [], (
+            "No global 2s animation wait_for_timeout should fire on the tiled path"
+        )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1290,6 +1294,6 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         timeout_values = [
             call[0][0] for call in mock_page.wait_for_timeout.call_args_list
         ]
-        assert timeout_values == [
-            0
-        ], f"Expected only [0] (headstart), got {timeout_values}"
+        assert timeout_values == [0], (
+            f"Expected only [0] (headstart), got {timeout_values}"
+        )

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -578,6 +578,101 @@ class TestWebDriverPlaywrightFallback:
         assert "Web event %s not detected" in exception_call
 
 
+@patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+@patch("superset.utils.webdriver._browser_manager")
+@patch("superset.utils.webdriver.logger")
+@patch("superset.utils.webdriver.app")
+def test_playwright_screenshot_emits_correlated_stage_markers(
+    mock_app, mock_logger, mock_browser_manager
+):
+    mock_app.config = {
+        "WEBDRIVER_OPTION_ARGS": [],
+        "WEBDRIVER_WINDOW": {"pixel_density": 1},
+        "SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT": 30000,
+        "SCREENSHOT_PLAYWRIGHT_WAIT_EVENT": "networkidle",
+        "SCREENSHOT_SELENIUM_HEADSTART": 0,
+        "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 0,
+        "SCREENSHOT_REPLACE_UNEXPECTED_ERRORS": False,
+        "SCREENSHOT_TILED_ENABLED": False,
+        "SCREENSHOT_LOCATE_WAIT": 10,
+        "SCREENSHOT_LOAD_WAIT": 10,
+    }
+    mock_browser = MagicMock()
+    mock_context = MagicMock()
+    mock_page = MagicMock()
+    mock_element = MagicMock()
+    mock_browser_manager.get_browser.return_value = mock_browser
+    mock_browser.new_context.return_value = mock_context
+    mock_context.new_page.return_value = mock_page
+    mock_page.locator.return_value = mock_element
+    mock_element.screenshot.return_value = b"screenshot"
+
+    with patch.object(WebDriverPlaywright, "auth", return_value=mock_context):
+        result = WebDriverPlaywright("chrome").get_screenshot(
+            "https://example.test/dashboard?secret=do-not-log",
+            "dashboard",
+            MagicMock(),
+            log_context="task-or-cache-key",
+        )
+
+    assert result == b"screenshot"
+    stage_calls = [
+        call
+        for call in mock_logger.info.call_args_list
+        if call.args and call.args[0].startswith("Playwright screenshot stage")
+    ]
+    started_stages = [
+        call.args[1] for call in stage_calls if "stage started" in call.args[0]
+    ]
+    assert started_stages == [
+        "browser_acquisition",
+        "browser_context_creation",
+        "machine_authentication",
+        "page_creation",
+        "navigation",
+        "dashboard_element_discovery",
+        "chart_container_discovery",
+        "tiling_decision",
+        "readiness",
+        "capture",
+        "browser_context_close",
+    ]
+    assert all(
+        any("task-or-cache-key" in str(arg) for arg in call.args)
+        for call in stage_calls
+    )
+    assert all("secret=do-not-log" not in str(call.args) for call in stage_calls)
+
+
+@patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+@patch("superset.utils.webdriver._browser_manager")
+@patch("superset.utils.webdriver.logger")
+@patch("superset.utils.webdriver.app")
+def test_playwright_screenshot_exception_logs_current_stage_and_elapsed(
+    mock_app, mock_logger, mock_browser_manager
+):
+    mock_app.config = {"WEBDRIVER_OPTION_ARGS": []}
+    error = RuntimeError("browser unavailable")
+    mock_browser_manager.get_browser.side_effect = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        WebDriverPlaywright("chrome").get_screenshot(
+            "https://example.test/dashboard?secret=do-not-log",
+            "dashboard",
+            log_context="task-id",
+        )
+
+    assert exc_info.value is error
+    mock_logger.warning.assert_called_once()
+    warning_call = mock_logger.warning.call_args
+    assert warning_call.args[1] == "browser_acquisition"
+    assert warning_call.args[-1] == " context=task-id"
+    assert "stage_elapsed=%.2fs" in warning_call.args[0]
+    assert "total_elapsed=%.2fs" in warning_call.args[0]
+    assert warning_call.kwargs == {"exc_info": True}
+    assert "secret=do-not-log" not in str(warning_call)
+
+
 class TestWebDriverConstantsWithImportError:
     """Test module-level constants behavior with import errors."""
 
@@ -1038,9 +1133,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         assert "animation_wait" in call_order
         spinner_idx = call_order.index("spinner_wait")
         anim_idx = call_order.index("animation_wait")
-        assert spinner_idx < anim_idx, (
-            "spinner wait must precede animation wait in non-tiled path"
-        )
+        assert (
+            spinner_idx < anim_idx
+        ), "spinner wait must precede animation wait in non-tiled path"
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1130,9 +1225,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
             for call in mock_page.wait_for_timeout.call_args_list
             if call[0][0] == 2 * 1000
         ]
-        assert animation_waits == [], (
-            "No global 2s animation wait_for_timeout should fire on the tiled path"
-        )
+        assert (
+            animation_waits == []
+        ), "No global 2s animation wait_for_timeout should fire on the tiled path"
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1195,6 +1290,6 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         timeout_values = [
             call[0][0] for call in mock_page.wait_for_timeout.call_args_list
         ]
-        assert timeout_values == [0], (
-            f"Expected only [0] (headstart), got {timeout_values}"
-        )
+        assert timeout_values == [
+            0
+        ], f"Expected only [0] (headstart), got {timeout_values}"


### PR DESCRIPTION
### SUMMARY

Adds focused INFO-level timing markers around the Playwright dashboard screenshot lifecycle so [Shortcut SC-113788](https://app.shortcut.com/preset/story/113788) can be localized to a specific stage.

The markers cover browser acquisition, browser-context creation, machine authentication, page creation and navigation, standalone/dashboard element discovery, chart-container discovery, the tiling decision, readiness, capture, and browser-context close. Thumbnail generation also reports capture, resize, and cache completion. Existing report execution IDs and thumbnail cache keys are threaded into the markers where available.

Exception logging includes the active stage plus stage and total elapsed time. The added markers do not include the target URL, cookies, JWTs, or authentication material.

**This is instrumentation only and is not a root-cause fix.** It does not alter timeout values, screenshot decisions, fallback behavior, or capture semantics.

Staging evidence in workspace `3de41981`: two unrelated dashboards entered `trying to generate screenshot`, emitted no navigation, tiling, or cache terminal markers, and then hit Celery's 300-second soft time limit exactly. Observed task IDs:

- `5fba2e74-7e81-4158-a60f-b38398b8a684`
- `aa2babc8-e8b2-4cba-8451-307b58b9ced9`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; logging-only backend instrumentation.

### TESTING INSTRUCTIONS

1. Enable `PLAYWRIGHT_REPORTS_AND_THUMBNAILS` and generate a dashboard screenshot or thumbnail.
2. Confirm INFO logs emit ordered `Playwright screenshot stage started/completed` markers with stage and elapsed timing.
3. Confirm a report run includes its existing execution ID and a thumbnail run includes its cache key.
4. Force a browser-acquisition or readiness exception and confirm the warning identifies the active stage and elapsed time while the original exception still propagates according to existing behavior.
5. Confirm stage markers do not contain the screenshot URL or sensitive authentication data.

Validation performed:

- `python3 -m ruff format --check superset/utils/webdriver.py superset/utils/screenshots.py tests/unit_tests/utils/webdriver_test.py`
- `python3 -m ruff check superset/utils/webdriver.py superset/utils/screenshots.py tests/unit_tests/utils/webdriver_test.py`
- `python3 -m py_compile superset/utils/webdriver.py superset/utils/screenshots.py tests/unit_tests/utils/webdriver_test.py`
- `git diff --check`
- `pre-commit run --all-files` was attempted from a writable clone. Relevant Python checks passed except for the pre-existing `PooledBaseScreenshot.get_screenshot` override mismatch; repository-wide frontend/cache and baseline lint checks also failed because the provisioned environment has read-only home caches and existing unrelated findings.
- Targeted pytest collection was attempted but the provisioned Python environment is missing runtime dependencies (`flask_talisman`, then `simplejson`).

### ADDITIONAL INFORMATION

- [x] Has associated issue: [Shortcut SC-113788](https://app.shortcut.com/preset/story/113788)
- [x] Required feature flags: `PLAYWRIGHT_REPORTS_AND_THUMBNAILS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
