### PR TITLE
feat(ci): publish Python unit test results as PR check annotations

### DIFF
--- a/.github/workflows/superset-python-unittest-report.yml
+++ b/.github/workflows/superset-python-unittest-report.yml
@@ -1,0 +1,65 @@
+name: Python Unit Test Results
+
+on:
+  # zizmor: ignore[dangerous-triggers] - runs in base-branch context and only consumes artifacts uploaded by Python-Unit; never checks out PR code (see note below)
+  workflow_run:
+    workflows: ["Python-Unit"]
+    types: [completed]
+
+# This workflow publishes a check run annotating failing Python unit tests
+# inline on the PR diff, using JUnit XML uploaded by the Python-Unit workflow.
+# It uses the workflow_run trigger so that it always runs in the base-branch
+# context and can safely be granted write permissions, even for PRs from
+# forks or Dependabot.
+#
+# IMPORTANT: This workflow must NEVER check out code from the PR branch. All
+# data comes from artifacts uploaded by the Python-Unit workflow.
+permissions:
+  contents: read
+  checks: write
+  issues: read
+  actions: read
+
+jobs:
+  report:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    if: >
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      # Fails soft (continue-on-error) because the source unit-tests job is
+      # itself gated on change detection: a docs-only PR skips it entirely,
+      # so there is nothing to download or report on.
+      - name: Download JUnit results
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: "junit-results-*"
+          path: artifacts
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download event file
+        id: download-event
+        if: steps.download.outcome == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: "Event File"
+          path: event
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish test results
+        if: steps.download.outcome == 'success' && steps.download-event.outcome == 'success'
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"
+          check_name: "Python Unit Test Results"
+          comment_mode: "off"

--- a/.github/workflows/superset-python-unittest-report.yml
+++ b/.github/workflows/superset-python-unittest-report.yml
@@ -36,9 +36,14 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          # merge-multiple is intentionally omitted: each matrix leg's
+          # artifact (junit-results-current, junit-results-next) uses the
+          # same XML filenames, so merging them into one directory would let
+          # one Python version's results overwrite the other's. Downloading
+          # into per-artifact subdirectories keeps both, and the glob below
+          # is recursive so it still picks up every XML file.
           pattern: "junit-results-*"
           path: artifacts
-          merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -74,14 +74,14 @@ jobs:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
-          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50
+          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50 --junit-xml=test-results/junit-unit.xml
       - name: Python 100% coverage unit tests
         env:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
-          pytest --durations-min=0.5 --cov=superset/sql/ ./tests/unit_tests/sql/ --cache-clear --cov-fail-under=100
-          pytest --durations-min=0.5 --cov=superset/semantic_layers/ ./tests/unit_tests/semantic_layers/ --cache-clear --cov-fail-under=100
+          pytest --durations-min=0.5 --cov=superset/sql/ ./tests/unit_tests/sql/ --cache-clear --cov-fail-under=100 --junit-xml=test-results/junit-sql-coverage.xml
+          pytest --durations-min=0.5 --cov=superset/semantic_layers/ ./tests/unit_tests/semantic_layers/ --cache-clear --cov-fail-under=100 --junit-xml=test-results/junit-semantic-layers-coverage.xml
       - name: Upload code coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -89,6 +89,33 @@ jobs:
           verbose: true
           use_oidc: true
           slug: apache/superset
+      # Uploaded even when a pytest step above fails, since that is exactly
+      # when the JUnit results are needed downstream, to annotate the PR with
+      # the failing tests. Consumed by the "Python Unit Test Results" workflow
+      # via workflow_run (see that workflow for why it can't just be a step
+      # here: it needs to run with write permissions, which this PR-triggered
+      # job can't safely have on a fork PR).
+      - name: Upload JUnit test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: junit-results-${{ matrix.python-version }}
+          path: test-results/
+          retention-days: 7
+
+  # Uploads the raw pull_request event payload so the "Python Unit Test
+  # Results" workflow (running via workflow_run, in base-branch context) can
+  # look up which PR/commit to annotate without checking out untrusted code.
+  event-file:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    steps:
+      - name: Upload event file
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+          retention-days: 7
 
   # Stable required-status-check anchor. `unit-tests` is a matrix job gated on
   # change detection, so on non-Python PRs it is skipped and never produces its


### PR DESCRIPTION
### SUMMARY
Right now a red check on Python-Unit just means scrolling raw pytest logs to find which test broke. This wires up EnricoMi/publish-unit-test-result-action so failing tests get annotated inline on the PR diff instead.

pytest already writes JUnit XML for free via `--junit-xml`, so I added that to all three pytest invocations in the `unit-tests` job (the main suite and the two 100%-coverage sub-suites) and upload the results as an artifact, even on failure since that's exactly when it matters. A second workflow publishes the check run, triggered via `workflow_run` so it always runs in the base-branch context and can safely hold `checks:write` even for fork or Dependabot PRs, without ever checking out PR code. Same pattern this repo already uses for the translation-regression bot.

Scoped to Python-Unit only for now. Jest's 8-way shard and the Python integration matrix (3 DBs + presto/hive) seem like natural follow-ups once this pattern proves out, figured it's better to land something small first.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, CI-only change.

### TESTING INSTRUCTIONS
`zizmor` and `pre-commit` both pass clean on the changed/new workflow files.

One thing worth flagging: the second workflow won't actually fire on this PR itself. `workflow_run` only triggers once both files are on `master`, so the check run won't show up until after merge, same deal as the existing translation-regression-comment workflow. Once merged, any PR touching Python code should get a "Python Unit Test Results" check with per-test annotations on failure.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
