### PR TITLE
fix(lru-cache): don't evict another entry when overwriting an existing key

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -54,7 +54,12 @@ class LRUCache<T> {
     if (typeof key !== 'string') {
       throw new TypeError('The LRUCache key must be string.');
     }
-    if (this.cache.size >= this.capacity) {
+    if (this.cache.has(key)) {
+      // Overwriting an existing key must not evict anything: the entry count is
+      // unchanged. Deleting first also refreshes the key's recency, since
+      // Map#set keeps the original insertion position for existing keys.
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.capacity) {
       // Forward-compat: TS 6.0 types IteratorResult.value as `string | undefined`
       // when not explicitly checked; guard before passing to Map#delete.
       const oldestKey = this.cache.keys().next().value;

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -53,6 +53,27 @@ test('LRU operations', () => {
   expect(cache.capacity).toBe(3);
 });
 
+test('overwriting an existing key does not evict another entry', () => {
+  const cache = lruCache<string>(2);
+  cache.set('a', 'a');
+  cache.set('b', 'b');
+  cache.set('b', 'b2');
+  expect(cache.size).toBe(2);
+  expect(cache.has('a')).toBeTruthy();
+  expect(cache.get('b')).toBe('b2');
+});
+
+test('overwriting an existing key refreshes its recency', () => {
+  const cache = lruCache<string>(2);
+  cache.set('a', 'a');
+  cache.set('b', 'b');
+  // `a` becomes the most recently used, so `b` is evicted next
+  cache.set('a', 'a2');
+  cache.set('c', 'c');
+  expect(cache.has('b')).toBeFalsy();
+  expect(cache.values()).toEqual(['a2', 'c']);
+});
+
 test('LRU handle null and undefined', () => {
   const cache = lruCache();
   cache.set('a', null);

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -59,7 +59,7 @@ test('overwriting an existing key does not evict another entry', () => {
   cache.set('b', 'b');
   cache.set('b', 'b2');
   expect(cache.size).toBe(2);
-  expect(cache.has('a')).toBeTruthy();
+  expect(cache.has('a')).toBe(true);
   expect(cache.get('b')).toBe('b2');
 });
 
@@ -70,7 +70,7 @@ test('overwriting an existing key refreshes its recency', () => {
   // `a` becomes the most recently used, so `b` is evicted next
   cache.set('a', 'a2');
   cache.set('c', 'c');
-  expect(cache.has('b')).toBeFalsy();
+  expect(cache.has('b')).toBe(false);
   expect(cache.values()).toEqual(['a2', 'c']);
 });
 


### PR DESCRIPTION
### SUMMARY

`LRUCache#set` decided whether to evict using only the size check:

```ts
if (this.cache.size >= this.capacity) { /* evict oldest */ }
this.cache.set(key, value);
```

Overwriting a key that is already in the cache does not increase the entry
count, so no eviction is needed — but the check does not test for presence,
so an unrelated entry is dropped. With capacity 2:

```js
cache.set('a', 'a');
cache.set('b', 'b');
cache.set('b', 'b2');   // evicts 'a'; size falls to 1
```

Where this surfaces: `getRecentActivityObjs` (`src/views/CRUD/utils.tsx`)
builds a `lruCache(6)` keyed on `item_url` to de-duplicate the welcome page's
"Recently viewed" list. Because repeat views of the same item hit the
overwrite path, each duplicate silently discards a distinct entry, so the list
can render fewer than 6 items.

Two changes:

- Skip eviction when the key is already present.
- `delete` before `set` for an existing key, so a write refreshes recency.
  `Map#set` keeps the original insertion position for existing keys, and `get`
  already refreshes on read, so `set` not doing so was inconsistent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not a visual change in itself. On the welcome page, "Recently viewed" could
previously show fewer than the intended 6 entries when the same dashboard or
chart appeared more than once in the recent-activity payload.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- packages/superset-ui-core/test/utils/lruCache.test.ts
```

Two tests are added:

- `overwriting an existing key does not evict another entry`
- `overwriting an existing key refreshes its recency`

The first is the regression test: revert the change and it fails with
`size Expected: 2, Received: 1`. The second documents the recency contract
(it happens to pass on the old code too, since the buggy eviction
coincidentally produced the same order in that particular scenario).

Consumers verified unaffected:

```bash
npm run test -- src/views/CRUD src/SqlLab/components/QueryAutoRefresh
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
