### PR TITLE
fix(sqllab): make dark-theme occurrence highlight readable

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
@@ -30,6 +30,7 @@ import {
   JsonEditor,
   ConfigEditor,
   aceCompletionHighlightStyles,
+  aceSelectedWordStyles,
 } from '.';
 
 import type { AceModule, AsyncAceEditorOptions } from './types';
@@ -53,6 +54,19 @@ test('themes the autocomplete completion highlight from the theme', () => {
 
   expect(styles).toContain('.ace_completion-highlight');
   expect(styles).toContain(supersetTheme.colorPrimaryText);
+});
+
+test('themes the selected-word occurrence markers from the theme', () => {
+  // The light `github` theme hardcodes a near-white box for the markers Ace
+  // paints on every other occurrence of the selected token, which makes the
+  // recolored token glyphs unreadable in dark mode. The shared editor overrides
+  // the marker to reuse the dark-aware selection color so it stays legible.
+  const { styles } = aceSelectedWordStyles(supersetTheme);
+
+  expect(styles).toContain('.ace_selected-word');
+  expect(styles).toContain(
+    supersetTheme.colorEditorSelection ?? supersetTheme.colorPrimaryBgHover,
+  );
 });
 
 test('SQLEditor uses fontFamilyCode from theme', async () => {

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
@@ -16,9 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { createRef } from 'react';
+import { createRef, type ReactNode } from 'react';
 import { render, screen, waitFor } from '@superset-ui/core/spec';
-import { supersetTheme } from '@apache-superset/core/theme';
+import {
+  supersetTheme,
+  ThemeProvider,
+  type SupersetTheme,
+} from '@apache-superset/core/theme';
 import type AceEditor from 'react-ace';
 import {
   AsyncAceEditor,
@@ -64,8 +68,60 @@ test('themes the selected-word occurrence markers from the theme', () => {
   const { styles } = aceSelectedWordStyles(supersetTheme);
 
   expect(styles).toContain('.ace_selected-word');
-  expect(styles).toContain(
-    supersetTheme.colorEditorSelection ?? supersetTheme.colorPrimaryBgHover,
+  // The default theme leaves `colorEditorSelection` unset, so the marker uses
+  // the documented `colorPrimaryBgHover` fallback.
+  expect(styles).toContain(supersetTheme.colorPrimaryBgHover);
+});
+
+// Collect every CSS rule the render injected: emotion's Global styles land in
+// <style> tags (non-speedy in test) while Ace's bundled theme uses the CSSOM,
+// so read both to reliably observe what actually reached the document.
+function getInjectedCss(): string {
+  const fromTags = Array.from(document.querySelectorAll('style'))
+    .map(tag => tag.textContent ?? '')
+    .join('\n');
+  const fromSheets = Array.from(document.styleSheets)
+    .map(sheet => {
+      try {
+        return Array.from(sheet.cssRules)
+          .map(rule => rule.cssText)
+          .join('\n');
+      } catch {
+        return '';
+      }
+    })
+    .join('\n');
+  return `${fromTags}\n${fromSheets}`;
+}
+
+test('wires the dark-aware selected-word marker into the editor Global styles', async () => {
+  // Guards the actual regression: Ace's bundled `github` theme already injects
+  // a near-white `.ace-github ... .ace_selected-word` rule, so the fix is only
+  // effective if the editor's own Global block also emits a `.ace_selected-word`
+  // override driven by the theme. Render with a distinctive `colorEditorSelection`
+  // and assert that value reaches the injected selected-word rule — this fails if
+  // the `${aceSelectedWordStyles(token)}` interpolation is dropped from <Global>.
+  const markerColor = '#010203';
+  const darkTheme: SupersetTheme = {
+    ...supersetTheme,
+    colorEditorSelection: markerColor,
+  };
+
+  const { container } = render(<SQLEditor />, {
+    wrapper: ({ children }: { children?: ReactNode }) => (
+      <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>
+    ),
+  });
+
+  await waitFor(() => {
+    expect(container.querySelector('[id="ace-editor"]')).toBeInTheDocument();
+  });
+
+  const css = getInjectedCss();
+  // The dark-aware color is tied specifically to the selected-word marker
+  // (not just the plain `.ace_selection`), so the occurrence markers inherit it.
+  expect(css).toMatch(
+    new RegExp(`\\.ace_selected-word[^}]*${markerColor}`, 'i'),
   );
 });
 

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { createRef, type ReactNode } from 'react';
+import { createRef } from 'react';
 import { render, screen, waitFor } from '@superset-ui/core/spec';
 import {
   supersetTheme,
@@ -107,11 +107,14 @@ test('wires the dark-aware selected-word marker into the editor Global styles', 
     colorEditorSelection: markerColor,
   };
 
-  const { container } = render(<SQLEditor />, {
-    wrapper: ({ children }: { children?: ReactNode }) => (
-      <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>
-    ),
-  });
+  // The shared `render` helper injects its own default `SupersetThemeProvider`,
+  // so nest the dark theme around the editor itself: the innermost emotion
+  // `ThemeProvider` is what the editor's `useTheme()` resolves.
+  const { container } = render(
+    <ThemeProvider theme={darkTheme}>
+      <SQLEditor />
+    </ThemeProvider>,
+  );
 
   await waitFor(() => {
     expect(container.querySelector('[id="ace-editor"]')).toBeInTheDocument();

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/AsyncAceEditor.test.tsx
@@ -71,6 +71,13 @@ test('themes the selected-word occurrence markers from the theme', () => {
   // The default theme leaves `colorEditorSelection` unset, so the marker uses
   // the documented `colorPrimaryBgHover` fallback.
   expect(styles).toContain(supersetTheme.colorPrimaryBgHover);
+  // The override also restyles the marker border from the theme...
+  expect(styles).toContain(supersetTheme.colorBorder);
+  // ...and carries `!important`, which is what lets it win over Ace's bundled
+  // non-important `.ace-github .ace_marker-layer .ace_selected-word` near-white
+  // rule regardless of stylesheet order (the effective-cascade guarantee that
+  // jsdom cannot verify by computed style).
+  expect(styles).toContain('!important');
 });
 
 // Collect every CSS rule the render injected: emotion's Global styles land in

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
@@ -127,6 +127,22 @@ export const aceCompletionHighlightStyles = (token: SupersetTheme) => css`
 `;
 
 /**
+ * Theme-aware styling for the "selected word" markers Ace paints on every other
+ * occurrence of the currently selected token. The light `github` theme hardcodes
+ * a near-white box (`rgb(250,250,255)`); in dark mode the recolored token glyphs
+ * sit on it unreadably. Reuse the same dark-aware selection color as
+ * `.ace_selection` so the markers stay legible in every theme.
+ */
+export const aceSelectedWordStyles = (token: SupersetTheme) => css`
+  .ace_editor .ace_marker-layer .ace_selected-word {
+    background-color: ${
+      token.colorEditorSelection ?? token.colorPrimaryBgHover
+    } !important;
+    border: 1px solid ${token.colorBorder} !important;
+  }
+`;
+
+/**
  * Get an async AceEditor with automatical loading of specified ace modules.
  */
 export function AsyncAceEditor(
@@ -393,6 +409,8 @@ export function AsyncAceEditor(
                     token.colorEditorSelection ?? token.colorPrimaryBgHover
                   } !important;
                 }
+
+                ${aceSelectedWordStyles(token)}
 
                 /* Improve active line highlighting */
                 .ace_editor .ace_active-line {

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
@@ -114,6 +114,14 @@ export type AsyncAceEditorOptions = {
 };
 
 /**
+ * Dark-aware color for text selection in the editor. Shared so the plain
+ * selection and the "selected word" occurrence markers always match, falling
+ * back to `colorPrimaryBgHover` on themes that don't define the token.
+ */
+export const editorSelectionColor = (token: SupersetTheme) =>
+  token.colorEditorSelection ?? token.colorPrimaryBgHover;
+
+/**
  * Theme-aware styling for the matched-prefix highlight in the autocomplete
  * popup. Ace ships a hardcoded `color: #000` that is invisible on the dark
  * popup, so the override needs `!important` to win. Lives in the shared editor
@@ -135,9 +143,7 @@ export const aceCompletionHighlightStyles = (token: SupersetTheme) => css`
  */
 export const aceSelectedWordStyles = (token: SupersetTheme) => css`
   .ace_editor .ace_marker-layer .ace_selected-word {
-    background-color: ${
-      token.colorEditorSelection ?? token.colorPrimaryBgHover
-    } !important;
+    background-color: ${editorSelectionColor(token)} !important;
     border: 1px solid ${token.colorBorder} !important;
   }
 `;
@@ -405,9 +411,7 @@ export function AsyncAceEditor(
                 }
                 /* Adjust selection color */
                 .ace_editor .ace_selection {
-                  background-color: ${
-                    token.colorEditorSelection ?? token.colorPrimaryBgHover
-                  } !important;
+                  background-color: ${editorSelectionColor(token)} !important;
                 }
 
                 ${aceSelectedWordStyles(token)}


### PR DESCRIPTION
### SUMMARY

Fixes SQL Lab dark theme so that highlighting a token readably highlights its other occurrences (sc-102561).

Root cause: SQL Lab's Ace editor uses the light `github` theme, with a token-based dark-mode `<Global>` CSS override block in `AsyncAceEditor/index.tsx`. That block overrode `.ace_selection` etc. but not `.ace_selected-word` (the marker Ace paints on every other occurrence of the selected token), so it kept the light theme's near-white default and the recolored dark-mode glyphs became unreadable on it. This adds a token-driven `.ace_selected-word` override (dark-aware `colorEditorSelection`, falling back to `colorPrimaryBgHover`, plus `colorBorder`) carrying `!important` so it wins over Ace's bundled rule, mirroring the existing `aceCompletionHighlightStyles` pattern (#41005). The `.ace_selection` color helper was deduped in the process with no behavior change.

Note: the new `.ace_selected-word` override is not gated on dark mode, so it also applies in light theme. There it replaces Ace's bundled near-white marker box (which was nearly invisible against the light editor background too) with the same `colorPrimaryBgHover` background as `.ace_selection` plus a `colorBorder` outline. This is a small, intentional visual change to light mode — the markers still read correctly, and the occurrence markers stay distinguishable from the active selection via the border. It is not a no-op for light theme.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Captured on the showtime env. Query has a repeated column name (`customer_id`); double-clicking one occurrence makes Ace mark the other occurrences. The double-clicked token (line 3) is the active selection; the markers under test are on lines 1 and 4.

**Dark theme** — before, the other occurrences render on Ace's near-white default marker box, so the recolored dark-mode glyphs are unreadable. After, the markers use the dark-aware selection color (`colorEditorSelection`) with a `colorBorder` outline and stay legible.

| Before (master) | After (this PR) |
| --- | --- |
| ![SQL Lab dark theme, occurrence markers unreadable on near-white box](https://raw.githubusercontent.com/sadpandajoe/superset/44dd65deee9fc34c5fa2b9d161103bb504c5e987/sqllab-selected-word-dark-before.png) | ![SQL Lab dark theme, occurrence markers legible on dark selection color](https://raw.githubusercontent.com/sadpandajoe/superset/44dd65deee9fc34c5fa2b9d161103bb504c5e987/sqllab-selected-word-dark-after.png) |

**Light theme** — the occurrence markers change from Ace's near-white box to the shared selection color plus a `colorBorder` outline. They stay readable and remain distinguishable from the active selection (this is the small, intentional light-mode change noted above).

| Before (master) | After (this PR) |
| --- | --- |
| ![SQL Lab light theme, near-white occurrence markers](https://raw.githubusercontent.com/sadpandajoe/superset/44dd65deee9fc34c5fa2b9d161103bb504c5e987/sqllab-selected-word-light-before.png) | ![SQL Lab light theme, occurrence markers with shared selection color and border](https://raw.githubusercontent.com/sadpandajoe/superset/44dd65deee9fc34c5fa2b9d161103bb504c5e987/sqllab-selected-word-light-after.png) |

### TESTING INSTRUCTIONS

1. Switch Superset to **dark theme** and open SQL Lab.
2. Type a query with a repeated column name, then double-click one occurrence.
3. The other occurrences are highlighted with readable contrast.
4. Switch to **light theme** and repeat: confirm the occurrence markers still look correct and stay distinguishable from the active selection. Note the light-theme markers change slightly under this PR, so verify they read well rather than checking for a pixel-identical result.

Unit tests assert the helper emits the dark-aware color, border, and `!important`, and that the override is wired into the editor's Global styles: `AsyncAceEditor.test.tsx`.

### ADDITIONAL INFORMATION

<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

