### PR TITLE
ci: use astral-sh/setup-uv to speed up backend CI

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Python version to set up. Accepts a version number, "current", or "next".'
     required: true
     default: 'current'
-  cache:
-    description: 'Cache dependencies. Options: pip'
-    required: false
-    default: 'pip'
   requirements-type:
     description: 'Type of requirements to install. Options: base, development, default'
     required: false
@@ -43,7 +39,12 @@ runs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
-        cache: ${{ inputs.cache }}
+    - name: Install uv
+      if: inputs.install-superset == 'true'
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        python-version: ${{ steps.set-python-version.outputs.python-version }}
+        enable-cache: true
     - name: Install dependencies
       env:
         INPUT_INSTALL_SUPERSET: ${{ inputs.install-superset }}
@@ -51,8 +52,6 @@ runs:
       run: |
         if [ "$INPUT_INSTALL_SUPERSET" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
-
-          pip install --upgrade pip setuptools wheel uv
 
           if [ "$INPUT_REQUIREMENTS_TYPE" = "dev" ]; then
             uv pip install --system -r requirements/development.txt

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -45,7 +45,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        run: pip install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: supersetbot bump-python -p "${{ github.event.inputs.package }}"
         env:


### PR DESCRIPTION
### SUMMARY
`setup-backend` (the composite action used in 17 job steps across 13 workflows) bootstrapped `uv` on every single run via `pip install --upgrade pip setuptools wheel uv`, and only cached pip's download dir through `actions/setup-python`'s `cache: pip`. Since pip wasn't doing the actual dependency installs (uv was, via `uv pip install --system ...`), that cache wasn't buying us anything -- we were paying to re-bootstrap uv from scratch, and re-resolve/re-download every wheel, on every job.

This swaps that bootstrap for [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv), which:
- ships a prebuilt `uv` binary instead of installing it through pip
- persists uv's own resolution/wheel cache in the GitHub Actions cache (`enable-cache: true`), keyed by default on `requirements/*.txt` and `pyproject.toml`

Also drops the `pip install --upgrade pip setuptools wheel` step entirely -- uv's build isolation installs whatever a package's build backend declares (our `pyproject.toml` already declares `setuptools`/`wheel` under `[build-system]`), so nothing needs to be preinstalled in the target environment for that anymore.

Same swap applied to the standalone `pip install uv` bootstrap in `bump-python-package.yml`, which doesn't go through `setup-backend`.

One wrinkle: `setup-backend` is also called with `install-superset: "false"` (helm chart linting), which skips all `uv pip install` calls. With caching enabled and nothing installed, there's nothing for uv to cache, and `setup-uv` fails the job by default in that case ("Cache path ... does not exist on disk"). So the new `Install uv` step is gated on `install-superset == 'true'`.

### TESTING INSTRUCTIONS
- Ran the full local test suite for the two touched YAML files through `action-validator`/`zizmor` via `pre-commit run` -- both pass.
- CI on this PR exercises `setup-backend` across most of its 17 call sites (unit tests, integration tests, e2e, presto/hive, pre-commit, translations, etc.) -- green CI here is the real validation that the composite action still behaves identically.
- Manually traced through `pyproject.toml`'s `[build-system]` table to confirm dropping the `pip install --upgrade pip setuptools wheel` step is safe for editable installs (`-e .`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API