### PR TITLE
perf(charts): reuse datasource in query context

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast, TYPE_CHECKING
 
 from flask import current_app
 
@@ -30,6 +30,9 @@ from superset.explorables.base import Explorable
 from superset.models.slice import Slice
 from superset.superset_typing import Column
 from superset.utils.core import DatasourceDict, DatasourceType, is_adhoc_column
+
+if TYPE_CHECKING:
+    from superset.connectors.sqla.models import BaseDatasource
 
 
 def create_query_object_factory() -> QueryObjectFactory:
@@ -81,6 +84,9 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                 self._query_object_factory.create(
                     result_type,
                     datasource=datasource,
+                    datasource_model_instance=cast(
+                        "BaseDatasource", datasource_model_instance
+                    ),
                     server_pagination=server_pagination,
                     **query_obj,
                 ),

--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -58,10 +58,10 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         time_range: str | None = None,
         time_shift: str | None = None,
         server_pagination: bool | None = None,
+        datasource_model_instance: BaseDatasource | None = None,
         **kwargs: Any,
     ) -> QueryObject:
-        datasource_model_instance = None
-        if datasource:
+        if datasource_model_instance is None and datasource:
             datasource_model_instance = self._convert_to_model(datasource)
         processed_extras = self._process_extras(extras)
         result_type = kwargs.setdefault("result_type", parent_result_type)

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -257,6 +257,28 @@ class TestQueryContextFactory:
         mock_dao.get_datasource.assert_called_once()
         assert result is not None
 
+    @patch("superset.daos.datasource.DatasourceDAO.get_datasource")
+    def test_create_loads_datasource_once_for_multiple_queries(
+        self,
+        mock_get_datasource,
+    ):
+        """Test query objects reuse the datasource resolved by the context."""
+        datasource = Mock()
+        datasource.columns = []
+        mock_get_datasource.return_value = datasource
+
+        query_context = self.factory.create(
+            datasource={"type": "table", "id": 123},
+            queries=[{"columns": []}, {"columns": []}],
+        )
+
+        mock_get_datasource.assert_called_once()
+        assert query_context.datasource is datasource
+        assert all(
+            query_object.datasource is datasource
+            for query_object in query_context.queries
+        )
+
     @patch("superset.common.query_context_factory.ChartDAO")
     def test_get_slice_found(self, mock_dao):
         """Test _get_slice when slice is found"""


### PR DESCRIPTION
### SUMMARY

`QueryContextFactory.create()` resolves the datasource model for the query context, but each nested `QueryObjectFactory.create()` resolves the same datasource again. A context with N query objects therefore performs N+1 identical datasource lookups.

This change passes the already-resolved datasource model into `QueryObjectFactory`. Standalone query-object construction keeps the existing fallback lookup, while query-context construction reuses one model instance for every query object. This avoids repeated metadata queries without introducing request-scoped ORM caching or changing behavior outside the context factory.

The regression test builds a context with two query objects and verifies that the datasource DAO is called once and that both query objects receive the context's datasource instance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this is a backend performance change with no UI changes.

### TESTING INSTRUCTIONS

1. Run the query context and query object factory unit tests:
   ```bash
   pytest -q tests/unit_tests/common/test_query_context_factory.py tests/unit_tests/common/test_query_object_factory.py
   ```
   Expected: `53 passed`.
2. Run pre-commit against the changed files:
   ```bash
   pre-commit run
   ```
   Expected: all applicable hooks pass, including MyPy, Ruff, and Pylint.

`pre-commit run --all-files` was also executed. All backend checks passed, including MyPy across the full source tree. Unrelated frontend/docs/Helm hooks could not complete because the local checkout does not have all frontend dependencies, Yarn, or `helm-docs` installed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
