### PR TITLE
fix(reports): make #42253 screenshot readiness production-safe

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -114,9 +114,6 @@ describe('ChartHolder', () => {
     renderWrapper();
 
     expect(
-      screen.getByTestId('dashboard-component-chart-holder'),
-    ).toHaveAttribute('data-test-chart-id', String(chartId));
-    expect(
       screen.getByText('No results were returned for this query'),
     ).toBeVisible();
     expect(

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -274,7 +274,6 @@ const ChartHolder = ({
             chartHolderRef.current = el;
           }}
           data-test="dashboard-component-chart-holder"
-          data-test-chart-id={chartId}
           style={focusHighlightStyles}
           css={isFullSize ? fullSizeStyle : undefined}
           className={cx(

--- a/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
@@ -148,9 +148,6 @@ describe('DynamicComponent', () => {
     expect(
       screen.getByTestId('dashboard-component-chart-holder'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('dashboard-component-chart-holder'),
-    ).not.toHaveAttribute('data-test-chart-id');
     expect(screen.getByTestId('mock-dynamic-component')).toBeInTheDocument();
   });
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
@@ -134,9 +134,6 @@ const setup = async (
 test('should render the markdown component', async () => {
   await setup();
   expect(screen.getByTestId('dashboard-markdown-editor')).toBeInTheDocument();
-  expect(
-    screen.getByTestId('dashboard-component-chart-holder'),
-  ).not.toHaveAttribute('data-test-chart-id');
 });
 
 test('should render the markdown content in preview mode by default', async () => {

--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -67,7 +67,7 @@ def resolve_screenshot_task_budget_seconds(
             limit * SCREENSHOT_TASK_BUDGET_MARGIN_FRACTION,
         )
         budget = max(0.0, float(limit) - margin)
-        logger.info(
+        logger.debug(
             "Screenshot budget derived from Celery task %s=%.1fs: %.1fs "
             "(cleanup margin=%.1fs)%s",
             "soft_time_limit" if soft_limit else "time_limit",
@@ -98,134 +98,113 @@ if TYPE_CHECKING:
     except ImportError:
         Page = None
 
-# Selectors used to build a positive readiness check, shared by both the
-# tiled (take_tiled_screenshot, below) and standard/non-tiled
-# (WebDriverPlaywright.get_screenshot in webdriver.py) capture paths. A chart
-# holder is only "ready" once it shows a terminal state (a rendered chart or
-# an error/empty state) -- the mere absence of a `.loading` element is not
-# sufficient, since a chart holder that intersects the viewport but hasn't
-# mounted anything yet (e.g. its IntersectionObserver callback hasn't fired)
-# would otherwise pass vacuously.
-# See superset-frontend/src/dashboard/components/gridComponents/ChartHolder/
-# ChartHolder.tsx for the chart-specific combination of
-# `data-test="dashboard-component-chart-holder"` and `data-test-chart-id`.
-# Markdown.tsx and DynamicComponent.tsx reuse the former styling/test hook but
-# intentionally lack the chart-id attribute, so they cannot participate in
-# chart readiness.
-# superset-frontend/src/components/Chart/Chart.tsx for `.slice_container`
-# (rendered chart container, `data-test="slice-container"`) and `.loading`
-# (spinner, via the shared Loading component), and
-# superset-frontend/packages/superset-ui-core/src/components/EmptyState for
-# `.ant-empty` (e.g. "no results"/"add required control values" states).
-#
-# Scoped to viewport-intersecting holders only (not just "in the tile", but
-# actually intersecting `window.innerHeight` at evaluation time) in both call
-# sites, since neither one resizes the browser viewport to the full dashboard
-# height before capturing: the tiled path scrolls tile-by-tile and the
-# standard path relies on Playwright's ability to capture below-the-fold
-# content without ever scrolling it into view. In both cases, chart holders
-# outside the current viewport are DashboardVirtualization placeholders that
-# haven't mounted anything real yet by design, so requiring them to reach a
-# terminal state would deadlock the wait.
-#
-# For diagnostics, each unready holder is additionally classified by *why*
-# it isn't ready, distinguishing a slow query from the virtualization race:
-#   - "waiting_on_database": `.loading` present with no `.slice_container`
-#     -- Chart.tsx's `renderSpinner()` replaces the whole container while
-#     the initial query is in flight (`chartStatus === 'loading'`).
-#   - "spinner_mounted": `.loading` present *inside* `.slice_container`
-#     -- the chart's query finished, but it isn't in the virtualization
-#     viewport yet, so `renderChartContainer()` shows a bare spinner instead
-#     of the chart.
-#   - "nothing_mounted": neither `.loading` nor any ready marker present --
-#     the vacuous-pass race this check exists to close.
-UNREADY_CHART_HOLDERS_JS_BODY = """
-    const holders = document.querySelectorAll(
-        '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
-    );
+# Production dashboard builds run ``babel-plugin-jsx-remove-data-test-id``
+# under the production BABEL_ENV (including Docker builds), so readiness must
+# never depend on ``data-test`` attributes. These runtime classes are the
+# production contract shared by readiness polling and diagnostics.
+CHART_HOLDER_SELECTOR = (
+    r'.dashboard-component-chart-holder[class*="dashboard-chart-id-"]'
+)
+SLICE_CONTAINER_SELECTOR = r".slice_container"
+LOADING_SELECTOR = r".loading"
+ALERT_SELECTOR = r'[role="alert"]'
+EMPTY_SELECTOR = r".ant-empty"
+MISSING_CHART_SELECTOR = r".missing-chart-container"
+TERMINAL_MARKER_SELECTOR = (
+    f"{SLICE_CONTAINER_SELECTOR}, {ALERT_SELECTOR}, {EMPTY_SELECTOR}, "
+    f"{MISSING_CHART_SELECTOR}"
+)
+CHART_ID_CLASS_PATTERN = r"\bdashboard-chart-id-(\d+)\b"
+
+# Shared body for holder readiness and timeout diagnostics. A holder is ready
+# only after a terminal marker appears and its loading marker disappears.
+UNREADY_CHART_HOLDERS_JS_BODY = f"""
+    const holders = document.querySelectorAll('{CHART_HOLDER_SELECTOR}');
     const unready = [];
-    for (const holder of holders) {
+    for (const holder of holders) {{
         const r = holder.getBoundingClientRect();
-        if (!(r.top < window.innerHeight && r.bottom > 0)) {
+        if (!(r.top < window.innerHeight && r.bottom > 0)) {{
             continue;
-        }
+        }}
         const hasSliceContainer = holder.querySelector(
-            '[data-test="slice-container"]'
+            '{SLICE_CONTAINER_SELECTOR}'
         ) !== null;
-        const stillLoading = holder.querySelector('.loading') !== null;
-        const isReady = hasSliceContainer || holder.querySelector(
-            '[role="alert"], .ant-empty, .missing-chart-container'
-        ) !== null;
-        if (stillLoading || !isReady) {
-            const chartId = holder.getAttribute('data-test-chart-id');
+        const stillLoading = holder.querySelector('{LOADING_SELECTOR}') !== null;
+        const isReady = holder.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null;
+        if (stillLoading || !isReady) {{
+            const chartIdMatch = holder.className.match(/{CHART_ID_CLASS_PATTERN}/);
+            const chartId = chartIdMatch ? chartIdMatch[1] : null;
             let state;
-            if (stillLoading && hasSliceContainer) {
+            if (stillLoading && hasSliceContainer) {{
                 state = 'spinner_mounted';
-            } else if (stillLoading) {
+            }} else if (stillLoading) {{
                 state = 'waiting_on_database';
-            } else {
+            }} else {{
                 state = 'nothing_mounted';
-            }
-            unready.push({
+            }}
+            unready.push({{
                 chartId: chartId,
                 state: state,
-            });
-        }
-    }
+            }});
+        }}
+    }}
 """
 
 # Diagnostic query for every chart holder, including terminal and virtualized
-# states. This is intentionally separate from the readiness predicate so
-# incident logs can distinguish a valid empty/error result from a holder that
-# never mounted or remained loading.
-FIND_CHART_HOLDER_STATES_JS = """
-() => {
-    const holders = document.querySelectorAll(
-        '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
-    );
-    return Array.from(holders).map(holder => {
-        const chartId = holder.getAttribute('data-test-chart-id');
+# states. It interpolates the same selector constants as the predicates.
+FIND_CHART_HOLDER_STATES_JS = f"""
+() => {{
+    const holders = document.querySelectorAll('{CHART_HOLDER_SELECTOR}');
+    return Array.from(holders).map(holder => {{
+        const chartIdMatch = holder.className.match(/{CHART_ID_CLASS_PATTERN}/);
+        const chartId = chartIdMatch ? chartIdMatch[1] : null;
         const r = holder.getBoundingClientRect();
-        if (!(r.top < window.innerHeight && r.bottom > 0)) {
-            return { chartId, state: 'virtualized' };
-        }
+        if (!(r.top < window.innerHeight && r.bottom > 0)) {{
+            return {{ chartId, state: 'virtualized' }};
+        }}
         const hasSliceContainer = holder.querySelector(
-            '[data-test="slice-container"]'
+            '{SLICE_CONTAINER_SELECTOR}'
         ) !== null;
-        const stillLoading = holder.querySelector('.loading') !== null;
-        if (stillLoading && hasSliceContainer) {
-            return { chartId, state: 'spinner_mounted' };
-        }
-        if (stillLoading) {
-            return { chartId, state: 'waiting_on_database' };
-        }
-        if (holder.querySelector('[role="alert"]') !== null) {
-            return { chartId, state: 'error' };
-        }
+        const stillLoading = holder.querySelector('{LOADING_SELECTOR}') !== null;
+        if (stillLoading && hasSliceContainer) {{
+            return {{ chartId, state: 'spinner_mounted' }};
+        }}
+        if (stillLoading) {{
+            return {{ chartId, state: 'waiting_on_database' }};
+        }}
+        if (holder.querySelector('{ALERT_SELECTOR}') !== null) {{
+            return {{ chartId, state: 'error' }};
+        }}
         if (holder.querySelector(
-            '.ant-empty, .missing-chart-container'
-        ) !== null) {
-            return { chartId, state: 'empty' };
-        }
-        if (hasSliceContainer) {
-            return { chartId, state: 'rendered' };
-        }
-        return { chartId, state: 'nothing_mounted' };
-    });
-}
+            '{EMPTY_SELECTOR}, {MISSING_CHART_SELECTOR}'
+        ) !== null) {{
+            return {{ chartId, state: 'empty' }};
+        }}
+        if (hasSliceContainer) {{
+            return {{ chartId, state: 'rendered' }};
+        }}
+        return {{ chartId, state: 'nothing_mounted' }};
+    }});
+}}
 """
 
-# Predicate for page.wait_for_function: true once every viewport-visible chart
-# holder has reached a terminal state.
 CHART_HOLDERS_READY_JS = (
     f"() => {{ {UNREADY_CHART_HOLDERS_JS_BODY} return unready.length === 0; }}"
 )
-
-# Diagnostic query for page.evaluate: chart id + state of holders still not
-# ready, used to build the timeout log message.
 FIND_UNREADY_CHART_HOLDERS_JS = (
     f"() => {{ {UNREADY_CHART_HOLDERS_JS_BODY} return unready; }}"
 )
+
+# A chart capture has one target rather than dashboard holders, but needs the
+# same positive terminal-state guarantee and loading exclusion.
+CHART_CONTAINER_READY_JS = f"""
+() => {{
+    const chart = document.querySelector('.chart-container');
+    return chart !== null
+        && chart.querySelector('{LOADING_SELECTOR}') === null
+        && chart.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null;
+}}
+"""
 
 
 def combine_screenshot_tiles(screenshot_tiles: list[bytes]) -> bytes:

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -43,6 +43,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from superset.extensions import machine_auth_provider_factory
 from superset.utils.retries import retry_call
 from superset.utils.screenshot_utils import (
+    CHART_CONTAINER_READY_JS,
     CHART_HOLDERS_READY_JS,
     FIND_CHART_HOLDER_STATES_JS,
     resolve_screenshot_task_budget_seconds,
@@ -291,6 +292,7 @@ class WebDriverPlaywright(WebDriverProxy):
         page: Page,
         url: str,
         load_wait: int,
+        element_name: str,
         log_context: str | None = None,
         screenshot_started_at: float | None = None,
     ) -> None:
@@ -322,12 +324,17 @@ class WebDriverPlaywright(WebDriverProxy):
             for holder in initial_chart_holder_states
             if holder.get("state") not in ready_states
         ]
-        logger.info(
+        logger.debug(
             "Chart holder states before readiness polling at url %s%s: %s",
             url,
             context_suffix,
             initial_chart_holder_states,
         )
+        if element_name == "standalone" and not initial_chart_holder_states:
+            logger.warning(
+                "dashboard capture proceeding with zero chart holders — "
+                "readiness gate inactive"
+            )
         if initial_unready_chart_holders:
             logger.info(
                 "Chart holders not ready before polling at url %s%s: %s",
@@ -347,7 +354,7 @@ class WebDriverPlaywright(WebDriverProxy):
             if remaining_budget is not None
             else float(load_wait)
         )
-        if effective_load_wait <= 0:
+        if remaining_budget is not None and effective_load_wait <= 0:
             logger.warning(
                 "Screenshot task budget exhausted before chart readiness wait "
                 "at url %s%s (%.2fs elapsed of %.2fs safe budget); unready chart "
@@ -376,9 +383,14 @@ class WebDriverPlaywright(WebDriverProxy):
             elapsed,
             context_suffix,
         )
+        readiness_predicate = (
+            CHART_CONTAINER_READY_JS
+            if element_name == "chart-container"
+            else CHART_HOLDERS_READY_JS
+        )
         try:
             page.wait_for_function(
-                CHART_HOLDERS_READY_JS,
+                readiness_predicate,
                 timeout=effective_load_wait * 1000,
             )
         except PlaywrightTimeout:
@@ -581,6 +593,7 @@ class WebDriverPlaywright(WebDriverProxy):
                             page,
                             url,
                             self._screenshot_load_wait,
+                            element_name,
                             log_context=log_context,
                             screenshot_started_at=screenshot_started_at,
                         )
@@ -616,6 +629,7 @@ class WebDriverPlaywright(WebDriverProxy):
                         page,
                         url,
                         self._screenshot_load_wait,
+                        element_name,
                         log_context=log_context,
                         screenshot_started_at=screenshot_started_at,
                     )

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -538,12 +538,11 @@ class TestTakeTiledScreenshot:
             assert "spinner_mounted" in js
             assert "waiting_on_database" in js
             assert "nothing_mounted" in js
-            assert "slice-container" in js
+            assert ".slice_container" in js
             assert (
-                '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
+                '.dashboard-component-chart-holder[class*="dashboard-chart-id-"]'
             ) in js
-            assert "holder.getAttribute('data-test-chart-id')" in js
-            assert "holder.querySelector('[data-test-chart-id]')" not in js
+            assert "holder.className.match(/\\bdashboard-chart-id-(\\d+)\\b/)" in js
 
         assert "rendered" in FIND_CHART_HOLDER_STATES_JS
         assert "empty" in FIND_CHART_HOLDER_STATES_JS
@@ -551,8 +550,24 @@ class TestTakeTiledScreenshot:
         assert "virtualized" in FIND_CHART_HOLDER_STATES_JS
         assert "waiting_on_database" in FIND_CHART_HOLDER_STATES_JS
         assert (
-            '[data-test="dashboard-component-chart-holder"][data-test-chart-id]'
+            '.dashboard-component-chart-holder[class*="dashboard-chart-id-"]'
         ) in FIND_CHART_HOLDER_STATES_JS
+
+    def test_readiness_constants_are_production_safe(self):
+        from superset.utils.screenshot_utils import (
+            CHART_CONTAINER_READY_JS,
+            CHART_HOLDERS_READY_JS,
+            FIND_CHART_HOLDER_STATES_JS,
+            FIND_UNREADY_CHART_HOLDERS_JS,
+        )
+
+        for js in (
+            CHART_CONTAINER_READY_JS,
+            CHART_HOLDERS_READY_JS,
+            FIND_CHART_HOLDER_STATES_JS,
+            FIND_UNREADY_CHART_HOLDERS_JS,
+        ):
+            assert "data-test" not in js
 
     def test_per_tile_timing_logged_at_debug(self, mock_page):
         """Each tile logs how long it waited for readiness, for profiling."""

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -709,7 +709,8 @@ class TestWebDriverPlaywrightErrorHandling:
         # positive terminal-state check instead (same predicate as the tiled
         # path, #42119).
         assert "dashboard-component-chart-holder" in js
-        assert "slice-container" in js
+        assert ".slice_container" in js
+        assert "data-test" not in js
         assert call_kwargs["timeout"] == 60 * 1000
         # Guard against reintroducing the old snapshot-based approach
         loading_locator_calls = [

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -1101,6 +1101,56 @@ class TestWebDriverPlaywrightChartReadiness:
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.app")
+    def test_chart_capture_uses_positive_terminal_state_predicate(
+        self, mock_app, mock_browser_manager
+    ):
+        """Chart captures require a terminal marker and no loading marker."""
+        from superset.utils.webdriver import PlaywrightTimeout
+
+        mock_app.config = {**self._base_config}
+        mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
+        timeout = PlaywrightTimeout("chart not ready")
+        mock_page.wait_for_function.side_effect = timeout
+
+        with patch.object(WebDriverPlaywright, "auth", return_value=mock_context):
+            with pytest.raises(PlaywrightTimeout):
+                WebDriverPlaywright("chrome").get_screenshot(
+                    "http://example.com", "chart-container", MagicMock()
+                )
+
+        predicate = mock_page.wait_for_function.call_args.args[0]
+        assert "document.querySelector('.chart-container')" in predicate
+        assert ".slice_container" in predicate
+        assert ".loading" in predicate
+        assert '[role="alert"]' in predicate
+        assert ".ant-empty" in predicate
+        assert ".missing-chart-container" in predicate
+        mock_page.locator.return_value.screenshot.assert_not_called()
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.logger")
+    @patch("superset.utils.webdriver.app")
+    def test_standalone_zero_holders_warns_before_polling(
+        self, mock_app, mock_logger, mock_browser_manager
+    ):
+        mock_app.config = {**self._base_config}
+        mock_context, mock_page = self._make_pw_mocks(mock_browser_manager)
+        mock_page.evaluate.return_value = []
+
+        with patch.object(WebDriverPlaywright, "auth", return_value=mock_context):
+            WebDriverPlaywright("chrome").get_screenshot(
+                "http://example.com", "standalone", MagicMock()
+            )
+
+        mock_logger.warning.assert_any_call(
+            "dashboard capture proceeding with zero chart holders — "
+            "readiness gate inactive"
+        )
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.app")
     def test_readiness_check_scoped_to_viewport_visible_holders(
         self, mock_app, mock_browser_manager
     ):
@@ -1201,6 +1251,24 @@ class TestWebDriverPlaywrightChartReadiness:
 
         assert mock_page.wait_for_function.call_args.kwargs["timeout"] == 230_000
 
+    def test_zero_load_wait_without_task_budget_preserves_playwright_no_timeout(self):
+        page = MagicMock()
+        page.evaluate.return_value = []
+
+        with patch(
+            "superset.utils.webdriver.resolve_screenshot_task_budget_seconds",
+            return_value=None,
+        ):
+            WebDriverPlaywright._wait_for_charts_ready(
+                page,
+                "http://example.com",
+                0,
+                "chart-container",
+            )
+
+        page.wait_for_function.assert_called_once()
+        assert page.wait_for_function.call_args.kwargs["timeout"] == 0
+
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
@@ -1263,7 +1331,7 @@ class TestWebDriverPlaywrightChartReadiness:
             with pytest.raises(PlaywrightTimeout):
                 driver.get_screenshot("http://example.com", "test-element", mock_user)
 
-        mock_logger.info.assert_any_call(
+        mock_logger.debug.assert_any_call(
             "Chart holder states before readiness polling at url %s%s: %s",
             "http://example.com",
             "",
@@ -1345,9 +1413,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         assert "animation_wait" in call_order
         spinner_idx = call_order.index("spinner_wait")
         anim_idx = call_order.index("animation_wait")
-        assert spinner_idx < anim_idx, (
-            "spinner wait must precede animation wait in non-tiled path"
-        )
+        assert (
+            spinner_idx < anim_idx
+        ), "spinner wait must precede animation wait in non-tiled path"
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1437,9 +1505,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
             for call in mock_page.wait_for_timeout.call_args_list
             if call[0][0] == 2 * 1000
         ]
-        assert animation_waits == [], (
-            "No global 2s animation wait_for_timeout should fire on the tiled path"
-        )
+        assert (
+            animation_waits == []
+        ), "No global 2s animation wait_for_timeout should fire on the tiled path"
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1502,6 +1570,6 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         timeout_values = [
             call[0][0] for call in mock_page.wait_for_timeout.call_args_list
         ]
-        assert timeout_values == [0], (
-            f"Expected only [0] (headstart), got {timeout_values}"
-        )
+        assert timeout_values == [
+            0
+        ], f"Expected only [0] (headstart), got {timeout_values}"

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -1413,9 +1413,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         assert "animation_wait" in call_order
         spinner_idx = call_order.index("spinner_wait")
         anim_idx = call_order.index("animation_wait")
-        assert (
-            spinner_idx < anim_idx
-        ), "spinner wait must precede animation wait in non-tiled path"
+        assert spinner_idx < anim_idx, (
+            "spinner wait must precede animation wait in non-tiled path"
+        )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1505,9 +1505,9 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
             for call in mock_page.wait_for_timeout.call_args_list
             if call[0][0] == 2 * 1000
         ]
-        assert (
-            animation_waits == []
-        ), "No global 2s animation wait_for_timeout should fire on the tiled path"
+        assert animation_waits == [], (
+            "No global 2s animation wait_for_timeout should fire on the tiled path"
+        )
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
@@ -1570,6 +1570,6 @@ class TestWebDriverPlaywrightAnimationWaitOrder:
         timeout_values = [
             call[0][0] for call in mock_page.wait_for_timeout.call_args_list
         ]
-        assert timeout_values == [
-            0
-        ], f"Expected only [0] (headstart), got {timeout_values}"
+        assert timeout_values == [0], (
+            f"Expected only [0] (headstart), got {timeout_values}"
+        )


### PR DESCRIPTION
### SUMMARY

Reviewed production-safety follow-up for #42253.

This replaces readiness and diagnostic selectors that rely on `data-test` attributes with the existing production classes (`.dashboard-component-chart-holder.dashboard-chart-id-*` and `.slice_container`). Production builds, including Docker builds under the production `BABEL_ENV`, run `babel-plugin-jsx-remove-data-test-id`, so the prior selectors became no-ops in the deployment mode that matters. The selector is shared across polling and diagnostics, and chart IDs are extracted from the unconditional `dashboard-chart-id-<digits>` class.

The shared selector change also changes tiled semantics: it excludes Markdown and Dynamic components that share the holder test hook but are not charts. This fixes the latent #42119 Markdown/Dynamic `nothing_mounted` deadlock. Because #42119 has already merged with a selector that is a production no-op, that merged path still needs a follow-up using this production-safe selector.

For non-tiled captures, dashboard/standalone captures use the holder predicate while `chart-container` captures use a positive chart predicate requiring a terminal marker and no `.loading`. Standalone dashboard captures warn when zero chart holders make the readiness gate inactive. The runtime guard derives an effective screenshot budget from Celery task hard/soft limits, reserving cleanup/error-transition time; this may duplicate or overlap the still-open #42118 and should be reconciled when that work lands.

This hardens and fixes #42253. It does **not** establish the root cause of the pre-existing PointFive SC-113788 incident.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend screenshot readiness and diagnostics only. The four frontend changes from the earlier patch are reverted because existing production classes are the contract.

### TESTING INSTRUCTIONS

- `python3 -m pytest -q tests/unit_tests/utils/test_screenshot_utils.py tests/unit_tests/utils/webdriver_test.py` (requires the complete Superset Python test environment)
- `ruff check superset/utils/screenshot_utils.py superset/utils/webdriver.py tests/unit_tests/utils/test_screenshot_utils.py tests/unit_tests/utils/webdriver_test.py`
- `ruff format --check superset/utils/screenshot_utils.py superset/utils/webdriver.py tests/unit_tests/utils/test_screenshot_utils.py tests/unit_tests/utils/webdriver_test.py`
- `pre-commit run --all-files` (mypy main and extension checks passed; local all-files run otherwise encountered environment/upstream blockers documented in the companion report)
- `git diff --check`

### ADDITIONAL INFORMATION

- [x] Has associated issue: fixes the #42253 production-safety gap and #42119 latent Markdown/Dynamic deadlock
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
