### PR TITLE
fix(echarts): guard cross-filter when labelMap entry is missing

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -46,6 +46,9 @@ const getCrossFilterDataMask =
     labelMap: Record<string, string[]>,
   ) =>
   (value: string) => {
+    if (!labelMap[value]) {
+      return undefined;
+    }
     const selected = Object.values(selectedValues);
     let values: string[];
     if (selected.includes(value)) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -46,10 +46,10 @@ const getCrossFilterDataMask =
     labelMap: Record<string, string[]>,
   ) =>
   (value: string) => {
-    if (!labelMap[value]) {
+    const selected = Object.values(selectedValues);
+    if (!labelMap[value] && !selected.includes(value)) {
       return undefined;
     }
-    const selected = Object.values(selectedValues);
     let values: string[];
     if (selected.includes(value)) {
       values = selected.filter(v => v !== value);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
@@ -198,3 +198,28 @@ test('cross-filter does nothing when name is missing from labelMap', () => {
 
   expect(setDataMask).not.toHaveBeenCalled();
 });
+
+test('cross-filter still deselects a previously selected value that is missing from labelMap', () => {
+  const setDataMask = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: {
+      cancellations: ['cancellations'],
+    },
+    // "Other" was selected before it dropped out of labelMap (e.g. a stale
+    // cross-filter from an earlier render or dashboard state).
+    selectedValues: { 0: 'Other' },
+    setDataMask,
+  });
+
+  const handlers = allEventHandlers(props);
+  handlers.click({ name: 'Other' });
+
+  expect(setDataMask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      extraFormData: {
+        filters: [],
+      },
+    }),
+  );
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
@@ -180,3 +180,21 @@ test('cross-filter does nothing when emitCrossFilters is false', () => {
 
   expect(setDataMask).not.toHaveBeenCalled();
 });
+
+test('cross-filter does nothing when name is missing from labelMap', () => {
+  const setDataMask = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: {
+      cancellations: ['cancellations'],
+    },
+    selectedValues: {},
+    setDataMask,
+  });
+
+  const handlers = allEventHandlers(props);
+  // e.g. Pie "Other" category is not present in labelMap
+  handlers.click({ name: 'Other' });
+
+  expect(setDataMask).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
### SUMMARY
Fixes [#42340](https://github.com/apache/superset/issues/42340).

When ECharts charts that share `eventHandlers.ts` (notably Pie) receive a click whose series `name` is not in `labelMap` — e.g. Pie **Other**, **Total**, or an empty/missing name — `getCrossFilterDataMask` still built a data mask. After `.filter(Boolean)`, `groupbyValues` could be empty while `values` was non-empty, which led to invalid cross-filters (`IN` with empty values, or unintended `IS NULL` because `[].every(...)` is `true`). Downstream charts then failed or returned wrong results.
This change returns `undefined` early when `labelMap[value]` is missing, so `clickEventHandler` does not call `setDataMask`. That matches the existing context-menu guard that already no-ops when `labelMap[e.name]` is absent.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (behavior fix; no UI change). See the recording on [#42340](https://github.com/apache/superset/issues/42340) for the previous incorrect behavior.
### TESTING INSTRUCTIONS
1. Create a dashboard with:
   - An ECharts Pie chart (groupby + metric), with **Show Total** enabled (and optionally **Threshold for Other**)
   - At least one other chart on the same / compatible dataset
2. Enable dashboard cross-filtering
3. Click the pie **Total** text and/or the **Other** slice
4. Confirm other charts are **not** filtered / do not error
5. Click a normal pie sector and confirm cross-filtering still works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: [#42340](https://github.com/apache/superset/issues/42340)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
