### PR TITLE
chore(mcp): remove unused MCP_SERVICE_HOST and MCP_SERVICE_PORT config

### DIFF
--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -56,10 +56,6 @@ SUPERSET_WEBSERVER_ADDRESS = "http://localhost:9001"
 WEBDRIVER_BASEURL = "http://localhost:9001/"
 WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 
-# MCP Service Host/Port
-MCP_SERVICE_HOST = "localhost"
-MCP_SERVICE_PORT = 5008
-
 # Bug-report support contact surfaced by the generate_bug_report tool. Each
 # deployment should override this in superset_config.py to point users at the
 # right channel (e.g. an internal support address, a vendor support team).
@@ -691,8 +687,6 @@ def get_mcp_config(app_config: dict[str, Any] | None = None) -> dict[str, Any]:
         "SUPERSET_WEBSERVER_ADDRESS": SUPERSET_WEBSERVER_ADDRESS,
         "WEBDRIVER_BASEURL": WEBDRIVER_BASEURL,
         "WEBDRIVER_BASEURL_USER_FRIENDLY": WEBDRIVER_BASEURL_USER_FRIENDLY,
-        "MCP_SERVICE_HOST": MCP_SERVICE_HOST,
-        "MCP_SERVICE_PORT": MCP_SERVICE_PORT,
         "MCP_DEBUG": MCP_DEBUG,
         "MCP_RBAC_ENABLED": MCP_RBAC_ENABLED,
         "MCP_DISABLED_TOOLS": set(MCP_DISABLED_TOOLS),


### PR DESCRIPTION
## Summary

Remove unused `MCP_SERVICE_HOST` and `MCP_SERVICE_PORT` configuration variables that are defined but never consumed by the MCP service runtime.

Related to #42425

## Changes

- Remove `MCP_SERVICE_HOST` and `MCP_SERVICE_PORT` definitions from `mcp_config.py`
- Remove corresponding entries from config dict export

## Testing

Verified these variables are not imported or referenced by any runtime code.