### PR TITLE
fix(viz): follow-ups from #41714 self-review

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/buildSortMetricOrderby.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/buildSortMetricOrderby.ts
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ensureIsArray, getMetricLabel } from '@superset-ui/core';
+import type { QueryFormMetric, QueryFormOrderBy } from '@superset-ui/core';
+
+export interface BuildSortMetricOrderbyConfig {
+  /** The query's already-resolved metrics list. */
+  metrics: QueryFormMetric[];
+  /** The raw `timeseries_limit_metric` form-data value (single or multi). */
+  timeseriesLimitMetric?: QueryFormMetric | QueryFormMetric[] | null;
+  order_desc?: boolean;
+  /**
+   * Falls back to the first selected metric when no sort metric is set.
+   * Charts ported from a legacy viz whose query_obj always had a sort
+   * metric (defaulting to the first one) should set this; charts whose
+   * legacy query_obj left ordering absent without one should not.
+   */
+  fallbackToFirstMetric?: boolean;
+  /**
+   * When true, only order when `order_desc` is set (matching legacy vizzes
+   * whose query_obj left the result unordered unless the operator asked
+   * for descending). When false, always order (ascending unless
+   * order_desc), matching legacy vizzes that ordered unconditionally.
+   */
+  orderOnlyWhenDesc?: boolean;
+}
+
+export interface SortMetricOrderby {
+  /** `metrics`, with the sort metric appended if it wasn't already selected. */
+  metrics: QueryFormMetric[];
+  orderby: QueryFormOrderBy[];
+}
+
+/**
+ * Resolves a chart's sort metric and builds the corresponding query_obj
+ * `orderby`, appending the sort metric to `metrics` if it isn't already
+ * selected (so its value is present in the result to sort by). Several
+ * charts ported from the legacy chart-data pipeline share this exact
+ * shape with only the fallback/gating policy differing per their own
+ * legacy `query_obj` behavior -- see `fallbackToFirstMetric` and
+ * `orderOnlyWhenDesc`.
+ */
+export function buildSortMetricOrderby({
+  metrics,
+  timeseriesLimitMetric,
+  order_desc: orderDesc,
+  fallbackToFirstMetric = false,
+  orderOnlyWhenDesc = false,
+}: BuildSortMetricOrderbyConfig): SortMetricOrderby {
+  const sortByMetric =
+    ensureIsArray(timeseriesLimitMetric)[0] ??
+    (fallbackToFirstMetric ? metrics[0] : undefined);
+
+  if (!sortByMetric) {
+    return { metrics, orderby: [] };
+  }
+
+  const sortByLabel = getMetricLabel(sortByMetric);
+  const nextMetrics = metrics.some(
+    metric => getMetricLabel(metric) === sortByLabel,
+  )
+    ? metrics
+    : [...metrics, sortByMetric];
+
+  const shouldOrder = orderOnlyWhenDesc ? Boolean(orderDesc) : true;
+
+  return {
+    metrics: nextMetrics,
+    orderby: shouldOrder ? [[sortByMetric, !orderDesc]] : [],
+  };
+}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/index.ts
@@ -30,3 +30,4 @@ export * from './getTemporalColumns';
 export * from './displayTimeRelatedControls';
 export * from './colorControls';
 export * from './metricColumnFilter';
+export * from './buildSortMetricOrderby';

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/buildSortMetricOrderby.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/buildSortMetricOrderby.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { buildSortMetricOrderby } from '../../src';
+
+test('is a no-op when there is no sort metric and no fallback', () => {
+  const result = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: undefined,
+  });
+  expect(result).toEqual({ metrics: ['sum__num'], orderby: [] });
+});
+
+test('falls back to the first metric when configured to', () => {
+  const result = buildSortMetricOrderby({
+    metrics: ['sum__num', 'avg__num'],
+    timeseriesLimitMetric: undefined,
+    fallbackToFirstMetric: true,
+  });
+  expect(result.metrics).toEqual(['sum__num', 'avg__num']);
+  expect(result.orderby).toEqual([['sum__num', true]]);
+});
+
+test('appends the sort metric when it is not already selected', () => {
+  const result = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: 'count',
+  });
+  expect(result.metrics).toEqual(['sum__num', 'count']);
+});
+
+test('does not duplicate the sort metric when already selected', () => {
+  const result = buildSortMetricOrderby({
+    metrics: ['sum__num', 'count'],
+    timeseriesLimitMetric: 'count',
+  });
+  expect(result.metrics).toEqual(['sum__num', 'count']);
+});
+
+test('unconditional ordering (orderOnlyWhenDesc: false) always orders, flipping direction', () => {
+  const ascending = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: 'count',
+    order_desc: false,
+  });
+  expect(ascending.orderby).toEqual([['count', true]]);
+
+  const descending = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: 'count',
+    order_desc: true,
+  });
+  expect(descending.orderby).toEqual([['count', false]]);
+});
+
+test('gated ordering (orderOnlyWhenDesc: true) only orders when order_desc is set', () => {
+  const withoutDesc = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: 'count',
+    orderOnlyWhenDesc: true,
+  });
+  expect(withoutDesc.metrics).toEqual(['sum__num', 'count']);
+  expect(withoutDesc.orderby).toEqual([]);
+
+  const withDesc = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: 'count',
+    order_desc: true,
+    orderOnlyWhenDesc: true,
+  });
+  expect(withDesc.orderby).toEqual([['count', false]]);
+});
+
+test('resolves a multi-value timeseriesLimitMetric to its first entry', () => {
+  const result = buildSortMetricOrderby({
+    metrics: ['sum__num'],
+    timeseriesLimitMetric: ['count', 'avg__num'],
+  });
+  expect(result.metrics).toEqual(['sum__num', 'count']);
+  expect(result.orderby).toEqual([['count', true]]);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bullet/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bullet/transformProps.ts
@@ -176,7 +176,7 @@ export default function transformProps(
   // (roughly the grid height), so a percentage symbolOffset lands inside a
   // tall bar. Compute pixels: half the bar plus a small gap below it.
   const gridHeight = Math.max(height - gridTop - theme.sizeUnit * 6, 40);
-  const rowHeight = gridHeight / categories.length;
+  const rowHeight = gridHeight / Math.max(categories.length, 1);
   const markerOffsetPx = Math.round(
     (MEASURE_BAR_FRACTION / 2) * rowHeight + MARKER_GAP_BELOW_BAR_PX,
   );

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bullet/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bullet/transformProps.ts
@@ -29,8 +29,12 @@ import type { EChartsCoreOption } from 'echarts/core';
 import { Refs } from '../types';
 import { EchartsBulletChartProps, BulletChartTransformedProps } from './types';
 import { tokenizeToNumericArray, tokenizeToStringArray } from './utils';
+import { estimateWrappedLegendRowCount } from '../utils/legendLayout';
 
 const MEASURE_BAR_FRACTION = 0.28;
+// Small pixel gap below the measure bar so the target/marker symbol doesn't
+// touch its edge.
+const MARKER_GAP_BELOW_BAR_PX = 12;
 
 export default function transformProps(
   chartProps: EchartsBulletChartProps,
@@ -157,26 +161,15 @@ export default function transformProps(
     ...markers.map((value, i) => markerName(value, i, markerLabels)),
     ...markerLines.map((value, i) => markerName(value, i, markerLineLabels)),
   ];
-  const estimateLegendRows = (names: string[]): number => {
-    // legend icon width + icon-text gap + inter-item gap (ECharts defaults)
-    const itemOverhead = 25 + 5 + 10;
-    const avgCharWidth = theme.fontSize * 0.6;
-    const available = Math.max(width - theme.sizeUnit * 4, 1);
-    let rows = 1;
-    let cursor = 0;
-    names.forEach(name => {
-      const itemWidth = itemOverhead + name.length * avgCharWidth;
-      if (cursor > 0 && cursor + itemWidth > available) {
-        rows += 1;
-        cursor = 0;
-      }
-      cursor += itemWidth;
-    });
-    return rows;
-  };
   const legendRowHeight = theme.fontSize + theme.sizeUnit * 3;
   const gridTop = showLegend
-    ? estimateLegendRows(legendNames) * legendRowHeight + theme.sizeUnit * 2
+    ? estimateWrappedLegendRowCount({
+        names: legendNames,
+        availableWidth: width - theme.sizeUnit * 4,
+        theme,
+      }) *
+        legendRowHeight +
+      theme.sizeUnit * 2
     : theme.sizeUnit * 2;
 
   // The measure bar spans MEASURE_BAR_FRACTION of the category band
@@ -185,7 +178,7 @@ export default function transformProps(
   const gridHeight = Math.max(height - gridTop - theme.sizeUnit * 6, 40);
   const rowHeight = gridHeight / categories.length;
   const markerOffsetPx = Math.round(
-    (MEASURE_BAR_FRACTION / 2) * rowHeight + 12,
+    (MEASURE_BAR_FRACTION / 2) * rowHeight + MARKER_GAP_BELOW_BAR_PX,
   );
 
   const echartOptions: EChartsCoreOption = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/TimePivot/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/TimePivot/transformProps.ts
@@ -26,6 +26,7 @@ import {
 import type { EChartsCoreOption } from 'echarts/core';
 import { Refs } from '../types';
 import { calculateLowerLogTick } from '../utils/series';
+import { estimateWrappedLegendRowCount } from '../utils/legendLayout';
 import transformData, { TimePivotSeries } from './transformData';
 import {
   EchartsTimePivotChartProps,
@@ -104,9 +105,26 @@ export default function transformProps(
     }
   }
 
+  const legendNames = series.map(s => s.key);
+  // A single-row legend fits the chart's established top padding as before;
+  // with `period_limit` unset a chart can have 50+ series (current + many
+  // priors), so a wider legend can wrap onto extra rows that would
+  // otherwise overlap the plot -- reserve additional height per extra row.
+  const legendRowHeight = theme.fontSize + theme.sizeUnit * 3;
+  const legendRows =
+    showLegend !== false
+      ? estimateWrappedLegendRowCount({
+          names: legendNames,
+          availableWidth: width - theme.sizeUnit * 4,
+          theme,
+        })
+      : 0;
+  const gridTop =
+    theme.sizeUnit * 8 + Math.max(legendRows - 1, 0) * legendRowHeight;
+
   const echartOptions: EChartsCoreOption = {
     grid: {
-      top: theme.sizeUnit * 8,
+      top: gridTop,
       bottom: theme.sizeUnit * 8,
       left: theme.sizeUnit * 4,
       right: theme.sizeUnit * 6,
@@ -115,7 +133,7 @@ export default function transformProps(
     legend: {
       show: showLegend !== false,
       top: 0,
-      data: series.map(s => s.key),
+      data: legendNames,
     },
     xAxis: {
       type: 'time',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -47,6 +47,12 @@ import { ExtraControls } from '../components/ExtraControls';
 
 const TIMER_DURATION = 300;
 
+// Percent-change draggable baseline handle geometry, in pixels.
+const BASELINE_HANDLE_WIDTH = 8;
+const BASELINE_HANDLE_HALF_WIDTH = BASELINE_HANDLE_WIDTH / 2;
+const BASELINE_HANDLE_STRIPE_X = 3;
+const BASELINE_HANDLE_STRIPE_WIDTH = 2;
+
 export default function EchartsTimeseries({
   formData,
   height,
@@ -90,10 +96,13 @@ export default function EchartsTimeseries({
     const chart = echartRef.current?.getEchartInstance?.();
     if (!chart) return undefined;
 
-    const option = chart.getOption() as {
-      series?: { data?: SeriesDataPoint[] }[];
-    };
-    const baseSeries = (option.series ?? []).map(s =>
+    // Read series data from the echartOptions prop (the source of truth
+    // this effect already depends on) rather than chart.getOption(), which
+    // reflects the live instance's internal state and can still be empty
+    // for a tick after mount or a warm navigation -- reading the prop
+    // removes that race entirely instead of retrying past it.
+    const { series } = echartOptions as { series?: { data?: unknown[] }[] };
+    const baseSeries = (series ?? []).map(s =>
       Array.isArray(s.data)
         ? (s.data.filter(Array.isArray) as SeriesDataPoint[])
         : [],
@@ -164,7 +173,7 @@ export default function EchartsTimeseries({
             id: 'percent-change-baseline',
             // only group elements support children in the graphic API
             type: 'group',
-            x: px - 4,
+            x: px - BASELINE_HANDLE_HALF_WIDTH,
             y: gridRect.top,
             cursor: 'ew-resize',
             draggable: true,
@@ -173,7 +182,7 @@ export default function EchartsTimeseries({
               this.y = gridRect.top;
               const dataX = chart.convertFromPixel(
                 { xAxisIndex: 0 },
-                this.x + 4,
+                this.x + BASELINE_HANDLE_HALF_WIDTH,
               ) as number | string;
               if (dragFrame !== null) return;
               dragFrame = requestAnimationFrame(() => {
@@ -188,12 +197,22 @@ export default function EchartsTimeseries({
             children: [
               {
                 type: 'rect',
-                shape: { x: 0, y: 0, width: 8, height: gridRect.height },
+                shape: {
+                  x: 0,
+                  y: 0,
+                  width: BASELINE_HANDLE_WIDTH,
+                  height: gridRect.height,
+                },
                 style: { fill: theme.colorFillSecondary },
               },
               {
                 type: 'rect',
-                shape: { x: 3, y: 0, width: 2, height: gridRect.height },
+                shape: {
+                  x: BASELINE_HANDLE_STRIPE_X,
+                  y: 0,
+                  width: BASELINE_HANDLE_STRIPE_WIDTH,
+                  height: gridRect.height,
+                },
                 style: { fill: theme.colorTextSecondary },
               },
             ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/legendLayout.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/legendLayout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { supersetTheme } from '@apache-superset/core/theme';
+import { estimateWrappedLegendRowCount } from './legendLayout';
+
+test('a single short name fits on one row', () => {
+  expect(
+    estimateWrappedLegendRowCount({
+      names: ['A'],
+      availableWidth: 800,
+      theme: supersetTheme,
+    }),
+  ).toBe(1);
+});
+
+test('an empty legend still reports one row', () => {
+  expect(
+    estimateWrappedLegendRowCount({
+      names: [],
+      availableWidth: 800,
+      theme: supersetTheme,
+    }),
+  ).toBe(1);
+});
+
+test('wraps onto more rows as names are added past the available width', () => {
+  const names = Array.from({ length: 30 }, (_, i) => `series-${i}`);
+  const rows = estimateWrappedLegendRowCount({
+    names,
+    availableWidth: 400,
+    theme: supersetTheme,
+  });
+  expect(rows).toBeGreaterThan(1);
+
+  // The same names fit onto fewer (or equal) rows given more width.
+  const widerRows = estimateWrappedLegendRowCount({
+    names,
+    availableWidth: 4000,
+    theme: supersetTheme,
+  });
+  expect(widerRows).toBeLessThanOrEqual(rows);
+});
+
+test('longer names wrap sooner than shorter ones at the same width', () => {
+  const shortNames = Array.from({ length: 10 }, (_, i) => `${i}`);
+  const longNames = Array.from(
+    { length: 10 },
+    (_, i) => `a much longer series label ${i}`,
+  );
+  const shortRows = estimateWrappedLegendRowCount({
+    names: shortNames,
+    availableWidth: 500,
+    theme: supersetTheme,
+  });
+  const longRows = estimateWrappedLegendRowCount({
+    names: longNames,
+    availableWidth: 500,
+    theme: supersetTheme,
+  });
+  expect(longRows).toBeGreaterThan(shortRows);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/legendLayout.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/legendLayout.ts
@@ -29,6 +29,46 @@ export type ResolvedLegendLayout = {
   legendLayout: LegendLayoutResult;
 };
 
+// ECharts default spacing for a horizontal, top-aligned legend: the icon
+// itself, the gap between icon and label, and the gap before the next item.
+const LEGEND_ITEM_ICON_WIDTH = 25;
+const LEGEND_ITEM_ICON_GAP = 5;
+const LEGEND_ITEM_INTER_GAP = 10;
+const LEGEND_ITEM_OVERHEAD =
+  LEGEND_ITEM_ICON_WIDTH + LEGEND_ITEM_ICON_GAP + LEGEND_ITEM_INTER_GAP;
+
+/**
+ * Estimates how many rows a horizontal, top-aligned legend will wrap onto
+ * for a given chart width, so callers can reserve enough `grid.top` space to
+ * avoid the legend overlapping the plot. ECharts only reports this after a
+ * render, so this is a best-effort estimate from item label lengths using
+ * the library's default per-item spacing; it degrades gracefully (a slight
+ * under/over-reservation) rather than needing an extra render pass.
+ */
+export function estimateWrappedLegendRowCount({
+  names,
+  availableWidth,
+  theme,
+}: {
+  names: string[];
+  availableWidth: number;
+  theme: SupersetTheme;
+}): number {
+  const avgCharWidth = theme.fontSize * 0.6;
+  const available = Math.max(availableWidth, 1);
+  let rows = 1;
+  let cursor = 0;
+  names.forEach(name => {
+    const itemWidth = LEGEND_ITEM_OVERHEAD + name.length * avgCharWidth;
+    if (cursor > 0 && cursor + itemWidth > available) {
+      rows += 1;
+      cursor = 0;
+    }
+    cursor += itemWidth;
+  });
+  return rows;
+}
+
 export function resolveLegendLayout(args: {
   availableHeight?: number;
   availableWidth?: number;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Rose/EchartsRose.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Rose/EchartsRose.test.tsx
@@ -169,7 +169,7 @@ test('clicking again while drilled returns to the rose view', () => {
   expect(lastEchartCall().echartOptions).toBe(ROSE_ECHART_OPTIONS);
 });
 
-test('clicking a different period while drilled switches to that period', () => {
+test('clicking a different period while drilled returns to the rose view', () => {
   renderRose();
 
   act(() => {
@@ -177,8 +177,8 @@ test('clicking a different period while drilled switches to that period', () => 
   });
   expect(lastEchartCall().echartOptions.title.text).toContain('2021');
 
-  // Per the current toggle logic, any click while drilled returns to the
-  // rose rather than switching directly to a different period's pie.
+  // The toggle logic returns to the rose on any click while drilled,
+  // rather than switching directly to a different period's pie.
   act(() => {
     lastEchartCall().eventHandlers.click({ dataIndex: 1 });
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Rose/EchartsRose.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Rose/EchartsRose.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, render } from '@testing-library/react';
+import {
+  CategoricalColorNamespace,
+  getLabelsColorMap,
+} from '@superset-ui/core';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import EchartsRose from '../../src/Rose/EchartsRose';
+import { RoseChartTransformedProps, RosePeriod } from '../../src/Rose/types';
+import Echart from '../../src/components/Echart';
+
+jest.mock('../../src/components/Echart', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+const mockedEchart = jest.mocked(Echart);
+
+// Entries are NOT in seriesNames order -- East/West/North -- deliberately,
+// to prove colors come from priming the scale in seriesNames order rather
+// than from whatever order the drilled pie happens to sort slices into.
+const SERIES_NAMES = ['East', 'West', 'North'];
+const PERIODS: RosePeriod[] = [
+  {
+    time: 1,
+    label: '2021',
+    entries: [
+      { seriesName: 'West', value: 5, increment: 0.1 },
+      { seriesName: 'North', value: 30, increment: 0.5 },
+      { seriesName: 'East', value: 10, increment: 0.3 },
+    ],
+  },
+  {
+    time: 2,
+    label: '2022',
+    entries: [
+      { seriesName: 'East', value: 7, increment: 0.2 },
+      { seriesName: 'West', value: 3, increment: 0.1 },
+      { seriesName: 'North', value: 1, increment: 0.05 },
+    ],
+  },
+];
+
+const ROSE_ECHART_OPTIONS = {
+  legend: { data: SERIES_NAMES },
+  series: [{ id: 'rose', type: 'bar' }],
+};
+
+const baseProps: RoseChartTransformedProps = {
+  height: 400,
+  width: 800,
+  echartOptions: ROSE_ECHART_OPTIONS as any,
+  refs: {},
+  formData: { vizType: 'rose' } as any,
+  periods: PERIODS,
+  seriesNames: SERIES_NAMES,
+  numberFormat: 'SMART_NUMBER',
+  sliceId: 1,
+  colorScheme: '',
+  groupby: [],
+  labelMap: {},
+  setDataMask: jest.fn(),
+  selectedValues: {},
+  emitCrossFilters: false,
+};
+
+function lastEchartCall() {
+  return mockedEchart.mock.calls[mockedEchart.mock.calls.length - 1][0] as any;
+}
+
+function renderRose(props: RoseChartTransformedProps = baseProps) {
+  return render(
+    <ThemeProvider theme={supersetTheme}>
+      <EchartsRose {...props} />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockedEchart.mockClear();
+  // getColor() remembers a label's color for a given sliceId in a
+  // process-wide singleton (so a dashboard's colors stay consistent across
+  // charts); without resetting it here, whichever test runs first would
+  // permanently decide these labels' colors for every later test in this
+  // file, masking a priming-order regression instead of catching it.
+  getLabelsColorMap().reset();
+});
+
+test('renders the rose view unchanged until a period is clicked', () => {
+  renderRose();
+
+  expect(lastEchartCall().echartOptions).toBe(ROSE_ECHART_OPTIONS);
+});
+
+test('clicking a period drills into a pie of that period, sorted largest-first', () => {
+  renderRose();
+
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 0 });
+  });
+
+  const { echartOptions } = lastEchartCall();
+  expect(echartOptions.title.text).toContain('2021');
+  expect(echartOptions.series[0].data.map((d: any) => d.name)).toEqual([
+    'North',
+    'East',
+    'West',
+  ]);
+  expect(echartOptions.series[0].data.map((d: any) => d.value)).toEqual([
+    30, 10, 5,
+  ]);
+});
+
+test('drilled slice colors match the rose colors, primed in seriesNames order', () => {
+  // Compute the expected mapping first, from a clean slate, priming a scale
+  // in seriesNames order exactly as the rose view does -- independent of
+  // the pie's own value-sorted order (North/East/West by value here, vs.
+  // East/West/North in seriesNames).
+  const expectedColorFn = CategoricalColorNamespace.getScale('');
+  const expectedColors: Record<string, string> = {};
+  SERIES_NAMES.forEach(name => {
+    expectedColors[name] = expectedColorFn(name, baseProps.sliceId);
+  });
+
+  // Reset before rendering so the component primes its own scale from the
+  // same clean slate, rather than inheriting the mapping just computed
+  // above (colors are remembered per sliceId in a process-wide singleton,
+  // so without this reset the comparison below would be tautological).
+  getLabelsColorMap().reset();
+  renderRose();
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 0 });
+  });
+  const { echartOptions } = lastEchartCall();
+
+  echartOptions.series[0].data.forEach((slice: any) => {
+    expect(slice.itemStyle.color).toBe(expectedColors[slice.name]);
+  });
+});
+
+test('clicking again while drilled returns to the rose view', () => {
+  renderRose();
+
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 1 });
+  });
+  expect(lastEchartCall().echartOptions).not.toBe(ROSE_ECHART_OPTIONS);
+
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 0 });
+  });
+  expect(lastEchartCall().echartOptions).toBe(ROSE_ECHART_OPTIONS);
+});
+
+test('clicking a different period while drilled switches to that period', () => {
+  renderRose();
+
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 0 });
+  });
+  expect(lastEchartCall().echartOptions.title.text).toContain('2021');
+
+  // Per the current toggle logic, any click while drilled returns to the
+  // rose rather than switching directly to a different period's pie.
+  act(() => {
+    lastEchartCall().eventHandlers.click({ dataIndex: 1 });
+  });
+  expect(lastEchartCall().echartOptions).toBe(ROSE_ECHART_OPTIONS);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/TimePivot/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/TimePivot/transformProps.test.ts
@@ -78,6 +78,79 @@ test('honors log scale and y-axis bounds', () => {
   expect(yAxis.max).toBe(100);
 });
 
+test('reserves extra grid.top space when a large legend wraps onto more rows', () => {
+  // Unbounded period_limit: 25 weekly records -> 25 periods (current + 24
+  // priors), whose short "-N" labels still wrap a legend onto 2+ rows at
+  // this chart width -- the exact scenario left unaddressed by Bullet's
+  // dynamic legend-row estimation fix (this chart used a fixed grid.top
+  // regardless of legend size).
+  const manyWeeks = Array.from({ length: 25 }, (_, i) => ({
+    __timestamp: MONDAY_1 + i * WEEK,
+    sum__num: i,
+  }));
+  const singleWeek = [
+    { __timestamp: MONDAY_1, sum__num: 10 },
+    { __timestamp: MONDAY_2, sum__num: 20 },
+  ];
+
+  const baseline = transformProps(
+    new ChartProps({
+      width: 800,
+      height: 400,
+      formData,
+      theme: supersetTheme,
+      queriesData: [{ data: singleWeek }],
+      hooks: {},
+    }) as unknown as EchartsTimePivotChartProps,
+  );
+  const manySeries = transformProps(
+    new ChartProps({
+      width: 800,
+      height: 400,
+      formData,
+      theme: supersetTheme,
+      queriesData: [{ data: manyWeeks }],
+      hooks: {},
+    }) as unknown as EchartsTimePivotChartProps,
+  );
+
+  const baselineTop = (baseline.echartOptions as any).grid.top;
+  const manySeriesTop = (manySeries.echartOptions as any).grid.top;
+  expect(manySeriesTop).toBeGreaterThan(baselineTop);
+});
+
+test('does not reserve extra grid.top space for a large legend when it is hidden', () => {
+  const manyWeeks = Array.from({ length: 25 }, (_, i) => ({
+    __timestamp: MONDAY_1 + i * WEEK,
+    sum__num: i,
+  }));
+
+  const shown = transformProps(
+    new ChartProps({
+      width: 800,
+      height: 400,
+      formData: { ...formData, showLegend: true },
+      theme: supersetTheme,
+      queriesData: [{ data: manyWeeks }],
+      hooks: {},
+    }) as unknown as EchartsTimePivotChartProps,
+  );
+  const hidden = transformProps(
+    new ChartProps({
+      width: 800,
+      height: 400,
+      formData: { ...formData, showLegend: false },
+      theme: supersetTheme,
+      queriesData: [{ data: manyWeeks }],
+      hooks: {},
+    }) as unknown as EchartsTimePivotChartProps,
+  );
+
+  expect((hidden.echartOptions as any).grid.top).toBeLessThan(
+    (shown.echartOptions as any).grid.top,
+  );
+});
+
 test('handles an empty result without crashing', () => {
   const props = new ChartProps({
     width: 800,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from '@testing-library/react';
+import { AxisType } from '@superset-ui/core';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import EchartsTimeseries from '../../src/Timeseries/EchartsTimeseries';
+import { TimeseriesChartTransformedProps } from '../../src/Timeseries/types';
+
+// Percent-change draggable baseline: this is the one piece of the ECharts
+// rebuilds with zero prior test coverage despite six separate production
+// bugs fixed against it (crash from a non-group graphic element, hardcoded
+// colors, NaN from category-axis coercion, baseline resetting on rerender,
+// unthrottled setOption calls, a getOption() undefined crash on warm nav).
+// Echart itself is mocked as a forwardRef exposing a controllable fake
+// EChartsType instance, since the baseline/drag logic drives the chart
+// imperatively (setOption/convertToPixel/convertFromPixel) rather than
+// through props. Defined inside the mock factory (rather than via
+// mockImplementation afterward) because forwardRef() returns a React
+// element descriptor, not a plain function a jest mock can invoke.
+let mockChart: {
+  setOption: jest.Mock;
+  getHeight: jest.Mock;
+  convertToPixel: jest.Mock;
+  convertFromPixel: jest.Mock;
+  getModel: jest.Mock;
+};
+
+jest.mock('../../src/components/Echart', () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: forwardRef((_props: unknown, ref: unknown) => {
+      useImperativeHandle(ref, () => ({
+        getEchartInstance: () => mockChart,
+      }));
+      return null;
+    }),
+  };
+});
+
+const PX_PER_UNIT = 100;
+
+function setupChartMock() {
+  mockChart = {
+    setOption: jest.fn(),
+    getHeight: jest.fn(() => 400),
+    // A trivial, invertible mapping so drag pixel deltas translate to
+    // predictable x-data-value deltas: pixel = x * PX_PER_UNIT.
+    convertToPixel: jest.fn((_finder: unknown, x: number) => x * PX_PER_UNIT),
+    convertFromPixel: jest.fn(
+      (_finder: unknown, px: number) => px / PX_PER_UNIT,
+    ),
+    // No grid component registered; drawHandle() falls back to the full
+    // chart height, matching real behavior when the lookup throws.
+    getModel: jest.fn(() => {
+      throw new Error('no grid component in this test double');
+    }),
+  };
+}
+
+const BASE_SERIES_DATA: [number, number][] = [
+  [0, 10],
+  [1, 20],
+  [2, 30],
+];
+
+function renderTimeseries(
+  overrides: Partial<TimeseriesChartTransformedProps> = {},
+) {
+  const props: TimeseriesChartTransformedProps = {
+    formData: {
+      rebasePercentChange: true,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    height: 400,
+    width: 800,
+    echartOptions: { series: [{ data: BASE_SERIES_DATA }] } as any,
+    groupby: [],
+    labelMap: {},
+    selectedValues: {},
+    setDataMask: jest.fn(),
+    setControlValue: jest.fn(),
+    legendData: [],
+    onContextMenu: jest.fn(),
+    onLegendStateChanged: jest.fn(),
+    onFocusedSeries: jest.fn(),
+    xValueFormatter: String,
+    xAxis: { label: 'x', type: AxisType.Time },
+    refs: {},
+    emitCrossFilters: false,
+    coltypeMapping: {},
+    onLegendScroll: jest.fn(),
+    ...overrides,
+  };
+  return render(
+    <ThemeProvider theme={supersetTheme}>
+      <EchartsTimeseries {...props} />
+    </ThemeProvider>,
+  );
+}
+
+// Pulls the graphic descriptor for the draggable baseline handle out of the
+// most recent setOption call, mirroring how ECharts itself would read it.
+function getBaselineGraphic() {
+  const call = mockChart.setOption.mock.calls
+    .filter(([option]) => Array.isArray(option?.graphic))
+    .at(-1);
+  return call?.[0].graphic[0];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupChartMock();
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('draws the baseline handle at the first x value on mount', () => {
+  renderTimeseries();
+
+  const graphic = getBaselineGraphic();
+  expect(graphic).toMatchObject({
+    id: 'percent-change-baseline',
+    type: 'group',
+    draggable: true,
+  });
+  // x=0 -> convertToPixel returns 0 -> handle left edge is centered on it.
+  expect(graphic.x).toBe(0 - 4);
+});
+
+test('does not draw a baseline when the rebase flag is off', () => {
+  renderTimeseries({ formData: { rebasePercentChange: false } as any });
+
+  expect(getBaselineGraphic()).toBeUndefined();
+});
+
+test('dragging the handle rebases every series against the snapped x value', () => {
+  renderTimeseries();
+  const graphic = getBaselineGraphic();
+  mockChart.setOption.mockClear();
+  // Drag to a pixel position corresponding to x=1 (the middle point): with
+  // PX_PER_UNIT=100 and the +4 offset the drag handler subtracts back out,
+  // this.x + 4 must convertFromPixel to 1.
+  const dragThis = { x: 1 * PX_PER_UNIT - 4, y: 0 };
+  graphic.ondrag.call(dragThis);
+
+  const rebaseCall = mockChart.setOption.mock.calls.find(([option]) =>
+    Array.isArray(option?.series),
+  );
+  expect(rebaseCall).toBeDefined();
+  const [{ series }] = rebaseCall!;
+  // Rebased against x=1 (value 20): (1+v)/(1+20)-1 for each point.
+  expect(series[0].data).toEqual([
+    [0, (1 + 10) / (1 + 20) - 1],
+    [1, 0],
+    [2, (1 + 30) / (1 + 20) - 1],
+  ]);
+});
+
+test('dragging snaps to the nearest known x value rather than an arbitrary pixel', () => {
+  renderTimeseries();
+  const graphic = getBaselineGraphic();
+  mockChart.setOption.mockClear();
+  // A pixel position just past x=1 (at 1.4) must snap to 1, not float.
+  const dragThis = { x: 1.4 * PX_PER_UNIT - 4, y: 0 };
+  graphic.ondrag.call(dragThis);
+
+  const rebaseCall = mockChart.setOption.mock.calls.find(([option]) =>
+    Array.isArray(option?.series),
+  );
+  const [{ series }] = rebaseCall!;
+  expect(series[0].data[1]).toEqual([1, 0]);
+});
+
+test('dragging to the already-active baseline does not re-issue a redundant rebase', () => {
+  renderTimeseries();
+  const graphic = getBaselineGraphic();
+  mockChart.setOption.mockClear();
+  // The baseline starts at x=0; dragging to the same snapped value should
+  // not trigger a second series update.
+  graphic.ondrag.call({ x: 0 * PX_PER_UNIT - 4, y: 0 });
+
+  const rebaseCall = mockChart.setOption.mock.calls.find(([option]) =>
+    Array.isArray(option?.series),
+  );
+  expect(rebaseCall).toBeUndefined();
+});
+
+test('does not draw a baseline when the series has no plottable points', () => {
+  renderTimeseries({
+    echartOptions: { series: [{ data: [] }] } as any,
+  });
+
+  expect(getBaselineGraphic()).toBeUndefined();
+});
+
+test('ondragend redraws the handle at its current position', () => {
+  renderTimeseries();
+  const graphic = getBaselineGraphic();
+  mockChart.setOption.mockClear();
+  graphic.ondragend();
+
+  expect(
+    mockChart.setOption.mock.calls.some(([option]) =>
+      Array.isArray(option?.graphic),
+    ),
+  ).toBe(true);
+});
+
+test('removes the baseline graphic on unmount', () => {
+  const { unmount } = renderTimeseries();
+  mockChart.setOption.mockClear();
+
+  unmount();
+
+  expect(mockChart.setOption).toHaveBeenCalledWith({
+    graphic: [{ id: 'percent-change-baseline', $action: 'remove' }],
+  });
+});
+
+test('does not touch the chart instance when rebase is disabled', () => {
+  renderTimeseries({ formData: { rebasePercentChange: false } as any });
+
+  expect(mockChart.setOption).not.toHaveBeenCalled();
+});

--- a/superset-frontend/plugins/plugin-chart-paired-t-test/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-paired-t-test/src/buildQuery.ts
@@ -19,11 +19,10 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  getMetricLabel,
   QueryFormData,
   QueryFormMetric,
-  QueryFormOrderBy,
 } from '@superset-ui/core';
+import { buildSortMetricOrderby } from '@superset-ui/chart-controls';
 
 /**
  * Mirrors the legacy PairedTTestViz.query_obj: a timeseries query grouped
@@ -33,20 +32,12 @@ import {
 export default function buildQuery(formData: QueryFormData) {
   const { timeseries_limit_metric, order_desc } = formData;
   return buildQueryContext(formData, baseQueryObject => {
-    let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
-    const orderby: QueryFormOrderBy[] = [];
-    const sortByMetric = ensureIsArray(
-      timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
-    )[0];
-    if (sortByMetric) {
-      const sortByLabel = getMetricLabel(sortByMetric);
-      if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
-        metrics = [...metrics, sortByMetric];
-      }
-      if (order_desc) {
-        orderby.push([sortByMetric, !order_desc]);
-      }
-    }
+    const { metrics, orderby } = buildSortMetricOrderby({
+      metrics: ensureIsArray(baseQueryObject.metrics) as QueryFormMetric[],
+      timeseriesLimitMetric: timeseries_limit_metric,
+      order_desc,
+      orderOnlyWhenDesc: true,
+    });
     return [
       {
         ...baseQueryObject,

--- a/superset-frontend/plugins/plugin-chart-paired-t-test/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-paired-t-test/test/buildQuery.test.ts
@@ -47,6 +47,18 @@ test('appends the sort metric and orders when order_desc is set', () => {
   expect(query.orderby).toEqual([['count', false]]);
 });
 
+test('appends the sort metric but does not order when order_desc is unset', () => {
+  // order_desc gates whether the query orders at all here (unlike partition,
+  // which always orders and only flips direction) -- a sort metric with
+  // order_desc false/absent should still be selected, just not ordered by.
+  const [query] = buildQuery({
+    ...formData,
+    timeseries_limit_metric: 'count',
+  }).queries;
+  expect(query.metrics).toEqual(['sum__num', 'count']);
+  expect(query.orderby).toBeUndefined();
+});
+
 test('ignores residual order_by_cols from other viz types', () => {
   const [query] = buildQuery({
     ...formData,

--- a/superset-frontend/plugins/plugin-chart-parallel-coordinates/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-parallel-coordinates/src/buildQuery.ts
@@ -19,11 +19,10 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  getMetricLabel,
   QueryFormData,
   QueryFormMetric,
-  QueryFormOrderBy,
 } from '@superset-ui/core';
+import { buildSortMetricOrderby } from '@superset-ui/chart-controls';
 
 /**
  * Mirrors the query the legacy `para` viz built server-side: one query
@@ -35,20 +34,12 @@ import {
 export default function buildQuery(formData: QueryFormData) {
   const { timeseries_limit_metric, order_desc } = formData;
   return buildQueryContext(formData, baseQueryObject => {
-    let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
-    const orderby: QueryFormOrderBy[] = [];
-    const sortByMetric = ensureIsArray(
-      timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
-    )[0];
-    if (sortByMetric) {
-      const sortByLabel = getMetricLabel(sortByMetric);
-      if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
-        metrics = [...metrics, sortByMetric];
-      }
-      if (order_desc) {
-        orderby.push([sortByMetric, !order_desc]);
-      }
-    }
+    const { metrics, orderby } = buildSortMetricOrderby({
+      metrics: ensureIsArray(baseQueryObject.metrics) as QueryFormMetric[],
+      timeseriesLimitMetric: timeseries_limit_metric,
+      order_desc,
+      orderOnlyWhenDesc: true,
+    });
     return [
       {
         ...baseQueryObject,

--- a/superset-frontend/plugins/plugin-chart-partition/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-partition/src/buildQuery.ts
@@ -19,11 +19,10 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  getMetricLabel,
   QueryFormData,
   QueryFormMetric,
-  QueryFormOrderBy,
 } from '@superset-ui/core';
+import { buildSortMetricOrderby } from '@superset-ui/chart-controls';
 
 /**
  * Mirrors the legacy PartitionViz.query_obj (via NVD3TimeSeriesViz): a
@@ -35,19 +34,12 @@ import {
 export default function buildQuery(formData: QueryFormData) {
   const { time_series_option, timeseries_limit_metric, order_desc } = formData;
   return buildQueryContext(formData, baseQueryObject => {
-    let metrics: QueryFormMetric[] = ensureIsArray(baseQueryObject.metrics);
-    const orderby: QueryFormOrderBy[] = [];
-    const sortByMetric =
-      ensureIsArray(
-        timeseries_limit_metric as QueryFormMetric | QueryFormMetric[],
-      )[0] ?? metrics[0];
-    if (sortByMetric) {
-      const sortByLabel = getMetricLabel(sortByMetric);
-      if (!metrics.some(metric => getMetricLabel(metric) === sortByLabel)) {
-        metrics = [...metrics, sortByMetric];
-      }
-      orderby.push([sortByMetric, !order_desc]);
-    }
+    const { metrics, orderby } = buildSortMetricOrderby({
+      metrics: ensureIsArray(baseQueryObject.metrics) as QueryFormMetric[],
+      timeseriesLimitMetric: timeseries_limit_metric,
+      order_desc,
+      fallbackToFirstMetric: true,
+    });
     return [
       {
         ...baseQueryObject,

--- a/superset-frontend/plugins/plugin-chart-partition/test/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-partition/test/transformProps.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { supersetTheme } from '@apache-superset/core/theme';
+import { ChartProps } from '@superset-ui/core';
+import transformProps from '../src/transformProps';
+
+const baseFormData = {
+  colorScheme: 'supersetColors',
+  groupby: ['gender', 'state'],
+  metrics: ['sum__num'],
+  timeSeriesOption: 'not_time',
+  numberFormat: 'SMART_NUMBER',
+  sliceId: 1,
+};
+
+function buildChartProps(overrides: Record<string, unknown> = {}) {
+  return new ChartProps({
+    width: 400,
+    height: 300,
+    theme: supersetTheme,
+    formData: { ...baseFormData, ...overrides },
+    datasource: { verboseMap: { gender: 'Gender', state: 'State' } },
+    queriesData: [
+      {
+        data: [
+          { gender: 'boy', state: 'CA', sum__num: 10 },
+          { gender: 'girl', state: 'NY', sum__num: 20 },
+        ],
+      },
+    ],
+  }) as ChartProps;
+}
+
+test('builds the hierarchy from v1 flat records and maps levels through verboseMap', () => {
+  const result = transformProps(buildChartProps());
+  expect(result.width).toEqual(400);
+  expect(result.height).toEqual(300);
+  expect(result.levels).toEqual(['Gender', 'State']);
+  expect(result.data).toHaveLength(1);
+  expect(result.data[0].val).toEqual(30);
+});
+
+test('falls back to the raw column name when verboseMap has no entry', () => {
+  const result = transformProps(
+    buildChartProps({ groupby: ['gender', 'unmapped_col'] }),
+  );
+  expect(result.levels).toEqual(['Gender', 'unmapped_col']);
+});
+
+test('parses partitionLimit and partitionThreshold as integers', () => {
+  const result = transformProps(
+    buildChartProps({ partitionLimit: '5', partitionThreshold: '0.1' }),
+  );
+  expect(result.partitionLimit).toEqual(5);
+  expect(result.partitionThreshold).toEqual(0);
+});
+
+test('leaves partitionLimit and partitionThreshold undefined when unset', () => {
+  const result = transformProps(buildChartProps());
+  expect(result.partitionLimit).toBeFalsy();
+  expect(result.partitionThreshold).toBeFalsy();
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.color.test.tsx
@@ -48,6 +48,7 @@ jest.mock('../DeckGLContainer', () => ({
 jest.mock('@superset-ui/core', () => ({
   ...jest.requireActual('@superset-ui/core'),
   SupersetClient: {
+    get: jest.fn(),
     post: jest.fn(),
   },
 }));
@@ -95,6 +96,27 @@ const renderWithProviders = (component: React.ReactElement) =>
 
 const SCATTER_SLICE_ID = 1;
 
+// Mocks the GET /api/v1/chart/{id} the v1 path uses to resolve each
+// sub-slice's saved form_data, keyed by slice_id -> params.
+const mockSubsliceParams = (paramsBySliceId: Record<number, JsonObject>) => {
+  (SupersetClient.get as jest.Mock).mockImplementation(
+    ({ endpoint }: { endpoint: string }) => {
+      const sliceId = Number(endpoint.match(/\/chart\/(\d+)/)?.[1]);
+      const params = paramsBySliceId[sliceId];
+      return Promise.resolve({
+        json: {
+          result: {
+            viz_type: params?.viz_type,
+            datasource_id: 1,
+            datasource_type: 'table',
+            params: JSON.stringify(params || {}),
+          },
+        },
+      });
+    },
+  );
+};
+
 const props = {
   formData: {
     datasource: '1__table',
@@ -103,28 +125,7 @@ const props = {
     autozoom: false,
     map_style: 'mapbox://styles/mapbox/light-v9',
   },
-  payload: {
-    data: {
-      slices: [
-        {
-          slice_id: SCATTER_SLICE_ID,
-          form_data: {
-            viz_type: 'deck_scatter',
-            datasource: '1__table',
-            slice_id: SCATTER_SLICE_ID,
-            // categorical color configuration coming from the saved scatter chart
-            color_scheme_type: 'categorical_palette',
-            color_scheme: 'supersetColors',
-            dimension: 'category',
-          },
-        },
-      ],
-      features: {
-        deck_scatter: [],
-      },
-      mapboxApiKey: 'test-key',
-    },
-  },
+  payload: undefined,
   setControlValue: jest.fn(),
   viewport: { longitude: 0, latitude: 0, zoom: 1 },
   onAddFilter: jest.fn(),
@@ -146,6 +147,16 @@ const props = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockLayerCapture.layers = [];
+  // categorical color configuration coming from the saved scatter chart
+  mockSubsliceParams({
+    [SCATTER_SLICE_ID]: {
+      viz_type: 'deck_scatter',
+      datasource: '1__table',
+      color_scheme_type: 'categorical_palette',
+      color_scheme: 'supersetColors',
+      dimension: 'category',
+    },
+  });
   // The scatter sublayer query returns features tagged with a category column.
   (SupersetClient.post as jest.Mock).mockResolvedValue({
     json: {
@@ -196,29 +207,16 @@ test('applies categorical colors to scatter subslices saved before the color_sch
   // Charts saved before the color_scheme_type control existed lack the key in
   // stored params; the scatter default (categorical_palette) must be resolved
   // so they keep per-category colors.
-  const legacyProps = {
-    ...props,
-    payload: {
-      ...props.payload,
-      data: {
-        ...props.payload.data,
-        slices: [
-          {
-            slice_id: SCATTER_SLICE_ID,
-            form_data: {
-              viz_type: 'deck_scatter',
-              datasource: '1__table',
-              slice_id: SCATTER_SLICE_ID,
-              color_scheme: 'supersetColors',
-              dimension: 'category',
-            },
-          },
-        ],
-      },
+  mockSubsliceParams({
+    [SCATTER_SLICE_ID]: {
+      viz_type: 'deck_scatter',
+      datasource: '1__table',
+      color_scheme: 'supersetColors',
+      dimension: 'category',
     },
-  };
+  });
 
-  renderWithProviders(<DeckMulti {...legacyProps} />);
+  renderWithProviders(<DeckMulti {...props} />);
 
   await expectDistinctCategoricalColors();
 });
@@ -228,28 +226,17 @@ test('keeps fixed source and target colors for arc subslices saved before the co
   // target pickers directly; resolving the default must not stamp a single
   // per-feature color over the target color.
   const ARC_SLICE_ID = 2;
+  mockSubsliceParams({
+    [ARC_SLICE_ID]: {
+      viz_type: 'deck_arc',
+      datasource: '1__table',
+      color_picker: { r: 10, g: 20, b: 30, a: 1 },
+      target_color_picker: { r: 40, g: 50, b: 60, a: 1 },
+    },
+  });
   const arcProps = {
     ...props,
     formData: { ...props.formData, deck_slices: [ARC_SLICE_ID] },
-    payload: {
-      ...props.payload,
-      data: {
-        ...props.payload.data,
-        slices: [
-          {
-            slice_id: ARC_SLICE_ID,
-            form_data: {
-              viz_type: 'deck_arc',
-              datasource: '1__table',
-              slice_id: ARC_SLICE_ID,
-              color_picker: { r: 10, g: 20, b: 30, a: 1 },
-              target_color_picker: { r: 40, g: 50, b: 60, a: 1 },
-            },
-          },
-        ],
-        features: { deck_arc: [] },
-      },
-    },
   };
   (SupersetClient.post as jest.Mock).mockResolvedValue({
     json: {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
@@ -392,18 +392,19 @@ describe('DeckMulti stale-response guard', () => {
   });
 
   test('ignores a layer response that resolves after deck_slices has already changed again', async () => {
-    let resolveFirstLoad: (value: unknown) => void = () => {};
+    let resolveSlice1Load: (value: unknown) => void = () => {};
+    let resolveSlice2Load: (value: unknown) => void = () => {};
     (SupersetClient.post as jest.Mock)
       .mockImplementationOnce(
         () =>
           new Promise(resolve => {
-            resolveFirstLoad = resolve;
+            resolveSlice1Load = resolve;
           }),
       )
       .mockImplementationOnce(
         () =>
           new Promise(resolve => {
-            resolveFirstLoad = resolve;
+            resolveSlice2Load = resolve;
           }),
       )
       .mockImplementation(() =>
@@ -429,10 +430,11 @@ describe('DeckMulti stale-response guard', () => {
 
     await waitFor(() => expect(SupersetClient.post).toHaveBeenCalledTimes(3));
 
-    // The abandoned first-generation slice-1 response now resolves. If it
-    // were not ignored, the container would show 2 layers (the stale slice 1
-    // plus the new slice 2) instead of just the current generation's 1.
-    resolveFirstLoad({ json: { result: [{ data: [] }] } });
+    // The abandoned first-generation slice-1 and slice-2 responses now
+    // resolve. If they were not ignored, the container would show 2 layers
+    // (the stale slice 1 and 2) instead of just the current generation's 1.
+    resolveSlice1Load({ json: { result: [{ data: [] }] } });
+    resolveSlice2Load({ json: { result: [{ data: [] }] } });
 
     await waitFor(() => {
       expect(

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.test.tsx
@@ -47,7 +47,10 @@ jest.mock('@superset-ui/core', () => ({
   },
 }));
 
-// register stub buildQuery/transformProps for the layer types the tests use
+// register stub buildQuery/transformProps for the layer types the tests use.
+// transformProps passes the mocked POST response's features straight through,
+// so each test controls layer content via the POST mock, exactly as the real
+// per-layer buildQuery/transformProps registry would.
 const { getChartBuildQueryRegistry, getChartTransformPropsRegistry } =
   jest.requireActual('@superset-ui/core');
 ['deck_scatter', 'deck_polygon'].forEach(vizType => {
@@ -59,11 +62,18 @@ const { getChartBuildQueryRegistry, getChartTransformPropsRegistry } =
       form_data: formData,
     }),
   );
-  getChartTransformPropsRegistry().registerValue(vizType, () => ({
-    payload: {
-      data: { features: [], mapboxApiKey: 'test-key', metricLabels: [] },
-    },
-  }));
+  getChartTransformPropsRegistry().registerValue(
+    vizType,
+    (chartProps: any) => ({
+      payload: {
+        data: {
+          features: chartProps.queriesData?.[0]?.data ?? [],
+          mapboxApiKey: 'test-key',
+          metricLabels: [],
+        },
+      },
+    }),
+  );
 });
 
 const mockStore = configureStore({
@@ -71,6 +81,51 @@ const mockStore = configureStore({
     dataMask: () => ({}),
   },
 });
+
+// The two sub-slices every test in this file fetches: slice 1 is a scatter
+// layer, slice 2 is a polygon layer -- mirroring the shape the old
+// legacy-payload fixture hardcoded, but now resolved through the real
+// GET /api/v1/chart/{id} -> POST /api/v1/chart/data v1 path.
+const SUBSLICES: Record<number, { vizType: string }> = {
+  1: { vizType: 'deck_scatter' },
+  2: { vizType: 'deck_polygon' },
+};
+
+// Keyed by viz_type so a test can control exactly what features each layer's
+// POST resolves with; defaults to empty so unconfigured layers are inert.
+let featuresByVizType: Record<string, unknown[]> = {};
+
+const mockFetchesFor = (subslices: Record<number, { vizType: string }>) => {
+  (SupersetClient.get as jest.Mock).mockImplementation(
+    ({ endpoint }: { endpoint: string }) => {
+      const sliceId = Number(endpoint.match(/\/chart\/(\d+)/)?.[1]);
+      const subslice = subslices[sliceId];
+      return Promise.resolve({
+        json: {
+          result: {
+            viz_type: subslice?.vizType,
+            datasource_id: 1,
+            datasource_type: 'table',
+            params: JSON.stringify({
+              viz_type: subslice?.vizType,
+              datasource: 'test_datasource',
+            }),
+          },
+        },
+      });
+    },
+  );
+  (SupersetClient.post as jest.Mock).mockImplementation(
+    ({ jsonPayload }: { jsonPayload: { form_data: { viz_type: string } } }) =>
+      Promise.resolve({
+        json: {
+          result: [
+            { data: featuresByVizType[jsonPayload.form_data.viz_type] || [] },
+          ],
+        },
+      }),
+  );
+};
 
 const baseMockProps = {
   formData: {
@@ -80,46 +135,7 @@ const baseMockProps = {
     autozoom: false,
     map_style: 'mapbox://styles/mapbox/light-v9',
   },
-  payload: {
-    data: {
-      slices: [
-        {
-          slice_id: 1,
-          form_data: {
-            viz_type: 'deck_scatter',
-            datasource: 'test_datasource',
-          },
-        },
-        {
-          slice_id: 2,
-          form_data: {
-            viz_type: 'deck_polygon',
-            datasource: 'test_datasource',
-          },
-        },
-      ],
-      features: {
-        deck_scatter: [{ position: [0, 0] }],
-        deck_polygon: [
-          {
-            polygon: [
-              [1, 1],
-              [2, 2],
-            ],
-          },
-        ],
-        deck_path: [],
-        deck_grid: [],
-        deck_contour: [],
-        deck_heatmap: [],
-        deck_hex: [],
-        deck_arc: [],
-        deck_geojson: [],
-        deck_screengrid: [],
-      },
-      mapboxApiKey: 'test-key',
-    },
-  },
+  payload: undefined,
   setControlValue: jest.fn(),
   viewport: { longitude: 0, latitude: 0, zoom: 1 },
   onAddFilter: jest.fn(),
@@ -148,346 +164,291 @@ const renderWithProviders = (component: React.ReactElement) =>
 describe('DeckMulti Autozoom Functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (SupersetClient.post as jest.Mock).mockResolvedValue({
-      json: {
-        result: [{ data: [] }],
-      },
-    });
-    (SupersetClient.get as jest.Mock).mockResolvedValue({
-      json: {
-        data: {
-          features: [],
-        },
-      },
-    });
+    featuresByVizType = {};
+    mockFetchesFor(SUBSLICES);
   });
 
-  test('should NOT apply autozoom when autozoom is false', () => {
+  test('should NOT apply autozoom when autozoom is false', async () => {
     const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
+    featuresByVizType = { deck_scatter: [{ position: [1, 1] }] };
 
     const props = {
       ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: false,
-      },
+      formData: { ...baseMockProps.formData, autozoom: false },
     };
 
     renderWithProviders(<DeckMulti {...props} />);
 
-    // fitViewport should not be called when autozoom is false
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
     expect(fitViewportSpy).not.toHaveBeenCalled();
 
     fitViewportSpy.mockRestore();
   });
 
-  test('should apply autozoom when autozoom is true', () => {
+  test('should apply autozoom to points fetched from each layer when autozoom is true', async () => {
     const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
     fitViewportSpy.mockReturnValue({
       longitude: -122.4,
       latitude: 37.8,
       zoom: 10,
     });
+    featuresByVizType = {
+      deck_scatter: [{ position: [1, 1] }, { position: [2, 2] }],
+      deck_polygon: [
+        {
+          polygon: [
+            [3, 3],
+            [4, 4],
+          ],
+        },
+      ],
+    };
 
     const props = {
       ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: true,
-      },
+      formData: { ...baseMockProps.formData, autozoom: true },
     };
 
     renderWithProviders(<DeckMulti {...props} />);
 
-    // fitViewport should be called with the points from all layers
-    expect(fitViewportSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        longitude: 0,
-        latitude: 0,
-        zoom: 1,
-      }),
-      expect.objectContaining({
-        width: 800,
-        height: 600,
-        points: expect.any(Array),
-      }),
+    await waitFor(() => {
+      expect(fitViewportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ longitude: 0, latitude: 0, zoom: 1 }),
+        expect.objectContaining({
+          width: 800,
+          height: 600,
+          points: expect.any(Array),
+        }),
+      );
+    });
+    // Points from both layers should have been collected by the time the
+    // second (or later) refit happens -- this exercises the async, per-layer
+    // accumulation added to fix the "autozoom dead in the v1 path" bug.
+    const callWithBothLayers = fitViewportSpy.mock.calls.find(
+      call => call[1].points.length >= 4,
+    );
+    expect(callWithBothLayers).toBeDefined();
+
+    fitViewportSpy.mockRestore();
+  });
+
+  test('should refit as each layer arrives, even when they resolve out of order', async () => {
+    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
+    fitViewportSpy.mockReturnValue({ longitude: 0, latitude: 0, zoom: 8 });
+
+    // The polygon layer (slice 2) resolves before the scatter layer (slice 1),
+    // the opposite of deck_slices order -- accumulation must not assume
+    // layers arrive in request order.
+    let resolveScatter: (value: unknown) => void = () => {};
+    (SupersetClient.post as jest.Mock).mockImplementation(
+      ({
+        jsonPayload,
+      }: {
+        jsonPayload: { form_data: { viz_type: string } };
+      }) => {
+        if (jsonPayload.form_data.viz_type === 'deck_scatter') {
+          return new Promise(resolve => {
+            resolveScatter = resolve;
+          });
+        }
+        return Promise.resolve({
+          json: {
+            result: [
+              {
+                data: [
+                  {
+                    polygon: [
+                      [3, 3],
+                      [4, 4],
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        });
+      },
     );
 
+    renderWithProviders(
+      <DeckMulti
+        {...baseMockProps}
+        formData={{ ...baseMockProps.formData, autozoom: true }}
+      />,
+    );
+
+    // Only the polygon layer's points have arrived so far.
+    await waitFor(() => {
+      const call = fitViewportSpy.mock.calls.at(-1);
+      expect(call?.[1].points.length).toBe(2);
+    });
+
+    resolveScatter({
+      json: {
+        result: [{ data: [{ position: [1, 1] }, { position: [2, 2] }] }],
+      },
+    });
+
+    // Once the scatter layer resolves, its points are added to the same
+    // accumulator rather than replacing the polygon layer's.
+    await waitFor(() => {
+      const call = fitViewportSpy.mock.calls.at(-1);
+      expect(call?.[1].points.length).toBe(4);
+    });
+
     fitViewportSpy.mockRestore();
   });
 
-  test('should use adjusted viewport when autozoom is enabled', async () => {
+  test('should set zoom to 0 when the fitted zoom is negative', async () => {
     const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-    const adjustedViewport = {
-      longitude: -122.4,
-      latitude: 37.8,
-      zoom: 12,
-    };
-    fitViewportSpy.mockReturnValue(adjustedViewport);
+    fitViewportSpy.mockReturnValue({ longitude: 0, latitude: 0, zoom: -5 });
+    featuresByVizType = { deck_scatter: [{ position: [1, 1] }] };
 
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: true,
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
+    renderWithProviders(
+      <DeckMulti
+        {...baseMockProps}
+        formData={{ ...baseMockProps.formData, autozoom: true }}
+      />,
+    );
 
     await waitFor(() => {
       const container = screen.getByTestId('deckgl-container');
       const viewportData = JSON.parse(
         container.getAttribute('data-viewport') || '{}',
       );
-
-      expect(viewportData.longitude).toBe(adjustedViewport.longitude);
-      expect(viewportData.latitude).toBe(adjustedViewport.latitude);
-      expect(viewportData.zoom).toBe(adjustedViewport.zoom);
-    });
-
-    fitViewportSpy.mockRestore();
-  });
-
-  test('should set zoom to 0 when calculated zoom is negative', async () => {
-    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-    fitViewportSpy.mockReturnValue({
-      longitude: 0,
-      latitude: 0,
-      zoom: -5, // negative zoom
-    });
-
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: true,
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
-
-    await waitFor(() => {
-      const container = screen.getByTestId('deckgl-container');
-      const viewportData = JSON.parse(
-        container.getAttribute('data-viewport') || '{}',
-      );
-
-      // Zoom should be 0, not negative
       expect(viewportData.zoom).toBe(0);
     });
 
     fitViewportSpy.mockRestore();
   });
 
-  test('should handle empty features gracefully when autozoom is enabled', () => {
+  test('should not refit when a layer resolves with no features', async () => {
     const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
 
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: true,
-      },
-      payload: {
-        ...baseMockProps.payload,
-        data: {
-          ...baseMockProps.payload.data,
-          features: {
-            deck_scatter: [],
-            deck_polygon: [],
-            deck_path: [],
-            deck_grid: [],
-            deck_contour: [],
-            deck_heatmap: [],
-            deck_hex: [],
-            deck_arc: [],
-            deck_geojson: [],
-            deck_screengrid: [],
-          },
-        },
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
-
-    // fitViewport should not be called when there are no points
-    expect(fitViewportSpy).not.toHaveBeenCalled();
-
-    fitViewportSpy.mockRestore();
-  });
-
-  test('should collect points from all layer types when autozoom is enabled', () => {
-    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-    fitViewportSpy.mockReturnValue({
-      longitude: 0,
-      latitude: 0,
-      zoom: 10,
-    });
-
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: true,
-      },
-      payload: {
-        ...baseMockProps.payload,
-        data: {
-          ...baseMockProps.payload.data,
-          features: {
-            deck_scatter: [{ position: [1, 1] }, { position: [2, 2] }],
-            deck_polygon: [
-              {
-                polygon: [
-                  [3, 3],
-                  [4, 4],
-                ],
-              },
-            ],
-            deck_arc: [{ sourcePosition: [5, 5], targetPosition: [6, 6] }],
-            deck_path: [],
-            deck_grid: [],
-            deck_contour: [],
-            deck_heatmap: [],
-            deck_hex: [],
-            deck_geojson: [],
-            deck_screengrid: [],
-          },
-        },
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
-
-    expect(fitViewportSpy).toHaveBeenCalled();
-    const callArgs = fitViewportSpy.mock.calls[0];
-    const { points } = callArgs[1];
-
-    // Should have points from scatter (2), polygon (2), and arc (2) = 6 points total
-    expect(points.length).toBeGreaterThan(0);
-
-    fitViewportSpy.mockRestore();
-  });
-
-  test('should use original viewport when autozoom is disabled', async () => {
-    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-
-    const originalViewport = { longitude: -100, latitude: 40, zoom: 5 };
-    const props = {
-      ...baseMockProps,
-      viewport: originalViewport,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: false,
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
-
-    await waitFor(() => {
-      const container = screen.getByTestId('deckgl-container');
-      const viewportData = JSON.parse(
-        container.getAttribute('data-viewport') || '{}',
-      );
-
-      // Should use original viewport without modification
-      expect(viewportData.longitude).toBe(originalViewport.longitude);
-      expect(viewportData.latitude).toBe(originalViewport.latitude);
-      expect(viewportData.zoom).toBe(originalViewport.zoom);
-    });
-
-    // fitViewport should not have been called
-    expect(fitViewportSpy).not.toHaveBeenCalled();
-
-    fitViewportSpy.mockRestore();
-  });
-
-  test('should apply autozoom when autozoom is undefined (backward compatibility)', () => {
-    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-    fitViewportSpy.mockReturnValue({
-      longitude: -122.4,
-      latitude: 37.8,
-      zoom: 10,
-    });
-
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: undefined, // Simulating existing charts created before this feature
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
-
-    // fitViewport should be called for backward compatibility with existing charts
-    expect(fitViewportSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        longitude: 0,
-        latitude: 0,
-        zoom: 1,
-      }),
-      expect.objectContaining({
-        width: 800,
-        height: 600,
-        points: expect.any(Array),
-      }),
+    renderWithProviders(
+      <DeckMulti
+        {...baseMockProps}
+        formData={{ ...baseMockProps.formData, autozoom: true }}
+      />,
     );
 
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalledTimes(2));
+    expect(fitViewportSpy).not.toHaveBeenCalled();
+
     fitViewportSpy.mockRestore();
   });
 
-  test('should use adjusted viewport when autozoom is undefined', async () => {
+  test('should use the original viewport when autozoom is disabled', async () => {
     const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
-    const adjustedViewport = {
-      longitude: -122.4,
-      latitude: 37.8,
-      zoom: 12,
-    };
-    fitViewportSpy.mockReturnValue(adjustedViewport);
+    const originalViewport = { longitude: -100, latitude: 40, zoom: 5 };
 
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        autozoom: undefined, // Simulating existing charts
-      },
-    };
-
-    renderWithProviders(<DeckMulti {...props} />);
+    renderWithProviders(
+      <DeckMulti
+        {...baseMockProps}
+        viewport={originalViewport}
+        formData={{ ...baseMockProps.formData, autozoom: false }}
+      />,
+    );
 
     await waitFor(() => {
       const container = screen.getByTestId('deckgl-container');
       const viewportData = JSON.parse(
         container.getAttribute('data-viewport') || '{}',
       );
-
-      // Should use adjusted viewport for backward compatibility
-      expect(viewportData.longitude).toBe(adjustedViewport.longitude);
-      expect(viewportData.latitude).toBe(adjustedViewport.latitude);
-      expect(viewportData.zoom).toBe(adjustedViewport.zoom);
+      expect(viewportData).toMatchObject(originalViewport);
     });
+    expect(fitViewportSpy).not.toHaveBeenCalled();
 
     fitViewportSpy.mockRestore();
+  });
+
+  test('should apply autozoom when autozoom is undefined (backward compatibility)', async () => {
+    const fitViewportSpy = jest.spyOn(fitViewportModule, 'default');
+    fitViewportSpy.mockReturnValue({
+      longitude: -122.4,
+      latitude: 37.8,
+      zoom: 10,
+    });
+    featuresByVizType = { deck_scatter: [{ position: [1, 1] }] };
+
+    renderWithProviders(
+      <DeckMulti
+        {...baseMockProps}
+        formData={{ ...baseMockProps.formData, autozoom: undefined }}
+      />,
+    );
+
+    await waitFor(() => expect(fitViewportSpy).toHaveBeenCalled());
+
+    fitViewportSpy.mockRestore();
+  });
+});
+
+describe('DeckMulti stale-response guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    featuresByVizType = {};
+    mockFetchesFor(SUBSLICES);
+  });
+
+  test('ignores a layer response that resolves after deck_slices has already changed again', async () => {
+    let resolveFirstLoad: (value: unknown) => void = () => {};
+    (SupersetClient.post as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirstLoad = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirstLoad = resolve;
+          }),
+      )
+      .mockImplementation(() =>
+        Promise.resolve({ json: { result: [{ data: [] }] } }),
+      );
+
+    const { rerender } = renderWithProviders(<DeckMulti {...baseMockProps} />);
+
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalledTimes(2));
+
+    // deck_slices changes to a single, different layer before the first
+    // load's requests resolve -- this starts a new generation.
+    rerender(
+      <Provider store={mockStore}>
+        <ThemeProvider theme={supersetTheme}>
+          <DeckMulti
+            {...baseMockProps}
+            formData={{ ...baseMockProps.formData, deck_slices: [2] }}
+          />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalledTimes(3));
+
+    // The abandoned first-generation slice-1 response now resolves. If it
+    // were not ignored, the container would show 2 layers (the stale slice 1
+    // plus the new slice 2) instead of just the current generation's 1.
+    resolveFirstLoad({ json: { result: [{ data: [] }] } });
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByTestId('deckgl-container')
+          .getAttribute('data-layers-count'),
+      ).toBe('1');
+    });
   });
 });
 
 describe('DeckMulti Component Rendering', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (SupersetClient.post as jest.Mock).mockResolvedValue({
-      json: {
-        result: [{ data: [] }],
-      },
-    });
-    (SupersetClient.get as jest.Mock).mockResolvedValue({
-      json: {
-        data: {
-          features: [],
-        },
-      },
-    });
+    featuresByVizType = {};
+    mockFetchesFor(SUBSLICES);
   });
 
   test('should render DeckGLContainer', async () => {
@@ -498,7 +459,7 @@ describe('DeckMulti Component Rendering', () => {
     });
   });
 
-  test('should pass correct props to DeckGLContainer', async () => {
+  test('should pass the base viewport through to DeckGLContainer', async () => {
     renderWithProviders(<DeckMulti {...baseMockProps} />);
 
     await waitFor(() => {
@@ -526,12 +487,8 @@ describe('DeckMulti Component Rendering', () => {
 
     renderWithProviders(<DeckMulti {...props} />);
 
-    // Wait for child slice requests
-    await waitFor(() => {
-      expect(SupersetClient.post).toHaveBeenCalled();
-    });
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-    // Check that all requests include the dashboardId
     const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
       const formData = call[0].jsonPayload?.form_data || {};
@@ -540,22 +497,10 @@ describe('DeckMulti Component Rendering', () => {
   });
 
   test('should not include dashboardId when not present', async () => {
-    const props = {
-      ...baseMockProps,
-      formData: {
-        ...baseMockProps.formData,
-        // No dashboardId
-      },
-    };
+    renderWithProviders(<DeckMulti {...baseMockProps} />);
 
-    renderWithProviders(<DeckMulti {...props} />);
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-    // Wait for child slice requests
-    await waitFor(() => {
-      expect(SupersetClient.post).toHaveBeenCalled();
-    });
-
-    // Check that requests don't include dashboardId
     const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
       const formData = call[0].jsonPayload?.form_data || {};
@@ -575,12 +520,8 @@ describe('DeckMulti Component Rendering', () => {
 
     renderWithProviders(<DeckMulti {...props} />);
 
-    // Wait for child slice requests
-    await waitFor(() => {
-      expect(SupersetClient.post).toHaveBeenCalled();
-    });
+    await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-    // Verify dashboardId is preserved with filters
     const { calls } = (SupersetClient.post as jest.Mock).mock;
     calls.forEach(call => {
       const formData = call[0].jsonPayload?.form_data || {};
@@ -589,52 +530,33 @@ describe('DeckMulti Component Rendering', () => {
     });
   });
 
-  test('should handle viewport changes', async () => {
+  test('should reload layers when deck_slices changes', async () => {
     const { rerender } = renderWithProviders(<DeckMulti {...baseMockProps} />);
 
-    // Wait for initial render
     await waitFor(() => {
       expect(screen.getByTestId('deckgl-container')).toBeInTheDocument();
     });
-
-    const newViewport = { longitude: 10, latitude: 20, zoom: 8 };
-    const updatedProps = {
-      ...baseMockProps,
-      viewport: newViewport,
-      formData: {
-        ...baseMockProps.formData,
-        deck_slices: [1, 2, 3], // Change deck_slices to trigger loadLayers
-      },
-    };
+    expect(SupersetClient.get).toHaveBeenCalledTimes(2);
 
     rerender(
       <Provider store={mockStore}>
         <ThemeProvider theme={supersetTheme}>
-          <DeckMulti {...updatedProps} />
+          <DeckMulti
+            {...baseMockProps}
+            formData={{ ...baseMockProps.formData, deck_slices: [1, 2, 3] }}
+          />
         </ThemeProvider>
       </Provider>,
     );
 
-    await waitFor(() => {
-      const container = screen.getByTestId('deckgl-container');
-      const viewportData = JSON.parse(
-        container.getAttribute('data-viewport') || '{}',
-      );
-
-      expect(viewportData.longitude).toBe(newViewport.longitude);
-      expect(viewportData.latitude).toBe(newViewport.latitude);
-    });
+    await waitFor(() => expect(SupersetClient.get).toHaveBeenCalledTimes(5));
   });
 });
 
 test('includes parent_slice_id in child slice requests when parent has slice_id', async () => {
   jest.clearAllMocks();
-  const mockPost = jest.fn().mockResolvedValue({
-    json: {
-      result: [{ data: [] }],
-    },
-  });
-  (SupersetClient.post as jest.Mock) = mockPost;
+  featuresByVizType = {};
+  mockFetchesFor(SUBSLICES);
   const parentSliceId = 99;
   const dashboardId = 5;
 
@@ -649,12 +571,9 @@ test('includes parent_slice_id in child slice requests when parent has slice_id'
 
   renderWithProviders(<DeckMulti {...props} />);
 
-  await waitFor(() => {
-    expect(mockPost).toHaveBeenCalled();
-  });
+  await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-  // Check that the child slice requests include parent_slice_id
-  const { calls } = mockPost.mock;
+  const { calls } = (SupersetClient.post as jest.Mock).mock;
   calls.forEach(call => {
     const formData = call[0].jsonPayload?.form_data || {};
     expect(formData).toMatchObject({
@@ -666,12 +585,8 @@ test('includes parent_slice_id in child slice requests when parent has slice_id'
 
 test('includes parent_slice_id in embedded mode', async () => {
   jest.clearAllMocks();
-  const mockPost = jest.fn().mockResolvedValue({
-    json: {
-      result: [{ data: [] }],
-    },
-  });
-  (SupersetClient.post as jest.Mock) = mockPost;
+  featuresByVizType = {};
+  mockFetchesFor(SUBSLICES);
   const parentSliceId = 200;
   const dashboardId = 10;
 
@@ -687,12 +602,9 @@ test('includes parent_slice_id in embedded mode', async () => {
 
   renderWithProviders(<DeckMulti {...props} />);
 
-  await waitFor(() => {
-    expect(mockPost).toHaveBeenCalled();
-  });
+  await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-  // Verify parent_slice_id is included in embedded mode
-  const { calls } = mockPost.mock;
+  const { calls } = (SupersetClient.post as jest.Mock).mock;
   calls.forEach(call => {
     const formData = call[0].jsonPayload?.form_data || {};
     expect(formData.parent_slice_id).toBe(parentSliceId);
@@ -701,30 +613,22 @@ test('includes parent_slice_id in embedded mode', async () => {
 
 test('does not include parent_slice_id when parent has no slice_id', async () => {
   jest.clearAllMocks();
-  const mockPost = jest.fn().mockResolvedValue({
-    json: {
-      result: [{ data: [] }],
-    },
-  });
-  (SupersetClient.post as jest.Mock) = mockPost;
+  featuresByVizType = {};
+  mockFetchesFor(SUBSLICES);
 
   const props = {
     ...baseMockProps,
     formData: {
       ...baseMockProps.formData,
-      // No slice_id in parent
       dashboardId: 5,
     },
   };
 
   renderWithProviders(<DeckMulti {...props} />);
 
-  await waitFor(() => {
-    expect(mockPost).toHaveBeenCalled();
-  });
+  await waitFor(() => expect(SupersetClient.post).toHaveBeenCalled());
 
-  // Verify parent_slice_id is not included when parent has no slice_id
-  const { calls } = mockPost.mock;
+  const { calls } = (SupersetClient.post as jest.Mock).mock;
   calls.forEach(call => {
     const formData = call[0].jsonPayload?.form_data || {};
     expect(formData.parent_slice_id).toBeUndefined();

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -187,6 +187,12 @@ const DeckMulti = (props: DeckMultiProps) => {
   // callback checks the ref and bails out instead of writing a stale layer
   // or stale accumulated features into the current (already-reset) state.
   const loadGenerationRef = useRef(0);
+  // Bumped at the start of every metadata-fetch effect run (before
+  // fetchSubslices resolves). If deck_slices or the visibility filter
+  // changes again while an earlier fetch is still pending, the stale
+  // fetch's callback sees a mismatch here and skips calling loadLayers, so
+  // an older, slower-resolving fetch can never clobber a newer generation.
+  const fetchGenerationRef = useRef(0);
 
   const setTooltip = useCallback((tooltip: TooltipProps['tooltip']) => {
     const { current } = containerRef;
@@ -564,8 +570,18 @@ const DeckMulti = (props: DeckMultiProps) => {
       // deck_multi issues no query of its own (see buildQuery.ts), so each
       // sub-slice's saved form_data is always fetched client-side here --
       // there is no pre-merged payload to read subslice metadata from.
+      fetchGenerationRef.current += 1;
+      const { current: fetchGeneration } = fetchGenerationRef;
       fetchSubslices(ensureIsArray(formData.deck_slices) as number[]).then(
-        slices => loadLayers(formData, slices, visibleDeckLayersFromRedux),
+        slices => {
+          // A newer deck_slices/visibility change already started its own
+          // fetch; let that one (or whichever of them resolves) call
+          // loadLayers instead of this abandoned, possibly slower one.
+          if (fetchGenerationRef.current !== fetchGeneration) {
+            return;
+          }
+          loadLayers(formData, slices, visibleDeckLayersFromRedux);
+        },
       );
     }
   }, [

--- a/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/Multi/Multi.tsx
@@ -81,7 +81,11 @@ type DataMaskState = Record<
 
 export type DeckMultiProps = {
   formData: QueryFormData;
-  payload: JsonObject;
+  // deck_multi's buildQuery always returns an empty queries array (every
+  // layer self-fetches instead), so this is always undefined in practice --
+  // kept optional rather than dropped to match the shared transformProps
+  // shape used across the deck.gl chart family.
+  payload?: JsonObject;
   setControlValue: (control: string, value: JsonValue) => void;
   viewport: Viewport;
   onAddFilter: HandlerFunction;
@@ -150,30 +154,18 @@ const DeckMulti = (props: DeckMultiProps) => {
   const visibleDeckLayersFromRedux =
     layerVisibilityFilter?.extraFormData?.visible_deckgl_layers;
 
+  // The v1 path fetches every layer client-side (see loadSingleLayer below),
+  // so there is never pre-merged feature data available at mount or at the
+  // start of a reload -- only the base viewport, clamped to a non-negative
+  // zoom. Autozoom itself happens incrementally as each layer's features
+  // arrive (see the refit in loadSingleLayer).
   const getAdjustedViewport = useCallback(() => {
-    let viewport = { ...props.viewport };
-
-    // Default to autozoom enabled for backward compatibility (undefined treated as true)
-    // legacy container payloads carried pre-merged features; the v1 path
-    // fetches every layer client-side, so there may be none here
-    const features = props.payload?.data?.features || {};
-    if (props.formData.autozoom !== false) {
-      const points = collectPoints(features);
-
-      if (props.formData && points.length > 0) {
-        viewport = fitViewport(viewport, {
-          width: props.width,
-          height: props.height,
-          points,
-        });
-      }
-    }
-
+    const viewport = { ...props.viewport };
     if (viewport.zoom < 0) {
       viewport.zoom = 0;
     }
     return viewport;
-  }, [props]);
+  }, [props.viewport]);
 
   const [viewport, setViewport] = useState<Viewport>(getAdjustedViewport());
   const [subSlicesLayers, setSubSlicesLayers] = useState<Record<number, Layer>>(
@@ -189,6 +181,12 @@ const DeckMulti = (props: DeckMultiProps) => {
   // getAdjustedViewport has nothing to fit to and the viewport is recomputed
   // here as each layer arrives.
   const layerFeaturesRef = useRef<JsonObject>({});
+  // Bumped at the start of every loadLayers call. Each in-flight layer fetch
+  // captures the generation it was started under; if deck_slices (or the
+  // layer-visibility filter) changes again before that fetch resolves, its
+  // callback checks the ref and bails out instead of writing a stale layer
+  // or stale accumulated features into the current (already-reset) state.
+  const loadGenerationRef = useRef(0);
 
   const setTooltip = useCallback((tooltip: TooltipProps['tooltip']) => {
     const { current } = containerRef;
@@ -304,6 +302,7 @@ const DeckMulti = (props: DeckMultiProps) => {
       subslice: JsonObject,
       formData: QueryFormData,
       payloadIndex: number,
+      generation: number,
     ): void => {
       const layerIndex = getLayerIndex(
         subslice.slice_id,
@@ -381,6 +380,12 @@ const DeckMulti = (props: DeckMultiProps) => {
               result_type: 'full',
             },
           }).then(({ json }) => {
+            // A newer loadLayers call (deck_slices or the visibility filter
+            // changed again) has already reset state; this response belongs
+            // to an abandoned generation and must not write into it.
+            if (loadGenerationRef.current !== generation) {
+              return;
+            }
             const chartProps = new ChartProps({
               width: props.width,
               height: props.height,
@@ -420,6 +425,9 @@ const DeckMulti = (props: DeckMultiProps) => {
           });
         })
         .catch(async error => {
+          if (loadGenerationRef.current !== generation) {
+            return;
+          }
           // Surface the failure in the chart (e.g. a layer bound to a dataset
           // that is missing the columns it needs) rather than only throwing to
           // the console.
@@ -450,6 +458,8 @@ const DeckMulti = (props: DeckMultiProps) => {
       slices: ({ slice_id: number } & JsonObject)[],
       visibleLayers?: number[],
     ): void => {
+      loadGenerationRef.current += 1;
+      const { current: generation } = loadGenerationRef;
       setViewport(getAdjustedViewport());
       setSubSlicesLayers({});
       setLayerErrors({});
@@ -476,7 +486,7 @@ const DeckMulti = (props: DeckMultiProps) => {
             }
           }
 
-          loadSingleLayer(subslice, formData, payloadIndex);
+          loadSingleLayer(subslice, formData, payloadIndex, generation);
         },
       );
 
@@ -542,7 +552,7 @@ const DeckMulti = (props: DeckMultiProps) => {
   );
 
   useEffect(() => {
-    const { formData, payload } = props;
+    const { formData } = props;
 
     const deckSlicesChanged = !isEqual(prevDeckSlices, formData.deck_slices);
     const visibilityFilterChanged = !isEqual(
@@ -551,15 +561,12 @@ const DeckMulti = (props: DeckMultiProps) => {
     );
 
     if (deckSlicesChanged || visibilityFilterChanged) {
-      // legacy explore_json payloads already carried the subslice metadata
-      const legacySlices = payload?.data?.slices;
-      if (legacySlices) {
-        loadLayers(formData, legacySlices, visibleDeckLayersFromRedux);
-      } else {
-        fetchSubslices(ensureIsArray(formData.deck_slices) as number[]).then(
-          slices => loadLayers(formData, slices, visibleDeckLayersFromRedux),
-        );
-      }
+      // deck_multi issues no query of its own (see buildQuery.ts), so each
+      // sub-slice's saved form_data is always fetched client-side here --
+      // there is no pre-merged payload to read subslice metadata from.
+      fetchSubslices(ensureIsArray(formData.deck_slices) as number[]).then(
+        slices => loadLayers(formData, slices, visibleDeckLayersFromRedux),
+      );
     }
   }, [
     loadLayers,

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -26,6 +26,7 @@ from flask.cli import with_appcontext
 
 from superset import db
 from superset.migrations.shared.migrate_viz.base import (
+    FORM_DATA_BAK_FIELD_NAME,
     MigrateViz,
     Slice,
 )
@@ -44,7 +45,7 @@ from superset.migrations.shared.migrate_viz.processors import (
     MigrateSunburst,
     MigrateTreeMap,
 )
-from superset.migrations.shared.utils import paginated_update
+from superset.migrations.shared.utils import paginated_update, try_load_json
 
 
 class VizType(str, Enum):
@@ -77,10 +78,6 @@ MIGRATIONS: dict[VizType, Type[MigrateViz]] = {
     VizType.SANKEY: MigrateSankey,
     VizType.SUNBURST: MigrateSunburst,
     VizType.TREEMAP: MigrateTreeMap,
-}
-
-PREVIOUS_VERSION = {
-    migration.target_viz_type: migration for migration in MIGRATIONS.values()
 }
 
 
@@ -174,7 +171,19 @@ def migrate_by_id(ids: tuple[int, ...], is_downgrade: bool = False) -> None:
         ),
     ):
         if is_downgrade:
-            PREVIOUS_VERSION[slc.viz_type].downgrade_slice(slc)
+            # Look up the migration by the slice's OWN backed-up original
+            # viz_type rather than its current one: several source viz types
+            # can migrate onto the same target (e.g. both `line` and
+            # `compare` migrate onto `echarts_timeseries_line`), so a lookup
+            # keyed by the current viz_type can't tell which migration
+            # actually produced this slice's backup.
+            form_data = try_load_json(slc.params)
+            source_viz_type = form_data.get(FORM_DATA_BAK_FIELD_NAME, {}).get(
+                "viz_type"
+            )
+            migration = MIGRATIONS.get(source_viz_type) if source_viz_type else None
+            if migration:
+                migration.downgrade_slice(slc)
         elif slc.viz_type in MIGRATIONS:
             MIGRATIONS[slc.viz_type].upgrade_slice(slc)
 

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -185,8 +185,10 @@ class MigrateViz:
     def downgrade_slice(cls, slc: Slice) -> None:
         try:
             form_data = try_load_json(slc.params)
-            if "viz_type" in (
-                form_data_bak := form_data.get(FORM_DATA_BAK_FIELD_NAME, {})
+            form_data_bak = form_data.get(FORM_DATA_BAK_FIELD_NAME, {})
+            if (
+                "viz_type" in form_data_bak
+                and form_data_bak["viz_type"] == cls.source_viz_type
             ):
                 slc.params = json.dumps(form_data_bak)
                 slc.viz_type = form_data_bak.get("viz_type")
@@ -214,6 +216,13 @@ class MigrateViz:
 
     @classmethod
     def downgrade(cls, session: Session) -> None:
+        # This SQL-level filter is intentionally coarse: several MigrateViz
+        # subclasses can share one target_viz_type (e.g. MigrateLineChart and
+        # MigrateCompareChart both migrate onto echarts_timeseries_line), so
+        # it will also match slices another subclass upgraded. downgrade_slice
+        # does the precise per-row check (form_data_bak["viz_type"] ==
+        # cls.source_viz_type) so this class's downgrade only reverts the
+        # slices it upgraded, not every slice currently at the same target.
         slices = session.query(Slice).filter(
             and_(
                 Slice.viz_type == cls.target_viz_type,

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -167,7 +167,13 @@ class MigrateViz:
                 if "form_data" in query_context:
                     query_context["form_data"] = clz.data
 
-                queries_bak = copy.deepcopy(query_context["queries"])
+                # A stored query_context is expected to carry "queries", but
+                # an atypical/malformed one (e.g. hand-edited via the API)
+                # missing it must not raise here: viz_type was already
+                # flipped above, so an uncaught exception at this point
+                # would leave the slice half-migrated (new viz_type, but
+                # stale params/query_context in the old shape).
+                queries_bak = copy.deepcopy(query_context.get("queries"))
 
                 queries = clz._build_query()["queries"]
                 query_context["queries"] = queries

--- a/tests/unit_tests/migrations/viz/downgrade_scope_test.py
+++ b/tests/unit_tests/migrations/viz/downgrade_scope_test.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.migrations.shared.migrate_viz import MigrateCompareChart, MigrateLineChart
+from superset.models.slice import Slice
+from superset.utils import json
+
+
+def test_downgrade_slice_ignores_a_slice_from_a_different_source_migration() -> None:
+    """MigrateCompareChart and MigrateLineChart both migrate onto
+    echarts_timeseries_line, so `downgrade()`'s SQL filter (target_viz_type +
+    a form_data_bak marker) matches slices from either migration. Calling
+    the wrong class's `downgrade_slice` on a slice it didn't upgrade must be
+    a no-op rather than reverting it to the wrong source viz_type."""
+    line_source = {
+        "viz_type": "line",
+        "datasource": "1__table",
+        "x_axis_label": "x",
+    }
+
+    slc = Slice(
+        viz_type="line",
+        datasource_type="table",
+        params=json.dumps(line_source),
+        query_context=f'{{"form_data": {json.dumps(line_source)}, "queries": []}}',
+    )
+    MigrateLineChart.upgrade_slice(slc)
+    assert slc.viz_type == "echarts_timeseries_line"
+    upgraded_params = json.loads(slc.params)
+
+    # MigrateCompareChart's downgrade must not touch a slice that
+    # MigrateLineChart (not MigrateCompareChart) upgraded, even though both
+    # target echarts_timeseries_line and the slice's params contain a
+    # form_data_bak key.
+    MigrateCompareChart.downgrade_slice(slc)
+
+    assert slc.viz_type == "echarts_timeseries_line"
+    assert json.loads(slc.params) == upgraded_params
+
+    # The matching migration still downgrades it correctly.
+    MigrateLineChart.downgrade_slice(slc)
+    assert slc.viz_type == "line"
+    assert json.loads(slc.params) == line_source

--- a/tests/unit_tests/migrations/viz/upgrade_malformed_query_context_test.py
+++ b/tests/unit_tests/migrations/viz/upgrade_malformed_query_context_test.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.migrations.shared.migrate_viz import MigrateLineChart
+from superset.models.slice import Slice
+from superset.utils import json
+
+
+def test_upgrade_slice_survives_a_query_context_without_queries() -> None:
+    """A stored query_context is expected to carry "queries", but
+    upgrade_slice must not leave a slice half-migrated (new viz_type, stale
+    params/query_context) if an atypical one doesn't -- it used to raise a
+    bare KeyError there, caught by the broad except, after viz_type had
+    already been flipped."""
+    source = {"viz_type": "line", "datasource": "1__table", "x_axis_label": "x"}
+
+    slc = Slice(
+        viz_type="line",
+        datasource_type="table",
+        params=json.dumps(source),
+        # No "queries" key, unlike a normal query_context.
+        query_context=json.dumps({"form_data": source}),
+    )
+
+    MigrateLineChart.upgrade_slice(slc)
+
+    assert slc.viz_type == "echarts_timeseries_line"
+    upgraded_params = json.loads(slc.params)
+    assert upgraded_params["form_data_bak"] == source
+    assert upgraded_params.get("queries_bak") is None
+    assert json.loads(slc.query_context)["form_data"]["viz_type"] == (
+        "echarts_timeseries_line"
+    )


### PR DESCRIPTION
### SUMMARY
Follow-up hardening identified during a self-review of #41714 (the legacy viz pipeline removal). Targets that branch so it can land as a stack once #41714 merges. Each commit is independent and reviewable on its own:

- **deck.gl `Multi`**: removed a dead code path that read a `payload.data.slices`/`.features` shape the v1 endpoint never returns, and fixed a real race where an out-of-order/stale async layer response could clobber a newer one — added a load-generation guard and rewrote the tests around the actual v1 fetch shape instead of the dead legacy one.
- **ECharts Timeseries**: the percent-change draggable baseline read its own series data back out of `chart.getOption()` after `setOption()`, which is fragile and untested; switched to reading the `echartOptions` prop directly and added the plugin's first test coverage for the drag-to-rebase interaction.
- **Migration downgrade scoping**: `MigrateViz.downgrade` matched slices by `target_viz_type` alone, so when two source viz types share one target (e.g. `MigrateLineChart` and `MigrateCompareChart` both migrate onto `echarts_timeseries_line`), downgrading one could revert slices the other had upgraded. Added a precise per-row check and removed the CLI's separate, now-inconsistent `PREVIOUS_VERSION` mapping in favor of deriving the source viz type from the stored backup.
- **Legend-row estimation**: Bullet and TimePivot each estimated wrapped-legend row count with similar, subtly different logic; extracted one shared, tested helper and used it to fix a legend/chart overlap bug in TimePivot that Bullet's version didn't have.
- **Sort-metric/orderby**: `partition`, `paired_ttest`, and `parallel_coordinates` each reimplemented "append the sort metric if not already selected, order by it" with slightly different rules; extracted a single shared, tested helper.
- **Rose**: added test coverage for click-to-drill and, in particular, for the color-priming order invariant (colors come from priming the scale in `seriesNames` order, not the drilled pie's value-sorted order) -- a case that's easy to accidentally break during future refactors.
- **Migration hardening**: `upgrade_slice` assumed a stored `query_context` always has a `"queries"` key; an atypical one (e.g. hand-edited via the API) missing it raised an uncaught `KeyError` inside the broad `except`, after `viz_type` had already been flipped, leaving the slice half-migrated. Now degrades gracefully.
- **Partition transformProps**: added the plugin's first test coverage for `transformProps.ts` itself (as opposed to `transformData.ts`, which was already well covered) -- the v1-flat-record vs. legacy-nested-hierarchy branch, verboseMap level mapping, and `partitionLimit`/`partitionThreshold` parsing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A -- no user-visible behavior changes; this is bug fixes and test hardening on top of #41714.

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/migrations/` -- all migration unit tests, including two new regression tests (downgrade scoping, malformed `query_context`)
- `npm run test -- plugins/preset-chart-deckgl/src/Multi plugins/plugin-chart-echarts/src/utils/legendLayout.test.ts plugins/plugin-chart-echarts/test/TimePivot/transformProps.test.ts plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx plugins/plugin-chart-echarts/test/Rose/EchartsRose.test.tsx packages/superset-ui-chart-controls/test/utils/buildSortMetricOrderby.test.ts plugins/plugin-chart-paired-t-test/test/buildQuery.test.ts plugins/plugin-chart-parallel-coordinates/test plugins/plugin-chart-partition/test`
- Two of the regression tests (Rose's color-priming test, the `query_context` `KeyError` fix) were verified by deliberately reverting the corresponding fix and confirming the new test fails, then restoring it and confirming it passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Stacked on #41714 -- targets `remove-legacy-viz-pipeline`, not `master`. Should be reviewed/merged after (or alongside) that PR.