### PR TITLE
chore(importers): log field names instead of full config on validation failure

### DIFF
--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -231,10 +231,20 @@ def load_configs(
                     exc.messages,
                 )
                 # Log field names only; full values can be huge (e.g. inline
-                # example data) and drown out the validation error above.
-                logger.debug(
-                    "Config fields present in %s: %s", file_name, sorted(config)
-                )
+                # example data) and drown out the validation error above. Guard
+                # the diagnostic so it can never raise and mask the validation
+                # error: config may be a non-mapping or have unsortable keys.
+                if isinstance(config, dict):
+                    field_names = ", ".join(sorted(map(str, config)))
+                    logger.debug(
+                        "Config fields present in %s: %s", file_name, field_names
+                    )
+                else:
+                    logger.debug(
+                        "Config in %s is not a mapping (type: %s)",
+                        file_name,
+                        type(config).__name__,
+                    )
                 exc.messages = {file_name: exc.messages}
                 exceptions.append(exc)
 

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -230,7 +230,11 @@ def load_configs(
                     prefix,
                     exc.messages,
                 )
-                logger.debug("Config content that failed validation: %s", config)
+                # Log field names only; full values can be huge (e.g. inline
+                # example data) and drown out the validation error above.
+                logger.debug(
+                    "Config fields present in %s: %s", file_name, sorted(config)
+                )
                 exc.messages = {file_name: exc.messages}
                 exceptions.append(exc)
 


### PR DESCRIPTION
### SUMMARY
When schema validation fails during an import, the debug log dumps the entire parsed config dict. Those blobs can be enormous (inline example data, multi-line keys) and bury the actual validation error that's logged right above. This trims the debug line to the file name plus its top-level field names, which is what you actually need to correlate the failure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (log output only)

### TESTING INSTRUCTIONS
```bash
pytest tests/unit_tests/commands/importers/v1/
```
With debug logging enabled, import a bundle with an invalid config and confirm the log shows the field-name list instead of the full config dump.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)