### PR TITLE
fix(semantic-layers): show a friendly warning when schema enrichment falls back

### DIFF
--- a/superset/semantic_layers/api.py
+++ b/superset/semantic_layers/api.py
@@ -614,8 +614,15 @@ class SemanticLayerRestApi(BaseSupersetApi):
         warning: str | None = None
         try:
             schema = cls.get_configuration_schema(parsed_config)
-        except Exception as ex:  # pylint: disable=broad-except
-            warning = str(ex)
+        except Exception:  # pylint: disable=broad-except
+            # Show a stable, user-friendly message in the UI; the exception
+            # detail goes to the server log below.
+            warning = str(
+                t(
+                    "Could not load metadata for this configuration; "
+                    "showing the default form. See the server logs for details."
+                )
+            )
             logger.exception(
                 "Error enriching semantic layer configuration schema for type %s",
                 sl_type,

--- a/tests/unit_tests/semantic_layers/api_test.py
+++ b/tests/unit_tests/semantic_layers/api_test.py
@@ -1186,7 +1186,12 @@ def test_configuration_schema_enrichment_error_fallback(
 
     assert response.status_code == 200
     assert response.json["result"] == {"type": "object"}
-    assert response.json["warning"] == "connection failed"
+    # The warning is a stable, user-friendly message; the exception detail
+    # only goes to the server log.
+    assert response.json["warning"] == (
+        "Could not load metadata for this configuration; "
+        "showing the default form. See the server logs for details."
+    )
     assert mock_cls.get_configuration_schema.call_count == 2
 
 


### PR DESCRIPTION
### SUMMARY
When configuration-schema enrichment fails (connection refused, driver hiccups, etc.), the raw exception text was passed through to the UI as a danger toast. That reads as raw internals, varies wildly by driver, and isn't translatable. This swaps it for a stable, translatable message pointing at the server logs, where the full exception is already recorded via `logger.exception`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: toast shows e.g. `connection failed` (whatever the driver raised).
After: toast shows "Could not load metadata for this configuration; showing the default form. See the server logs for details."

### TESTING INSTRUCTIONS
```bash
pytest tests/unit_tests/semantic_layers/api_test.py
```
Or point a semantic layer config at an unreachable host in the modal and confirm the toast shows the new message while the fallback form still renders.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)