### PR TITLE
ci: add Kesin11/actions-timeline to the heavy CI workflows

### DIFF
--- a/.github/workflows/check-python-deps.yml
+++ b/.github/workflows/check-python-deps.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 # cancel previous workflow jobs for PRs
 concurrency:
@@ -21,6 +22,10 @@ jobs:
   check-python-deps:
     runs-on: ubuntu-26.04
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   dependency-review:
@@ -50,6 +51,10 @@ jobs:
     # You cannot use a liccheck.ini file in this workflow.
     runs-on: ubuntu-26.04
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout Repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -213,3 +213,14 @@ jobs:
         shell: bash
         run: |
           docker compose -f docker-compose-image-tag.yml up superset-init --exit-code-from superset-init
+
+  actions-timeline:
+    needs: [docker-build, docker-compose-image-tag]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 # cancel previous workflow jobs for PRs
 concurrency:
@@ -32,6 +33,10 @@ jobs:
         # rarely differ across patch versions, so 3x per PR is wasteful.
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["current", "next"]') }}
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/superset-app-cli.yml
+++ b/.github/workflows/superset-app-cli.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 # cancel previous workflow jobs for PRs
 concurrency:
@@ -40,6 +41,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -30,6 +30,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   config:
@@ -59,6 +60,10 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-26.04
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.event.workflow_run.head_sha || github.sha }}"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -340,3 +340,14 @@ jobs:
             exit 1
           fi
           echo "playwright-tests result: $RESULT (changes: $CHANGES)"
+
+  actions-timeline:
+    needs: [cypress-matrix, playwright-tests]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true

--- a/.github/workflows/superset-extensions-cli.yml
+++ b/.github/workflows/superset-extensions-cli.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 # cancel previous workflow jobs for PRs
 concurrency:
@@ -30,6 +31,10 @@ jobs:
       run:
         working-directory: superset-extensions-cli
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -195,3 +195,14 @@ jobs:
         run: |
           docker run --rm $TAG bash -c \
           "npm run build-storybook && npx playwright install-deps && npx playwright install chromium && npm run test-storybook:ci"
+
+  actions-timeline:
+    needs: [report-coverage, lint-frontend, validate-frontend, test-storybook]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true

--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 # Serialize runs per PR without cancelling: when a first-time contributor's
 # queued runs are approved together, cancel-in-progress lets an older run
@@ -21,6 +22,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-26.04
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -54,6 +54,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +80,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       # -------------------------------------------------------
       # Conditional checkout based on context (same as Cypress workflow)
       - name: Checkout for push or pull_request event

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -255,3 +255,14 @@ jobs:
             exit 1
           fi
           echo "test-postgres result: $RESULT"
+
+  actions-timeline:
+    needs: [test-mysql, test-postgres, test-sqlite]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -158,3 +158,14 @@ jobs:
           verbose: true
           use_oidc: true
           slug: apache/superset
+
+  actions-timeline:
+    needs: [test-postgres-presto, test-postgres-hive]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -101,7 +101,14 @@ jobs:
     if: always()
     runs-on: ubuntu-26.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
     steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true
+
       - name: Check unit-tests result
         env:
           RESULT: ${{ needs.unit-tests.result }}

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -156,3 +156,14 @@ jobs:
       - name: Fail if regression detected
         if: steps.regression.outcome == 'failure'
         run: exit 1
+
+  actions-timeline:
+    needs: [frontend-check-translations, babel-extract]
+    if: always()
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        with:
+          expand-composite-actions: true


### PR DESCRIPTION
### SUMMARY
Stacked on #42498 (base branch is `ci/setup-uv`, not `master`) -- rebase onto `master` once that merges, at which point this diff will shrink to just this change.

[Kesin11/actions-timeline](https://github.com/Kesin11/actions-timeline) renders a Gantt chart (mermaid diagram) of every job and step's duration directly in the run summary page. Arguably this should have been step zero for the last two PRs -- instead of guessing where the minutes go, this makes it visible.

Added to the 15 substantive CI workflows: the 13 `setup-backend` consumers plus `superset-frontend.yml` and `docker.yml`, the other two heaviest CI paths. Skipped the trivial bot/label/notification workflows (labeler, welcome-new-users, no-hold-label, etc.) that run in seconds and have nothing worth visualizing.

**Placement:**
- Single-job workflows (or a linear chain with one heavy job at the end): the step goes first, before checkout. It's a post-action -- the actual timeline rendering happens in its post-processing hook, and registering it first means that hook runs *last*, after every other step's own cleanup, capturing the whole job.
- Workflows with multiple independent parallel jobs (e.g. `test-mysql`/`test-postgres`/`test-sqlite`, or the frontend's 6-job fan-out): added one dedicated `actions-timeline` terminal job (`needs: [...]`, `if: always()`) instead of duplicating the step into every parallel job. The action fetches every job of the *entire run* from the GitHub API regardless of which job it executes in, so a single copy that waits for all siblings to finish produces one complete, authoritative timeline -- N copies dropped into N parallel jobs would each render an incomplete gantt racing against their still-running siblings.

`expand-composite-actions: true` is set everywhere, so `setup-backend`'s internal steps (Python setup, `uv` install, apt package caching, dependency install) show up as their own bars instead of one opaque blob -- directly useful given the composite-action changes from the last two PRs.

`actions: read` permission is added wherever the new step needs it to read job/step timing from the Actions API -- to the workflow's top-level `permissions:` block when the job has no override, or directly into the job's own `permissions:` block when one already exists (job-level permissions replace the workflow-level ones rather than merging with them).

### TESTING INSTRUCTIONS
- `pre-commit run` (`zizmor` GHA security audit) and `npx @action-validator/cli` (the schema check `github-action-validator.yml` runs in CI) both pass on all 15 touched files.
- CI on this PR is itself the test: every touched workflow should produce a Gantt-chart summary on its run page.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API