### PR TITLE
feat(ci): auto-approve Dependabot patch-level bumps

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,61 @@
+name: Auto-approve Dependabot patch bumps
+
+# Posts an approving review on Dependabot PRs that only bump a patch
+# version, using the same trigger/guard convention already proven to work
+# for Dependabot PRs in sync-requirements-for-python-dep-upgrade-pr.yml
+# (plain `pull_request` gets a working, write-capable GITHUB_TOKEN here
+# because Dependabot pushes branches directly to this repo, not a fork).
+#
+# This does NOT auto-merge anything - repo-wide auto-merge is disabled
+# (Settings > General > Pull Requests > "Allow auto-merge" is off), and
+# flipping that is a separate, repo-wide decision this workflow doesn't
+# make on its own. Branch protection also still requires 1 approving
+# review; this just means that review can already exist by the time a
+# human looks at the PR, for the (large majority of) ecosystems whose
+# files aren't matched by any CODEOWNERS pattern. One ecosystem - the npm
+# bump under .github/actions - matches the /.github/ CODEOWNERS entry, so
+# those PRs will still need a human owner's approval regardless of this
+# workflow; it posts a review there too, but that alone won't satisfy the
+# code-owner requirement.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# Cancel a superseded run if Dependabot pushes to the same PR again before
+# the previous run finished (matches the pattern used elsewhere in
+# superset-docs-verify.yml).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  approve-patch-bump:
+    name: Approve patch-level bump
+    # Mirrors the guard in sync-requirements-for-python-dep-upgrade-pr.yml:
+    # limited to (1) PRs authored by Dependabot and (2) the upstream repo,
+    # since forked PRs don't get a write-capable token here anyway.
+    if: >
+      github.repository == 'apache/superset' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to post the approving review via `gh pr review`
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        # Do not bump this action version without opening an ASF Infra
+        # ticket to allow the new SHA first!
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Approve patch-level bump
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved: patch-level bump only ($DEPENDENCY_NAMES)."

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -46,8 +46,10 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        # Do not bump this action version without opening an ASF Infra
-        # ticket to allow the new SHA first!
+        # This exact SHA is on ASF Infra's action allowlist
+        # (apache/infrastructure-actions approved_patterns.yml) as of this
+        # writing. Do not bump without opening an Infra ticket to allow
+        # the new SHA first!
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       - name: Approve patch-level bump


### PR DESCRIPTION
### SUMMARY

Adds a workflow that auto-approves Dependabot PRs bumping a dependency by a **patch version only**, using [`dependabot/fetch-metadata`](https://github.com/dependabot/fetch-metadata)'s `update-type` output. Minor and major bumps get no automated review — normal human review as today.

This was originally suggested as "gate auto-approve/auto-merge on patch-level bumps." I checked before building anything, and **auto-merge doesn't hold up as suggested** — see below. What's in this PR is the auto-approve half only, scoped down deliberately.

### Why not auto-merge too

- `allow_auto_merge` is `false` at the repo level (confirmed via the API) — GitHub's native auto-merge is switched off repo-wide. Enabling it is a separate, repo-wide settings decision (affects every PR, not just Dependabot's) that this workflow doesn't make on its own.
- Branch protection (`.asf.yaml`) requires `require_code_owner_reviews: true` plus 1 approving review. I checked `.github/CODEOWNERS` against every path Dependabot actually opens PRs against (`superset-frontend/`, `docs/`, `superset-websocket/` ×2, and `pip` at `/`) — none match any CODEOWNERS pattern, so a bot-posted approval satisfies the plain 1-approval requirement for those, the same way GitHub's own documented `fetch-metadata` + `gh pr review --approve` recipe works for repos with required reviews. **One exception**: the `npm` ecosystem scoped to `.github/actions` matches the `/.github/` CODEOWNERS entry — those PRs will still need a real human owner's approval no matter what this workflow does. It posts a review there too (harmless), but it won't satisfy the code-owner requirement alone.

So: for most of the actual Dependabot PR volume, this should get the review requirement out of the way before a human ever opens the PR, but merging is still a manual click same as today — auto-merge would need someone to deliberately flip the repo setting, which felt like a decision for a maintainer to make explicitly rather than something to bundle into this PR.

### Trigger choice

Uses a plain `pull_request` trigger (types: `opened`, `synchronize`), not `pull_request_target`. I'd assumed Dependabot-triggered `pull_request` events get a read-only token regardless of the `permissions:` block (a real, commonly-cited GitHub Actions restriction) and almost built this around `pull_request_target` to work around it — but this repo's own `sync-requirements-for-python-dep-upgrade-pr.yml` already does a `git push` (needs `contents: write`) under a plain `pull_request` trigger for genuine Dependabot PRs, and I checked its actual run history/logs to confirm that push step succeeds today. Copied that same proven trigger/guard convention here instead of assuming the more complex trigger was necessary.

### Allowlist status

`dependabot/fetch-metadata@25dd0e34...` (the exact SHA pinned here) is already on ASF Infra's action allowlist — checked `apache/infrastructure-actions`' `approved_patterns.yml` directly rather than assume. No Infra ticket needed for this PR to run.

### TESTING INSTRUCTIONS

1. Watch the next patch-level Dependabot PR (any of the `npm`/`pip` ecosystems except `.github/actions`) and confirm it picks up an approving review automatically.
2. Confirm a minor/major bump PR gets no automated review.
3. Confirm a patch bump under the `.github/actions` npm scope still shows as needing review (the bot's approval alone shouldn't satisfy the code-owner gate there).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

