### PR TITLE
feat(ci): auto-label PRs with merge conflicts using requires:rebase

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,45 @@
+name: Label Merge Conflicts
+
+# Sweeps every open PR and labels the ones GitHub reports as CONFLICTING with
+# `requires:rebase` (removing it once a rebase makes the PR mergeable again),
+# so the label can be used to filter the PR backlog for the ones that need a
+# rebase before they can be reviewed/merged.
+#
+# The action itself always re-checks *every* open PR via GraphQL on each run
+# regardless of what triggered it (see eps1lon/actions-label-merge-conflict's
+# sources/main.ts) - there's no way to scope it to "just this PR". The
+# project's own README suggests triggering on `push` (to the default branch)
+# plus `pull_request_target: [synchronize]`, but on a repo with Superset's PR
+# volume that combination would re-sweep the entire open-PR list on every
+# merge to master *and* every push to *any* open PR - many times an hour.
+# A schedule bounds that to a fixed, predictable cadence instead; adjust it
+# if 2 hours turns out to be too slow or too chatty in practice.
+on:
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-merge-conflicts:
+    # Scheduled/dispatch workflows still run on forks that carry this file;
+    # skip anywhere but the canonical repo.
+    if: github.repository == 'apache/superset'
+    name: Label Merge Conflicts
+    runs-on: ubuntu-latest
+    steps:
+      # Do not bump this action version without opening an ASF Infra ticket
+      # to allow the new SHA first!
+      - uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
+        with:
+          dirtyLabel: "requires:rebase"
+          # A conflicting PR isn't actually ready to merge; strip that signal
+          # if it was previously set so reviewers don't act on a stale one.
+          removeOnDirtyLabel: "need:merge"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          # Intentionally no commentOnDirty/commentOnClean: the label alone is
+          # the signal (matches the label's existing description, and avoids
+          # a one-time comment storm across the whole backlog on first run).

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -19,9 +19,14 @@ on:
     - cron: "0 */2 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
+# Avoid two full backlog sweeps racing (a manual workflow_dispatch landing
+# mid-schedule-tick, say); queue rather than cancel so an in-progress
+# paginated sweep always runs to completion.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
   label-merge-conflicts:
@@ -30,9 +35,13 @@ jobs:
     if: github.repository == 'apache/superset'
     name: Label Merge Conflicts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # to add/remove requires:rebase and need:merge
     steps:
-      # Do not bump this action version without opening an ASF Infra ticket
-      # to allow the new SHA first!
+      # ASF Infra allowlists this whole action via a wildcard
+      # (eps1lon/actions-label-merge-conflict@*), so any pinned SHA/version
+      # is already fine here - no Infra ticket needed for future bumps.
       - uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           dirtyLabel: "requires:rebase"


### PR DESCRIPTION
### SUMMARY

Adds automation to apply the existing `requires:rebase` label ("Requires rebasing on top of current master") to open PRs that GitHub reports as `CONFLICTING`, and remove it once a rebase makes the PR mergeable again. The label already exists in the repo but nothing currently applies it — this is meant to make it possible to filter the ~400-PR backlog down to "PRs that actually need attention before they can be reviewed," using [`eps1lon/actions-label-merge-conflict`](https://github.com/eps1lon/actions-label-merge-conflict).

### Design notes (please sanity-check the cadence choice)

The action always re-checks **every open PR** in the repo via a paginated GraphQL query on every run, regardless of what triggered it (confirmed by reading its source — there's no "just check this one PR" mode). The project's own README suggests triggering on `push` (to the default branch) plus `pull_request_target: [synchronize]`. For most repos that's fine, but on a repo with Superset's merge/push volume that combination means a full open-PR-backlog sweep on *every* merge to `master` and *every* push to *any* open PR — many times an hour.

Instead this runs on a `schedule` (every 2 hours) plus `workflow_dispatch` for manual runs. Same end result for triage purposes (the label doesn't need to update within seconds of a conflict appearing), but bounded to 12 sweeps/day instead of being proportional to the repo's push volume. Flagging this as a deliberate deviation from the upstream example in case there's a reason to want it more (or less) real-time than that — trivial to adjust the cron.

Also deliberately **not** using `commentOnDirty`/`commentOnClean`: the label is the whole signal (matches its existing description), and posting a comment on every currently-conflicting PR the first time this runs would be a burst of notification noise across the existing backlog.

One small bonus: wired up `removeOnDirtyLabel: "need:merge"` — if a PR was marked ready-to-merge and then drifts into conflict, this strips that stale signal so reviewers don't act on a "ready to merge" label that's no longer true.

### Allowlist status

An earlier revision of this PR said this would need an ASF Infra ticket. That was wrong — checked `apache/infrastructure-actions`' `approved_patterns.yml` directly (the actual source of truth for the org's action allowlist), and it lists `eps1lon/actions-label-merge-conflict@*` — a wildcard covering any version/SHA. No ticket needed, now or for future version bumps to this action.

While fixing that, also picked up a few `zizmor --persona=pedantic` findings on the workflow itself: `permissions` is now scoped to the job instead of the whole workflow, there's a `concurrency` group so a manual `workflow_dispatch` run can't race a scheduled sweep, and the `pull-requests: write` grant has an explanatory comment. No behavior change, just code-smell cleanup.

### TESTING INSTRUCTIONS

1. Trigger the workflow manually via `workflow_dispatch` and confirm it runs without errors.
2. Spot-check a few PRs: one with a known conflict should pick up `requires:rebase`; a clean one should not (and should have the label removed if it was previously conflicting).
3. Confirm a PR carrying `need:merge` that's also conflicting loses that label.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

