### PR TITLE
feat(semantic layers): derive Explore picker modes from declared semantic view features

### DIFF
--- a/docs/developer_docs/extensions/contribution-types.md
+++ b/docs/developer_docs/extensions/contribution-types.md
@@ -291,3 +291,46 @@ class MySemanticLayer(SemanticLayer[MyConfig, MySemanticView]):
 - **Host context**: Original ID used as-is
 
 The decorator registers the class in the semantic layers registry, making it available in the UI for users to create connections. The `configuration_class` should be a Pydantic model that defines the fields needed to connect (credentials, project, database, etc.). Superset uses the model's JSON schema to render the configuration form dynamically.
+
+#### Declaring semantic view features
+
+A `SemanticView` advertises what its backend supports through the `features`
+frozenset. Declaration is opt-in: a view that declares nothing gets the most
+conservative behavior, so a new provider is safe by default.
+
+```python
+from superset_core.semantic_layers.view import SemanticView, SemanticViewFeature
+
+
+class MySemanticView(SemanticView):
+    features = frozenset(
+        {
+            # The backend accepts simple/custom-SQL column expressions built
+            # in Explore. Omit this member if it only accepts the view's own
+            # dimensions.
+            SemanticViewFeature.ADHOC_COLUMN_EXPRESSIONS,
+            SemanticViewFeature.GROUP_LIMIT,
+        }
+    )
+```
+
+The declared members are serialized to the Explore datasource payload as
+`semantic_view_features` (their stable string values). The provider's registry
+key is deliberately **not** sent: because the `@semantic_layer` decorator
+prefixes extension IDs, no stable bare key exists to publish, and behavior
+keyed off provider identity would not survive that prefixing.
+
+Explore translates `semantic_view_features` exactly once, in the
+datasource-to-picker-capabilities adapter
+(`superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.ts`),
+into a provider-neutral `ColumnPickerCapabilities` value. That adapter is the
+anti-corruption boundary between provider metadata and generic UI: picker
+components consume capabilities and must not read `semantic_view_features`, a
+registry key, or a user-editable display name. New provider-specific behavior
+belongs in a capability, not in a comparison inside a picker component.
+
+A view that does not declare `ADHOC_COLUMN_EXPRESSIONS` gets a Saved-only
+column picker: its dimensions are listed as Saved options and the Simple and
+Custom SQL modes are visible but disabled, so users cannot build an expression
+the backend would reject. Unknown feature strings and payloads with no
+`semantic_view_features` field are ignored, preserving existing behavior.

--- a/docs/developer_docs/extensions/contribution-types.md
+++ b/docs/developer_docs/extensions/contribution-types.md
@@ -290,3 +290,46 @@ class MySemanticLayer(SemanticLayer[MyConfig, MySemanticView]):
 - **Host context**: Original ID used as-is
 
 The decorator registers the class in the semantic layers registry, making it available in the UI for users to create connections. The `configuration_class` should be a Pydantic model that defines the fields needed to connect (credentials, project, database, etc.). Superset uses the model's JSON schema to render the configuration form dynamically.
+
+#### Declaring semantic view features
+
+A `SemanticView` advertises what its backend supports through the `features`
+frozenset. Declaration is opt-in: a view that declares nothing gets the most
+conservative behavior, so a new provider is safe by default.
+
+```python
+from superset_core.semantic_layers.view import SemanticView, SemanticViewFeature
+
+
+class MySemanticView(SemanticView):
+    features = frozenset(
+        {
+            # The backend accepts simple/custom-SQL column expressions built
+            # in Explore. Omit this member if it only accepts the view's own
+            # dimensions.
+            SemanticViewFeature.ADHOC_COLUMN_EXPRESSIONS,
+            SemanticViewFeature.GROUP_LIMIT,
+        }
+    )
+```
+
+The declared members are serialized to the Explore datasource payload as
+`semantic_view_features` (their stable string values). The provider's registry
+key is deliberately **not** sent: because the `@semantic_layer` decorator
+prefixes extension IDs, no stable bare key exists to publish, and behavior
+keyed off provider identity would not survive that prefixing.
+
+Explore translates `semantic_view_features` exactly once, in the
+datasource-to-picker-capabilities adapter
+(`superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.ts`),
+into a provider-neutral `ColumnPickerCapabilities` value. That adapter is the
+anti-corruption boundary between provider metadata and generic UI: picker
+components consume capabilities and must not read `semantic_view_features`, a
+registry key, or a user-editable display name. New provider-specific behavior
+belongs in a capability, not in a comparison inside a picker component.
+
+A view that does not declare `ADHOC_COLUMN_EXPRESSIONS` gets a Saved-only
+column picker: its dimensions are listed as Saved options and the Simple and
+Custom SQL modes are visible but disabled, so users cannot build an expression
+the backend would reject. Unknown feature strings and payloads with no
+`semantic_view_features` field are ignored, preserving existing behavior.

--- a/superset-core/src/superset_core/semantic_layers/view.py
+++ b/superset-core/src/superset_core/semantic_layers/view.py
@@ -35,6 +35,7 @@ class SemanticViewFeature(enum.Enum):
     Custom features supported by semantic layers.
     """
 
+    ADHOC_COLUMN_EXPRESSIONS = "ADHOC_COLUMN_EXPRESSIONS"
     ADHOC_EXPRESSIONS_IN_ORDERBY = "ADHOC_EXPRESSIONS_IN_ORDERBY"
     GROUP_LIMIT = "GROUP_LIMIT"
     GROUP_OTHERS = "GROUP_OTHERS"

--- a/superset-core/src/superset_core/semantic_layers/view.py
+++ b/superset-core/src/superset_core/semantic_layers/view.py
@@ -46,7 +46,10 @@ class SemanticView(ABC):
     Abstract base class for semantic views.
     """
 
-    features: frozenset[SemanticViewFeature]
+    # Defaults to no optional features: providers opt in by overriding, and
+    # consumers can rely on the attribute existing and degrade to the
+    # conservative (Saved-only) picker for views that declare nothing.
+    features: frozenset[SemanticViewFeature] = frozenset()
 
     # Implementations must expose a display name for the view.
     # Declared here as a type annotation (not abstract) so that existing

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -98,6 +98,11 @@ export interface Dataset {
   normalize_columns?: boolean;
   always_filter_main_dttm?: boolean;
   extra?: object | string;
+  /**
+   * Stable string values of the features a semantic view's provider declares.
+   * Only present for semantic views; absent elsewhere.
+   */
+  semantic_view_features?: string[];
 }
 
 export interface ControlPanelState {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -97,6 +97,11 @@ export interface Dataset {
   normalize_columns?: boolean;
   always_filter_main_dttm?: boolean;
   extra?: object | string;
+  /**
+   * Stable string values of the features a semantic view's provider declares.
+   * Only present for semantic views; absent elsewhere.
+   */
+  semantic_view_features?: string[];
 }
 
 export interface ControlPanelState {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Datasource.ts
@@ -48,6 +48,13 @@ export interface Datasource {
    * you only need the display name.
    */
   parent?: { name: string };
+  /**
+   * Stable string values of the features a semantic view's provider declares
+   * (for example "ADHOC_COLUMN_EXPRESSIONS"). Only present for semantic
+   * views; absent for tables, queries, and older payloads. Consumed by the
+   * explore picker-capability adapter — carries no provider identity.
+   */
+  semantic_view_features?: string[];
   columns: Column[];
   metrics: Metric[];
   description?: string;

--- a/superset-frontend/src/explore/actions/exploreActions.test.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.test.ts
@@ -242,44 +242,120 @@ describe('reducers', () => {
   });
 });
 
+type CompatibilityResponse = {
+  json: {
+    result: {
+      compatible_metrics: string[];
+      compatible_dimensions: string[];
+    };
+  };
+};
+
+const getCompatibilityActions = (dispatch: jest.Mock) =>
+  dispatch.mock.calls
+    .map(call => call[0])
+    .filter((action: AnyAction) => action.type === actions.SET_COMPATIBILITY);
+
+test('fetchCompatibility resets to idle for non-semantic datasources', async () => {
+  const dispatch = jest.fn();
+
+  await actions.fetchCompatibility('table', 3, ['m1'], ['d1'])(dispatch as any);
+
+  expect(getCompatibilityActions(dispatch)).toEqual([
+    { type: actions.SET_COMPATIBILITY, compatibility: { status: 'idle' } },
+  ]);
+});
+
+test('fetchCompatibility transitions loading then verified with values', async () => {
+  const dispatch = jest.fn();
+  const postSpy = jest.spyOn(SupersetClient, 'post').mockResolvedValueOnce({
+    json: {
+      result: {
+        compatible_metrics: ['m1'],
+        compatible_dimensions: ['d1', 'd2'],
+      },
+    },
+  } as never);
+
+  await actions.fetchCompatibility(
+    'semantic_view',
+    7,
+    ['m1'],
+    ['d1'],
+  )(dispatch as any);
+
+  expect(getCompatibilityActions(dispatch)).toEqual([
+    { type: actions.SET_COMPATIBILITY, compatibility: { status: 'loading' } },
+    {
+      type: actions.SET_COMPATIBILITY,
+      compatibility: {
+        status: 'verified',
+        metrics: ['m1'],
+        dimensions: ['d1', 'd2'],
+      },
+    },
+  ]);
+
+  postSpy.mockRestore();
+});
+
+test('fetchCompatibility keeps empty verified arrays distinct from idle and failed', async () => {
+  const dispatch = jest.fn();
+  const postSpy = jest.spyOn(SupersetClient, 'post').mockResolvedValueOnce({
+    json: {
+      result: {
+        compatible_metrics: [],
+        compatible_dimensions: [],
+      },
+    },
+  } as never);
+
+  await actions.fetchCompatibility(
+    'semantic_view',
+    7,
+    [],
+    [],
+  )(dispatch as any);
+
+  expect(getCompatibilityActions(dispatch)).toContainEqual({
+    type: actions.SET_COMPATIBILITY,
+    compatibility: { status: 'verified', metrics: [], dimensions: [] },
+  });
+
+  postSpy.mockRestore();
+});
+
+test('fetchCompatibility marks the latest request failed on error', async () => {
+  const dispatch = jest.fn();
+  const postSpy = jest
+    .spyOn(SupersetClient, 'post')
+    .mockRejectedValueOnce(new Error('network down'));
+
+  await actions.fetchCompatibility(
+    'semantic_view',
+    7,
+    ['m1'],
+    ['d1'],
+  )(dispatch as any);
+
+  expect(getCompatibilityActions(dispatch)).toEqual([
+    { type: actions.SET_COMPATIBILITY, compatibility: { status: 'loading' } },
+    { type: actions.SET_COMPATIBILITY, compatibility: { status: 'failed' } },
+  ]);
+
+  postSpy.mockRestore();
+});
+
 test('fetchCompatibility ignores stale async responses', async () => {
   const dispatch = jest.fn();
 
-  let resolveFirst: (value: {
-    json: {
-      result: {
-        compatible_metrics: string[];
-        compatible_dimensions: string[];
-      };
-    };
-  }) => void;
-  let resolveSecond: (value: {
-    json: {
-      result: {
-        compatible_metrics: string[];
-        compatible_dimensions: string[];
-      };
-    };
-  }) => void;
+  let resolveFirst: (value: CompatibilityResponse) => void;
+  let resolveSecond: (value: CompatibilityResponse) => void;
 
-  const firstPromise = new Promise<{
-    json: {
-      result: {
-        compatible_metrics: string[];
-        compatible_dimensions: string[];
-      };
-    };
-  }>(resolve => {
+  const firstPromise = new Promise<CompatibilityResponse>(resolve => {
     resolveFirst = resolve;
   });
-  const secondPromise = new Promise<{
-    json: {
-      result: {
-        compatible_metrics: string[];
-        compatible_dimensions: string[];
-      };
-    };
-  }>(resolve => {
+  const secondPromise = new Promise<CompatibilityResponse>(resolve => {
     resolveSecond = resolve;
   });
 
@@ -321,27 +397,81 @@ test('fetchCompatibility ignores stale async responses', async () => {
   });
   await firstThunk;
 
-  const compatibilityActions = dispatch.mock.calls
-    .map(call => call[0])
-    .filter((action: AnyAction) => action.type === actions.SET_COMPATIBILITY);
-  const successfulActions = compatibilityActions.filter(
-    (action: AnyAction) => action.compatibilityLoading === false,
+  const verifiedActions = getCompatibilityActions(dispatch).filter(
+    (action: AnyAction) => action.compatibility.status === 'verified',
   );
 
-  expect(successfulActions).toContainEqual(
-    expect.objectContaining({
-      compatibleMetrics: ['m2'],
-      compatibleDimensions: ['d2'],
-      compatibilityLoading: false,
-    }),
+  expect(verifiedActions).toEqual([
+    {
+      type: actions.SET_COMPATIBILITY,
+      compatibility: {
+        status: 'verified',
+        metrics: ['m2'],
+        dimensions: ['d2'],
+      },
+    },
+  ]);
+
+  postSpy.mockRestore();
+});
+
+test('fetchCompatibility ignores a stale failure after a newer success', async () => {
+  const dispatch = jest.fn();
+
+  let rejectFirst: (reason: Error) => void;
+  let resolveSecond: (value: CompatibilityResponse) => void;
+
+  const firstPromise = new Promise<CompatibilityResponse>((_, reject) => {
+    rejectFirst = reject;
+  });
+  const secondPromise = new Promise<CompatibilityResponse>(resolve => {
+    resolveSecond = resolve;
+  });
+
+  const postSpy = jest.spyOn(SupersetClient, 'post');
+  postSpy
+    .mockImplementationOnce(() => firstPromise as never)
+    .mockImplementationOnce(() => secondPromise as never);
+
+  const firstThunk = actions.fetchCompatibility(
+    'semantic_view',
+    7,
+    ['m1'],
+    ['d1'],
+  )(dispatch as any);
+  const secondThunk = actions.fetchCompatibility(
+    'semantic_view',
+    7,
+    ['m2'],
+    ['d2'],
+  )(dispatch as any);
+
+  resolveSecond!({
+    json: {
+      result: {
+        compatible_metrics: ['m2'],
+        compatible_dimensions: ['d2'],
+      },
+    },
+  });
+  await secondThunk;
+
+  rejectFirst!(new Error('stale failure'));
+  await firstThunk;
+
+  const compatibilityActions = getCompatibilityActions(dispatch);
+
+  expect(compatibilityActions).not.toContainEqual(
+    expect.objectContaining({ compatibility: { status: 'failed' } }),
   );
-  expect(successfulActions).not.toContainEqual(
-    expect.objectContaining({
-      compatibleMetrics: ['m1'],
-      compatibleDimensions: ['d1'],
-      compatibilityLoading: false,
-    }),
-  );
+  expect(compatibilityActions[compatibilityActions.length - 1]).toEqual({
+    type: actions.SET_COMPATIBILITY,
+    compatibility: {
+      status: 'verified',
+      metrics: ['m2'],
+      dimensions: ['d2'],
+    },
+  });
 
   postSpy.mockRestore();
 });

--- a/superset-frontend/src/explore/actions/exploreActions.test.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.test.ts
@@ -310,12 +310,7 @@ test('fetchCompatibility keeps empty verified arrays distinct from idle and fail
     },
   } as never);
 
-  await actions.fetchCompatibility(
-    'semantic_view',
-    7,
-    [],
-    [],
-  )(dispatch as any);
+  await actions.fetchCompatibility('semantic_view', 7, [], [])(dispatch as any);
 
   expect(getCompatibilityActions(dispatch)).toContainEqual({
     type: actions.SET_COMPATIBILITY,

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -27,7 +27,7 @@ import {
   toastActions,
 } from 'src/components/MessageToasts/actions';
 import { Slice } from 'src/types/Chart';
-import { SaveActionType } from 'src/explore/types';
+import { CompatibilityResult, SaveActionType } from 'src/explore/types';
 
 export const UPDATE_FORM_DATA_BY_DATASOURCE = 'UPDATE_FORM_DATA_BY_DATASOURCE';
 export function updateFormDataByDatasource(
@@ -182,12 +182,8 @@ export function updateExploreChartState(
 }
 
 export const SET_COMPATIBILITY = 'SET_COMPATIBILITY';
-export function setCompatibility(payload: {
-  compatibleMetrics: string[] | null;
-  compatibleDimensions: string[] | null;
-  compatibilityLoading: boolean;
-}) {
-  return { type: SET_COMPATIBILITY, ...payload };
+export function setCompatibility(compatibility: CompatibilityResult) {
+  return { type: SET_COMPATIBILITY, compatibility };
 }
 
 let compatibilityRequestSeq = 0;
@@ -213,23 +209,11 @@ export function fetchCompatibility(
     const requestSeq = compatibilityRequestSeq;
 
     if (datasourceType !== 'semantic_view') {
-      dispatch(
-        setCompatibility({
-          compatibleMetrics: null,
-          compatibleDimensions: null,
-          compatibilityLoading: false,
-        }),
-      );
+      dispatch(setCompatibility({ status: 'idle' }));
       return;
     }
 
-    dispatch(
-      setCompatibility({
-        compatibleMetrics: null,
-        compatibleDimensions: null,
-        compatibilityLoading: true,
-      }),
-    );
+    dispatch(setCompatibility({ status: 'loading' }));
 
     try {
       const { json } = await SupersetClient.post({
@@ -244,23 +228,19 @@ export function fetchCompatibility(
       }
       dispatch(
         setCompatibility({
-          compatibleMetrics: json.result.compatible_metrics,
-          compatibleDimensions: json.result.compatible_dimensions,
-          compatibilityLoading: false,
+          status: 'verified',
+          metrics: json.result.compatible_metrics ?? [],
+          dimensions: json.result.compatible_dimensions ?? [],
         }),
       );
     } catch {
-      // On error fall back to no filtering so the user is never blocked.
+      // A failed request must stay distinguishable from loading and from a
+      // valid empty result; consumers fall back to no filtering so the user
+      // is never blocked.
       if (requestSeq !== compatibilityRequestSeq) {
         return;
       }
-      dispatch(
-        setCompatibility({
-          compatibleMetrics: null,
-          compatibleDimensions: null,
-          compatibilityLoading: false,
-        }),
-      );
+      dispatch(setCompatibility({ status: 'failed' }));
     }
   };
 }

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -27,7 +27,7 @@ import {
   toastActions,
 } from 'src/components/MessageToasts/actions';
 import { Slice } from 'src/types/Chart';
-import { SaveActionType } from 'src/explore/types';
+import { CompatibilityResult, SaveActionType } from 'src/explore/types';
 
 export const UPDATE_FORM_DATA_BY_DATASOURCE = 'UPDATE_FORM_DATA_BY_DATASOURCE';
 export function updateFormDataByDatasource(
@@ -167,12 +167,8 @@ export function updateExploreChartState(
 }
 
 export const SET_COMPATIBILITY = 'SET_COMPATIBILITY';
-export function setCompatibility(payload: {
-  compatibleMetrics: string[] | null;
-  compatibleDimensions: string[] | null;
-  compatibilityLoading: boolean;
-}) {
-  return { type: SET_COMPATIBILITY, ...payload };
+export function setCompatibility(compatibility: CompatibilityResult) {
+  return { type: SET_COMPATIBILITY, compatibility };
 }
 
 let compatibilityRequestSeq = 0;
@@ -198,23 +194,11 @@ export function fetchCompatibility(
     const requestSeq = compatibilityRequestSeq;
 
     if (datasourceType !== 'semantic_view') {
-      dispatch(
-        setCompatibility({
-          compatibleMetrics: null,
-          compatibleDimensions: null,
-          compatibilityLoading: false,
-        }),
-      );
+      dispatch(setCompatibility({ status: 'idle' }));
       return;
     }
 
-    dispatch(
-      setCompatibility({
-        compatibleMetrics: null,
-        compatibleDimensions: null,
-        compatibilityLoading: true,
-      }),
-    );
+    dispatch(setCompatibility({ status: 'loading' }));
 
     try {
       const { json } = await SupersetClient.post({
@@ -229,23 +213,19 @@ export function fetchCompatibility(
       }
       dispatch(
         setCompatibility({
-          compatibleMetrics: json.result.compatible_metrics,
-          compatibleDimensions: json.result.compatible_dimensions,
-          compatibilityLoading: false,
+          status: 'verified',
+          metrics: json.result.compatible_metrics ?? [],
+          dimensions: json.result.compatible_dimensions ?? [],
         }),
       );
     } catch {
-      // On error fall back to no filtering so the user is never blocked.
+      // A failed request must stay distinguishable from loading and from a
+      // valid empty result; consumers fall back to no filtering so the user
+      // is never blocked.
       if (requestSeq !== compatibilityRequestSeq) {
         return;
       }
-      dispatch(
-        setCompatibility({
-          compatibleMetrics: null,
-          compatibleDimensions: null,
-          compatibilityLoading: false,
-        }),
-      );
+      dispatch(setCompatibility({ status: 'failed' }));
     }
   };
 }

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/DatasourcePanelDragOption.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/DatasourcePanelDragOption.test.tsx
@@ -34,3 +34,77 @@ test('should render', async () => {
   ).toBeInTheDocument();
   expect(screen.getByText('test')).toBeInTheDocument();
 });
+
+test('prevents dragging a metric absent from a verified compatibility result', async () => {
+  render(
+    <DatasourcePanelDragOption
+      value={{ metric_name: 'test', uuid: '1' }}
+      type={DndItemType.Metric}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: {
+        explore: {
+          compatibility: {
+            status: 'verified',
+            metrics: ['other_metric'],
+            dimensions: [],
+          },
+        },
+      },
+    },
+  );
+
+  expect(await screen.findByTestId('DatasourcePanelDragOption')).toHaveStyle({
+    cursor: 'not-allowed',
+  });
+});
+
+test('keeps a column draggable when it appears in the verified dimensions', async () => {
+  render(
+    <DatasourcePanelDragOption
+      value={{ column_name: 'd1' }}
+      type={DndItemType.Column}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: {
+        explore: {
+          compatibility: {
+            status: 'verified',
+            metrics: [],
+            dimensions: ['d1'],
+          },
+        },
+      },
+    },
+  );
+
+  expect(
+    await screen.findByTestId('DatasourcePanelDragOption'),
+  ).not.toHaveStyle({ cursor: 'not-allowed' });
+});
+
+test.each([
+  [{ status: 'idle' }],
+  [{ status: 'loading' }],
+  [{ status: 'failed' }],
+])('applies no filtering for the %o compatibility state', async state => {
+  render(
+    <DatasourcePanelDragOption
+      value={{ metric_name: 'test', uuid: '1' }}
+      type={DndItemType.Metric}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: { explore: { compatibility: state } },
+    },
+  );
+
+  expect(
+    await screen.findByTestId('DatasourcePanelDragOption'),
+  ).not.toHaveStyle({ cursor: 'not-allowed' });
+});

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
@@ -28,7 +28,10 @@ import {
   StyledMetricOption,
 } from 'src/explore/components/optionRenderers';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { ExplorePageState } from 'src/explore/types';
+import {
+  selectCompatibleDimensionNames,
+  selectCompatibleMetricNames,
+} from 'src/explore/selectors/compatibility';
 
 import { DatasourcePanelDndItem } from '../types';
 
@@ -76,15 +79,10 @@ export default function DatasourcePanelDragOption(
   const theme = useTheme();
 
   // Read compatibility lists from Redux.
-  // `null` means no filtering is active (SQL datasets, or no selection yet).
-  const compatibleMetrics = useSelector<
-    ExplorePageState,
-    string[] | null | undefined
-  >(state => state.explore.compatibleMetrics);
-  const compatibleDimensions = useSelector<
-    ExplorePageState,
-    string[] | null | undefined
-  >(state => state.explore.compatibleDimensions);
+  // `null` means no filtering is active (SQL datasets, no selection yet, or
+  // an unresolved/failed compatibility request).
+  const compatibleMetrics = useSelector(selectCompatibleMetricNames);
+  const compatibleDimensions = useSelector(selectCompatibleDimensionNames);
 
   // An item is compatible when the list is null (no filter) or when its
   // name explicitly appears in the list returned by the backend.

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -700,3 +700,90 @@ test('default routing skips a disabled Simple mode for non-semantic datasources'
     'true',
   );
 });
+
+test('a feature-declaring semantic view keeps expression-based classification and Save', async () => {
+  const onChange = jest.fn();
+  const columns = [
+    { column_name: 'plain_dimension', verbose_name: 'Plain Dimension' },
+    { column_name: 'calc_dimension', expression: 'a + b' },
+  ];
+  const store = mockStore({
+    explore: {
+      datasource: {
+        type: 'semantic_view',
+        semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+      },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={columns}
+      getCurrentTab={jest.fn()}
+      onChange={onChange}
+    />,
+    { store },
+  );
+
+  // Simple keeps the expression-less column; Saved keeps the calculated one.
+  const simpleCombobox = screen.getByRole('combobox', {
+    name: 'Columns and metrics',
+  });
+  userEvent.click(simpleCombobox);
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Plain Dimension')).toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('calc_dimension'),
+  ).not.toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Plain Dimension'));
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(columns[0]);
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+});
+
+test('non-semantic datasources still filter Saved options by compatibility metadata only when verified', () => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'table' },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['keep_me'],
+      },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'keep_me' }, { column_name: 'drop_me' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Columns and metrics' }),
+  );
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(
+    within(dropdown).getByText('keep_me').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+  expect(
+    within(dropdown).getByText('drop_me').closest('.ant-select-item'),
+  ).toHaveClass('ant-select-item-option-disabled');
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -511,7 +511,7 @@ test('a failed compatibility request shows a non-blocking warning and unfiltered
     },
   );
 
-  expect(screen.getByRole('status')).toHaveTextContent(
+  expect(screen.getByRole('alert')).toHaveTextContent(
     /could not verify|compatib/i,
   );
 
@@ -533,7 +533,7 @@ test('a loading compatibility request shows neither warning nor a filtered list'
     },
   );
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
   openDimensionsDropdown();
   expect(getOptionItem('Order Date')).not.toHaveClass(
@@ -563,7 +563,7 @@ test('non-semantic datasources never show the compatibility failure warning', ()
     { store },
   );
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
 
 test('an edited dimension that became incompatible cannot be saved until replaced', async () => {
@@ -735,7 +735,7 @@ test('a feature-declaring semantic view keeps expression-based classification an
     name: 'Columns and metrics',
   });
   userEvent.click(simpleCombobox);
-  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
   expect(within(dropdown).getByText('Plain Dimension')).toBeInTheDocument();
   expect(
     within(dropdown).queryByText('calc_dimension'),
@@ -747,7 +747,7 @@ test('a feature-declaring semantic view keeps expression-based classification an
   userEvent.click(saveButton);
   expect(onChange).toHaveBeenCalledWith(columns[0]);
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
 
 test('non-semantic datasources still filter Saved options by compatibility metadata only when verified', () => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -643,6 +643,68 @@ test('a legacy edited adhoc value opens Saved, stays inspectable, and blocks Sav
   expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
 });
 
+const SEMANTIC_METRICS = [
+  {
+    metric_name: 'total_sales',
+    verbose_name: 'Total Sales',
+    expression: 'SUM(sales)',
+    uuid: 'm1',
+  },
+  {
+    metric_name: 'tax_amount',
+    verbose_name: 'Tax Amount',
+    expression: 'SUM(tax)',
+    uuid: 'm2',
+  },
+];
+
+test('disables Saved metrics by the compatible-metric list, not the dimension list', () => {
+  // Adversarial fixture: the dimension list contains the OTHER metric name, so
+  // keying metric options off compatible dimensions inverts both outcomes.
+  renderSemanticPopover(
+    {
+      metrics: SEMANTIC_METRICS,
+      selectedMetrics: ['total_sales', 'tax_amount'],
+    },
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: {
+        status: 'verified',
+        metrics: ['total_sales'],
+        dimensions: ['tax_amount', 'order_date'],
+      },
+    },
+  );
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Dimensions and metrics',
+  });
+  userEvent.click(combobox);
+
+  expect(getOptionItem('Total Sales')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Tax Amount')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a metrics-only semantic view still renders the Saved select', () => {
+  renderSemanticPopover({
+    columns: [],
+    metrics: SEMANTIC_METRICS,
+    selectedMetrics: ['total_sales', 'tax_amount'],
+  });
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Dimensions and metrics',
+  });
+  userEvent.click(combobox);
+
+  expect(getOptionItem('Total Sales')).toBeInTheDocument();
+  expect(getOptionItem('Tax Amount')).toBeInTheDocument();
+});
+
 test('table datasources keep expression-based classification and enabled modes', async () => {
   const store = mockStore({ explore: { datasource: { type: 'table' } } });
   render(

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -463,6 +463,59 @@ test('reopens an existing semantic dimension on Saved with the item selected', (
   ).toBeInTheDocument();
 });
 
+test('clearing the Saved-only dimension resets the selection', async () => {
+  // In Saved-only mode Simple and Custom SQL are disabled, so the Saved
+  // picker's clear (×) is the user's only reset control. It must actually
+  // reset — antd fires onChange(undefined), which onSavedItemChange now maps
+  // to a full reset (clearing the label back to '').
+  const setLabel = jest.fn();
+  renderSemanticPopover({ editedColumn: SEMANTIC_COLUMNS[1], setLabel });
+
+  const savedPanel = screen.getByRole('tabpanel', { name: 'Saved' });
+  const clearButton = savedPanel.querySelector(
+    '.ant-select-clear',
+  ) as HTMLElement;
+  expect(clearButton).toBeInTheDocument();
+
+  userEvent.click(clearButton);
+
+  await waitFor(() => expect(setLabel).toHaveBeenCalledWith(''));
+});
+
+test('clearing the Simple-mode item resets the selection', async () => {
+  // onSimpleItemChange shares onSavedItemChange's clear branch; pin it too so
+  // the combined Simple picker's clear (×) can't regress independently.
+  const setLabel = jest.fn();
+  const columns = [{ column_name: 'year' }];
+  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel
+      isTemporal
+      label="Custom Label"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={setLabel}
+      columns={columns}
+      editedColumn={columns[0]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  const simplePanel = screen.getByRole('tabpanel', { name: 'Simple' });
+  const clearButton = simplePanel.querySelector(
+    '.ant-select-clear',
+  ) as HTMLElement;
+  expect(clearButton).toBeInTheDocument();
+
+  userEvent.click(clearButton);
+
+  await waitFor(() => expect(setLabel).toHaveBeenCalledWith(''));
+});
+
 test('disables Saved dimensions absent from a verified compatibility result', () => {
   renderSemanticPopover(
     {},

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -22,6 +22,7 @@ import {
   fireEvent,
   screen,
   userEvent,
+  waitFor,
   within,
 } from 'spec/helpers/testing-library';
 import configureMockStore from 'redux-mock-store';
@@ -316,4 +317,386 @@ test('Should filter saved expressions by column_name and verbose_name', async ()
   expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Tax Amount')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Discount Rate')).not.toBeInTheDocument();
+});
+
+const SEMANTIC_COLUMNS = [
+  { column_name: 'order_date', verbose_name: 'Order Date', is_dttm: true },
+  { column_name: 'category', verbose_name: 'Product Category' },
+  { column_name: 'region' },
+];
+
+const renderSemanticPopover = (
+  props: Partial<ColumnSelectPopoverProps> = {},
+  exploreState: Record<string, unknown> = {},
+) => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      ...exploreState,
+    },
+  });
+
+  return render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={SEMANTIC_COLUMNS}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+      {...props}
+    />,
+    { store },
+  );
+};
+
+const openDimensionsDropdown = () => {
+  const combobox = screen.getByRole('combobox', { name: 'Dimensions' });
+  userEvent.click(combobox);
+  return combobox;
+};
+
+const getOptionItem = (label: string) => {
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  return within(dropdown).getByText(label).closest('.ant-select-item');
+};
+
+test('saved-only semantic view opens on Saved with Simple and Custom SQL disabled', () => {
+  const getCurrentTab = jest.fn();
+  renderSemanticPopover({ getCurrentTab });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(getCurrentTab).toHaveBeenCalledWith('saved');
+});
+
+test('semantic view declaring adhoc expressions keeps the existing default mode', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: {
+        type: 'semantic_view',
+        semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+      },
+    },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('lists every expression-less dimension as a Saved option without mutating metadata', async () => {
+  const onChange = jest.fn();
+  renderSemanticPopover({ onChange });
+
+  openDimensionsDropdown();
+
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Order Date')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  expect(within(dropdown).getByText('region')).toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Order Date'));
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('searches Saved dimensions by name and verbose name', async () => {
+  renderSemanticPopover();
+
+  const combobox = openDimensionsDropdown();
+  await userEvent.type(combobox, 'Product');
+
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Order Date')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('region')).not.toBeInTheDocument();
+
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, 'region');
+
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('region')).toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('Product Category'),
+  ).not.toBeInTheDocument();
+});
+
+test('reopens an existing semantic dimension on Saved with the item selected', () => {
+  renderSemanticPopover({ editedColumn: SEMANTIC_COLUMNS[1] });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(
+    within(screen.getByRole('tabpanel', { name: 'Saved' })).getByText(
+      'Product Category',
+    ),
+  ).toBeInTheDocument();
+});
+
+test('disables Saved dimensions absent from a verified compatibility result', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['order_date'],
+      },
+    },
+  );
+
+  openDimensionsDropdown();
+
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('region')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a verified empty compatibility result disables every Saved dimension', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'verified', metrics: [], dimensions: [] },
+    },
+  );
+
+  openDimensionsDropdown();
+
+  expect(getOptionItem('Order Date')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a failed compatibility request shows a non-blocking warning and unfiltered options', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'failed' },
+    },
+  );
+
+  expect(screen.getByRole('status')).toHaveTextContent(
+    /could not verify|compatib/i,
+  );
+
+  openDimensionsDropdown();
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a loading compatibility request shows neither warning nor a filtered list', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'loading' },
+    },
+  );
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+  openDimensionsDropdown();
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('non-semantic datasources never show the compatibility failure warning', () => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'table' },
+      compatibility: { status: 'failed' },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'year' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+});
+
+test('an edited dimension that became incompatible cannot be saved until replaced', async () => {
+  const onChange = jest.fn();
+  renderSemanticPopover(
+    { onChange, editedColumn: SEMANTIC_COLUMNS[1] },
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['order_date'],
+      },
+    },
+  );
+
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  expect(saveButton).toBeDisabled();
+
+  const feedback = screen.getByRole('status');
+  expect(feedback).toHaveTextContent(/compatible/i);
+  expect(feedback.id).toBeTruthy();
+  expect(saveButton).toHaveAttribute('aria-describedby', feedback.id);
+
+  openDimensionsDropdown();
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  userEvent.click(within(dropdown).getByText('Order Date'));
+
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('a legacy edited adhoc value opens Saved, stays inspectable, and blocks Save until replaced', async () => {
+  const onChange = jest.fn();
+  const legacyValue = {
+    label: 'Legacy value',
+    sqlExpression: "state || '_legacy'",
+    expressionType: 'SQL' as const,
+  };
+  renderSemanticPopover({ onChange, editedColumn: legacyValue });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  expect(saveButton).toBeDisabled();
+  const feedback = screen.getByRole('status');
+  expect(saveButton).toHaveAttribute('aria-describedby', feedback.id);
+
+  // The legacy value is preserved for inspection, not translated or dropped.
+  const customSqlTab = screen.getByRole('tab', { name: 'Custom SQL' });
+  expect(customSqlTab).not.toHaveAttribute('aria-disabled', 'true');
+  fireEvent.click(customSqlTab);
+  expect(screen.getByDisplayValue("state || '_legacy'")).toBeInTheDocument();
+
+  // Explicitly choosing a compatible dimension is the only way to save.
+  fireEvent.click(screen.getByRole('tab', { name: 'Saved' }));
+  openDimensionsDropdown();
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  userEvent.click(within(dropdown).getByText('Order Date'));
+
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('table datasources keep expression-based classification and enabled modes', async () => {
+  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[
+        { column_name: 'plain_col' },
+        { column_name: 'calc_col', expression: 'a + b' },
+      ]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Columns and metrics',
+  });
+  userEvent.click(combobox);
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('plain_col')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('calc_col')).not.toBeInTheDocument();
+});
+
+test('default routing skips a disabled Simple mode for non-semantic datasources', () => {
+  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'year' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+      disabledTabs={new Set(['simple'])}
+    />,
+    { store },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -359,7 +359,9 @@ const openDimensionsDropdown = () => {
 };
 
 const getOptionItem = (label: string) => {
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   return within(dropdown).getByText(label).closest('.ant-select-item');
 };
 
@@ -409,7 +411,9 @@ test('lists every expression-less dimension as a Saved option without mutating m
 
   openDimensionsDropdown();
 
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   expect(within(dropdown).getByText('Order Date')).toBeInTheDocument();
   expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
   expect(within(dropdown).getByText('region')).toBeInTheDocument();
@@ -428,7 +432,9 @@ test('searches Saved dimensions by name and verbose name', async () => {
   const combobox = openDimensionsDropdown();
   await userEvent.type(combobox, 'Product');
 
-  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  let dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
   expect(within(dropdown).queryByText('Order Date')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('region')).not.toBeInTheDocument();
@@ -436,7 +442,7 @@ test('searches Saved dimensions by name and verbose name', async () => {
   await userEvent.clear(combobox);
   await userEvent.type(combobox, 'region');
 
-  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  dropdown = document.querySelector('.ant-select-dropdown-list') as HTMLElement;
   expect(within(dropdown).getByText('region')).toBeInTheDocument();
   expect(
     within(dropdown).queryByText('Product Category'),
@@ -589,7 +595,9 @@ test('an edited dimension that became incompatible cannot be saved until replace
   expect(saveButton).toHaveAttribute('aria-describedby', feedback.id);
 
   openDimensionsDropdown();
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   userEvent.click(within(dropdown).getByText('Order Date'));
 
   await waitFor(() => expect(saveButton).toBeEnabled());
@@ -625,7 +633,9 @@ test('a legacy edited adhoc value opens Saved, stays inspectable, and blocks Sav
   // Explicitly choosing a compatible dimension is the only way to save.
   fireEvent.click(screen.getByRole('tab', { name: 'Saved' }));
   openDimensionsDropdown();
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   userEvent.click(within(dropdown).getByText('Order Date'));
 
   await waitFor(() => expect(saveButton).toBeEnabled());
@@ -669,7 +679,9 @@ test('table datasources keep expression-based classification and enabled modes',
     name: 'Columns and metrics',
   });
   userEvent.click(combobox);
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   expect(within(dropdown).getByText('plain_col')).toBeInTheDocument();
   expect(within(dropdown).queryByText('calc_col')).not.toBeInTheDocument();
 });
@@ -735,7 +747,9 @@ test('a feature-declaring semantic view keeps expression-based classification an
     name: 'Columns and metrics',
   });
   userEvent.click(simpleCombobox);
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   expect(within(dropdown).getByText('Plain Dimension')).toBeInTheDocument();
   expect(
     within(dropdown).queryByText('calc_dimension'),
@@ -779,7 +793,9 @@ test('non-semantic datasources still filter Saved options by compatibility metad
   userEvent.click(
     screen.getByRole('combobox', { name: 'Columns and metrics' }),
   );
-  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
   expect(
     within(dropdown).getByText('keep_me').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -696,3 +696,90 @@ test('default routing skips a disabled Simple mode for non-semantic datasources'
     'true',
   );
 });
+
+test('a feature-declaring semantic view keeps expression-based classification and Save', async () => {
+  const onChange = jest.fn();
+  const columns = [
+    { column_name: 'plain_dimension', verbose_name: 'Plain Dimension' },
+    { column_name: 'calc_dimension', expression: 'a + b' },
+  ];
+  const store = mockStore({
+    explore: {
+      datasource: {
+        type: 'semantic_view',
+        semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+      },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={columns}
+      getCurrentTab={jest.fn()}
+      onChange={onChange}
+    />,
+    { store },
+  );
+
+  // Simple keeps the expression-less column; Saved keeps the calculated one.
+  const simpleCombobox = screen.getByRole('combobox', {
+    name: 'Columns and metrics',
+  });
+  userEvent.click(simpleCombobox);
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Plain Dimension')).toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('calc_dimension'),
+  ).not.toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Plain Dimension'));
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(columns[0]);
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+});
+
+test('non-semantic datasources still filter Saved options by compatibility metadata only when verified', () => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'table' },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['keep_me'],
+      },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'keep_me' }, { column_name: 'drop_me' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Columns and metrics' }),
+  );
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(
+    within(dropdown).getByText('keep_me').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+  expect(
+    within(dropdown).getByText('drop_me').closest('.ant-select-item'),
+  ).toHaveClass('ant-select-item-option-disabled');
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -22,6 +22,7 @@ import {
   fireEvent,
   screen,
   userEvent,
+  waitFor,
   within,
 } from 'spec/helpers/testing-library';
 import configureMockStore from 'redux-mock-store';
@@ -312,4 +313,386 @@ test('Should filter saved expressions by column_name and verbose_name', async ()
   expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Tax Amount')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Discount Rate')).not.toBeInTheDocument();
+});
+
+const SEMANTIC_COLUMNS = [
+  { column_name: 'order_date', verbose_name: 'Order Date', is_dttm: true },
+  { column_name: 'category', verbose_name: 'Product Category' },
+  { column_name: 'region' },
+];
+
+const renderSemanticPopover = (
+  props: Partial<ColumnSelectPopoverProps> = {},
+  exploreState: Record<string, unknown> = {},
+) => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      ...exploreState,
+    },
+  });
+
+  return render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={SEMANTIC_COLUMNS}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+      {...props}
+    />,
+    { store },
+  );
+};
+
+const openDimensionsDropdown = () => {
+  const combobox = screen.getByRole('combobox', { name: 'Dimensions' });
+  userEvent.click(combobox);
+  return combobox;
+};
+
+const getOptionItem = (label: string) => {
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  return within(dropdown).getByText(label).closest('.ant-select-item');
+};
+
+test('saved-only semantic view opens on Saved with Simple and Custom SQL disabled', () => {
+  const getCurrentTab = jest.fn();
+  renderSemanticPopover({ getCurrentTab });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(getCurrentTab).toHaveBeenCalledWith('saved');
+});
+
+test('semantic view declaring adhoc expressions keeps the existing default mode', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: {
+        type: 'semantic_view',
+        semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+      },
+    },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('lists every expression-less dimension as a Saved option without mutating metadata', async () => {
+  const onChange = jest.fn();
+  renderSemanticPopover({ onChange });
+
+  openDimensionsDropdown();
+
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Order Date')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  expect(within(dropdown).getByText('region')).toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Order Date'));
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('searches Saved dimensions by name and verbose name', async () => {
+  renderSemanticPopover();
+
+  const combobox = openDimensionsDropdown();
+  await userEvent.type(combobox, 'Product');
+
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Order Date')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('region')).not.toBeInTheDocument();
+
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, 'region');
+
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('region')).toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('Product Category'),
+  ).not.toBeInTheDocument();
+});
+
+test('reopens an existing semantic dimension on Saved with the item selected', () => {
+  renderSemanticPopover({ editedColumn: SEMANTIC_COLUMNS[1] });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(
+    within(screen.getByRole('tabpanel', { name: 'Saved' })).getByText(
+      'Product Category',
+    ),
+  ).toBeInTheDocument();
+});
+
+test('disables Saved dimensions absent from a verified compatibility result', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['order_date'],
+      },
+    },
+  );
+
+  openDimensionsDropdown();
+
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('region')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a verified empty compatibility result disables every Saved dimension', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'verified', metrics: [], dimensions: [] },
+    },
+  );
+
+  openDimensionsDropdown();
+
+  expect(getOptionItem('Order Date')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a failed compatibility request shows a non-blocking warning and unfiltered options', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'failed' },
+    },
+  );
+
+  expect(screen.getByRole('status')).toHaveTextContent(
+    /could not verify|compatib/i,
+  );
+
+  openDimensionsDropdown();
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(getOptionItem('Product Category')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('a loading compatibility request shows neither warning nor a filtered list', () => {
+  renderSemanticPopover(
+    {},
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: { status: 'loading' },
+    },
+  );
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+  openDimensionsDropdown();
+  expect(getOptionItem('Order Date')).not.toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+});
+
+test('non-semantic datasources never show the compatibility failure warning', () => {
+  const store = mockStore({
+    explore: {
+      datasource: { type: 'table' },
+      compatibility: { status: 'failed' },
+    },
+  });
+
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'year' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+});
+
+test('an edited dimension that became incompatible cannot be saved until replaced', async () => {
+  const onChange = jest.fn();
+  renderSemanticPopover(
+    { onChange, editedColumn: SEMANTIC_COLUMNS[1] },
+    {
+      datasource: { type: 'semantic_view', semantic_view_features: [] },
+      compatibility: {
+        status: 'verified',
+        metrics: [],
+        dimensions: ['order_date'],
+      },
+    },
+  );
+
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  expect(saveButton).toBeDisabled();
+
+  const feedback = screen.getByRole('status');
+  expect(feedback).toHaveTextContent(/compatible/i);
+  expect(feedback.id).toBeTruthy();
+  expect(saveButton).toHaveAttribute('aria-describedby', feedback.id);
+
+  openDimensionsDropdown();
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  userEvent.click(within(dropdown).getByText('Order Date'));
+
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('a legacy edited adhoc value opens Saved, stays inspectable, and blocks Save until replaced', async () => {
+  const onChange = jest.fn();
+  const legacyValue = {
+    label: 'Legacy value',
+    sqlExpression: "state || '_legacy'",
+    expressionType: 'SQL' as const,
+  };
+  renderSemanticPopover({ onChange, editedColumn: legacyValue });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+
+  const saveButton = screen.getByTestId('ColumnEdit#save');
+  expect(saveButton).toBeDisabled();
+  const feedback = screen.getByRole('status');
+  expect(saveButton).toHaveAttribute('aria-describedby', feedback.id);
+
+  // The legacy value is preserved for inspection, not translated or dropped.
+  const customSqlTab = screen.getByRole('tab', { name: 'Custom SQL' });
+  expect(customSqlTab).not.toHaveAttribute('aria-disabled', 'true');
+  fireEvent.click(customSqlTab);
+  expect(screen.getByDisplayValue("state || '_legacy'")).toBeInTheDocument();
+
+  // Explicitly choosing a compatible dimension is the only way to save.
+  fireEvent.click(screen.getByRole('tab', { name: 'Saved' }));
+  openDimensionsDropdown();
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  userEvent.click(within(dropdown).getByText('Order Date'));
+
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+  expect(onChange).toHaveBeenCalledWith(SEMANTIC_COLUMNS[0]);
+});
+
+test('table datasources keep expression-based classification and enabled modes', async () => {
+  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[
+        { column_name: 'plain_col' },
+        { column_name: 'calc_col', expression: 'a + b' },
+      ]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+    />,
+    { store },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Columns and metrics',
+  });
+  userEvent.click(combobox);
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('plain_col')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('calc_col')).not.toBeInTheDocument();
+});
+
+test('default routing skips a disabled Simple mode for non-semantic datasources', () => {
+  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+  render(
+    <ColumnSelectPopover
+      hasCustomLabel={false}
+      label="My column"
+      onClose={jest.fn()}
+      setDatasetModal={jest.fn()}
+      setLabel={jest.fn()}
+      columns={[{ column_name: 'year' }]}
+      getCurrentTab={jest.fn()}
+      onChange={jest.fn()}
+      disabledTabs={new Set(['simple'])}
+    />,
+    { store },
+  );
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -507,7 +507,7 @@ test('a failed compatibility request shows a non-blocking warning and unfiltered
     },
   );
 
-  expect(screen.getByRole('status')).toHaveTextContent(
+  expect(screen.getByRole('alert')).toHaveTextContent(
     /could not verify|compatib/i,
   );
 
@@ -529,7 +529,7 @@ test('a loading compatibility request shows neither warning nor a filtered list'
     },
   );
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
   openDimensionsDropdown();
   expect(getOptionItem('Order Date')).not.toHaveClass(
@@ -559,7 +559,7 @@ test('non-semantic datasources never show the compatibility failure warning', ()
     { store },
   );
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
 
 test('an edited dimension that became incompatible cannot be saved until replaced', async () => {
@@ -731,7 +731,7 @@ test('a feature-declaring semantic view keeps expression-based classification an
     name: 'Columns and metrics',
   });
   userEvent.click(simpleCombobox);
-  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  const dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
   expect(within(dropdown).getByText('Plain Dimension')).toBeInTheDocument();
   expect(
     within(dropdown).queryByText('calc_dimension'),
@@ -743,7 +743,7 @@ test('a feature-declaring semantic view keeps expression-based classification an
   userEvent.click(saveButton);
   expect(onChange).toHaveBeenCalledWith(columns[0]);
 
-  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
 
 test('non-semantic datasources still filter Saved options by compatibility metadata only when verified', () => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -37,8 +37,13 @@ import {
   QueryFormMetric,
 } from '@superset-ui/core';
 import { styled, css } from '@apache-superset/core/theme';
-import { ColumnMeta, isSavedExpression } from '@superset-ui/chart-controls';
+import {
+  ColumnMeta,
+  Dataset,
+  isSavedExpression,
+} from '@superset-ui/chart-controls';
 import Tabs from '@superset-ui/core/components/Tabs';
+import { Alert } from '@apache-superset/core/components';
 import {
   Button,
   Form,
@@ -56,8 +61,12 @@ import {
   POPOVER_INITIAL_WIDTH,
 } from 'src/explore/constants';
 import { ExplorePageState } from 'src/explore/types';
-import { selectCompatibleDimensionNames } from 'src/explore/selectors/compatibility';
+import {
+  selectCompatibility,
+  selectCompatibleDimensionNames,
+} from 'src/explore/selectors/compatibility';
 import useResizeButton from './useResizeButton';
+import { getColumnPickerCapabilities } from './utils/pickerCapabilities';
 
 const TABS_KEYS = {
   SAVED: 'saved',
@@ -115,11 +124,14 @@ export interface ColumnSelectPopoverProps {
   disabledTabs?: Set<string>;
   metrics?: Metric[];
   selectedMetrics?: QueryFormMetric[];
-  datasource?: any;
+  datasource?: Dataset | null;
 }
 
+const INVALID_SELECTION_FEEDBACK_ID = 'column-select-invalid-selection';
+
 const getInitialColumnValues = (
-  editedColumn?: ColumnMeta | AdhocColumn,
+  editedColumn: ColumnMeta | AdhocColumn | undefined,
+  savedClassification: boolean,
 ): [AdhocColumn?, ColumnMeta?, ColumnMeta?] => {
   if (!editedColumn) {
     return [undefined, undefined, undefined];
@@ -127,7 +139,9 @@ const getInitialColumnValues = (
   if (isAdhocColumn(editedColumn)) {
     return [editedColumn, undefined, undefined];
   }
-  if (isSavedExpression(editedColumn)) {
+  // With Saved classification every datasource dimension is a Saved option,
+  // so an edited dimension reopens on the Saved tab.
+  if (isSavedExpression(editedColumn) || savedClassification) {
     return [undefined, editedColumn, undefined];
   }
   return [undefined, undefined, editedColumn];
@@ -150,13 +164,21 @@ const ColumnSelectPopover = ({
   datasource,
 }: ColumnSelectPopoverProps) => {
   // const theme = useTheme(); // Unused variable
-  const datasourceType = useSelector<ExplorePageState, string | undefined>(
-    state => state.explore.datasource.type,
+  const reduxDatasource = useSelector<
+    ExplorePageState,
+    ExplorePageState['explore']['datasource'] | undefined
+  >(state => state.explore.datasource);
+  const datasourceType = reduxDatasource?.type;
+  const capabilities = useMemo(
+    () => getColumnPickerCapabilities(reduxDatasource),
+    [reduxDatasource],
   );
+  const savedClassification = capabilities.dimensionClassification === 'saved';
+  const compatibility = useSelector(selectCompatibility);
   const compatibleDimensions = useSelector(selectCompatibleDimensionNames);
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =
-    getInitialColumnValues(editedColumn);
+    getInitialColumnValues(editedColumn, savedClassification);
 
   const [adhocColumn, setAdhocColumn] = useState<AdhocColumn | undefined>(
     initialAdhocColumn,
@@ -182,7 +204,9 @@ const ColumnSelectPopover = ({
   const [calculatedColumns, simpleColumns] = useMemo(() => {
     const [calc, simple] = (columns ?? []).reduce(
       (acc: [ColumnMeta[], ColumnMeta[]], column: ColumnMeta) => {
-        if (column.expression) {
+        // Saved classification presents every dimension as a Saved option
+        // without requiring (or mutating) an expression on its metadata.
+        if (savedClassification || column.expression) {
           acc[0].push(column);
         } else {
           acc[1].push(column);
@@ -194,7 +218,7 @@ const ColumnSelectPopover = ({
     const alpha = (a: ColumnMeta, b: ColumnMeta) =>
       (a.column_name ?? '').localeCompare(b.column_name ?? '');
     return [calc.sort(alpha), simple.sort(alpha)];
-  }, [columns]);
+  }, [columns, savedClassification]);
 
   // Filter metrics that are already selected in the chart
   const availableMetrics = useMemo(() => {
@@ -289,11 +313,34 @@ const ColumnSelectPopover = ({
     [columnMap, metricMap, onSimpleColumnChange, onSimpleMetricChange],
   );
 
-  const defaultActiveTabKey = initialAdhocColumn
-    ? 'sqlExpression'
+  const effectiveDisabledTabs = useMemo(() => {
+    const merged = new Set([...disabledTabs, ...capabilities.disabledModes]);
+    // A legacy adhoc value must stay inspectable: keep Custom SQL reachable
+    // for viewing even though such a value can no longer be saved.
+    if (initialAdhocColumn && savedClassification) {
+      merged.delete(TABS_KEYS.SQL_EXPRESSION);
+    }
+    return merged;
+  }, [
+    disabledTabs,
+    capabilities.disabledModes,
+    initialAdhocColumn,
+    savedClassification,
+  ]);
+
+  const preferredTabKey = initialAdhocColumn
+    ? savedClassification
+      ? // A legacy adhoc value cannot be re-saved: open the supported mode.
+        'saved'
+      : 'sqlExpression'
     : selectedCalculatedColumn
       ? 'saved'
       : 'simple';
+  const defaultActiveTabKey = !effectiveDisabledTabs.has(preferredTabKey)
+    ? preferredTabKey
+    : ([TABS_KEYS.SAVED, TABS_KEYS.SIMPLE, TABS_KEYS.SQL_EXPRESSION].find(
+        key => !effectiveDisabledTabs.has(key),
+      ) ?? preferredTabKey);
 
   useEffect(() => {
     getCurrentTab(defaultActiveTabKey);
@@ -327,6 +374,11 @@ const ColumnSelectPopover = ({
   ]);
 
   const onSave = useCallback(() => {
+    // Saved-only datasources never commit adhoc values (legacy or edited);
+    // the Save button is disabled in that state, this is a guard.
+    if (savedClassification && adhocColumn) {
+      return;
+    }
     if (adhocColumn && adhocColumn.label !== label) {
       adhocColumn.label = label;
     }
@@ -343,6 +395,7 @@ const ColumnSelectPopover = ({
     label,
     onChange,
     onClose,
+    savedClassification,
     selectedCalculatedColumn,
     selectedSimpleColumn,
     selectedMetric,
@@ -390,7 +443,40 @@ const ColumnSelectPopover = ({
     selectedMetric?.metric_name !== undefined ||
     adhocColumn?.sqlExpression !== initialAdhocColumn?.sqlExpression;
 
-  const savedExpressionsLabel = t('Saved expressions');
+  // With Saved classification, a value that can no longer be committed keeps
+  // Save disabled until the user explicitly picks a compatible dimension.
+  const invalidSelectionFeedback = useMemo(() => {
+    if (!savedClassification) {
+      return null;
+    }
+    if (adhocColumn) {
+      return t(
+        'Custom column values are not supported here. Select a saved dimension to replace this value.',
+      );
+    }
+    if (
+      selectedCalculatedColumn &&
+      compatibleDimensions != null &&
+      !compatibleDimensions.includes(selectedCalculatedColumn.column_name)
+    ) {
+      return t(
+        'This dimension is not compatible with the current selections. Select a compatible dimension.',
+      );
+    }
+    return null;
+  }, [
+    savedClassification,
+    adhocColumn,
+    selectedCalculatedColumn,
+    compatibleDimensions,
+  ]);
+
+  const showCompatibilityFailureWarning =
+    capabilities.showCompatibilityFailure && compatibility.status === 'failed';
+
+  const savedExpressionsLabel = savedClassification
+    ? t('Dimensions')
+    : t('Saved expressions');
   const simpleColumnsLabel = t('Columns and metrics');
   const keywords = useMemo(
     () => sqlKeywords.concat(getColumnKeywords(columns)),
@@ -399,6 +485,18 @@ const ColumnSelectPopover = ({
 
   return (
     <Form layout="vertical" id="metrics-edit-popover">
+      {showCompatibilityFailureWarning && (
+        <Alert
+          role="status"
+          type="warning"
+          closable={false}
+          data-test="compatibility-failure-warning"
+        >
+          {t(
+            'Could not verify which dimensions are compatible. All dimensions are shown.',
+          )}
+        </Alert>
+      )}
       <Tabs
         id="adhoc-metric-edit-tabs"
         defaultActiveKey={defaultActiveTabKey}
@@ -411,7 +509,7 @@ const ColumnSelectPopover = ({
         `}
         items={[
           // Only show Saved tab if not disabled
-          ...(disabledTabs.has('saved')
+          ...(effectiveDisabledTabs.has('saved')
             ? []
             : [
                 {
@@ -444,6 +542,12 @@ const ColumnSelectPopover = ({
                                 column_name: calculatedColumn.column_name,
                                 verbose_name:
                                   calculatedColumn.verbose_name ?? '',
+                                disabled:
+                                  savedClassification &&
+                                  compatibleDimensions != null &&
+                                  !compatibleDimensions.includes(
+                                    calculatedColumn.column_name,
+                                  ),
                               }),
                             )}
                             optionFilterProps={['column_name', 'verbose_name']}
@@ -511,6 +615,7 @@ const ColumnSelectPopover = ({
           {
             key: TABS_KEYS.SIMPLE,
             label: t('Simple'),
+            disabled: effectiveDisabledTabs.has(TABS_KEYS.SIMPLE),
             children: (
               <>
                 {isTemporal && simpleColumns.length === 0 ? (
@@ -602,7 +707,7 @@ const ColumnSelectPopover = ({
           {
             key: TABS_KEYS.SQL_EXPRESSION,
             label: t('Custom SQL'),
-            disabled: disabledTabs.has('sqlExpression'),
+            disabled: effectiveDisabledTabs.has(TABS_KEYS.SQL_EXPRESSION),
             children: (
               <>
                 <SQLEditorWithValidation
@@ -631,6 +736,17 @@ const ColumnSelectPopover = ({
       />
 
       <div>
+        {invalidSelectionFeedback && (
+          <div
+            id={INVALID_SELECTION_FEEDBACK_ID}
+            role="status"
+            css={(theme: { colorErrorText: string }) => css`
+              color: ${theme.colorErrorText};
+            `}
+          >
+            {invalidSelectionFeedback}
+          </div>
+        )}
         <Button
           buttonSize="small"
           buttonStyle="secondary"
@@ -640,11 +756,18 @@ const ColumnSelectPopover = ({
           {t('Close')}
         </Button>
         <Button
-          disabled={!stateIsValid || !hasUnsavedChanges}
+          disabled={
+            !stateIsValid ||
+            !hasUnsavedChanges ||
+            Boolean(invalidSelectionFeedback)
+          }
           buttonStyle="primary"
           buttonSize="small"
           onClick={onSave}
           data-test="ColumnEdit#save"
+          aria-describedby={
+            invalidSelectionFeedback ? INVALID_SELECTION_FEEDBACK_ID : undefined
+          }
           cta
         >
           {t('Save')}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -509,8 +509,9 @@ const ColumnSelectPopover = ({
   return (
     <Form layout="vertical" id="metrics-edit-popover">
       {showCompatibilityFailureWarning && (
+        // Alert renders role="alert" with a polite live region, satisfying
+        // the accessible non-blocking feedback contract.
         <Alert
-          role="status"
           type="warning"
           closable={false}
           data-test="compatibility-failure-warning"
@@ -802,15 +803,17 @@ const ColumnSelectPopover = ({
 
       <div>
         {invalidSelectionFeedback && (
-          <div
+          // ``output`` carries an implicit ``status`` role, announcing the
+          // corrective message without stealing focus.
+          <output
             id={INVALID_SELECTION_FEEDBACK_ID}
-            role="status"
             css={(theme: { colorErrorText: string }) => css`
+              display: block;
               color: ${theme.colorErrorText};
             `}
           >
             {invalidSelectionFeedback}
-          </div>
+          </output>
         )}
         <Button
           buttonSize="small"

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -64,6 +64,7 @@ import { ExplorePageState } from 'src/explore/types';
 import {
   selectCompatibility,
   selectCompatibleDimensionNames,
+  selectCompatibleMetricNames,
 } from 'src/explore/selectors/compatibility';
 import useResizeButton from './useResizeButton';
 import { getColumnPickerCapabilities } from './utils/pickerCapabilities';
@@ -176,6 +177,7 @@ const ColumnSelectPopover = ({
   const savedClassification = capabilities.dimensionClassification === 'saved';
   const compatibility = useSelector(selectCompatibility);
   const compatibleDimensions = useSelector(selectCompatibleDimensionNames);
+  const compatibleMetrics = useSelector(selectCompatibleMetricNames);
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =
     getInitialColumnValues(editedColumn, savedClassification);
@@ -484,12 +486,26 @@ const ColumnSelectPopover = ({
         'This dimension is not compatible with the current selections. Select a compatible dimension.',
       );
     }
+    // A metric can be selected while verification is still in flight, so an
+    // unfavourable result must also block Save (options are disabled too, but
+    // only after the result arrives).
+    if (
+      selectedMetric &&
+      compatibleMetrics != null &&
+      !compatibleMetrics.includes(selectedMetric.metric_name)
+    ) {
+      return t(
+        'This metric is not compatible with the current selections. Select a compatible metric.',
+      );
+    }
     return null;
   }, [
     savedClassification,
     adhocColumn,
     selectedCalculatedColumn,
     compatibleDimensions,
+    selectedMetric,
+    compatibleMetrics,
   ]);
 
   const showCompatibilityFailureWarning =
@@ -541,7 +557,8 @@ const ColumnSelectPopover = ({
                   label: t('Saved'),
                   children: (
                     <>
-                      {calculatedColumns.length > 0 ? (
+                      {calculatedColumns.length > 0 ||
+                      (savedClassification && availableMetrics.length > 0) ? (
                         <FormItem label={savedExpressionsLabel}>
                           <StyledSelect
                             ariaLabel={savedExpressionsLabel}
@@ -605,8 +622,8 @@ const ColumnSelectPopover = ({
                                     metric_name: metric.metric_name,
                                     verbose_name: metric.verbose_name ?? '',
                                     disabled:
-                                      compatibleDimensions != null &&
-                                      !compatibleDimensions.includes(
+                                      compatibleMetrics != null &&
+                                      !compatibleMetrics.includes(
                                         metric.metric_name,
                                       ),
                                   }))

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -56,6 +56,7 @@ import {
   POPOVER_INITIAL_WIDTH,
 } from 'src/explore/constants';
 import { ExplorePageState } from 'src/explore/types';
+import { selectCompatibleDimensionNames } from 'src/explore/selectors/compatibility';
 import useResizeButton from './useResizeButton';
 
 const TABS_KEYS = {
@@ -152,10 +153,7 @@ const ColumnSelectPopover = ({
   const datasourceType = useSelector<ExplorePageState, string | undefined>(
     state => state.explore.datasource.type,
   );
-  const compatibleDimensions = useSelector<
-    ExplorePageState,
-    string[] | null | undefined
-  >(state => state.explore.compatibleDimensions);
+  const compatibleDimensions = useSelector(selectCompatibleDimensionNames);
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =
     getInitialColumnValues(editedColumn);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -299,8 +299,25 @@ const ColumnSelectPopover = ({
     [setLabel, availableMetrics],
   );
 
+  // Full reset for the combined pickers' clear (×). antd's ``allowClear``
+  // fires ``onChange(undefined)``, which the item dispatchers below can't map
+  // to a column or metric, so an explicit clear branch is what returns the
+  // control to empty: it drops every selection (column/metric/adhoc) and
+  // resets the label.
+  const resetSelection = useCallback(() => {
+    setSelectedCalculatedColumn(undefined);
+    setSelectedSimpleColumn(undefined);
+    setSelectedMetric(undefined);
+    setAdhocColumn(undefined);
+    setLabel('');
+  }, [setLabel]);
+
   const onSimpleItemChange = useCallback(
-    (selectedValue: string) => {
+    (selectedValue?: string) => {
+      if (!selectedValue) {
+        resetSelection();
+        return;
+      }
       const selectedColumn = columnMap[selectedValue];
       if (selectedColumn) {
         onSimpleColumnChange(selectedValue);
@@ -312,14 +329,24 @@ const ColumnSelectPopover = ({
         onSimpleMetricChange(selectedValue);
       }
     },
-    [columnMap, metricMap, onSimpleColumnChange, onSimpleMetricChange],
+    [
+      columnMap,
+      metricMap,
+      onSimpleColumnChange,
+      onSimpleMetricChange,
+      resetSelection,
+    ],
   );
 
   // With Saved classification the combined column/metric controls surface
   // their metrics in the Saved mode (Simple is disabled), so metric
   // selection keeps working there.
   const onSavedItemChange = useCallback(
-    (selectedValue: string) => {
+    (selectedValue?: string) => {
+      if (!selectedValue) {
+        resetSelection();
+        return;
+      }
       if (calculatedColumns.some(col => col.column_name === selectedValue)) {
         onCalculatedColumnChange(selectedValue);
         return;
@@ -333,6 +360,7 @@ const ColumnSelectPopover = ({
       metricMap,
       onCalculatedColumnChange,
       onSimpleMetricChange,
+      resetSelection,
     ],
   );
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -313,6 +313,27 @@ const ColumnSelectPopover = ({
     [columnMap, metricMap, onSimpleColumnChange, onSimpleMetricChange],
   );
 
+  // With Saved classification the combined column/metric controls surface
+  // their metrics in the Saved mode (Simple is disabled), so metric
+  // selection keeps working there.
+  const onSavedItemChange = useCallback(
+    (selectedValue: string) => {
+      if (calculatedColumns.some(col => col.column_name === selectedValue)) {
+        onCalculatedColumnChange(selectedValue);
+        return;
+      }
+      if (metricMap[selectedValue]) {
+        onSimpleMetricChange(selectedValue);
+      }
+    },
+    [
+      calculatedColumns,
+      metricMap,
+      onCalculatedColumnChange,
+      onSimpleMetricChange,
+    ],
+  );
+
   const effectiveDisabledTabs = useMemo(() => {
     const merged = new Set([...disabledTabs, ...capabilities.disabledModes]);
     // A legacy adhoc value must stay inspectable: keep Custom SQL reachable
@@ -475,7 +496,9 @@ const ColumnSelectPopover = ({
     capabilities.showCompatibilityFailure && compatibility.status === 'failed';
 
   const savedExpressionsLabel = savedClassification
-    ? t('Dimensions')
+    ? availableMetrics.length > 0
+      ? t('Dimensions and metrics')
+      : t('Dimensions')
     : t('Saved expressions');
   const simpleColumnsLabel = t('Columns and metrics');
   const keywords = useMemo(
@@ -521,16 +544,32 @@ const ColumnSelectPopover = ({
                         <FormItem label={savedExpressionsLabel}>
                           <StyledSelect
                             ariaLabel={savedExpressionsLabel}
-                            value={selectedCalculatedColumn?.column_name}
-                            onChange={onCalculatedColumnChange}
+                            value={
+                              selectedCalculatedColumn?.column_name ||
+                              (savedClassification
+                                ? selectedMetric?.metric_name
+                                : undefined)
+                            }
+                            onChange={
+                              savedClassification
+                                ? onSavedItemChange
+                                : onCalculatedColumnChange
+                            }
                             allowClear
-                            autoFocus={!selectedCalculatedColumn}
-                            placeholder={t(
-                              '%s column(s)',
-                              calculatedColumns.length,
-                            )}
-                            options={calculatedColumns.map(
-                              calculatedColumn => ({
+                            autoFocus={
+                              !selectedCalculatedColumn && !selectedMetric
+                            }
+                            placeholder={
+                              savedClassification
+                                ? t(
+                                    '%s item(s)',
+                                    calculatedColumns.length +
+                                      availableMetrics.length,
+                                  )
+                                : t('%s column(s)', calculatedColumns.length)
+                            }
+                            options={[
+                              ...calculatedColumns.map(calculatedColumn => ({
                                 value: calculatedColumn.column_name,
                                 label: (
                                   <StyledColumnOption
@@ -548,9 +587,35 @@ const ColumnSelectPopover = ({
                                   !compatibleDimensions.includes(
                                     calculatedColumn.column_name,
                                   ),
-                              }),
-                            )}
-                            optionFilterProps={['column_name', 'verbose_name']}
+                              })),
+                              ...(savedClassification
+                                ? availableMetrics.map(metric => ({
+                                    value: metric.metric_name,
+                                    label: (
+                                      <MetricOptionContainer>
+                                        <MetricIcon>ƒ</MetricIcon>
+                                        <MetricLabel>
+                                          {metric.verbose_name ||
+                                            metric.metric_name}
+                                        </MetricLabel>
+                                      </MetricOptionContainer>
+                                    ),
+                                    key: `metric-${metric.metric_name}`,
+                                    metric_name: metric.metric_name,
+                                    verbose_name: metric.verbose_name ?? '',
+                                    disabled:
+                                      compatibleDimensions != null &&
+                                      !compatibleDimensions.includes(
+                                        metric.metric_name,
+                                      ),
+                                  }))
+                                : []),
+                            ]}
+                            optionFilterProps={[
+                              'column_name',
+                              'verbose_name',
+                              'metric_name',
+                            ]}
                           />
                         </FormItem>
                       ) : datasourceType === DatasourceType.Table ? (

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -26,9 +26,13 @@ import {
   Metric,
   QueryFormMetric,
 } from '@superset-ui/core';
-import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
+import { ColumnMeta, Dataset, isColumnMeta } from '@superset-ui/chart-controls';
 import { ExplorePopoverContent } from 'src/explore/components/ExploreContentPopover';
-import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
+import {
+  ISaveableDatasource,
+  SaveDatasetModal,
+} from 'src/SqlLab/components/SaveDatasetModal';
+import { ExplorePageState } from 'src/explore/types';
 import ColumnSelectPopover from './ColumnSelectPopover';
 import { DndColumnSelectPopoverTitle } from './DndColumnSelectPopoverTitle';
 import ControlPopover from '../ControlPopover/ControlPopover';
@@ -52,7 +56,7 @@ interface ColumnSelectPopoverTriggerProps {
 }
 
 interface ColumnSelectPopoverTriggerInnerProps extends ColumnSelectPopoverTriggerProps {
-  datasource?: any;
+  datasource?: Dataset | null;
 }
 
 const ColumnSelectPopoverTriggerInner = ({
@@ -189,7 +193,9 @@ const ColumnSelectPopoverTriggerInner = ({
           modalDescription={t(
             'Save this query as a virtual dataset to continue exploring',
           )}
-          datasource={datasource}
+          // The explore datasource has always been forwarded here; the modal
+          // only reads the saveable subset of its fields.
+          datasource={datasource as unknown as ISaveableDatasource}
         />
       )}
       <ControlPopover
@@ -212,8 +218,8 @@ const ColumnSelectPopoverTriggerInner = ({
 const ColumnSelectPopoverTriggerWrapper = (
   props: ColumnSelectPopoverTriggerProps,
 ) => {
-  const datasource = useSelector(
-    (state: any) => state?.explore?.datasource || null,
+  const datasource = useSelector<ExplorePageState, Dataset | null>(
+    state => state?.explore?.datasource || null,
   );
 
   return <ColumnSelectPopoverTriggerInner {...props} datasource={datasource} />;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
@@ -380,9 +380,10 @@ test('saved-only semantic view disables Simple and Custom SQL in the combined pi
 
   fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
 
-  expect(
-    await screen.findByRole('tab', { name: 'Saved' }),
-  ).toHaveAttribute('aria-selected', 'true');
+  expect(await screen.findByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
   expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
     'aria-disabled',
     'true',

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
@@ -18,7 +18,12 @@
  */
 import { useDroppable } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
-import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import { DndColumnMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect';
 import { DndItemType } from 'src/explore/components/DndItemType';
 import {
@@ -343,4 +348,148 @@ test('handles mixed value types correctly', () => {
 
   expect(screen.getByText('column_a')).toBeVisible();
   expect(screen.getByText('metric_a')).toBeVisible();
+});
+
+const SEMANTIC_METRIC_PROPS = {
+  ...defaultProps,
+  columns: [
+    { column_name: 'order_date', verbose_name: 'Order Date' },
+    { column_name: 'category', verbose_name: 'Product Category' },
+  ],
+  datasource: {
+    type: 'semantic_view',
+    id: 1,
+    semantic_view_features: [],
+  },
+};
+
+test('saved-only semantic view disables Simple and Custom SQL in the combined picker', async () => {
+  render(<DndColumnMetricSelect {...SEMANTIC_METRIC_PROPS} value={[]} />, {
+    useDndKit: true,
+    useRedux: true,
+    initialState: {
+      explore: {
+        datasource: {
+          type: 'semantic_view',
+          id: 1,
+          semantic_view_features: [],
+        },
+      },
+    },
+  });
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  expect(
+    await screen.findByRole('tab', { name: 'Saved' }),
+  ).toHaveAttribute('aria-selected', 'true');
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('semantic view declaring adhoc expressions keeps Simple enabled in the combined picker', async () => {
+  render(
+    <DndColumnMetricSelect
+      {...SEMANTIC_METRIC_PROPS}
+      datasource={{
+        type: 'semantic_view',
+        id: 1,
+        semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+      }}
+      value={[]}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: {
+        explore: {
+          datasource: {
+            type: 'semantic_view',
+            id: 1,
+            semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+          },
+        },
+      },
+    },
+  );
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  expect(
+    await screen.findByRole('tab', { name: 'Simple' }),
+  ).not.toHaveAttribute('aria-disabled', 'true');
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('Sort by entry point commits a compatible Cube dimension through the picker', async () => {
+  const onChange = jest.fn();
+  render(
+    <DndColumnMetricSelect
+      {...SEMANTIC_METRIC_PROPS}
+      onChange={onChange}
+      value={[]}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: {
+        explore: {
+          datasource: {
+            type: 'semantic_view',
+            id: 1,
+            semantic_view_features: [],
+          },
+        },
+      },
+    },
+  );
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  const combobox = await screen.findByRole('combobox', { name: 'Dimensions' });
+  fireEvent.mouseDown(combobox);
+  const option = await screen.findByRole('option', { name: /Order Date/i });
+  fireEvent.click(option);
+
+  const saveButton = await screen.findByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith(['order_date']);
+  });
+});
+
+test('Cube saved-metric selection through the metric popover is unchanged', async () => {
+  render(<DndColumnMetricSelect {...SEMANTIC_METRIC_PROPS} value={[]} />, {
+    useDndKit: true,
+    useRedux: true,
+    initialState: {
+      explore: {
+        datasource: {
+          type: 'semantic_view',
+          id: 1,
+          semantic_view_features: [],
+        },
+      },
+    },
+  });
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  // Metrics stay selectable from the Saved-mode picker flow used by the
+  // combined control; the saved metrics list itself is not affected by
+  // dimension capabilities.
+  expect(
+    await screen.findByRole('tab', { name: 'Saved' }),
+  ).toHaveAttribute('aria-selected', 'true');
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.test.tsx
@@ -469,27 +469,52 @@ test('Sort by entry point commits a compatible Cube dimension through the picker
   });
 });
 
-test('Cube saved-metric selection through the metric popover is unchanged', async () => {
-  render(<DndColumnMetricSelect {...SEMANTIC_METRIC_PROPS} value={[]} />, {
-    useDndKit: true,
-    useRedux: true,
-    initialState: {
-      explore: {
-        datasource: {
-          type: 'semantic_view',
-          id: 1,
-          semantic_view_features: [],
+test('Cube saved metrics remain listed and selectable when Simple is disabled', async () => {
+  const onChange = jest.fn();
+  render(
+    <DndColumnMetricSelect
+      {...SEMANTIC_METRIC_PROPS}
+      selectedMetrics={['metric_a', 'metric_b']}
+      onChange={onChange}
+      value={[]}
+    />,
+    {
+      useDndKit: true,
+      useRedux: true,
+      initialState: {
+        explore: {
+          datasource: {
+            type: 'semantic_view',
+            id: 1,
+            semantic_view_features: [],
+          },
         },
       },
     },
-  });
+  );
 
   fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
 
-  // Metrics stay selectable from the Saved-mode picker flow used by the
-  // combined control; the saved metrics list itself is not affected by
-  // dimension capabilities.
-  expect(
-    await screen.findByRole('tab', { name: 'Saved' }),
-  ).toHaveAttribute('aria-selected', 'true');
+  // Simple is disabled for saved-only semantic views, so the combined
+  // control's metrics must remain reachable from the Saved mode.
+  expect(await screen.findByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+
+  const combobox = await screen.findByRole('combobox', {
+    name: 'Dimensions and metrics',
+  });
+  fireEvent.mouseDown(combobox);
+
+  const option = await screen.findByRole('option', { name: /Metric B/i });
+  fireEvent.click(option);
+
+  const saveButton = await screen.findByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith(['metric_b']);
+  });
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
@@ -130,15 +130,9 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
     formData,
   } = props;
 
-  // Semantic views do not support arbitrary SQL expressions as dimensions.
-  // Merge 'sqlExpression' into disabledTabs so the Custom SQL tab is hidden.
-  const effectiveDisabledTabs = useMemo(
-    () =>
-      String(datasource?.type) === 'semantic_view'
-        ? new Set([...(disabledTabs ?? []), 'sqlExpression'])
-        : disabledTabs,
-    [datasource?.type, disabledTabs],
-  );
+  // Provider-specific mode rules (for example semantic views disabling
+  // Custom SQL) live in the picker-capability adapter consumed by
+  // ColumnSelectPopover; this wrapper only forwards caller-specified tabs.
 
   const [newColumnPopoverVisible, setNewColumnPopoverVisible] = useState(false);
 
@@ -312,7 +306,7 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
               }}
               editedColumn={column}
               isTemporal={isTemporal}
-              disabledTabs={effectiveDisabledTabs}
+              disabledTabs={disabledTabs}
             >
               <OptionWrapper
                 key={`column-${idx}`}
@@ -452,7 +446,7 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
         togglePopover={toggleColumnPopover}
         closePopover={closeColumnPopover}
         isTemporal={false}
-        disabledTabs={effectiveDisabledTabs}
+        disabledTabs={disabledTabs}
         metrics={savedMetrics}
         selectedMetrics={selectedMetrics}
       >

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
@@ -492,3 +492,147 @@ test('should create adhoc column via Custom SQL tab workflow', async () => {
 
   // Preserves Custom SQL workflow from original Cypress test
 });
+
+const SEMANTIC_OPTIONS = [
+  { column_name: 'order_date', verbose_name: 'Order Date', is_dttm: true },
+  { column_name: 'category', verbose_name: 'Product Category' },
+];
+
+const semanticViewStore = (features: string[] = []) =>
+  mockStore({
+    explore: {
+      datasource: {
+        type: 'semantic_view',
+        id: 1,
+        semantic_view_features: features,
+        columns: SEMANTIC_OPTIONS,
+      },
+      form_data: {},
+      controls: {},
+    },
+  });
+
+test('saved-only semantic view disables Simple and Custom SQL modes in the picker', async () => {
+  render(
+    <DndColumnSelect {...defaultProps} options={SEMANTIC_OPTIONS} value={[]} />,
+    { useDndKit: true, store: semanticViewStore() },
+  );
+
+  userEvent.click(screen.getByText(/Drop columns here or click/i));
+
+  await waitFor(() => {
+    expect(screen.getByRole('tab', { name: 'Saved' })).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole('tab', { name: 'Saved' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('semantic view declaring adhoc expressions keeps existing modes in the picker', async () => {
+  render(
+    <DndColumnSelect {...defaultProps} options={SEMANTIC_OPTIONS} value={[]} />,
+    {
+      useDndKit: true,
+      store: semanticViewStore(['ADHOC_COLUMN_EXPRESSIONS']),
+    },
+  );
+
+  userEvent.click(screen.getByText(/Drop columns here or click/i));
+
+  await waitFor(() => {
+    expect(screen.getByRole('tab', { name: 'Simple' })).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole('tab', { name: 'Simple' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Simple' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+  expect(screen.getByRole('tab', { name: 'Custom SQL' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test('commits a visible Cube dimension in two interactions after opening the picker', async () => {
+  const mockOnChange = jest.fn();
+  render(
+    <DndColumnSelect
+      {...defaultProps}
+      onChange={mockOnChange}
+      options={SEMANTIC_OPTIONS}
+      value={[]}
+    />,
+    { useDndKit: true, store: semanticViewStore() },
+  );
+
+  userEvent.click(screen.getByText(/Drop columns here or click/i));
+
+  const combobox = await screen.findByRole('combobox', {
+    name: 'Dimensions',
+  });
+
+  // Interaction 1: select the visible dimension.
+  userEvent.click(combobox);
+  const option = await screen.findByRole('option', { name: /Order Date/i });
+  userEvent.click(option);
+
+  // Interaction 2: save.
+  const saveButton = await screen.findByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(mockOnChange).toHaveBeenCalledWith(['order_date']);
+  });
+});
+
+test('commits a searched Cube dimension in no more than three interactions', async () => {
+  const mockOnChange = jest.fn();
+  render(
+    <DndColumnSelect
+      {...defaultProps}
+      onChange={mockOnChange}
+      options={SEMANTIC_OPTIONS}
+      value={[]}
+    />,
+    { useDndKit: true, store: semanticViewStore() },
+  );
+
+  userEvent.click(screen.getByText(/Drop columns here or click/i));
+
+  const combobox = await screen.findByRole('combobox', {
+    name: 'Dimensions',
+  });
+
+  // Interaction 1: search.
+  await userEvent.type(combobox, 'Product');
+
+  // Interaction 2: select the match.
+  const option = await screen.findByRole('option', {
+    name: /Product Category/i,
+  });
+  userEvent.click(option);
+
+  // Interaction 3: save.
+  const saveButton = await screen.findByTestId('ColumnEdit#save');
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  userEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(mockOnChange).toHaveBeenCalledWith(['category']);
+  });
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { useCallback, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { t, tn } from '@apache-superset/core/translation';
 import { AdhocColumn, QueryFormColumn, isAdhocColumn } from '@superset-ui/core';
 import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
@@ -27,7 +26,6 @@ import OptionWrapper from 'src/explore/components/controls/DndColumnSelectContro
 import { OptionSelector } from 'src/explore/components/controls/DndColumnSelectControl/utils';
 import { DatasourcePanelDndItem } from 'src/explore/components/DatasourcePanel/types';
 import { DndItemType } from 'src/explore/components/DndItemType';
-import { ExplorePageState } from 'src/explore/types';
 import ColumnSelectPopoverTrigger from './ColumnSelectPopoverTrigger';
 import { DndControlProps } from './types';
 import { datasetLabelLower } from 'src/features/semanticLayers/label';
@@ -52,17 +50,9 @@ function DndColumnSelect(props: DndColumnSelectProps) {
     disabledTabs,
   } = props;
 
-  // Semantic views do not support arbitrary SQL expressions as dimensions.
-  const datasourceType = useSelector<ExplorePageState, string | undefined>(
-    state => state.explore.datasource?.type,
-  );
-  const effectiveDisabledTabs = useMemo(
-    () =>
-      datasourceType === 'semantic_view'
-        ? new Set([...(disabledTabs ?? []), 'sqlExpression'])
-        : disabledTabs,
-    [datasourceType, disabledTabs],
-  );
+  // Provider-specific mode rules (for example semantic views disabling
+  // Custom SQL) live in the picker-capability adapter consumed by
+  // ColumnSelectPopover; this wrapper only forwards caller-specified tabs.
 
   const [newColumnPopoverVisible, setNewColumnPopoverVisible] = useState(false);
 
@@ -139,7 +129,7 @@ function DndColumnSelect(props: DndColumnSelectProps) {
             }}
             editedColumn={column}
             isTemporal={isTemporal}
-            disabledTabs={effectiveDisabledTabs}
+            disabledTabs={disabledTabs}
           >
             <OptionWrapper
               key={idx}
@@ -228,7 +218,7 @@ function DndColumnSelect(props: DndColumnSelectProps) {
         closePopover={closePopover}
         visible={newColumnPopoverVisible}
         isTemporal={isTemporal}
-        disabledTabs={effectiveDisabledTabs}
+        disabledTabs={disabledTabs}
       >
         <div />
       </ColumnSelectPopoverTrigger>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -446,3 +446,81 @@ test('onChange is not called when close is clicked and canDelete is string, warn
   expect(defaultProps.onChange).not.toHaveBeenCalled();
   expect(await screen.findByText('Test warning')).toBeInTheDocument();
 });
+
+test('Filter control commits a compatible Cube dimension as a filter subject', async () => {
+  const onChange = jest.fn();
+  const semanticColumns = [
+    {
+      column_name: 'order_date',
+      verbose_name: 'Order Date',
+      type: 'TIMESTAMP',
+      id: 10,
+    },
+    {
+      column_name: 'category',
+      verbose_name: 'Product Category',
+      type: 'VARCHAR(255)',
+      id: 11,
+    },
+  ] as ColumnMeta[];
+  const semanticDatasource = {
+    ...PLACEHOLDER_DATASOURCE,
+    type: 'semantic_view',
+    semantic_view_features: [],
+    columns: semanticColumns,
+  } as unknown as Datasource;
+
+  const semanticStore = mockStore({
+    explore: {
+      datasource: {
+        type: 'semantic_view',
+        id: 1,
+        semantic_view_features: [],
+      },
+    },
+  });
+
+  render(
+    setup({
+      columns: semanticColumns,
+      datasource: semanticDatasource,
+      additionalProps: { onChange },
+    }),
+    { useDndKit: true, store: semanticStore },
+  );
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  const subjectSelect = await screen.findByRole('combobox', {
+    name: 'Select subject',
+  });
+  fireEvent.mouseDown(subjectSelect);
+
+  const dropdown = await waitFor(() => {
+    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    if (!list) throw new Error('dropdown not open');
+    return list;
+  });
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  fireEvent.click(within(dropdown).getByText('Product Category'));
+
+  const operatorSelect = await screen.findByRole('combobox', {
+    name: 'Select operator',
+  });
+  fireEvent.mouseDown(operatorSelect);
+  const operatorOption = await screen.findByText('Is not null');
+  fireEvent.click(operatorOption);
+
+  const saveButton = await screen.findByRole('button', { name: 'Save' });
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        subject: 'category',
+        operator: 'IS NOT NULL',
+      }),
+    ]);
+  });
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -417,3 +417,81 @@ test('onChange is not called when close is clicked and canDelete is string, warn
   expect(defaultProps.onChange).not.toHaveBeenCalled();
   expect(await screen.findByText('Test warning')).toBeInTheDocument();
 });
+
+test('Filter control commits a compatible Cube dimension as a filter subject', async () => {
+  const onChange = jest.fn();
+  const semanticColumns = [
+    {
+      column_name: 'order_date',
+      verbose_name: 'Order Date',
+      type: 'TIMESTAMP',
+      id: 10,
+    },
+    {
+      column_name: 'category',
+      verbose_name: 'Product Category',
+      type: 'VARCHAR(255)',
+      id: 11,
+    },
+  ] as ColumnMeta[];
+  const semanticDatasource = {
+    ...PLACEHOLDER_DATASOURCE,
+    type: 'semantic_view',
+    semantic_view_features: [],
+    columns: semanticColumns,
+  } as unknown as Datasource;
+
+  const semanticStore = mockStore({
+    explore: {
+      datasource: {
+        type: 'semantic_view',
+        id: 1,
+        semantic_view_features: [],
+      },
+    },
+  });
+
+  render(
+    setup({
+      columns: semanticColumns,
+      datasource: semanticDatasource,
+      additionalProps: { onChange },
+    }),
+    { useDndKit: true, store: semanticStore },
+  );
+
+  fireEvent.click(screen.getByText('Drop columns/metrics here or click'));
+
+  const subjectSelect = await screen.findByRole('combobox', {
+    name: 'Select subject',
+  });
+  fireEvent.mouseDown(subjectSelect);
+
+  const dropdown = await waitFor(() => {
+    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    if (!list) throw new Error('dropdown not open');
+    return list;
+  });
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+  fireEvent.click(within(dropdown).getByText('Product Category'));
+
+  const operatorSelect = await screen.findByRole('combobox', {
+    name: 'Select operator',
+  });
+  fireEvent.mouseDown(operatorSelect);
+  const operatorOption = await screen.findByText('Is not null');
+  fireEvent.click(operatorOption);
+
+  const saveButton = await screen.findByRole('button', { name: 'Save' });
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        subject: 'category',
+        operator: 'IS NOT NULL',
+      }),
+    ]);
+  });
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -497,7 +497,9 @@ test('Filter control commits a compatible Cube dimension as a filter subject', a
   fireEvent.mouseDown(subjectSelect);
 
   const dropdown = await waitFor(() => {
-    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    const list = document.querySelector(
+      '.ant-select-dropdown-list',
+    ) as HTMLElement;
     if (!list) throw new Error('dropdown not open');
     return list;
   });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.test.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.test.ts
@@ -59,7 +59,10 @@ test('unknown feature strings are ignored', () => {
   expect(
     getColumnPickerCapabilities({
       type: 'semantic_view',
-      semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS', 'SOME_FUTURE_FEATURE'],
+      semantic_view_features: [
+        'ADHOC_COLUMN_EXPRESSIONS',
+        'SOME_FUTURE_FEATURE',
+      ],
     }),
   ).toEqual({
     dimensionClassification: 'expression',

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.test.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getColumnPickerCapabilities } from './pickerCapabilities';
+
+test('semantic view without the adhoc-expressions feature is Saved-only', () => {
+  expect(
+    getColumnPickerCapabilities({
+      type: 'semantic_view',
+      semantic_view_features: [],
+    }),
+  ).toEqual({
+    dimensionClassification: 'saved',
+    disabledModes: ['simple', 'sqlExpression'],
+    showCompatibilityFailure: true,
+  });
+});
+
+test('semantic view declaring the adhoc-expressions feature keeps existing modes', () => {
+  expect(
+    getColumnPickerCapabilities({
+      type: 'semantic_view',
+      semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS'],
+    }),
+  ).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: ['sqlExpression'],
+    showCompatibilityFailure: false,
+  });
+});
+
+test('unknown feature strings are ignored', () => {
+  expect(
+    getColumnPickerCapabilities({
+      type: 'semantic_view',
+      semantic_view_features: ['SOME_FUTURE_FEATURE'],
+    }),
+  ).toEqual({
+    dimensionClassification: 'saved',
+    disabledModes: ['simple', 'sqlExpression'],
+    showCompatibilityFailure: true,
+  });
+
+  expect(
+    getColumnPickerCapabilities({
+      type: 'semantic_view',
+      semantic_view_features: ['ADHOC_COLUMN_EXPRESSIONS', 'SOME_FUTURE_FEATURE'],
+    }),
+  ).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: ['sqlExpression'],
+    showCompatibilityFailure: false,
+  });
+});
+
+test('semantic view without feature metadata keeps existing semantic-view behavior', () => {
+  expect(getColumnPickerCapabilities({ type: 'semantic_view' })).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: ['sqlExpression'],
+    showCompatibilityFailure: false,
+  });
+});
+
+test('non-semantic datasources produce default capabilities', () => {
+  expect(getColumnPickerCapabilities({ type: 'table' })).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: [],
+    showCompatibilityFailure: false,
+  });
+});
+
+test('absent datasource metadata produces default capabilities', () => {
+  expect(getColumnPickerCapabilities(undefined)).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: [],
+    showCompatibilityFailure: false,
+  });
+  expect(getColumnPickerCapabilities(null)).toEqual({
+    dimensionClassification: 'expression',
+    disabledModes: [],
+    showCompatibilityFailure: false,
+  });
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/pickerCapabilities.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { DatasourceType } from '@superset-ui/core';
+import { ColumnPickerCapabilities } from 'src/explore/types';
+
+/**
+ * SemanticViewFeature value marking views whose backend accepts adhoc
+ * (simple / custom SQL) column expressions. Mirrors the Python enum member
+ * in superset-core.
+ */
+export const ADHOC_COLUMN_EXPRESSIONS = 'ADHOC_COLUMN_EXPRESSIONS';
+
+const DEFAULT_CAPABILITIES: ColumnPickerCapabilities = {
+  dimensionClassification: 'expression',
+  disabledModes: [],
+  showCompatibilityFailure: false,
+};
+
+/**
+ * Subset of datasource metadata the adapter reads. Kept structural so both
+ * the core `Datasource` and chart-controls `Dataset` shapes are accepted.
+ */
+export interface PickerCapabilityDatasource {
+  type?: string;
+  semantic_view_features?: string[];
+}
+
+/**
+ * Translate datasource metadata into provider-neutral picker capabilities.
+ *
+ * This adapter is the single interpretation point (anti-corruption boundary)
+ * for `semantic_view_features`: picker components must consume the returned
+ * capabilities instead of reading feature strings or provider identity.
+ *
+ * Semantic views always disable Custom SQL. A semantic view whose feature
+ * list is present but does not declare `ADHOC_COLUMN_EXPRESSIONS` is
+ * Saved-only: its dimensions cannot be composed into adhoc expressions, so
+ * Simple is disabled and dimensions are presented as Saved options. Missing
+ * feature metadata (older payloads) and unknown feature strings degrade to
+ * the pre-existing behavior for the datasource type.
+ */
+export function getColumnPickerCapabilities(
+  datasource?: PickerCapabilityDatasource | null,
+): ColumnPickerCapabilities {
+  if (datasource?.type !== DatasourceType.SemanticView) {
+    return DEFAULT_CAPABILITIES;
+  }
+
+  const features = datasource.semantic_view_features;
+  const supportsAdhocExpressions =
+    !Array.isArray(features) || features.includes(ADHOC_COLUMN_EXPRESSIONS);
+
+  if (supportsAdhocExpressions) {
+    return {
+      dimensionClassification: 'expression',
+      disabledModes: ['sqlExpression'],
+      showCompatibilityFailure: false,
+    };
+  }
+
+  return {
+    dimensionClassification: 'saved',
+    disabledModes: ['simple', 'sqlExpression'],
+    showCompatibilityFailure: true,
+  };
+}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -1150,7 +1150,9 @@ test('Filter subject lists and commits an expression-less Cube dimension', async
   userEvent.click(subjectSelect);
 
   const dropdown = await waitFor(() => {
-    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    const list = document.querySelector(
+      '.ant-select-dropdown-list',
+    ) as HTMLElement;
     if (!list) throw new Error('dropdown not open');
     return list;
   });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -1115,3 +1115,53 @@ test('does not say the list is partial when it is complete', async () => {
   expect(await screen.findByTitle('alpha')).toBeInTheDocument();
   expect(screen.queryByText(/Only the first/)).not.toBeInTheDocument();
 });
+
+test('Filter subject lists and commits an expression-less Cube dimension', async () => {
+  const semanticDimensions = [
+    {
+      column_name: 'order_date',
+      verbose_name: 'Order Date',
+      type: 'TIMESTAMP',
+      expression: null,
+      id: 10,
+    },
+    {
+      column_name: 'category',
+      verbose_name: 'Product Category',
+      type: 'VARCHAR(255)',
+      expression: null,
+      id: 11,
+    },
+  ];
+  const props = setup({
+    options: semanticDimensions,
+    datasource: {
+      ...TestDataset,
+      type: 'semantic_view',
+      semantic_view_features: [],
+      columns: semanticDimensions,
+      filter_select: false,
+    },
+  });
+
+  const subjectSelect = screen.getByRole('combobox', {
+    name: 'Select subject',
+  });
+  userEvent.click(subjectSelect);
+
+  const dropdown = await waitFor(() => {
+    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    if (!list) throw new Error('dropdown not open');
+    return list;
+  });
+  expect(within(dropdown).getByText('Order Date')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Product Category'));
+
+  await waitFor(() => {
+    expect(props.onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ subject: 'category' }),
+    );
+  });
+});

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -23,6 +23,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'spec/helpers/testing-library';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -775,4 +776,54 @@ test('dropdown should remain open when clicked after filter is configured', asyn
   });
 
   expect(operatorDropdown).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('Filter subject lists and commits an expression-less Cube dimension', async () => {
+  const semanticDimensions = [
+    {
+      column_name: 'order_date',
+      verbose_name: 'Order Date',
+      type: 'TIMESTAMP',
+      expression: null,
+      id: 10,
+    },
+    {
+      column_name: 'category',
+      verbose_name: 'Product Category',
+      type: 'VARCHAR(255)',
+      expression: null,
+      id: 11,
+    },
+  ];
+  const props = setup({
+    options: semanticDimensions,
+    datasource: {
+      ...TestDataset,
+      type: 'semantic_view',
+      semantic_view_features: [],
+      columns: semanticDimensions,
+      filter_select: false,
+    },
+  });
+
+  const subjectSelect = screen.getByRole('combobox', {
+    name: 'Select subject',
+  });
+  userEvent.click(subjectSelect);
+
+  const dropdown = await waitFor(() => {
+    const list = document.querySelector('.rc-virtual-list') as HTMLElement;
+    if (!list) throw new Error('dropdown not open');
+    return list;
+  });
+  expect(within(dropdown).getByText('Order Date')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Product Category')).toBeInTheDocument();
+
+  userEvent.click(within(dropdown).getByText('Product Category'));
+
+  await waitFor(() => {
+    expect(props.onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ subject: 'category' }),
+    );
+  });
 });

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -458,3 +458,57 @@ test('Should filter columns by column_name and verbose_name in Simple tab', asyn
   expect(within(dropdown).queryByText('Order Amount')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Product Title')).not.toBeInTheDocument();
 });
+
+test('disables saved metrics absent from a verified compatibility result', async () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} />, {
+    useRedux: true,
+    initialState: {
+      explore: {
+        compatibility: {
+          status: 'verified',
+          metrics: ['count'],
+          dimensions: [],
+        },
+      },
+    },
+  });
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Select saved metrics' }),
+  );
+
+  const dropdown = (await screen.findByText('sum').then(() =>
+    document.querySelector('.rc-virtual-list'),
+  )) as HTMLElement;
+  expect(within(dropdown).getByText('sum').closest('.ant-select-item')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(
+    within(dropdown).getByText('count').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+});
+
+test('keeps every saved metric enabled after a failed compatibility request', async () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} />, {
+    useRedux: true,
+    initialState: {
+      explore: { compatibility: { status: 'failed' } },
+    },
+  });
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Select saved metrics' }),
+  );
+
+  const dropdown = (await screen.findByText('sum').then(() =>
+    document.querySelector('.rc-virtual-list'),
+  )) as HTMLElement;
+  expect(
+    within(dropdown).getByText('sum').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+  expect(
+    within(dropdown).getByText('count').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+});

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -478,12 +478,12 @@ test('disables saved metrics absent from a verified compatibility result', async
     screen.getByRole('combobox', { name: 'Select saved metrics' }),
   );
 
-  const dropdown = (await screen.findByText('sum').then(() =>
-    document.querySelector('.rc-virtual-list'),
-  )) as HTMLElement;
-  expect(within(dropdown).getByText('sum').closest('.ant-select-item')).toHaveClass(
-    'ant-select-item-option-disabled',
-  );
+  const dropdown = (await screen
+    .findByText('sum')
+    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
+  expect(
+    within(dropdown).getByText('sum').closest('.ant-select-item'),
+  ).toHaveClass('ant-select-item-option-disabled');
   expect(
     within(dropdown).getByText('count').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');
@@ -502,9 +502,9 @@ test('keeps every saved metric enabled after a failed compatibility request', as
     screen.getByRole('combobox', { name: 'Select saved metrics' }),
   );
 
-  const dropdown = (await screen.findByText('sum').then(() =>
-    document.querySelector('.rc-virtual-list'),
-  )) as HTMLElement;
+  const dropdown = (await screen
+    .findByText('sum')
+    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
   expect(
     within(dropdown).getByText('sum').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -480,7 +480,9 @@ test('disables saved metrics absent from a verified compatibility result', async
 
   const dropdown = (await screen
     .findByText('sum')
-    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
+    .then(() =>
+      document.querySelector('.ant-select-dropdown-list'),
+    )) as HTMLElement;
   expect(
     within(dropdown).getByText('sum').closest('.ant-select-item'),
   ).toHaveClass('ant-select-item-option-disabled');
@@ -504,7 +506,9 @@ test('keeps every saved metric enabled after a failed compatibility request', as
 
   const dropdown = (await screen
     .findByText('sum')
-    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
+    .then(() =>
+      document.querySelector('.ant-select-dropdown-list'),
+    )) as HTMLElement;
   expect(
     within(dropdown).getByText('sum').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -474,12 +474,12 @@ test('disables saved metrics absent from a verified compatibility result', async
     screen.getByRole('combobox', { name: 'Select saved metrics' }),
   );
 
-  const dropdown = (await screen.findByText('sum').then(() =>
-    document.querySelector('.rc-virtual-list'),
-  )) as HTMLElement;
-  expect(within(dropdown).getByText('sum').closest('.ant-select-item')).toHaveClass(
-    'ant-select-item-option-disabled',
-  );
+  const dropdown = (await screen
+    .findByText('sum')
+    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
+  expect(
+    within(dropdown).getByText('sum').closest('.ant-select-item'),
+  ).toHaveClass('ant-select-item-option-disabled');
   expect(
     within(dropdown).getByText('count').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');
@@ -498,9 +498,9 @@ test('keeps every saved metric enabled after a failed compatibility request', as
     screen.getByRole('combobox', { name: 'Select saved metrics' }),
   );
 
-  const dropdown = (await screen.findByText('sum').then(() =>
-    document.querySelector('.rc-virtual-list'),
-  )) as HTMLElement;
+  const dropdown = (await screen
+    .findByText('sum')
+    .then(() => document.querySelector('.rc-virtual-list'))) as HTMLElement;
   expect(
     within(dropdown).getByText('sum').closest('.ant-select-item'),
   ).not.toHaveClass('ant-select-item-option-disabled');

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -454,3 +454,57 @@ test('Should filter columns by column_name and verbose_name in Simple tab', asyn
   expect(within(dropdown).queryByText('Order Amount')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Product Title')).not.toBeInTheDocument();
 });
+
+test('disables saved metrics absent from a verified compatibility result', async () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} />, {
+    useRedux: true,
+    initialState: {
+      explore: {
+        compatibility: {
+          status: 'verified',
+          metrics: ['count'],
+          dimensions: [],
+        },
+      },
+    },
+  });
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Select saved metrics' }),
+  );
+
+  const dropdown = (await screen.findByText('sum').then(() =>
+    document.querySelector('.rc-virtual-list'),
+  )) as HTMLElement;
+  expect(within(dropdown).getByText('sum').closest('.ant-select-item')).toHaveClass(
+    'ant-select-item-option-disabled',
+  );
+  expect(
+    within(dropdown).getByText('count').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+});
+
+test('keeps every saved metric enabled after a failed compatibility request', async () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} />, {
+    useRedux: true,
+    initialState: {
+      explore: { compatibility: { status: 'failed' } },
+    },
+  });
+
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Select saved metrics' }),
+  );
+
+  const dropdown = (await screen.findByText('sum').then(() =>
+    document.querySelector('.rc-virtual-list'),
+  )) as HTMLElement;
+  expect(
+    within(dropdown).getByText('sum').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+  expect(
+    within(dropdown).getByText('count').closest('.ant-select-item'),
+  ).not.toHaveClass('ant-select-item-option-disabled');
+});

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
@@ -50,7 +50,7 @@ import {
 } from 'src/explore/components/optionRenderers';
 import { getColumnKeywords } from 'src/explore/controlUtils/getColumnKeywords';
 import SQLEditorWithValidation from 'src/components/SQLEditorWithValidation';
-import type { ExplorePageState } from 'src/explore/types';
+import { selectCompatibleMetricNames } from 'src/explore/selectors/compatibility';
 import type { RefObject } from 'react';
 
 interface ColumnType {
@@ -136,10 +136,7 @@ function AdhocMetricEditPopover({
   const [width, setWidth] = useState(POPOVER_INITIAL_WIDTH);
   const [height, setHeight] = useState(POPOVER_INITIAL_HEIGHT);
 
-  const compatibleMetrics = useSelector<
-    ExplorePageState,
-    string[] | null | undefined
-  >(state => state.explore?.compatibleMetrics);
+  const compatibleMetrics = useSelector(selectCompatibleMetricNames);
 
   const aceEditorRef = useRef<editors.EditorHandle>(null);
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
@@ -49,7 +49,7 @@ import {
 } from 'src/explore/components/optionRenderers';
 import { getColumnKeywords } from 'src/explore/controlUtils/getColumnKeywords';
 import SQLEditorWithValidation from 'src/components/SQLEditorWithValidation';
-import type { ExplorePageState } from 'src/explore/types';
+import { selectCompatibleMetricNames } from 'src/explore/selectors/compatibility';
 import type { RefObject } from 'react';
 
 interface ColumnType {
@@ -135,10 +135,7 @@ function AdhocMetricEditPopover({
   const [width, setWidth] = useState(POPOVER_INITIAL_WIDTH);
   const [height, setHeight] = useState(POPOVER_INITIAL_HEIGHT);
 
-  const compatibleMetrics = useSelector<
-    ExplorePageState,
-    string[] | null | undefined
-  >(state => state.explore?.compatibleMetrics);
+  const compatibleMetrics = useSelector(selectCompatibleMetricNames);
 
   const aceEditorRef = useRef<editors.EditorHandle>(null);
 

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -18,8 +18,9 @@
  */
 
 import exploreReducer, { ExploreState } from './exploreReducer';
-import { setStashFormData } from '../actions/exploreActions';
+import { setCompatibility, setStashFormData } from '../actions/exploreActions';
 import { QueryFormData } from '@superset-ui/core';
+import { CompatibilityResult } from '../types';
 
 test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const initialState: ExploreState = {
@@ -38,6 +39,46 @@ test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const newState2 = exploreReducer(newState, restoreAction);
   expect(newState2.form_data).toEqual({ c: 4 });
   expect(newState2.hiddenFormData).toEqual({ a: 3 });
+});
+
+test('SET_COMPATIBILITY stores each mutually exclusive request state', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+  };
+
+  const states: CompatibilityResult[] = [
+    { status: 'loading' },
+    { status: 'verified', metrics: ['m1'], dimensions: ['d1'] },
+    { status: 'verified', metrics: [], dimensions: [] },
+    { status: 'failed' },
+    { status: 'idle' },
+  ];
+
+  states.forEach(compatibility => {
+    const newState = exploreReducer(
+      initialState,
+      setCompatibility(compatibility) as Parameters<typeof exploreReducer>[1],
+    );
+    expect(newState.compatibility).toEqual(compatibility);
+  });
+});
+
+test('SET_COMPATIBILITY replaces the previous result instead of merging', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+    compatibility: { status: 'verified', metrics: ['m1'], dimensions: ['d1'] },
+  };
+
+  const newState = exploreReducer(
+    initialState,
+    setCompatibility({ status: 'failed' }) as Parameters<
+      typeof exploreReducer
+    >[1],
+  );
+
+  expect(newState.compatibility).toEqual({ status: 'failed' });
 });
 
 test('skips updates when the field is already updated on SET_STASH_FORM_DATA', () => {

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -21,7 +21,12 @@ import { QueryFormData } from '@superset-ui/core';
 import { sections, CustomControlItem } from '@superset-ui/chart-controls';
 import { getControlStateFromControlConfig } from 'src/explore/controlUtils';
 import exploreReducer, { ExploreState } from './exploreReducer';
-import { setControlValue, setStashFormData } from '../actions/exploreActions';
+import {
+  setCompatibility,
+  setControlValue,
+  setStashFormData,
+} from '../actions/exploreActions';
+import { CompatibilityResult } from '../types';
 
 test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const initialState: ExploreState = {
@@ -40,6 +45,46 @@ test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const newState2 = exploreReducer(newState, restoreAction);
   expect(newState2.form_data).toEqual({ c: 4 });
   expect(newState2.hiddenFormData).toEqual({ a: 3 });
+});
+
+test('SET_COMPATIBILITY stores each mutually exclusive request state', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+  };
+
+  const states: CompatibilityResult[] = [
+    { status: 'loading' },
+    { status: 'verified', metrics: ['m1'], dimensions: ['d1'] },
+    { status: 'verified', metrics: [], dimensions: [] },
+    { status: 'failed' },
+    { status: 'idle' },
+  ];
+
+  states.forEach(compatibility => {
+    const newState = exploreReducer(
+      initialState,
+      setCompatibility(compatibility) as Parameters<typeof exploreReducer>[1],
+    );
+    expect(newState.compatibility).toEqual(compatibility);
+  });
+});
+
+test('SET_COMPATIBILITY replaces the previous result instead of merging', () => {
+  const initialState: ExploreState = {
+    form_data: {} as unknown as QueryFormData,
+    controls: {},
+    compatibility: { status: 'verified', metrics: ['m1'], dimensions: ['d1'] },
+  };
+
+  const newState = exploreReducer(
+    initialState,
+    setCompatibility({ status: 'failed' }) as Parameters<
+      typeof exploreReducer
+    >[1],
+  );
+
+  expect(newState.compatibility).toEqual({ status: 'failed' });
 });
 
 test('skips updates when the field is already updated on SET_STASH_FORM_DATA', () => {

--- a/superset-frontend/src/explore/reducers/exploreReducer.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.ts
@@ -40,7 +40,7 @@ import {
 import * as actions from 'src/explore/actions/exploreActions';
 import { HYDRATE_EXPLORE, HydrateExplore } from '../actions/hydrateExplore';
 import { Slice } from 'src/types/Chart';
-import { SaveActionType } from 'src/explore/types';
+import { CompatibilityResult, SaveActionType } from 'src/explore/types';
 
 // Type definitions for explore state
 export interface ExploreState {
@@ -70,9 +70,7 @@ export interface ExploreState {
   metadata?: {
     editors?: string[] | null;
   };
-  compatibleMetrics?: string[] | null;
-  compatibleDimensions?: string[] | null;
-  compatibilityLoading?: boolean;
+  compatibility?: CompatibilityResult;
   saveAction?: SaveActionType | null;
   chartStates?: Record<number, JsonObject>;
 }
@@ -183,9 +181,7 @@ interface UpdateExploreChartStateAction {
 
 interface SetCompatibilityAction {
   type: typeof actions.SET_COMPATIBILITY;
-  compatibleMetrics: string[] | null;
-  compatibleDimensions: string[] | null;
-  compatibilityLoading: boolean;
+  compatibility: CompatibilityResult;
 }
 
 type ExploreAction =
@@ -650,9 +646,7 @@ export default function exploreReducer(
       const typedAction = action as SetCompatibilityAction;
       return {
         ...state,
-        compatibleMetrics: typedAction.compatibleMetrics,
-        compatibleDimensions: typedAction.compatibleDimensions,
-        compatibilityLoading: typedAction.compatibilityLoading,
+        compatibility: typedAction.compatibility,
       };
     },
     [actions.UPDATE_EXPLORE_CHART_STATE]() {

--- a/superset-frontend/src/explore/selectors/compatibility.test.ts
+++ b/superset-frontend/src/explore/selectors/compatibility.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { CompatibilityResult, ExplorePageState } from 'src/explore/types';
+import {
+  selectCompatibility,
+  selectCompatibleDimensionNames,
+  selectCompatibleMetricNames,
+} from './compatibility';
+
+const stateWith = (compatibility?: CompatibilityResult) =>
+  ({ explore: { compatibility } }) as unknown as ExplorePageState;
+
+test('verified results expose their metric and dimension names for filtering', () => {
+  const state = stateWith({
+    status: 'verified',
+    metrics: ['m1', 'm2'],
+    dimensions: ['d1'],
+  });
+
+  expect(selectCompatibleMetricNames(state)).toEqual(['m1', 'm2']);
+  expect(selectCompatibleDimensionNames(state)).toEqual(['d1']);
+});
+
+test('verified empty lists filter everything instead of falling back', () => {
+  const state = stateWith({ status: 'verified', metrics: [], dimensions: [] });
+
+  expect(selectCompatibleMetricNames(state)).toEqual([]);
+  expect(selectCompatibleDimensionNames(state)).toEqual([]);
+});
+
+test('idle, loading, and failed results apply no filtering', () => {
+  const unfiltered: CompatibilityResult[] = [
+    { status: 'idle' },
+    { status: 'loading' },
+    { status: 'failed' },
+  ];
+
+  unfiltered.forEach(compatibility => {
+    const state = stateWith(compatibility);
+    expect(selectCompatibleMetricNames(state)).toBeNull();
+    expect(selectCompatibleDimensionNames(state)).toBeNull();
+  });
+});
+
+test('missing compatibility state defaults to idle', () => {
+  const state = stateWith(undefined);
+
+  expect(selectCompatibility(state)).toEqual({ status: 'idle' });
+  expect(selectCompatibleMetricNames(state)).toBeNull();
+  expect(selectCompatibleDimensionNames(state)).toBeNull();
+});

--- a/superset-frontend/src/explore/selectors/compatibility.ts
+++ b/superset-frontend/src/explore/selectors/compatibility.ts
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { CompatibilityResult, ExplorePageState } from 'src/explore/types';
+
+const IDLE: CompatibilityResult = { status: 'idle' };
+
+/**
+ * The discriminated result of the latest compatibility request; `idle` when
+ * no request has run in this Explore session.
+ */
+export const selectCompatibility = (
+  state: ExplorePageState,
+): CompatibilityResult => state.explore?.compatibility ?? IDLE;
+
+/**
+ * Metric names verified as compatible with the current selection, or `null`
+ * when no filtering should be applied (idle, loading, or failed requests
+ * deliberately fall back to unfiltered options so the user is never
+ * blocked). A verified empty array is a valid "nothing is compatible"
+ * result, not a fallback.
+ */
+export const selectCompatibleMetricNames = (
+  state: ExplorePageState,
+): string[] | null => {
+  const compatibility = selectCompatibility(state);
+  return compatibility.status === 'verified' ? compatibility.metrics : null;
+};
+
+/**
+ * Dimension names verified as compatible with the current selection, or
+ * `null` when no filtering should be applied. See
+ * `selectCompatibleMetricNames` for the fallback semantics.
+ */
+export const selectCompatibleDimensionNames = (
+  state: ExplorePageState,
+): string[] | null => {
+  const compatibility = selectCompatibility(state);
+  return compatibility.status === 'verified' ? compatibility.dimensions : null;
+};

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -118,6 +118,43 @@ export interface ExploreResponsePayload {
   };
 }
 
+/**
+ * Picker modes a column control can offer. Mirrors the tab keys used by
+ * ColumnSelectPopover.
+ */
+export type ColumnPickerMode = 'saved' | 'simple' | 'sqlExpression';
+
+/**
+ * Provider-neutral column-picker behavior derived from datasource metadata.
+ *
+ * This is the anti-corruption boundary between datasource payloads (for
+ * example `semantic_view_features`) and the generic Explore picker: picker
+ * components consume these capabilities and must not read provider metadata
+ * directly.
+ */
+export interface ColumnPickerCapabilities {
+  /**
+   * How expression-less datasource columns are classified in the picker:
+   * 'expression' keeps the existing split (truthy expression → Saved),
+   * 'saved' presents every dimension as a Saved option.
+   */
+  dimensionClassification: 'expression' | 'saved';
+  /** Picker modes rendered as visible but disabled. */
+  disabledModes: ColumnPickerMode[];
+  /** Whether a failed compatibility request shows non-blocking feedback. */
+  showCompatibilityFailure: boolean;
+}
+
+/**
+ * Discriminated result of the latest metric/dimension compatibility request,
+ * making loading, failure, and a valid empty result mutually exclusive.
+ */
+export type CompatibilityResult =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'verified'; metrics: string[]; dimensions: string[] }
+  | { status: 'failed' };
+
 export interface ExplorePageState {
   user: UserWithPermissionsAndRoles;
   common: {
@@ -145,9 +182,7 @@ export interface ExplorePageState {
     standalone: boolean;
     force: boolean;
     common: JsonObject;
-    compatibleMetrics?: string[] | null;
-    compatibleDimensions?: string[] | null;
-    compatibilityLoading?: boolean;
+    compatibility?: CompatibilityResult;
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -102,6 +102,43 @@ export interface ExploreResponsePayload {
   };
 }
 
+/**
+ * Picker modes a column control can offer. Mirrors the tab keys used by
+ * ColumnSelectPopover.
+ */
+export type ColumnPickerMode = 'saved' | 'simple' | 'sqlExpression';
+
+/**
+ * Provider-neutral column-picker behavior derived from datasource metadata.
+ *
+ * This is the anti-corruption boundary between datasource payloads (for
+ * example `semantic_view_features`) and the generic Explore picker: picker
+ * components consume these capabilities and must not read provider metadata
+ * directly.
+ */
+export interface ColumnPickerCapabilities {
+  /**
+   * How expression-less datasource columns are classified in the picker:
+   * 'expression' keeps the existing split (truthy expression → Saved),
+   * 'saved' presents every dimension as a Saved option.
+   */
+  dimensionClassification: 'expression' | 'saved';
+  /** Picker modes rendered as visible but disabled. */
+  disabledModes: ColumnPickerMode[];
+  /** Whether a failed compatibility request shows non-blocking feedback. */
+  showCompatibilityFailure: boolean;
+}
+
+/**
+ * Discriminated result of the latest metric/dimension compatibility request,
+ * making loading, failure, and a valid empty result mutually exclusive.
+ */
+export type CompatibilityResult =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'verified'; metrics: string[]; dimensions: string[] }
+  | { status: 'failed' };
+
 export interface ExplorePageState {
   user: UserWithPermissionsAndRoles;
   common: {
@@ -129,9 +166,7 @@ export interface ExplorePageState {
     standalone: boolean;
     force: boolean;
     common: JsonObject;
-    compatibleMetrics?: string[] | null;
-    compatibleDimensions?: string[] | null;
-    compatibilityLoading?: boolean;
+    compatibility?: CompatibilityResult;
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -125,6 +125,18 @@ def get_column_type(semantic_type: pa.DataType) -> GenericDataType:
     return GenericDataType.STRING
 
 
+def _feature_value(feature: object) -> str:
+    """Normalize a declared semantic-view feature to its stable string value.
+
+    Features are typed ``frozenset[SemanticViewFeature]``, but a third-party
+    provider may hand back a raw string (or any object) instead of the enum
+    member. Fall back to the value itself rather than 500-ing Explore for that
+    datasource, so a new provider stays safe by default.
+    """
+    value = getattr(feature, "value", feature)
+    return value if isinstance(value, str) else str(value)
+
+
 @dataclass(frozen=True)
 class MetricMetadata:
     metric_name: str
@@ -583,13 +595,11 @@ class SemanticView(AuditMixinNullable, Model):
             "uid": self.uid,
             "type": "semantic_view",
             # Sorted for a deterministic payload; values are the stable
-            # SemanticViewFeature strings, never provider identity. A provider
-            # may hand back a raw string instead of the enum member, so fall
-            # back to the value itself rather than 500-ing Explore for that
-            # datasource (a new provider must stay safe by default).
+            # SemanticViewFeature strings, never provider identity.
+            # ``_feature_value`` tolerates a provider that hands back a raw
+            # string instead of the enum member (see its docstring).
             "semantic_view_features": sorted(
-                getattr(feature, "value", feature)
-                for feature in self.implementation.features
+                _feature_value(feature) for feature in self.implementation.features
             ),
             "name": self.name,
             "columns": [

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -413,6 +413,11 @@ class SemanticView(AuditMixinNullable, Model):
             "id": self.id,
             "uid": self.uid,
             "type": "semantic_view",
+            # Sorted for a deterministic payload; values are the stable
+            # SemanticViewFeature strings, never provider identity.
+            "semantic_view_features": sorted(
+                feature.value for feature in self.implementation.features
+            ),
             "name": self.name,
             "columns": [
                 {

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -414,9 +414,13 @@ class SemanticView(AuditMixinNullable, Model):
             "uid": self.uid,
             "type": "semantic_view",
             # Sorted for a deterministic payload; values are the stable
-            # SemanticViewFeature strings, never provider identity.
+            # SemanticViewFeature strings, never provider identity. A provider
+            # may hand back a raw string instead of the enum member, so fall
+            # back to the value itself rather than 500-ing Explore for that
+            # datasource (a new provider must stay safe by default).
             "semantic_view_features": sorted(
-                feature.value for feature in self.implementation.features
+                getattr(feature, "value", feature)
+                for feature in self.implementation.features
             ),
             "name": self.name,
             "columns": [

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -371,6 +371,11 @@ class SemanticView(AuditMixinNullable, Model):
             "id": self.id,
             "uid": self.uid,
             "type": "semantic_view",
+            # Sorted for a deterministic payload; values are the stable
+            # SemanticViewFeature strings, never provider identity.
+            "semantic_view_features": sorted(
+                feature.value for feature in self.implementation.features
+            ),
             "name": self.name,
             "columns": [
                 {

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -331,6 +331,12 @@ class ExplorableData(TypedDict, total=False):
     verbose_map: dict[str, str]
     select_star: str | None
 
+    # Semantic-view fields
+    # Stable string values of the SemanticViewFeature members the view's
+    # provider declares; consumed by the explore UI to derive picker
+    # capabilities. Absent for non-semantic explorables.
+    semantic_view_features: list[str]
+
     # Additional fields from SqlaTable and data_for_slices
     column_types: list["GenericDataType"]
     column_names: set[str] | list[str]

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -693,6 +693,20 @@ def test_semantic_view_supports_samples_is_false() -> None:
     assert SemanticView.supports_samples is False
 
 
+def test_semantic_view_abc_features_default_empty() -> None:
+    """A provider that declares nothing inherits an empty feature set.
+
+    ``features`` is a class attribute with a ``frozenset()`` default, so
+    ``implementation.features`` never raises for minimal providers and the
+    picker degrades to Saved-only instead of a 500.
+    """
+    from superset_core.semantic_layers.view import (
+        SemanticView as SemanticViewABC,
+    )
+
+    assert SemanticViewABC.features == frozenset()
+
+
 def test_semantic_view_data_features_empty(
     mock_implementation: MagicMock,
     semantic_view: SemanticView,

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -30,6 +30,7 @@ from superset_core.semantic_layers.types import (
     Grains,
     Metric,
 )
+from superset_core.semantic_layers.view import SemanticViewFeature
 
 from superset.semantic_layers.models import (
     ColumnMetadata,
@@ -321,6 +322,7 @@ def mock_implementation(
     impl.get_dimensions.return_value = mock_dimensions
     impl.get_metrics.return_value = mock_metrics
     impl.uid.return_value = "semantic_view_uid_123"
+    impl.features = frozenset()
     return impl
 
 
@@ -691,6 +693,41 @@ def test_semantic_view_supports_samples_is_false() -> None:
     assert SemanticView.supports_samples is False
 
 
+def test_semantic_view_data_features_empty(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """A view with no declared features serializes an empty feature list."""
+    mock_implementation.features = frozenset()
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == []
+
+
+def test_semantic_view_data_features_declared(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """Declared view features are serialized as their stable string values."""
+    mock_implementation.features = frozenset(
+        {
+            SemanticViewFeature.ADHOC_COLUMN_EXPRESSIONS,
+            SemanticViewFeature.GROUP_LIMIT,
+        }
+    )
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == [
+        "ADHOC_COLUMN_EXPRESSIONS",
+        "GROUP_LIMIT",
+    ]
+    # Declaring features must not change the expression-less dimension
+    # contract from #41456: semantic dimensions stay "physical" to the UI.
+    assert all(column["expression"] is None for column in data["columns"])
+
+
 @pytest.fixture
 def mock_grain_variant_dimensions() -> list[Dimension]:
     """Time column exposed as multiple Dimension variants, one per grain."""
@@ -773,6 +810,7 @@ def test_semantic_view_data_populates_time_grain_sqla(
     impl.get_dimensions.return_value = mock_grain_variant_dimensions
     impl.get_metrics.return_value = mock_metrics
     impl.uid.return_value = "semantic_view_uid_123"
+    impl.features = frozenset()
 
     layer = SemanticLayer()
     layer.name = "My Semantic Layer"
@@ -801,6 +839,11 @@ def test_semantic_view_data_populates_time_grain_sqla(
     # ``time_grain_sqla`` in ExplorableData is ``(duration, name)`` tuples.
     grain_durations = sorted(entry[0] for entry in data["time_grain_sqla"])
     assert grain_durations == sorted(["PT1H", "P1D", "P1M"])
+    # #41456 contract: temporal semantic dimensions keep ``expression=None``
+    # so the explore UI preserves the time-grain affordance, and the feature
+    # list serializes alongside without altering column metadata.
+    assert all(column["expression"] is None for column in data["columns"])
+    assert data["semantic_view_features"] == []
 
 
 def test_semantic_view_supports_drill_to_detail_is_false() -> None:

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -765,6 +765,21 @@ def test_semantic_view_data_features_tolerates_raw_string(
     ]
 
 
+def test_semantic_view_data_features_coerces_non_string_member(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """A feature that is neither a SemanticViewFeature nor a string is coerced
+    to its string form (the ``str(value)`` fallback in ``_feature_value``),
+    keeping ``sorted`` from raising on a mixed-type comparison rather than
+    500-ing Explore."""
+    mock_implementation.features = frozenset({SemanticViewFeature.GROUP_LIMIT, 7})
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == ["7", "GROUP_LIMIT"]
+
+
 @pytest.fixture
 def mock_grain_variant_dimensions() -> list[Dimension]:
     """Time column exposed as multiple Dimension variants, one per grain."""

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -742,6 +742,25 @@ def test_semantic_view_data_features_declared(
     assert all(column["expression"] is None for column in data["columns"])
 
 
+def test_semantic_view_data_features_tolerates_raw_string(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """A provider may hand back a raw string instead of a SemanticViewFeature
+    member; the payload degrades to the string value rather than 500-ing
+    Explore for that datasource (new providers stay safe by default)."""
+    mock_implementation.features = frozenset(
+        {SemanticViewFeature.GROUP_LIMIT, "CUSTOM_PROVIDER_FEATURE"}
+    )
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == [
+        "CUSTOM_PROVIDER_FEATURE",
+        "GROUP_LIMIT",
+    ]
+
+
 @pytest.fixture
 def mock_grain_variant_dimensions() -> list[Dimension]:
     """Time column exposed as multiple Dimension variants, one per grain."""

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -30,6 +30,7 @@ from superset_core.semantic_layers.types import (
     Grains,
     Metric,
 )
+from superset_core.semantic_layers.view import SemanticViewFeature
 
 from superset.semantic_layers.models import (
     ColumnMetadata,
@@ -315,6 +316,7 @@ def mock_implementation(
     impl.get_dimensions.return_value = mock_dimensions
     impl.get_metrics.return_value = mock_metrics
     impl.uid.return_value = "semantic_view_uid_123"
+    impl.features = frozenset()
     return impl
 
 
@@ -655,6 +657,41 @@ def test_semantic_view_data(
         assert data["offset"] == 0
 
 
+def test_semantic_view_data_features_empty(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """A view with no declared features serializes an empty feature list."""
+    mock_implementation.features = frozenset()
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == []
+
+
+def test_semantic_view_data_features_declared(
+    mock_implementation: MagicMock,
+    semantic_view: SemanticView,
+) -> None:
+    """Declared view features are serialized as their stable string values."""
+    mock_implementation.features = frozenset(
+        {
+            SemanticViewFeature.ADHOC_COLUMN_EXPRESSIONS,
+            SemanticViewFeature.GROUP_LIMIT,
+        }
+    )
+
+    data = semantic_view.data
+
+    assert data["semantic_view_features"] == [
+        "ADHOC_COLUMN_EXPRESSIONS",
+        "GROUP_LIMIT",
+    ]
+    # Declaring features must not change the expression-less dimension
+    # contract from #41456: semantic dimensions stay "physical" to the UI.
+    assert all(column["expression"] is None for column in data["columns"])
+
+
 @pytest.fixture
 def mock_grain_variant_dimensions() -> list[Dimension]:
     """Time column exposed as multiple Dimension variants, one per grain."""
@@ -737,6 +774,7 @@ def test_semantic_view_data_populates_time_grain_sqla(
     impl.get_dimensions.return_value = mock_grain_variant_dimensions
     impl.get_metrics.return_value = mock_metrics
     impl.uid.return_value = "semantic_view_uid_123"
+    impl.features = frozenset()
 
     layer = SemanticLayer()
     layer.name = "My Semantic Layer"
@@ -765,6 +803,11 @@ def test_semantic_view_data_populates_time_grain_sqla(
     # ``time_grain_sqla`` in ExplorableData is ``(duration, name)`` tuples.
     grain_durations = sorted(entry[0] for entry in data["time_grain_sqla"])
     assert grain_durations == sorted(["PT1H", "P1D", "P1M"])
+    # #41456 contract: temporal semantic dimensions keep ``expression=None``
+    # so the explore UI preserves the time-grain affordance, and the feature
+    # list serializes alongside without altering column metadata.
+    assert all(column["expression"] is None for column in data["columns"])
+    assert data["semantic_view_features"] == []
 
 
 def test_semantic_view_get_query_result(


### PR DESCRIPTION
### SUMMARY

> **⚠️ Merge coordination (updated).** Merging this PR into apache/superset is
> safe on its own — nothing changes for any deployment until it consumes this
> commit. The constraint sits on the private shell repo: the
> `ADHOC_COLUMN_EXPRESSIONS` polarity is opt-in, so the shell **must not
> advance its `superset-oss` submodule pin past this commit without also
> staging the one-line feature declaration on `SnowflakeSemanticView`**
> (tracked as sc-115357; being specced as part of the shell's semantic-layer
> remediation round). Otherwise the Snowflake picker silently degrades to
> Saved-only at that deploy. Committers: review and merge freely.


Semantic-view providers can now declare what their backend supports, and the Explore column picker adapts its modes and dimension classification to that declaration instead of guessing from column metadata.

**A note on the originating report.** The internal story behind this describes the "Columns and metrics" picker showing `0 item(s)` for a Cube-backed semantic view, and that literal symptom no longer reproduces on master. Reproduced against a live Cube instance through the real model path: dimensions arrive with `expression=None`, so the picker's expression-based split routes all four into Simple, not zero.

The empty picker came from the pre-#41456 payload, which set `expression=dimension.definition`. Because `ColumnSelectPopover` treats any column with a truthy `expression` as a Saved/calculated column, every dimension landed under Saved and Simple rendered `0 item(s)`. #41456 (`e28b259de0`) flipped that field to `None` so temporal dimensions keep their time-grain affordance — and the dimensions moved into Simple.

That fixed the emptiness but landed them in the wrong mode. The behavior agreed with design at the time was: dimensions and metrics presented under **Saved**, with Simple and Custom SQL disabled, because a semantic view whose backend cannot execute adhoc column expressions should not offer modes that compose them. The "disable Simple" half was never implemented, and #41456 additionally moved dimensions out of Saved. This PR implements that intent — generalized so it is driven by what a provider declares rather than by which provider it is:

**1. Providers declare features; Explore consumes capabilities.** A new opt-in `SemanticViewFeature.ADHOC_COLUMN_EXPRESSIONS` marks views whose backend accepts simple/custom-SQL column expressions. The declared set serializes to the datasource payload as `semantic_view_features`. A view that does not declare it gets a Saved-only picker: dimensions listed as Saved options, Simple and Custom SQL visible but disabled, so users cannot compose an expression the backend would reject.

Polarity is opt-in to match the existing provider convention — Snowflake declares its features, Cube and MetricFlow deliberately ship `frozenset()`. A companion one-line declaration on `SnowflakeSemanticView` keeps Snowflake's picker behavior unchanged and ships separately in the shell repo.

Provider identity is deliberately **not** sent over the wire. The `@semantic_layer` decorator prefixes extension IDs (`extensions.preset-io.cube-semantic-layer.cube`), so there is no stable bare registry key to publish, and behavior keyed off provider identity would not survive that prefixing. Features are translated exactly once, in `utils/pickerCapabilities.ts`, into a provider-neutral `ColumnPickerCapabilities`. Picker components consume capabilities and never read feature strings, registry keys, or display names. Two DnD wrappers that each carried their own copy of the "semantic views disable Custom SQL" rule now defer to that adapter.

**2. Compatibility request state was conflated (a real defect).** `fetchCompatibility` dispatched an identical `{compatibleMetrics: null, compatibleDimensions: null, compatibilityLoading: false}` both when the datasource is non-semantic and when the request *failed*. A failed compatibility lookup was therefore indistinguishable from "no filtering applies", so no UI could ever surface it. That state is now a discriminated `CompatibilityResult` (`idle | loading | verified | failed`) read through typed selectors, and every existing consumer — column picker, datasource-panel drag options, adhoc metric popover — was migrated in the same change so the replacement cannot strand an old reader. Idle, loading, and failed keep the existing no-filter fallback; a `verified` empty result is a valid "nothing is compatible" answer, not a fallback; `failed` additionally shows an accessible non-blocking warning where the capability enables it.

Incompatible or legacy adhoc values can no longer be silently committed: Saved becomes the active mode, the legacy value stays inspectable under Custom SQL, and Save is disabled with accessible corrective feedback associated to it until the user explicitly picks a compatible dimension.

`expression=None` on semantic dimensions is preserved throughout — #41456's time-grain behavior is a protected invariant here, not a cleanup opportunity, and there is a regression assertion to that effect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not included: rendering a Cube-backed semantic view requires the proprietary provider extension, which is not installable in an OSS checkout. Behavior is covered by component tests that drive the real picker, and by a local reproduction against a Cube instance described below.

### TESTING INSTRUCTIONS

Automated (no provider extension needed):

```bash
# Frontend — picker, wrappers, control entry points, state, selectors, adapter
cd superset-frontend
npm test -- src/explore/components/controls/DndColumnSelectControl \
            src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent \
            src/explore/components/controls/MetricControl/AdhocMetricEditPopover \
            src/explore/components/DatasourcePanel \
            src/explore/actions src/explore/reducers src/explore/selectors

# Backend — feature serialization and the #41456 expression/time-grain invariant
pytest tests/unit_tests/semantic_layers/models_test.py
```

Manual, with a semantic-layer provider available:

1. Open Explore on a semantic view whose provider declares no features. Open an X-axis or Dimensions control: the picker opens on **Saved** listing every dimension by verbose name; Simple and Custom SQL are visible but disabled. Select one and save — it commits to the control.
2. Select a metric first so compatibility narrows, then reopen: dimensions outside the compatible set are visible but disabled. With no compatible dimensions, the picker says so rather than looking like a loading or failed state.
3. Repeat on a view whose provider declares `ADHOC_COLUMN_EXPRESSIONS` (and on a plain table dataset): modes, defaults, search, and Save are unchanged.
4. Repeat through Filter subject and Sort by.

The `0 item(s)` claim above was verified against the Cube fixture in `db-infra/databases/cube` (REST API on `:4000`) using a throwaway provider stub over `SemanticView.data`; the stub is not part of this PR.

### ADDITIONAL INFORMATION
- [x] Has associated issue: SC-107939 (Preset-internal)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

Backwards compatible: `semantic_view_features` is additive and optional. Payloads without it, unknown feature strings, and non-semantic datasources all resolve to existing behavior, so no `UPDATING.md` entry is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


