### PR TITLE
chore: enable MCP AI agent service in docker compose, add z.ai Claude…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Python version installed; we need 3.11-3.12
 PYTHON=`command -v python3.11 || command -v python3.12`
 
-.PHONY: install superset venv pre-commit up down logs ps nuke ports open
+.PHONY: install superset venv pre-commit up down logs ps nuke ports open enable-claude-zai
 
 install: superset pre-commit
 
@@ -144,3 +144,15 @@ ports:
 
 open:
 	./scripts/docker-compose-up.sh open
+
+# Configure Claude Code to use the z.ai GLM Coding Plan as its backend for
+# THIS project only. Writes to .claude/settings.local.json, which is
+# gitignored, so the API key never gets committed.
+# Get a key at https://z.ai/manage-apikey/apikey-list
+# Usage: make enable-claude-zai ZAI_API_KEY=your_zai_api_key
+enable-claude-zai:
+	@if [ -z "$(ZAI_API_KEY)" ]; then echo "ERROR: ZAI_API_KEY is required. Get one at https://z.ai/manage-apikey/apikey-list"; echo "Usage: make enable-claude-zai ZAI_API_KEY=your_zai_api_key"; exit 1; fi
+	@mkdir -p .claude
+	@ZAI_API_KEY="$(ZAI_API_KEY)" python3 -c "import json, os; path = '.claude/settings.local.json'; data = json.load(open(path)) if os.path.exists(path) else {}; data.setdefault('env', {}).update({'ANTHROPIC_BASE_URL': 'https://api.z.ai/api/anthropic', 'ANTHROPIC_AUTH_TOKEN': os.environ['ZAI_API_KEY'], 'ANTHROPIC_DEFAULT_OPUS_MODEL': 'glm-5.2[1m]', 'ANTHROPIC_DEFAULT_SONNET_MODEL': 'glm-5.2[1m]', 'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'glm-4.5-air', 'CLAUDE_CODE_AUTO_COMPACT_WINDOW': '1000000', 'API_TIMEOUT_MS': '3000000'}); json.dump(data, open(path, 'w'), indent=2); print('Wrote', path)"
+	@echo "Claude Code is now configured to use z.ai's GLM Coding Plan for this project."
+	@echo "Run 'claude' inside this repo to start (fully restart it first if it's already running)."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@
 # - Set SUPERSET_LOG_LEVEL=debug in docker/.env-local for detailed Superset logs
 # -----------------------------------------------------------------------
 x-superset-user: &superset-user root
-x-superset-volumes: &superset-volumes
-  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
+x-superset-volumes:
+  &superset-volumes # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
   - ./docker:/app/docker
   - ./superset:/app/superset
   - ./superset-core:/app/superset-core
@@ -135,6 +135,26 @@ services:
         condition: service_completed_successfully
     volumes: *superset-volumes
 
+  superset-mcp:
+    env_file:
+      - path: docker/.env # default
+        required: true
+      - path: docker/.env-local # optional override
+        required: false
+    build:
+      <<: *common-build
+    command: ["superset", "mcp", "run", "--host", "0.0.0.0", "--port", "5008"]
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:${MCP_SERVICE_PORT:-5008}:5008
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    user: *superset-user
+    depends_on:
+      superset-init:
+        condition: service_completed_successfully
+    volumes: *superset-volumes
+
   superset-websocket:
     build: ./superset-websocket
     ports:
@@ -207,7 +227,7 @@ services:
       # Webpack dev server must bind to 0.0.0.0 to be accessible from outside the container
       WEBPACK_DEVSERVER_HOST: "0.0.0.0"
     ports:
-      - "127.0.0.1:${NODE_PORT:-9000}:9000"  # exposing the dynamic webpack dev server
+      - "127.0.0.1:${NODE_PORT:-9000}:9000" # exposing the dynamic webpack dev server
     command: ["/app/docker/docker-frontend.sh"]
     env_file:
       - path: docker/.env # default
@@ -236,7 +256,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME",
+        ]
     # Bump memory limit if processing selenium / thumbnails on superset-worker
     # mem_limit: 2038m
     # mem_reservation: 128M
@@ -283,7 +307,11 @@ services:
     user: *superset-user
     volumes: *superset-volumes
     healthcheck:
-      test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+      test:
+        [
+          "CMD-SHELL",
+          "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME",
+        ]
 
 volumes:
   superset_home:

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -113,6 +113,13 @@ FEATURE_FLAGS = {
     "SEMANTIC_LAYERS": True,
 }
 EXTENSIONS_PATH = "/app/docker/extensions"
+
+# MCP server (AI agent) configuration for local development.
+# Runs unauthenticated as MCP_DEV_USERNAME -- never use this in production.
+MCP_SERVICE_HOST = "0.0.0.0"
+MCP_SERVICE_PORT = int(os.environ.get("MCP_SERVICE_PORT", "5008"))
+MCP_AUTH_ENABLED = False
+MCP_DEV_USERNAME = os.environ.get("MCP_DEV_USERNAME", "admin")
 ALERT_REPORTS_NOTIFICATION_DRY_RUN = True
 WEBDRIVER_BASEURL = f"http://superset_app{os.environ.get('SUPERSET_APP_ROOT', '/')}/"  # When using docker compose baseurl should be http://superset_nginx{ENV{BASEPATH}}/  # noqa: E501
 # The base URL for the email report hyperlinks.


### PR DESCRIPTION
… Code helper

- Add superset-mcp service to docker-compose.yml (AI agent, port 5008)
- Configure MCP_SERVICE_HOST/PORT, dev-mode auth in superset_config.py
- Add 'make enable-claude-zai' target to wire Claude Code to z.ai's GLM Coding Plan for this project (writes gitignored .claude/settings.local.json)

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
