### PR TITLE
fix(sqla): catch TemplateError alongside SupersetSyntaxErrorException in models.py

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1097,8 +1097,8 @@ class TableColumn(AuditMixinNullable, ImportExportMixin, CertificationMixin, Mod
             if template_processor:
                 try:
                     expression = template_processor.process_template(expression)
-                except SupersetSyntaxErrorException as ex:
-                    msg = str(ex)
+                except (TemplateError, SupersetSyntaxErrorException) as ex:
+                    msg = getattr(ex, "message", str(ex))
                     raise QueryObjectValidationError(
                         _(
                             "Error in jinja expression in column expression: %(msg)s",
@@ -1144,8 +1144,8 @@ class TableColumn(AuditMixinNullable, ImportExportMixin, CertificationMixin, Mod
             if template_processor:
                 try:
                     expression = template_processor.process_template(expression)
-                except SupersetSyntaxErrorException as ex:
-                    msg = str(ex)
+                except (TemplateError, SupersetSyntaxErrorException) as ex:
+                    msg = getattr(ex, "message", str(ex))
                     raise QueryObjectValidationError(
                         _(
                             "Error in jinja expression in datetime column: %(msg)s",
@@ -1239,8 +1239,8 @@ class SqlMetric(AuditMixinNullable, ImportExportMixin, CertificationMixin, Model
         if template_processor:
             try:
                 expression = template_processor.process_template(expression)
-            except SupersetSyntaxErrorException as ex:
-                msg = str(ex)
+            except (TemplateError, SupersetSyntaxErrorException) as ex:
+                msg = getattr(ex, "message", str(ex))
                 raise QueryObjectValidationError(
                     _(
                         "Error in jinja expression in metric expression: %(msg)s",
@@ -1769,11 +1769,11 @@ class SqlaTable(
             return sql_expression
         try:
             return template_processor.process_template(sql_expression)
-        except SupersetSyntaxErrorException as ex:
+        except (TemplateError, SupersetSyntaxErrorException) as ex:
             raise QueryObjectValidationError(
                 _(
                     "Error in jinja expression in adhoc column: %(msg)s",
-                    msg=str(ex),
+                    msg=getattr(ex, "message", str(ex)),
                 )
             ) from ex
 

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -33,10 +33,12 @@ from superset.daos.dataset import DatasetDAO
 from superset.daos.exceptions import DatasourceNotFound
 from superset.exceptions import (
     OAuth2RedirectError,
+    QueryObjectValidationError,
     SupersetDisallowedSQLFunctionException,
     SupersetDisallowedSQLTableException,
     SupersetSecurityException,
 )
+from superset.jinja_context import get_template_processor
 from superset.models.core import Database
 from superset.sql.parse import Table
 from superset.superset_typing import QueryObjectDict
@@ -1264,3 +1266,32 @@ def test_validate_stored_expression_rejects_subquery_around_jinja(
             None,
             "(SELECT password FROM ab_user LIMIT 1) {# x #}",
         )
+
+
+def test_get_sqla_col_wraps_raw_jinja_undefined_error() -> None:
+    """
+    A raw ``jinja2.exceptions.UndefinedError`` raised while rendering a
+    column's Jinja expression (e.g. an arithmetic operation on an undefined
+    variable) must surface as a ``QueryObjectValidationError``, not
+    propagate as an unhandled 500.
+    """
+    database = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
+    table = SqlaTable(
+        id=1,
+        table_name="test_table",
+        database=database,
+        schema="my_schema",
+        sql=None,
+        columns=[
+            TableColumn(
+                column_name="my_column",
+                type="VARCHAR",
+                expression="{{ nonexistent_var + 1 }}",
+            )
+        ],
+    )
+    column = table.columns[0]
+    processor = get_template_processor(database=database, table=table)
+
+    with pytest.raises(QueryObjectValidationError):
+        column.get_sqla_col(template_processor=processor)


### PR DESCRIPTION
### SUMMARY
Four call sites in `superset/connectors/sqla/models.py` that render Jinja expressions only caught `SupersetSyntaxErrorException`, missing `jinja2.exceptions.TemplateError`. A raw `TemplateError` (e.g. `UndefinedError`) from these sites propagated as an unhandled 500 instead of a clear, actionable `QueryObjectValidationError`. This mirrors the same bug class fixed for `get_rendered_sql()` in #42366, and this file already has two sibling call sites (RLS filters, `get_fetch_values_predicate`) that catch the error correctly — this PR brings the remaining four in line with that existing pattern.

### PROBLEM
`TableColumn.get_sqla_col`, `TableColumn.get_timestamp_expression`, `SqlMetric.get_sqla_col`, and `SqlaTable._render_adhoc_expression_for_metadata_lookup` each wrap `template_processor.process_template(...)` in a `try`/`except SupersetSyntaxErrorException`. Since `jinja2.exceptions.UndefinedError` is a subclass of `TemplateError`, not `SupersetSyntaxErrorException`, a column/metric/adhoc-column Jinja expression that references an undefined variable (e.g. an arithmetic operation on an undefined name) raises a raw `UndefinedError` that these `except` clauses don't catch, surfacing as an unhandled 500 during chart explore/render.

### FIX
Widen the `except` clause at all four sites to `except (TemplateError, SupersetSyntaxErrorException) as ex:` and extract the message via `getattr(ex, "message", str(ex))`, exactly matching the two already-correct sibling call sites in this same file. `TemplateError` was already imported at the top of the file. No other exception handling was touched, and `superset/models/helpers.py` (already fixed in #42366) was left untouched.

### TESTING INSTRUCTIONS
- Added `tests/unit_tests/connectors/sqla/models_test.py::test_get_sqla_col_wraps_raw_jinja_undefined_error`, which constructs a `TableColumn` with the Jinja expression `{{ nonexistent_var + 1 }}` and asserts `get_sqla_col()` raises `QueryObjectValidationError` instead of a raw `UndefinedError`. Verified the test fails on pre-fix code and passes after.
- Ran `pytest tests/unit_tests/connectors/sqla/models_test.py` (44 passed) and `pytest tests/unit_tests/jinja_context_test.py` (101 passed, no regressions).
- Ran `ruff check` and `mypy` on the changed files — no new issues.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API