### PR TITLE
fix(core): don't blank a datetime column when its format coerces every value to NaT

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -2017,13 +2017,26 @@ def _process_datetime_column(
 
         # Parse with or without format (suppress warning if no format)
         if format_to_use:
-            df[col.col_label] = pd.to_datetime(
+            converted = pd.to_datetime(
                 df[col.col_label],
                 utc=False,
                 format=format_to_use,
                 errors="coerce",
                 exact=False,
             )
+            # A format that coerces every non-null value to NaT is a mismatch
+            # (e.g. an epoch-millis column that inherited a '%Y' string format
+            # when used as a chart's granularity). Assigning it would silently
+            # blank the whole column, so keep the original values instead.
+            if df[col.col_label].notna().any() and not converted.notna().any():
+                logger.warning(
+                    "Datetime format %s coerced every value of column %s to NaT; "
+                    "keeping the original values",
+                    format_to_use,
+                    col.col_label,
+                )
+            else:
+                df[col.col_label] = converted
         else:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=".*Could not infer format.*")

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -273,6 +273,22 @@ def test_normalize_dttm_col() -> None:
     assert df["__time"].astype(str).tolist() == ["2017-07-01"]
 
 
+def test_normalize_dttm_col_mismatched_format_keeps_values() -> None:
+    """A datetime format that coerces every value to NaT is a mismatch (e.g. an
+    epoch-millis column that inherited a ``%Y`` string format when used as a
+    chart's granularity); applying it would silently blank the whole column, so
+    the original values are kept instead of being nulled. Regression for the
+    Samples pane showing N/A for such columns."""
+    df = pd.DataFrame({"year": [1136073600000, 473385600000]})  # epoch ms
+    before = df["year"].tolist()
+
+    normalize_dttm_col(df, (DateColumn(col_label="year", timestamp_format="%Y"),))
+
+    # not blanked to NaT/None
+    assert df["year"].notna().all()
+    assert df["year"].tolist() == before
+
+
 def test_normalize_dttm_col_epoch_seconds() -> None:
     """Test conversion of epoch seconds."""
     df = pd.DataFrame(


### PR DESCRIPTION
### SUMMARY
When a temporal column's declared `python_date_format` doesn't match its actual data, `pd.to_datetime(..., errors="coerce")` returns all-`NaT`, and `_process_datetime_column` assigned that result unconditionally — silently nulling the entire column.

This surfaces in the **Samples / drill-detail pane**: a chart whose granularity is a temporal column can send that column through normalization with a format that no longer fits the value it receives. Concretely, `video_game_sales.year` is an epoch-millis-backed column that inherits a `%Y` string format; `pd.to_datetime(1136073600000, format="%Y")` → `NaT`, so every `year` value in the Samples tab renders as **N/A**, even though the chart itself renders (its SQL path passes the already-epoch value straight through). Any time-series chart on a dataset with a misfit temporal-column format hits this.

The fix: when a format coerces *every* non-null value to `NaT`, treat it as a mismatch and keep the original values rather than blanking the column. A format that successfully parses any value is applied exactly as before, so no currently-working case changes.

### BEFORE/AFTER
- **Before:** the whole column becomes `NaT` → Samples shows N/A for every row.
- **After:** the original values are kept (a warning is logged), so the column renders.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/utils/test_core.py -k normalize_dttm` — the new `test_normalize_dttm_col_mismatched_format_keeps_values` fails before the fix (column blanked to NaT) and passes after; the existing normalize tests are unchanged.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI (the Samples pane rendering)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)