### PR TITLE
chore(ci): swap linkinator-action for lychee-action in docs link checker

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  linkinator:
-    # See docs here: https://github.com/marketplace/actions/linkinator
+  lychee:
+    # See docs here: https://github.com/lycheeverse/lychee-action
     # Only run on pull_request, not workflow_run
     if: github.event_name == 'pull_request'
     name: Link Checking
@@ -31,37 +31,50 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # Do not bump this linkinator-action version without opening
+      # Restores the on-disk request cache (.lycheecache) lychee writes when
+      # `--cache` is set, so re-runs don't re-check every external link from
+      # scratch. Key never matches exactly (github.run_id is unique per run),
+      # so actions/cache always saves a fresh copy afterwards; restore-keys
+      # falls back to the most recent prior cache on lookup.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .lycheecache
+          key: lychee-cache-${{ github.run_id }}
+          restore-keys: lychee-cache-
+      # Do not bump this lychee-action version without opening
       # an ASF Infra ticket to allow the new version first!
-      - uses: JustinBeckwith/linkinator-action@af984b9f30f63e796ae2ea5be5e07cb587f1bbd9 # v2.3
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         continue-on-error: true # This will make the job advisory (non-blocking, no red X)
         with:
-          paths: "**/*.md, **/*.mdx"
-          linksToSkip: >-
-            ^https://github.com/apache/(superset|incubator-superset)/(pull|issues)/\d+,
-            ^https://github.com/apache/(superset|incubator-superset)/commit/[a-f0-9]+,
-            superset-frontend/.*CHANGELOG\.md,
-            http://localhost:8088/,
-            http://127.0.0.1:3000/,
-            http://localhost:9001/,
-            https://charts.bitnami.com/bitnami,
-            https://www.li.me/,
-            https://www.fanatics.com/,
-            https://tails.com/gb/,
-            https://www.techaudit.info/,
-            https://avetilearning.com/,
-            https://www.udemy.com/,
-            https://trustmedis.com/,
-            http://theiconic.com.au/,
-            https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html,
-            ^https://img\.shields\.io/.*,
-            https://vkusvill.ru/,
-            https://www.linkedin.com/in/mark-thomas-b16751158/,
-            https://theiconic.com.au/,
-            https://wattbewerb.de/,
-            https://timbr.ai/,
-            https://opensource.org/license/apache-2-0,
-            https://www.plaidcloud.com/
+          fail: false
+          args: >-
+            --verbose --no-progress
+            --cache --max-cache-age 7d
+            --exclude '^https://github.com/apache/(superset|incubator-superset)/(pull|issues)/\d+'
+            --exclude '^https://github.com/apache/(superset|incubator-superset)/commit/[a-f0-9]+'
+            --exclude 'superset-frontend/.*CHANGELOG\.md'
+            --exclude 'http://localhost:8088/'
+            --exclude 'http://127.0.0.1:3000/'
+            --exclude 'http://localhost:9001/'
+            --exclude 'https://charts.bitnami.com/bitnami'
+            --exclude 'https://www.li.me/'
+            --exclude 'https://www.fanatics.com/'
+            --exclude 'https://tails.com/gb/'
+            --exclude 'https://www.techaudit.info/'
+            --exclude 'https://avetilearning.com/'
+            --exclude 'https://www.udemy.com/'
+            --exclude 'https://trustmedis.com/'
+            --exclude 'http://theiconic.com.au/'
+            --exclude 'https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html'
+            --exclude '^https://img\.shields\.io/.*'
+            --exclude 'https://vkusvill.ru/'
+            --exclude 'https://www.linkedin.com/in/mark-thomas-b16751158/'
+            --exclude 'https://theiconic.com.au/'
+            --exclude 'https://wattbewerb.de/'
+            --exclude 'https://timbr.ai/'
+            --exclude 'https://opensource.org/license/apache-2-0'
+            --exclude 'https://www.plaidcloud.com/'
+            './**/*.md' './**/*.mdx'
 
   build-on-pr:
     # Build docs when PR changes docs/** (uses committed databases.json)

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -41,10 +41,11 @@ jobs:
           path: .lycheecache
           key: lychee-cache-${{ github.run_id }}
           restore-keys: lychee-cache-
-      # v2.8.0 is the version ASF Infra has allowlisted for this org. Do not
-      # bump this lychee-action version without opening an Infra ticket to
-      # allow the new version first!
-      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+      # v2.8.0 and v2.9.0 are both on ASF Infra's action allowlist
+      # (apache/infrastructure-actions approved_patterns.yml) as of this
+      # writing. Do not bump past v2.9.0 without opening an Infra ticket
+      # to allow the new SHA first!
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         continue-on-error: true # This will make the job advisory (non-blocking, no red X)
         with:
           fail: false

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -41,9 +41,10 @@ jobs:
           path: .lycheecache
           key: lychee-cache-${{ github.run_id }}
           restore-keys: lychee-cache-
-      # Do not bump this lychee-action version without opening
-      # an ASF Infra ticket to allow the new version first!
-      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+      # v2.8.0 is the version ASF Infra has allowlisted for this org. Do not
+      # bump this lychee-action version without opening an Infra ticket to
+      # allow the new version first!
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         continue-on-error: true # This will make the job advisory (non-blocking, no red X)
         with:
           fail: false


### PR DESCRIPTION
### SUMMARY

Swaps `JustinBeckwith/linkinator-action` for `lycheeverse/lychee-action` in the docs "Link Checking" job (`superset-docs-verify.yml`). lychee is a Rust link checker with real on-disk caching support, and handles a docs site the size of ours (a lot of `.md`/`.mdx` under `docs/`) noticeably better than linkinator in practice.

What changed:
- Pinned to `lychee-action` **v2.9.0** (`e7477775783ea5526144ba13e8db5eec57747ce8`). Checked `apache/infrastructure-actions`' `approved_patterns.yml` directly (the actual source of truth for the org's action allowlist): both v2.8.0 and v2.9.0 are already present, so no Infra ticket is needed here at all. (An earlier revision of this PR pinned to v2.8.0 on the assumption only that SHA was allowed — that assumption was wrong, corrected back to the newer tag.)
- All 24 `linksToSkip` regex patterns carried over 1:1 as `--exclude` flags (diffed programmatically against the old list, not just eyeballed, to make sure nothing got dropped or reworded in translation).
- Added an `actions/cache` step to persist `.lycheecache` (lychee's own request cache, enabled via `--cache`) across CI runs — `linkinator-action` has no equivalent, so every run previously re-checked every external link from cold. Keyed on `github.run_id` with a prefix `restore-keys` fallback, so every run saves a fresh cache while always restoring the nearest prior one. `--max-cache-age 7d` keeps entries from going stale forever.
- Job stays fully advisory, same as before: `continue-on-error: true` plus lychee-action's own `fail: false`.
- Job key renamed `linkinator` → `lychee`; the **display name** ("Link Checking") is unchanged, so this shouldn't touch branch protection if anything matches on it.

### On `.mdx` handling

An earlier revision of this PR claimed lychee falls back to generic best-effort link extraction for `.mdx` (going only off the README's one-line summary: "supports HTML and Markdown... falls back to plain text" for anything else). That was wrong — checked `lychee-lib/src/types/file.rs` directly, and `.mdx` is one of ten extensions in `FileType::MARKDOWN_EXTENSIONS` (along with `md`, `markdown`, `qmd`, `rmd`, and others), with lychee's own test suite asserting `FileType::from("foo.mdx") == FileType::Markdown`. So `.mdx` gets the same real markdown link-extraction path as `.md` in both tools. No coverage regression there.

### Future version bumps

v2.8.0 and v2.9.0 are both already allowlisted as of this writing. Bumping past v2.9.0 later will need an ASF Infra ticket to add the new SHA to the org's allowlist first, same as this file already required for `linkinator-action` bumps.

### TESTING INSTRUCTIONS

1. Confirm CI's "Link Checking" job runs and produces a job summary.
2. Spot-check that a known-broken link still gets flagged, and that a couple of the excluded domains (e.g. `localhost:8088`) are still silently skipped.
3. Confirm a second run restores the `.lycheecache` cache (visible in the job's cache-restore log line) rather than re-checking every link cold.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
