### PR TITLE
fix(viz): correct duplicate/incorrect ISO codes in Iran country map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/test/countries/iran.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/test/countries/iran.test.ts
@@ -39,8 +39,15 @@ type IranFeature = {
 const getIranFeatures = (): IranFeature[] =>
   JSON.parse(fs.readFileSync(iranGeojsonPath, 'utf-8')).features;
 
-test('every province in the Iran map has a unique ISO code', () => {
-  const isoCodes = getIranFeatures().map(feature => feature.properties.ISO);
+test('every province in the Iran map has a unique, non-empty ISO code', () => {
+  const features = getIranFeatures();
+  // Iran has 31 provinces; assert the count so a deleted feature is caught,
+  // not just a duplicated ISO code among whatever features remain.
+  expect(features).toHaveLength(31);
+
+  const isoCodes = features.map(feature => feature.properties.ISO);
+  isoCodes.forEach(iso => expect(iso).toBeTruthy());
+
   const uniqueIsoCodes = new Set(isoCodes);
   expect(uniqueIsoCodes.size).toBe(isoCodes.length);
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/test/countries/iran.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/test/countries/iran.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+
+// The geojson is loaded via fs rather than a normal import because the
+// webpack/jest loaders treat *.geojson as an opaque asset (a URL string in
+// the browser build, an empty mock object under jest), so neither exposes
+// the actual feature data to a unit test.
+const iranGeojsonPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'countries',
+  'iran.geojson',
+);
+
+type IranFeature = {
+  properties: { ISO: string; NAME_1: string };
+};
+
+const getIranFeatures = (): IranFeature[] =>
+  JSON.parse(fs.readFileSync(iranGeojsonPath, 'utf-8')).features;
+
+test('every province in the Iran map has a unique ISO code', () => {
+  const isoCodes = getIranFeatures().map(feature => feature.properties.ISO);
+  const uniqueIsoCodes = new Set(isoCodes);
+  expect(uniqueIsoCodes.size).toBe(isoCodes.length);
+});
+
+test('Tehran, Alborz and Razavi Khorasan have their correct, distinct ISO codes', () => {
+  const provincesByIso = Object.fromEntries(
+    getIranFeatures().map(feature => [
+      feature.properties.NAME_1,
+      feature.properties.ISO,
+    ]),
+  );
+
+  expect(provincesByIso.Tehran).toBe('IR-07');
+  expect(provincesByIso.Alborz).toBe('IR-30');
+  expect(provincesByIso['Razavi Khorasan']).toBe('IR-09');
+});

--- a/superset-frontend/plugins/plugin-chart-country-map/test/countries/iran.test.ts
+++ b/superset-frontend/plugins/plugin-chart-country-map/test/countries/iran.test.ts
@@ -53,14 +53,14 @@ test('every province in the Iran map has a unique, non-empty ISO code', () => {
 });
 
 test('Tehran, Alborz and Razavi Khorasan have their correct, distinct ISO codes', () => {
-  const provincesByIso = Object.fromEntries(
+  const isoByProvince = Object.fromEntries(
     getIranFeatures().map(feature => [
       feature.properties.NAME_1,
       feature.properties.ISO,
     ]),
   );
 
-  expect(provincesByIso.Tehran).toBe('IR-07');
-  expect(provincesByIso.Alborz).toBe('IR-30');
-  expect(provincesByIso['Razavi Khorasan']).toBe('IR-09');
+  expect(isoByProvince.Tehran).toBe('IR-07');
+  expect(isoByProvince.Alborz).toBe('IR-30');
+  expect(isoByProvince['Razavi Khorasan']).toBe('IR-09');
 });


### PR DESCRIPTION
### SUMMARY
Tehran and Alborz provinces in `iran.geojson` were both mapped to `IR-07`, and Razavi Khorasan was mapped to `IR-30` (Alborz's real code), leaving `IR-09` unused entirely. That made it impossible to color Tehran and Alborz independently in the country map viz, and any data keyed on `IR-09` (Razavi Khorasan) or `IR-30` (Alborz) would land on the wrong province. This matches what came up in #31991: Alborz now gets `IR-30` and Razavi Khorasan gets `IR-09`, per [ISO 3166-2:IR](https://en.wikipedia.org/wiki/ISO_3166-2:IR). Tehran keeps `IR-07`.

The geojson data fix itself already landed on `master` separately (the country map plugin was also renamed `legacy-plugin-chart-country-map` → `plugin-chart-country-map` in the meantime). This PR now just pins the fix down going forward with a unit test asserting every province in the geojson has a unique, non-empty ISO code and that the three provinces in question map correctly, rebased onto the current plugin path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, this only touches test coverage, not rendering code.

### TESTING INSTRUCTIONS
`npm run test -- plugins/plugin-chart-country-map/test/countries/iran.test.ts`

Or build a country map chart with country set to Iran and confirm Tehran and Alborz can be colored independently.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #31991
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes #31991
