### PR TITLE
fix(explore): ensure unsaved-changes dialog renders above View SQL modal v2

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
@@ -22,7 +22,7 @@ import type { FC, ReactElement } from 'react';
 
 // Ant Design's default modal zIndex is 1000. Using a higher value ensures
 // this dialog always renders above other open modals (e.g. a draggable View SQL modal).
-const UNSAVED_CHANGES_MODAL_Z_INDEX = 1100;
+const UNSAVED_CHANGES_MODAL_Z_INDEX = 1300;
 
 export type UnsavedChangesModalProps = {
   showModal: boolean;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since the z-index of the "View SQL" modal window (1200) was higher than UNSAVED_CHANGES_MODAL_Z_INDEX (1100), this dialog box was overlapped.

fix #42510

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

BEFORE

<img width="902" height="374" alt="Снимок экрана от 2026-07-29 00-36-21" src="https://github.com/user-attachments/assets/8075f67e-0312-4e02-9c70-479852a1f4cd" />

AFTER

<img width="902" height="374" alt="Снимок экрана от 2026-07-29 00-37-59" src="https://github.com/user-attachments/assets/6e986dab-45d3-4703-8abe-d2ae162329f8" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
