### PR TITLE
fix(explore): keep derived currency formats when the datasource is replaced

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
@@ -22,12 +22,38 @@ import {
   ensureIsArray,
   getNumberFormatter,
   isSavedMetric,
+  Metric,
   QueryFormMetric,
   ValueFormatter,
 } from '@superset-ui/core';
 import { normalizeCurrency, hasMixedCurrencies } from './CurrencyFormatter';
 import { RowData, RowDataValue } from './types';
 import { AUTO_CURRENCY_SYMBOL } from './CurrencyFormats';
+
+/**
+ * Builds the metric name to currency lookup that charts use to format values.
+ *
+ * The lookup is derived client side from each metric's ``currency``, so it is
+ * easy to lose: any code path that swaps in a fresh datasource payload drops
+ * it unless it recomputes. Keeping the derivation here gives such paths one
+ * rule to call instead of each carrying its own copy.
+ *
+ * Values are passed through as the metric reports them, so they are only as
+ * precise as ``Metric['currency']`` -- an unparseable currency reaches the
+ * client as an empty object. Such entries are kept rather than filtered so
+ * that this stays byte for byte the derivation the call sites used to inline.
+ */
+export const getCurrencyFormats = (
+  metrics?: Metric[] | null,
+): Record<string, Currency> =>
+  Object.fromEntries(
+    ensureIsArray(metrics)
+      .filter(metric => !!metric.currency)
+      .map((metric): [string, Currency] => [
+        metric.metric_name,
+        metric.currency!,
+      ]),
+  );
 
 export const analyzeCurrencyInData = (
   data: RowData[],

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@superset-ui/core';
 import {
   analyzeCurrencyInData,
+  getCurrencyFormats,
   resolveAutoCurrency,
 } from '../../src/currency-format/utils';
 
@@ -411,4 +412,56 @@ test('getValueFormatter returns NumberFormatter via line 205 when AUTO resolves 
     undefined, // no data → else branch → resolvedCurrencyFormat = null
   );
   expect(formatter).toBeInstanceOf(NumberFormatter);
+});
+
+test('getCurrencyFormats maps metric names to their currency', () => {
+  expect(
+    getCurrencyFormats([
+      {
+        uuid: 'sales-uuid',
+        metric_name: 'sales',
+        currency: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      {
+        uuid: 'cost-uuid',
+        metric_name: 'cost',
+        currency: { symbol: 'EUR', symbolPosition: 'suffix' },
+      },
+    ]),
+  ).toEqual({
+    sales: { symbol: 'USD', symbolPosition: 'prefix' },
+    cost: { symbol: 'EUR', symbolPosition: 'suffix' },
+  });
+});
+
+test('getCurrencyFormats skips metrics without a currency', () => {
+  // toStrictEqual rather than toEqual: the latter ignores keys whose value is
+  // undefined, which would hide a metric that should have been filtered out.
+  expect(
+    getCurrencyFormats([
+      {
+        uuid: 'sales-uuid',
+        metric_name: 'sales',
+        currency: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      { uuid: 'count-uuid', metric_name: 'count' },
+      { uuid: 'ratio-uuid', metric_name: 'ratio', currency: null },
+    ]),
+  ).toStrictEqual({ sales: { symbol: 'USD', symbolPosition: 'prefix' } });
+});
+
+test('getCurrencyFormats keeps a currency the backend could not parse', () => {
+  // Unparseable currencies come back as `{}`. Keeping them preserves the
+  // behaviour of the derivations this helper replaced.
+  expect(
+    getCurrencyFormats([
+      { uuid: 'legacy-uuid', metric_name: 'legacy', currency: {} as Currency },
+    ]),
+  ).toStrictEqual({ legacy: {} });
+});
+
+test('getCurrencyFormats tolerates missing metrics', () => {
+  expect(getCurrencyFormats()).toStrictEqual({});
+  expect(getCurrencyFormats(null)).toStrictEqual({});
+  expect(getCurrencyFormats([])).toStrictEqual({});
 });

--- a/superset-frontend/src/explore/actions/datasourcesActions.test.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.test.ts
@@ -16,9 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DatasourceType, getClientErrorObject } from '@superset-ui/core';
+import {
+  Currency,
+  DatasourceType,
+  getClientErrorObject,
+} from '@superset-ui/core';
 import fetchMock from 'fetch-mock';
 import {
+  SET_DATASOURCE,
   setDatasource,
   changeDatasource,
   saveDataset,
@@ -60,6 +65,16 @@ const NEW_DATASOURCE = {
   description: null,
 };
 
+const USD: Currency = { symbol: 'USD', symbolPosition: 'prefix' };
+
+const DATASOURCE_WITH_CURRENCY = {
+  ...NEW_DATASOURCE,
+  metrics: [
+    { uuid: 'sales-uuid', metric_name: 'sales', currency: USD },
+    { uuid: 'count-uuid', metric_name: 'count' },
+  ],
+};
+
 const SAVE_DATASET_POST_ARGS = {
   schema: 'foo',
   sql: 'select * from bar',
@@ -80,9 +95,16 @@ test('sets new datasource', () => {
     defaultDatasourcesReducerState,
     setDatasource(NEW_DATASOURCE),
   );
-  expect(newState).toEqual({
+  expect(newState).toStrictEqual({
     ...defaultDatasourcesReducerState,
-    '2__table': NEW_DATASOURCE,
+    '2__table': { ...NEW_DATASOURCE, currency_formats: {} },
+  });
+});
+
+test('setDatasource derives currency formats from the metrics', () => {
+  expect(setDatasource(DATASOURCE_WITH_CURRENCY).datasource).toStrictEqual({
+    ...DATASOURCE_WITH_CURRENCY,
+    currency_formats: { sales: USD },
   });
 });
 
@@ -93,60 +115,46 @@ test('change datasource action', () => {
       datasource: CURRENT_DATASOURCE,
     },
   }));
-  // NEW_DATASOURCE has no metrics with currency, so currency_formats is {}
-  const expectedDatasource = { ...NEW_DATASOURCE, currency_formats: {} };
   // ignore getState type check - we dont need explore.datasource field for this test
   // @ts-expect-error
   changeDatasource(NEW_DATASOURCE)(dispatch, getState);
   expect(dispatch).toHaveBeenCalledTimes(2);
-  expect(dispatch).toHaveBeenNthCalledWith(
-    1,
-    setDatasource(expectedDatasource),
-  );
+  // Spelled out rather than reusing setDatasource(), so that the expectation
+  // cannot drift along with the implementation it is meant to pin.
+  expect(dispatch).toHaveBeenNthCalledWith(1, {
+    type: SET_DATASOURCE,
+    datasource: { ...NEW_DATASOURCE, currency_formats: {} },
+  });
   expect(dispatch).toHaveBeenNthCalledWith(
     2,
-    updateFormDataByDatasource(CURRENT_DATASOURCE, expectedDatasource),
+    updateFormDataByDatasource(CURRENT_DATASOURCE, {
+      ...NEW_DATASOURCE,
+      currency_formats: {},
+    }),
   );
 });
 
-test('changeDatasource computes currency_formats from metric currencies', () => {
+test('changeDatasource feeds both reducers the same derived datasource', () => {
+  // state.explore.datasource comes from UPDATE_FORM_DATA_BY_DATASOURCE and is
+  // what charts render from, so it has to carry the derived formats too, not
+  // just the copy stored under state.datasources.
   const dispatch = jest.fn();
   const getState = jest.fn(() => ({
     explore: { datasource: CURRENT_DATASOURCE },
   }));
-  const datasourceWithCurrencyMetric = {
-    ...NEW_DATASOURCE,
-    metrics: [
-      {
-        uuid: 'uuid-revenue',
-        metric_name: 'revenue',
-        expression: 'SUM(revenue)',
-        currency: { symbol: 'EUR', symbolPosition: 'prefix' },
-      },
-      {
-        uuid: 'uuid-cost',
-        metric_name: 'cost',
-        expression: 'SUM(cost)',
-        currency: null,
-      },
-    ],
-  };
-  const expectedDatasource = {
-    ...datasourceWithCurrencyMetric,
-    currency_formats: {
-      revenue: { symbol: 'EUR', symbolPosition: 'prefix' },
-    },
-  };
-  // @ts-expect-error
-  changeDatasource(datasourceWithCurrencyMetric)(dispatch, getState);
-  expect(dispatch).toHaveBeenNthCalledWith(
-    1,
-    setDatasource(expectedDatasource),
-  );
-  expect(dispatch).toHaveBeenNthCalledWith(
-    2,
-    updateFormDataByDatasource(CURRENT_DATASOURCE, expectedDatasource),
-  );
+  // @ts-expect-error - only explore.datasource is needed here
+  changeDatasource(DATASOURCE_WITH_CURRENCY)(dispatch, getState);
+
+  const setAction = dispatch.mock.calls[0][0];
+  const updateAction = dispatch.mock.calls[1][0];
+  expect(setAction.datasource.currency_formats).toStrictEqual({ sales: USD });
+  // Assert the value rather than only the shared reference: identity alone
+  // still holds when neither dispatch derives anything, so it would not catch
+  // a regression that drops the derivation from both paths at once.
+  expect(updateAction.newDatasource.currency_formats).toStrictEqual({
+    sales: USD,
+  });
+  expect(updateAction.newDatasource).toBe(setAction.datasource);
 });
 
 test('saveDataset handles success', async () => {

--- a/superset-frontend/src/explore/actions/datasourcesActions.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.ts
@@ -21,9 +21,9 @@ import { Dispatch, AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { Dataset } from '@superset-ui/chart-controls';
 import {
-  Currency,
   SupersetClient,
   getClientErrorObject,
+  getCurrencyFormats,
 } from '@superset-ui/core';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { updateFormDataByDatasource } from './exploreActions';
@@ -46,7 +46,15 @@ export interface SetDatasource {
   datasource: Dataset;
 }
 export function setDatasource(datasource: Dataset) {
-  return { type: SET_DATASOURCE, datasource };
+  // Derive here so that a datasource handed over straight from an API response
+  // still carries the lookup by the time it reaches the store.
+  return {
+    type: SET_DATASOURCE,
+    datasource: {
+      ...datasource,
+      currency_formats: getCurrencyFormats(datasource.metrics),
+    },
+  };
 }
 
 export function changeDatasource(newDatasource: Dataset) {
@@ -54,25 +62,12 @@ export function changeDatasource(newDatasource: Dataset) {
     const {
       explore: { datasource: prevDatasource },
     } = getState();
-    // Recompute currency_formats from the updated metrics, mirroring the
-    // logic in hydrateExplore. The raw API response does not carry this
-    // derived field, so without this step any currency change made via
-    // Edit Dataset would not be reflected in the chart preview.
-    const datasourceWithCurrencyFormats: Dataset = {
-      ...newDatasource,
-      currency_formats: Object.fromEntries(
-        (newDatasource.metrics ?? [])
-          .filter(metric => !!metric.currency)
-          .map((metric): [string, Currency] => [
-            metric.metric_name,
-            metric.currency!,
-          ]),
-      ),
-    };
-    dispatch(setDatasource(datasourceWithCurrencyFormats));
-    dispatch(
-      updateFormDataByDatasource(prevDatasource, datasourceWithCurrencyFormats),
-    );
+    // Both reducers must see the same object: ``SET_DATASOURCE`` feeds
+    // state.datasources while ``UPDATE_FORM_DATA_BY_DATASOURCE`` feeds
+    // state.explore.datasource, which is the one charts render from.
+    const action = setDatasource(newDatasource);
+    dispatch(action);
+    dispatch(updateFormDataByDatasource(prevDatasource, action.datasource));
   };
 }
 

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -342,4 +342,8 @@ test('extracts currency formats from metrics in dataset', () => {
       }),
     }),
   );
+  // The caller's object must not be written through: chart pages hydrate from
+  // a module level fallback payload, which would otherwise end up being the
+  // datasource the store holds.
+  expect(datasetWithMetrics).not.toHaveProperty('currency_formats');
 });

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -27,13 +27,13 @@ import { getChartKey } from 'src/explore/exploreUtils';
 import { getControlsState, handleDeprecatedControls } from 'src/explore/store';
 import { Dispatch } from 'redux';
 import {
-  Currency,
   DataMaskStateWithId,
   JsonObject,
   ensureIsArray,
   FeatureFlag,
   getCategoricalSchemeRegistry,
   getColumnLabel,
+  getCurrencyFormats,
   getSequentialSchemeRegistry,
   isFeatureEnabled,
   NO_TIME_RANGE,
@@ -113,15 +113,14 @@ export const hydrateExplore =
       initialFormData.dashboardId = dashboardId;
     }
 
-    const initialDatasource = dataset;
-    initialDatasource.currency_formats = Object.fromEntries(
-      (initialDatasource.metrics ?? [])
-        .filter(metric => !!metric.currency)
-        .map((metric): [string, Currency] => [
-          metric.metric_name,
-          metric.currency!,
-        ]),
-    );
+    // Derived onto a copy of ``dataset`` rather than onto the caller's object:
+    // the fallback payload used for failed chart loads is a module level
+    // constant, and writing through would make that constant itself the
+    // datasource held in the store.
+    const initialDatasource = {
+      ...dataset,
+      currency_formats: getCurrencyFormats(dataset.metrics),
+    };
 
     // Normalize deprecated controls (e.g., migrate old per-axis matrixify
     // flags to matrixify_enable) before form_data is stored in Redux state.

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -18,8 +18,13 @@
  */
 
 import exploreReducer, { ExploreState } from './exploreReducer';
-import { setStashFormData } from '../actions/exploreActions';
-import { QueryFormData } from '@superset-ui/core';
+import {
+  setStashFormData,
+  updateFormDataByDatasource,
+} from '../actions/exploreActions';
+import { setDatasource } from '../actions/datasourcesActions';
+import { Dataset } from '@superset-ui/chart-controls';
+import { Currency, DatasourceType, QueryFormData } from '@superset-ui/core';
 
 test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const initialState: ExploreState = {
@@ -38,6 +43,56 @@ test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const newState2 = exploreReducer(newState, restoreAction);
   expect(newState2.form_data).toEqual({ c: 4 });
   expect(newState2.hiddenFormData).toEqual({ a: 3 });
+});
+
+test('carries the derived currency formats into state.explore.datasource', () => {
+  // Charts render from state.explore.datasource, which this action writes, so
+  // the reducer is fed whatever setDatasource actually produced. That pins the
+  // action-to-reducer seam; datasourcesActions.test.ts pins the thunk half.
+  const usd: Currency = { symbol: 'USD', symbolPosition: 'prefix' };
+  const prevDatasource: Dataset & { uid: string } = {
+    id: 1,
+    uid: '1__table',
+    type: DatasourceType.Table,
+    columns: [],
+    metrics: [],
+    column_formats: {},
+    currency_formats: {},
+    verbose_map: {},
+    main_dttm_col: '__timestamp',
+    datasource_name: 'test datasource',
+    description: null,
+  };
+  // Shaped like an API payload: metrics carry the currency and the lookup key
+  // is absent altogether.
+  const rawDatasource: Dataset & { uid: string } = {
+    id: 2,
+    uid: '2__table',
+    type: DatasourceType.Table,
+    columns: [],
+    metrics: [{ uuid: 'sales-uuid', metric_name: 'sales', currency: usd }],
+    column_formats: {},
+    verbose_map: {},
+    main_dttm_col: '__timestamp',
+    datasource_name: 'test datasource',
+    description: null,
+  };
+  const initialState: ExploreState = {
+    form_data: { datasource: '1__table' } as unknown as QueryFormData,
+    controls: {},
+    datasource: prevDatasource,
+  };
+
+  const { datasource } = setDatasource(rawDatasource);
+  const newState = exploreReducer(
+    initialState,
+    updateFormDataByDatasource(prevDatasource, datasource) as Parameters<
+      typeof exploreReducer
+    >[1],
+  );
+
+  expect(newState.datasource?.currency_formats).toStrictEqual({ sales: usd });
+  expect(newState.form_data.datasource).toEqual('2__table');
 });
 
 test('skips updates when the field is already updated on SET_STASH_FORM_DATA', () => {

--- a/superset-frontend/src/hooks/apiResources/dashboards.ts
+++ b/superset-frontend/src/hooks/apiResources/dashboards.ts
@@ -20,7 +20,7 @@
 import rison from 'rison';
 import { Dashboard, Datasource, EmbeddedDashboard } from 'src/dashboard/types';
 import { Chart } from 'src/types/Chart';
-import { Currency } from '@superset-ui/core';
+import { getCurrencyFormats } from '@superset-ui/core';
 import { useApiV1Resource, useTransformedResource } from './apiResources';
 
 export const DASHBOARD_GET_COLUMNS = [
@@ -79,14 +79,7 @@ export const useDashboardDatasets = (idOrSlug: string | number) =>
     datasets =>
       datasets.map(dataset => ({
         ...dataset,
-        currencyFormats: Object.fromEntries(
-          (dataset.metrics ?? [])
-            .filter(metric => !!metric.currency)
-            .map((metric): [string, Currency] => [
-              metric.metric_name,
-              metric.currency!,
-            ]),
-        ),
+        currencyFormats: getCurrencyFormats(dataset.metrics),
       })),
   );
 


### PR DESCRIPTION
### SUMMARY

Editing a metric's currency through **Chart Source → Edit dataset** saves fine, but the chart keeps rendering with the old formatting until the page is fully reloaded (#42468).

`currency_formats` is a lookup of metric name to `Currency` that charts read when formatting values. The backend never sends it: it only ships `currency` on each metric, and the lookup is derived on the client. Until now that derivation happened in exactly one place, when explore first hydrates. Saving the dataset hands a fresh `GET /api/v1/dataset/{id}` payload to `changeDatasource`, that payload has no `currency_formats`, and the derived value is simply overwritten with nothing. The metric's own `d3format` survives the same round trip, because charts read it directly off `datasource.metrics`, which is why only currency appears to be ignored.

One detail worth calling out for review: charts render from `state.explore.datasource`, which is written by `UPDATE_FORM_DATA_BY_DATASOURCE`, not by `SET_DATASOURCE`. Deriving inside `setDatasource` alone therefore does not fix the bug, so `changeDatasource` now feeds both reducers the same derived object.

Changes:

- Add `getCurrencyFormats` to `@superset-ui/core`, next to `buildCustomFormatters` and `getValueFormatter`, and route the two existing inline derivations (`hydrateExplore`, `useDashboardDatasets`) through it.
- Derive in `setDatasource`, so a datasource handed over straight from an API response carries the lookup by the time it reaches the store.
- `hydrateExplore` now derives onto a copy instead of writing through to the caller's object. Chart pages hydrate from a module level fallback payload, so writing through made that constant itself the datasource held in the store.

**Why not add a `currency_formats` property on the backend?** It is a fair question, since `column_formats` is the exact structural twin (`{m.metric_name: m.d3format for m in self.metrics if m.d3format}`) and is exposed through `show_columns`. Three things argue against doing it here: `SemanticView` is a second datasource implementation where `column_formats` is currently a hardcoded placeholder, so each implementation would need its own copy; the field would have to be added to both `explore/schemas.py` and `dashboards/schemas.py`, which widens the surface and raises mixed version questions; and the dashboard side consumes a camelCase `currencyFormats`, so a snake_case server field would not be a drop in replacement. The client side fix is small and backportable, and a server side property remains a reasonable follow up.

**Known gaps, deliberately left out of scope.** Two dashboard writers of the same store slice have the same defect and are not touched here: `fetchDatasourceMetadata` (`src/dashboard/actions/datasources.ts`) on a store miss, and `saveDashboardRequest` (`src/dashboard/actions/dashboardState.ts`) after saving dashboard properties. Both are reachable and both drop the lookup. I kept this PR to the explore path the issue reports, and will file a follow up for the dashboard side.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Verified end to end on a locally built image, with a Big Number chart on a metric configured as USD, changing the currency to EUR through Edit dataset and **not** reloading the page:

| | before edit | after saving, no reload |
|---|---|---|
| master | `$ 10,032,628.85` | `10,032,628.85` |
| this PR | `$ 10,032,628.85` | `€ 10,032,628.85` |

On master the symbol disappears entirely rather than staying stale, which matches the root cause: the lookup is gone, so the formatter falls back to plain numbers.

### TESTING INSTRUCTIONS

1. Pick any dataset and give one metric a currency (Edit dataset → Metrics → Metric currency), for example `$ (USD)` with a `,.2f` D3 format.
2. Build a Big Number chart on that metric. It renders with the currency symbol.
3. In explore, open **Chart Source → ⋯ → Edit dataset → Metrics**, expand the same metric, change **Metric currency** to `€ (EUR)`, and save.
4. Without reloading the page, the value should immediately render with the new symbol. On master it loses its symbol until a full reload.

Unit tests: `npm run test -- src/explore/actions src/explore/reducers packages/superset-ui-core/test/currency-format src/hooks/apiResources/dashboards`.

Each production hunk was mutation checked: reverting the derivation in `setDatasource`, the object sharing in `changeDatasource`, the copy in `hydrateExplore`, or the filter in `getCurrencyFormats` turns at least one test red.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #42468
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
