### PR TITLE
fix(sqllab): add filterBySqlLab prop to decouple expose_in_sqllab filter from UI rendering mode

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -160,6 +160,7 @@ const SqlEditorLeftBar = ({
         }
         schema={modalSchema?.value}
         sqlLabMode={false}
+        filterBySqlLab
       />
       <Flex justify="flex-end" gap="small">
         <Button

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -390,3 +390,21 @@ test('Sends the correct schema when changing the schema', async () => {
   );
   expect(props.onSchemaChange).toHaveBeenCalledTimes(1);
 });
+
+test('should include expose_in_sqllab filter when filterBySqlLab is true', async () => {
+  const props = createProps();
+  render(<DatabaseSelector {...props} sqlLabMode={false} filterBySqlLab />, {
+    useRedux: true,
+    store,
+  });
+  const select = screen.getByRole('combobox', {
+    name: 'Select database or type to search databases',
+  });
+  await userEvent.click(select);
+  await waitFor(() => {
+    const calls = fetchMock.callHistory.calls(databaseApiRoute);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall.url).toContain('expose_in_sqllab');
+  });
+});

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -188,6 +188,7 @@ export function DatabaseSelector({
   readOnly = false,
   compactMode = false,
   sqlLabMode = false,
+  filterBySqlLab = false,
   onOpenModal,
 }: DatabaseSelectorProps) {
   const showCatalogSelector = !!db?.allow_multi_catalog;
@@ -228,7 +229,7 @@ export function DatabaseSelector({
           order_direction: 'asc',
           page,
           page_size: pageSize,
-          ...(formMode || !sqlLabMode
+          ...(formMode || !(sqlLabMode || filterBySqlLab)
             ? { filters: [{ col: 'database_name', opr: 'ct', value: search }] }
             : {
                 filters: [
@@ -278,7 +279,7 @@ export function DatabaseSelector({
           };
         });
       },
-    [formMode, getDbList, sqlLabMode, onEmptyResults],
+    [formMode, getDbList, sqlLabMode, filterBySqlLab, onEmptyResults],
   );
 
   useEffect(() => {

--- a/superset-frontend/src/components/DatabaseSelector/types.ts
+++ b/superset-frontend/src/components/DatabaseSelector/types.ts
@@ -50,6 +50,7 @@ export interface DatabaseSelectorProps {
   schema?: string;
   readOnly?: boolean;
   sqlLabMode?: boolean;
+  filterBySqlLab?: boolean;
   compactMode?: boolean;
   onOpenModal?: () => void;
 }


### PR DESCRIPTION
## Summary

The `expose_in_sqllab` filter in `DatabaseSelector` was tied to `sqlLabMode`, which controls the UI rendering (compact button vs full dropdown). When the SQL Lab popover passed `sqlLabMode={false}` to render the dropdown, the `expose_in_sqllab` filter was also disabled, allowing databases with `expose_in_sqllab=false` to appear in SQL Lab.

## Before / After

**Before**: The popover's `DatabaseSelector` in SQL Lab passed `sqlLabMode={false}` (to render the dropdown instead of a compact button). The `loadDatabases` function checked `formMode || !sqlLabMode` -- since `sqlLabMode=false`, this evaluated to `true`, skipping the `expose_in_sqllab` filter.

**After**: Added a new `filterBySqlLab` prop that controls the `expose_in_sqllab` filter independently from the UI rendering mode. The popover's `DatabaseSelector` now passes `filterBySqlLab={true}` to apply the filter while still rendering the dropdown.

## Testing Instructions

1. Create a database with `expose_in_sqllab = false`
2. Create another database with `expose_in_sqllab = true`
3. Open SQL Lab -- the database with `expose_in_sqllab = false` should NOT appear in the dropdown

## Additional Information

- Fixes #40850
- Regression introduced in 6.1.0 when the SQL Lab left bar was refactored to use a popover instead of inline dropdown
- Added unit test verifying the `expose_in_sqllab` filter is included in API calls when `filterBySqlLab={true}`
