### PR TITLE
fix(menu): highlight Datasets tab on /dataset/add/ and /dataset/:id

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -1053,14 +1053,16 @@ describe('active tab highlighting (regression #36403)', () => {
   });
 
   test.each([
+    ['/tablemodelview/list/', 'the legacy FAB dataset list route'],
     ['/dataset/add/', 'the modern React dataset create route'],
     ['/dataset/42', 'a dataset detail route'],
   ])(
     'highlights the Datasets tab on %s (%s) — regression #42467',
     async (route, _label) => {
-      // Legacy list URL (``/tablemodelview/list/``) already highlights the
-      // tab; these newer React-managed routes did not until #42467 added
-      // ``/dataset`` as a second prefix in the active-tab matcher.
+      // ``/tablemodelview/list/`` is the pre-existing legacy path (kept as
+      // a coverage anchor so future prefix-matching changes cannot silently
+      // regress it); the ``/dataset/*`` routes are the modern React ones
+      // added by #42467.
       useSelectorMock.mockReturnValue({ roles: user.roles });
       window.history.pushState({}, '', route);
 

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -1052,6 +1052,32 @@ describe('active tab highlighting (regression #36403)', () => {
     expect(getMenuItemByText('Дашборды')).toHaveClass('ant-menu-item-selected');
   });
 
+  test.each([
+    ['/dataset/add/', 'the modern React dataset create route'],
+    ['/dataset/42', 'a dataset detail route'],
+  ])(
+    'highlights the Datasets tab on %s (%s) — regression #42467',
+    async (route, _label) => {
+      // Legacy list URL (``/tablemodelview/list/``) already highlights the
+      // tab; these newer React-managed routes did not until #42467 added
+      // ``/dataset`` as a second prefix in the active-tab matcher.
+      useSelectorMock.mockReturnValue({ roles: user.roles });
+      window.history.pushState({}, '', route);
+
+      render(<Menu {...mockedProps} />, {
+        useRedux: true,
+        useQueryParams: true,
+        useRouter: true,
+        useTheme: true,
+      });
+
+      await screen.findByText('Datasets');
+      expect(getMenuItemByText('Datasets')).toHaveClass(
+        'ant-menu-item-selected',
+      );
+    },
+  );
+
   test('highlights the active SQL tab when the label is localized', async () => {
     // The SQL Lab top-level entry is a FAB category: its stable `name` is
     // "SQL Lab" while its label ("SQL") is localized.

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -1071,12 +1071,37 @@ describe('active tab highlighting (regression #36403)', () => {
         useTheme: true,
       });
 
-      await screen.findByText('Datasets');
-      expect(getMenuItemByText('Datasets')).toHaveClass(
-        'ant-menu-item-selected',
-      );
+      // Datasets is a child under the Sources submenu — expand it first so
+      // the item is in the DOM (same pattern as the existing "render the top
+      // navbar child menu items" test).
+      const sources = await screen.findByText('Sources');
+      userEvent.hover(sources);
+
+      const datasets = await screen.findByText('Datasets');
+      expect(datasets.closest('li')).toHaveClass('ant-menu-item-selected');
     },
   );
+
+  test('does not highlight the Datasets tab on lookalike prefixes (e.g. /datasetXyz)', async () => {
+    // The active-tab matcher must use a boundary-aware startsWith so that
+    // an unrelated future route beginning with ``/dataset`` (e.g. a
+    // hypothetical ``/datasetXyz``) does not falsely trigger the highlight.
+    useSelectorMock.mockReturnValue({ roles: user.roles });
+    window.history.pushState({}, '', '/datasetXyz');
+
+    render(<Menu {...mockedProps} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
+
+    const sources = await screen.findByText('Sources');
+    userEvent.hover(sources);
+
+    const datasets = await screen.findByText('Datasets');
+    expect(datasets.closest('li')).not.toHaveClass('ant-menu-item-selected');
+  });
 
   test('highlights the active SQL tab when the label is localized', async () => {
     // The SQL Lab top-level entry is a FAB category: its stable `name` is

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -244,7 +244,9 @@ export function Menu({
       case path.startsWith(Paths.Chart) || path.startsWith(Paths.Explore):
         setActiveTabs([MenuKeys.Charts]);
         break;
-      case path.startsWith(Paths.Datasets) || path.startsWith(Paths.Dataset):
+      case path.startsWith(Paths.Datasets) ||
+        path === Paths.Dataset ||
+        path.startsWith(`${Paths.Dataset}/`):
         setActiveTabs([MenuKeys.Datasets]);
         break;
       case path.startsWith(Paths.SqlLab) || path.startsWith(Paths.SavedQueries):

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -212,6 +212,12 @@ export function Menu({
     Dashboard = '/dashboard',
     Chart = '/chart',
     Datasets = '/tablemodelview',
+    // The legacy FAB dataset list still lives at ``/tablemodelview/list/``,
+    // but the modern React-managed dataset add + detail routes are under
+    // ``/dataset/*`` (``/dataset/add/``, ``/dataset/:datasetId``). Both
+    // prefixes must map to the Datasets tab so the top-nav highlight
+    // survives navigation into the create/edit flow. See #42467.
+    Dataset = '/dataset',
     SqlLab = '/sqllab',
     SavedQueries = '/savedqueryview',
   }
@@ -238,7 +244,7 @@ export function Menu({
       case path.startsWith(Paths.Chart) || path.startsWith(Paths.Explore):
         setActiveTabs([MenuKeys.Charts]);
         break;
-      case path.startsWith(Paths.Datasets):
+      case path.startsWith(Paths.Datasets) || path.startsWith(Paths.Dataset):
         setActiveTabs([MenuKeys.Datasets]);
         break;
       case path.startsWith(Paths.SqlLab) || path.startsWith(Paths.SavedQueries):


### PR DESCRIPTION
### SUMMARY

Fixes #42467.

The active-tab logic in `superset-frontend/src/features/home/Menu.tsx` matches the Datasets tab against the legacy FAB list URL prefix `/tablemodelview`. Newer React-managed routes for creating and viewing datasets live under `/dataset/*` (`/dataset/add/`, `/dataset/:datasetId`) and never match, so the top-nav Datasets tab shows no active-state highlight when the user is on those pages.

Adding `/dataset` as a second prefix restores the highlight without touching any other tab or route.

**Note on Dashboard:** the issue reporter also mentioned Dashboard, but tracing the routes shows all Dashboard URLs (`/dashboard/list/`, `/dashboard/:idOrSlug/`, `/dashboard/new/`) already start with `/dashboard` and match the current `Paths.Dashboard` prefix. Focused this PR on the confirmed Datasets bug; happy to follow up if a Dashboard case is later confirmed.

Root cause diagnosis on the issue thread by @dosu.

### TESTING INSTRUCTIONS

Manual:
1. Log in, go to **Datasets** — tab highlighted ✓
2. Click **+ Dataset** (URL → `/dataset/add/`)
3. **Before fix:** Datasets tab NOT highlighted
4. **After fix:** Datasets tab remains highlighted (green underline)
5. Also verify direct dataset view: navigate to `/dataset/{id}` and confirm the tab stays highlighted

Automated:
```bash
cd superset-frontend && pnpm test src/features/home/Menu.test.tsx
```

New parametrized test covers both `/dataset/add/` and `/dataset/{id}` variants.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42467
- [x] Required feature flags: none
- [x] Changes UI: yes (restores missing tab-highlight — no visual redesign)
- [x] Includes DB Migration: no
- [x] Includes CLI or Node.js commands: no
- [x] Breaking change: no