### PR TITLE
feat(chart): support multi-level Sankey flows via intermediate level columns

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/buildQuery.ts
@@ -16,12 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { buildQueryContext, QueryFormOrderBy } from '@superset-ui/core';
+import {
+  buildQueryContext,
+  ensureIsArray,
+  QueryFormOrderBy,
+} from '@superset-ui/core';
 import { SankeyFormData } from './types';
 
 export default function buildQuery(formData: SankeyFormData) {
-  const { metric, sort_by_metric, source, target, row_limit } = formData;
-  const groupby = [source, target];
+  const {
+    metric,
+    sort_by_metric,
+    source,
+    target,
+    intermediate_levels,
+    row_limit,
+  } = formData;
+  const groupby = [source, ...ensureIsArray(intermediate_levels), target];
   const orderby: QueryFormOrderBy[] = [];
   const shouldApplyOrderBy =
     row_limit !== undefined && row_limit !== null && row_limit !== 0;
@@ -29,7 +40,7 @@ export default function buildQuery(formData: SankeyFormData) {
   if (sort_by_metric && metric) {
     orderby.push([metric, false]);
   }
-  [source, target].forEach(column => {
+  groupby.forEach(column => {
     if (column) {
       orderby.push([column, true]);
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/controlPanel.tsx
@@ -46,6 +46,23 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'intermediate_levels',
+            config: {
+              ...dndGroupByControl,
+              label: t('Intermediate levels'),
+              multi: true,
+              default: [],
+              description: t(
+                'Optional ordered columns rendered as intermediate stages ' +
+                  'between Source and Target. Drag to reorder. When set, ' +
+                  'each row flows Source → level 1 → … → Target.',
+              ),
+              freeForm: false,
+            },
+          },
+        ],
+        [
+          {
             name: 'target',
             config: {
               ...dndGroupByControl,
@@ -68,7 +85,50 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [['color_scheme']],
+      controlSetRows: [
+        ['color_scheme'],
+        [
+          {
+            name: 'roam',
+            config: {
+              type: 'SelectControl',
+              label: t('Enable graph roaming'),
+              renderTrigger: true,
+              default: true,
+              choices: [
+                [false, t('Disabled')],
+                ['scale', t('Scale only')],
+                ['move', t('Move only')],
+                [true, t('Scale and Move')],
+              ],
+              description: t(
+                'Whether to enable panning and zooming the diagram, which ' +
+                  'keeps dense flows readable in a small dashboard tile.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'node_alignment',
+            config: {
+              type: 'RadioButtonControl',
+              renderTrigger: true,
+              label: t('Node alignment'),
+              default: 'justify',
+              options: [
+                ['justify', t('Justify')],
+                ['left', t('Left')],
+                ['right', t('Right')],
+              ],
+              description: t(
+                'Horizontal alignment of nodes in the diagram. Justify ' +
+                  'pushes nodes without outgoing flows to the last level.',
+              ),
+            },
+          },
+        ],
+      ],
     },
   ],
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
@@ -21,7 +21,9 @@ import type { SankeySeriesOption } from 'echarts/charts';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
 import {
   CategoricalColorNamespace,
+  DataRecordValue,
   NumberFormats,
+  ensureIsArray,
   getColumnLabel,
   getMetricLabel,
   getNumberFormatter,
@@ -29,11 +31,20 @@ import {
 } from '@superset-ui/core';
 import { SankeyChartProps, SankeyTransformedProps } from './types';
 import { Refs } from '../types';
+import { NULL_STRING } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { getPercentFormatter } from '../utils/formatters';
 
 type Link = { source: string; target: string; value: number };
 type EChartsOption = ComposeOption<SankeySeriesOption>;
+
+// Separates the level index from the display value in internal node names of
+// multi-level charts. NUL cannot occur in SQL string values, so the prefix
+// can always be stripped unambiguously.
+const LEVEL_DELIMITER = '\0';
+
+// Pixel budget for node labels before they are truncated with an ellipsis.
+const LABEL_MAX_WIDTH = 120;
 
 export default function transformProps(
   chartProps: SankeyChartProps,
@@ -41,61 +52,111 @@ export default function transformProps(
   const refs: Refs = {};
   const { formData, height, hooks, queriesData, width, theme } = chartProps;
   const { onLegendStateChanged } = hooks;
-  const { colorScheme, metric, source, target, sliceId } = formData;
+  const {
+    colorScheme,
+    metric,
+    source,
+    target,
+    intermediateLevels,
+    nodeAlignment,
+    roam,
+    sliceId,
+  } = formData;
   const { data } = queriesData[0];
   const colorFn = CategoricalColorNamespace.getScale(colorScheme);
   const metricLabel = getMetricLabel(metric);
   const valueFormatter = getNumberFormatter(NumberFormats.FLOAT_2_POINT);
   const percentFormatter = getPercentFormatter(NumberFormats.PERCENT_2_POINT);
 
-  const links: Link[] = [];
-  const set = new Set<string>();
-  data.forEach(datum => {
-    const sourceName = String(datum[getColumnLabel(source)]);
-    const targetName = String(datum[getColumnLabel(target)]);
-    const value = datum[metricLabel] as number;
-    set.add(sourceName);
-    set.add(targetName);
-    links.push({
-      source: sourceName,
-      target: targetName,
-      value,
-    });
-  });
+  const levelColumns = [
+    source,
+    ...ensureIsArray(intermediateLevels),
+    target,
+  ].map(getColumnLabel);
+  // Node names are level-prefixed only in multi-level mode: it guarantees
+  // unique names per level and forward-only links (no accidental merges or
+  // cycles), while the plain two-column mode keeps raw names so edge-list
+  // datasets can still chain flows across rows via shared node names.
+  const isMultiLevel = levelColumns.length > 2;
 
+  const makeNodeName = (levelIndex: number, value: DataRecordValue): string => {
+    const display =
+      value === null || value === undefined ? NULL_STRING : String(value);
+    return isMultiLevel ? `${levelIndex}${LEVEL_DELIMITER}${display}` : display;
+  };
+
+  const displayName = (name: string): string =>
+    isMultiLevel ? name.slice(name.indexOf(LEVEL_DELIMITER) + 1) : name;
+
+  const linkMap = new Map<string, Link>();
+  const nodeLevels = new Map<string, number>();
+  data.forEach(datum => {
+    const value = datum[metricLabel] as number;
+    for (let level = 0; level < levelColumns.length - 1; level += 1) {
+      const sourceName = makeNodeName(level, datum[levelColumns[level]]);
+      const targetName = makeNodeName(
+        level + 1,
+        datum[levelColumns[level + 1]],
+      );
+      nodeLevels.set(sourceName, level);
+      nodeLevels.set(targetName, level + 1);
+      const linkKey = `${sourceName}${LEVEL_DELIMITER}${LEVEL_DELIMITER}${targetName}`;
+      const link = linkMap.get(linkKey);
+      if (link) {
+        link.value += value;
+      } else {
+        linkMap.set(linkKey, {
+          source: sourceName,
+          target: targetName,
+          value,
+        });
+      }
+    }
+  });
+  const links = Array.from(linkMap.values());
+
+  const lastLevel = levelColumns.length - 1;
   const seriesData: NonNullable<SankeySeriesOption['data']> = Array.from(
-    set,
-  ).map(name => ({
+    nodeLevels,
+  ).map(([name, level]) => ({
     name,
+    // Pinning each node to its column keeps the layout stable even when a
+    // value only appears in later levels.
+    ...(isMultiLevel && { depth: level }),
     itemStyle: {
-      color: colorFn(name, sliceId),
+      // color by display name so the same value shares a color across levels
+      color: colorFn(displayName(name), sliceId),
     },
     label: {
       color: theme.colorText,
       textShadow: theme.colorBgBase,
+      // keep last-level labels inside the plot area
+      ...(isMultiLevel && level === lastLevel && { position: 'left' as const }),
     },
   }));
 
   // stores a map with the total values for each node considering the links
   const incomingFlows = new Map<string, number>();
   const outgoingFlows = new Map<string, number>();
-  const allNodeNames = new Set<string>();
 
   links.forEach(link => {
-    const { source, target, value } = link;
-    allNodeNames.add(source);
-    allNodeNames.add(target);
-    incomingFlows.set(target, (incomingFlows.get(target) || 0) + value);
-    outgoingFlows.set(source, (outgoingFlows.get(source) || 0) + value);
+    incomingFlows.set(
+      link.target,
+      (incomingFlows.get(link.target) || 0) + link.value,
+    );
+    outgoingFlows.set(
+      link.source,
+      (outgoingFlows.get(link.source) || 0) + link.value,
+    );
   });
 
   const nodeValues = new Map<string, number>();
 
-  allNodeNames.forEach(nodeName => {
-    const totalIncoming = incomingFlows.get(nodeName) || 0;
-    const totalOutgoing = outgoingFlows.get(nodeName) || 0;
+  nodeLevels.forEach((level, name) => {
+    const totalIncoming = incomingFlows.get(name) || 0;
+    const totalOutgoing = outgoingFlows.get(name) || 0;
 
-    nodeValues.set(nodeName, Math.max(totalIncoming, totalOutgoing));
+    nodeValues.set(name, Math.max(totalIncoming, totalOutgoing));
   });
 
   const tooltipFormatter = (params: CallbackDataParams) => {
@@ -105,25 +166,51 @@ export default function transformProps(
     const { source, target } = data as Link;
     if (source && target) {
       rows.push([
-        `% (${source})`,
+        `% (${displayName(source)})`,
         percentFormatter.format(value / nodeValues.get(source)!),
       ]);
       rows.push([
-        `% (${target})`,
+        `% (${displayName(target)})`,
         percentFormatter.format(value / nodeValues.get(target)!),
       ]);
+      const title = isMultiLevel
+        ? `${displayName(source)} → ${displayName(target)}`
+        : name;
+      return tooltipHtml(rows, title);
     }
-    return tooltipHtml(rows, name);
+    return tooltipHtml(rows, displayName(name));
   };
 
   const echartOptions: EChartsOption = {
     series: {
       animation: false,
       data: seriesData,
+      emphasis: {
+        focus: 'adjacency',
+      },
+      label: {
+        formatter: params => displayName(params.name),
+        // Long category values (cloud service names, product SKUs) otherwise
+        // push the flow area off the canvas; the full value stays in the
+        // tooltip.
+        width: LABEL_MAX_WIDTH,
+        overflow: 'truncate',
+      },
       lineStyle: {
-        color: 'source',
+        color: 'gradient',
+        curveness: 0.5,
+        opacity: 0.5,
       },
       links,
+      nodeAlign: nodeAlignment ?? 'justify',
+      // nodeGap is a fixed pixel budget: nodeGap * (nodes in the tallest
+      // column) competes with the canvas height, and ECharts drops the whole
+      // column once the gaps no longer fit. Keep its default rather than a
+      // larger value so high-cardinality levels still render.
+      nodeWidth: 12,
+      // Pan/zoom so a diagram with more nodes than fit stays explorable in a
+      // small dashboard tile.
+      roam: roam ?? true,
       type: 'sankey',
     },
     tooltip: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
@@ -88,6 +88,20 @@ export default function transformProps(
   const displayName = (name: string): string =>
     isMultiLevel ? name.slice(name.indexOf(LEVEL_DELIMITER) + 1) : name;
 
+  // The same value can occupy several levels, and the color scale hands out a
+  // fresh color per call when it has no sliceId to memoize against, so each
+  // display value is resolved once to keep a category one color across levels.
+  const colorCache = new Map<string, string>();
+  const nodeColor = (name: string): string => {
+    const label = displayName(name);
+    let color = colorCache.get(label);
+    if (color === undefined) {
+      color = colorFn(label, sliceId);
+      colorCache.set(label, color);
+    }
+    return color;
+  };
+
   const linkMap = new Map<string, Link>();
   const nodeLevels = new Map<string, number>();
   data.forEach(datum => {
@@ -125,7 +139,7 @@ export default function transformProps(
     ...(isMultiLevel && { depth: level }),
     itemStyle: {
       // color by display name so the same value shares a color across levels
-      color: colorFn(displayName(name), sliceId),
+      color: nodeColor(name),
     },
     label: {
       color: theme.colorText,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/types.ts
@@ -23,11 +23,19 @@ import {
 } from '@superset-ui/core';
 import { BaseChartProps, BaseTransformedProps } from '../types';
 
+export type SankeyNodeAlignment = 'justify' | 'left' | 'right';
+
 export type SankeyFormData = QueryFormData & {
   colorScheme: string;
   metric: QueryFormMetric;
   source: QueryFormColumn;
   target: QueryFormColumn;
+  // populated as intermediate_levels in raw form data (buildQuery) and as
+  // intermediateLevels after ChartProps camelCase conversion (transformProps)
+  intermediate_levels?: QueryFormColumn[];
+  intermediateLevels?: QueryFormColumn[];
+  nodeAlignment?: SankeyNodeAlignment;
+  roam?: boolean | 'scale' | 'move';
 };
 
 export interface SankeyChartProps extends BaseChartProps<SankeyFormData> {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/buildQuery.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import buildQuery from '../../src/Sankey/buildQuery';
+import { SankeyFormData } from '../../src/Sankey/types';
+
+const baseFormData: SankeyFormData = {
+  colorScheme: 'supersetColors',
+  datasource: '1__table',
+  metric: 'count',
+  source: 'source_col',
+  target: 'target_col',
+  viz_type: 'sankey_v2',
+};
+
+test('two-column form data builds a single source/target groupby', () => {
+  const [query] = buildQuery(baseFormData).queries;
+  expect(query.groupby).toEqual(['source_col', 'target_col']);
+});
+
+test('intermediate levels are included in order between source and target', () => {
+  const [query] = buildQuery({
+    ...baseFormData,
+    intermediate_levels: ['level_1', 'level_2'],
+  }).queries;
+  expect(query.groupby).toEqual([
+    'source_col',
+    'level_1',
+    'level_2',
+    'target_col',
+  ]);
+});
+
+test('empty intermediate levels behaves as two-column form data', () => {
+  const [query] = buildQuery({
+    ...baseFormData,
+    intermediate_levels: [],
+  }).queries;
+  expect(query.groupby).toEqual(['source_col', 'target_col']);
+});
+
+test('orderby covers all level columns when row_limit is set', () => {
+  const [query] = buildQuery({
+    ...baseFormData,
+    intermediate_levels: ['level_1'],
+    row_limit: 100,
+  }).queries;
+  expect(query.orderby).toEqual([
+    ['source_col', true],
+    ['level_1', true],
+    ['target_col', true],
+  ]);
+});
+
+test('sort_by_metric orders by metric before level columns', () => {
+  const [query] = buildQuery({
+    ...baseFormData,
+    intermediate_levels: ['level_1'],
+    sort_by_metric: true,
+    row_limit: 100,
+  }).queries;
+  expect(query.orderby?.[0]).toEqual(['count', false]);
+  expect(query.orderby).toHaveLength(4);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/transformProps.test.ts
@@ -22,12 +22,25 @@ import type { SankeySeriesOption } from 'echarts/charts';
 import transformProps from '../../src/Sankey/transformProps';
 import { SankeyChartProps } from '../../src/Sankey/types';
 
-type SankeyNode = { name: string; depth?: number };
+type SankeyNode = {
+  name: string;
+  depth?: number;
+  itemStyle: { color: string };
+  label: { position?: string };
+};
 type SankeyLink = { source: string; target: string; value: number };
 
 const getSeries = (props: ChartProps): SankeySeriesOption => {
   const { echartOptions } = transformProps(props as SankeyChartProps);
   return (echartOptions as { series: SankeySeriesOption }).series;
+};
+
+const getTooltipFormatter = (props: ChartProps) => {
+  const { echartOptions } = transformProps(props as SankeyChartProps);
+  const { tooltip } = echartOptions as {
+    tooltip: { formatter: (params: unknown) => string };
+  };
+  return tooltip.formatter;
 };
 
 const getNodes = (props: ChartProps) => getSeries(props).data as SankeyNode[];
@@ -78,10 +91,17 @@ test('three-column mode chains adjacent pairs with level-prefixed names', () => 
     { source: '0\0a', target: '1\0m', value: 10 },
     { source: '1\0m', target: '2\0z', value: 10 },
   ]);
-  expect(getNodes(props)).toEqual([
+  const nodes = getNodes(props);
+  expect(nodes).toEqual([
     expect.objectContaining({ name: '0\0a', depth: 0 }),
     expect.objectContaining({ name: '1\0m', depth: 1 }),
     expect.objectContaining({ name: '2\0z', depth: 2 }),
+  ]);
+  // only the last column flips its labels inward, to keep them on canvas
+  expect(nodes.map(node => node.label.position)).toEqual([
+    undefined,
+    undefined,
+    'left',
   ]);
 });
 
@@ -94,6 +114,29 @@ test('four-column mode aggregates duplicate adjacent pairs across rows', () => {
   expect(links).toHaveLength(4);
   expect(links).toContainEqual({ source: '1\0m', target: '2\0n', value: 15 });
   expect(links).toContainEqual({ source: '2\0n', target: '3\0z', value: 15 });
+});
+
+test('two-column mode aggregates repeated pairs into a single link', () => {
+  const props = makeProps({}, [
+    { source_col: 'a', target_col: 'b', count: 1 },
+    { source_col: 'a', target_col: 'b', count: 2 },
+    { source_col: 'a', target_col: 'b', count: 4 },
+  ]);
+  // one hoverable edge carrying the total, rather than three stacked ribbons
+  // each reporting its share against that same total
+  expect(getLinks(props)).toEqual([{ source: 'a', target: 'b', value: 7 }]);
+});
+
+test('null and missing values coalesce to NULL_STRING in two-column mode too', () => {
+  const props = makeProps({}, [
+    { source_col: null, target_col: 'b', count: 10 },
+    // target_col absent from the row entirely
+    { source_col: 'a', count: 5 },
+  ]);
+  expect(getLinks(props)).toEqual([
+    { source: '<NULL>', target: 'b', value: 10 },
+    { source: 'a', target: '<NULL>', value: 5 },
+  ]);
 });
 
 test('null intermediate values coalesce to NULL_STRING and preserve totals', () => {
@@ -110,9 +153,15 @@ test('the same value in different levels creates distinct nodes', () => {
   const props = makeProps({ intermediateLevels: ['mid_col'] }, [
     { source_col: 'direct', mid_col: 'x', target_col: 'direct', count: 10 },
   ]);
-  const names = getNodes(props).map(node => node.name);
+  const nodes = getNodes(props);
+  const names = nodes.map(node => node.name);
   expect(names).toContain('0\0direct');
   expect(names).toContain('2\0direct');
+  // distinct nodes, but the same category keeps one color across levels
+  const [first, last] = ['0\0direct', '2\0direct'].map(
+    name => nodes.find(node => node.name === name)!.itemStyle.color,
+  );
+  expect(first).toEqual(last);
 });
 
 test('the same value in adjacent levels does not create a self-loop', () => {
@@ -140,6 +189,71 @@ test('label formatter is an identity for two-column mode', () => {
   const { label } = getSeries(props);
   const formatter = label?.formatter as (params: { name: string }) => string;
   expect(formatter({ name: 'a' })).toEqual('a');
+});
+
+test('link tooltips strip the level prefix from the title and both shares', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'a', mid_col: 'm', target_col: 'z', count: 10 },
+  ]);
+  const html = getTooltipFormatter(props)({
+    name: '0\0a > 1\0m',
+    value: 10,
+    data: { source: '0\0a', target: '1\0m', value: 10 },
+  });
+  expect(html).toContain('a → m');
+  expect(html).toContain('% (a)');
+  expect(html).toContain('% (m)');
+  // a leaked prefix would put raw NUL control characters in user-facing HTML
+  expect(html).not.toContain('\0');
+});
+
+test('node tooltips strip the level prefix from the title', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'a', mid_col: 'm', target_col: 'z', count: 10 },
+  ]);
+  const html = getTooltipFormatter(props)({
+    name: '1\0m',
+    value: 10,
+    data: {},
+  });
+  expect(html).toContain('m');
+  expect(html).not.toContain('\0');
+});
+
+test('two-column tooltips report each endpoint share against its node total', () => {
+  const props = makeProps({}, [
+    { source_col: 'a', target_col: 'b', count: 3 },
+    { source_col: 'a', target_col: 'c', count: 1 },
+  ]);
+  const html = getTooltipFormatter(props)({
+    name: 'a > b',
+    value: 3,
+    data: { source: 'a', target: 'b', value: 3 },
+  });
+  // a sends 4 in total, b receives only this link
+  expect(html).toContain('75.00%');
+  expect(html).toContain('100.00%');
+});
+
+test('adhoc intermediate levels are resolved by their column label', () => {
+  const props = makeProps(
+    {
+      intermediateLevels: [
+        {
+          sqlExpression: 'CASE WHEN x THEN 1 END',
+          label: 'bucket',
+          expressionType: 'SQL',
+        },
+      ],
+    },
+    [{ source_col: 'a', bucket: 'm', target_col: 'z', count: 10 }],
+  );
+  // without label resolution the row lookup misses and every middle node
+  // collapses into a single <NULL> bucket
+  expect(getLinks(props)).toEqual([
+    { source: '0\0a', target: '1\0m', value: 10 },
+    { source: '1\0m', target: '2\0z', value: 10 },
+  ]);
 });
 
 // ECharts spends nodeGap as a fixed pixel budget per column, so a large value

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sankey/transformProps.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps, DataRecord } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import type { SankeySeriesOption } from 'echarts/charts';
+import transformProps from '../../src/Sankey/transformProps';
+import { SankeyChartProps } from '../../src/Sankey/types';
+
+type SankeyNode = { name: string; depth?: number };
+type SankeyLink = { source: string; target: string; value: number };
+
+const getSeries = (props: ChartProps): SankeySeriesOption => {
+  const { echartOptions } = transformProps(props as SankeyChartProps);
+  return (echartOptions as { series: SankeySeriesOption }).series;
+};
+
+const getNodes = (props: ChartProps) => getSeries(props).data as SankeyNode[];
+
+const getLinks = (props: ChartProps) => getSeries(props).links as SankeyLink[];
+
+const makeProps = (
+  formDataOverrides: Record<string, unknown>,
+  data: DataRecord[],
+) =>
+  new ChartProps({
+    formData: {
+      colorScheme: 'supersetColors',
+      datasource: '1__table',
+      metric: 'count',
+      source: 'source_col',
+      target: 'target_col',
+      vizType: 'sankey_v2',
+      ...formDataOverrides,
+    },
+    width: 800,
+    height: 600,
+    queriesData: [{ data }],
+    theme: supersetTheme,
+  });
+
+test('two-column mode emits raw pairwise links and node names', () => {
+  const props = makeProps({}, [
+    { source_col: 'a', target_col: 'b', count: 10 },
+    { source_col: 'b', target_col: 'c', count: 5 },
+  ]);
+  expect(getLinks(props)).toEqual([
+    { source: 'a', target: 'b', value: 10 },
+    { source: 'b', target: 'c', value: 5 },
+  ]);
+  const nodes = getNodes(props);
+  expect(nodes.map(node => node.name).sort()).toEqual(['a', 'b', 'c']);
+  // no level prefixes and no depth pinning: cross-row chaining (a→b→c)
+  // must keep working for edge-list datasets
+  nodes.forEach(node => expect(node.depth).toBeUndefined());
+});
+
+test('three-column mode chains adjacent pairs with level-prefixed names', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'a', mid_col: 'm', target_col: 'z', count: 10 },
+  ]);
+  expect(getLinks(props)).toEqual([
+    { source: '0\0a', target: '1\0m', value: 10 },
+    { source: '1\0m', target: '2\0z', value: 10 },
+  ]);
+  expect(getNodes(props)).toEqual([
+    expect.objectContaining({ name: '0\0a', depth: 0 }),
+    expect.objectContaining({ name: '1\0m', depth: 1 }),
+    expect.objectContaining({ name: '2\0z', depth: 2 }),
+  ]);
+});
+
+test('four-column mode aggregates duplicate adjacent pairs across rows', () => {
+  const props = makeProps({ intermediateLevels: ['mid_1', 'mid_2'] }, [
+    { source_col: 'a', mid_1: 'm', mid_2: 'n', target_col: 'z', count: 10 },
+    { source_col: 'b', mid_1: 'm', mid_2: 'n', target_col: 'z', count: 5 },
+  ]);
+  const links = getLinks(props);
+  expect(links).toHaveLength(4);
+  expect(links).toContainEqual({ source: '1\0m', target: '2\0n', value: 15 });
+  expect(links).toContainEqual({ source: '2\0n', target: '3\0z', value: 15 });
+});
+
+test('null intermediate values coalesce to NULL_STRING and preserve totals', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'a', mid_col: null, target_col: 'z', count: 10 },
+  ]);
+  expect(getLinks(props)).toEqual([
+    { source: '0\0a', target: '1\0<NULL>', value: 10 },
+    { source: '1\0<NULL>', target: '2\0z', value: 10 },
+  ]);
+});
+
+test('the same value in different levels creates distinct nodes', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'direct', mid_col: 'x', target_col: 'direct', count: 10 },
+  ]);
+  const names = getNodes(props).map(node => node.name);
+  expect(names).toContain('0\0direct');
+  expect(names).toContain('2\0direct');
+});
+
+test('the same value in adjacent levels does not create a self-loop', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'x', mid_col: 'x', target_col: 'z', count: 10 },
+  ]);
+  const links = getLinks(props);
+  expect(links).toContainEqual({ source: '0\0x', target: '1\0x', value: 10 });
+  links.forEach(link => expect(link.source).not.toEqual(link.target));
+});
+
+test('label formatter strips the level prefix in multi-level mode', () => {
+  const props = makeProps({ intermediateLevels: ['mid_col'] }, [
+    { source_col: 'a', mid_col: 'm', target_col: 'z', count: 10 },
+  ]);
+  const { label } = getSeries(props);
+  const formatter = label?.formatter as (params: { name: string }) => string;
+  expect(formatter({ name: '1\0m' })).toEqual('m');
+});
+
+test('label formatter is an identity for two-column mode', () => {
+  const props = makeProps({}, [
+    { source_col: 'a', target_col: 'b', count: 10 },
+  ]);
+  const { label } = getSeries(props);
+  const formatter = label?.formatter as (params: { name: string }) => string;
+  expect(formatter({ name: 'a' })).toEqual('a');
+});
+
+// ECharts spends nodeGap as a fixed pixel budget per column, so a large value
+// makes it drop every node once gaps exceed the canvas height (33 nodes at
+// nodeGap 20 renders nothing below 800px tall). Keep the default.
+test('nodeGap is left at the ECharts default', () => {
+  const series = getSeries(
+    makeProps({}, [{ source_col: 'a', target_col: 'b', count: 10 }]),
+  );
+  expect(series.nodeGap).toBeUndefined();
+});
+
+test('labels are truncated to a fixed width so flows keep their space', () => {
+  const { label } = getSeries(
+    makeProps({}, [{ source_col: 'a', target_col: 'b', count: 10 }]),
+  );
+  expect(label?.width).toBeGreaterThan(0);
+  expect(label?.overflow).toEqual('truncate');
+});
+
+test('roam is enabled by default and honors the form data value', () => {
+  const data = [{ source_col: 'a', target_col: 'b', count: 10 }];
+  expect(getSeries(makeProps({}, data)).roam).toBe(true);
+  expect(getSeries(makeProps({ roam: 'move' }, data)).roam).toEqual('move');
+  expect(getSeries(makeProps({ roam: false }, data)).roam).toBe(false);
+});
+
+test('nodeAlign defaults to justify and honors the form data value', () => {
+  const data = [{ source_col: 'a', target_col: 'b', count: 10 }];
+  expect(getSeries(makeProps({}, data)).nodeAlign).toEqual('justify');
+  expect(
+    getSeries(makeProps({ nodeAlignment: 'left' }, data)).nodeAlign,
+  ).toEqual('left');
+});

--- a/superset-frontend/src/dashboard/util/charts/chartTypeLimitations.ts
+++ b/superset-frontend/src/dashboard/util/charts/chartTypeLimitations.ts
@@ -55,12 +55,6 @@ export const CHART_TYPE_LIMITATIONS: Record<string, ChartTypeLimitation> = {
     warningMessage: (usedColumns, ignoredColumns) =>
       `Graph charts only support two dimensions (source and target). Using "${usedColumns[0]}" for source and "${usedColumns[1]}" for target. Additional columns (${ignoredColumns.join(', ')}) will be ignored.`,
   },
-  sankey_v2: {
-    maxDimensions: 2,
-    dimensionNames: ['source', 'target'],
-    warningMessage: (usedColumns, ignoredColumns) =>
-      `Sankey charts only support two dimensions (source and target). Using "${usedColumns[0]}" for source and "${usedColumns[1]}" for target. Additional columns (${ignoredColumns.join(', ')}) will be ignored.`,
-  },
   bubble_v2: {
     maxDimensions: 2,
     dimensionNames: ['series', 'entity'],

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -246,8 +246,11 @@ function applyChartSpecificGroupBy(
       groupByFormData.target = limitedColumns[1];
     }
   } else if (chartType === 'sankey_v2') {
-    groupByFormData.source = groupByColumns[0];
+    // A flow needs both ends, so a single column is left unapplied rather than
+    // overriding the source while target and intermediate levels keep the
+    // columns configured on the chart.
     if (groupByColumns.length > 1) {
+      groupByFormData.source = groupByColumns[0];
       groupByFormData.target = groupByColumns[groupByColumns.length - 1];
       groupByFormData.intermediate_levels = groupByColumns.slice(1, -1);
     }
@@ -290,6 +293,7 @@ function processGroupByCustomizations(
   entity?: string;
   source?: string;
   target?: string;
+  intermediate_levels?: string[];
   groupbyColumns?: string[];
 } {
   if (!chartCustomizationItems || chartCustomizationItems.length === 0) {

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -246,13 +246,10 @@ function applyChartSpecificGroupBy(
       groupByFormData.target = limitedColumns[1];
     }
   } else if (chartType === 'sankey_v2') {
-    const { limitedColumns } = limitColumnsForChartType(
-      chartType,
-      groupByColumns,
-    );
-    groupByFormData.source = limitedColumns[0];
-    if (limitedColumns.length > 1) {
-      groupByFormData.target = limitedColumns[1];
+    groupByFormData.source = groupByColumns[0];
+    if (groupByColumns.length > 1) {
+      groupByFormData.target = groupByColumns[groupByColumns.length - 1];
+      groupByFormData.intermediate_levels = groupByColumns.slice(1, -1);
     }
   } else if (['chord'].includes(chartType)) {
     groupByFormData.groupby =

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -394,6 +394,27 @@ test('sankey chart with two dynamic group by columns has no intermediate levels'
   expect(result.target).toEqual('outcome');
 });
 
+test('sankey chart leaves its configured columns alone when only one dynamic group by column is selected', () => {
+  const result = getFormDataWithExtraFilters({
+    ...makeGroupByArgs(['country']),
+    chart: {
+      ...mockChart,
+      form_data: {
+        ...mockChart.form_data,
+        viz_type: 'sankey_v2',
+        datasource: '3__table',
+        source: 'configured_source',
+        target: 'configured_target',
+        intermediate_levels: ['configured_level'],
+      },
+    },
+  }) as Record<string, unknown>;
+
+  expect(result.source).toEqual('configured_source');
+  expect(result.target).toEqual('configured_target');
+  expect(result.intermediate_levels).toEqual(['configured_level']);
+});
+
 test('structural conflict: metric column blocks groupby override (nonConflictingColumns guard)', () => {
   const customizationId = 'CHART_CUSTOMIZATION-groupby-conflict';
   const argsWithMetricConflict: GetFormDataWithExtraFiltersArguments = {

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -358,6 +358,42 @@ test('dynamic group by normalizes a single-select string value into a one-item g
   expectGroupBy(result, ['status']);
 });
 
+test('sankey chart maps dynamic group by columns to source, intermediate levels and target', () => {
+  const result = getFormDataWithExtraFilters({
+    ...makeGroupByArgs(['country', 'product', 'channel', 'outcome']),
+    chart: {
+      ...mockChart,
+      form_data: {
+        ...mockChart.form_data,
+        viz_type: 'sankey_v2',
+        datasource: '3__table',
+      },
+    },
+  }) as Record<string, unknown>;
+
+  expect(result.source).toEqual('country');
+  expect(result.intermediate_levels).toEqual(['product', 'channel']);
+  expect(result.target).toEqual('outcome');
+});
+
+test('sankey chart with two dynamic group by columns has no intermediate levels', () => {
+  const result = getFormDataWithExtraFilters({
+    ...makeGroupByArgs(['country', 'outcome']),
+    chart: {
+      ...mockChart,
+      form_data: {
+        ...mockChart.form_data,
+        viz_type: 'sankey_v2',
+        datasource: '3__table',
+      },
+    },
+  }) as Record<string, unknown>;
+
+  expect(result.source).toEqual('country');
+  expect(result.intermediate_levels).toEqual([]);
+  expect(result.target).toEqual('outcome');
+});
+
 test('structural conflict: metric column blocks groupby override (nonConflictingColumns guard)', () => {
   const customizationId = 'CHART_CUSTOMIZATION-groupby-conflict';
   const argsWithMetricConflict: GetFormDataWithExtraFiltersArguments = {

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -788,13 +788,25 @@ def _collect_sortable_identifiers(
     params = stored_chart.params_dict
     column_config = params.get("column_config")
 
-    for key in ("columns", "groupby", "all_columns"):
+    for key in ("columns", "groupby", "all_columns", "intermediate_levels"):
         _add_visible_sort_targets(
             allowed,
             params.get(key),
             column_config,
             is_metric=False,
         )
+    # sankey_v2's source/target are single columns (scalar strings), not
+    # lists -- _add_visible_sort_targets returns immediately for a
+    # non-list/tuple value, so these need the same wrap-in-a-list handling
+    # as the legacy singular ``metric`` key below, not a plain tuple entry.
+    for scalar_key in ("source", "target"):
+        if params.get(scalar_key) is not None:
+            _add_visible_sort_targets(
+                allowed,
+                [params[scalar_key]],
+                column_config,
+                is_metric=False,
+            )
     _add_visible_sort_targets(
         allowed,
         params.get("metrics"),
@@ -812,13 +824,21 @@ def _collect_sortable_identifiers(
 
     if stored_query_context:
         for query in stored_query_context.get("queries") or []:
-            for key in ("columns", "groupby", "all_columns"):
+            for key in ("columns", "groupby", "all_columns", "intermediate_levels"):
                 _add_visible_sort_targets(
                     allowed,
                     query.get(key),
                     column_config,
                     is_metric=False,
                 )
+            for scalar_key in ("source", "target"):
+                if query.get(scalar_key) is not None:
+                    _add_visible_sort_targets(
+                        allowed,
+                        [query[scalar_key]],
+                        column_config,
+                        is_metric=False,
+                    )
             _add_visible_sort_targets(
                 allowed,
                 query.get("metrics"),
@@ -1015,6 +1035,14 @@ _STORED_COLUMN_PARAMS = (
     "series_columns",
     "x_axis",
     "granularity_sqla",
+    # sankey_v2's endpoint/intermediate-level controls (see this PR's own
+    # chart params: source/target are single columns, intermediate_levels
+    # is a list) -- without these, a guest embedding a sankey_v2 chart gets
+    # "Guest user cannot modify chart payload" on every request, since this
+    # tuple drives the subset check in _stored_param_values below.
+    "source",
+    "target",
+    "intermediate_levels",
 )
 
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -994,7 +994,7 @@ def _collect_sortable_identifiers(
     params = stored_chart.params_dict
     column_config = params.get("column_config")
 
-    for key in ("columns", "groupby", "all_columns"):
+    for key in ("columns", "groupby", "all_columns", "intermediate_levels"):
         _add_visible_sort_targets(
             allowed,
             params.get(key),
@@ -1011,6 +1011,18 @@ def _collect_sortable_identifiers(
             column_config,
             is_metric=False,
         )
+    # sankey_v2's source/target are single columns (scalar strings), not
+    # lists -- _add_visible_sort_targets returns immediately for a
+    # non-list/tuple value, so these need the same wrap-in-a-list handling
+    # as the legacy singular ``metric`` key below, not a plain tuple entry.
+    for scalar_key in ("source", "target"):
+        if params.get(scalar_key) is not None:
+            _add_visible_sort_targets(
+                allowed,
+                [params[scalar_key]],
+                column_config,
+                is_metric=False,
+            )
     _add_visible_sort_targets(
         allowed,
         params.get("metrics"),
@@ -1028,13 +1040,21 @@ def _collect_sortable_identifiers(
 
     if stored_query_context:
         for query in stored_query_context.get("queries") or []:
-            for key in ("columns", "groupby", "all_columns"):
+            for key in ("columns", "groupby", "all_columns", "intermediate_levels"):
                 _add_visible_sort_targets(
                     allowed,
                     query.get(key),
                     column_config,
                     is_metric=False,
                 )
+            for scalar_key in ("source", "target"):
+                if query.get(scalar_key) is not None:
+                    _add_visible_sort_targets(
+                        allowed,
+                        [query[scalar_key]],
+                        column_config,
+                        is_metric=False,
+                    )
             _add_visible_sort_targets(
                 allowed,
                 query.get("metrics"),
@@ -1506,6 +1526,14 @@ _STORED_COLUMN_PARAMS = (
     "series_columns",
     "x_axis",
     "granularity_sqla",
+    # sankey_v2's endpoint/intermediate-level controls (see this PR's own
+    # chart params: source/target are single columns, intermediate_levels
+    # is a list) -- without these, a guest embedding a sankey_v2 chart gets
+    # "Guest user cannot modify chart payload" on every request, since this
+    # tuple drives the subset check in _stored_param_values below.
+    "source",
+    "target",
+    "intermediate_levels",
 )
 
 

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1419,6 +1419,98 @@ def test_query_context_modified_orderby_unknown_column(mocker: MockerFixture) ->
     assert query_context_modified(query_context)
 
 
+def _sankey_query_context(mocker: MockerFixture, *, with_orderby: bool = True) -> Any:
+    """
+    Build a query context replaying a sankey_v2 chart's own generated
+    payload exactly: source/target are single columns (not lists),
+    intermediate_levels is a list, metric is the legacy singular key. This
+    is the real shape a guest-embedded sankey_v2 dashboard sends.
+    """
+    metric: AdhocMetric = {
+        "aggregate": "SUM",
+        "column": {"column_name": "effective_cost"},
+        "expressionType": "SIMPLE",
+        "label": "SUM(effective_cost)",
+    }
+    params_dict = {
+        "viz_type": "sankey_v2",
+        "source": "sub_account_name",
+        "intermediate_levels": ["service_category", "service_name"],
+        "target": "region_name",
+        "metric": metric,
+    }
+    orderby = (
+        [
+            (metric, False),
+            ("sub_account_name", True),
+            ("service_category", True),
+            ("service_name", True),
+            ("region_name", True),
+        ]
+        if with_orderby
+        else []
+    )
+    query_context = mocker.MagicMock()
+    query_context.queries = [
+        QueryObject(
+            columns=[],
+            groupby=[
+                "sub_account_name",
+                "service_category",
+                "service_name",
+                "region_name",
+            ],
+            metrics=[metric],
+            orderby=orderby,
+        ),
+    ]
+    query_context.form_data = {"slice_id": 10, "dashboardId": 1}
+    query_context.slice_.id = 10
+    query_context.slice_.params_dict = params_dict
+    query_context.slice_.query_context = None
+    return query_context
+
+
+def test_query_context_modified_sankey_v2_columns_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A guest replaying a sankey_v2 chart's own source/intermediate_levels/
+    target columns and singular metric is not tampering. Regression test:
+    source/target/intermediate_levels were previously absent from
+    _STORED_COLUMN_PARAMS, so every real request read as tampering
+    regardless of content.
+    """
+    query_context = _sankey_query_context(mocker, with_orderby=False)
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_sankey_v2_orderby_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A guest replaying a sankey_v2 chart's own default sort (by its metric,
+    then by each of source/intermediate_levels/target) is not tampering.
+    Regression test: _collect_sortable_identifiers's own separate hardcoded
+    column-key tuple did not include intermediate_levels, and its helper
+    does not accept a scalar value the way _stored_param_values does, so
+    source/target (scalar strings on this viz type) were silently dropped
+    even after fixing _STORED_COLUMN_PARAMS alone.
+    """
+    query_context = _sankey_query_context(mocker, with_orderby=True)
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_sankey_v2_orderby_unknown_column_blocked(
+    mocker: MockerFixture,
+) -> None:
+    """A guest sorting a sankey_v2 chart by a column it does not reference
+    is still rejected -- the fix must not make this viz type permissive."""
+    query_context = _sankey_query_context(mocker, with_orderby=False)
+    query_context.queries[0].orderby = [("unrelated_column", True)]
+    assert query_context_modified(query_context)
+
+
 def test_query_context_modified_orderby_empty(mocker: MockerFixture) -> None:
     """An empty order-by is not a modification."""
     query_context = _table_sort_query_context(mocker, orderby=[])

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -2255,6 +2255,98 @@ def test_query_context_modified_orderby_unknown_column(mocker: MockerFixture) ->
     assert query_context_modified(query_context)
 
 
+def _sankey_query_context(mocker: MockerFixture, *, with_orderby: bool = True) -> Any:
+    """
+    Build a query context replaying a sankey_v2 chart's own generated
+    payload exactly: source/target are single columns (not lists),
+    intermediate_levels is a list, metric is the legacy singular key. This
+    is the real shape a guest-embedded sankey_v2 dashboard sends.
+    """
+    metric: AdhocMetric = {
+        "aggregate": "SUM",
+        "column": {"column_name": "effective_cost"},
+        "expressionType": "SIMPLE",
+        "label": "SUM(effective_cost)",
+    }
+    params_dict = {
+        "viz_type": "sankey_v2",
+        "source": "sub_account_name",
+        "intermediate_levels": ["service_category", "service_name"],
+        "target": "region_name",
+        "metric": metric,
+    }
+    orderby = (
+        [
+            (metric, False),
+            ("sub_account_name", True),
+            ("service_category", True),
+            ("service_name", True),
+            ("region_name", True),
+        ]
+        if with_orderby
+        else []
+    )
+    query_context = mocker.MagicMock()
+    query_context.queries = [
+        QueryObject(
+            columns=[],
+            groupby=[
+                "sub_account_name",
+                "service_category",
+                "service_name",
+                "region_name",
+            ],
+            metrics=[metric],
+            orderby=orderby,
+        ),
+    ]
+    query_context.form_data = {"slice_id": 10, "dashboardId": 1}
+    query_context.slice_.id = 10
+    query_context.slice_.params_dict = params_dict
+    query_context.slice_.query_context = None
+    return query_context
+
+
+def test_query_context_modified_sankey_v2_columns_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A guest replaying a sankey_v2 chart's own source/intermediate_levels/
+    target columns and singular metric is not tampering. Regression test:
+    source/target/intermediate_levels were previously absent from
+    _STORED_COLUMN_PARAMS, so every real request read as tampering
+    regardless of content.
+    """
+    query_context = _sankey_query_context(mocker, with_orderby=False)
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_sankey_v2_orderby_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A guest replaying a sankey_v2 chart's own default sort (by its metric,
+    then by each of source/intermediate_levels/target) is not tampering.
+    Regression test: _collect_sortable_identifiers's own separate hardcoded
+    column-key tuple did not include intermediate_levels, and its helper
+    does not accept a scalar value the way _stored_param_values does, so
+    source/target (scalar strings on this viz type) were silently dropped
+    even after fixing _STORED_COLUMN_PARAMS alone.
+    """
+    query_context = _sankey_query_context(mocker, with_orderby=True)
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_sankey_v2_orderby_unknown_column_blocked(
+    mocker: MockerFixture,
+) -> None:
+    """A guest sorting a sankey_v2 chart by a column it does not reference
+    is still rejected -- the fix must not make this viz type permissive."""
+    query_context = _sankey_query_context(mocker, with_orderby=False)
+    query_context.queries[0].orderby = [("unrelated_column", True)]
+    assert query_context_modified(query_context)
+
+
 def test_query_context_modified_orderby_empty(mocker: MockerFixture) -> None:
     """An empty order-by is not a modification."""
     query_context = _table_sort_query_context(mocker, orderby=[])


### PR DESCRIPTION
### SUMMARY

The Sankey chart accepts exactly one source and one target column, so a flow spanning three or more dimensions (for example `Country → Product → Channel → Outcome`) cannot be built. The ECharts sankey series already lays out an arbitrary number of levels from chained links, so the limitation lives only in the plugin's control panel and query — `buildQuery.ts` hard-codes `groupby = [source, target]` and both controls are `multi: false`.

This adds an optional ordered **Intermediate levels** column control between the existing Source and Target. When set, `buildQuery` groups by `[source, ...intermediateLevels, target]` in a single query, and `transformProps` emits links for each adjacent pair, aggregating the metric.

Long-standing requests for this: #3059, #20887, and discussion #38713 (where the only suggested workaround is a `UNION ALL` virtual dataset of stacked source/target pairs).

**Design notes**

- **Backward compatible.** `intermediate_levels` is a new optional form-data key, so existing saved charts are untouched and no migration is needed. With it unset, the link/node output is identical to today.
- **Node identity.** In multi-level mode node names carry their level index internally (NUL-delimited) and each node is pinned to its column via `depth`. This is what makes the feature safe: without it, a value appearing in two levels (say `Other` at level 1 and level 3) silently merges into one node, and the resulting back-edge makes ECharts throw `Sankey is a DAG, the original data has cycle!`, which aborts the render. Labels and tooltips strip the prefix, so it is invisible to users.
- **Two-column mode keeps raw node names** rather than prefixing, so edge-list datasets that intentionally chain flows across rows (`A→B`, `B→C`) still connect. This is the one behavioral tension in the change and the reason prefixing is conditional.
- **Missing values** at any level become `NULL_STRING` instead of dropping the row, which keeps per-level totals equal (a dropped row would remove its value from every level).

**Rendering fixes needed to make deep charts usable**

- `nodeGap` is left at the ECharts default. It is a fixed pixel budget per column: once `nodeGap × nodes` exceeds the plot height ECharts drops **every** node in that column. Measured with 33 first-level nodes at 900×600, a `nodeGap` of 20 rendered 0 of 34 node rects while the default of 8 rendered all of them.
- Node labels are truncated to a fixed width, because long category values otherwise push the flow area off the canvas. The full value remains in the tooltip.
- Adds a **roaming** control (pan/zoom), defaulting to `true` to match the existing Graph and Tree charts, so a dense diagram stays explorable inside a dashboard tile.
- The series also picks up gradient links and `emphasis: { focus: 'adjacency' }` on hover, which makes an individual path traceable through several levels. Note this applies to two-column charts too — it is a visual refresh, not a data change.

**Dashboard integration**

Sankey no longer has a two-dimension limit, so its entry is removed from `CHART_TYPE_LIMITATIONS` (which previously warned that extra columns "will be ignored"), and the dynamic-groupby mapping in `getFormDataWithExtraFilters` now assigns the first column to source, the last to target, and everything between to intermediate levels.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Skipped — the only datasets available on the machine used for development are private. Happy to add screenshots from the examples data if a reviewer would like them; the testing instructions below reproduce the behavior in a couple of minutes.

### TESTING INSTRUCTIONS

Unit tests (17 new for Sankey, plus 2 added to the dashboard util suite):

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/Sankey
npm run test -- src/dashboard/util/getFormDataWithExtraFilters.test.ts
```

Manual, on any dataset with three or more categorical columns and a numeric measure:

1. Create a Sankey chart. Set **Source**, **Target**, and a `SUM(...)` metric — confirm it behaves exactly as before.
2. Add one column to **Intermediate levels** → three columns of nodes appear, chained through the middle level. Add a second → four levels.
3. Hover a node: it and its adjacent links highlight while the rest dims. Hover a link: the tooltip shows the metric plus each endpoint's share.
4. Use a dataset where the *same value occurs in two different levels* (e.g. the same column as both Source and Target). Confirm two distinct nodes render and no "Sankey is a DAG" error appears.
5. Confirm labels show plain values (no level prefix) and long values are truncated with an ellipsis.
6. Set **Node alignment** to Left/Right and confirm it re-renders without re-querying; scroll-zoom and drag to confirm roaming.
7. Verify totals: for each level boundary, the sum of link values should equal the metric total — nulls and duplicate pairs must not change it.
8. Open an existing saved two-column Sankey and confirm identical topology; on a dashboard, drive it with a dimension-selector control and confirm first/middle/last mapping.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #3059, #20887, discussion #38713
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

Known gaps, deliberately out of scope: cross-filtering is still unimplemented for this chart (pre-existing `TODO` in `Sankey/index.ts`), and per-level styling via the ECharts `levels` option is a natural follow-up. Cyclic data in two-column mode still surfaces the ECharts DAG error, as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
