### PR TITLE
fix(dashboard): resolve display-control and drill datasources by type, not id alone

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
@@ -210,3 +210,79 @@ test('drill by modal uses the scope selected in the submenu over the raw context
   );
   expect(modalConfig.filters).toEqual([{ col: 'selected_scope' }]);
 });
+
+/**
+ * sc-111089 T014: a semantic-view datasource resolves its drill metadata
+ * from the view's structure — never from the colliding regular dataset's
+ * drill_info — and the menu renders cleanly against the narrowed
+ * (dimension-derived) column shape. Without the drillby extension, the
+ * view's dimensions pass the drillable filter, which is deliberate:
+ * dimensions are the view's groupable surface.
+ */
+test('semantic-view datasource resolves via the structure endpoint and renders the menu', async () => {
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        name: 'orders',
+        dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+        metrics: [],
+      },
+    },
+  });
+
+  const SemanticWrapper = () => {
+    const contextMenuRef = useRef<ChartContextMenuRef>(null);
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => contextMenuRef.current?.open(100, 100, {})}
+          data-test="open-semantic-context-menu"
+        >
+          Open
+        </button>
+        <ChartContextMenu
+          ref={contextMenuRef}
+          id={sliceId}
+          formData={{ datasource: '1__semantic_view', viz_type: VizType.Pie }}
+          onSelection={jest.fn()}
+          onClose={jest.fn()}
+          displayedItems={ContextMenuItem.All}
+        />
+      </>
+    );
+  };
+
+  render(<SemanticWrapper />, {
+    useRedux: true,
+    initialState: {
+      ...mockState,
+      user: {
+        ...mockState.user,
+        roles: {
+          Admin: [
+            ['can_explore', 'Superset'],
+            ['can_samples', 'Datasource'],
+            ['can_write', 'ExploreFormDataRestApi'],
+            ['can_get_drill_info', 'Dataset'],
+          ],
+        },
+      },
+    },
+  });
+
+  userEvent.click(screen.getByTestId('open-semantic-context-menu'));
+  // The menu opens without crashing on the dimension-derived shape.
+  expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+  await waitFor(() =>
+    expect(mockCachedSupersetGet).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/1/structure',
+    }),
+  );
+  const drillInfoCalls = mockCachedSupersetGet.mock.calls.filter(call =>
+    String(call[0]?.endpoint).includes('/drill_info/'),
+  );
+  expect(drillInfoCalls).toHaveLength(0);
+});

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
@@ -150,3 +150,79 @@ test('tooltip is restored when user selects a menu item', async () => {
     expect(screen.getByTestId('tooltip-visible')).toBeInTheDocument();
   });
 });
+
+/**
+ * sc-111089 T014: a semantic-view datasource resolves its drill metadata
+ * from the view's structure — never from the colliding regular dataset's
+ * drill_info — and the menu renders cleanly against the narrowed
+ * (dimension-derived) column shape. Without the drillby extension, the
+ * view's dimensions pass the drillable filter, which is deliberate:
+ * dimensions are the view's groupable surface.
+ */
+test('semantic-view datasource resolves via the structure endpoint and renders the menu', async () => {
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        name: 'orders',
+        dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+        metrics: [],
+      },
+    },
+  });
+
+  const SemanticWrapper = () => {
+    const contextMenuRef = useRef<ChartContextMenuRef>(null);
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => contextMenuRef.current?.open(100, 100, {})}
+          data-test="open-semantic-context-menu"
+        >
+          Open
+        </button>
+        <ChartContextMenu
+          ref={contextMenuRef}
+          id={sliceId}
+          formData={{ datasource: '1__semantic_view', viz_type: VizType.Pie }}
+          onSelection={jest.fn()}
+          onClose={jest.fn()}
+          displayedItems={ContextMenuItem.All}
+        />
+      </>
+    );
+  };
+
+  render(<SemanticWrapper />, {
+    useRedux: true,
+    initialState: {
+      ...mockState,
+      user: {
+        ...mockState.user,
+        roles: {
+          Admin: [
+            ['can_explore', 'Superset'],
+            ['can_samples', 'Datasource'],
+            ['can_write', 'ExploreFormDataRestApi'],
+            ['can_get_drill_info', 'Dataset'],
+          ],
+        },
+      },
+    },
+  });
+
+  userEvent.click(screen.getByTestId('open-semantic-context-menu'));
+  // The menu opens without crashing on the dimension-derived shape.
+  expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+  await waitFor(() =>
+    expect(mockCachedSupersetGet).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/1/structure',
+    }),
+  );
+  const drillInfoCalls = mockCachedSupersetGet.mock.calls.filter(call =>
+    String(call[0]?.endpoint).includes('/drill_info/'),
+  );
+  expect(drillInfoCalls).toHaveLength(0);
+});

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -378,3 +378,27 @@ test('should use verbose_map for column headers when available', async () => {
     screen.queryByRole('columnheader', { name: 'na_sales' }),
   ).not.toBeInTheDocument();
 });
+
+/**
+ * sc-111089 T013: a semantic-view drill resource shows the view's name; the
+ * metadata rows the structure payload cannot fill render their explicit
+ * "Not available" state — an accepted, pinned degradation, never another
+ * object's values.
+ */
+test('renders a semantic-view resource with Not available metadata rows', async () => {
+  fetchWithNoData();
+  setup({
+    dataset: {
+      id: 3,
+      table_name: 'orders',
+      datasource_type: 'semantic_view',
+      columns: [{ column_name: 'Orders Status' }],
+      metrics: [],
+      verbose_map: { 'Orders Status': 'Orders Status' },
+    },
+  });
+
+  expect(await screen.findByText('orders')).toBeInTheDocument();
+  const notAvailable = await screen.findAllByText('Not available');
+  expect(notAvailable.length).toBeGreaterThan(0);
+});

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -380,10 +380,17 @@ test('should use verbose_map for column headers when available', async () => {
 });
 
 /**
- * sc-111089 T013: a semantic-view drill resource shows the view's name; the
- * metadata rows the structure payload cannot fill render their explicit
- * "Not available" state — an accepted, pinned degradation, never another
- * object's values.
+ * sc-111089 T013: given a semantic-view-shaped resource, the pane shows the
+ * view's name and renders the metadata rows the structure payload cannot fill
+ * in their explicit "Not available" state — an accepted, pinned degradation,
+ * never another object's values.
+ *
+ * Scope note: DrillDetailPane receives its `dataset` as a prop, so this test
+ * pins only that rendering degradation. The type-aware RESOLUTION that keeps a
+ * semantic view off the colliding regular-dataset id lives upstream in
+ * useDatasetDrillInfo and is guarded directly in
+ * hooks/apiResources/datasets.test.ts (T012); it is deliberately not
+ * re-exercised here.
  */
 test('renders a semantic-view resource with Not available metadata rows', async () => {
   fetchWithNoData();

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -372,3 +372,27 @@ test('should use verbose_map for column headers when available', async () => {
     screen.queryByRole('columnheader', { name: 'na_sales' }),
   ).not.toBeInTheDocument();
 });
+
+/**
+ * sc-111089 T013: a semantic-view drill resource shows the view's name; the
+ * metadata rows the structure payload cannot fill render their explicit
+ * "Not available" state — an accepted, pinned degradation, never another
+ * object's values.
+ */
+test('renders a semantic-view resource with Not available metadata rows', async () => {
+  fetchWithNoData();
+  setup({
+    dataset: {
+      id: 3,
+      table_name: 'orders',
+      datasource_type: 'semantic_view',
+      columns: [{ column_name: 'Orders Status' }],
+      metrics: [],
+      verbose_map: { 'Orders Status': 'Orders Status' },
+    },
+  });
+
+  expect(await screen.findByText('orders')).toBeInTheDocument();
+  const notAvailable = await screen.findAllByText('Not available');
+  expect(notAvailable.length).toBeGreaterThan(0);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -69,7 +69,7 @@ test('preserves source order when sortAscending is unset', () => {
 });
 
 /**
- * Characterization tests (sc-111089 T002): pin today's regular-dataset
+ * Characterization tests (sc-111089 T002): pin the existing regular-dataset
  * behaviour BEFORE the type-aware refactor, so FR-004's "byte-identical"
  * regression guard is falsifiable. Each test uses a distinct dataset id —
  * cachedSupersetGet holds a module-level cache keyed by endpoint.

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -16,20 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  ChartCustomizationType,
-  type ChartCustomization,
-} from '@superset-ui/core';
+import fetchMock from 'fetch-mock';
 import { LabeledValue } from '@superset-ui/core/components';
-import { render, screen } from 'spec/helpers/testing-library';
+import {
+  ChartCustomization,
+  ChartCustomizationType,
+  DatasourceType,
+  NativeFilterTarget,
+} from '@superset-ui/core';
+import {
+  render,
+  screen,
+  waitFor,
+  userEvent,
+} from 'spec/helpers/testing-library';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
 import GroupByFilterCard, {
   createLabelSortComparator,
 } from './GroupByFilterCard';
 
-jest.mock('src/utils/cachedSupersetGet', () => ({
-  // Never resolves, pinning the card in its column-loading state.
-  cachedSupersetGet: jest.fn(() => new Promise(() => {})),
+jest.mock('src/dashboard/actions/chartCustomizationActions', () => ({
+  ...jest.requireActual('src/dashboard/actions/chartCustomizationActions'),
+  setPendingChartCustomization: jest.fn(() => ({ type: 'MOCK_SET_PENDING' })),
 }));
+
+jest.mock('src/components/MessageToasts/actions', () => ({
+  ...jest.requireActual('src/components/MessageToasts/actions'),
+  addDangerToast: jest.fn(() => ({ type: 'MOCK_DANGER_TOAST' })),
+}));
+
+const mockedAddDangerToast = addDangerToast as unknown as jest.Mock;
 
 const apple: LabeledValue = { value: 'a', label: 'Apple' };
 const banana: LabeledValue = { value: 'b', label: 'Banana' };
@@ -52,25 +68,271 @@ test('preserves source order when sortAscending is unset', () => {
   expect(compare(banana, apple)).toBe(0);
 });
 
-const groupByCustomization: ChartCustomization = {
-  id: 'groupby-1',
-  name: 'Group By',
-  filterType: 'filter_groupby',
+/**
+ * Characterization tests (sc-111089 T002): pin today's regular-dataset
+ * behaviour BEFORE the type-aware refactor, so FR-004's "byte-identical"
+ * regression guard is falsifiable. Each test uses a distinct dataset id —
+ * cachedSupersetGet holds a module-level cache keyed by endpoint.
+ */
+
+const customization = (
+  targets: Partial<NativeFilterTarget>[],
+): ChartCustomization => ({
+  id: 'cc-1',
   type: ChartCustomizationType.ChartCustomization,
-  targets: [{ datasetId: 1 }],
+  name: 'Group by control',
+  filterType: 'chart_customization_dynamic_groupby',
+  targets,
   scope: { rootPath: [], excluded: [] },
-  controlValues: {},
   defaultDataMask: {},
+  controlValues: {},
+});
+
+const initialState = {
+  dataMask: {},
+  nativeFilters: { filters: {} },
 };
 
-test('renders the column-loading spinner small and muted', async () => {
-  render(<GroupByFilterCard customizationItem={groupByCustomization} />, {
+const renderCard = (targets: Partial<NativeFilterTarget>[]) =>
+  render(<GroupByFilterCard customizationItem={customization(targets)} />, {
     useRedux: true,
-    initialState: {
-      dataMask: {},
-      nativeFilters: { filters: {} },
+    initialState,
+  });
+
+afterEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+  mockedAddDangerToast.mockClear();
+});
+
+test('fetches the bare dataset endpoint with no query projection', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/301', {
+    result: { table_name: 'Vehicle Sales', columns: [] },
+  });
+
+  renderCard([{ datasetId: 301 }]);
+
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/301'),
+    ).toHaveLength(1),
+  );
+  const { url } = fetchMock.callHistory.calls('glob:*/api/v1/dataset/301')[0];
+  // Characterized: the full resource, no rison ?q= column projection.
+  expect(url.endsWith('/api/v1/dataset/301')).toBe(true);
+});
+
+test('maps columns to options honouring filterable and verbose_name', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/302', {
+    result: {
+      table_name: 'Vehicle Sales',
+      columns: [
+        { column_name: 'deal_size', verbose_name: 'Deal Size' },
+        { column_name: 'internal_only', filterable: false },
+        { column_name: 'city' },
+      ],
     },
   });
+
+  renderCard([{ datasetId: 302 }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/302'),
+    ).toHaveLength(1),
+  );
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+
+  expect(await screen.findByText('Deal Size')).toBeInTheDocument();
+  expect(screen.getByText('city')).toBeInTheDocument();
+  // filterable === false columns are excluded from the options.
+  expect(screen.queryByText('internal_only')).not.toBeInTheDocument();
+});
+
+test('fetch failure fires the danger toast and leaves options empty', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/303', 500);
+
+  renderCard([{ datasetId: 303 }]);
+
+  await waitFor(() => expect(mockedAddDangerToast).toHaveBeenCalled());
+  // Characterized copy: dataset-flavoured noun + raw numeric id.
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).toMatch(/303/);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  expect(screen.queryByText('Deal Size')).not.toBeInTheDocument();
+});
+
+test('normalizes legacy datasetId shapes: plain number, string, and {value} object', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/304', {
+    result: { table_name: 'A', columns: [] },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/305', {
+    result: { table_name: 'B', columns: [] },
+  });
+
+  // string-shaped id
+  renderCard([{ datasetId: '304' as unknown as number }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/304'),
+    ).toHaveLength(1),
+  );
+
+  // legacy {value} object shape
+  renderCard([{ datasetId: { value: 305 } as unknown as number }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/305'),
+    ).toHaveLength(1),
+  );
+});
+
+/**
+ * sc-111089 T010: wiring-altitude tests for the type-aware card. The hook's
+ * branch matrix is proven in useDisplayControlDatasource.test.ts — these
+ * cover the card's wiring: collision rendering, target persistence through
+ * user interactions, and the error affordance.
+ */
+
+const { setPendingChartCustomization } = jest.requireMock(
+  'src/dashboard/actions/chartCustomizationActions',
+);
+
+test('semantic-view target lists only the view dimensions under an id collision', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/306/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+    },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/306', {
+    result: {
+      table_name: 'Vehicle Sales',
+      columns: [{ column_name: 'address_line1' }],
+    },
+  });
+
+  renderCard([{ datasetId: 306, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+
+  expect(await screen.findByText('Orders Status')).toBeInTheDocument();
+  expect(screen.queryByText('address_line1')).not.toBeInTheDocument();
+  // The colliding dataset endpoint is never touched.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/306')).toHaveLength(
+    0,
+  );
+});
+
+test('selecting a dimension persists a target that still carries datasourceType', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/307/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders Users City', type: 'VARCHAR' }],
+    },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/307', { result: {} });
+
+  renderCard([{ datasetId: 307, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByText('Orders Users City'));
+
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  const persisted =
+    setPendingChartCustomization.mock.calls[
+      setPendingChartCustomization.mock.calls.length - 1
+    ][0];
+  expect(persisted.targets[0]).toMatchObject({
+    datasetId: 307,
+    datasourceType: DatasourceType.SemanticView,
+  });
+  // No refetch of the colliding dataset endpoint after the interaction.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/307')).toHaveLength(
+    0,
+  );
+});
+
+test('clearing the selection keeps the datasource binding intact', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/308/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders State', type: 'VARCHAR' }],
+    },
+  });
+
+  renderCard([{ datasetId: 308, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByText('Orders State'));
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  setPendingChartCustomization.mockClear();
+
+  // Deselect (multi-select toggle) — the cleared target must keep the
+  // datasource binding rather than collapsing to an empty object. After
+  // selection the label exists twice (selection tag + dropdown option);
+  // toggle via the option role.
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByRole('option', { name: 'Orders State' }));
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  const cleared =
+    setPendingChartCustomization.mock.calls[
+      setPendingChartCustomization.mock.calls.length - 1
+    ][0];
+  expect(cleared.targets[0]).toMatchObject({
+    datasetId: 308,
+    datasourceType: DatasourceType.SemanticView,
+  });
+});
+
+test('semantic structure failure renders empty options and toasts exactly once with view wording', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/309/structure', 500);
+  fetchMock.get('glob:*/api/v1/dataset/*', { result: {} });
+
+  const { rerender } = renderCard([
+    { datasetId: 309, datasourceType: DatasourceType.SemanticView },
+  ]);
+
+  await waitFor(() => expect(mockedAddDangerToast).toHaveBeenCalledTimes(1));
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).toMatch(
+    /semantic view 309/,
+  );
+  // Re-render (StrictMode-style double pass) must not re-toast the same binding.
+  rerender(
+    <GroupByFilterCard
+      customizationItem={customization([
+        { datasetId: 309, datasourceType: DatasourceType.SemanticView },
+      ])}
+    />,
+  );
+  await new Promise(resolve => setTimeout(resolve, 50));
+  expect(mockedAddDangerToast).toHaveBeenCalledTimes(1);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  expect(screen.queryByText('Orders Status')).not.toBeInTheDocument();
+  // Never a cross-type fallback.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/*')).toHaveLength(
+    0,
+  );
+});
+
+/**
+ * Upstream #42879 muted the column-loading spinner. Re-expressed here in this
+ * suite's fetchMock idiom: a never-resolving dataset route pins the card in
+ * its loading state without a module-level cachedSupersetGet mock, which
+ * would freeze every other test in this file.
+ */
+test('renders the column-loading spinner small and muted', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/399', new Promise(() => {}));
+
+  renderCard([{ datasetId: 399 }]);
+
   const spinner = await screen.findByTestId('loading-indicator');
   expect(spinner).toHaveClass('inline');
   expect(spinner).toHaveStyle({ opacity: 0.25, width: '40px' });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -322,6 +322,40 @@ test('semantic structure failure renders empty options and toasts exactly once w
   );
 });
 
+test('switching from a failed binding to a healthy one never toasts the healthy datasource', async () => {
+  // Regression for the toast/binding mismatch: the hook clears its error one
+  // render after a binding change, so the render right after the switch pairs
+  // the PREVIOUS binding's error with the NEW binding's id. Un-guarded, that
+  // fires a danger toast naming the healthy datasource (sc-111089 review).
+  fetchMock.get('glob:*/api/v1/dataset/310', 500);
+  fetchMock.get('glob:*/api/v1/dataset/311', {
+    result: { table_name: 'Healthy', columns: [{ column_name: 'city' }] },
+  });
+
+  const { rerender } = renderCard([{ datasetId: 310 }]);
+
+  await waitFor(() => expect(mockedAddDangerToast).toHaveBeenCalledTimes(1));
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).toMatch(/310/);
+
+  // Rebind to the healthy datasource.
+  rerender(
+    <GroupByFilterCard
+      customizationItem={customization([{ datasetId: 311 }])}
+    />,
+  );
+
+  // The healthy binding resolves and renders its columns — this render is
+  // strictly after the switch, so any spurious toast would already have fired
+  // and been counted by the time it settles (no wall-clock sleep needed).
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  expect(await screen.findByText('city')).toBeInTheDocument();
+
+  // No toast ever names the healthy datasource 311.
+  expect(mockedAddDangerToast).toHaveBeenCalledTimes(1);
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).not.toMatch(/311/);
+});
+
 /**
  * Upstream #42879 muted the column-loading spinner. Re-expressed here in this
  * suite's fetchMock idiom: a never-resolving dataset route pins the card in

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -16,8 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import fetchMock from 'fetch-mock';
 import { LabeledValue } from '@superset-ui/core/components';
-import { createLabelSortComparator } from './GroupByFilterCard';
+import {
+  ChartCustomization,
+  ChartCustomizationType,
+  DatasourceType,
+  NativeFilterTarget,
+} from '@superset-ui/core';
+import {
+  render,
+  screen,
+  waitFor,
+  userEvent,
+} from 'spec/helpers/testing-library';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import GroupByFilterCard, {
+  createLabelSortComparator,
+} from './GroupByFilterCard';
+
+jest.mock('src/dashboard/actions/chartCustomizationActions', () => ({
+  ...jest.requireActual('src/dashboard/actions/chartCustomizationActions'),
+  setPendingChartCustomization: jest.fn(() => ({ type: 'MOCK_SET_PENDING' })),
+}));
+
+jest.mock('src/components/MessageToasts/actions', () => ({
+  ...jest.requireActual('src/components/MessageToasts/actions'),
+  addDangerToast: jest.fn(() => ({ type: 'MOCK_DANGER_TOAST' })),
+}));
+
+const mockedAddDangerToast = addDangerToast as unknown as jest.Mock;
 
 const apple: LabeledValue = { value: 'a', label: 'Apple' };
 const banana: LabeledValue = { value: 'b', label: 'Banana' };
@@ -38,4 +66,258 @@ test('preserves source order when sortAscending is unset', () => {
   const compare = createLabelSortComparator(undefined);
   expect(compare(apple, banana)).toBe(0);
   expect(compare(banana, apple)).toBe(0);
+});
+
+/**
+ * Characterization tests (sc-111089 T002): pin today's regular-dataset
+ * behaviour BEFORE the type-aware refactor, so FR-004's "byte-identical"
+ * regression guard is falsifiable. Each test uses a distinct dataset id —
+ * cachedSupersetGet holds a module-level cache keyed by endpoint.
+ */
+
+const customization = (
+  targets: Partial<NativeFilterTarget>[],
+): ChartCustomization => ({
+  id: 'cc-1',
+  type: ChartCustomizationType.ChartCustomization,
+  name: 'Group by control',
+  filterType: 'chart_customization_dynamic_groupby',
+  targets,
+  scope: { rootPath: [], excluded: [] },
+  defaultDataMask: {},
+  controlValues: {},
+});
+
+const initialState = {
+  dataMask: {},
+  nativeFilters: { filters: {} },
+};
+
+const renderCard = (targets: Partial<NativeFilterTarget>[]) =>
+  render(<GroupByFilterCard customizationItem={customization(targets)} />, {
+    useRedux: true,
+    initialState,
+  });
+
+afterEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+  mockedAddDangerToast.mockClear();
+});
+
+test('fetches the bare dataset endpoint with no query projection', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/301', {
+    result: { table_name: 'Vehicle Sales', columns: [] },
+  });
+
+  renderCard([{ datasetId: 301 }]);
+
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/301'),
+    ).toHaveLength(1),
+  );
+  const { url } = fetchMock.callHistory.calls('glob:*/api/v1/dataset/301')[0];
+  // Characterized: the full resource, no rison ?q= column projection.
+  expect(url.endsWith('/api/v1/dataset/301')).toBe(true);
+});
+
+test('maps columns to options honouring filterable and verbose_name', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/302', {
+    result: {
+      table_name: 'Vehicle Sales',
+      columns: [
+        { column_name: 'deal_size', verbose_name: 'Deal Size' },
+        { column_name: 'internal_only', filterable: false },
+        { column_name: 'city' },
+      ],
+    },
+  });
+
+  renderCard([{ datasetId: 302 }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/302'),
+    ).toHaveLength(1),
+  );
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+
+  expect(await screen.findByText('Deal Size')).toBeInTheDocument();
+  expect(screen.getByText('city')).toBeInTheDocument();
+  // filterable === false columns are excluded from the options.
+  expect(screen.queryByText('internal_only')).not.toBeInTheDocument();
+});
+
+test('fetch failure fires the danger toast and leaves options empty', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/303', 500);
+
+  renderCard([{ datasetId: 303 }]);
+
+  await waitFor(() => expect(mockedAddDangerToast).toHaveBeenCalled());
+  // Characterized copy: dataset-flavoured noun + raw numeric id.
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).toMatch(/303/);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  expect(screen.queryByText('Deal Size')).not.toBeInTheDocument();
+});
+
+test('normalizes legacy datasetId shapes: plain number, string, and {value} object', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/304', {
+    result: { table_name: 'A', columns: [] },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/305', {
+    result: { table_name: 'B', columns: [] },
+  });
+
+  // string-shaped id
+  renderCard([{ datasetId: '304' as unknown as number }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/304'),
+    ).toHaveLength(1),
+  );
+
+  // legacy {value} object shape
+  renderCard([{ datasetId: { value: 305 } as unknown as number }]);
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/305'),
+    ).toHaveLength(1),
+  );
+});
+
+/**
+ * sc-111089 T010: wiring-altitude tests for the type-aware card. The hook's
+ * branch matrix is proven in useDisplayControlDatasource.test.ts — these
+ * cover the card's wiring: collision rendering, target persistence through
+ * user interactions, and the error affordance.
+ */
+
+const { setPendingChartCustomization } = jest.requireMock(
+  'src/dashboard/actions/chartCustomizationActions',
+);
+
+test('semantic-view target lists only the view dimensions under an id collision', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/306/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+    },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/306', {
+    result: {
+      table_name: 'Vehicle Sales',
+      columns: [{ column_name: 'address_line1' }],
+    },
+  });
+
+  renderCard([{ datasetId: 306, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+
+  expect(await screen.findByText('Orders Status')).toBeInTheDocument();
+  expect(screen.queryByText('address_line1')).not.toBeInTheDocument();
+  // The colliding dataset endpoint is never touched.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/306')).toHaveLength(
+    0,
+  );
+});
+
+test('selecting a dimension persists a target that still carries datasourceType', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/307/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders Users City', type: 'VARCHAR' }],
+    },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/307', { result: {} });
+
+  renderCard([{ datasetId: 307, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByText('Orders Users City'));
+
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  const persisted =
+    setPendingChartCustomization.mock.calls[
+      setPendingChartCustomization.mock.calls.length - 1
+    ][0];
+  expect(persisted.targets[0]).toMatchObject({
+    datasetId: 307,
+    datasourceType: DatasourceType.SemanticView,
+  });
+  // No refetch of the colliding dataset endpoint after the interaction.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/307')).toHaveLength(
+    0,
+  );
+});
+
+test('clearing the selection keeps the datasource binding intact', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/308/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders State', type: 'VARCHAR' }],
+    },
+  });
+
+  renderCard([{ datasetId: 308, datasourceType: DatasourceType.SemanticView }]);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByText('Orders State'));
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  setPendingChartCustomization.mockClear();
+
+  // Deselect (multi-select toggle) — the cleared target must keep the
+  // datasource binding rather than collapsing to an empty object. After
+  // selection the label exists twice (selection tag + dropdown option);
+  // toggle via the option role.
+  userEvent.click(combobox);
+  userEvent.click(await screen.findByRole('option', { name: 'Orders State' }));
+  await waitFor(() => expect(setPendingChartCustomization).toHaveBeenCalled());
+  const cleared =
+    setPendingChartCustomization.mock.calls[
+      setPendingChartCustomization.mock.calls.length - 1
+    ][0];
+  expect(cleared.targets[0]).toMatchObject({
+    datasetId: 308,
+    datasourceType: DatasourceType.SemanticView,
+  });
+});
+
+test('semantic structure failure renders empty options and toasts exactly once with view wording', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/309/structure', 500);
+  fetchMock.get('glob:*/api/v1/dataset/*', { result: {} });
+
+  const { rerender } = renderCard([
+    { datasetId: 309, datasourceType: DatasourceType.SemanticView },
+  ]);
+
+  await waitFor(() => expect(mockedAddDangerToast).toHaveBeenCalledTimes(1));
+  expect(String(mockedAddDangerToast.mock.calls[0][0])).toMatch(
+    /semantic view 309/,
+  );
+  // Re-render (StrictMode-style double pass) must not re-toast the same binding.
+  rerender(
+    <GroupByFilterCard
+      customizationItem={customization([
+        { datasetId: 309, datasourceType: DatasourceType.SemanticView },
+      ])}
+    />,
+  );
+  await new Promise(resolve => setTimeout(resolve, 50));
+  expect(mockedAddDangerToast).toHaveBeenCalledTimes(1);
+
+  const combobox = await screen.findByRole('combobox');
+  userEvent.click(combobox);
+  expect(screen.queryByText('Orders Status')).not.toBeInTheDocument();
+  // Never a cross-type fallback.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/*')).toHaveLength(
+    0,
+  );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -50,7 +50,10 @@ import { setPendingChartCustomization } from 'src/dashboard/actions/chartCustomi
 import { TooltipWithTruncation } from 'src/dashboard/components/nativeFilters/FilterCard/TooltipWithTruncation';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { dispatchChartCustomizationHoverAction } from './utils';
-import { useDisplayControlDatasource } from '../../useDisplayControlDatasource';
+import {
+  displayControlBindingKey,
+  useDisplayControlDatasource,
+} from '../../useDisplayControlDatasource';
 import {
   datasetLabel as getDatasetLabel,
   datasetLabelLower,
@@ -333,7 +336,14 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
     if (!datasourceError || normalizedDatasetId === undefined) {
       return;
     }
-    const binding = `${normalizedDatasetId}__${datasourceType || 'table'}`;
+    // The hook scopes `error` to the current binding, so a truthy error here
+    // always belongs to this datasource — no cross-binding mis-toast. The key
+    // is only used to toast a given binding's failure once, across the hook's
+    // re-renders and StrictMode's double-invoked effects.
+    const binding = displayControlBindingKey(
+      normalizedDatasetId,
+      datasourceType,
+    );
     if (toastedBindingRef.current === binding) {
       return;
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -16,17 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import {
   DataMask,
   DataMaskStateWithId,
+  DatasourceType,
   Filter,
   useTruncation,
   ChartCustomization,
   NativeFilterTarget,
-  Filters,
-  NativeFilterType,
 } from '@superset-ui/core';
 import {
   styled,
@@ -50,20 +49,12 @@ import { RootState } from 'src/dashboard/types';
 import { setPendingChartCustomization } from 'src/dashboard/actions/chartCustomizationActions';
 import { TooltipWithTruncation } from 'src/dashboard/components/nativeFilters/FilterCard/TooltipWithTruncation';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
-import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import { dispatchChartCustomizationHoverAction } from './utils';
-import { mergeExtraFormData } from '../../utils';
+import { useDisplayControlDatasource } from '../../useDisplayControlDatasource';
 import {
   datasetLabel as getDatasetLabel,
   datasetLabelLower,
 } from 'src/features/semanticLayers/label';
-
-interface ColumnApiResponse {
-  column_name?: string;
-  name?: string;
-  verbose_name?: string;
-  filterable?: boolean;
-}
 
 interface GroupByFilterCardProps {
   customizationItem: ChartCustomization;
@@ -294,16 +285,74 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
 }) => {
   const theme = useTheme();
   const dataset = customizationItem.targets?.[0]?.datasetId;
+  // Semantic views and regular datasets have independent id sequences —
+  // the persisted type is what disambiguates a colliding numeric id
+  // (sc-111089). Absent type means a regular dataset.
+  const datasourceType = customizationItem.targets?.[0]?.datasourceType;
   const [filterTitleRef, , titleElementsTruncated] = useTruncation();
 
-  const [loading, setLoading] = useState(false);
   const [isHoverCardVisible, setIsHoverCardVisible] = useState(false);
-  const [columnOptions, setColumnOptions] = useState<
-    { label: string; value: string }[]
-  >([]);
-  const [datasetName, setDatasetName] = useState<string | undefined>();
 
   const dispatch = useDispatch();
+
+  // Legacy persisted targets may carry the id as a number, string, or
+  // {value} object; the card owns this normalization and hands the hook
+  // a clean id.
+  const normalizedDatasetId = useMemo(() => {
+    if (typeof dataset === 'number' || typeof dataset === 'string') {
+      return dataset;
+    }
+    if (typeof dataset === 'object' && dataset !== null && 'value' in dataset) {
+      return (dataset as { value: string | number }).value;
+    }
+    return undefined;
+  }, [dataset]);
+
+  const {
+    name: datasetName,
+    columns: datasourceColumns,
+    loading,
+    error: datasourceError,
+  } = useDisplayControlDatasource(normalizedDatasetId, datasourceType);
+
+  const columnOptions = useMemo(
+    () =>
+      datasourceColumns
+        .filter(col => col.filterable !== false)
+        .map(col => ({
+          label: col.verbose_name || col.column_name || col.name || '',
+          value: col.column_name || col.name || '',
+        })),
+    [datasourceColumns],
+  );
+
+  // Surface load failures as a toast, once per binding — the hook can
+  // re-render (and StrictMode double-invokes effects) without re-toasting.
+  const toastedBindingRef = useRef<string | undefined>();
+  useEffect(() => {
+    if (!datasourceError || normalizedDatasetId === undefined) {
+      return;
+    }
+    const binding = `${normalizedDatasetId}__${datasourceType || 'table'}`;
+    if (toastedBindingRef.current === binding) {
+      return;
+    }
+    toastedBindingRef.current = binding;
+    dispatch(
+      addDangerToast(
+        datasourceType === DatasourceType.SemanticView
+          ? t(
+              'Failed to load dimensions for semantic view %s',
+              normalizedDatasetId,
+            )
+          : t(
+              'Failed to load columns for %s %s',
+              datasetLabelLower(),
+              normalizedDatasetId,
+            ),
+      ),
+    );
+  }, [datasourceError, normalizedDatasetId, datasourceType, dispatch]);
 
   const isHorizontalLayout = orientation === 'horizontal';
 
@@ -377,14 +426,24 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
           ? value
           : null;
 
+      // Preserve datasourceType (and datasetId) when rebuilding the
+      // target: dropping the type here would silently degrade a
+      // semantic-view binding to the colliding regular dataset on the
+      // next resolution (sc-111089 review finding).
       const targets: [Partial<NativeFilterTarget>] = columnValue
         ? ([
             {
               datasetId: dataset,
+              ...(datasourceType ? { datasourceType } : {}),
               column: { name: columnValue },
             },
           ] as [Partial<NativeFilterTarget>])
-        : ([{}] as [Partial<NativeFilterTarget>]);
+        : ([
+            {
+              datasetId: dataset,
+              ...(datasourceType ? { datasourceType } : {}),
+            },
+          ] as [Partial<NativeFilterTarget>]);
 
       dispatch(
         setPendingChartCustomization({
@@ -419,94 +478,17 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
     [
       canSelectMultiple,
       dataset,
+      datasourceType,
       dispatch,
       customizationItem,
       onFilterSelectionChange,
     ],
   );
 
-  const filters = useSelector<RootState, Filters>(
-    state => state.nativeFilters.filters,
-  );
-
-  const dependencies = useMemo(() => {
-    let deps = {};
-
-    Object.entries(filters).forEach(([filterId, filter]) => {
-      if (
-        filter.type === NativeFilterType.Divider ||
-        !effectiveDataMask[filterId]?.filterState?.value
-      ) {
-        return;
-      }
-
-      const filterState = effectiveDataMask[filterId];
-      deps = mergeExtraFormData(deps, filterState?.extraFormData);
-    });
-
-    return deps;
-  }, [effectiveDataMask, filters]);
-
-  useEffect(() => {
-    const fetchColumnOptions = async () => {
-      const datasetSource = dataset;
-
-      if (!datasetSource) {
-        return;
-      }
-
-      const datasetId =
-        typeof datasetSource === 'number'
-          ? datasetSource
-          : typeof datasetSource === 'string'
-            ? datasetSource
-            : typeof datasetSource === 'object' &&
-                datasetSource !== null &&
-                'value' in datasetSource
-              ? (datasetSource as { value: string | number }).value
-              : null;
-
-      if (!datasetId) {
-        return;
-      }
-
-      setLoading(true);
-      try {
-        const endpoint = `/api/v1/dataset/${datasetId}`;
-        const { json } = await cachedSupersetGet({ endpoint });
-
-        if (json?.result) {
-          if (json.result.table_name) {
-            setDatasetName(json.result.table_name);
-          }
-          if (json.result.columns) {
-            const options = json.result.columns
-              .filter((col: ColumnApiResponse) => col.filterable !== false)
-              .map((col: ColumnApiResponse) => ({
-                label: col.verbose_name || col.column_name || col.name || '',
-                value: col.column_name || col.name || '',
-              }));
-            setColumnOptions(options);
-          }
-        }
-      } catch (error) {
-        setColumnOptions([]);
-        dispatch(
-          addDangerToast(
-            t(
-              'Failed to load columns for %s %s',
-              datasetLabelLower(),
-              datasetId,
-            ),
-          ),
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchColumnOptions();
-  }, [dataset, dependencies, dispatch]);
+  // The previous fetch effect listed a `dependencies` aggregation of other
+  // filters' extraFormData in its dep array, but the request never used it —
+  // dead coupling that only triggered no-op refetches (removed with the
+  // move to useDisplayControlDatasource; sc-111089 review).
 
   const displayTitle = columnDisplayName;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -63,7 +63,11 @@ import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from 'src/logger/LogUtils';
 import { FilterBarOrientation, RootState } from 'src/dashboard/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { isChartCustomization } from '../FiltersConfigModal/utils';
-import { checkIsApplyDisabled, getFiltersToApply } from './utils';
+import {
+  checkIsApplyDisabled,
+  clearedCustomizationTarget,
+  getFiltersToApply,
+} from './utils';
 import { extractLabel } from '../selectors';
 import { FiltersBarProps } from './types';
 import {
@@ -482,17 +486,11 @@ const FilterBar: FC<FiltersBarProps> = ({
     } else if (hasClearedChartCustomizations) {
       const clearedChartCustomizations = chartCustomizationValues.map(item => ({
         ...item,
-        targets: [
-          {
-            datasetId: item.targets?.[0]?.datasetId,
-            // Keep the datasource type through a clear: dropping it would
-            // silently rebind a semantic view to the regular dataset that
-            // shares its numeric id on the next resolution (sc-111089).
-            ...(item.targets?.[0]?.datasourceType
-              ? { datasourceType: item.targets[0].datasourceType }
-              : {}),
-          },
-        ] as [Partial<NativeFilterTarget>],
+        // Keep the datasource type through a clear (sc-111089) — the invariant
+        // and its regression test live in clearedCustomizationTarget.
+        targets: [clearedCustomizationTarget(item.targets?.[0])] as [
+          Partial<NativeFilterTarget>,
+        ],
       }));
 
       chartCustomizationValues.forEach(item => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -485,6 +485,12 @@ const FilterBar: FC<FiltersBarProps> = ({
         targets: [
           {
             datasetId: item.targets?.[0]?.datasetId,
+            // Keep the datasource type through a clear: dropping it would
+            // silently rebind a semantic view to the regular dataset that
+            // shares its numeric id on the next resolution (sc-111089).
+            ...(item.targets?.[0]?.datasourceType
+              ? { datasourceType: item.targets[0].datasourceType }
+              : {}),
           },
         ] as [Partial<NativeFilterTarget>],
       }));

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -484,6 +484,12 @@ const FilterBar: FC<FiltersBarProps> = ({
         targets: [
           {
             datasetId: item.targets?.[0]?.datasetId,
+            // Keep the datasource type through a clear: dropping it would
+            // silently rebind a semantic view to the regular dataset that
+            // shares its numeric id on the next resolution (sc-111089).
+            ...(item.targets?.[0]?.datasourceType
+              ? { datasourceType: item.targets[0].datasourceType }
+              : {}),
           },
         ] as [Partial<NativeFilterTarget>],
       }));

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -20,6 +20,7 @@
 import {
   DataMaskStateWithId,
   DataRecordValue,
+  DatasourceType,
   Filter,
   FilterState,
 } from '@superset-ui/core';
@@ -27,6 +28,7 @@ import {
   checkIsApplyDisabled,
   checkIsValidateError,
   checkIsMissingRequiredValue,
+  clearedCustomizationTarget,
   getOnlyExtraFormData,
   getFiltersToApply,
 } from './utils';
@@ -839,4 +841,40 @@ test('getFiltersToApply handles null dataMask entries', () => {
 
   expect(result).not.toContain('filter-1');
   expect(result).toContain('filter-2');
+});
+
+test('clearedCustomizationTarget preserves the datasourceType of a semantic view through a clear', () => {
+  const cleared = clearedCustomizationTarget({
+    datasetId: 306,
+    datasourceType: DatasourceType.SemanticView,
+    column: { name: 'Orders Status' },
+  });
+
+  // The selected column is dropped, but the binding (id + type) survives —
+  // dropping datasourceType would rebind the view to the colliding regular
+  // dataset on the next resolution (sc-111089).
+  expect(cleared).toEqual({
+    datasetId: 306,
+    datasourceType: DatasourceType.SemanticView,
+  });
+});
+
+test('clearedCustomizationTarget omits datasourceType for a regular dataset target', () => {
+  const cleared = clearedCustomizationTarget({
+    datasetId: 306,
+    column: { name: 'city' },
+  });
+
+  // No type key is emitted (not `datasourceType: undefined`), matching a
+  // regular dataset and the legacy shape.
+  expect(cleared).toEqual({ datasetId: 306 });
+  expect('datasourceType' in cleared).toBe(false);
+});
+
+test('clearedCustomizationTarget tolerates an absent target', () => {
+  // toStrictEqual (not toEqual) so the `datasetId` key must actually be present,
+  // rather than the assertion passing against a bare {}.
+  expect(clearedCustomizationTarget(undefined)).toStrictEqual({
+    datasetId: undefined,
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -22,6 +22,7 @@ import {
   ExtraFormData,
   Filter,
   FilterState,
+  NativeFilterTarget,
 } from '@superset-ui/core';
 import { isEqual } from 'lodash-es';
 import { useSelector } from 'react-redux';
@@ -191,3 +192,17 @@ export const getFiltersToApply = (
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';
 export const getFilterBarTestId = testWithId(FILTER_BAR_TEST_ID);
+
+/**
+ * Reduce a chart-customization target to just its datasource binding, dropping
+ * the selected column(s) on a "clear all". The datasourceType MUST survive the
+ * clear: dropping it would silently rebind a semantic view to the regular
+ * dataset that shares its numeric id on the next resolution (sc-111089). Absent
+ * type is omitted rather than emitted as undefined, matching a regular dataset.
+ */
+export const clearedCustomizationTarget = (
+  target?: Partial<NativeFilterTarget>,
+): Partial<NativeFilterTarget> => ({
+  datasetId: target?.datasetId,
+  ...(target?.datasourceType ? { datasourceType: target.datasourceType } : {}),
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -19,12 +19,10 @@
 import { useCallback, useState, useMemo, useEffect } from 'react';
 import rison from 'rison';
 import { t } from '@apache-superset/core/translation';
-import { GenericDataType } from '@apache-superset/core/common';
 import {
   Column,
   DatasourceType,
   ensureIsArray,
-  JsonResponse,
   useChangeEffect,
   getClientErrorObject,
 } from '@superset-ui/core';
@@ -32,7 +30,10 @@ import { type FormInstance, Select } from '@superset-ui/core/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import { NativeFiltersForm, NativeFiltersFormItem } from '../types';
-import { mapSemanticTypeToGenericDataType } from './utils';
+import {
+  fetchSemanticViewStructure,
+  semanticViewDimensionsToColumns,
+} from './utils';
 
 interface ColumnSelectProps {
   allowClear?: boolean;
@@ -116,23 +117,9 @@ export function ColumnSelect({
       };
 
       if (datasourceType === DatasourceType.SemanticView) {
-        cachedSupersetGet({
-          endpoint: `/api/v1/semantic_view/${datasetId}/structure`,
-        })
-          .then((response: JsonResponse) => {
-            const { dimensions = [] } = response.json?.result ?? {};
-            const cols: Column[] = dimensions.map(
-              (dim: { name: string; type: string }) => {
-                const mappedType = mapSemanticTypeToGenericDataType(dim.type);
-                return {
-                  column_name: dim.name,
-                  type: dim.type,
-                  is_dttm: mappedType === GenericDataType.Temporal,
-                  type_generic: mappedType,
-                  filterable: true,
-                };
-              },
-            );
+        fetchSemanticViewStructure(datasetId)
+          .then(({ dimensions }) => {
+            const cols: Column[] = semanticViewDimensionsToColumns(dimensions);
             const lookupValue = Array.isArray(value) ? value : [value];
             const valueExists = cols.some((column: Column) =>
               lookupValue?.includes(column.column_name),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -767,16 +767,16 @@ const FiltersConfigForm = (
         fetchSemanticViewStructure(datasetId)
           .then(({ name: svName, dimensions, metrics: svMetrics }) => {
             const columns = semanticViewDimensionsToColumns(dimensions);
-            // verbose_name stays null at runtime (pre-refactor value —
-            // consumers only falsy-check it); Metric types it as an
-            // optional string, hence the cast.
+            // The /structure wire carries no metric uuid, and this state's
+            // consumers key on metric_name/verbose_name without reading
+            // uuid — so the cast is narrowed to exactly that one absent
+            // property; every other field stays compiler-checked.
             const mappedMetrics = svMetrics.map(
               (m: { name: string; definition: string }) => ({
                 metric_name: m.name,
                 expression: m.definition,
-                verbose_name: null,
               }),
-            ) as unknown as Metric[];
+            ) as Omit<Metric, 'uuid'>[] as Metric[];
             setMetrics(mappedMetrics);
             setDatasetDetails({
               columns,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -114,7 +114,8 @@ import {
   setNativeFilterFieldValues,
   shouldShowTimeRangePicker,
   useForceUpdate,
-  mapSemanticTypeToGenericDataType,
+  fetchSemanticViewStructure,
+  semanticViewDimensionsToColumns,
   doesChartMatchFilterDatasource,
 } from './utils';
 import {
@@ -763,34 +764,19 @@ const FiltersConfigForm = (
   useEffect(() => {
     if (datasetId) {
       if (datasourceType === DatasourceType.SemanticView) {
-        cachedSupersetGet({
-          endpoint: `/api/v1/semantic_view/${datasetId}/structure`,
-        })
-          .then((response: JsonResponse) => {
-            const {
-              name: svName,
-              dimensions = [],
-              metrics: svMetrics = [],
-            } = response.json?.result ?? {};
-            const columns = dimensions.map(
-              (dim: { name: string; type: string }) => {
-                const mappedType = mapSemanticTypeToGenericDataType(dim.type);
-                return {
-                  column_name: dim.name,
-                  type: dim.type,
-                  is_dttm: mappedType === GenericDataType.Temporal,
-                  filterable: true,
-                  type_generic: mappedType,
-                };
-              },
-            );
+        fetchSemanticViewStructure(datasetId)
+          .then(({ name: svName, dimensions, metrics: svMetrics }) => {
+            const columns = semanticViewDimensionsToColumns(dimensions);
+            // verbose_name stays null at runtime (pre-refactor value —
+            // consumers only falsy-check it); Metric types it as an
+            // optional string, hence the cast.
             const mappedMetrics = svMetrics.map(
               (m: { name: string; definition: string }) => ({
                 metric_name: m.name,
                 expression: m.definition,
                 verbose_name: null,
               }),
-            );
+            ) as unknown as Metric[];
             setMetrics(mappedMetrics);
             setDatasetDetails({
               columns,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.test.ts
@@ -419,21 +419,35 @@ test('fetchSemanticViewStructure defaults missing arrays to empty', async () => 
 
 test('semanticViewDimensionsToColumns maps dimension fields incl. temporal detection', () => {
   const { semanticViewDimensionsToColumns: toColumns } = require('./utils');
+  // Wire-shaped types: /structure serialises pyarrow types
+  // (timestamp[us], string, double), not SQL type names.
   const columns = toColumns([
-    { name: 'ordered_at', type: 'TIMESTAMP' },
-    { name: 'status', type: 'VARCHAR' },
+    { name: 'ordered_at', type: 'timestamp[us]' },
+    { name: 'status', type: 'string' },
+    { name: 'amount', type: 'double' },
   ]);
 
+  // type_generic is asserted explicitly: downstream filter-type logic (e.g.
+  // the Numerical range column filter) selects on it, so a regression in
+  // mapSemanticTypeToGenericDataType must fail here, not pass silently.
   expect(columns[0]).toMatchObject({
     column_name: 'ordered_at',
-    type: 'TIMESTAMP',
+    type: 'timestamp[us]',
     is_dttm: true,
     filterable: true,
+    type_generic: GenericDataType.Temporal,
   });
   expect(columns[1]).toMatchObject({
     column_name: 'status',
     is_dttm: false,
     filterable: true,
+    type_generic: GenericDataType.String,
+  });
+  expect(columns[2]).toMatchObject({
+    column_name: 'amount',
+    is_dttm: false,
+    filterable: true,
+    type_generic: GenericDataType.Numeric,
   });
 });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.test.ts
@@ -377,3 +377,67 @@ test('doesChartMatchFilterDatasource falls back to datasource UID parsing', () =
     ),
   ).toBe(true);
 });
+
+test('fetchSemanticViewStructure returns name, dimensions, and metrics from the structure payload', async () => {
+  const fetchMock = require('fetch-mock').default;
+  const { fetchSemanticViewStructure: fetchStructure } = require('./utils');
+  fetchMock.get('glob:*/api/v1/semantic_view/9101/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+      metrics: [{ name: 'order_count', definition: 'COUNT(*)' }],
+    },
+  });
+
+  const structure = await fetchStructure(9101);
+
+  expect(structure.name).toBe('orders');
+  expect(structure.dimensions).toEqual([
+    { name: 'Orders Status', type: 'VARCHAR' },
+  ]);
+  expect(structure.metrics).toEqual([
+    { name: 'order_count', definition: 'COUNT(*)' },
+  ]);
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+});
+
+test('fetchSemanticViewStructure defaults missing arrays to empty', async () => {
+  const fetchMock = require('fetch-mock').default;
+  const { fetchSemanticViewStructure: fetchStructure } = require('./utils');
+  fetchMock.get('glob:*/api/v1/semantic_view/9102/structure', {
+    result: { name: 'sparse' },
+  });
+
+  const structure = await fetchStructure(9102);
+
+  expect(structure.dimensions).toEqual([]);
+  expect(structure.metrics).toEqual([]);
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+});
+
+test('semanticViewDimensionsToColumns maps dimension fields incl. temporal detection', () => {
+  const { semanticViewDimensionsToColumns: toColumns } = require('./utils');
+  const columns = toColumns([
+    { name: 'ordered_at', type: 'TIMESTAMP' },
+    { name: 'status', type: 'VARCHAR' },
+  ]);
+
+  expect(columns[0]).toMatchObject({
+    column_name: 'ordered_at',
+    type: 'TIMESTAMP',
+    is_dttm: true,
+    filterable: true,
+  });
+  expect(columns[1]).toMatchObject({
+    column_name: 'status',
+    is_dttm: false,
+    filterable: true,
+  });
+});
+
+test('semanticViewDimensionsToColumns returns empty for empty dimensions', () => {
+  const { semanticViewDimensionsToColumns: toColumns } = require('./utils');
+  expect(toColumns([])).toEqual([]);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -23,7 +23,6 @@ import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';
 import { Column, DatasourceType, ensureIsArray } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { DatasourcesState, ChartsState } from 'src/dashboard/types';
-import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import { FILTER_SUPPORTED_TYPES } from './constants';
 
 const FILTERS_FIELD_NAME = 'filters';
@@ -102,94 +101,15 @@ export const doesColumnMatchFilterType = (filterType: string, column: Column) =>
     filterType as keyof typeof FILTER_SUPPORTED_TYPES
   ]?.includes(column.type_generic);
 
-export const mapSemanticTypeToGenericDataType = (
-  semanticType?: string | null,
-): GenericDataType | undefined => {
-  if (!semanticType) {
-    return undefined;
-  }
-
-  const normalized = semanticType.toLowerCase();
-
-  if (
-    /^(struct|list|map|array|fixed_size_list|large_list|union|dictionary)\b/.test(
-      normalized,
-    )
-  ) {
-    return undefined;
-  }
-
-  if (normalized.includes('bool')) {
-    return GenericDataType.Boolean;
-  }
-
-  if (/(date|time|timestamp|datetime)/.test(normalized)) {
-    return GenericDataType.Temporal;
-  }
-
-  if (
-    /(\b(u?int\d*)\b|\bfloat\d*\b|\bdouble\b|\bdecimal\d*\b|\bnumber\b)/.test(
-      normalized,
-    )
-  ) {
-    return GenericDataType.Numeric;
-  }
-
-  if (
-    /(\bstr(ing)?\b|\butf8\b|\blarge_string\b|\bbinary\b|\bjson\b|\buuid\b)/.test(
-      normalized,
-    )
-  ) {
-    return GenericDataType.String;
-  }
-
-  return undefined;
-};
-
-/** The slice of `GET /api/v1/semantic_view/<id>/structure` consumers rely on. */
-export interface SemanticViewStructure {
-  name?: string;
-  dimensions: { name: string; type: string }[];
-  metrics: { name: string; definition: string }[];
-}
-
-/**
- * Fetch a semantic view's structure — the single, shared entry point for
- * every type-aware datasource consumer (ColumnSelect, FiltersConfigForm,
- * display controls, drill metadata). Semantic views and regular datasets
- * have independent numeric-id sequences, so callers must route here (and
- * never to `/api/v1/dataset/<id>`) whenever the binding's datasourceType
- * is SemanticView.
- */
-export const fetchSemanticViewStructure = async (
-  semanticViewId: number | string,
-): Promise<SemanticViewStructure> => {
-  const response = await cachedSupersetGet({
-    endpoint: `/api/v1/semantic_view/${semanticViewId}/structure`,
-  });
-  const { name, dimensions = [], metrics = [] } = response.json?.result ?? {};
-  return { name, dimensions, metrics };
-};
-
-/**
- * Map structure dimensions onto the `Column` shape the filter/control
- * machinery expects. Mapping semantics are shared by every consumer:
- * temporal detection via `mapSemanticTypeToGenericDataType`, and
- * `filterable: true` (semantic-view dimensions are always selectable).
- */
-export const semanticViewDimensionsToColumns = (
-  dimensions: SemanticViewStructure['dimensions'],
-): Column[] =>
-  dimensions.map(dim => {
-    const mappedType = mapSemanticTypeToGenericDataType(dim.type);
-    return {
-      column_name: dim.name,
-      type: dim.type,
-      is_dttm: mappedType === GenericDataType.Temporal,
-      type_generic: mappedType,
-      filterable: true,
-    };
-  });
+// Shared semantic-view structure helpers live in a layer-neutral module so
+// non-dashboard consumers (e.g. the dataset drill-info hook) need not import
+// from this filter-form utility. Re-exported here for existing call sites.
+export {
+  mapSemanticTypeToGenericDataType,
+  fetchSemanticViewStructure,
+  semanticViewDimensionsToColumns,
+} from 'src/utils/semanticViewStructure';
+export type { SemanticViewStructure } from 'src/utils/semanticViewStructure';
 
 // Validates that a filter default value is present when the default value option is enabled.
 // For range filters, at least one of the two values must be non-null.

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -23,6 +23,7 @@ import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';
 import { Column, DatasourceType, ensureIsArray } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { DatasourcesState, ChartsState } from 'src/dashboard/types';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import { FILTER_SUPPORTED_TYPES } from './constants';
 
 const FILTERS_FIELD_NAME = 'filters';
@@ -144,6 +145,51 @@ export const mapSemanticTypeToGenericDataType = (
 
   return undefined;
 };
+
+/** The slice of `GET /api/v1/semantic_view/<id>/structure` consumers rely on. */
+export interface SemanticViewStructure {
+  name?: string;
+  dimensions: { name: string; type: string }[];
+  metrics: { name: string; definition: string }[];
+}
+
+/**
+ * Fetch a semantic view's structure — the single, shared entry point for
+ * every type-aware datasource consumer (ColumnSelect, FiltersConfigForm,
+ * display controls, drill metadata). Semantic views and regular datasets
+ * have independent numeric-id sequences, so callers must route here (and
+ * never to `/api/v1/dataset/<id>`) whenever the binding's datasourceType
+ * is SemanticView.
+ */
+export const fetchSemanticViewStructure = async (
+  semanticViewId: number | string,
+): Promise<SemanticViewStructure> => {
+  const response = await cachedSupersetGet({
+    endpoint: `/api/v1/semantic_view/${semanticViewId}/structure`,
+  });
+  const { name, dimensions = [], metrics = [] } = response.json?.result ?? {};
+  return { name, dimensions, metrics };
+};
+
+/**
+ * Map structure dimensions onto the `Column` shape the filter/control
+ * machinery expects. Mapping semantics are shared by every consumer:
+ * temporal detection via `mapSemanticTypeToGenericDataType`, and
+ * `filterable: true` (semantic-view dimensions are always selectable).
+ */
+export const semanticViewDimensionsToColumns = (
+  dimensions: SemanticViewStructure['dimensions'],
+): Column[] =>
+  dimensions.map(dim => {
+    const mappedType = mapSemanticTypeToGenericDataType(dim.type);
+    return {
+      column_name: dim.name,
+      type: dim.type,
+      is_dttm: mappedType === GenericDataType.Temporal,
+      type_generic: mappedType,
+      filterable: true,
+    };
+  });
 
 // Validates that a filter default value is present when the default value option is enabled.
 // For range filters, at least one of the two values must be non-null.

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
@@ -135,6 +135,35 @@ test('structure failure yields error and empty columns with no cross-type fallba
   );
 });
 
+// The hook scopes `error` to the current binding so a one-render-stale failure
+// never surfaces against a new binding. That guard only bites during the single
+// render between a binding change and the clearing effect — which renderHook's
+// act()-wrapped rerender flushes past — so it cannot be observed here. It is
+// guarded end-to-end where it matters, in GroupByFilterCard.test.tsx
+// ('switching from a failed binding to a healthy one never toasts ...'), which
+// fails if the gate is removed.
+
+test('dataset-branch failure evicts the cache so a retry re-issues the request', async () => {
+  // cachedSupersetGet caches the in-flight promise and never evicts a
+  // rejected one; without eviction a single 500 poisons the endpoint for the
+  // whole page session. A fresh consumer for the same id must hit the network
+  // again rather than re-await the cached rejected promise.
+  fetchMock.get('glob:*/api/v1/dataset/405', 500);
+
+  const first = renderHook(() => useDisplayControlDatasource(405));
+  await waitFor(() => expect(first.result.current.error).toBeDefined());
+  const callsAfterFirst = fetchMock.callHistory.calls(
+    'glob:*/api/v1/dataset/405',
+  ).length;
+
+  renderHook(() => useDisplayControlDatasource(405));
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls('glob:*/api/v1/dataset/405').length,
+    ).toBeGreaterThan(callsAfterFirst),
+  );
+});
+
 test('nullish id is inert: no fetch, empty columns, not loading', async () => {
   fetchMock.get('glob:*', 200);
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { DatasourceType } from '@superset-ui/core';
+import { useDisplayControlDatasource } from './useDisplayControlDatasource';
+
+afterEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+});
+
+test('dataset branch issues the legacy bare-resource request and maps the payload', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/401', {
+    result: {
+      table_name: 'Vehicle Sales',
+      columns: [{ column_name: 'city' }],
+    },
+  });
+
+  const { result } = renderHook(() => useDisplayControlDatasource(401));
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const { url } = fetchMock.callHistory.calls('glob:*/api/v1/dataset/401')[0];
+  expect(url.endsWith('/api/v1/dataset/401')).toBe(true);
+  expect(result.current.name).toBe('Vehicle Sales');
+  expect(result.current.columns).toEqual([{ column_name: 'city' }]);
+});
+
+test('semantic-view branch resolves only the structure endpoint and maps dimensions', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/402/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [
+        { name: 'Orders Status', type: 'VARCHAR' },
+        { name: 'Ordered At', type: 'TIMESTAMP' },
+      ],
+    },
+  });
+  fetchMock.get('glob:*/api/v1/dataset/*', 200);
+
+  const { result } = renderHook(() =>
+    useDisplayControlDatasource(402, DatasourceType.SemanticView),
+  );
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  // The colliding dataset endpoint must never be touched.
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/*')).toHaveLength(
+    0,
+  );
+  expect(result.current.name).toBe('orders');
+  expect(result.current.columns).toEqual([
+    expect.objectContaining({
+      column_name: 'Orders Status',
+      is_dttm: false,
+      filterable: true,
+    }),
+    expect.objectContaining({ column_name: 'Ordered At', is_dttm: true }),
+  ]);
+});
+
+test('same numeric id with a type flip refetches and discards the stale response', async () => {
+  // Deliberately slow dataset response vs fast structure response: the
+  // late dataset payload must not overwrite the semantic result.
+  fetchMock.get(
+    'glob:*/api/v1/dataset/403',
+    new Promise(resolve =>
+      setTimeout(
+        () =>
+          resolve({
+            result: {
+              table_name: 'Colliding Dataset',
+              columns: [{ column_name: 'wrong_col' }],
+            },
+          }),
+        150,
+      ),
+    ),
+  );
+  fetchMock.get('glob:*/api/v1/semantic_view/403/structure', {
+    result: { name: 'right view', dimensions: [{ name: 'dim', type: 'TEXT' }] },
+  });
+
+  const { result, rerender } = renderHook(
+    ({ type }: { type?: DatasourceType }) =>
+      useDisplayControlDatasource(403, type),
+    { initialProps: { type: undefined as DatasourceType | undefined } },
+  );
+
+  // Flip to semantic view while the dataset request is still in flight.
+  rerender({ type: DatasourceType.SemanticView });
+
+  await waitFor(() =>
+    expect(result.current.columns).toEqual([
+      expect.objectContaining({ column_name: 'dim' }),
+    ]),
+  );
+  // Let the stale dataset response land, then confirm it was discarded.
+  await new Promise(resolve => setTimeout(resolve, 200));
+  expect(result.current.name).toBe('right view');
+  expect(result.current.columns).toEqual([
+    expect.objectContaining({ column_name: 'dim' }),
+  ]);
+});
+
+test('structure failure yields error and empty columns with no cross-type fallback', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/404/structure', 500);
+  fetchMock.get('glob:*/api/v1/dataset/*', 200);
+
+  const { result } = renderHook(() =>
+    useDisplayControlDatasource(404, DatasourceType.SemanticView),
+  );
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.error).toBeDefined();
+  expect(result.current.columns).toEqual([]);
+  expect(fetchMock.callHistory.calls('glob:*/api/v1/dataset/*')).toHaveLength(
+    0,
+  );
+});
+
+test('nullish id is inert: no fetch, empty columns, not loading', async () => {
+  fetchMock.get('glob:*', 200);
+
+  const { result } = renderHook(() => useDisplayControlDatasource(undefined));
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.columns).toEqual([]);
+  expect(result.current.name).toBeUndefined();
+  await new Promise(resolve => setTimeout(resolve, 50));
+  expect(fetchMock.callHistory.calls('glob:*')).toHaveLength(0);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts
@@ -146,3 +146,18 @@ test('nullish id is inert: no fetch, empty columns, not loading', async () => {
   await new Promise(resolve => setTimeout(resolve, 50));
   expect(fetchMock.callHistory.calls('glob:*')).toHaveLength(0);
 });
+
+test('legacy 0 null-sentinel id is inert: no fetch to /dataset/0, no toast', async () => {
+  // migrateChartCustomization.extractDatasetId emits 0 for an unresolvable
+  // legacy dataset; the falsy guard must treat it as unbound, not fetch it.
+  fetchMock.get('glob:*', 200);
+
+  const { result } = renderHook(() => useDisplayControlDatasource(0));
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.columns).toEqual([]);
+  expect(result.current.name).toBeUndefined();
+  expect(result.current.error).toBeUndefined();
+  await new Promise(resolve => setTimeout(resolve, 50));
+  expect(fetchMock.callHistory.calls('glob:*')).toHaveLength(0);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
@@ -74,8 +74,12 @@ export function useDisplayControlDatasource(
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    if (datasetId === undefined || datasetId === null || datasetId === '') {
-      // Unbound control: inert, nothing to fetch.
+    if (!datasetId) {
+      // Unbound control: inert, nothing to fetch. The falsy guard covers
+      // undefined/null/'' and the legacy `0` null-sentinel that
+      // migrateChartCustomization.extractDatasetId emits for an unresolvable
+      // dataset (runs on dashboard hydrate) — restoring byte-identical legacy
+      // behaviour and avoiding a spurious GET /api/v1/dataset/0 → 404 + toast.
       setName(undefined);
       setColumns([]);
       setLoading(false);

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
@@ -18,7 +18,10 @@
  */
 import { useEffect, useRef, useState } from 'react';
 import { DatasourceType } from '@superset-ui/core';
-import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+import {
+  cachedSupersetGet,
+  supersetGetCache,
+} from 'src/utils/cachedSupersetGet';
 import {
   fetchSemanticViewStructure,
   semanticViewDimensionsToColumns,
@@ -37,8 +40,26 @@ export interface DisplayControlDatasource {
   name: string | undefined;
   columns: DisplayControlColumn[];
   loading: boolean;
+  /**
+   * Set only while it belongs to the CURRENT (id, type) binding. The error
+   * state lags a binding change by one render (the hook clears it in an
+   * effect), so the hook gates it here rather than leak that timing to every
+   * consumer — a stale failure from a previous binding never surfaces against
+   * the new one.
+   */
   error: Error | undefined;
 }
+
+/**
+ * Stable identity for an (id, type) binding. Used by the hook to gate a lagging
+ * error to the binding that produced it, and shared with consumers that need
+ * the same key (e.g. de-duplicating a per-binding toast). Absent type resolves
+ * to a regular dataset, matching the resolution branch.
+ */
+export const displayControlBindingKey = (
+  datasetId: number | string,
+  datasourceType?: DatasourceType,
+): string => `${datasetId}__${datasourceType || DatasourceType.Table}`;
 
 /**
  * The single, type-aware datasource resolution point for dashboard display
@@ -66,6 +87,7 @@ export function useDisplayControlDatasource(
   const [columns, setColumns] = useState<DisplayControlColumn[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>();
+  const [errorBinding, setErrorBinding] = useState<string | undefined>();
   const requestIdRef = useRef(0);
 
   useEffect(() => {
@@ -84,11 +106,14 @@ export function useDisplayControlDatasource(
       setColumns([]);
       setLoading(false);
       setError(undefined);
+      setErrorBinding(undefined);
       return undefined;
     }
 
     setLoading(true);
     setError(undefined);
+    setErrorBinding(undefined);
+    const binding = displayControlBindingKey(datasetId, datasourceType);
 
     const load = async (): Promise<{
       name: string | undefined;
@@ -101,13 +126,22 @@ export function useDisplayControlDatasource(
           columns: semanticViewDimensionsToColumns(structure.dimensions),
         };
       }
-      const { json } = await cachedSupersetGet({
-        endpoint: `/api/v1/dataset/${datasetId}`,
-      });
-      return {
-        name: json?.result?.table_name,
-        columns: json?.result?.columns ?? [],
-      };
+      const endpoint = `/api/v1/dataset/${datasetId}`;
+      try {
+        const { json } = await cachedSupersetGet({ endpoint });
+        return {
+          name: json?.result?.table_name,
+          columns: json?.result?.columns ?? [],
+        };
+      } catch (err) {
+        // cachedSupersetGet caches the in-flight promise but never evicts a
+        // rejected one, so a single 500 would poison this endpoint for the
+        // whole page session — a later type-flip or retry would re-await the
+        // same failure. Evict on rejection, mirroring the semantic-view branch
+        // (sc-111089 review).
+        supersetGetCache.delete(endpoint);
+        throw err;
+      }
     };
 
     load()
@@ -121,6 +155,7 @@ export function useDisplayControlDatasource(
         setName(undefined);
         setColumns([]);
         setError(err);
+        setErrorBinding(binding);
       })
       .finally(() => {
         if (requestId === requestIdRef.current) {
@@ -133,5 +168,14 @@ export function useDisplayControlDatasource(
     };
   }, [datasetId, datasourceType]);
 
-  return { name, columns, loading, error };
+  // Encapsulate the one-render error lag: `error`/`errorBinding` clear a render
+  // after a binding change, so surface the error only while it still belongs to
+  // the live binding. Consumers — and future adopters of this single resolution
+  // point — then never have to re-derive that guard.
+  const currentBinding = datasetId
+    ? displayControlBindingKey(datasetId, datasourceType)
+    : undefined;
+  const scopedError = errorBinding === currentBinding ? error : undefined;
+
+  return { name, columns, loading, error: scopedError };
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { DatasourceType } from '@superset-ui/core';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+import {
+  fetchSemanticViewStructure,
+  semanticViewDimensionsToColumns,
+} from './FiltersConfigModal/FiltersConfigForm/utils';
+
+/** The column fields display controls read to build their options. */
+export interface DisplayControlColumn {
+  column_name?: string;
+  name?: string;
+  verbose_name?: string | null;
+  filterable?: boolean;
+}
+
+export interface DisplayControlDatasource {
+  /** The datasource's display name (dataset table_name / semantic view name). */
+  name: string | undefined;
+  columns: DisplayControlColumn[];
+  loading: boolean;
+  error: Error | undefined;
+}
+
+/**
+ * The single, type-aware datasource resolution point for dashboard display
+ * controls (Dynamic group by today; siblings adopt this hook as they gain
+ * loaders).
+ *
+ * Semantic views and regular datasets have independent numeric-id
+ * sequences, so a binding must be resolved by BOTH id and datasourceType —
+ * an id-only lookup silently reads whatever regular dataset shares the
+ * view's number (sc-111089). The default branch preserves the legacy
+ * display-control request (`GET /api/v1/dataset/<id>`, full resource, no
+ * projection) byte-for-byte; changing that shape is a deliberate,
+ * separately-tested decision, not a drive-by.
+ *
+ * Responses are guarded by a monotonic request id: on a same-id type flip
+ * a slow response for the previous binding is discarded rather than
+ * overwriting the newer one — reintroducing the wrong-object bug through
+ * a race would otherwise be possible.
+ */
+export function useDisplayControlDatasource(
+  datasetId: number | string | undefined | null,
+  datasourceType?: DatasourceType,
+): DisplayControlDatasource {
+  const [name, setName] = useState<string | undefined>();
+  const [columns, setColumns] = useState<DisplayControlColumn[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | undefined>();
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    // Invalidate any in-flight request on every binding change (and on
+    // unmount, via the cleanup below).
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    if (datasetId === undefined || datasetId === null || datasetId === '') {
+      // Unbound control: inert, nothing to fetch.
+      setName(undefined);
+      setColumns([]);
+      setLoading(false);
+      setError(undefined);
+      return undefined;
+    }
+
+    setLoading(true);
+    setError(undefined);
+
+    const load = async (): Promise<{
+      name: string | undefined;
+      columns: DisplayControlColumn[];
+    }> => {
+      if (datasourceType === DatasourceType.SemanticView) {
+        const structure = await fetchSemanticViewStructure(datasetId);
+        return {
+          name: structure.name,
+          columns: semanticViewDimensionsToColumns(structure.dimensions),
+        };
+      }
+      const { json } = await cachedSupersetGet({
+        endpoint: `/api/v1/dataset/${datasetId}`,
+      });
+      return {
+        name: json?.result?.table_name,
+        columns: json?.result?.columns ?? [],
+      };
+    };
+
+    load()
+      .then(resolved => {
+        if (requestId !== requestIdRef.current) return;
+        setName(resolved.name);
+        setColumns(resolved.columns);
+      })
+      .catch((err: Error) => {
+        if (requestId !== requestIdRef.current) return;
+        setName(undefined);
+        setColumns([]);
+        setError(err);
+      })
+      .finally(() => {
+        if (requestId === requestIdRef.current) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [datasetId, datasourceType]);
+
+  return { name, columns, loading, error };
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/useDisplayControlDatasource.ts
@@ -42,8 +42,8 @@ export interface DisplayControlDatasource {
 
 /**
  * The single, type-aware datasource resolution point for dashboard display
- * controls (Dynamic group by today; siblings adopt this hook as they gain
- * loaders).
+ * controls (Dynamic group by is the first adopter; siblings adopt this
+ * hook as they gain loaders).
  *
  * Semantic views and regular datasets have independent numeric-id
  * sequences, so a binding must be resolved by BOTH id and datasourceType —

--- a/superset-frontend/src/hooks/apiResources/datasets.test.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.test.ts
@@ -448,3 +448,84 @@ test('useDatasetDrillInfo falls back to REST API when extension exists but formD
     verbose_map: { col1: 'Column 1' },
   });
 });
+
+/**
+ * sc-111089 T012: type-aware resolution — semantic views resolve their own
+ * structure and never touch /drill_info/ (which would hit the colliding
+ * regular dataset id), including when a drillby extension is registered.
+ */
+
+test('getDatasourceTypeFromId parses the semantic_view suffix and falls back to table', () => {
+  const { getDatasourceTypeFromId } = jest.requireActual('./datasets');
+  expect(getDatasourceTypeFromId('3__semantic_view')).toBe('semantic_view');
+  expect(getDatasourceTypeFromId('3__table')).toBe('table');
+  expect(getDatasourceTypeFromId('3__bogus')).toBe('table');
+  expect(getDatasourceTypeFromId(3)).toBe('table');
+});
+
+test('useDatasetDrillInfo resolves a semantic view from its structure with zero drill_info calls', async () => {
+  mockedCachedSupersetGet.mockResolvedValue({
+    json: {
+      result: {
+        name: 'orders',
+        dimensions: [{ name: 'Orders Status', type: 'VARCHAR' }],
+        metrics: [{ name: 'order_count', definition: 'COUNT(*)' }],
+      },
+    },
+  } as any);
+
+  const { result } = renderHook(() =>
+    useDatasetDrillInfo('3__semantic_view', 456),
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('complete'));
+
+  expect(mockedCachedSupersetGet).toHaveBeenCalledWith({
+    endpoint: '/api/v1/semantic_view/3/structure',
+  });
+  const drillInfoCalls = mockedCachedSupersetGet.mock.calls.filter(call =>
+    String(call[0]?.endpoint).includes('/drill_info/'),
+  );
+  expect(drillInfoCalls).toHaveLength(0);
+
+  expect(result.current.result?.table_name).toBe('orders');
+  expect(result.current.result?.verbose_map).toMatchObject({
+    'Orders Status': 'Orders Status',
+    order_count: 'order_count',
+  });
+});
+
+test('semantic view wins over a registered drillby extension', async () => {
+  setupExtensionMock();
+  mockedCachedSupersetGet.mockResolvedValue({
+    json: {
+      result: { name: 'orders', dimensions: [], metrics: [] },
+    },
+  } as any);
+  const mockFormData = { datasource: '3__semantic_view' } as any;
+
+  const { result } = renderHook(() =>
+    useDatasetDrillInfo('3__semantic_view', 456, mockFormData),
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('complete'));
+
+  // The extension path must not run for semantic views — it receives only
+  // the numeric id and would resolve the colliding regular dataset.
+  expect(mockExtension).not.toHaveBeenCalled();
+  expect(result.current.result?.table_name).toBe('orders');
+});
+
+test('a malformed type suffix falls back to the regular dataset drill_info path', async () => {
+  mockedCachedSupersetGet.mockResolvedValue({
+    json: { result: { id: 3, columns: [], metrics: [] } },
+  } as any);
+
+  const { result } = renderHook(() => useDatasetDrillInfo('3__bogus', 456));
+
+  await waitFor(() => expect(result.current.status).toBe('complete'));
+
+  expect(mockedCachedSupersetGet).toHaveBeenCalledWith({
+    endpoint: '/api/v1/dataset/3/drill_info/?q=(dashboard_id:456)',
+  });
+});

--- a/superset-frontend/src/hooks/apiResources/datasets.test.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.test.ts
@@ -455,12 +455,15 @@ test('useDatasetDrillInfo falls back to REST API when extension exists but formD
  * regular dataset id), including when a drillby extension is registered.
  */
 
-test('getDatasourceTypeFromId parses the semantic_view suffix and falls back to table', () => {
-  const { getDatasourceTypeFromId } = jest.requireActual('./datasets');
-  expect(getDatasourceTypeFromId('3__semantic_view')).toBe('semantic_view');
-  expect(getDatasourceTypeFromId('3__table')).toBe('table');
-  expect(getDatasourceTypeFromId('3__bogus')).toBe('table');
-  expect(getDatasourceTypeFromId(3)).toBe('table');
+test('getDatasourceTypeFromDatasourceId parses the semantic_view suffix and falls back to table', () => {
+  const { getDatasourceTypeFromDatasourceId } =
+    jest.requireActual('./datasets');
+  expect(getDatasourceTypeFromDatasourceId('3__semantic_view')).toBe(
+    'semantic_view',
+  );
+  expect(getDatasourceTypeFromDatasourceId('3__table')).toBe('table');
+  expect(getDatasourceTypeFromDatasourceId('3__bogus')).toBe('table');
+  expect(getDatasourceTypeFromDatasourceId(3)).toBe('table');
 });
 
 test('useDatasetDrillInfo resolves a semantic view from its structure with zero drill_info calls', async () => {

--- a/superset-frontend/src/hooks/apiResources/datasets.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.ts
@@ -19,6 +19,7 @@
  */
 import {
   Column,
+  DatasourceType,
   Metric,
   ensureIsArray,
   getExtensionsRegistry,
@@ -31,6 +32,10 @@ import {
   cachedSupersetGet,
   supersetGetCache,
 } from 'src/utils/cachedSupersetGet';
+import {
+  fetchSemanticViewStructure,
+  semanticViewDimensionsToColumns,
+} from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils';
 import { Resource, ResourceStatus } from './apiResources';
 
 /**
@@ -40,6 +45,26 @@ export const getDatasetId = (datasetId: string | number): number =>
   typeof datasetId === 'string'
     ? Number(datasetId.split('__')[0])
     : Number(datasetId);
+
+/**
+ * Extract the datasource type from an `<id>__<type>` datasource string.
+ * Semantic views and regular datasets have independent numeric-id
+ * sequences, so the type is load-bearing: resolving by id alone reads
+ * whatever regular dataset shares the number (sc-111089). Absent or
+ * unrecognized suffixes fall back to a regular dataset, preserving
+ * legacy behaviour.
+ */
+export const getDatasourceTypeFromId = (
+  datasetId: string | number,
+): DatasourceType => {
+  if (typeof datasetId !== 'string') {
+    return DatasourceType.Table;
+  }
+  const suffix = datasetId.split('__')[1];
+  return suffix === DatasourceType.SemanticView
+    ? DatasourceType.SemanticView
+    : DatasourceType.Table;
+};
 
 /**
  * Helper function to create verbose_map from a dataset
@@ -89,7 +114,29 @@ export const useDatasetDrillInfo = (
         );
         let result;
 
-        if (loadDrillByOptionsExtension && formData) {
+        if (
+          getDatasourceTypeFromId(datasetId) === DatasourceType.SemanticView
+        ) {
+          // Semantic views short-circuit BEFORE the extension check: the
+          // extension receives only the numeric id, which would resolve
+          // the colliding regular dataset (sc-111089 review consensus).
+          // The structure payload carries no changed_on/owners metadata —
+          // those metadata-bar rows render their not-available state, an
+          // accepted degradation. Columns are narrowed to metadata needs;
+          // no drill flags are fabricated.
+          const structure = await fetchSemanticViewStructure(numericDatasetId);
+          result = {
+            id: numericDatasetId,
+            table_name: structure.name,
+            datasource_type: DatasourceType.SemanticView,
+            columns: semanticViewDimensionsToColumns(structure.dimensions),
+            metrics: structure.metrics.map(metric => ({
+              metric_name: metric.name,
+              expression: metric.definition,
+              verbose_name: null,
+            })),
+          } as unknown as Dataset;
+        } else if (loadDrillByOptionsExtension && formData) {
           const response = await loadDrillByOptionsExtension(
             numericDatasetId,
             formData,

--- a/superset-frontend/src/hooks/apiResources/datasets.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.ts
@@ -35,7 +35,7 @@ import {
 import {
   fetchSemanticViewStructure,
   semanticViewDimensionsToColumns,
-} from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils';
+} from 'src/utils/semanticViewStructure';
 import { Resource, ResourceStatus } from './apiResources';
 
 /**
@@ -54,7 +54,7 @@ export const getDatasetId = (datasetId: string | number): number =>
  * unrecognized suffixes fall back to a regular dataset, preserving
  * legacy behaviour.
  */
-export const getDatasourceTypeFromId = (
+export const getDatasourceTypeFromDatasourceId = (
   datasetId: string | number,
 ): DatasourceType => {
   if (typeof datasetId !== 'string') {
@@ -115,7 +115,8 @@ export const useDatasetDrillInfo = (
         let result;
 
         if (
-          getDatasourceTypeFromId(datasetId) === DatasourceType.SemanticView
+          getDatasourceTypeFromDatasourceId(datasetId) ===
+          DatasourceType.SemanticView
         ) {
           // Semantic views short-circuit BEFORE the extension check: the
           // extension receives only the numeric id, which would resolve
@@ -125,17 +126,18 @@ export const useDatasetDrillInfo = (
           // accepted degradation. Columns are narrowed to metadata needs;
           // no drill flags are fabricated.
           const structure = await fetchSemanticViewStructure(numericDatasetId);
+          // A structurally valid Dataset, no cast: consumers read only
+          // columns/metrics (and derive verbose_map), so no id or
+          // datasource_type fields are fabricated, and verbose_name is
+          // omitted rather than null — consumers only falsy-check it.
           result = {
-            id: numericDatasetId,
             table_name: structure.name,
-            datasource_type: DatasourceType.SemanticView,
             columns: semanticViewDimensionsToColumns(structure.dimensions),
             metrics: structure.metrics.map(metric => ({
               metric_name: metric.name,
               expression: metric.definition,
-              verbose_name: null,
             })),
-          } as unknown as Dataset;
+          };
         } else if (loadDrillByOptionsExtension && formData) {
           const response = await loadDrillByOptionsExtension(
             numericDatasetId,

--- a/superset-frontend/src/hooks/apiResources/datasets.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.ts
@@ -112,7 +112,7 @@ export const useDatasetDrillInfo = (
         const loadDrillByOptionsExtension = getExtensionsRegistry().get(
           'load.drillby.options',
         );
-        let result;
+        let result: Dataset | undefined;
 
         if (
           getDatasourceTypeFromDatasourceId(datasetId) ===
@@ -126,17 +126,24 @@ export const useDatasetDrillInfo = (
           // accepted degradation. Columns are narrowed to metadata needs;
           // no drill flags are fabricated.
           const structure = await fetchSemanticViewStructure(numericDatasetId);
-          // A structurally valid Dataset, no cast: consumers read only
-          // columns/metrics (and derive verbose_map), so no id or
-          // datasource_type fields are fabricated, and verbose_name is
-          // omitted rather than null — consumers only falsy-check it.
+          // Built as a partial Dataset (the declaration is typed, so
+          // table_name/columns are genuinely checked): no id or
+          // datasource_type is fabricated, and verbose_name is omitted rather
+          // than null — consumers only falsy-check it. The metrics are the one
+          // narrowing: the structure payload carries no uuid or full metric
+          // metadata, so each is asserted to Metric with only the fields
+          // consumers read (metric_name for verbose_map; expression for
+          // parity). Fabricating a uuid would be worse than the assertion.
           result = {
             table_name: structure.name,
             columns: semanticViewDimensionsToColumns(structure.dimensions),
-            metrics: structure.metrics.map(metric => ({
-              metric_name: metric.name,
-              expression: metric.definition,
-            })),
+            metrics: structure.metrics.map(
+              metric =>
+                ({
+                  metric_name: metric.name,
+                  expression: metric.definition,
+                }) as Metric,
+            ),
           };
         } else if (loadDrillByOptionsExtension && formData) {
           const response = await loadDrillByOptionsExtension(

--- a/superset-frontend/src/utils/semanticViewStructure.test.ts
+++ b/superset-frontend/src/utils/semanticViewStructure.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { supersetGetCache } from 'src/utils/cachedSupersetGet';
+import { fetchSemanticViewStructure } from './semanticViewStructure';
+
+afterEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+  supersetGetCache.clear();
+});
+
+test('maps the structure payload', async () => {
+  fetchMock.get('glob:*/api/v1/semantic_view/501/structure', {
+    result: {
+      name: 'orders',
+      dimensions: [{ name: 'Status', type: 'VARCHAR' }],
+      metrics: [{ name: 'revenue', definition: 'SUM(amount)' }],
+    },
+  });
+
+  const structure = await fetchSemanticViewStructure(501);
+
+  expect(structure.name).toBe('orders');
+  expect(structure.dimensions).toEqual([{ name: 'Status', type: 'VARCHAR' }]);
+  expect(structure.metrics).toEqual([
+    { name: 'revenue', definition: 'SUM(amount)' },
+  ]);
+});
+
+test('evicts the cache on failure so a later call refetches after recovery', async () => {
+  const endpoint = 'glob:*/api/v1/semantic_view/502/structure';
+  // First response fails: without eviction, the rejected promise would stay
+  // cached and every later call would replay the failure for the session.
+  fetchMock.getOnce(endpoint, 500);
+
+  await expect(fetchSemanticViewStructure(502)).rejects.toBeTruthy();
+  expect(
+    fetchMock.callHistory.calls('glob:*/api/v1/semantic_view/502/structure'),
+  ).toHaveLength(1);
+
+  // Endpoint healthy again: the second call must hit the network, not a
+  // poisoned cache entry.
+  fetchMock.get(endpoint, {
+    result: { name: 'orders', dimensions: [], metrics: [] },
+  });
+
+  const structure = await fetchSemanticViewStructure(502);
+
+  expect(structure.name).toBe('orders');
+  expect(
+    fetchMock.callHistory.calls('glob:*/api/v1/semantic_view/502/structure'),
+  ).toHaveLength(2);
+});

--- a/superset-frontend/src/utils/semanticViewStructure.ts
+++ b/superset-frontend/src/utils/semanticViewStructure.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Column } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/common';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+
+/**
+ * Shared semantic-view structure helpers. This module is deliberately
+ * layer-neutral (`src/utils`) because its consumers span layers: the
+ * native-filter configuration form, its column select, and the generic
+ * dataset drill-info hook all resolve semantic views through it.
+ */
+
+export const mapSemanticTypeToGenericDataType = (
+  semanticType?: string | null,
+): GenericDataType | undefined => {
+  if (!semanticType) {
+    return undefined;
+  }
+
+  const normalized = semanticType.toLowerCase();
+
+  if (
+    /^(struct|list|map|array|fixed_size_list|large_list|union|dictionary)\b/.test(
+      normalized,
+    )
+  ) {
+    return undefined;
+  }
+
+  if (normalized.includes('bool')) {
+    return GenericDataType.Boolean;
+  }
+
+  if (/(date|time|timestamp|datetime)/.test(normalized)) {
+    return GenericDataType.Temporal;
+  }
+
+  if (
+    /(\b(u?int\d*)\b|\bfloat\d*\b|\bdouble\b|\bdecimal\d*\b|\bnumber\b)/.test(
+      normalized,
+    )
+  ) {
+    return GenericDataType.Numeric;
+  }
+
+  if (
+    /(\bstr(ing)?\b|\butf8\b|\blarge_string\b|\bbinary\b|\bjson\b|\buuid\b)/.test(
+      normalized,
+    )
+  ) {
+    return GenericDataType.String;
+  }
+
+  return undefined;
+};
+
+/** The slice of `GET /api/v1/semantic_view/<id>/structure` consumers rely on. */
+export interface SemanticViewStructure {
+  name?: string;
+  dimensions: { name: string; type: string }[];
+  metrics: { name: string; definition: string }[];
+}
+
+/**
+ * Fetch a semantic view's structure — the single, shared entry point for
+ * every type-aware datasource consumer (ColumnSelect, FiltersConfigForm,
+ * display controls, drill metadata). Semantic views and regular datasets
+ * have independent numeric-id sequences, so callers must route here (and
+ * never to `/api/v1/dataset/<id>`) whenever the binding's datasourceType
+ * is SemanticView.
+ */
+export const fetchSemanticViewStructure = async (
+  semanticViewId: number | string,
+): Promise<SemanticViewStructure> => {
+  const response = await cachedSupersetGet({
+    endpoint: `/api/v1/semantic_view/${semanticViewId}/structure`,
+  });
+  const { name, dimensions = [], metrics = [] } = response.json?.result ?? {};
+  return { name, dimensions, metrics };
+};
+
+/**
+ * Map structure dimensions onto the `Column` shape the filter/control
+ * machinery expects. Mapping semantics are shared by every consumer:
+ * temporal detection via `mapSemanticTypeToGenericDataType`, and
+ * `filterable: true` (semantic-view dimensions are always selectable).
+ */
+export const semanticViewDimensionsToColumns = (
+  dimensions: SemanticViewStructure['dimensions'],
+): Column[] =>
+  dimensions.map(dim => {
+    const mappedType = mapSemanticTypeToGenericDataType(dim.type);
+    return {
+      column_name: dim.name,
+      type: dim.type,
+      is_dttm: mappedType === GenericDataType.Temporal,
+      type_generic: mappedType,
+      filterable: true,
+    };
+  });

--- a/superset-frontend/src/utils/semanticViewStructure.ts
+++ b/superset-frontend/src/utils/semanticViewStructure.ts
@@ -18,7 +18,10 @@
  */
 import { Column } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
-import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+import {
+  cachedSupersetGet,
+  supersetGetCache,
+} from 'src/utils/cachedSupersetGet';
 
 /**
  * Shared semantic-view structure helpers. This module is deliberately
@@ -89,11 +92,19 @@ export interface SemanticViewStructure {
 export const fetchSemanticViewStructure = async (
   semanticViewId: number | string,
 ): Promise<SemanticViewStructure> => {
-  const response = await cachedSupersetGet({
-    endpoint: `/api/v1/semantic_view/${semanticViewId}/structure`,
-  });
-  const { name, dimensions = [], metrics = [] } = response.json?.result ?? {};
-  return { name, dimensions, metrics };
+  const endpoint = `/api/v1/semantic_view/${semanticViewId}/structure`;
+  try {
+    const response = await cachedSupersetGet({ endpoint });
+    const { name, dimensions = [], metrics = [] } = response.json?.result ?? {};
+    return { name, dimensions, metrics };
+  } catch (error) {
+    // cacheWrapper caches the promise itself and never evicts on rejection, so
+    // a single failed response would poison this endpoint for the rest of the
+    // page session. Evict on error so a later call refetches — mirroring the
+    // regular-dataset drill branch (hooks/apiResources/datasets.ts).
+    supersetGetCache.delete(endpoint);
+    throw error;
+  }
 };
 
 /**


### PR DESCRIPTION
### SUMMARY

Semantic views and regular datasets have **independent numeric-id sequences**, so a semantic view with `id=3` and a regular dataset with `id=3` both exist. Two surfaces resolved their bound datasource by id alone and silently read the wrong object:

1. **Dynamic group by display control** — the FilterBar loader fetched `/api/v1/dataset/<id>` while ignoring the `datasourceType` already persisted on `targets[0]`, so the dropdown offered the colliding *dataset's* columns with no error shown.
2. **Drill to detail** — `useDatasetDrillInfo` parsed the `<id>__<type>` composite but discarded the type, so the drill modal's name and `verbose_map` came from the colliding dataset.

Both are extensions of the type-aware pattern already shipped in #40475, applied at a shared resolution point rather than as a fourth and fifth inline copy:

- **Extract** `fetchSemanticViewStructure` / `semanticViewDimensionsToColumns` from the two existing inline copies (`ColumnSelect.tsx`, `FiltersConfigForm.tsx`) and migrate both onto them. Behaviour-preserving; existing suites unchanged.
- **New `useDisplayControlDatasource` hook** — type-branched resolution with a monotonic request-id stale-response guard (a slow `/dataset/3` must not overwrite a fast `/semantic_view/3/structure` after a type flip), inert when the control is unbound. The regular-dataset branch preserves the legacy request byte-for-byte; characterization tests for that path were authored against the *unmodified* component first so the claim is falsifiable.
- **Preserve `datasourceType` at both target-rewrite sites** (`handleColumnChange` and the FilterBar clear-customizations path). Without this the fix self-reverts: the first select-and-apply rebuilt the target without the type, silently degrading the binding back to the colliding dataset.
- **`useDatasetDrillInfo`** — the `semantic_view` branch short-circuits *before* the `load.drillby.options` extension check, because that extension receives only the numeric id and would resolve the collision itself. Non-semantic types keep byte-identical behaviour including extension precedence.
- Dropped the display-control effect's dead `dependencies` coupling (it was in the dep array but the request never used it).

**Known, deliberate degradation:** the drill modal's metadata bar renders its explicit "Not available" state for Last modified / Modified by on semantic views — the structure endpoint carries no `changed_on`/owners metadata. This is pinned by test rather than papered over.

Everything here is behind `FeatureFlag.SemanticLayers`, which is off by default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — the visible difference requires a semantic-layer provider configured with an id collision against a regular dataset. Covered by tests instead (below).

### TESTING INSTRUCTIONS

**Automated** (100 tests across 6 suites):

```bash
cd superset-frontend
npm run test -- \
  src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx \
  src/dashboard/components/nativeFilters/useDisplayControlDatasource.test.ts \
  src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.test.ts \
  src/hooks/apiResources/datasets.test.ts \
  src/components/Chart/DrillDetail/DrillDetailPane.test.tsx \
  src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
```

Notable cases: the collision fixture (dataset 306 vs semantic view 306) asserting the dataset endpoint is *never* called; the select-and-apply persistence guard for the self-revert; the stale-response discard; and the four pre-change characterization tests pinning the regular-dataset path.

**Manual** (requires a semantic-layer provider — `FeatureFlag.SemanticLayers` enabled and a configured extension):

1. Create a semantic view whose numeric id collides with an existing regular dataset (the sequences are independent, so this happens naturally as both tables grow).
2. Add a chart on that semantic view to a dashboard, then add a **Dynamic group by** display control bound to it.
3. The dropdown must list the semantic view's *dimensions*, not the colliding dataset's columns.
4. Select a dimension, apply, then reopen the filter bar — the list must still show dimensions (this is the path that previously regressed after the first interaction).
5. Clear the customization and confirm the binding survives.
6. Right-click a chart on the semantic view → **Drill to detail**. The modal header must show the semantic view's name; the metadata bar will show "Not available" for Last modified / Modified by, which is expected.

Regression check on regular datasets: repeat steps 2-6 against a normal dataset-backed chart; behaviour should be indistinguishable from master.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SemanticLayers`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
