### PR TITLE
ci: de-vendor helm/chart-releaser-action

### DIFF
--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           install-superset: "false"
 
+      # Still vendored (not de-vendored like chart-releaser-action below): the
+      # allowlisted helm/chart-testing-action@v2.8.0 depends internally on
+      # astral-sh/setup-uv@v7.0.0, which isn't itself on the ASF Actions
+      # allowlist (only v8.1.0+ are, at apache/infrastructure-actions'
+      # actions.yml). Needs an INFRA request before this can de-vendor too.
       - name: Set up chart-testing
         uses: ./.github/actions/chart-testing-action
 

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -86,13 +86,8 @@ jobs:
           # Return to the original branch
           git checkout local_gha_temp
 
-      - name: Fetch/list all tags
-        run: |
-          git submodule update
-          cat .github/actions/chart-releaser-action/action.yml
-
       - name: Run chart-releaser
-        uses: ./.github/actions/chart-releaser-action
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           version: v1.6.0
           charts_dir: helm

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,9 +30,6 @@
 [submodule ".github/actions/chart-testing-action"]
 	path = .github/actions/chart-testing-action
 	url = https://github.com/helm/chart-testing-action
-[submodule ".github/actions/chart-releaser-action"]
-	path = .github/actions/chart-releaser-action
-	url = https://github.com/helm/chart-releaser-action
 [submodule ".github/actions/github-action-push-to-another-repository"]
 	path = .github/actions/github-action-push-to-another-repository
 	url = https://github.com/cpina/github-action-push-to-another-repository


### PR DESCRIPTION
### SUMMARY
`helm/chart-releaser-action` is now allowlisted upstream by ASF Infra (`apache/infrastructure-actions/actions.yml`) at v1.7.0 (`cae68fefc6b5f367a0275617c9f83181ba54714f`), so the git-submodule fork under `.github/actions/chart-releaser-action` — added as a workaround back when it wasn't allowlisted — is no longer needed.

Also drops a now-dead debug step in `superset-helm-release.yml` that just `cat`'d the vendored action's `action.yml`.

**`helm/chart-testing-action` intentionally NOT included here.** It's also allowlisted (v2.8.0, `6ec842c01de15ebb84c8627d2744a0c2f2755c9f`), but that release depends internally on `astral-sh/setup-uv@v7.0.0`, which isn't itself on the allowlist (only v8.1.0+ currently are). Confirmed this directly rather than assuming — see TESTING INSTRUCTIONS. De-vendoring it needs an ASF Infra request to add that specific `setup-uv` SHA (or for `chart-testing-action` to cut a release pinning a currently-allowlisted `setup-uv` version) first. Left it on the vendored submodule with a comment explaining why.

Also skipping `helm/kind-action` per discussion — installing/testing the chart in CI via `kind` is a separate, larger change than de-vendoring, and not something we're pursuing right now.

### FOLLOW-UP
Not filing an ASF Infra ticket for the missing `setup-uv` SHA right now — helm chart support is being deprecated, so it's not worth spending Infra's time reviving an old allowlist entry for it. Worth revisiting if/when either of these lands:
- ASF Infra decides to allowlist `astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c` (v7.0.0) directly, or
- upstream [helm/chart-testing-action#218](https://github.com/helm/chart-testing-action/pull/218) (an already-open, mergeable dependabot PR bumping `setup-uv` from 7.3.0 to 8.3.0 — currently allowlisted) merges and ships in a release, at which point that release's SHA just needs a normal Infra allowlist request.

The repo is actively maintained (commits within the last week, 19 open issues, dependabot running), so no need to file anything new upstream — #218 already covers this.

### TESTING INSTRUCTIONS
Validated directly against real CI on this branch before opening:
- `helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f` (v1.7.0): ran successfully in an isolated diagnostic job (`install_only: true`, no release/publish side effects) — https://github.com/apache/superset/actions/runs/30331312381 (job `diagnostic-chart-releaser-allowlist`).
- `helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f` (v2.8.0): failed at `Set up job` — https://github.com/apache/superset/actions/runs/30331090959 — annotation confirms `astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c` (v7.0.0) is not allowlisted. This is why it's staying vendored for now.
- The actual `superset-helm-release.yml` release job itself was **not** run end-to-end (it force-pushes branches and opens a real PR to `gh-pages` — too disruptive to trigger just for validation); the `chart-releaser-action` swap is validated via the isolated `install_only` job instead, which exercises the same allowlist gate without the side effects.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
