### PR TITLE
ci: speed up backend CI with astral-sh/setup-uv and apt package caching

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -45,14 +45,18 @@ runs:
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
         enable-cache: true
+    - name: Install apt packages
+      if: inputs.install-superset == 'true'
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+      with:
+        packages: libldap2-dev libsasl2-dev
+        version: 1.0
     - name: Install dependencies
       env:
         INPUT_INSTALL_SUPERSET: ${{ inputs.install-superset }}
         INPUT_REQUIREMENTS_TYPE: ${{ inputs.requirements-type }}
       run: |
         if [ "$INPUT_INSTALL_SUPERSET" = "true" ]; then
-          sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
-
           if [ "$INPUT_REQUIREMENTS_TYPE" = "dev" ]; then
             uv pip install --system -r requirements/development.txt
           elif [ "$INPUT_REQUIREMENTS_TYPE" = "base" ]; then

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Python version to set up. Accepts a version number, "current", or "next".'
     required: true
     default: 'current'
-  cache:
-    description: 'Cache dependencies. Options: pip'
-    required: false
-    default: 'pip'
   requirements-type:
     description: 'Type of requirements to install. Options: base, development, default'
     required: false
@@ -43,7 +39,12 @@ runs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
-        cache: ${{ inputs.cache }}
+    - name: Install uv
+      if: inputs.install-superset == 'true'
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        python-version: ${{ steps.set-python-version.outputs.python-version }}
+        enable-cache: true
     - name: Install dependencies
       env:
         INPUT_INSTALL_SUPERSET: ${{ inputs.install-superset }}
@@ -51,8 +52,6 @@ runs:
       run: |
         if [ "$INPUT_INSTALL_SUPERSET" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
-
-          pip install --upgrade pip setuptools wheel uv
 
           if [ "$INPUT_REQUIREMENTS_TYPE" = "dev" ]; then
             uv pip install --system -r requirements/development.txt

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -45,6 +45,13 @@ runs:
       with:
         python-version: ${{ steps.set-python-version.outputs.python-version }}
         enable-cache: true
+    - name: Update apt package lists
+      # cache-apt-pkgs-action assumes a fresh `apt-cache` index (true on GitHub-hosted
+      # runners, not on all self-hosted/custom runner images), so refresh it explicitly
+      # or package lookups silently resolve to an empty list.
+      if: inputs.install-superset == 'true'
+      shell: bash
+      run: sudo apt-get update
     - name: Install apt packages
       if: inputs.install-superset == 'true'
       uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -45,7 +45,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        run: pip install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: supersetbot bump-python -p "${{ github.event.inputs.package }}"
         env:

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           packages: graphviz
           version: 1.0
+          execute_install_scripts: true
       - name: Compute Entity Relationship diagram (ERD)
         env:
           SUPERSET_SECRET_KEY: not-a-secret

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -81,7 +81,10 @@ jobs:
           distribution: "zulu"
           java-version: "21"
       - name: Install Graphviz
-        run: sudo apt-get install -y graphviz
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: graphviz
+          version: 1.0
       - name: Compute Entity Relationship diagram (ERD)
         env:
           SUPERSET_SECRET_KEY: not-a-secret

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -78,7 +78,10 @@ jobs:
 
       - name: Install gettext tools
         if: steps.check.outputs.python == 'true' || steps.check.outputs.frontend == 'true'
-        run: sudo apt-get update && sudo apt-get install -y gettext
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: gettext
+          version: 1.0
 
       # Fetch the base ref so we can compare PR-introduced regressions
       # against a fair baseline (also runs babel_update against the base


### PR DESCRIPTION
### SUMMARY
Two related CI speedups, now combined in this PR (#42499 was merged in on top):

**1. astral-sh/setup-uv** -- `setup-backend` (the composite action used in 17 job steps across 13 workflows) bootstrapped `uv` on every single run via `pip install --upgrade pip setuptools wheel uv`, and only cached pip's download dir through `actions/setup-python`'s `cache: pip`. Since pip wasn't doing the actual dependency installs (uv was, via `uv pip install --system ...`), that cache wasn't buying us anything -- we were paying to re-bootstrap uv from scratch, and re-resolve/re-download every wheel, on every job.

This swaps that bootstrap for [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv), which:
- ships a prebuilt `uv` binary instead of installing it through pip
- persists uv's own resolution/wheel cache in the GitHub Actions cache (`enable-cache: true`), keyed by default on `requirements/*.txt` and `pyproject.toml`

Also drops the `pip install --upgrade pip setuptools wheel` step entirely -- uv's build isolation installs whatever a package's build backend declares (our `pyproject.toml` already declares `setuptools`/`wheel` under `[build-system]`), so nothing needs to be preinstalled in the target environment for that anymore.

Same swap applied to the standalone `pip install uv` bootstrap in `bump-python-package.yml`, which doesn't go through `setup-backend`.

One wrinkle: `setup-backend` is also called with `install-superset: "false"` (helm chart linting), which skips all `uv pip install` calls. With caching enabled and nothing installed, there's nothing for uv to cache, and `setup-uv` fails the job by default in that case ("Cache path ... does not exist on disk"). So the new `Install uv` step is gated on `install-superset == 'true'`.

**2. awalsh128/cache-apt-pkgs-action** -- `setup-backend` also ran `sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev` unconditionally, on every one of its 17 call sites, on every push. `apt-get update` alone is real per-job network/registry-sync tax paid regardless of whether the package list has ever changed.

[awalsh128/cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action) caches the resolved `.deb` archives (keyed on the package list + version + architecture) and reinstalls straight from the GitHub Actions cache on a hit, skipping `apt-get update` and the download entirely.

Same shape, same fix, applied to two other one-off `apt-get` installs that had the identical unconditional-update pattern:
- `gettext` in `superset-translations.yml`
- `graphviz` in `superset-docs-deploy.yml`

Didn't touch `setup-docker`'s `docker-compose-plugin` install -- that one adds a whole new apt repository (with a GPG key import) before installing, which doesn't map cleanly onto this action's package-cache model, and felt like a separate, riskier change to bundle in here.

### TESTING INSTRUCTIONS
- `pre-commit run` (`action-validator` via the GHA schema check, `zizmor` GHA security audit) passes on all touched files.
- CI on this PR exercises `setup-backend` across most of its 17 call sites (unit tests, integration tests, e2e, presto/hive, pre-commit, translations, helm lint, etc.) -- green CI here is the real validation that the composite action still behaves identically, just faster on cache hits.
- Manually traced through `pyproject.toml`'s `[build-system]` table to confirm dropping the `pip install --upgrade pip setuptools wheel` step is safe for editable installs (`-e .`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API