### PR TITLE
fix(reports): bound chart readiness below task timeout

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -114,6 +114,9 @@ describe('ChartHolder', () => {
     renderWrapper();
 
     expect(
+      screen.getByTestId('dashboard-component-chart-holder'),
+    ).toHaveAttribute('data-test-chart-id', String(chartId));
+    expect(
       screen.getByText('No results were returned for this query'),
     ).toBeVisible();
     expect(

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -274,6 +274,7 @@ const ChartHolder = ({
             chartHolderRef.current = el;
           }}
           data-test="dashboard-component-chart-holder"
+          data-test-chart-id={chartId}
           style={focusHighlightStyles}
           css={isFullSize ? fullSizeStyle : undefined}
           className={cx(

--- a/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
@@ -148,6 +148,9 @@ describe('DynamicComponent', () => {
     expect(
       screen.getByTestId('dashboard-component-chart-holder'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('dashboard-component-chart-holder'),
+    ).not.toHaveAttribute('data-test-chart-id');
     expect(screen.getByTestId('mock-dynamic-component')).toBeInTheDocument();
   });
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
@@ -134,6 +134,9 @@ const setup = async (
 test('should render the markdown component', async () => {
   await setup();
   expect(screen.getByTestId('dashboard-markdown-editor')).toBeInTheDocument();
+  expect(
+    screen.getByTestId('dashboard-component-chart-holder'),
+  ).not.toHaveAttribute('data-test-chart-id');
 });
 
 test('should render the markdown content in preview mode by default', async () => {

--- a/superset/config.py
+++ b/superset/config.py
@@ -1281,8 +1281,7 @@ SUPERSET_CACHE_WARMUP_USER: str | None = None
 # Time before selenium times out after trying to locate an element on the page and wait
 # for that element to load for a screenshot.
 SCREENSHOT_LOCATE_WAIT = int(timedelta(seconds=10).total_seconds())
-# Time before selenium times out after waiting for all DOM class elements named
-# "loading" are gone.
+# Time before screenshot capture times out while waiting for chart readiness.
 SCREENSHOT_LOAD_WAIT = int(timedelta(minutes=1).total_seconds())
 # Maximum time (in seconds) selenium waits for an initial page navigation
 # (driver.get) to complete. Without it the navigation blocks indefinitely when

--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -22,12 +22,70 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from celery import current_task
 from PIL import Image
 
 logger = logging.getLogger(__name__)
 
 # Time to wait after scrolling for content to settle and load (in milliseconds)
 SCROLL_SETTLE_TIMEOUT_MS = 1000
+
+# Runtime task-budget policy shared with the approach introduced in #42118.
+# Celery exposes the effective per-task hard/soft limits only on the running
+# task, so a static Superset timeout cannot reliably stay below task-level
+# overrides. Reserve at most 20% (capped at five minutes) for browser cleanup,
+# cache error transition, and the remaining report pipeline.
+SCREENSHOT_TASK_BUDGET_MARGIN_FRACTION = 0.2
+SCREENSHOT_TASK_BUDGET_MAX_MARGIN_SECONDS = 300
+
+
+def resolve_screenshot_task_budget_seconds(
+    log_context: str | None = None,
+) -> float | None:
+    """
+    Return the safe screenshot budget derived from the active Celery task.
+
+    Celery exposes ``request.timelimit`` as ``(hard, soft)``. Prefer the soft
+    limit because cleanup must finish before Celery raises it, falling back to
+    the hard limit when no soft limit is configured. Outside Celery, or when
+    the metadata is absent or malformed, return ``None`` so callers preserve
+    their configured standalone timeout.
+    """
+    context_suffix = f" [{log_context}]" if log_context else ""
+    try:
+        if not current_task:
+            return None
+        timelimit = current_task.request.timelimit
+        if not isinstance(timelimit, (tuple, list)) or len(timelimit) != 2:
+            return None
+        hard_limit, soft_limit = timelimit
+        limit = soft_limit or hard_limit
+        if isinstance(limit, bool) or not isinstance(limit, (int, float)) or limit <= 0:
+            return None
+        margin = min(
+            SCREENSHOT_TASK_BUDGET_MAX_MARGIN_SECONDS,
+            limit * SCREENSHOT_TASK_BUDGET_MARGIN_FRACTION,
+        )
+        budget = max(0.0, float(limit) - margin)
+        logger.info(
+            "Screenshot budget derived from Celery task %s=%.1fs: %.1fs "
+            "(cleanup margin=%.1fs)%s",
+            "soft_time_limit" if soft_limit else "time_limit",
+            limit,
+            budget,
+            margin,
+            context_suffix,
+        )
+        return budget
+    except Exception:
+        logger.debug(
+            "Failed to derive screenshot budget from Celery task context; "
+            "using the configured screenshot timeout%s",
+            context_suffix,
+            exc_info=True,
+        )
+        return None
+
 
 try:
     from playwright.sync_api import TimeoutError as PlaywrightTimeout
@@ -49,7 +107,11 @@ if TYPE_CHECKING:
 # mounted anything yet (e.g. its IntersectionObserver callback hasn't fired)
 # would otherwise pass vacuously.
 # See superset-frontend/src/dashboard/components/gridComponents/ChartHolder/
-# ChartHolder.tsx for `data-test="dashboard-component-chart-holder"`,
+# ChartHolder.tsx for the chart-specific combination of
+# `data-test="dashboard-component-chart-holder"` and `data-test-chart-id`.
+# Markdown.tsx and DynamicComponent.tsx reuse the former styling/test hook but
+# intentionally lack the chart-id attribute, so they cannot participate in
+# chart readiness.
 # superset-frontend/src/components/Chart/Chart.tsx for `.slice_container`
 # (rendered chart container, `data-test="slice-container"`) and `.loading`
 # (spinner, via the shared Loading component), and
@@ -79,7 +141,7 @@ if TYPE_CHECKING:
 #     the vacuous-pass race this check exists to close.
 UNREADY_CHART_HOLDERS_JS_BODY = """
     const holders = document.querySelectorAll(
-        '[data-test="dashboard-component-chart-holder"]'
+        '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
     );
     const unready = [];
     for (const holder of holders) {
@@ -95,7 +157,7 @@ UNREADY_CHART_HOLDERS_JS_BODY = """
             '[role="alert"], .ant-empty, .missing-chart-container'
         ) !== null;
         if (stillLoading || !isReady) {
-            const chartIdEl = holder.querySelector('[data-test-chart-id]');
+            const chartId = holder.getAttribute('data-test-chart-id');
             let state;
             if (stillLoading && hasSliceContainer) {
                 state = 'spinner_mounted';
@@ -105,13 +167,52 @@ UNREADY_CHART_HOLDERS_JS_BODY = """
                 state = 'nothing_mounted';
             }
             unready.push({
-                chartId: chartIdEl
-                    ? chartIdEl.getAttribute('data-test-chart-id')
-                    : 'unknown',
+                chartId: chartId,
                 state: state,
             });
         }
     }
+"""
+
+# Diagnostic query for every chart holder, including terminal and virtualized
+# states. This is intentionally separate from the readiness predicate so
+# incident logs can distinguish a valid empty/error result from a holder that
+# never mounted or remained loading.
+FIND_CHART_HOLDER_STATES_JS = """
+() => {
+    const holders = document.querySelectorAll(
+        '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
+    );
+    return Array.from(holders).map(holder => {
+        const chartId = holder.getAttribute('data-test-chart-id');
+        const r = holder.getBoundingClientRect();
+        if (!(r.top < window.innerHeight && r.bottom > 0)) {
+            return { chartId, state: 'virtualized' };
+        }
+        const hasSliceContainer = holder.querySelector(
+            '[data-test="slice-container"]'
+        ) !== null;
+        const stillLoading = holder.querySelector('.loading') !== null;
+        if (stillLoading && hasSliceContainer) {
+            return { chartId, state: 'spinner_mounted' };
+        }
+        if (stillLoading) {
+            return { chartId, state: 'waiting_on_database' };
+        }
+        if (holder.querySelector('[role="alert"]') !== null) {
+            return { chartId, state: 'error' };
+        }
+        if (holder.querySelector(
+            '.ant-empty, .missing-chart-container'
+        ) !== null) {
+            return { chartId, state: 'empty' };
+        }
+        if (hasSliceContainer) {
+            return { chartId, state: 'rendered' };
+        }
+        return { chartId, state: 'nothing_mounted' };
+    });
+}
 """
 
 # Predicate for page.wait_for_function: true once every viewport-visible chart

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import time
 from abc import ABC, abstractmethod
 from enum import Enum
 from time import sleep
@@ -43,7 +44,8 @@ from superset.extensions import machine_auth_provider_factory
 from superset.utils.retries import retry_call
 from superset.utils.screenshot_utils import (
     CHART_HOLDERS_READY_JS,
-    FIND_UNREADY_CHART_HOLDERS_JS,
+    FIND_CHART_HOLDER_STATES_JS,
+    resolve_screenshot_task_budget_seconds,
     take_tiled_screenshot,
 )
 
@@ -56,6 +58,11 @@ PLAYWRIGHT_INSTALL_MESSAGE = (
     "and enable WebGL/DeckGL screenshot support, install Playwright with: "
     "pip install playwright && playwright install chromium"
 )
+
+
+class ScreenshotTaskBudgetExceededError(RuntimeError):
+    """Raised when no safe task budget remains before screenshot capture."""
+
 
 if TYPE_CHECKING:
     from typing import Any
@@ -285,6 +292,7 @@ class WebDriverPlaywright(WebDriverProxy):
         url: str,
         load_wait: int,
         log_context: str | None = None,
+        screenshot_started_at: float | None = None,
     ) -> None:
         """
         Wait for every viewport-visible chart holder to reach a terminal state
@@ -307,30 +315,93 @@ class WebDriverPlaywright(WebDriverProxy):
         design and must not block this wait.
         """
         context_suffix = f" [{log_context}]" if log_context else ""
+        ready_states = {"rendered", "empty", "error", "virtualized"}
+        initial_chart_holder_states = page.evaluate(FIND_CHART_HOLDER_STATES_JS)
+        initial_unready_chart_holders = [
+            holder
+            for holder in initial_chart_holder_states
+            if holder.get("state") not in ready_states
+        ]
+        logger.info(
+            "Chart holder states before readiness polling at url %s%s: %s",
+            url,
+            context_suffix,
+            initial_chart_holder_states,
+        )
+        if initial_unready_chart_holders:
+            logger.info(
+                "Chart holders not ready before polling at url %s%s: %s",
+                url,
+                context_suffix,
+                initial_unready_chart_holders,
+            )
+        task_budget = resolve_screenshot_task_budget_seconds(log_context)
+        elapsed = (
+            max(0.0, time.monotonic() - screenshot_started_at)
+            if task_budget is not None and screenshot_started_at is not None
+            else 0.0
+        )
+        remaining_budget = task_budget - elapsed if task_budget is not None else None
+        effective_load_wait = (
+            min(float(load_wait), remaining_budget)
+            if remaining_budget is not None
+            else float(load_wait)
+        )
+        if effective_load_wait <= 0:
+            logger.warning(
+                "Screenshot task budget exhausted before chart readiness wait "
+                "at url %s%s (%.2fs elapsed of %.2fs safe budget); unready chart "
+                "holders (chart id, state): %s; all chart holder states: %s. "
+                "Aborting before capture so cleanup and cache error transition "
+                "can complete.",
+                url,
+                context_suffix,
+                elapsed,
+                task_budget,
+                initial_unready_chart_holders,
+                initial_chart_holder_states,
+            )
+            raise ScreenshotTaskBudgetExceededError(
+                f"Screenshot task budget of {task_budget:.2f}s exhausted "
+                "before chart readiness"
+            )
         logger.debug(
             "Waiting for all chart holders to reach a terminal state at "
-            "url: %s (SCREENSHOT_LOAD_WAIT=%ss)%s",
+            "url: %s (SCREENSHOT_LOAD_WAIT=%ss, effective_wait=%.2fs, "
+            "task_budget=%s, elapsed=%.2fs)%s",
             url,
             load_wait,
+            effective_load_wait,
+            task_budget,
+            elapsed,
             context_suffix,
         )
         try:
             page.wait_for_function(
                 CHART_HOLDERS_READY_JS,
-                timeout=load_wait * 1000,
+                timeout=effective_load_wait * 1000,
             )
         except PlaywrightTimeout:
-            unready_chart_holders = page.evaluate(FIND_UNREADY_CHART_HOLDERS_JS)
+            chart_holder_states = page.evaluate(FIND_CHART_HOLDER_STATES_JS)
+            unready_chart_holders = [
+                holder
+                for holder in chart_holder_states
+                if holder.get("state") not in ready_states
+            ]
             logger.warning(
                 "Timed out waiting for %s chart container(s) to become ready "
-                "at url %s (SCREENSHOT_LOAD_WAIT=%ss)%s; unready chart "
-                "holders (chart id, state): %s. Aborting screenshot rather "
+                "at url %s (SCREENSHOT_LOAD_WAIT=%ss, effective_wait=%.2fs)%s; "
+                "unready chart "
+                "holders (chart id, state): %s; all chart holder states: %s. "
+                "Aborting screenshot rather "
                 "than capturing a blank or partially-loaded dashboard.",
                 len(unready_chart_holders),
                 url,
                 load_wait,
+                effective_load_wait,
                 context_suffix,
                 unready_chart_holders,
+                chart_holder_states,
             )
             raise
         logger.debug("All chart holders ready at url: %s%s", url, context_suffix)
@@ -342,6 +413,7 @@ class WebDriverPlaywright(WebDriverProxy):
         user: User | None = None,
         log_context: str | None = None,
     ) -> bytes | None:
+        screenshot_started_at = time.monotonic()
         if not PLAYWRIGHT_AVAILABLE:
             logger.info(
                 "Playwright not available - falling back to Selenium. "
@@ -510,6 +582,7 @@ class WebDriverPlaywright(WebDriverProxy):
                             url,
                             self._screenshot_load_wait,
                             log_context=log_context,
+                            screenshot_started_at=screenshot_started_at,
                         )
                         if selenium_animation_wait > 0:
                             logger.debug(
@@ -544,6 +617,7 @@ class WebDriverPlaywright(WebDriverProxy):
                         url,
                         self._screenshot_load_wait,
                         log_context=log_context,
+                        screenshot_started_at=screenshot_started_at,
                     )
                     if selenium_animation_wait > 0:
                         logger.debug(

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -23,9 +23,57 @@ from PIL import Image
 
 from superset.utils.screenshot_utils import (
     combine_screenshot_tiles,
+    resolve_screenshot_task_budget_seconds,
+    SCREENSHOT_TASK_BUDGET_MAX_MARGIN_SECONDS,
     SCROLL_SETTLE_TIMEOUT_MS,
     take_tiled_screenshot,
 )
+
+
+class TestResolveScreenshotTaskBudget:
+    def _task(self, timelimit):
+        task = MagicMock()
+        task.request.timelimit = timelimit
+        return task
+
+    def test_prefers_soft_limit_and_reserves_scaled_margin(self):
+        task = self._task((400, 300))
+        with patch("superset.utils.screenshot_utils.current_task", task):
+            budget = resolve_screenshot_task_budget_seconds()
+
+        assert budget == 240
+
+    def test_uses_hard_limit_and_caps_cleanup_margin(self):
+        task = self._task((2000, None))
+        with patch("superset.utils.screenshot_utils.current_task", task):
+            budget = resolve_screenshot_task_budget_seconds()
+
+        assert budget == 2000 - SCREENSHOT_TASK_BUDGET_MAX_MARGIN_SECONDS
+
+    @pytest.mark.parametrize("timelimit", [None, (), (None, None), "300", (0, 0)])
+    def test_absent_or_malformed_timelimit_preserves_standalone_timeout(
+        self, timelimit
+    ):
+        task = self._task(timelimit)
+        with patch("superset.utils.screenshot_utils.current_task", task):
+            assert resolve_screenshot_task_budget_seconds() is None
+
+    def test_outside_celery_preserves_standalone_timeout(self):
+        with patch("superset.utils.screenshot_utils.current_task", None):
+            assert resolve_screenshot_task_budget_seconds() is None
+
+    def test_broken_task_metadata_preserves_standalone_timeout(self):
+        task = MagicMock()
+        type(task).request = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        with (
+            patch("superset.utils.screenshot_utils.current_task", task),
+            patch("superset.utils.screenshot_utils.logger") as mock_logger,
+        ):
+            assert resolve_screenshot_task_budget_seconds("execution_id=abc") is None
+
+        assert mock_logger.debug.call_args.kwargs["exc_info"] is True
 
 
 class TestCombineScreenshotTiles:
@@ -482,6 +530,7 @@ class TestTakeTiledScreenshot:
         """
         from superset.utils.screenshot_utils import (
             CHART_HOLDERS_READY_JS,
+            FIND_CHART_HOLDER_STATES_JS,
             FIND_UNREADY_CHART_HOLDERS_JS,
         )
 
@@ -490,6 +539,20 @@ class TestTakeTiledScreenshot:
             assert "waiting_on_database" in js
             assert "nothing_mounted" in js
             assert "slice-container" in js
+            assert (
+                '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
+            ) in js
+            assert "holder.getAttribute('data-test-chart-id')" in js
+            assert "holder.querySelector('[data-test-chart-id]')" not in js
+
+        assert "rendered" in FIND_CHART_HOLDER_STATES_JS
+        assert "empty" in FIND_CHART_HOLDER_STATES_JS
+        assert "error" in FIND_CHART_HOLDER_STATES_JS
+        assert "virtualized" in FIND_CHART_HOLDER_STATES_JS
+        assert "waiting_on_database" in FIND_CHART_HOLDER_STATES_JS
+        assert (
+            '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
+        ) in FIND_CHART_HOLDER_STATES_JS
 
     def test_per_tile_timing_logged_at_debug(self, mock_page):
         """Each tile logs how long it waited for readiness, for profiling."""

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -778,7 +778,7 @@ class TestWebDriverPlaywrightErrorHandling:
         assert warning_call.args[1] == 1
         assert warning_call.args[2] == "http://example.com"
         assert warning_call.args[3] == 60
-        assert warning_call.args[5] == [{"chartId": "42", "state": "nothing_mounted"}]
+        assert warning_call.args[6] == [{"chartId": "42", "state": "nothing_mounted"}]
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -884,6 +884,8 @@ class TestWebDriverPlaywrightErrorHandling:
                 return 1
             if "const target = document.querySelector" in script:
                 return 0
+            if "dashboard-component-chart-holder" in script:
+                return []
             return None
 
         mock_page.evaluate.side_effect = evaluate_side_effect
@@ -1091,8 +1093,10 @@ class TestWebDriverPlaywrightChartReadiness:
             )
 
         assert result == b"screenshot"
-        # No timeout, so the unready-holder diagnostics query never runs.
-        mock_page.evaluate.assert_not_called()
+        # Readiness diagnostics are emitted before polling so a task killed by
+        # an outer limit still leaves useful state in the logs.
+        mock_page.evaluate.assert_called_once()
+        assert "state: 'rendered'" in mock_page.evaluate.call_args.args[0]
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1160,9 +1164,121 @@ class TestWebDriverPlaywrightChartReadiness:
                     log_context="execution_id=abc-123",
                 )
 
-        # context_suffix is the 5th positional arg (index 4); assert its
+        # context_suffix is the 6th positional arg (index 5); assert its
         # exact value rather than tuple-element membership via `in`.
-        assert mock_logger.warning.call_args.args[4] == " [execution_id=abc-123]"
+        assert mock_logger.warning.call_args.args[5] == " [execution_id=abc-123]"
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.logger")
+    @patch("superset.utils.webdriver.app")
+    def test_wait_is_capped_to_remaining_runtime_task_budget(
+        self, mock_app, mock_logger, mock_browser_manager
+    ):
+        """Elapsed setup time is removed from the task-derived safe budget."""
+        mock_user = MagicMock()
+        mock_user.username = "test_user"
+        mock_app.config = {
+            **self._base_config,
+            "SCREENSHOT_LOAD_WAIT": 600,
+        }
+        mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
+
+        with (
+            patch.object(WebDriverPlaywright, "auth", return_value=mock_context),
+            patch(
+                "superset.utils.webdriver.resolve_screenshot_task_budget_seconds",
+                return_value=240,
+            ),
+            patch(
+                "superset.utils.webdriver.time.monotonic",
+                side_effect=[100.0, 110.0],
+            ),
+        ):
+            WebDriverPlaywright("chrome").get_screenshot(
+                "http://example.com", "test-element", mock_user
+            )
+
+        assert mock_page.wait_for_function.call_args.kwargs["timeout"] == 230_000
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.logger")
+    @patch("superset.utils.webdriver.app")
+    def test_exhausted_task_budget_raises_before_capture(
+        self, mock_app, mock_logger, mock_browser_manager
+    ):
+        """An exhausted budget fails loudly while cleanup time remains."""
+        from superset.utils.webdriver import ScreenshotTaskBudgetExceededError
+
+        mock_user = MagicMock()
+        mock_app.config = {**self._base_config, "SCREENSHOT_LOAD_WAIT": 600}
+        mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
+        diagnostics = [{"chartId": "17", "state": "nothing_mounted"}]
+        mock_page.evaluate.return_value = diagnostics
+
+        with (
+            patch.object(WebDriverPlaywright, "auth", return_value=mock_context),
+            patch(
+                "superset.utils.webdriver.resolve_screenshot_task_budget_seconds",
+                return_value=240,
+            ),
+            patch(
+                "superset.utils.webdriver.time.monotonic",
+                side_effect=[100.0, 341.0],
+            ),
+        ):
+            with pytest.raises(ScreenshotTaskBudgetExceededError):
+                WebDriverPlaywright("chrome").get_screenshot(
+                    "http://example.com", "test-element", mock_user
+                )
+
+        mock_page.wait_for_function.assert_not_called()
+        mock_page.locator.return_value.screenshot.assert_not_called()
+        mock_context.close.assert_called_once()
+        warning_args = mock_logger.warning.call_args.args
+        assert "budget exhausted" in warning_args[0]
+        assert warning_args[5] == diagnostics
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.logger")
+    @patch("superset.utils.webdriver.app")
+    def test_unready_diagnostics_logged_early_and_at_failure(
+        self, mock_app, mock_logger, mock_browser_manager
+    ):
+        """Unready IDs/states are logged before polling and on timeout."""
+        from superset.utils.webdriver import PlaywrightTimeout
+
+        mock_user = MagicMock()
+        mock_user.username = "test_user"
+        mock_app.config = {**self._base_config}
+        mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
+        diagnostics = [{"chartId": "17", "state": "waiting_on_database"}]
+        mock_page.evaluate.return_value = diagnostics
+        mock_page.wait_for_function.side_effect = PlaywrightTimeout("timed out")
+
+        with patch.object(WebDriverPlaywright, "auth", return_value=mock_context):
+            driver = WebDriverPlaywright("chrome")
+            with pytest.raises(PlaywrightTimeout):
+                driver.get_screenshot("http://example.com", "test-element", mock_user)
+
+        mock_logger.info.assert_any_call(
+            "Chart holder states before readiness polling at url %s%s: %s",
+            "http://example.com",
+            "",
+            diagnostics,
+        )
+        mock_logger.info.assert_any_call(
+            "Chart holders not ready before polling at url %s%s: %s",
+            "http://example.com",
+            "",
+            diagnostics,
+        )
+        failure_args = mock_logger.warning.call_args.args
+        assert failure_args[6] == diagnostics
+        assert failure_args[7] == diagnostics
+        mock_page.locator.return_value.screenshot.assert_not_called()
 
 
 class TestWebDriverPlaywrightAnimationWaitOrder:
@@ -1253,7 +1369,7 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
 
         # Small dashboard: 3 charts, 1000px height — below both thresholds
-        mock_page.evaluate.side_effect = [3, 1000]
+        mock_page.evaluate.side_effect = [3, 1000, []]
 
         call_order: list[str] = []
 


### PR DESCRIPTION
### SUMMARY

Fix-forward stacked on #42253 (`fix-non-tiled-vacuous-pass`) 

The apples-to-apples staging trace completed browser startup, authentication, navigation, and chart discovery by **8.83s**, then spent **290.78s** inside `_wait_for_charts_ready` until the thumbnails task's **300s Celery soft limit** terminated it. With a configuration of`SCREENSHOT_LOAD_WAIT=600` #42253's readiness timeout could not fire before task termination. Builds without #42253 returned visually verified chart-bearing PDFs in about **16s**.

Follow-up validation on the corrected build confirmed the runtime budget behaved correctly: the 300s soft limit produced a 240s safe budget, the effective readiness wait was about 234s, browser cleanup ran, and the cache became `Error`. The remaining blocker was a single `{'chartId': 'unknown', 'state': 'nothing_mounted'}` while real charts were rendered. Frontend inspection showed that Markdown and DynamicComponent reuse `[data-test="dashboard-component-chart-holder"]`; it was not a chart-specific selector.

This revision establishes an explicit selector contract: `ChartHolder.tsx` places `data-test-chart-id` directly on its outer holder, and readiness selects only `[data-test="dashboard-component-chart-holder"][data-test-chart-id]`. This identifies a real chart before its inner `Chart` mounts, retains `nothing_mounted` blocking with the correct ID, and excludes Markdown/DynamicComponent by construction rather than silently ignoring unknown holders.

This revision replaces the earlier fixed `SCREENSHOT_LOAD_WAIT_MAX=240` proposal with the runtime task-budget approach introduced and validated by #42118. Credit to #42118 for establishing that the effective limit must come from the running Celery task rather than a second static timeout setting.

The implementation:

- reads Celery's effective `(hard, soft)` limits from `current_task.request.timelimit`, preferring the soft limit;
- reserves the #42118 cleanup policy: 20% of the active limit, capped at 300s, for browser cleanup, cache error transition, and the remaining report pipeline;
- starts the screenshot wall clock before browser/navigation work and caps the non-tiled readiness wait to `min(SCREENSHOT_LOAD_WAIT, safe_task_budget - elapsed)`;
- preserves configured behavior outside Celery and when task-limit metadata is absent, malformed, non-positive, or inaccessible;
- raises before capture when the safe budget is already exhausted, allowing `finally` to close the browser context and the cache path to become `ERROR`;
- keeps #42253's positive readiness predicate—never reverting to absence-of-spinner—and classifies holders as `rendered`, `empty`, `error`, `waiting_on_database`, `spinner_mounted`, `nothing_mounted`, or offscreen `virtualized`;
- narrows the DOM contract to actual `ChartHolder` elements carrying the new outer `data-test-chart-id`, excluding Markdown and DynamicComponent holders while preserving pre-mount chart detection;
- logs all classified holder states plus unready chart IDs before polling and again on timeout/budget exhaustion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend screenshot orchestration and diagnostics only.

### TESTING INSTRUCTIONS

Automated:

```bash
python -m pytest -q tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py
# 76 passed

ruff check superset/utils/webdriver.py superset/utils/screenshot_utils.py tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py
ruff format --check superset/utils/webdriver.py superset/utils/screenshot_utils.py tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py

pre-commit run ruff-format --files superset/utils/webdriver.py superset/utils/screenshot_utils.py tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py
pre-commit run ruff --files superset/utils/webdriver.py superset/utils/screenshot_utils.py tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py
pre-commit run mypy --files superset/utils/webdriver.py superset/utils/screenshot_utils.py tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py
# all passed

# Frontend formatting
npx prettier --check ChartHolder.tsx ChartHolder.test.tsx Markdown.test.tsx DynamicComponent.test.tsx
# passed
```

Backend coverage includes soft-vs-hard task limits, scaled and capped safety margins, elapsed-time subtraction, absent/malformed/inaccessible limits, compatibility outside Celery, already-exhausted budgets, early/final diagnostics, terminal states, loading/nothing-mounted states, virtualization, and no capture on failure. Frontend unit assertions prove the outer ChartHolder carries its chart ID while Markdown and DynamicComponent holders do not. The frontend Jest/ESLint suite could not be installed locally because this checkout requires Node 24/npm 11 and its package lock is not synchronized under the available Node 22/npm 10 runtime; CI is authoritative for those checks.

Deployment test plan (not performed by this PR):

1. Deploy to the with `SCREENSHOT_LOAD_WAIT=600` and the thumbnails task's 300s soft limit.
2. Generate the affected PDF directly and through the cache path; visually verify chart-bearing output and runtime near the known-good ~16s baseline.
3. Exercise rendered, empty, error, loading, nothing-mounted, and below-fold virtualized holders; verify terminal states succeed and virtualized holders do not block.
4. Force a readiness failure; verify the initial and final logs contain chart IDs/states, the runtime wait reflects the remaining safe budget, browser cleanup executes, cache status becomes `ERROR`, and no blank/partial screenshot is captured or served.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #42253; #42118; 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

