### PR TITLE
ci: run pre-commit checks via prek

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,7 +61,6 @@ jobs:
       - name: Install prek
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.11/prek-installer.sh | sh
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,11 +12,6 @@ on:
   # importing test) can pass every PR yet leave master red. This catches that.
   schedule:
     - cron: "0 6 * * *"
-  # Spike-only: lets us force a full --all-files run on demand (workflow_dispatch
-  # has no diffable base, so "Determine changed files" below falls back to
-  # mode=all) to validate prek against the whole tree without waiting for the
-  # nightly cron. Remove if/when this spike is promoted or dropped.
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,11 @@ on:
   # importing test) can pass every PR yet leave master red. This catches that.
   schedule:
     - cron: "0 6 * * *"
+  # Spike-only: lets us force a full --all-files run on demand (workflow_dispatch
+  # has no diffable base, so "Determine changed files" below falls back to
+  # mode=all) to validate prek against the whole tree without waiting for the
+  # nightly cron. Remove if/when this spike is promoted or dropped.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Install helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
 
+      # Spike: run the existing .pre-commit-config.yaml through prek (a Rust
+      # reimplementation of pre-commit) instead of pre-commit itself, to see
+      # whether it's viable to speed up this job. CI-only — contributors keep
+      # installing/running `pre-commit` locally exactly as documented; nothing
+      # here changes that.
+      - name: Install prek
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.11/prek-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -70,13 +80,13 @@ jobs:
           cd docs
           yarn install --immutable
 
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-v2-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: prek-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            pre-commit-v2-${{ runner.os }}-py${{ matrix.python-version }}-
+            prek-v1-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Determine changed files
         id: changed_files
@@ -142,7 +152,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - name: pre-commit
+      - name: pre-commit (via prek)
         env:
           MODE: ${{ steps.changed_files.outputs.mode }}
           CHANGED_FILES: ${{ steps.changed_files.outputs.files }}
@@ -152,22 +162,22 @@ jobs:
 
           case "${MODE}" in
             all)
-              echo "ℹ️ Running pre-commit on all files."
-              pre-commit run --all-files
+              echo "ℹ️ Running prek on all files."
+              prek run --all-files
               ;;
             files)
-              echo "ℹ️ Running pre-commit on changed files:"
+              echo "ℹ️ Running prek on changed files:"
               echo "${CHANGED_FILES}"
               # shellcheck disable=SC2086
-              pre-commit run --files ${CHANGED_FILES}
+              prek run --files ${CHANGED_FILES}
               ;;
             none)
-              echo "ℹ️ No source files changed; nothing for pre-commit to check."
+              echo "ℹ️ No source files changed; nothing for prek to check."
               exit 0
               ;;
             *)
               echo "⚠️ Unrecognized changed-files mode '${MODE}'; checking all files."
-              pre-commit run --all-files
+              prek run --all-files
               ;;
           esac
           PRE_COMMIT_EXIT_CODE=$?


### PR DESCRIPTION
### SUMMARY
Spike/experiment for maintainer discussion — not asking anyone to bless prek as the permanent tool yet, just sharing a validated result.

[prek](https://github.com/j178/prek) is a Rust reimplementation of `pre-commit` that reads the same `.pre-commit-config.yaml` unmodified, shares toolchains/environments across hooks instead of building a fresh venv per repo, and is already used in CI by CPython, FastAPI, and Apache Airflow.

This PR swaps only the binary this workflow invokes — same changed-files diffing logic, same `SKIP` handling, same fail-closed behavior, just `prek run` instead of `pre-commit run`, plus repointing the environment cache from `~/.cache/pre-commit` to `~/.cache/prek`.

**Explicitly out of scope:** anything contributor-facing. `pre-commit install` / `pre-commit run` locally, `requirements/development.txt`, and the contributing docs are all untouched. If this pans out, adopting prek locally (optionally via its `pre-commit`-shim install mode, so the command contributors already type keeps working) would be a separate, later decision — we don't want to disrupt the pattern people are already used to.

### VALIDATION
Ran this PR's own `pre-commit checks` job twice against real CI (not just locally):

1. **Per-PR changed-files mode** (this PR's own diff, cold `~/.cache/prek`): lint step ran in **4s**. Three recent baseline `pre-commit` runs on master (warm `~/.cache/pre-commit`) took 2s–54s for the equivalent step. https://github.com/apache/superset/actions/runs/30329626124

2. **Full `--all-files` sweep** (temporarily added `workflow_dispatch`, ran it, then removed it — see commit history): mypy + everything else across the whole tree, cold cache: **95s (Python 3.11) / 110s (3.12)**. The most recent nightly `pre-commit` full sweep (warm cache) took 102s/114s for the same step. https://github.com/apache/superset/actions/runs/30330021867

So: prek matched-or-beat pre-commit's *warm-cache* time while running from a completely cold cache, on both a small-diff run and a full-tree run including mypy. All 23 hooks in `.pre-commit-config.yaml` — `repo:` mirrors, `language: system` local hooks, and `language: python` hooks with `additional_dependencies` — resolved and ran correctly.

### TESTING INSTRUCTIONS
See the two CI runs linked above. To reproduce: check out this branch, `prek run --all-files` (after `cargo install prek` / `brew install prek` / etc.) against the unmodified `.pre-commit-config.yaml`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API