### PR TITLE
fix(errors): downgrade SSH tunnel connection-failure logging to WARNING (SC-115347)

### DIFF
--- a/superset/views/error_handling.py
+++ b/superset/views/error_handling.py
@@ -23,12 +23,14 @@ import typing
 from importlib.resources import files
 from typing import Any, Callable, cast
 
+import sshtunnel
 from flask import (
     Flask,
     request,
     Response,
     send_file,
 )
+from flask_babel import gettext as _
 from flask_wtf.csrf import CSRFError
 from sqlalchemy import exc
 from werkzeug.exceptions import HTTPException
@@ -86,6 +88,29 @@ def json_error_response(
     )
 
 
+def handle_ssh_tunnel_error(ex: sshtunnel.BaseSSHTunnelForwarderError) -> FlaskResponse:
+    """
+    Build the structured response for an unreachable/misconfigured SSH tunnel
+    gateway. This is an expected environmental failure (analogous to a
+    database connection failure), so it is logged at WARNING rather than
+    ERROR to avoid alarm fatigue on otherwise-actionable alerting.
+    """
+    logger.warning("BaseSSHTunnelForwarderError", exc_info=True)
+    return json_error_response(
+        [
+            SupersetError(
+                message=_(
+                    "Failed to establish an SSH tunnel to the database: %(reason)s",
+                    reason=str(ex),
+                ),
+                error_type=SupersetErrorType.CONNECTION_HOST_DOWN_ERROR,
+                level=ErrorLevel.WARNING,
+            ),
+        ],
+        status=400,
+    )
+
+
 def handle_api_exception(
     f: Callable[..., FlaskResponse],
 ) -> Callable[..., FlaskResponse]:
@@ -121,6 +146,8 @@ def handle_api_exception(
         except (exc.IntegrityError, exc.DatabaseError, exc.DataError) as ex:
             logger.exception(ex)
             return json_error_response(utils.error_msg_from_exception(ex), status=422)
+        except sshtunnel.BaseSSHTunnelForwarderError as ex:
+            return handle_ssh_tunnel_error(ex)
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(ex)
             return json_error_response(utils.error_msg_from_exception(ex))
@@ -215,6 +242,9 @@ def set_app_error_handlers(app: Flask) -> None:  # noqa: C901
     @app.errorhandler(500)
     def show_unexpected_exception(ex: Exception) -> FlaskResponse:
         """Catch-all, to ensure all errors from the backend conform to SIP-40"""
+        if isinstance(ex, sshtunnel.BaseSSHTunnelForwarderError):
+            return handle_ssh_tunnel_error(ex)
+
         logger.warning("Exception", exc_info=True)
         logger.exception(ex)
 

--- a/superset/views/error_handling.py
+++ b/superset/views/error_handling.py
@@ -238,13 +238,16 @@ def set_app_error_handlers(app: Flask) -> None:  # noqa: C901
             status=ex.status,
         )
 
+    @app.errorhandler(sshtunnel.BaseSSHTunnelForwarderError)
+    def show_ssh_tunnel_error(
+        ex: sshtunnel.BaseSSHTunnelForwarderError,
+    ) -> FlaskResponse:
+        return handle_ssh_tunnel_error(ex)
+
     @app.errorhandler(Exception)
     @app.errorhandler(500)
     def show_unexpected_exception(ex: Exception) -> FlaskResponse:
         """Catch-all, to ensure all errors from the backend conform to SIP-40"""
-        if isinstance(ex, sshtunnel.BaseSSHTunnelForwarderError):
-            return handle_ssh_tunnel_error(ex)
-
         logger.warning("Exception", exc_info=True)
         logger.exception(ex)
 

--- a/tests/unit_tests/views/test_error_handling.py
+++ b/tests/unit_tests/views/test_error_handling.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from typing import cast
+
+import pytest
+import sshtunnel
+from flask import Flask, Response
+from flask_babel import Babel
+
+from superset.errors import SupersetErrorType
+from superset.superset_typing import FlaskResponse
+from superset.utils import json
+from superset.views.error_handling import handle_api_exception, set_app_error_handlers
+
+
+class TestHandleApiExceptionSSHTunnelError:
+    def test_returns_400_with_connection_host_down_error_and_no_error_log(
+        self, app, caplog: pytest.LogCaptureFixture
+    ):
+        @handle_api_exception
+        def view(self: object) -> FlaskResponse:
+            raise sshtunnel.BaseSSHTunnelForwarderError(
+                "Could not establish session to SSH gateway"
+            )
+
+        with app.test_request_context():
+            with caplog.at_level(logging.WARNING):
+                response = cast(Response, view(self=object()))
+
+        assert response.status_code == 400
+        payload = json.loads(response.data)
+        assert (
+            payload["errors"][0]["error_type"]
+            == SupersetErrorType.CONNECTION_HOST_DOWN_ERROR.value
+        )
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+        assert any(
+            record.levelno == logging.WARNING
+            and "BaseSSHTunnelForwarderError" in record.message
+            for record in caplog.records
+        )
+
+
+class TestShowUnexpectedException:
+    def _build_app_with_handlers(self) -> Flask:
+        # A fresh, minimal Flask app per test: `set_app_error_handlers` can
+        # only register handlers before the app has served its first
+        # request, so it can't share the module-scoped `app` fixture across
+        # tests in this class.
+        test_app = Flask(__name__)
+        test_app.config["DEBUG"] = False
+        Babel(test_app)
+        set_app_error_handlers(test_app)
+
+        @test_app.route("/ssh-tunnel-error")
+        def ssh_tunnel_error_view() -> FlaskResponse:
+            raise sshtunnel.BaseSSHTunnelForwarderError(
+                "Could not establish session to SSH gateway"
+            )
+
+        @test_app.route("/generic-error")
+        def generic_error_view() -> FlaskResponse:
+            raise ValueError("boom")
+
+        return test_app
+
+    def test_ssh_tunnel_error_returns_structured_400(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        client = self._build_app_with_handlers().test_client()
+
+        with caplog.at_level(logging.WARNING):
+            response = client.get("/ssh-tunnel-error")
+
+        assert response.status_code == 400
+        payload = json.loads(response.data)
+        assert (
+            payload["errors"][0]["error_type"]
+            == SupersetErrorType.CONNECTION_HOST_DOWN_ERROR.value
+        )
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+    def test_generic_exception_still_returns_original_500_shape(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        client = self._build_app_with_handlers().test_client()
+
+        with caplog.at_level(logging.WARNING):
+            response = client.get("/generic-error")
+
+        assert response.status_code == 500
+        payload = json.loads(response.data)
+        assert (
+            payload["errors"][0]["error_type"]
+            == SupersetErrorType.GENERIC_BACKEND_ERROR.value
+        )
+        assert any(record.levelno >= logging.ERROR for record in caplog.records)


### PR DESCRIPTION
## Summary
Two Sentry issues share a root cause:
- [SUPERSET-PYTHON-YY5](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-YY5) — `BaseSSHTunnelForwarderError: Could not establish session to SSH gateway`, `ChartDataRestApi.data`, 2041 events / 34 users
- [SUPERSET-PYTHON-T7B](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-T7B) — same exception, `DashboardRestApi.get_datasets`, 3006 events / 25 users

Both are raised from `Database.get_sqla_engine()` (`superset/models/core.py`) when a workspace's configured SSH tunnel gateway is unreachable or misconfigured — an expected, customer-environment-driven failure (analogous to a DB connection failure), not a Superset bug.

## Root cause
`sshtunnel.BaseSSHTunnelForwarderError` is not a `SupersetException` subtype, so it isn't caught by any specific handler in `superset/views/error_handling.py`. It falls into one of two ERROR-level catch-alls depending on whether the endpoint is decorated with `@handle_api_exception`:

1. **`handle_api_exception.wraps`** — used by `DashboardRestApi.get_datasets` and other `@handle_api_exception`-decorated endpoints. Confirmed via T7B's Sentry stacktrace (`error_handling.py:100 wraps` frame present): hits the final broad `except Exception as ex: logger.exception(ex)`.
2. **`show_unexpected_exception`** (the global `@app.errorhandler(Exception)`) — `ChartDataRestApi.data` has no `@handle_api_exception` decorator; YY5's full Sentry stacktrace has *no* `error_handling.py` frame at all, confirming it propagates all the way to this global handler, which currently double-logs at ERROR (`logger.warning(..., exc_info=True)` + `logger.exception(ex)`).

Both paths also return an opaque generic 500 with no actionable error type.

Checked for existing SSH-tunnel-specific handling: `superset/commands/database/ssh_tunnel/exceptions.py` only covers config-time validation (creating/updating a DB's SSH tunnel settings) — nothing exists for query-time connection failures.

## Fix
Added a shared `handle_ssh_tunnel_error()` helper in `superset/views/error_handling.py` that logs at WARNING (not ERROR — expected/environmental, not a code bug) and returns a structured `SupersetError` (`error_type=CONNECTION_HOST_DOWN_ERROR`, HTTP 400) instead of the opaque 500. Wired into both catch-alls so the fix covers `@handle_api_exception`-decorated and non-decorated endpoints alike.

Reused the existing `CONNECTION_HOST_DOWN_ERROR` type (already used elsewhere for "host might be down" DB connection failures, e.g. `superset/db_engine_specs/postgres.py`) rather than adding a new type for a single call site.

## Tradeoffs
- **No functional/connectivity change** — this only changes logging level and the shape of the error response for an already-failing request. No raise→suppress or silently-swallowed-error semantics introduced.
- **HTTP status code changes 500 → 400** for these two failure modes. This is a real, user-visible behavior change for any API client that specifically branches on status code, even though 400 is the more correct code for a client/environment-config-driven failure. Flagging explicitly per our disclosure convention.
- Users now get an actionable "Failed to establish an SSH tunnel to the database: ..." message instead of a generic 500 — incidental UX improvement, not the primary goal.

## Testing
Added `tests/unit_tests/views/test_error_handling.py` (3 new tests, all passing):
- `@handle_api_exception`-wrapped view raising the SSH tunnel error → 400 + `CONNECTION_HOST_DOWN_ERROR`, asserts no ERROR-level log record emitted.
- `show_unexpected_exception` given the SSH tunnel error → same structured 400, no ERROR-level log.
- Regression check: `show_unexpected_exception` given a generic `ValueError` still returns the original 500 + ERROR-level log (SIP-40 catch-all untouched).

`ruff check` / `ruff format --check` (CI-pinned `ruff==0.9.7`) clean. `mypy` clean on both changed files (pre-existing unrelated errors in transitively-imported modules unchanged before/after, verified via `git stash` comparison).

## Links
- Shortcut: https://app.shortcut.com/preset/story/115347

Fixes SUPERSET-PYTHON-YY5
Fixes SUPERSET-PYTHON-T7B

🤖 Generated with [Claude Code](https://claude.com/claude-code)