### PR TITLE
fix(mcp_service): downgrade client-disconnect transport noise to WARNING (SC-115264)

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -30,6 +30,7 @@ from typing import Annotated, Any, Callable
 import uvicorn
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware
+from starlette.requests import ClientDisconnect
 
 from superset.mcp_service.app import create_mcp_app, init_fastmcp_server
 from superset.mcp_service.jwt_verifier import BrowserHelloMiddleware
@@ -112,6 +113,46 @@ class FastMCPValidationFilter(logging.Filter):
         return True
 
 
+class MCPTransportDisconnectFilter(logging.Filter):
+    """Downgrade MCP SDK client-disconnect transport logs from ERROR to WARNING.
+
+    When an MCP client disconnects mid-request (a cancelled or timed-out tool
+    call — normal client behavior, not a Superset bug), the ``mcp`` SDK's own
+    transport code logs it at ERROR with a full traceback, and separately
+    re-raises it into the session's message loop, which logs a second ERROR.
+    Both are expected under normal client behavior and should not page or
+    open incidents; downgrading to WARNING keeps them visible in log
+    aggregation without polluting ERROR-level alerting.
+
+    Two different loggers require two different matching strategies:
+
+    - ``mcp.server.streamable_http`` (``_handle_post_request``) catches the
+      disconnect via a broad ``except Exception`` and logs it with
+      ``logger.exception(...)``, so ``record.exc_info`` carries the actual
+      exception object — we can check its type directly.
+    - ``mcp.server.lowlevel.server`` (``_handle_message``) receives the same
+      exception secondhand, already wrapped as a bare
+      ``Exception(ClientDisconnect())`` pushed onto the read stream. The
+      original type is lost by the time it's logged, so exception-type
+      checks are impossible here. ``ClientDisconnect`` is always raised with
+      zero args, so ``str(ClientDisconnect())`` is always ``""`` — making the
+      rendered message a fixed, matchable string instead.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.ERROR:
+            return True
+        if record.name == "mcp.server.streamable_http":
+            if record.exc_info and isinstance(record.exc_info[1], ClientDisconnect):
+                record.levelno = logging.WARNING
+                record.levelname = "WARNING"
+        elif record.name == "mcp.server.lowlevel.server":
+            if record.getMessage() == "Received exception from stream: ":
+                record.levelno = logging.WARNING
+                record.levelname = "WARNING"
+        return True
+
+
 def configure_logging(debug: bool = False) -> None:
     """Configure logging for the MCP service."""
     import sys
@@ -146,6 +187,17 @@ def configure_logging(debug: bool = False) -> None:
     # Downgrade these specific messages from ERROR to WARNING.
     fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
     fastmcp_server_logger.addFilter(FastMCPValidationFilter())
+
+    # MCP client disconnects (cancelled/timed-out tool calls) are logged at
+    # ERROR by the mcp SDK's transport and lowlevel server loggers. These are
+    # expected client behavior, not Superset bugs — downgrade to WARNING.
+    transport_disconnect_filter = MCPTransportDisconnectFilter()
+    logging.getLogger("mcp.server.streamable_http").addFilter(
+        transport_disconnect_filter
+    )
+    logging.getLogger("mcp.server.lowlevel.server").addFilter(
+        transport_disconnect_filter
+    )
 
 
 def create_event_store(config: dict[str, Any] | None = None) -> Any | None:

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -85,6 +85,12 @@ def _suppress_third_party_warnings() -> None:
     )
 
 
+def _downgrade_to_warning(record: logging.LogRecord) -> None:
+    """Mutate *record* in place to WARNING level."""
+    record.levelno = logging.WARNING
+    record.levelname = "WARNING"
+
+
 class FastMCPValidationFilter(logging.Filter):
     """Downgrade FastMCP's user-error logs from ERROR to WARNING.
 
@@ -108,8 +114,7 @@ class FastMCPValidationFilter(logging.Filter):
         if record.levelno != logging.ERROR:
             return True
         if "Error validating tool" in record.getMessage():
-            record.levelno = logging.WARNING
-            record.levelname = "WARNING"
+            _downgrade_to_warning(record)
         return True
 
 
@@ -144,12 +149,16 @@ class MCPTransportDisconnectFilter(logging.Filter):
             return True
         if record.name == "mcp.server.streamable_http":
             if record.exc_info and isinstance(record.exc_info[1], ClientDisconnect):
-                record.levelno = logging.WARNING
-                record.levelname = "WARNING"
+                _downgrade_to_warning(record)
         elif record.name == "mcp.server.lowlevel.server":
+            # NOTE: This matches the literal log message from the mcp SDK's
+            # lowlevel/server.py (``_handle_message``, line ~689 in the
+            # ``mcp==1.24.0`` pinned in requirements/development.txt):
+            # ``logger.error(f"Received exception from stream: {message}")``.
+            # If the SDK changes this f-string's wording, this filter will
+            # stop working silently.
             if record.getMessage() == "Received exception from stream: ":
-                record.levelno = logging.WARNING
-                record.levelname = "WARNING"
+                _downgrade_to_warning(record)
         return True
 
 

--- a/tests/unit_tests/mcp_service/test_logging_filters.py
+++ b/tests/unit_tests/mcp_service/test_logging_filters.py
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for MCPTransportDisconnectFilter.
+
+Tests verify that:
+- streamable_http ERROR records carrying a ClientDisconnect exc_info are
+  downgraded to WARNING
+- streamable_http ERROR records carrying an unrelated exception stay at ERROR
+- lowlevel.server ERROR records with the exact "Received exception from
+  stream: " message are downgraded to WARNING
+- lowlevel.server ERROR records with a different message stay at ERROR
+- records below ERROR level pass through unchanged regardless of logger name
+"""
+
+import logging
+
+from starlette.requests import ClientDisconnect
+
+from superset.mcp_service.server import MCPTransportDisconnectFilter
+
+
+def _make_record(
+    name: str,
+    level: int,
+    msg: str,
+    exc_info: tuple | None = None,
+) -> logging.LogRecord:
+    return logging.getLogger(name).makeRecord(
+        name, level, "test_file.py", 1, msg, (), exc_info
+    )
+
+
+def _get_client_disconnect_exc_info() -> tuple:
+    try:
+        raise ClientDisconnect()
+    except ClientDisconnect:
+        import sys
+
+        return sys.exc_info()
+
+
+def _get_value_error_exc_info() -> tuple:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        return sys.exc_info()
+
+
+class TestMCPTransportDisconnectFilterStreamableHttp:
+    """Tests for the mcp.server.streamable_http branch of the filter."""
+
+    def test_client_disconnect_downgraded_to_warning(self) -> None:
+        record = _make_record(
+            "mcp.server.streamable_http",
+            logging.ERROR,
+            "Error handling POST request",
+            exc_info=_get_client_disconnect_exc_info(),
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.WARNING
+        assert record.levelname == "WARNING"
+
+    def test_other_exception_stays_at_error(self) -> None:
+        record = _make_record(
+            "mcp.server.streamable_http",
+            logging.ERROR,
+            "Error handling POST request",
+            exc_info=_get_value_error_exc_info(),
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.ERROR
+        assert record.levelname == "ERROR"
+
+    def test_no_exc_info_stays_at_error(self) -> None:
+        record = _make_record(
+            "mcp.server.streamable_http",
+            logging.ERROR,
+            "Error handling POST request",
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.ERROR
+
+
+class TestMCPTransportDisconnectFilterLowlevelServer:
+    """Tests for the mcp.server.lowlevel.server branch of the filter."""
+
+    def test_empty_exception_message_downgraded_to_warning(self) -> None:
+        record = _make_record(
+            "mcp.server.lowlevel.server",
+            logging.ERROR,
+            "Received exception from stream: ",
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.WARNING
+        assert record.levelname == "WARNING"
+
+    def test_different_message_stays_at_error(self) -> None:
+        record = _make_record(
+            "mcp.server.lowlevel.server",
+            logging.ERROR,
+            "Received exception from stream: something else",
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.ERROR
+
+    def test_unrelated_message_stays_at_error(self) -> None:
+        record = _make_record(
+            "mcp.server.lowlevel.server",
+            logging.ERROR,
+            "Some unrelated error",
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.ERROR
+
+
+class TestMCPTransportDisconnectFilterPassthrough:
+    """Records below ERROR level are always left unchanged."""
+
+    def test_warning_level_passes_through_unchanged(self) -> None:
+        record = _make_record(
+            "mcp.server.lowlevel.server",
+            logging.WARNING,
+            "Received exception from stream: ",
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.WARNING
+
+    def test_info_level_passes_through_unchanged(self) -> None:
+        record = _make_record(
+            "mcp.server.streamable_http",
+            logging.INFO,
+            "Error handling POST request",
+            exc_info=_get_client_disconnect_exc_info(),
+        )
+
+        assert MCPTransportDisconnectFilter().filter(record) is True
+        assert record.levelno == logging.INFO

--- a/tests/unit_tests/mcp_service/test_logging_filters.py
+++ b/tests/unit_tests/mcp_service/test_logging_filters.py
@@ -29,24 +29,30 @@ Tests verify that:
 """
 
 import logging
+from types import TracebackType
 
 from starlette.requests import ClientDisconnect
 
 from superset.mcp_service.server import MCPTransportDisconnectFilter
+
+_SysExcInfo = (
+    tuple[type[BaseException], BaseException, TracebackType | None]
+    | tuple[None, None, None]
+)
 
 
 def _make_record(
     name: str,
     level: int,
     msg: str,
-    exc_info: tuple | None = None,
+    exc_info: _SysExcInfo | None = None,
 ) -> logging.LogRecord:
     return logging.getLogger(name).makeRecord(
         name, level, "test_file.py", 1, msg, (), exc_info
     )
 
 
-def _get_client_disconnect_exc_info() -> tuple:
+def _get_client_disconnect_exc_info() -> _SysExcInfo:
     try:
         raise ClientDisconnect()
     except ClientDisconnect:
@@ -55,7 +61,7 @@ def _get_client_disconnect_exc_info() -> tuple:
         return sys.exc_info()
 
 
-def _get_value_error_exc_info() -> tuple:
+def _get_value_error_exc_info() -> _SysExcInfo:
     try:
         raise ValueError("boom")
     except ValueError:


### PR DESCRIPTION
### SUMMARY

Fixes two Sentry issues in org `preset-inc` caused by the same underlying incident:

- [SUPERSET-PYTHON-XVB](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-XVB) — 2413 events, first seen 2025-10-16, still firing daily, 0 users impacted
- [SUPERSET-PYTHON-YYS](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-YYS) — 2428 events, first seen 2026-01-18, still firing daily, 0 users impacted

**Root cause:** `superset/mcp_service/` runs a FastMCP server (the `/mcp` service, port 5008) on top of the third-party `mcp` SDK. When an MCP client disconnects mid-request — a cancelled or timed-out tool call, normal client behavior and not a Superset bug — the SDK's own code logs it at ERROR with a full traceback, from a single incident, twice:

1. `mcp/server/streamable_http.py:_handle_post_request` catches `starlette.requests.ClientDisconnect` (raised from `await request.body()`) in a broad `except Exception as err:` and calls `logger.exception("Error handling POST request")` on logger `mcp.server.streamable_http`.
2. That same except block also does `await writer.send(Exception(err))`, pushing a bare-wrapped exception onto the session's read stream. The low-level server's message loop (`mcp/server/lowlevel/server.py:_handle_message`) receives it and logs `logger.error(f"Received exception from stream: {message}")` on logger `mcp.server.lowlevel.server`. Since `ClientDisconnect` is always raised with zero args, `str(ClientDisconnect())` is always `""`, so this line always renders as the literal string `"Received exception from stream: "` — matching the observed Sentry event text exactly.

Sampled events for both issues share the same trace_id/request_id/session_id, confirming a single root incident producing two separate Sentry issues.

This is the same bug class already fixed once in this file — `FastMCPValidationFilter` downgrades FastMCP's own "Error validating tool" ERROR logs to WARNING for the same reason (expected client conditions logged too loudly by a third-party SDK, captured by Sentry's default `LoggingIntegration(event_level=ERROR)`).

**Fix:** Add `MCPTransportDisconnectFilter`, following the same pattern, registered on both `mcp.server.streamable_http` and `mcp.server.lowlevel.server` loggers. It downgrades ERROR → WARNING only for these two exact patterns:
- `mcp.server.streamable_http`: `record.exc_info[1]` is a `ClientDisconnect` instance
- `mcp.server.lowlevel.server`: `record.getMessage() == "Received exception from stream: "` (exact match)

Every other ERROR on these loggers is left untouched, so genuine transport bugs still surface and page.

### TRADEOFFS

This changes failure-mode **log severity only**. The WARNING is still logged and remains fully visible in Datadog/log aggregation — it just no longer creates or reopens a Sentry issue. There is no change to request-handling behavior, no raise→warn/suppress/degrade semantics change, and no functional behavior change of any kind to disclose.

### TESTING INSTRUCTIONS

New unit test file `tests/unit_tests/mcp_service/test_logging_filters.py` covers:
- `mcp.server.streamable_http` ERROR record with `exc_info` set to a real `ClientDisconnect` → downgraded to WARNING
- same logger with an unrelated exception (e.g. `ValueError`) → stays ERROR
- `mcp.server.lowlevel.server` ERROR record with message exactly `"Received exception from stream: "` → downgraded to WARNING
- same logger with a different/unrelated message → stays ERROR
- records below ERROR level pass through unchanged regardless of logger name/message

```
$ pytest tests/unit_tests/mcp_service/test_logging_filters.py -v
...
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterStreamableHttp::test_client_disconnect_downgraded_to_warning PASSED [ 12%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterStreamableHttp::test_other_exception_stays_at_error PASSED [ 25%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterStreamableHttp::test_no_exc_info_stays_at_error PASSED [ 37%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterLowlevelServer::test_empty_exception_message_downgraded_to_warning PASSED [ 50%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterLowlevelServer::test_different_message_stays_at_error PASSED [ 62%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterLowlevelServer::test_unrelated_message_stays_at_error PASSED [ 75%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterPassthrough::test_warning_level_passes_through_unchanged PASSED [ 87%]
tests/unit_tests/mcp_service/test_logging_filters.py::TestMCPTransportDisconnectFilterPassthrough::test_info_level_passes_through_unchanged PASSED [100%]
========================= 8 passed, 1 warning in 0.89s =========================
```

Also verified: full `test_middleware_logging.py` + `test_mcp_server.py` suites still pass (40 passed), `ruff check`/`ruff format --check` clean on both changed files (pinned ruff==0.9.7, matching `requirements/development.txt`), and `mypy --check-untyped-defs` on `superset/mcp_service/server.py` introduces zero new errors. The absolute pre-existing error count is environment-dependent (varies with installed stub-package/mypy-cache versions — 1489 in one sandbox run, 1510 in another reviewer's), but the load-bearing claim — identical count before vs. after this change, verified via `git stash` in each environment — holds in both.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Shortcut story https://app.shortcut.com/preset/story/115264
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
