### PR TITLE
chore(table): drop dead th.ant-column-cell selector

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -66,12 +66,6 @@ const StyledTable = styled(Table)<{
   showRowCount?: boolean;
 }>`
   ${({ theme, isPaginationSticky, showRowCount }) => `
-    th.ant-column-cell {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
     .actions {
       opacity: 0;
       font-size: ${theme.fontSizeXL}px;


### PR DESCRIPTION
### SUMMARY
`TableCollection` styles `th.ant-column-cell`, but no such class exists (antd header cells are `th.ant-table-cell`), so the rule has never matched. Its intent is also already covered: the `.ant-table-cell` block in the same stylesheet applies ellipsis/nowrap truncation to header and body cells alike. Doubly dead, so this drops the block rather than renaming it.

Found while sweeping every `ant-*` class our Emotion styles reference against the set of classes antd v6 can actually emit; this was the only dead reference left after #42146 (it's dead in v5 too, so it's long-standing cruft rather than a migration regression).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No visual change; the removed rule never matched.

### TESTING INSTRUCTIONS
Open any list view (e.g. Dashboards): long column headers still truncate with an ellipsis, exactly as before, via the `.ant-table-cell` rule.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)