### PR TITLE
chore(ci): remove nyc usage for merging coverage results as Codecov natively supports the action

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -122,25 +122,13 @@ jobs:
           pattern: coverage-artifacts-*
           path: coverage/
 
-      - name: Reorganize test result reports
-        run: |
-          find coverage/
-          for i in {1..8}; do
-            mv coverage/coverage-artifacts-${i}/coverage-final.json coverage/coverage-shard-${i}.json
-          done
-        shell: bash
-
-      - name: Merge Code Coverage
-        run: npx nyc merge coverage/ merged-output/coverage-summary.json
-
       - name: Upload Code Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: javascript
           use_oidc: true
           verbose: true
-          disable_search: true
-          files: merged-output/coverage-summary.json
+          directory: coverage
           slug: apache/superset
 
   lint-frontend:

--- a/superset-frontend/src/database/actions.test.ts
+++ b/superset-frontend/src/database/actions.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { executeQuery } from './actions';
+import fetchMock from 'fetch-mock';
+
+fetchMock.post('glob:*/sqllab/execute', { result: [] });
+
+afterAll(() => {
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('executeQuery', async () => {
+  const mockDispatch = jest.fn();
+  const mockedQueryExecutePayload = {
+    client_id: 'client_id_1',
+    database_id: 1,
+    runAsync: false,
+    catalog: null,
+    schema: 'schema_1',
+    sql: '1',
+    tmp_table_name: 'tmp_table_1',
+    select_as_cta: false,
+    ctas_method: 'SELECT',
+    queryLimit: 10,
+    expand_data: false,
+  };
+
+  const returnedDispatchFunc = executeQuery(mockedQueryExecutePayload);
+  await returnedDispatchFunc(mockDispatch);
+
+  const [
+    [setQueryIsLoadingActionObject],
+    [setQueryResultActionObject],
+    [setQueryIsNotLoadingActionObject],
+  ] = mockDispatch.mock.calls;
+  expect(setQueryIsLoadingActionObject).toStrictEqual({
+    type: 'SET_QUERY_IS_LOADING',
+    payload: true,
+  });
+  expect(setQueryResultActionObject).toStrictEqual({
+    type: 'SET_QUERY_RESULT',
+    payload: {
+      result: [],
+    },
+  });
+  expect(setQueryIsNotLoadingActionObject).toStrictEqual({
+    type: 'SET_QUERY_IS_LOADING',
+    payload: false,
+  });
+});

--- a/superset-frontend/src/database/actions.ts
+++ b/superset-frontend/src/database/actions.ts
@@ -67,7 +67,7 @@ export function executeQuery(payload: QueryExecutePayload) {
       const result = await executeQueryApi(payload);
       dispatch(setQueryResult(result as QueryExecuteResponse));
     } catch (error) {
-      dispatch(setQueryError(error.message));
+      dispatch(setQueryError((error as Error).message));
     } finally {
       dispatch(setQueryIsLoading(false));
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(ci): remove nyc usage for merging coverage results as Codecov natively supports the action

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Very much self-titled. I sorta want to remove the `npx <package>` pattern from the project as they are easy target for supply chain attacks. Also added a small frontend unit test to increase coverage plus testing out the changes in the PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Green CI
- Codecov's coverage results are all good.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
