### PR TITLE
fix(datasets): log datetime format-detection DB query failures at WARNING

### DIFF
--- a/superset/datasets/datetime_format_detector.py
+++ b/superset/datasets/datetime_format_detector.py
@@ -122,8 +122,23 @@ class DatetimeFormatDetector:
             # This handles different SQL dialects (LIMIT, TOP, FETCH FIRST, etc.)
             sql = database.apply_limit_to_sql(sql, limit=self.sample_size, force=True)
 
-            # Execute query and get results
-            df = database.get_df(sql, dataset.schema)
+            # Execute query and get results. Failures here come from the
+            # target database itself (bad connection config, transient
+            # outage, permission errors, etc.), not from Superset's own
+            # logic. Format detection is a best-effort optimization with no
+            # user-facing impact when it's skipped, so log at WARNING
+            # instead of capturing an ERROR-level exception for every sample
+            # query a misconfigured/unreachable database rejects.
+            try:
+                df = database.get_df(sql, dataset.schema)
+            except Exception as ex:
+                logger.warning(
+                    "Could not query column %s.%s for format detection: %s",
+                    dataset.table_name,
+                    column.column_name,
+                    str(ex),
+                )
+                return None
 
             if df.empty or column.column_name not in df.columns:
                 logger.warning(

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -16,6 +16,7 @@
 # under the License.
 """Tests for datetime format detector."""
 
+import logging
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -108,16 +109,48 @@ def test_detect_column_format_empty_data(
 
 
 def test_detect_column_format_error_handling(
-    mock_dataset: MagicMock, mock_column: MagicMock
+    mock_dataset: MagicMock, mock_column: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test error handling during format detection."""
+    """Test error handling during format detection.
+
+    A failure while querying the target database (bad connection config,
+    transient outage, permission errors, etc.) is expected and already
+    fully handled -- it must not be captured as an ERROR-level exception,
+    since that floods Sentry with noise for every sample query a
+    misconfigured/unreachable database rejects.
+    """
     # Simulate database error
     mock_dataset.database.get_df.side_effect = Exception("Database error")
 
     detector = DatetimeFormatDetector()
-    detected_format = detector.detect_column_format(mock_dataset, mock_column)
+    with caplog.at_level(logging.WARNING):
+        detected_format = detector.detect_column_format(mock_dataset, mock_column)
 
     assert detected_format is None
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert any(
+        record.levelno == logging.WARNING and "Could not query column" in record.message
+        for record in caplog.records
+    )
+
+
+def test_detect_column_format_internal_error_still_logs_at_error(
+    mock_dataset: MagicMock, mock_column: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A genuine internal bug (not a database-query failure) should still be
+    logged at ERROR so it remains visible/actionable, unlike the expected
+    database-query failure case above."""
+    mock_dataset.database.get_sqla_engine.side_effect = RuntimeError(
+        "unexpected internal error"
+    )
+
+    detector = DatetimeFormatDetector()
+    with caplog.at_level(logging.WARNING):
+        detected_format = detector.detect_column_format(mock_dataset, mock_column)
+
+    assert detected_format is None
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
+    mock_dataset.database.get_df.assert_not_called()
 
 
 def test_detect_all_formats(mock_dataset: MagicMock) -> None:


### PR DESCRIPTION
### SUMMARY

Kills [SUPERSET-PYTHON-YDB](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-YDB) — `DatabaseError: ... Cannot parse  as CloudRegion` — ~90k occurrences across 24 users, firing since 2025-12.

### PROBLEM

`DatetimeFormatDetector.detect_column_format()` opportunistically samples a temporal column to pre-compute its datetime format when a dataset is saved. It already wraps the entire method body in `except Exception: logger.exception(...); return None`, so any failure here is fully handled and has zero user-facing impact — format detection is simply skipped.

The observed Sentry error is a genuine BigQuery-side 400 rejection ("Cannot parse '' as CloudRegion") from `database.get_df()`, coming from a specific customer's misconfigured/unreachable BigQuery connection. Because the whole method shared one broad `except Exception`, this already-handled, environment-dependent failure was logged via `logger.exception()` (ERROR + full traceback), which Sentry's logging integration captures as an issue on every single occurrence.

### FIX

Wrap only the `database.get_df()` call in its own `try/except`, logging at WARNING instead — matching the log level already used a few lines below for the sibling "No data returned" / "Could not detect format" cases. The outer `except Exception` is untouched, so genuine internal bugs (SQL building, identifier quoting, etc.) still log at ERROR and stay visible/actionable.

No functional/behavioral change: `detect_column_format()` still always returns `None` on any failure; `detect_all_formats()` callers are unaffected.

### TRADEOFFS

Query-execution failures against the *customer's own database* during this specific best-effort operation no longer create a Sentry issue. Real connectivity/auth problems with that database are still visible elsewhere (e.g. when the customer actually queries the dataset/chart, which raises separate, already-tracked Sentry issues) — this only mutes the redundant, non-actionable copy that fired on every dataset save against a broken connection.

### FOLLOW-UP (not in this PR)

The underlying BigQuery connection issue (empty/invalid `location`) is a customer-side configuration problem, not a Superset bug.

### TESTING INSTRUCTIONS

- Updated `tests/unit_tests/datasets/test_datetime_format_detector.py`: the existing error-handling test now asserts WARNING-only (no ERROR) on a `get_df` failure; a new test asserts a genuine internal error (`get_sqla_engine` raising) still logs at ERROR.
- `pytest tests/unit_tests/datasets/test_datetime_format_detector.py` — 12 passed.
- `ruff check` + `ruff format --check` clean.

Shortcut: [sc-115217](https://app.shortcut.com/preset/story/115217)

🤖 Generated with [Claude Code](https://claude.com/claude-code)