### PR TITLE
feat(waterfall): add show/hide toggles for X and Y axes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -195,6 +195,8 @@ const config: ControlPanelConfig = {
               label: t('X Axis Label'),
               renderTrigger: true,
               default: '',
+              visibility: ({ controls }) =>
+                controls?.show_x_axis?.value !== false,
             },
           },
         ],
@@ -205,6 +207,8 @@ const config: ControlPanelConfig = {
               ...sharedControls.x_axis_time_format,
               default: DEFAULT_TIME_FORMAT,
               description: `${D3_TIME_FORMAT_DOCS}.`,
+              visibility: ({ controls }) =>
+                controls?.show_x_axis?.value !== false,
             },
           },
         ],
@@ -225,6 +229,8 @@ const config: ControlPanelConfig = {
               clearable: false,
               renderTrigger: true,
               description: t('The way the ticks are laid out on the X-axis'),
+              visibility: ({ controls }) =>
+                controls?.show_x_axis?.value !== false,
             },
           },
         ],
@@ -256,6 +262,8 @@ const config: ControlPanelConfig = {
               label: t('Y Axis Label'),
               renderTrigger: true,
               default: '',
+              visibility: ({ controls }) =>
+                controls?.show_y_axis?.value !== false,
             },
           },
         ],
@@ -265,6 +273,12 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
+    y_axis_format: {
+      visibility: ({ controls }) => controls?.show_y_axis?.value !== false,
+    },
+    currency_format: {
+      visibility: ({ controls }) => controls?.show_y_axis?.value !== false,
+    },
     groupby: {
       label: t('Breakdowns'),
       description:

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -273,12 +273,10 @@ const config: ControlPanelConfig = {
     },
   ],
   controlOverrides: {
-    y_axis_format: {
-      visibility: ({ controls }) => controls?.show_y_axis?.value !== false,
-    },
-    currency_format: {
-      visibility: ({ controls }) => controls?.show_y_axis?.value !== false,
-    },
+    // Note: y_axis_format and currency_format are intentionally NOT gated on
+    // show_y_axis. They drive `defaultFormatter`, which formats the bar labels
+    // and tooltips as well as the axis, so they must stay configurable even
+    // when the Y axis itself is hidden.
     groupby: {
       label: t('Breakdowns'),
       description:

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -177,6 +177,18 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         [
           {
+            name: 'show_x_axis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show X axis'),
+              renderTrigger: true,
+              default: true,
+              description: t('Show or hide the X axis line, ticks, and labels'),
+            },
+          },
+        ],
+        [
+          {
             name: 'x_axis_label',
             config: {
               type: 'TextControl',
@@ -222,6 +234,20 @@ const config: ControlPanelConfig = {
       label: t('Y Axis'),
       expanded: true,
       controlSetRows: [
+        [
+          {
+            name: 'show_y_axis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Y axis'),
+              renderTrigger: true,
+              default: true,
+              description: t(
+                'Show or hide the Y axis line, ticks, gridlines, and labels',
+              ),
+            },
+          },
+        ],
         [
           {
             name: 'y_axis_label',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -185,6 +185,8 @@ export default function transformProps(
     xTicksLayout,
     xAxisTimeFormat,
     showLegend,
+    showXAxis = true,
+    showYAxis = true,
     yAxisLabel,
     xAxisLabel,
     yAxisFormat,
@@ -370,6 +372,7 @@ export default function transformProps(
   }
   axisLabel.formatter = xAxisFormatter;
   axisLabel.hideOverlap = false;
+  axisLabel.show = showXAxis;
 
   const seriesProps: Pick<BarSeriesOption, 'type' | 'stack' | 'emphasis'> = {
     type: 'bar',
@@ -445,12 +448,14 @@ export default function transformProps(
     xAxis: {
       data: xAxisData,
       type: 'category',
-      name: xAxisLabel,
+      name: showXAxis ? xAxisLabel : '',
       nameTextStyle: {
         padding: [theme.sizeUnit * 4, 0, 0, 0],
       },
       nameLocation: 'middle',
       axisLabel,
+      axisLine: { show: showXAxis },
+      axisTick: { show: showXAxis },
     },
     yAxis: {
       ...defaultYAxis,
@@ -459,8 +464,11 @@ export default function transformProps(
         padding: [0, 0, theme.sizeUnit * 5, 0],
       },
       nameLocation: 'middle',
-      name: yAxisLabel,
-      axisLabel: { formatter: defaultFormatter },
+      name: showYAxis ? yAxisLabel : '',
+      axisLabel: { show: showYAxis, formatter: defaultFormatter },
+      axisLine: { show: showYAxis },
+      axisTick: { show: showYAxis },
+      splitLine: { show: showYAxis },
     },
     tooltip: {
       ...getDefaultTooltip(refs),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -435,8 +435,10 @@ export default function transformProps(
     grid: {
       ...defaultGrid,
       top: theme.sizeUnit * 7,
-      bottom: theme.sizeUnit * 7,
-      left: theme.sizeUnit * 5,
+      // Reclaim the axis-oriented padding when an axis is hidden so an
+      // axis-free chart gets a clean, tight layout instead of empty margins.
+      bottom: theme.sizeUnit * (showXAxis ? 7 : 3),
+      left: theme.sizeUnit * (showYAxis ? 5 : 2),
       right: theme.sizeUnit * 7,
     },
     legend: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -372,7 +372,6 @@ export default function transformProps(
   }
   axisLabel.formatter = xAxisFormatter;
   axisLabel.hideOverlap = false;
-  axisLabel.show = showXAxis;
 
   const seriesProps: Pick<BarSeriesOption, 'type' | 'stack' | 'emphasis'> = {
     type: 'bar',
@@ -446,29 +445,26 @@ export default function transformProps(
       data: [legendNames.INCREASE, legendNames.DECREASE, legendNames.TOTAL],
     },
     xAxis: {
+      show: showXAxis,
       data: xAxisData,
       type: 'category',
-      name: showXAxis ? xAxisLabel : '',
+      name: xAxisLabel,
       nameTextStyle: {
         padding: [theme.sizeUnit * 4, 0, 0, 0],
       },
       nameLocation: 'middle',
       axisLabel,
-      axisLine: { show: showXAxis },
-      axisTick: { show: showXAxis },
     },
     yAxis: {
       ...defaultYAxis,
+      show: showYAxis,
       type: 'value',
       nameTextStyle: {
         padding: [0, 0, theme.sizeUnit * 5, 0],
       },
       nameLocation: 'middle',
-      name: showYAxis ? yAxisLabel : '',
-      axisLabel: { show: showYAxis, formatter: defaultFormatter },
-      axisLine: { show: showYAxis },
-      axisTick: { show: showYAxis },
-      splitLine: { show: showYAxis },
+      name: yAxisLabel,
+      axisLabel: { formatter: defaultFormatter },
     },
     tooltip: {
       ...getDefaultTooltip(refs),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/types.ts
@@ -55,8 +55,10 @@ export type EchartsWaterfallFormData = QueryFormData &
     xAxisLabel: string;
     xAxisTimeFormat?: string;
     xTicksLayout?: WaterfallFormXTicksLayout;
+    showXAxis: boolean;
     yAxisLabel: string;
     yAxisFormat: string;
+    showYAxis: boolean;
     increaseLabel?: string;
     decreaseLabel?: string;
     totalLabel?: string;
@@ -65,6 +67,8 @@ export type EchartsWaterfallFormData = QueryFormData &
 
 export const DEFAULT_FORM_DATA: Partial<EchartsWaterfallFormData> = {
   showLegend: true,
+  showXAxis: true,
+  showYAxis: true,
 };
 
 export interface EchartsWaterfallChartProps extends ChartProps {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
@@ -166,3 +166,45 @@ test('hide totals', () => {
     ['-', '-'],
   ]);
 });
+
+const buildAxes = (extraFormData: Record<string, unknown>) => {
+  const chartProps = new ChartProps({
+    formData: { ...formData, ...extraFormData },
+    width: 800,
+    height: 600,
+    queriesData: [{ data }],
+    theme: supersetTheme,
+  });
+  const transformedProps = transformProps(
+    chartProps as unknown as EchartsWaterfallChartProps,
+  );
+  return {
+    xAxis: transformedProps.echartOptions.xAxis as any,
+    yAxis: transformedProps.echartOptions.yAxis as any,
+  };
+};
+
+test('shows both axes by default', () => {
+  const { xAxis, yAxis } = buildAxes({});
+  expect(xAxis.axisLabel.show).not.toBe(false);
+  expect(xAxis.axisLine.show).not.toBe(false);
+  expect(yAxis.axisLabel.show).not.toBe(false);
+  expect(yAxis.splitLine.show).not.toBe(false);
+});
+
+test('hides the X axis chrome when showXAxis is false', () => {
+  const { xAxis } = buildAxes({ showXAxis: false });
+  expect(xAxis.axisLabel.show).toBe(false);
+  expect(xAxis.axisLine.show).toBe(false);
+  expect(xAxis.axisTick.show).toBe(false);
+  expect(xAxis.name).toBe('');
+});
+
+test('hides the Y axis chrome when showYAxis is false', () => {
+  const { yAxis } = buildAxes({ showYAxis: false });
+  expect(yAxis.axisLabel.show).toBe(false);
+  expect(yAxis.axisLine.show).toBe(false);
+  expect(yAxis.axisTick.show).toBe(false);
+  expect(yAxis.splitLine.show).toBe(false);
+  expect(yAxis.name).toBe('');
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
@@ -186,25 +186,18 @@ const buildAxes = (extraFormData: Record<string, unknown>) => {
 
 test('shows both axes by default', () => {
   const { xAxis, yAxis } = buildAxes({});
-  expect(xAxis.axisLabel.show).not.toBe(false);
-  expect(xAxis.axisLine.show).not.toBe(false);
-  expect(yAxis.axisLabel.show).not.toBe(false);
-  expect(yAxis.splitLine.show).not.toBe(false);
+  expect(xAxis.show).not.toBe(false);
+  expect(yAxis.show).not.toBe(false);
 });
 
-test('hides the X axis chrome when showXAxis is false', () => {
+test('hides the whole X axis when showXAxis is false', () => {
   const { xAxis } = buildAxes({ showXAxis: false });
-  expect(xAxis.axisLabel.show).toBe(false);
-  expect(xAxis.axisLine.show).toBe(false);
-  expect(xAxis.axisTick.show).toBe(false);
-  expect(xAxis.name).toBe('');
+  // echarts hides the axis line, ticks, labels, name, and gridlines when
+  // `show` is false — a single flag rather than a set of sub-flags.
+  expect(xAxis.show).toBe(false);
 });
 
-test('hides the Y axis chrome when showYAxis is false', () => {
+test('hides the whole Y axis when showYAxis is false', () => {
   const { yAxis } = buildAxes({ showYAxis: false });
-  expect(yAxis.axisLabel.show).toBe(false);
-  expect(yAxis.axisLine.show).toBe(false);
-  expect(yAxis.axisTick.show).toBe(false);
-  expect(yAxis.splitLine.show).toBe(false);
-  expect(yAxis.name).toBe('');
+  expect(yAxis.show).toBe(false);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
@@ -181,6 +181,7 @@ const buildAxes = (extraFormData: Record<string, unknown>) => {
   return {
     xAxis: transformedProps.echartOptions.xAxis as any,
     yAxis: transformedProps.echartOptions.yAxis as any,
+    grid: transformedProps.echartOptions.grid as any,
   };
 };
 
@@ -200,4 +201,21 @@ test('hides the whole X axis when showXAxis is false', () => {
 test('hides the whole Y axis when showYAxis is false', () => {
   const { yAxis } = buildAxes({ showYAxis: false });
   expect(yAxis.show).toBe(false);
+});
+
+test('reclaims the bottom grid margin when the X axis is hidden', () => {
+  const { grid: shown } = buildAxes({ showXAxis: true });
+  const { grid: hidden } = buildAxes({ showXAxis: false });
+  // The bottom margin reserves room for the X-axis labels and name; with the
+  // axis hidden that space should be reclaimed for a clean, axis-free layout.
+  expect(hidden.bottom).toBeLessThan(shown.bottom);
+  // Hiding the X axis must not shrink the Y-axis (left) margin.
+  expect(hidden.left).toBe(shown.left);
+});
+
+test('reclaims the left grid margin when the Y axis is hidden', () => {
+  const { grid: shown } = buildAxes({ showYAxis: true });
+  const { grid: hidden } = buildAxes({ showYAxis: false });
+  expect(hidden.left).toBeLessThan(shown.left);
+  expect(hidden.bottom).toBe(shown.bottom);
 });


### PR DESCRIPTION
### SUMMARY

The Waterfall chart's control panel lets users **label** the X and Y axes but provides no way to **hide** them. Teams recreating Tableau-style waterfall "movement" views need a clean, axis-free chart, and today that isn't achievable — the axis line, ticks, and value labels are always rendered.

This adds two `renderTrigger` checkbox controls:

- **Show X axis** (X Axis section)
- **Show Y axis** (Y Axis section)

Both default to **on**, so every existing waterfall renders identically. When a toggle is turned off, that axis's line, ticks, tick labels, axis name, and — for the Y axis — gridlines are hidden, giving a clean hide rather than just a blank label.

Implementation is contained to the `Waterfall` plugin: two boolean form-data fields (`showXAxis` / `showYAxis`, following the same per-plugin pattern the Gauge chart uses for `showAxisTick`), passed through `transformProps` to the ECharts `xAxis`/`yAxis` `axisLine`/`axisTick`/`axisLabel`/`splitLine` options.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_N/A — control-panel toggles; behavior with defaults is unchanged. Reviewers can verify via the testing instructions below._

### TESTING INSTRUCTIONS

1. Create or open a Waterfall chart.
2. In **Customize → X Axis**, uncheck **Show X axis** → the X axis line, ticks, and labels disappear without re-querying (renderTrigger).
3. In **Customize → Y Axis**, uncheck **Show Y axis** → the Y axis line, ticks, value labels, and gridlines disappear.
4. Re-check either box → the axis returns. Confirm an existing saved waterfall (no new fields) renders exactly as before.

Unit tests: `cd superset-frontend && npx jest plugins/plugin-chart-echarts/test/Waterfall/` — added cases cover default-on and both hide paths.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)