### PR TITLE
fix(reports): prevent bad-date crontab from crashing the report scheduler for all tenants

### DIFF
--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 
-from croniter import croniter
+from croniter import croniter, CroniterBadDateError
 from flask import current_app
 from pytz import timezone as pytz_timezone, UnknownTimeZoneError
 
@@ -42,8 +42,15 @@ def cron_schedule_window(
     start_at = time_now - timedelta(seconds=window_size / 2)
     stop_at = time_now + timedelta(seconds=window_size / 2)
     crons = croniter(cron, start_at)
-    for schedule in crons.all_next(datetime):
-        if schedule >= stop_at:
-            break
-        # convert schedule back to utc
-        yield schedule.astimezone(utc).replace(tzinfo=None)
+    try:
+        for schedule in crons.all_next(datetime):
+            if schedule >= stop_at:
+                break
+            # convert schedule back to utc
+            yield schedule.astimezone(utc).replace(tzinfo=None)
+    except CroniterBadDateError:
+        logger.error(
+            "Cron schedule %s can never match a valid date; "
+            "it will not produce any executions",
+            cron,
+        )

--- a/tests/unit_tests/tasks/test_cron_util.py
+++ b/tests/unit_tests/tasks/test_cron_util.py
@@ -235,3 +235,24 @@ def test_cron_schedule_window_chicago_daylight(
     assert (
         list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected  # noqa: C400
     )
+
+
+@pytest.mark.parametrize(
+    "current_dttm, cron, expected",
+    [
+        ("2020-01-01T08:59:01+00:00", "0 0 30 2 *", []),
+        ("2020-01-01T08:59:01+00:00", "0 0 31 4 *", []),
+    ],
+)
+def test_cron_schedule_window_invalid_cron_date(
+    current_dttm: str, cron: str, expected: list[FakeDatetime]
+) -> None:
+    """
+    Reports scheduler: Test cron schedule window for a cron that is
+    syntactically valid but can never match a real calendar date
+    """
+
+    datetimes = cron_schedule_window(datetime.fromisoformat(current_dttm), cron, "UTC")
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected  # noqa: C400
+    )


### PR DESCRIPTION
### SUMMARY
A crontab expression that's syntactically valid but can never match a real calendar date (e.g. `0 0 30 2 *` for Feb 30th, or `0 0 31 4 *` for April 31st — April only has 30 days) passes API schema validation on report/alert create/update, because `superset/reports/schemas.py::validate_crontab()` only checks `croniter.is_valid()`, which is a purely syntactic check.

Once such a schedule is saved as active, the celery-beat task `reports.scheduler` (`superset/tasks/scheduler.py`) iterates over **every** active `ReportSchedule` and calls `cron_schedule_window()` (`superset/tasks/cron_util.py`) for each, with no per-schedule isolation:

```python
for active_schedule in active_schedules:
    for schedule in cron_schedule_window(
        triggered_at, active_schedule.crontab, active_schedule.timezone
    ):
```

Inside `cron_schedule_window`, iterating `crons.all_next(datetime)` raises `croniter.CroniterBadDateError` for a bad-date cron (croniter's internal max-year search gives up), uncaught anywhere in the chain. Because the loop has no per-schedule isolation, **one** report/alert with a bad-but-syntactically-valid crontab crashes the scheduler task for every other active schedule too — on every celery-beat tick, across the whole instance — until someone finds and fixes/deletes the offending schedule directly in the database.

### PROBLEM
```pycon
>>> from croniter import croniter
>>> from datetime import datetime, timezone
>>> croniter.is_valid("0 0 30 2 *")
True
>>> next(iter(croniter("0 0 30 2 *", datetime(2026, 7, 27, tzinfo=timezone.utc)).all_next(datetime)))
croniter.croniter.CroniterBadDateError: failed to find next date
```
`CroniterBadDateError` is a subclass of `CroniterError`, itself a subclass of `ValueError` — a raw library exception with no Superset-level handling on this path.

### FIX
`cron_schedule_window()` already has an established precedent for degrading gracefully on bad per-schedule input a few lines above this bug: it catches `UnknownTimeZoneError` for an invalid timezone string and falls back to UTC with a `logger.warning`. This PR follows the same convention for the cron expression itself: the `crons.all_next(datetime)` iteration is now wrapped in `try/except CroniterBadDateError`, logging an error (this case is not a graceful degrade like the timezone fallback — it means the schedule can never fire until someone fixes it, so it's logged loudly) and letting the generator end instead of propagating and crashing the whole scheduler run.

This is a background celery-task loop, not an HTTP request/response path, so there's no 4xx/500 status to map to — the fix intentionally does not introduce a new `superset/exceptions.py` subclass (unlike the API-layer fixes in the related PRs below).

### TESTING INSTRUCTIONS
New parametrized test `test_cron_schedule_window_invalid_cron_date` added to `tests/unit_tests/tasks/test_cron_util.py`, covering `"0 0 30 2 *"` (Feb 30th) and `"0 0 31 4 *"` (April 31st), asserting `cron_schedule_window()` returns `[]` instead of raising.

Verified empirically both ways:
- **Pre-fix** (fix stashed, test kept): both new cases fail with an uncaught `croniter.croniter.CroniterBadDateError: failed to find next date` propagating out of the test.
- **Post-fix**: full `tests/unit_tests/tasks/test_cron_util.py` — 36 passed, no regressions to the timezone-fallback or normal-schedule cases.

`ruff check` / `ruff format --check` clean on both changed files (verified against both the repo's ambient ruff and the CI-pinned `ruff==0.9.7` via `uvx`). `mypy` shows the same pre-existing missing-stub errors (`croniter`, `pytz`, `freezegun.api.FakeDatetime`) before and after — no new errors introduced.

### Tradeoffs
Additive-only: a cron that can never fire now logs an error and produces zero scheduled executions instead of crashing the whole scheduler task. No change to the failure mode for any valid crontab.

### ADDITIONAL INFORMATION
Same bug class / cleanup series as apache/superset#42366, apache/superset#42401, apache/superset#42426, apache/superset#42442 (raw system/library exception reaching a live code path instead of being handled) — this one surfaces in the report-scheduling background task rather than an API request path.

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API