### PR TITLE
fix(explore): recompute currency_formats when dataset is saved from c…

### DIFF
--- a/superset-frontend/src/explore/actions/datasourcesActions.test.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.test.ts
@@ -93,14 +93,59 @@ test('change datasource action', () => {
       datasource: CURRENT_DATASOURCE,
     },
   }));
+  // NEW_DATASOURCE has no metrics with currency, so currency_formats is {}
+  const expectedDatasource = { ...NEW_DATASOURCE, currency_formats: {} };
   // ignore getState type check - we dont need explore.datasource field for this test
   // @ts-expect-error
   changeDatasource(NEW_DATASOURCE)(dispatch, getState);
   expect(dispatch).toHaveBeenCalledTimes(2);
-  expect(dispatch).toHaveBeenNthCalledWith(1, setDatasource(NEW_DATASOURCE));
+  expect(dispatch).toHaveBeenNthCalledWith(
+    1,
+    setDatasource(expectedDatasource),
+  );
   expect(dispatch).toHaveBeenNthCalledWith(
     2,
-    updateFormDataByDatasource(CURRENT_DATASOURCE, NEW_DATASOURCE),
+    updateFormDataByDatasource(CURRENT_DATASOURCE, expectedDatasource),
+  );
+});
+
+test('changeDatasource computes currency_formats from metric currencies', () => {
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({
+    explore: { datasource: CURRENT_DATASOURCE },
+  }));
+  const datasourceWithCurrencyMetric = {
+    ...NEW_DATASOURCE,
+    metrics: [
+      {
+        uuid: 'uuid-revenue',
+        metric_name: 'revenue',
+        expression: 'SUM(revenue)',
+        currency: { symbol: 'EUR', symbolPosition: 'prefix' },
+      },
+      {
+        uuid: 'uuid-cost',
+        metric_name: 'cost',
+        expression: 'SUM(cost)',
+        currency: null,
+      },
+    ],
+  };
+  const expectedDatasource = {
+    ...datasourceWithCurrencyMetric,
+    currency_formats: {
+      revenue: { symbol: 'EUR', symbolPosition: 'prefix' },
+    },
+  };
+  // @ts-expect-error
+  changeDatasource(datasourceWithCurrencyMetric)(dispatch, getState);
+  expect(dispatch).toHaveBeenNthCalledWith(
+    1,
+    setDatasource(expectedDatasource),
+  );
+  expect(dispatch).toHaveBeenNthCalledWith(
+    2,
+    updateFormDataByDatasource(CURRENT_DATASOURCE, expectedDatasource),
   );
 });
 

--- a/superset-frontend/src/explore/actions/datasourcesActions.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.ts
@@ -20,7 +20,11 @@
 import { Dispatch, AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { Dataset } from '@superset-ui/chart-controls';
-import { SupersetClient, getClientErrorObject } from '@superset-ui/core';
+import {
+  Currency,
+  SupersetClient,
+  getClientErrorObject,
+} from '@superset-ui/core';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { updateFormDataByDatasource } from './exploreActions';
 import { ExplorePageState } from '../types';
@@ -50,8 +54,25 @@ export function changeDatasource(newDatasource: Dataset) {
     const {
       explore: { datasource: prevDatasource },
     } = getState();
-    dispatch(setDatasource(newDatasource));
-    dispatch(updateFormDataByDatasource(prevDatasource, newDatasource));
+    // Recompute currency_formats from the updated metrics, mirroring the
+    // logic in hydrateExplore. The raw API response does not carry this
+    // derived field, so without this step any currency change made via
+    // Edit Dataset would not be reflected in the chart preview.
+    const datasourceWithCurrencyFormats: Dataset = {
+      ...newDatasource,
+      currency_formats: Object.fromEntries(
+        (newDatasource.metrics ?? [])
+          .filter(metric => !!metric.currency)
+          .map((metric): [string, Currency] => [
+            metric.metric_name,
+            metric.currency!,
+          ]),
+      ),
+    };
+    dispatch(setDatasource(datasourceWithCurrencyFormats));
+    dispatch(
+      updateFormDataByDatasource(prevDatasource, datasourceWithCurrencyFormats),
+    );
   };
 }
 


### PR DESCRIPTION
### SUMMARY

When editing a metric's currency via **Edit Dataset** from the chart editor, the chart preview did not reflect the new currency until the page was refreshed.

**Root cause:** `currency_formats` — a derived map of `metric_name → Currency` used by all chart plugins (as camelCase `currencyFormats`) — is only computed once in `hydrateExplore.ts` at initial page load. When `changeDatasource` is dispatched after an inline dataset save, it passes the raw API response directly to Redux. The API response contains the updated `metrics[].currency` data but never carries the pre-computed `currency_formats` field, so chart plugins receive `currencyFormats: {}` and render without any currency formatting.

**Why removal appeared to work:** Removing a currency also results in `currencyFormats: {}`, which is the correct outcome (no currency → no formatting), so it appeared to work immediately.

**Fix:** In `changeDatasource` — the canonical entry point for all datasource updates — derive `currency_formats` from `metrics[].currency` before dispatching, exactly mirroring what `hydrateExplore.ts` does on initial page load. This ensures every caller gets consistent, up-to-date currency formatting without any component needing to know about this derived field.

Fixes #42468

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Changing a metric's currency in Edit Dataset has no effect on the chart preview; a full page refresh is required.

**After:** The chart preview immediately reflects the updated currency after saving the dataset.

https://github.com/user-attachments/assets/4641bf0f-cdc2-4c55-b5ea-91c340e038da


### TESTING INSTRUCTIONS

1. Open an existing chart (e.g. a Big Number chart backed by a dataset with a metric).
2. In Chart Source, click **...** beside the dataset name → **Edit Dataset**.
3. Open the **Metrics** tab, expand a metric, and change its currency (e.g. from USD to EUR).
4. Save the dataset and return to the chart preview.
5. Verify the chart immediately renders with the updated currency symbol — no page refresh required.

Automated: `npx jest --testPathPatterns="datasourcesActions.test"` — all 5 tests pass, including a new test that verifies `currency_formats` is correctly derived from metric currencies when `changeDatasource` is called.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #42468
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API