### PR TITLE
fix(semantic-layers): survive large multi-metric selection in Semantic View modal

### DIFF
--- a/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
@@ -126,10 +126,9 @@ test('caps rendered tags at large selection counts while keeping the full value'
     />,
   );
   const tags = container.querySelectorAll('.ant-select-selection-item');
-  // MAX_TAG_COUNT tags plus one overflow summary tag — never one per
-  // selection. The cap comes from the wrapped Select's exported default.
-  expect(tags.length).toBeLessThanOrEqual(MAX_TAG_COUNT + 2);
-  expect(tags.length).toBeGreaterThan(0);
+  // Exactly MAX_TAG_COUNT tags plus one overflow summary tag — never one
+  // per selection. The cap comes from the wrapped Select's exported default.
+  expect(tags.length).toBe(MAX_TAG_COUNT + 1);
   const overflow = Array.from(tags).find(el =>
     /\+\s*\d+/.test(el.textContent ?? ''),
   );
@@ -206,6 +205,7 @@ test('DynamicFieldControl handles a 500-option enum via search (FR-006 sibling)'
       'x-dynamic': true,
       'x-dependsOn': [],
     } as ControlProps['schema'],
+    data: undefined,
   });
   render(<DynamicFieldControl {...props} />);
   const combobox = screen.getByRole('combobox');
@@ -220,4 +220,20 @@ test('DynamicFieldControl handles a 500-option enum via search (FR-006 sibling)'
   });
   await userEvent.click(option);
   expect(handleChange).toHaveBeenLastCalledWith('mode', 'metric_042');
+});
+
+test('renders options alphabetically for an unsorted backend enum', async () => {
+  // The renderers dropped their manual sort because the wrapped Select
+  // alphabetises by label; pin that inherited behaviour here so a future
+  // change to the shared component surfaces in this feature's suite.
+  const props = baseProps({
+    schema: { type: 'array', items: { enum: ['zebra', 'apple', 'mango'] } },
+  });
+  const { container } = render(<MultiEnumControl {...props} />);
+  await userEvent.click(screen.getByRole('combobox'));
+  await screen.findAllByText('apple');
+  const labels = Array.from(
+    container.ownerDocument.querySelectorAll('.ant-select-item-option-content'),
+  ).map(el => el.textContent);
+  expect(labels).toEqual(['apple', 'mango', 'zebra']);
 });

--- a/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
@@ -161,12 +161,12 @@ test('propagates the full selection array when adding to a large selection', asy
     return el;
   });
   await userEvent.click(option);
-  expect(handleChange).toHaveBeenLastCalledWith(
-    'tags',
-    expect.arrayContaining(['metric_499']),
-  );
-  const lastValue = handleChange.mock.calls.at(-1)?.[1];
+  // Assert the exact resulting set, not just length + the new member: a
+  // component that dropped an existing selection while adding a new one
+  // could otherwise still satisfy a length check.
+  const lastValue = handleChange.mock.calls.at(-1)?.[1] as string[];
   expect(lastValue).toHaveLength(LARGE_CATALOG_SIZE);
+  expect([...lastValue].sort()).toEqual([...largeMetricEnum].sort());
 });
 
 test('does not render a Select-all bulk affordance', async () => {

--- a/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
@@ -17,9 +17,20 @@
  * under the License.
  */
 import type { ControlProps } from '@jsonforms/core';
-import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 
 import { MultiEnumControl } from './jsonFormsHelpers';
+import {
+  LARGE_CATALOG_SIZE,
+  largeMetricEnum,
+  largeMultiEnumFieldSchema,
+  duplicateLabelEnumSchema,
+} from './testFixtures';
 
 const baseProps = (overrides: Partial<ControlProps> = {}): ControlProps =>
   ({
@@ -58,9 +69,10 @@ test('falls back to raw enum values when x-enumNames is absent', async () => {
   const options = container.ownerDocument.querySelectorAll(
     '.ant-select-item-option-content',
   );
+  // The wrapped Select alphabetises options by label.
   expect(Array.from(options).map(el => el.textContent)).toEqual([
-    'red',
     'green',
+    'red',
   ]);
 });
 
@@ -85,7 +97,8 @@ test('shows a loading state when config.refreshingSchema is true', () => {
   const { container } = render(
     <MultiEnumControl {...baseProps({ config: { refreshingSchema: true } })} />,
   );
-  expect(container.querySelector('.ant-select-suffix-loading')).toBeTruthy();
+  // The wrapped Select renders loading as a Spin suffix icon.
+  expect(container.querySelector('.ant-spin')).toBeTruthy();
 });
 
 test('treats non-array data as an empty selection without crashing', () => {
@@ -93,4 +106,88 @@ test('treats non-array data as an empty selection without crashing', () => {
   // No tags rendered when data is missing
   expect(screen.queryByText('Apple')).not.toBeInTheDocument();
   expect(screen.queryByText('Banana')).not.toBeInTheDocument();
+});
+
+// ---------------------------------------------------------------------------
+// Large-catalog regression tests (sc-107832). The wrapped Select virtualizes
+// its dropdown above 20 options, so interactions go through search-then-click
+// or prop-driven values — never option-DOM counting.
+// ---------------------------------------------------------------------------
+
+test('caps rendered tags at large selection counts while keeping the full value', () => {
+  const { container } = render(
+    <MultiEnumControl
+      {...baseProps({
+        schema: largeMultiEnumFieldSchema,
+        data: largeMetricEnum,
+      })}
+    />,
+  );
+  const tags = container.querySelectorAll('.ant-select-selection-item');
+  // maxTagCount tags plus one overflow summary tag — never one per selection.
+  expect(tags.length).toBeLessThanOrEqual(6);
+  expect(tags.length).toBeGreaterThan(0);
+  const overflow = Array.from(tags).find(el =>
+    /\+\s*\d+/.test(el.textContent ?? ''),
+  );
+  expect(overflow?.textContent).toMatch(
+    new RegExp(`\\+\\s*${LARGE_CATALOG_SIZE - 4}`),
+  );
+});
+
+test('propagates the full selection array when adding to a large selection', async () => {
+  const handleChange = jest.fn();
+  const allButOne = largeMetricEnum.slice(0, LARGE_CATALOG_SIZE - 1);
+  render(
+    <MultiEnumControl
+      {...baseProps({
+        schema: largeMultiEnumFieldSchema,
+        data: allButOne,
+        handleChange,
+      })}
+    />,
+  );
+  const combobox = screen.getByRole('combobox');
+  await userEvent.click(combobox);
+  // Search-then-click: virtualization renders only a window of options.
+  await userEvent.type(combobox, 'metric_499');
+  const option = await waitFor(() => {
+    const el = Array.from(
+      document.querySelectorAll('.ant-select-item-option'),
+    ).find(e => e.getAttribute('title') === 'metric_499');
+    if (!el) throw new Error('option not rendered yet');
+    return el;
+  });
+  await userEvent.click(option);
+  expect(handleChange).toHaveBeenLastCalledWith(
+    'tags',
+    expect.arrayContaining(['metric_499']),
+  );
+  const lastValue = handleChange.mock.calls.at(-1)?.[1];
+  expect(lastValue).toHaveLength(LARGE_CATALOG_SIZE);
+});
+
+test('does not render a Select-all bulk affordance', async () => {
+  render(
+    <MultiEnumControl
+      {...baseProps({ schema: largeMultiEnumFieldSchema, data: [] })}
+    />,
+  );
+  await userEvent.click(screen.getByRole('combobox'));
+  expect(screen.queryByText(/Select all/i)).not.toBeInTheDocument();
+});
+
+test('keeps duplicated display labels individually selectable', async () => {
+  const handleChange = jest.fn();
+  render(
+    <MultiEnumControl
+      {...baseProps({ schema: duplicateLabelEnumSchema, handleChange })}
+    />,
+  );
+  const combobox = screen.getByRole('combobox');
+  await userEvent.click(combobox);
+  const revenues = await screen.findAllByText('Revenue');
+  expect(revenues.length).toBeGreaterThanOrEqual(2);
+  await userEvent.click(revenues[0]);
+  expect(handleChange).toHaveBeenLastCalledWith('tags', ['metric_a_v1']);
 });

--- a/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
@@ -205,7 +205,7 @@ test('DynamicFieldControl handles a 500-option enum via search (FR-006 sibling)'
       enum: largeMetricEnum,
       'x-dynamic': true,
       'x-dependsOn': [],
-    },
+    } as ControlProps['schema'],
   });
   render(<DynamicFieldControl {...props} />);
   const combobox = screen.getByRole('combobox');

--- a/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/MultiEnumControl.test.tsx
@@ -24,7 +24,9 @@ import {
   waitFor,
 } from 'spec/helpers/testing-library';
 
-import { MultiEnumControl } from './jsonFormsHelpers';
+import { MAX_TAG_COUNT } from '@superset-ui/core/components';
+
+import { DynamicFieldControl, MultiEnumControl } from './jsonFormsHelpers';
 import {
   LARGE_CATALOG_SIZE,
   largeMetricEnum,
@@ -124,14 +126,15 @@ test('caps rendered tags at large selection counts while keeping the full value'
     />,
   );
   const tags = container.querySelectorAll('.ant-select-selection-item');
-  // maxTagCount tags plus one overflow summary tag — never one per selection.
-  expect(tags.length).toBeLessThanOrEqual(6);
+  // MAX_TAG_COUNT tags plus one overflow summary tag — never one per
+  // selection. The cap comes from the wrapped Select's exported default.
+  expect(tags.length).toBeLessThanOrEqual(MAX_TAG_COUNT + 2);
   expect(tags.length).toBeGreaterThan(0);
   const overflow = Array.from(tags).find(el =>
     /\+\s*\d+/.test(el.textContent ?? ''),
   );
   expect(overflow?.textContent).toMatch(
-    new RegExp(`\\+\\s*${LARGE_CATALOG_SIZE - 4}`),
+    new RegExp(`\\+\\s*${LARGE_CATALOG_SIZE - MAX_TAG_COUNT}`),
   );
 });
 
@@ -190,4 +193,31 @@ test('keeps duplicated display labels individually selectable', async () => {
   expect(revenues.length).toBeGreaterThanOrEqual(2);
   await userEvent.click(revenues[0]);
   expect(handleChange).toHaveBeenLastCalledWith('tags', ['metric_a_v1']);
+});
+
+test('DynamicFieldControl handles a 500-option enum via search (FR-006 sibling)', async () => {
+  const handleChange = jest.fn();
+  const props = baseProps({
+    handleChange,
+    path: 'mode',
+    schema: {
+      type: 'string',
+      enum: largeMetricEnum,
+      'x-dynamic': true,
+      'x-dependsOn': [],
+    },
+  });
+  render(<DynamicFieldControl {...props} />);
+  const combobox = screen.getByRole('combobox');
+  await userEvent.click(combobox);
+  await userEvent.type(combobox, 'metric_042');
+  const option = await waitFor(() => {
+    const el = Array.from(
+      document.querySelectorAll('.ant-select-item-option'),
+    ).find(e => e.getAttribute('title') === 'metric_042');
+    if (!el) throw new Error('option not rendered yet');
+    return el;
+  });
+  await userEvent.click(option);
+  expect(handleChange).toHaveBeenLastCalledWith('mode', 'metric_042');
 });

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.test.ts
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.test.ts
@@ -206,3 +206,11 @@ test('stableSerialize keeps array order significant', () => {
     stableSerialize({ enum: ['b', 'a'] }),
   );
 });
+
+test('stableSerialize preserves __proto__ keys from parsed payloads', () => {
+  // A plain-object accumulator would treat __proto__ as a prototype
+  // assignment and drop it, making two different schemas compare equal.
+  const withProto = JSON.parse('{"properties":{"b":1},"__proto__":{"a":1}}');
+  const without = JSON.parse('{"properties":{"b":1}}');
+  expect(stableSerialize(withProto)).not.toEqual(stableSerialize(without));
+});

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.test.ts
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.test.ts
@@ -19,6 +19,7 @@
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 
 import {
+  stableSerialize,
   areDependenciesSatisfied,
   sanitizeSchema,
   buildUiSchema,
@@ -190,4 +191,18 @@ test('enumNamesEntry.tester does not match array schemas (multiEnum owns those)'
     'x-enumNames': ['Alpha'],
   } as JsonSchema;
   expect(enumNamesEntry.tester(control, schema, ctx)).toBe(-1);
+});
+
+test('stableSerialize ignores object key order', () => {
+  const a = { properties: { m: { enum: ['x', 'y'] }, d: { type: 'array' } } };
+  const b = { properties: { d: { type: 'array' }, m: { enum: ['x', 'y'] } } };
+  expect(stableSerialize(a)).toEqual(stableSerialize(b));
+});
+
+test('stableSerialize keeps array order significant', () => {
+  // x-propertyOrder / enum ordering can be meaningful, so reordered arrays
+  // must NOT compare equal.
+  expect(stableSerialize({ enum: ['a', 'b'] })).not.toEqual(
+    stableSerialize({ enum: ['b', 'a'] }),
+  );
 });

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { Spin, Select, Form } from 'antd';
+import { FormItem, Select } from '@superset-ui/core/components';
+import { Spin } from '@superset-ui/core/components/Spin';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import type {
   JsonSchema,
@@ -68,6 +69,16 @@ const passwordEntry = {
 };
 
 /**
+ * Value equality for default/const backfill guards. Reference equality is
+ * not enough: an object or array default (e.g. ``default: []``) gets a new
+ * identity from JSON Forms on every change cycle, so a reference comparison
+ * would call ``handleChange`` forever ("Maximum update depth exceeded").
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  return a === b || JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
  * Renderer for `const` properties (e.g. Pydantic discriminator fields).
  * Renders nothing visually but ensures the const value is set in form data,
  * so discriminated unions resolve correctly on the backend.
@@ -75,7 +86,7 @@ const passwordEntry = {
 function ConstControl({ data, handleChange, path, schema }: ControlProps) {
   const constValue = (schema as Record<string, unknown>).const;
   useEffect(() => {
-    if (constValue !== undefined && data !== constValue) {
+    if (constValue !== undefined && !valuesEqual(data, constValue)) {
       handleChange(path, constValue);
     }
   }, [constValue, data, handleChange, path]);
@@ -111,7 +122,7 @@ function ReadOnlyControl({
     (schema as Record<string, unknown>).const ??
     (schema as Record<string, unknown>).default;
   useEffect(() => {
-    if (defaultValue !== undefined && data !== defaultValue) {
+    if (defaultValue !== undefined && !valuesEqual(data, defaultValue)) {
       handleChange(path, defaultValue);
     }
   }, [defaultValue, data, handleChange, path]);
@@ -191,41 +202,48 @@ function DynamicFieldControl(props: ControlProps) {
   const enumValues = Array.isArray(schema.enum)
     ? (schema.enum as unknown[])
     : undefined;
+  // Honour ``x-enumNames`` when present so labels can differ from values
+  // (e.g. MetricFlow's mode picker maps "full" / "cube" to human strings).
+  const enumNames = Array.isArray(schema['x-enumNames'])
+    ? (schema['x-enumNames'] as unknown[])
+    : undefined;
+  // The backend returns these as a set, so order is undefined. Sort by
+  // label so the dropdown is stable and alphabetised. Memoized so a
+  // re-render without an enum change (every host-form keystroke passes a
+  // fresh ``config`` to all controls) does not rebuild and re-sort the
+  // full option list.
+  const options = useMemo(
+    () =>
+      (enumValues ?? [])
+        .map((value, index) => ({
+          value: value as string | number,
+          label:
+            enumNames?.[index] !== undefined
+              ? String(enumNames[index])
+              : String(value),
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [enumValues, enumNames],
+  );
 
   if (enumValues && enumValues.length > 0) {
-    // Honour ``x-enumNames`` when present so labels can differ from values
-    // (e.g. MetricFlow's mode picker maps "full" / "cube" to human strings).
-    const enumNames = Array.isArray(schema['x-enumNames'])
-      ? (schema['x-enumNames'] as unknown[])
-      : undefined;
-    // The backend returns these as a set, so order is undefined. Sort by
-    // label so the dropdown is stable and alphabetised.
-    const options = enumValues
-      .map((value, index) => ({
-        value: value as string | number,
-        label:
-          enumNames?.[index] !== undefined
-            ? String(enumNames[index])
-            : String(value),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
     const tooltip = (props.uischema?.options as Record<string, unknown>)
       ?.tooltip as string | undefined;
     const placeholder = (props.uischema?.options as Record<string, unknown>)
       ?.placeholderText as string | undefined;
     return (
-      <Form.Item label={props.label} tooltip={tooltip}>
+      <FormItem label={props.label} tooltip={tooltip}>
         <Select
+          ariaLabel={props.label || undefined}
           value={(props.data as string | number | undefined) ?? undefined}
           onChange={value => props.handleChange(props.path, value)}
           options={options}
-          style={{ width: '100%' }}
           disabled={!props.enabled || refreshing}
           loading={refreshing}
           allowClear
           placeholder={refreshing ? t('Loading...') : placeholder}
         />
-      </Form.Item>
+      </FormItem>
     );
   }
 
@@ -275,21 +293,25 @@ function EnumNamesControl(props: ControlProps) {
   const enumNames =
     (schema['x-enumNames'] as string[]) ?? enumValues.map(String);
 
-  const options = enumValues.map((value, index) => ({
-    value,
-    label: enumNames[index] ?? String(value),
-  }));
+  const options = useMemo(
+    () =>
+      enumValues.map((value, index) => ({
+        value: value as string | number,
+        label: enumNames[index] ?? String(value),
+      })),
+    [enumValues, enumNames],
+  );
 
   const tooltip = (props.uischema?.options as Record<string, unknown>)
     ?.tooltip as string | undefined;
 
   return (
-    <Form.Item label={props.label} tooltip={tooltip}>
+    <FormItem label={props.label} tooltip={tooltip}>
       <Select
-        value={props.data ?? null}
+        ariaLabel={props.label || undefined}
+        value={props.data ?? undefined}
         onChange={value => props.handleChange(props.path, value)}
         options={options}
-        style={{ width: '100%' }}
         disabled={!props.enabled}
         allowClear
         loading={!!refreshingSchema}
@@ -298,7 +320,7 @@ function EnumNamesControl(props: ControlProps) {
             ?.placeholderText as string | undefined
         }
       />
-    </Form.Item>
+    </FormItem>
   );
 }
 const EnumNamesRenderer = withJsonFormsControlProps(EnumNamesControl);
@@ -343,13 +365,19 @@ export function MultiEnumControl(props: ControlProps) {
     ({} as Record<string, unknown>);
 
   const enumValues = (itemsSchema.enum as unknown[]) ?? [];
-  const enumNames =
-    (itemsSchema['x-enumNames'] as string[]) ?? enumValues.map(String);
+  const enumNames = (itemsSchema['x-enumNames'] as string[]) ?? undefined;
 
-  const options = enumValues.map((value, index) => ({
-    value: value as string | number,
-    label: enumNames[index] ?? String(value),
-  }));
+  // Memoized: the host form passes a fresh ``config`` to every control on
+  // each change, so without the memo a catalog of N options is rebuilt on
+  // every one of the user's M selections (O(N·M)).
+  const options = useMemo(
+    () =>
+      enumValues.map((value, index) => ({
+        value: value as string | number,
+        label: enumNames?.[index] ?? String(value),
+      })),
+    [enumValues, enumNames],
+  );
 
   const value = Array.isArray(props.data) ? (props.data as unknown[]) : [];
 
@@ -357,23 +385,26 @@ export function MultiEnumControl(props: ControlProps) {
     ?.tooltip as string | undefined;
 
   return (
-    <Form.Item label={props.label} tooltip={tooltip}>
+    <FormItem label={props.label} tooltip={tooltip}>
       <Select
+        ariaLabel={props.label || undefined}
         mode="multiple"
         value={value as (string | number)[]}
         onChange={next => props.handleChange(props.path, next)}
         options={options}
-        style={{ width: '100%' }}
         disabled={!props.enabled}
         loading={!!refreshingSchema}
         allowClear
-        optionFilterProp="label"
+        // Stability fix only: the wrapped Select's bulk select-all/clear
+        // affordance is out of scope for this control (sc-107832).
+        allowSelectAll={false}
+        optionFilterProps={['label']}
         placeholder={
           (props.uischema?.options as Record<string, unknown>)
             ?.placeholderText as string | undefined
         }
       />
-    </Form.Item>
+    </FormItem>
   );
 }
 const MultiEnumRenderer = withJsonFormsControlProps(MultiEnumControl);

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useEffect, useMemo } from 'react';
+import { isEqual } from 'lodash';
 import { t } from '@apache-superset/core/translation';
 import { FormItem, Select } from '@superset-ui/core/components';
 import { Spin } from '@superset-ui/core/components/Spin';
@@ -73,9 +74,11 @@ const passwordEntry = {
  * not enough: an object or array default (e.g. ``default: []``) gets a new
  * identity from JSON Forms on every change cycle, so a reference comparison
  * would call ``handleChange`` forever ("Maximum update depth exceeded").
+ * Deep equality (rather than serialized comparison) keeps the guard
+ * insensitive to object key order.
  */
 function valuesEqual(a: unknown, b: unknown): boolean {
-  return a === b || JSON.stringify(a) === JSON.stringify(b);
+  return a === b || isEqual(a, b);
 }
 
 /**
@@ -183,10 +186,10 @@ export function areDependenciesSatisfied(
  * refreshed with dynamic values from the backend.
  *
  * Enum-typed fields (e.g. the Snowflake ``schema`` dropdown) get an explicit
- * Antd Select so the ``loading``/``disabled`` props work natively — wrapping
+ * wrapped Select so the ``loading``/``disabled`` props work natively — wrapping
  * TextControl with ``inputProps.suffix`` doesn't reach the underlying Select.
  */
-function DynamicFieldControl(props: ControlProps) {
+export function DynamicFieldControl(props: ControlProps) {
   const { refreshingSchema, formData: cfgData } = props.config ?? {};
   const schema = props.schema as Record<string, unknown>;
   const deps = schema?.['x-dependsOn'];
@@ -207,22 +210,19 @@ function DynamicFieldControl(props: ControlProps) {
   const enumNames = Array.isArray(schema['x-enumNames'])
     ? (schema['x-enumNames'] as unknown[])
     : undefined;
-  // The backend returns these as a set, so order is undefined. Sort by
-  // label so the dropdown is stable and alphabetised. Memoized so a
-  // re-render without an enum change (every host-form keystroke passes a
-  // fresh ``config`` to all controls) does not rebuild and re-sort the
-  // full option list.
+  // Memoized so a re-render without an enum change (every host-form
+  // keystroke passes a fresh ``config`` to all controls) does not rebuild
+  // the full option list. No manual sort: the wrapped Select alphabetises
+  // options by label itself, so the backend's undefined set order is fine.
   const options = useMemo(
     () =>
-      (enumValues ?? [])
-        .map((value, index) => ({
-          value: value as string | number,
-          label:
-            enumNames?.[index] !== undefined
-              ? String(enumNames[index])
-              : String(value),
-        }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
+      (enumValues ?? []).map((value, index) => ({
+        value: value as string | number,
+        label:
+          enumNames?.[index] !== undefined
+            ? String(enumNames[index])
+            : String(value),
+      })),
     [enumValues, enumNames],
   );
 
@@ -281,7 +281,7 @@ const dynamicFieldEntry = {
 
 /**
  * Renderer for fields that carry an ``x-enumNames`` array alongside their
- * ``enum`` values.  Renders as an Antd Select showing human-readable labels
+ * ``enum`` values.  Renders as a wrapped Select showing human-readable labels
  * (from ``x-enumNames``) while storing the underlying enum values in form
  * data.  Used for MetricFlow's integer-ID fields (account, project,
  * environment) where the backend provides both IDs and display names.
@@ -289,15 +289,17 @@ const dynamicFieldEntry = {
 function EnumNamesControl(props: ControlProps) {
   const { refreshingSchema } = props.config ?? {};
   const schema = props.schema as Record<string, unknown>;
-  const enumValues = (schema.enum as unknown[]) ?? [];
+  // ``?? undefined`` (not a fresh fallback array) keeps the memo deps
+  // stable across renders; fallbacks live inside the memo.
+  const enumValues = (schema.enum as unknown[] | undefined) ?? undefined;
   const enumNames =
-    (schema['x-enumNames'] as string[]) ?? enumValues.map(String);
+    (schema['x-enumNames'] as string[] | undefined) ?? undefined;
 
   const options = useMemo(
     () =>
-      enumValues.map((value, index) => ({
+      (enumValues ?? []).map((value, index) => ({
         value: value as string | number,
-        label: enumNames[index] ?? String(value),
+        label: enumNames?.[index] ?? String(value),
       })),
     [enumValues, enumNames],
   );
@@ -344,7 +346,7 @@ export const enumNamesEntry = {
 
 /**
  * Renderer for ``{type: 'array', items: {enum: [...]}}`` schemas.  Renders
- * a single Antd Select with ``mode="multiple"`` (tag-style multi-select),
+ * a single wrapped Select with ``mode="multiple"`` (tag-style multi-select),
  * matching the natural expectation of a "pick several from a list" control.
  *
  * Without this, the default ``PrimitiveArrayControl`` from the upstream
@@ -364,15 +366,18 @@ export function MultiEnumControl(props: ControlProps) {
     (arraySchema.items as Record<string, unknown>) ??
     ({} as Record<string, unknown>);
 
-  const enumValues = (itemsSchema.enum as unknown[]) ?? [];
-  const enumNames = (itemsSchema['x-enumNames'] as string[]) ?? undefined;
+  // ``?? undefined`` keeps memo deps identity-stable; fallbacks live in
+  // the memo body.
+  const enumValues = (itemsSchema.enum as unknown[] | undefined) ?? undefined;
+  const enumNames =
+    (itemsSchema['x-enumNames'] as string[] | undefined) ?? undefined;
 
   // Memoized: the host form passes a fresh ``config`` to every control on
   // each change, so without the memo a catalog of N options is rebuilt on
   // every one of the user's M selections (O(N·M)).
   const options = useMemo(
     () =>
-      enumValues.map((value, index) => ({
+      (enumValues ?? []).map((value, index) => ({
         value: value as string | number,
         label: enumNames?.[index] ?? String(value),
       })),
@@ -437,6 +442,25 @@ export const renderers = [
   multiEnumEntry,
   dynamicFieldEntry,
 ];
+
+/**
+ * Serializes a value with object keys sorted, so two structurally equal
+ * schemas compare equal regardless of the backend's JSON property order.
+ * Array order is deliberately significant: ``x-propertyOrder`` and enum
+ * ordering can be meaningful, so only key order is canonicalized.
+ */
+export function stableSerialize(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === 'object' && !Array.isArray(val)
+      ? Object.keys(val as Record<string, unknown>)
+          .sort()
+          .reduce((acc: Record<string, unknown>, k) => {
+            acc[k] = (val as Record<string, unknown>)[k];
+            return acc;
+          }, {})
+      : val,
+  );
+}
 
 /**
  * Removes empty `enum` arrays from schema properties. The JSON Schema spec

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useEffect, useMemo } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { FormItem, Select } from '@superset-ui/core/components';
 import { Spin } from '@superset-ui/core/components/Spin';
@@ -366,11 +366,14 @@ export function MultiEnumControl(props: ControlProps) {
     (arraySchema.items as Record<string, unknown>) ??
     ({} as Record<string, unknown>);
 
-  // ``?? undefined`` keeps memo deps identity-stable; fallbacks live in
-  // the memo body.
-  const enumValues = (itemsSchema.enum as unknown[] | undefined) ?? undefined;
-  const enumNames =
-    (itemsSchema['x-enumNames'] as string[] | undefined) ?? undefined;
+  // No fallback allocations out here: a fresh ``[]`` per render would give
+  // the memo new deps every time. Fallbacks live inside the memo.
+  const enumValues = Array.isArray(itemsSchema.enum)
+    ? (itemsSchema.enum as unknown[])
+    : undefined;
+  const enumNames = Array.isArray(itemsSchema['x-enumNames'])
+    ? (itemsSchema['x-enumNames'] as string[])
+    : undefined;
 
   // Memoized: the host form passes a fresh ``config`` to every control on
   // each change, so without the memo a catalog of N options is rebuilt on

--- a/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
+++ b/superset-frontend/src/features/semanticLayers/jsonFormsHelpers.tsx
@@ -450,15 +450,23 @@ export const renderers = [
  * ordering can be meaningful, so only key order is canonicalized.
  */
 export function stableSerialize(value: unknown): string {
-  return JSON.stringify(value, (_key, val) =>
-    val && typeof val === 'object' && !Array.isArray(val)
-      ? Object.keys(val as Record<string, unknown>)
-          .sort()
-          .reduce((acc: Record<string, unknown>, k) => {
-            acc[k] = (val as Record<string, unknown>)[k];
-            return acc;
-          }, {})
-      : val,
+  return (
+    JSON.stringify(value, (_key, val) =>
+      val && typeof val === 'object' && !Array.isArray(val)
+        ? Object.keys(val as Record<string, unknown>)
+            .sort()
+            // Null-prototype accumulator: a plain object would treat a
+            // ``__proto__`` key as a prototype assignment and silently drop
+            // it from the output, hiding a genuine schema difference.
+            .reduce(
+              (acc: Record<string, unknown>, k) => {
+                acc[k] = (val as Record<string, unknown>)[k];
+                return acc;
+              },
+              Object.create(null) as Record<string, unknown>,
+            )
+        : val,
+    ) ?? ''
   );
 }
 

--- a/superset-frontend/src/features/semanticLayers/testFixtures.ts
+++ b/superset-frontend/src/features/semanticLayers/testFixtures.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { JsonSchema } from '@jsonforms/core';
+
+export const LARGE_CATALOG_SIZE = 500;
+
+/** Enum values for a large metric catalog: metric_000 … metric_499. */
+export const largeMetricEnum = Array.from(
+  { length: LARGE_CATALOG_SIZE },
+  (_, i) => `metric_${String(i).padStart(3, '0')}`,
+);
+
+/**
+ * An `{type: 'array', items: {enum: [...]}}` field schema at the guaranteed
+ * acceptance scale (spec sc-107832 SC-001), shaped like the runtime schemas
+ * semantic-layer extensions return (see tests/unit_tests/semantic_layers/
+ * api_test.py).
+ */
+export const largeMultiEnumFieldSchema = {
+  type: 'array',
+  items: { enum: largeMetricEnum },
+} as JsonSchema;
+
+/**
+ * A runtime schema exposing a large metrics multi-select plus a dynamic
+ * dimensions field that depends on it — the shape that makes each metric
+ * selection eligible to trigger a schema refresh.
+ */
+export const largeRuntimeSchema = {
+  type: 'object',
+  properties: {
+    metrics: largeMultiEnumFieldSchema,
+    dimensions: {
+      type: 'array',
+      items: { enum: ['dim_a', 'dim_b', 'dim_c'] },
+      'x-dynamic': true,
+      'x-dependsOn': ['metrics'],
+    },
+  },
+} as JsonSchema;
+
+/** Enum with duplicated display labels but distinct values (spec edge case). */
+export const duplicateLabelEnumSchema = {
+  type: 'array',
+  items: {
+    enum: ['metric_a_v1', 'metric_a_v2'],
+    'x-enumNames': ['Revenue', 'Revenue'],
+  },
+} as JsonSchema;

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
@@ -24,6 +24,11 @@ import {
 } from 'spec/helpers/testing-library';
 import { SupersetClient } from '@superset-ui/core';
 
+import {
+  largeMetricEnum,
+  largeRuntimeSchema,
+} from 'src/features/semanticLayers/testFixtures';
+
 import AddSemanticViewModal from './AddSemanticViewModal';
 
 jest.mock('@superset-ui/core', () => ({
@@ -371,20 +376,23 @@ test('a const array default does not loop updates', async () => {
     },
   });
   const consoleError = jest.spyOn(console, 'error').mockImplementation();
-  render(<AddSemanticViewModal {...createProps()} />);
-  await selectOption('Semantic layer', 'Snowflake SL');
+  try {
+    render(<AddSemanticViewModal {...createProps()} />);
+    await selectOption('Semantic layer', 'Snowflake SL');
 
-  // Pre-fix, ConstControl's reference comparison re-fired handleChange on
-  // every cycle for an array const → "Maximum update depth exceeded".
-  expect(
-    await screen.findByRole('combobox', { name: /metrics/i }),
-  ).toBeInTheDocument();
-  expect(
-    consoleError.mock.calls.find(args =>
-      String(args[0]).includes('Maximum update depth'),
-    ),
-  ).toBeUndefined();
-  consoleError.mockRestore();
+    // Pre-fix, ConstControl's reference comparison re-fired handleChange on
+    // every cycle for an array const → "Maximum update depth exceeded".
+    expect(
+      await screen.findByRole('combobox', { name: /metrics/i }),
+    ).toBeInTheDocument();
+    expect(
+      consoleError.mock.calls.find(args =>
+        String(args[0]).includes('Maximum update depth'),
+      ),
+    ).toBeUndefined();
+  } finally {
+    consoleError.mockRestore();
+  }
 });
 
 test('a failed schema refresh surfaces a toast and preserves selections', async () => {
@@ -459,4 +467,23 @@ test('the save payload carries every selected metric', async () => {
       },
     });
   });
+});
+
+test('renders and selects within a 500-metric runtime schema', async () => {
+  mockLayerWithSchema(largeRuntimeSchema as Record<string, unknown>);
+  render(<AddSemanticViewModal {...createProps()} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  const metricsBox = await screen.findByRole('combobox', { name: /metrics/i });
+  await userEvent.click(metricsBox);
+  await userEvent.type(metricsBox, largeMetricEnum[42]);
+  const option = await waitFor(() => {
+    const el = Array.from(
+      document.querySelectorAll('.ant-select-item-option'),
+    ).find(e => e.getAttribute('title') === largeMetricEnum[42]);
+    if (!el) throw new Error('option not rendered yet');
+    return el as HTMLElement;
+  });
+  await userEvent.click(option);
+  expect(selectedTag(largeMetricEnum[42])).toBeTruthy();
 });

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
@@ -292,6 +292,20 @@ const dynamicMetricsSchema = {
   },
 };
 
+/**
+ * Same metrics picker without the dynamic dependency: selections trigger no
+ * schema-refresh cycle, so tests that only care about form-state wiring wait
+ * on a single debounce instead of one per pick.
+ */
+const staticMetricsSchema = {
+  properties: {
+    metrics: {
+      type: 'array',
+      items: { enum: ['m1', 'm2', 'm3'] },
+    },
+  },
+};
+
 const pickFromSelect = async (name: RegExp, optionTitle: string) => {
   const box = await screen.findByRole('combobox', { name });
   await userEvent.click(box);
@@ -353,7 +367,7 @@ test('metric selections survive identical schema refreshes without losing state'
       );
       expect(refreshCalls.length).toBeGreaterThanOrEqual(1);
     },
-    { timeout: 3000 },
+    { timeout: 10000 },
   );
   expect(selectedTag('m1')).toBeTruthy();
 
@@ -362,7 +376,7 @@ test('metric selections survive identical schema refreshes without losing state'
     () => {
       expect(selectedTag('m2')).toBeTruthy();
     },
-    { timeout: 3000 },
+    { timeout: 10000 },
   );
   // Both selections intact after two refresh cycles.
   expect(selectedTag('m1')).toBeTruthy();
@@ -417,7 +431,7 @@ test('a failed schema refresh surfaces a toast and preserves selections', async 
         'An error occurred while refreshing the runtime schema',
       );
     },
-    { timeout: 3000 },
+    { timeout: 10000 },
   );
   expect(refreshCount).toBeGreaterThanOrEqual(1);
   // The user's selection is untouched by the failure (spec FR-005).
@@ -425,7 +439,10 @@ test('a failed schema refresh surfaces a toast and preserves selections', async 
 });
 
 test('the save payload carries every selected metric', async () => {
-  mockLayerWithSchema(dynamicMetricsSchema);
+  // Static schema on purpose: this test pins the form-state -> payload
+  // wiring, not the refresh cycle (covered by the refresh tests above), so
+  // it waits on one views-fetch debounce rather than one per pick.
+  mockLayerWithSchema(staticMetricsSchema);
   render(<AddSemanticViewModal {...createProps()} />);
   await selectOption('Semantic layer', 'Snowflake SL');
 
@@ -433,15 +450,13 @@ test('the save payload carries every selected metric', async () => {
   await pickFromSelect(/metrics/i, 'm2');
   await pickFromSelect(/metrics/i, 'm3');
 
-  // The views fetch trails the last metric pick by two debounce windows;
-  // the picker stays disabled until options arrive.
   await waitFor(
     () => {
       expect(
         screen.getByRole('combobox', { name: 'Semantic views' }),
       ).toBeEnabled();
     },
-    { timeout: 5000 },
+    { timeout: 10000 },
   );
   await pickFromSelect(/semantic views/i, 'orders');
   await userEvent.click(

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
@@ -262,3 +262,201 @@ test('shows toast when add semantic views fails', async () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Large-catalog / refresh-stability regression tests (sc-107832)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime schema whose metrics field is a dependency of a dynamic field, so
+ * every metrics selection triggers the debounced schema-refresh cycle — the
+ * shape that made per-selection refreshes remount the form pre-fix.
+ */
+const dynamicMetricsSchema = {
+  properties: {
+    metrics: {
+      type: 'array',
+      items: { enum: ['m1', 'm2', 'm3'] },
+    },
+    dimensions: {
+      type: 'array',
+      items: { enum: ['d1', 'd2'] },
+      'x-dynamic': true,
+      'x-dependsOn': ['metrics'],
+    },
+  },
+};
+
+const pickFromSelect = async (name: RegExp, optionTitle: string) => {
+  const box = await screen.findByRole('combobox', { name });
+  await userEvent.click(box);
+  const option = await waitFor(() => {
+    const el = Array.from(
+      document.querySelectorAll('.ant-select-item-option'),
+    ).find(e => e.getAttribute('title') === optionTitle);
+    if (!el) throw new Error(`option ${optionTitle} not rendered yet`);
+    return el as HTMLElement;
+  });
+  await userEvent.click(option);
+};
+
+const selectedTag = (title: string) =>
+  document.querySelector(`.ant-select-selection-item[title="${title}"]`);
+
+const mockLayerWithSchema = (
+  schema: Record<string, unknown>,
+  overrides: Record<string, (payload?: unknown) => Promise<unknown>> = {},
+) => {
+  mockedGet.mockResolvedValue({
+    json: { result: [{ uuid: 'layer-1', name: 'Snowflake SL' }] },
+  });
+  mockedPost.mockImplementation(
+    ({ endpoint, jsonPayload }: { endpoint: string; jsonPayload: unknown }) => {
+      if (overrides[endpoint]) return overrides[endpoint](jsonPayload);
+      if (endpoint === '/api/v1/semantic_layer/layer-1/schema/runtime') {
+        return Promise.resolve({ json: { result: schema } });
+      }
+      if (endpoint === '/api/v1/semantic_layer/layer-1/views') {
+        return Promise.resolve({
+          json: { result: [{ name: 'orders', already_added: false }] },
+        });
+      }
+      if (endpoint === '/api/v1/semantic_view/') {
+        return Promise.resolve({
+          json: { result: { created: [{ uuid: 'view-1', name: 'orders' }] } },
+        });
+      }
+      return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`));
+    },
+  );
+};
+
+test('metric selections survive identical schema refreshes without losing state', async () => {
+  mockLayerWithSchema(dynamicMetricsSchema);
+  render(<AddSemanticViewModal {...createProps()} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  await pickFromSelect(/metrics/i, 'm1');
+  // The debounced refresh fires and returns a payload identical to the
+  // current schema; the form must not remount and the selection must hold.
+  await waitFor(
+    () => {
+      const refreshCalls = mockedPost.mock.calls.filter(
+        ([{ endpoint, jsonPayload }]) =>
+          endpoint === '/api/v1/semantic_layer/layer-1/schema/runtime' &&
+          (jsonPayload as { runtime_data?: unknown })?.runtime_data,
+      );
+      expect(refreshCalls.length).toBeGreaterThanOrEqual(1);
+    },
+    { timeout: 3000 },
+  );
+  expect(selectedTag('m1')).toBeTruthy();
+
+  await pickFromSelect(/metrics/i, 'm2');
+  await waitFor(
+    () => {
+      expect(selectedTag('m2')).toBeTruthy();
+    },
+    { timeout: 3000 },
+  );
+  // Both selections intact after two refresh cycles.
+  expect(selectedTag('m1')).toBeTruthy();
+});
+
+test('a const array default does not loop updates', async () => {
+  mockLayerWithSchema({
+    properties: {
+      marker: { const: [] },
+      metrics: { type: 'array', items: { enum: ['m1', 'm2'] } },
+    },
+  });
+  const consoleError = jest.spyOn(console, 'error').mockImplementation();
+  render(<AddSemanticViewModal {...createProps()} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  // Pre-fix, ConstControl's reference comparison re-fired handleChange on
+  // every cycle for an array const → "Maximum update depth exceeded".
+  expect(
+    await screen.findByRole('combobox', { name: /metrics/i }),
+  ).toBeInTheDocument();
+  expect(
+    consoleError.mock.calls.find(args =>
+      String(args[0]).includes('Maximum update depth'),
+    ),
+  ).toBeUndefined();
+  consoleError.mockRestore();
+});
+
+test('a failed schema refresh surfaces a toast and preserves selections', async () => {
+  let refreshCount = 0;
+  mockLayerWithSchema(dynamicMetricsSchema, {
+    '/api/v1/semantic_layer/layer-1/schema/runtime': (payload: unknown) => {
+      if ((payload as { runtime_data?: unknown })?.runtime_data) {
+        refreshCount += 1;
+        return Promise.reject(new Error('refresh boom'));
+      }
+      return Promise.resolve({ json: { result: dynamicMetricsSchema } });
+    },
+  });
+  const props = createProps();
+  render(<AddSemanticViewModal {...props} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  await pickFromSelect(/metrics/i, 'm1');
+  await waitFor(
+    () => {
+      expect(props.addDangerToast).toHaveBeenCalledWith(
+        'An error occurred while refreshing the runtime schema',
+      );
+    },
+    { timeout: 3000 },
+  );
+  expect(refreshCount).toBeGreaterThanOrEqual(1);
+  // The user's selection is untouched by the failure (spec FR-005).
+  expect(selectedTag('m1')).toBeTruthy();
+});
+
+test('the save payload carries every selected metric', async () => {
+  mockLayerWithSchema(dynamicMetricsSchema);
+  render(<AddSemanticViewModal {...createProps()} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  await pickFromSelect(/metrics/i, 'm1');
+  await pickFromSelect(/metrics/i, 'm2');
+  await pickFromSelect(/metrics/i, 'm3');
+
+  // The views fetch trails the last metric pick by two debounce windows;
+  // the picker stays disabled until options arrive.
+  await waitFor(
+    () => {
+      expect(
+        screen.getByRole('combobox', { name: 'Semantic views' }),
+      ).toBeEnabled();
+    },
+    { timeout: 5000 },
+  );
+  await pickFromSelect(/semantic views/i, 'orders');
+  await userEvent.click(
+    screen.getByRole('button', { name: /add 1 view\(s\)/i }),
+  );
+
+  // Every selected metric reaches the persistence payload untruncated
+  // (spec FR-004; the 500-value propagation itself is pinned at the
+  // control level in MultiEnumControl.test.tsx).
+  await waitFor(() => {
+    expect(mockedPost).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/',
+      jsonPayload: {
+        views: [
+          {
+            name: 'orders',
+            semantic_layer_uuid: 'layer-1',
+            configuration: expect.objectContaining({
+              metrics: ['m1', 'm2', 'm3'],
+            }),
+          },
+        ],
+      },
+    });
+  });
+});

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
@@ -559,3 +559,49 @@ test('a persistently failing refresh retries once, not on every edit', async () 
     ),
   ).toHaveLength(1);
 });
+
+test('a superseded refresh response cannot toast or clobber a newer one', async () => {
+  // Exercises schemaRefreshGenRef: when two refreshes overlap and the older
+  // one settles last, its failure must be ignored — no error toast, and no
+  // rollback of the dependency snapshot the newer request committed.
+  let call = 0;
+  const resolvers: Array<() => void> = [];
+  mockLayerWithSchema(dynamicMetricsSchema, {
+    '/api/v1/semantic_layer/layer-1/schema/runtime': (payload: unknown) => {
+      if (!(payload as { runtime_data?: unknown })?.runtime_data) {
+        return Promise.resolve({ json: { result: dynamicMetricsSchema } });
+      }
+      call += 1;
+      if (call === 1) {
+        // First (soon-to-be superseded) refresh: fails, but only after the
+        // second one has already been issued.
+        return new Promise((_resolve, reject) => {
+          resolvers.push(() => reject(new Error('stale refresh boom')));
+        });
+      }
+      return Promise.resolve({ json: { result: dynamicMetricsSchema } });
+    },
+  });
+  const props = createProps();
+  render(<AddSemanticViewModal {...props} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  await pickFromSelect(/metrics/i, 'm1');
+  await waitFor(() => expect(call).toBe(1), { timeout: 10000 });
+  // Second selection supersedes the in-flight refresh.
+  await pickFromSelect(/metrics/i, 'm2');
+  await waitFor(() => expect(call).toBe(2), { timeout: 10000 });
+  // Now let the stale first request fail, last.
+  resolvers.forEach(fn => fn());
+  await new Promise(resolve => {
+    setTimeout(resolve, 1000);
+  });
+
+  expect(
+    props.addDangerToast.mock.calls.filter(([msg]) =>
+      String(msg).includes('refreshing the runtime schema'),
+    ),
+  ).toHaveLength(0);
+  expect(selectedTag('m1')).toBeTruthy();
+  expect(selectedTag('m2')).toBeTruthy();
+});

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.test.tsx
@@ -485,6 +485,7 @@ test('the save payload carries every selected metric', async () => {
 });
 
 test('renders and selects within a 500-metric runtime schema', async () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   mockLayerWithSchema(largeRuntimeSchema as Record<string, unknown>);
   render(<AddSemanticViewModal {...createProps()} />);
   await selectOption('Semantic layer', 'Snowflake SL');
@@ -501,4 +502,60 @@ test('renders and selects within a 500-metric runtime schema', async () => {
   });
   await userEvent.click(option);
   expect(selectedTag(largeMetricEnum[42])).toBeTruthy();
+
+  // largeRuntimeSchema's dimensions field depends on metrics, so the pick
+  // schedules a refresh — wait for it so the dedupe/apply path is exercised
+  // at 500-metric scale rather than ending before the debounce elapses.
+  await waitFor(
+    () => {
+      const refreshes = mockedPost.mock.calls.filter(
+        ([{ endpoint, jsonPayload }]) =>
+          endpoint === '/api/v1/semantic_layer/layer-1/schema/runtime' &&
+          (jsonPayload as { runtime_data?: unknown })?.runtime_data,
+      );
+      expect(refreshes.length).toBeGreaterThanOrEqual(1);
+    },
+    { timeout: 10000 },
+  );
+  expect(selectedTag(largeMetricEnum[42])).toBeTruthy();
+  expect(
+    consoleErrorSpy.mock.calls.find(args =>
+      String(args[0]).includes('Maximum update depth'),
+    ),
+  ).toBeUndefined();
+});
+
+test('a persistently failing refresh retries once, not on every edit', async () => {
+  let refreshCount = 0;
+  mockLayerWithSchema(dynamicMetricsSchema, {
+    '/api/v1/semantic_layer/layer-1/schema/runtime': (payload: unknown) => {
+      if ((payload as { runtime_data?: unknown })?.runtime_data) {
+        refreshCount += 1;
+        return Promise.reject(new Error('refresh boom'));
+      }
+      return Promise.resolve({ json: { result: dynamicMetricsSchema } });
+    },
+  });
+  const props = createProps();
+  render(<AddSemanticViewModal {...props} />);
+  await selectOption('Semantic layer', 'Snowflake SL');
+
+  await pickFromSelect(/metrics/i, 'm1');
+  await waitFor(() => expect(refreshCount).toBe(1), { timeout: 10000 });
+
+  // One bounded retry for this dependency state, then no further attempts
+  // however many more edits the user makes during the outage.
+  await pickFromSelect(/dimensions/i, 'd1');
+  await waitFor(() => expect(refreshCount).toBe(2), { timeout: 10000 });
+  await pickFromSelect(/dimensions/i, 'd2');
+  await new Promise(resolve => {
+    setTimeout(resolve, 1200);
+  });
+  expect(refreshCount).toBe(2);
+  // And the user was told once, not once per attempt.
+  expect(
+    props.addDangerToast.mock.calls.filter(([msg]) =>
+      String(msg).includes('refreshing the runtime schema'),
+    ),
+  ).toHaveLength(1);
 });

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
@@ -204,13 +204,24 @@ export default function AddSemanticViewModal({
 
   const lastSchemaJsonRef = useRef('');
   const refreshErrorToastShownRef = useRef(false);
+  // Incremented per scheduled refresh so an out-of-order response from a
+  // superseded request cannot apply a stale schema, toast, or roll back the
+  // snapshot a newer request committed.
+  const schemaRefreshGenRef = useRef(0);
+  // Dependency state whose failed refresh has already been retried once, so
+  // a persistent outage cannot re-fire on every subsequent form edit.
+  const retriedDepSnapshotRef = useRef('');
   const applyRuntimeSchema = useCallback((rawSchema: JsonSchema) => {
     dynamicDepsRef.current = getDynamicDependencies(rawSchema);
     const schema = sanitizeSchema(rawSchema);
-    // Key-order-canonical serialization: providers may serialize the same
-    // schema with different property order between refreshes; that must not
-    // defeat the dedupe below.
-    const schemaJson = stableSerialize(schema);
+    const uiSchema = buildUiSchema(schema);
+    // Dedupe key = key-order-canonical schema + the derived ui schema.
+    // Canonicalizing alone would hide a refresh whose only change is
+    // property order, but ``buildUiSchema`` derives field display order from
+    // that order when ``x-propertyOrder`` is absent — including the ui schema
+    // keeps such reorderings visible while still ignoring incidental
+    // serialization differences elsewhere.
+    const schemaJson = `${stableSerialize(schema)}|${JSON.stringify(uiSchema)}`;
     // A refresh response whose sanitized schema is unchanged keeps the
     // existing object identities: JSON Forms then neither rebuilds its AJV
     // validator (which caches one compiled copy per schema object — a per-
@@ -219,7 +230,7 @@ export default function AddSemanticViewModal({
     if (schemaJson === lastSchemaJsonRef.current) return;
     lastSchemaJsonRef.current = schemaJson;
     setRuntimeSchema(schema);
-    setRuntimeUiSchema(buildUiSchema(schema));
+    setRuntimeUiSchema(uiSchema);
   }, []);
 
   const scheduleFetchViews = useCallback(
@@ -255,6 +266,8 @@ export default function AddSemanticViewModal({
       lastDepSnapshotRef.current = '';
       lastSchemaJsonRef.current = '';
       refreshErrorToastShownRef.current = false;
+      retriedDepSnapshotRef.current = '';
+      schemaRefreshGenRef.current += 1;
       setAvailableViews([]);
       setSelectedViewNames([]);
       lastViewsKeyRef.current = '';
@@ -325,6 +338,8 @@ export default function AddSemanticViewModal({
             lastViewsKeyRef.current = '';
             if (schemaTimerRef.current) clearTimeout(schemaTimerRef.current);
             const uuid = selectedLayerUuid;
+            schemaRefreshGenRef.current += 1;
+            const refreshGen = schemaRefreshGenRef.current;
             schemaTimerRef.current = setTimeout(async () => {
               setRefreshingSchema(true);
               try {
@@ -332,16 +347,34 @@ export default function AddSemanticViewModal({
                   endpoint: `/api/v1/semantic_layer/${uuid}/schema/runtime`,
                   jsonPayload: { runtime_data: data },
                 });
-                if (gen !== fetchGenRef.current) return;
-                applyRuntimeSchema(json.result);
+                if (
+                  gen !== fetchGenRef.current ||
+                  refreshGen !== schemaRefreshGenRef.current
+                )
+                  return;
+                if (json.result) applyRuntimeSchema(json.result);
                 refreshErrorToastShownRef.current = false;
+                retriedDepSnapshotRef.current = '';
               } catch (error) {
-                if (gen !== fetchGenRef.current) return;
+                if (
+                  gen !== fetchGenRef.current ||
+                  refreshGen !== schemaRefreshGenRef.current
+                )
+                  return;
                 logging.error('Runtime schema refresh failed', error);
-                // Clear the committed snapshot so a change event with the
-                // same dependency values re-attempts the refresh instead of
-                // leaving dynamic narrowing stale until deps change twice.
-                lastDepSnapshotRef.current = '';
+                // Allow exactly one retry per dependency state: clearing the
+                // committed snapshot lets the next change event re-attempt
+                // the refresh, but only if this state hasn't been retried
+                // already, so a persistent outage doesn't re-fire on every
+                // edit. Only clear a snapshot this attempt still owns — a
+                // newer change may have committed its own since.
+                if (
+                  lastDepSnapshotRef.current === snapshot &&
+                  retriedDepSnapshotRef.current !== snapshot
+                ) {
+                  retriedDepSnapshotRef.current = snapshot;
+                  lastDepSnapshotRef.current = '';
+                }
                 // The form (and the user's selections) stay intact; only the
                 // dynamic narrowing is stale, so surface it without blocking
                 // — once per outage, not once per debounced attempt.
@@ -352,7 +385,11 @@ export default function AddSemanticViewModal({
                   );
                 }
               } finally {
-                if (gen === fetchGenRef.current) setRefreshingSchema(false);
+                if (
+                  gen === fetchGenRef.current &&
+                  refreshGen === schemaRefreshGenRef.current
+                )
+                  setRefreshingSchema(false);
               }
             }, SCHEMA_REFRESH_DEBOUNCE_MS);
             return;
@@ -410,6 +447,8 @@ export default function AddSemanticViewModal({
       lastDepSnapshotRef.current = '';
       lastSchemaJsonRef.current = '';
       refreshErrorToastShownRef.current = false;
+      retriedDepSnapshotRef.current = '';
+      schemaRefreshGenRef.current += 1;
       setAvailableViews([]);
       setSelectedViewNames([]);
       setLoadingViews(false);

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
@@ -352,9 +352,12 @@ export default function AddSemanticViewModal({
                   refreshGen !== schemaRefreshGenRef.current
                 )
                   return;
-                if (json.result) applyRuntimeSchema(json.result);
+                // Reset before applying: the request itself succeeded, so a
+                // throw inside applyRuntimeSchema must not be reported (or
+                // retried) as a transient network failure.
                 refreshErrorToastShownRef.current = false;
                 retriedDepSnapshotRef.current = '';
+                if (json.result) applyRuntimeSchema(json.result);
               } catch (error) {
                 if (
                   gen !== fetchGenRef.current ||

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
@@ -18,6 +18,7 @@
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { t } from '@apache-superset/core/translation';
+import { logging } from '@apache-superset/core/utils';
 import { styled } from '@apache-superset/core/theme';
 import { SupersetClient } from '@superset-ui/core';
 import { Select } from '@superset-ui/core/components';
@@ -39,6 +40,7 @@ import {
   getDynamicDependencies,
   areDependenciesSatisfied,
   serializeDependencyValues,
+  stableSerialize,
   SCHEMA_REFRESH_DEBOUNCE_MS,
 } from 'src/features/semanticLayers/jsonFormsHelpers';
 
@@ -201,10 +203,14 @@ export default function AddSemanticViewModal({
   );
 
   const lastSchemaJsonRef = useRef('');
+  const refreshErrorToastShownRef = useRef(false);
   const applyRuntimeSchema = useCallback((rawSchema: JsonSchema) => {
     dynamicDepsRef.current = getDynamicDependencies(rawSchema);
     const schema = sanitizeSchema(rawSchema);
-    const schemaJson = JSON.stringify(schema);
+    // Key-order-canonical serialization: providers may serialize the same
+    // schema with different property order between refreshes; that must not
+    // defeat the dedupe below.
+    const schemaJson = stableSerialize(schema);
     // A refresh response whose sanitized schema is unchanged keeps the
     // existing object identities: JSON Forms then neither rebuilds its AJV
     // validator (which caches one compiled copy per schema object — a per-
@@ -248,6 +254,7 @@ export default function AddSemanticViewModal({
       dynamicDepsRef.current = {};
       lastDepSnapshotRef.current = '';
       lastSchemaJsonRef.current = '';
+      refreshErrorToastShownRef.current = false;
       setAvailableViews([]);
       setSelectedViewNames([]);
       lastViewsKeyRef.current = '';
@@ -327,13 +334,23 @@ export default function AddSemanticViewModal({
                 });
                 if (gen !== fetchGenRef.current) return;
                 applyRuntimeSchema(json.result);
-              } catch {
+                refreshErrorToastShownRef.current = false;
+              } catch (error) {
                 if (gen !== fetchGenRef.current) return;
+                logging.error('Runtime schema refresh failed', error);
+                // Clear the committed snapshot so a change event with the
+                // same dependency values re-attempts the refresh instead of
+                // leaving dynamic narrowing stale until deps change twice.
+                lastDepSnapshotRef.current = '';
                 // The form (and the user's selections) stay intact; only the
-                // dynamic narrowing is stale, so surface it without blocking.
-                addDangerToast(
-                  t('An error occurred while refreshing the runtime schema'),
-                );
+                // dynamic narrowing is stale, so surface it without blocking
+                // — once per outage, not once per debounced attempt.
+                if (!refreshErrorToastShownRef.current) {
+                  refreshErrorToastShownRef.current = true;
+                  addDangerToast(
+                    t('An error occurred while refreshing the runtime schema'),
+                  );
+                }
               } finally {
                 if (gen === fetchGenRef.current) setRefreshingSchema(false);
               }
@@ -392,6 +409,7 @@ export default function AddSemanticViewModal({
       dynamicDepsRef.current = {};
       lastDepSnapshotRef.current = '';
       lastSchemaJsonRef.current = '';
+      refreshErrorToastShownRef.current = false;
       setAvailableViews([]);
       setSelectedViewNames([]);
       setLoadingViews(false);

--- a/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
+++ b/superset-frontend/src/features/semanticViews/AddSemanticViewModal.tsx
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import { SupersetClient } from '@superset-ui/core';
-import { Spin } from 'antd';
 import { Select } from '@superset-ui/core/components';
+import { Spin } from '@superset-ui/core/components/Spin';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { JsonForms } from '@jsonforms/react';
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
@@ -200,11 +200,20 @@ export default function AddSemanticViewModal({
     [addDangerToast],
   );
 
+  const lastSchemaJsonRef = useRef('');
   const applyRuntimeSchema = useCallback((rawSchema: JsonSchema) => {
+    dynamicDepsRef.current = getDynamicDependencies(rawSchema);
     const schema = sanitizeSchema(rawSchema);
+    const schemaJson = JSON.stringify(schema);
+    // A refresh response whose sanitized schema is unchanged keeps the
+    // existing object identities: JSON Forms then neither rebuilds its AJV
+    // validator (which caches one compiled copy per schema object — a per-
+    // selection memory leak at large enum sizes) nor remounts the renderer
+    // tree.
+    if (schemaJson === lastSchemaJsonRef.current) return;
+    lastSchemaJsonRef.current = schemaJson;
     setRuntimeSchema(schema);
     setRuntimeUiSchema(buildUiSchema(schema));
-    dynamicDepsRef.current = getDynamicDependencies(rawSchema);
   }, []);
 
   const scheduleFetchViews = useCallback(
@@ -238,6 +247,7 @@ export default function AddSemanticViewModal({
       errorsRef.current = [];
       dynamicDepsRef.current = {};
       lastDepSnapshotRef.current = '';
+      lastSchemaJsonRef.current = '';
       setAvailableViews([]);
       setSelectedViewNames([]);
       lastViewsKeyRef.current = '';
@@ -318,7 +328,12 @@ export default function AddSemanticViewModal({
                 if (gen !== fetchGenRef.current) return;
                 applyRuntimeSchema(json.result);
               } catch {
-                // Silent fail on refresh — form still works
+                if (gen !== fetchGenRef.current) return;
+                // The form (and the user's selections) stay intact; only the
+                // dynamic narrowing is stale, so surface it without blocking.
+                addDangerToast(
+                  t('An error occurred while refreshing the runtime schema'),
+                );
               } finally {
                 if (gen === fetchGenRef.current) setRefreshingSchema(false);
               }
@@ -333,7 +348,7 @@ export default function AddSemanticViewModal({
         scheduleFetchViews(selectedLayerUuid, data);
       }
     },
-    [selectedLayerUuid, applyRuntimeSchema, scheduleFetchViews],
+    [selectedLayerUuid, applyRuntimeSchema, scheduleFetchViews, addDangerToast],
   );
 
   // After a schema refresh settles, JSON Forms re-validates and fires
@@ -376,6 +391,7 @@ export default function AddSemanticViewModal({
       errorsRef.current = [];
       dynamicDepsRef.current = {};
       lastDepSnapshotRef.current = '';
+      lastSchemaJsonRef.current = '';
       setAvailableViews([]);
       setSelectedViewNames([]);
       setLoadingViews(false);
@@ -456,6 +472,27 @@ export default function AddSemanticViewModal({
     runtimeSchema?.properties &&
     Object.keys(runtimeSchema.properties).length > 0;
 
+  // Stable identity unless its inputs change: JSON Forms hands ``config`` to
+  // every control, so an inline literal would re-render all of them on each
+  // modal render.
+  const jsonFormsConfig = useMemo(
+    () => ({ refreshingSchema, formData: runtimeData }),
+    [refreshingSchema, runtimeData],
+  );
+
+  // Sorted copy — sorting in place would mutate React state during render.
+  const viewOptions = useMemo(
+    () =>
+      [...availableViews]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(v => ({
+          value: v.name,
+          label: v.already_added ? `${v.name} (${t('already added')})` : v.name,
+          disabled: v.already_added,
+        })),
+    [availableViews],
+  );
+
   const viewsDisabled =
     loadingViews || (!loadingViews && availableViews.length === 0);
 
@@ -531,7 +568,7 @@ export default function AddSemanticViewModal({
                 data={runtimeData}
                 renderers={renderers}
                 cells={cellRegistryEntries}
-                config={{ refreshingSchema, formData: runtimeData }}
+                config={jsonFormsConfig}
                 validationMode="ValidateAndHide"
                 onChange={handleRuntimeFormChange}
               />
@@ -554,15 +591,7 @@ export default function AddSemanticViewModal({
               disabled={viewsDisabled}
               value={selectedViewNames}
               onChange={values => setSelectedViewNames(values as string[])}
-              options={availableViews
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map(v => ({
-                  value: v.name,
-                  label: v.already_added
-                    ? `${v.name} (${t('already added')})`
-                    : v.name,
-                  disabled: v.already_added,
-                }))}
+              options={viewOptions}
               getPopupContainer={() => document.body}
             />
           </ModalFormField>

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -291,23 +291,26 @@ const LARGE_STRUCTURE = {
 test('renders a 500-metric structure paginated instead of unbounded', async () => {
   mockedGet.mockResolvedValue({ json: LARGE_STRUCTURE });
   const consoleError = jest.spyOn(console, 'error').mockImplementation();
-  render(<SemanticViewEditModal {...createProps()} />);
+  try {
+    render(<SemanticViewEditModal {...createProps()} />);
 
-  // Tab labels report the full counts.
-  await userEvent.click(await screen.findByText('Metrics (500)'));
-  // Pagination caps the rendered rows: first page only, not all 500.
-  await waitFor(() => {
-    expect(screen.getByText('metric_000')).toBeInTheDocument();
-  });
-  expect(screen.queryByText('metric_499')).not.toBeInTheDocument();
-  const rows = document.querySelectorAll('.ant-table-tbody tr');
-  expect(rows.length).toBeLessThanOrEqual(101);
-  expect(
-    consoleError.mock.calls.find(args =>
-      String(args[0]).includes('Maximum update depth'),
-    ),
-  ).toBeUndefined();
-  consoleError.mockRestore();
+    // Tab labels report the full counts.
+    await userEvent.click(await screen.findByText('Metrics (500)'));
+    // Pagination caps the rendered rows: first page only, not all 500.
+    await waitFor(() => {
+      expect(screen.getByText('metric_000')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('metric_499')).not.toBeInTheDocument();
+    const rows = document.querySelectorAll('.ant-table-tbody tr');
+    expect(rows.length).toBeLessThanOrEqual(101);
+    expect(
+      consoleError.mock.calls.find(args =>
+        String(args[0]).includes('Maximum update depth'),
+      ),
+    ).toBeUndefined();
+  } finally {
+    consoleError.mockRestore();
+  }
 });
 
 test('keeps small structures unpaginated', async () => {

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -265,3 +265,56 @@ test('details tab save still works after viewing structure tabs', async () => {
   });
   expect(props.addSuccessToast).toHaveBeenCalledWith('Semantic view updated');
 });
+
+// ---------------------------------------------------------------------------
+// Large-catalog structure rendering (sc-107832 / spec US2)
+// ---------------------------------------------------------------------------
+
+const LARGE_STRUCTURE = {
+  result: {
+    dimensions: Array.from({ length: 500 }, (_, i) => ({
+      name: `dim_${String(i).padStart(3, '0')}`,
+      type: 'string',
+      definition: null,
+      description: null,
+      grain: null,
+    })),
+    metrics: Array.from({ length: 500 }, (_, i) => ({
+      name: `metric_${String(i).padStart(3, '0')}`,
+      type: 'double',
+      definition: 'SIMPLE',
+      description: null,
+    })),
+  },
+};
+
+test('renders a 500-metric structure paginated instead of unbounded', async () => {
+  mockedGet.mockResolvedValue({ json: LARGE_STRUCTURE });
+  const consoleError = jest.spyOn(console, 'error').mockImplementation();
+  render(<SemanticViewEditModal {...createProps()} />);
+
+  // Tab labels report the full counts.
+  await userEvent.click(await screen.findByText('Metrics (500)'));
+  // Pagination caps the rendered rows: first page only, not all 500.
+  await waitFor(() => {
+    expect(screen.getByText('metric_000')).toBeInTheDocument();
+  });
+  expect(screen.queryByText('metric_499')).not.toBeInTheDocument();
+  const rows = document.querySelectorAll('.ant-table-tbody tr');
+  expect(rows.length).toBeLessThanOrEqual(101);
+  expect(
+    consoleError.mock.calls.find(args =>
+      String(args[0]).includes('Maximum update depth'),
+    ),
+  ).toBeUndefined();
+  consoleError.mockRestore();
+});
+
+test('keeps small structures unpaginated', async () => {
+  render(<SemanticViewEditModal {...createProps()} />);
+  await userEvent.click(await screen.findByText('Metrics (1)'));
+  await waitFor(() => {
+    expect(screen.getByText('orders')).toBeInTheDocument();
+  });
+  expect(document.querySelector('.ant-pagination')).toBeNull();
+});

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
@@ -90,6 +90,11 @@ const METRIC_COLUMNS: ColumnsType<SemanticMetric> = [
   { title: t('Definition'), dataIndex: 'definition', key: 'definition' },
 ];
 
+// Structure tables are read-only; small catalogs render in full, but a
+// large semantic layer can expose hundreds of rows, so switch to
+// pagination past this threshold instead of rendering unboundedly.
+const STRUCTURE_PAGINATION_THRESHOLD = 100;
+
 const STRUCTURE_INFO_MESSAGE = t(
   'Structure is managed by the upstream semantic layer and is read-only.',
 );
@@ -168,11 +173,6 @@ export default function SemanticViewEditModal({
 
   const dimensions = structure?.dimensions ?? [];
   const metrics = structure?.metrics ?? [];
-
-  // Structure tables are read-only; small catalogs render in full, but a
-  // large semantic layer can expose hundreds of rows, so switch to
-  // pagination past this threshold instead of rendering unboundedly.
-  const STRUCTURE_PAGINATION_THRESHOLD = 100;
 
   return (
     <StandardModal

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
@@ -169,6 +169,11 @@ export default function SemanticViewEditModal({
   const dimensions = structure?.dimensions ?? [];
   const metrics = structure?.metrics ?? [];
 
+  // Structure tables are read-only; small catalogs render in full, but a
+  // large semantic layer can expose hundreds of rows, so switch to
+  // pagination past this threshold instead of rendering unboundedly.
+  const STRUCTURE_PAGINATION_THRESHOLD = 100;
+
   return (
     <StandardModal
       show={show}
@@ -216,7 +221,8 @@ export default function SemanticViewEditModal({
               columns={DIMENSION_COLUMNS}
               size={TableSize.Small}
               rowKey="name"
-              usePagination={false}
+              usePagination={dimensions.length > STRUCTURE_PAGINATION_THRESHOLD}
+              defaultPageSize={STRUCTURE_PAGINATION_THRESHOLD}
             />
           </Tabs.TabPane>
           <Tabs.TabPane tab={t('Metrics (%s)', metrics.length)} key="metrics">
@@ -231,7 +237,8 @@ export default function SemanticViewEditModal({
               columns={METRIC_COLUMNS}
               size={TableSize.Small}
               rowKey="name"
-              usePagination={false}
+              usePagination={metrics.length > STRUCTURE_PAGINATION_THRESHOLD}
+              defaultPageSize={STRUCTURE_PAGINATION_THRESHOLD}
             />
           </Tabs.TabPane>
         </Tabs>


### PR DESCRIPTION
### SUMMARY

Selecting many metrics while creating a Semantic View crashes the application once the selection count passes a threshold ([sc-107832](https://app.shortcut.com/preset/story/107832)). Semantic layers commonly expose large metric catalogs, so this blocks a mainstream configuration path.

The metrics/dimensions pickers in the Add Semantic View modal are produced by a custom JSON Forms renderer (`MultiEnumControl` in `jsonFormsHelpers.tsx`). Four compounding defects combined into the crash:

1. **Unbounded tag rendering** — the renderer used a *direct antd* `Select` with no `maxTagCount`: one tag DOM node per selected metric, all re-rendered on every subsequent selection. (The sibling "views" picker in the same modal uses Superset's wrapped Select, whose default caps tags at 4.)
2. **Per-selection schema remount + validator-cache growth** — when the metrics field is a dependency of a dynamic field, each selection re-fetches the runtime schema; the response always got new object identities, so JSON Forms rebuilt its AJV validator and remounted the whole renderer tree per selection, while AJV cached another compiled copy of the full enum schema each time (cumulative memory growth).
3. **O(N·M) re-render churn** — the JSON Forms `config` prop was an inline literal (new identity per render → every control re-renders per selection) and the renderers rebuilt (one even sorted) their full option arrays per render, unmemoized.
4. **Latent infinite-update loop** — `ConstControl`/`ReadOnlyControl` compared array/object defaults by reference; a `default: []` field calls `handleChange` forever ("Maximum update depth exceeded").

**The fix**

- `MultiEnumControl`, `DynamicFieldControl`, and `EnumNamesControl` migrate to the wrapped `@superset-ui/core/components` `Select` — capped tag display with "+ N" overflow, `allowSelectAll={false}` (this is a pure stability fix; no new bulk-selection affordance), `ariaLabel`, the wrapped `optionFilterProps` API — with option arrays memoized. `Spin`/`Form` migrate alongside, leaving the file with **zero direct antd imports** (repo guideline: use wrapped component packages).
- `applyRuntimeSchema` skips refresh responses whose sanitized schema is unchanged, so identical refreshes cause no remount and no new AJV compilation; the schema-refresh failure path now surfaces an error toast (previously silent) with all form state preserved.
- The JSON Forms `config` prop is memoized; the views options list no longer sorts React state in place during render.
- The edit modal's read-only structure tables paginate past 100 rows instead of rendering unboundedly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Both captures render the **same** control with the **same** 500-metric catalog, every metric selected. "Before" is the pre-fix renderer taken verbatim from this branch's merge-base (raw antd `Select`, no `maxTagCount`); "after" is the shipped component. Measured height of the rendered control: **2748px → 36px**.

**Before** — one tag per selected metric. The control fills the viewport and keeps going (only ~150 of the 500 tags fit on screen); every subsequent selection re-renders all of them, which is the crash mechanism:

![before: 500 individual metric tags overflowing the viewport](https://raw.githubusercontent.com/mikebridge/superset/sc-107832-assets/before_tags.png)

**After** — capped tag summary, single row, full selection intact behind the overflow count:

![after: four metric tags plus a "+ 496" overflow summary in one row](https://raw.githubusercontent.com/mikebridge/superset/sc-107832-assets/after_tags.png)

### TESTING INSTRUCTIONS

Unit tests use a provider-independent 500-value enum fixture (`testFixtures.ts`) — the crash mechanics are fully client-side, so no provider extension is required:

```
cd superset-frontend
npm run test -- features/semanticLayers/ features/semanticViews/
```

Covers: tag cap + "+ N" overflow at 500 selections with the full value array propagated, no Select-all affordance, duplicated display labels individually selectable, selections surviving identical schema refreshes, `const: []` no-loop, failed-refresh toast with selections preserved, the persistence payload carrying every selected metric, and 500-row structure tables rendering paginated in the edit modal (small structures stay unpaginated).

Manual verification in a deployment with a semantic-layer extension installed: create a Semantic View from a layer exposing hundreds of metrics and select them all — the picker stays responsive and the app does not crash; saving persists the full selection.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

