### PR TITLE
fix(table): pick totals query positionally so all_records percent metrics don't shift it

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -712,11 +712,26 @@ const transformProps = (
   let totalQuery;
   let rowCount;
   if (serverPagination) {
-    [baseQuery, countQuery, totalQuery] = queriesData;
+    [baseQuery, countQuery] = queriesData;
     rowCount = (countQuery?.data?.[0]?.rowcount as number) ?? 0;
   } else {
-    [baseQuery, totalQuery] = queriesData;
+    [baseQuery] = queriesData;
     rowCount = baseQuery?.rowcount ?? 0;
+  }
+  // `buildQuery` may prepend an extra query (used to compute percent metrics
+  // against the entire result set when `percent_metric_calculation` is set to
+  // `all_records`) before the totals query. Since the totals query, when
+  // present, is always the last entry in `queriesData`, look it up positionally
+  // from the end rather than assuming a fixed index. The minimum number of
+  // queries expected without a totals query is 1 (base query), or 2 when
+  // server pagination is enabled (base query + row count query).
+  const minQueriesWithoutTotals = serverPagination ? 2 : 1;
+  if (
+    showTotals &&
+    queryMode === QueryMode.Aggregate &&
+    queriesData.length > minQueriesWithoutTotals
+  ) {
+    totalQuery = queriesData[queriesData.length - 1];
   }
   const data = processDataRecords(baseQuery?.data, columns);
   const comparisonData = processComparisonDataRecords(

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -436,61 +436,6 @@ describe('plugin-chart-table', () => {
       expect(timestampColumn).toBeDefined();
     });
 
-    test(
-      'should read the totals row from the correct query when percent metrics ' +
-        'use the "all records" calculation mode',
-      () => {
-        // When `percent_metric_calculation` is `all_records`, buildQuery adds an
-        // extra query (used to compute percentages against the entire result set)
-        // *before* the totals query in `queriesData`. Verify totals are still
-        // sourced from the actual totals query and not this preceding query.
-        const props = {
-          ...testData.basic,
-          rawFormData: {
-            ...testData.basic.rawFormData,
-            query_mode: QueryMode.Aggregate,
-            metrics: ['sum__num'],
-            percent_metrics: ['count'],
-            percent_metric_calculation: 'all_records',
-            show_totals: true,
-            column_config: {
-              sum__num: { d3NumberFormat: '.0%' },
-            },
-          },
-          queriesData: [
-            {
-              ...testData.basic.queriesData[0],
-              colnames: ['name', 'sum__num', '%count'],
-              coltypes: [
-                GenericDataType.String,
-                GenericDataType.Numeric,
-                GenericDataType.Numeric,
-              ],
-              data: [{ name: 'Michael', sum__num: 0.1, '%count': 0.05 }],
-            },
-            // extra "all records" query used only to compute percent metrics
-            {
-              ...testData.basic.queriesData[0],
-              colnames: ['count'],
-              coltypes: [GenericDataType.Numeric],
-              data: [{ count: 999 }],
-            },
-            // actual totals query
-            {
-              ...testData.basic.queriesData[0],
-              colnames: ['sum__num'],
-              coltypes: [GenericDataType.Numeric],
-              data: [{ sum__num: 0.27 }],
-            },
-          ],
-        };
-
-        const transformedProps = transformProps(props);
-
-        expect(transformedProps.totals).toEqual({ sum__num: 0.27 });
-      },
-    );
-
     describe('TableChart', () => {
       test('render basic data', () => {
         render(
@@ -2630,6 +2575,61 @@ describe('plugin-chart-table', () => {
     );
     expect(screen.queryByText('Search by')).toBeInTheDocument();
   });
+
+  test(
+    'should read the totals row from the correct query when percent metrics ' +
+      'use the "all records" calculation mode',
+    () => {
+      // When `percent_metric_calculation` is `all_records`, buildQuery adds an
+      // extra query (used to compute percentages against the entire result set)
+      // *before* the totals query in `queriesData`. Verify totals are still
+      // sourced from the actual totals query and not this preceding query.
+      const props = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Aggregate,
+          metrics: ['sum__num'],
+          percent_metrics: ['count'],
+          percent_metric_calculation: 'all_records',
+          show_totals: true,
+          column_config: {
+            sum__num: { d3NumberFormat: '.0%' },
+          },
+        },
+        queriesData: [
+          {
+            ...testData.basic.queriesData[0],
+            colnames: ['name', 'sum__num', '%count'],
+            coltypes: [
+              GenericDataType.String,
+              GenericDataType.Numeric,
+              GenericDataType.Numeric,
+            ],
+            data: [{ name: 'Michael', sum__num: 0.1, '%count': 0.05 }],
+          },
+          // extra "all records" query used only to compute percent metrics
+          {
+            ...testData.basic.queriesData[0],
+            colnames: ['count'],
+            coltypes: [GenericDataType.Numeric],
+            data: [{ count: 999 }],
+          },
+          // actual totals query
+          {
+            ...testData.basic.queriesData[0],
+            colnames: ['sum__num'],
+            coltypes: [GenericDataType.Numeric],
+            data: [{ sum__num: 0.27 }],
+          },
+        ],
+      };
+
+      const transformedProps = transformProps(props);
+
+      expect(transformedProps.totals).toEqual({ sum__num: 0.27 });
+    },
+  );
 });
 
 /**

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -436,6 +436,61 @@ describe('plugin-chart-table', () => {
       expect(timestampColumn).toBeDefined();
     });
 
+    test(
+      'should read the totals row from the correct query when percent metrics ' +
+        'use the "all records" calculation mode',
+      () => {
+        // When `percent_metric_calculation` is `all_records`, buildQuery adds an
+        // extra query (used to compute percentages against the entire result set)
+        // *before* the totals query in `queriesData`. Verify totals are still
+        // sourced from the actual totals query and not this preceding query.
+        const props = {
+          ...testData.basic,
+          rawFormData: {
+            ...testData.basic.rawFormData,
+            query_mode: QueryMode.Aggregate,
+            metrics: ['sum__num'],
+            percent_metrics: ['count'],
+            percent_metric_calculation: 'all_records',
+            show_totals: true,
+            column_config: {
+              sum__num: { d3NumberFormat: '.0%' },
+            },
+          },
+          queriesData: [
+            {
+              ...testData.basic.queriesData[0],
+              colnames: ['name', 'sum__num', '%count'],
+              coltypes: [
+                GenericDataType.String,
+                GenericDataType.Numeric,
+                GenericDataType.Numeric,
+              ],
+              data: [{ name: 'Michael', sum__num: 0.1, '%count': 0.05 }],
+            },
+            // extra "all records" query used only to compute percent metrics
+            {
+              ...testData.basic.queriesData[0],
+              colnames: ['count'],
+              coltypes: [GenericDataType.Numeric],
+              data: [{ count: 999 }],
+            },
+            // actual totals query
+            {
+              ...testData.basic.queriesData[0],
+              colnames: ['sum__num'],
+              coltypes: [GenericDataType.Numeric],
+              data: [{ sum__num: 0.27 }],
+            },
+          ],
+        };
+
+        const transformedProps = transformProps(props);
+
+        expect(transformedProps.totals).toEqual({ sum__num: 0.27 });
+      },
+    );
+
     describe('TableChart', () => {
       test('render basic data', () => {
         render(


### PR DESCRIPTION
### SUMMARY
When "Percentage metric calculation" is set to "Use all records" and "Show totals" is enabled, `buildQuery` inserts an extra query (used to compute percent metrics against the full result set) *ahead* of the totals query inside `queriesData`. `transformProps` picked the totals query by a fixed array index, so in this configuration it grabbed the percent-metrics-only query instead, and the summary/totals row ended up with the wrong values (and, since those values didn't line up with the columns' configured `d3NumberFormat`, effectively unformatted-looking numbers).

This locates the totals query positionally (it's always the last entry in `queriesData` when present) instead of assuming a fixed index, so it's no longer displaced by the extra percent-metrics query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable — logic fix in query result wiring, not a visual/styling change.

### TESTING INSTRUCTIONS
1. Create a Table chart in Aggregate mode with at least one metric and a percent metric.
2. Set "Percentage metric calculation" to "Use all records".
3. Enable "Show totals".
4. Set a custom number format on a metric column via "Customize columns".
5. Confirm the summary/totals row now reflects the correct total (and format) for that column, rather than a value pulled from the percent-metrics query.

Also covered by a new unit test in `superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx` that pins down the correct `totals` query is picked when the "all records" percent-metric query precedes it in `queriesData`.

Note: I wasn't able to run the frontend test suite in this environment (broken/hanging local `node_modules`), so please treat CI as the source of truth here.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #39587
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API