### PR TITLE
fix(chart): stop duplicate metrics when switching between Waterfall and other chart types

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -23,6 +23,7 @@ import {
   D3_TIME_FORMAT_DOCS,
   DEFAULT_TIME_FORMAT,
   formatSelectOptions,
+  getStandardizedControls,
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { showValueControl } from '../controls';
@@ -245,6 +246,11 @@ const config: ControlPanelConfig = {
       multi: false,
     },
   },
+  formDataOverrides: formData => ({
+    ...formData,
+    metric: getStandardizedControls().shiftMetric(),
+    groupby: getStandardizedControls().popAllColumns(),
+  }),
 };
 
 export default config;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
+import { ensureIsArray } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlSubSectionHeader,
@@ -249,7 +250,13 @@ const config: ControlPanelConfig = {
   formDataOverrides: formData => ({
     ...formData,
     metric: getStandardizedControls().shiftMetric(),
-    groupby: getStandardizedControls().popAllColumns(),
+    // Waterfall's `groupby` is a single-value control (multi: false;
+    // buildQuery groups by the whole array but transformProps only reads
+    // groupby[0]), so only one column should be taken off the queue here.
+    // Using popAllColumns() would let a memorized multi-column breakdown
+    // (e.g. from Table/Pivot) push extra dimensions into the SQL query
+    // that never surface in the rendered chart.
+    groupby: ensureIsArray(getStandardizedControls().shiftColumn()),
   }),
 };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/controlPanel.test.ts
@@ -19,14 +19,14 @@
 import { SqlaFormData } from '@superset-ui/core';
 
 // Mock getStandardizedControls so we can assert the Waterfall control panel
-// actually consumes (shifts/pops) the queued metrics and columns instead of
+// actually consumes (shifts) the queued metric and column instead of
 // leaving them for the next viz-type switch to pick up again. Regression
 // test for https://github.com/apache/superset/issues/32835, where switching
 // away from and back to another chart type (e.g. Line) produced duplicate
 // metrics because Waterfall never drained the shared standardized-controls
 // queue.
 const mockShiftMetric = jest.fn(() => 'shiftedMetric');
-const mockPopAllColumns = jest.fn(() => ['poppedColumn']);
+const mockShiftColumn = jest.fn(() => 'shiftedColumn');
 
 jest.mock('@superset-ui/chart-controls', () => {
   const actual = jest.requireActual('@superset-ui/chart-controls');
@@ -34,7 +34,7 @@ jest.mock('@superset-ui/chart-controls', () => {
     ...actual,
     getStandardizedControls: jest.fn(() => ({
       shiftMetric: mockShiftMetric,
-      popAllColumns: mockPopAllColumns,
+      shiftColumn: mockShiftColumn,
     })),
   };
 });
@@ -42,7 +42,7 @@ jest.mock('@superset-ui/chart-controls', () => {
 // eslint-disable-next-line import/first
 import controlPanel from '../../src/Waterfall/controlPanel';
 
-test('formDataOverrides consumes a single metric and all columns from getStandardizedControls', () => {
+test('formDataOverrides consumes a single metric and a single column from getStandardizedControls', () => {
   expect(controlPanel.formDataOverrides).toBeDefined();
 
   const dummyFormData = { someProp: 'test' } as unknown as SqlaFormData;
@@ -56,7 +56,10 @@ test('formDataOverrides consumes a single metric and all columns from getStandar
   expect(newFormData.metric).toBe('shiftedMetric');
   expect(mockShiftMetric).toHaveBeenCalled();
 
-  // all queued columns are consumed for the (single) groupby control
-  expect(newFormData.groupby).toEqual(['poppedColumn']);
-  expect(mockPopAllColumns).toHaveBeenCalled();
+  // only a single column is taken for the (single-value) groupby control,
+  // leaving any remaining queued columns for the next viz-type switch;
+  // popping the whole queue here would let buildQuery group by columns
+  // that transformProps (which only reads groupby[0]) never renders.
+  expect(newFormData.groupby).toEqual(['shiftedColumn']);
+  expect(mockShiftColumn).toHaveBeenCalled();
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/controlPanel.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SqlaFormData } from '@superset-ui/core';
+
+// Mock getStandardizedControls so we can assert the Waterfall control panel
+// actually consumes (shifts/pops) the queued metrics and columns instead of
+// leaving them for the next viz-type switch to pick up again. Regression
+// test for https://github.com/apache/superset/issues/32835, where switching
+// away from and back to another chart type (e.g. Line) produced duplicate
+// metrics because Waterfall never drained the shared standardized-controls
+// queue.
+const mockShiftMetric = jest.fn(() => 'shiftedMetric');
+const mockPopAllColumns = jest.fn(() => ['poppedColumn']);
+
+jest.mock('@superset-ui/chart-controls', () => {
+  const actual = jest.requireActual('@superset-ui/chart-controls');
+  return {
+    ...actual,
+    getStandardizedControls: jest.fn(() => ({
+      shiftMetric: mockShiftMetric,
+      popAllColumns: mockPopAllColumns,
+    })),
+  };
+});
+
+// eslint-disable-next-line import/first
+import controlPanel from '../../src/Waterfall/controlPanel';
+
+test('formDataOverrides consumes a single metric and all columns from getStandardizedControls', () => {
+  expect(controlPanel.formDataOverrides).toBeDefined();
+
+  const dummyFormData = { someProp: 'test' } as unknown as SqlaFormData;
+  const newFormData = controlPanel.formDataOverrides!(dummyFormData);
+
+  // original properties are preserved
+  expect(newFormData.someProp).toBe('test');
+
+  // only a single metric is taken (Waterfall only supports one metric),
+  // leaving any remaining queued metrics for the next viz-type switch
+  expect(newFormData.metric).toBe('shiftedMetric');
+  expect(mockShiftMetric).toHaveBeenCalled();
+
+  // all queued columns are consumed for the (single) groupby control
+  expect(newFormData.groupby).toEqual(['poppedColumn']);
+  expect(mockPopAllColumns).toHaveBeenCalled();
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The Waterfall control panel never defined `formDataOverrides`, so it never drained the shared "standardized controls" metric/column queue that Explore uses to hand off metrics/columns between viz types on switch.

Every other single-metric echarts chart (Pie, Gauge, Sunburst, Radar, BigNumber, etc.) consumes exactly one metric from that queue via `getStandardizedControls().shiftMetric()`. Waterfall skipped this, so:

1. Switching from e.g. Line (`metrics: [A, B]`) to Waterfall queued `[A, B]` but never shifted anything out.
2. Whatever metric the user ended up with on Waterfall got pushed back onto the (still full) queue.
3. Switching back to Line popped the whole queue, producing `[metric_from_waterfall, A, B]` — duplicate measures.

This PR adds the standard `formDataOverrides` to the Waterfall control panel so it shifts a single metric and pops all columns from the queue, matching the pattern used everywhere else.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this is a form-data plumbing fix, not a rendering change. See the repro steps in #32835 and the linked video from @msyavuz there.

### TESTING INSTRUCTIONS
1. Create a chart with a Line viz and two metrics (e.g. `COUNT(*)` and `SUM(some_column)`).
2. Switch the viz type to Waterfall.
3. Switch back to Line.
4. Before this fix: the metrics list would contain a duplicate. After this fix: the original two metrics are preserved with no duplication.

Also added a unit test (`plugins/plugin-chart-echarts/test/Waterfall/controlPanel.test.ts`) pinning that Waterfall's `formDataOverrides` consumes a single metric and all queued columns from `getStandardizedControls()`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #32835
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API