### PR TITLE
fix(dashboard): apply the import overwrite permission check to slug-matched dashboards

### DIFF
--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -324,7 +324,27 @@ def import_dashboard(  # noqa: C901
     # overwrite branches below are intentionally skipped because the caller has
     # already established trust at the command level.
     user = get_user()
-    if existing := find_existing_for_import(Dashboard, config["uuid"]):
+    existing = find_existing_for_import(Dashboard, config["uuid"])
+    if not existing and (incoming_slug := config.get("slug")) is not None:
+        # ``Dashboard.import_from_dict`` matches an existing row on any of the
+        # model's unique constraints, which include ``slug`` as well as
+        # ``uuid``. A config carrying a fresh UUID but a slug that already
+        # belongs to an active dashboard would therefore be matched-and-updated
+        # by slug, without passing through the permission gate below (which only
+        # ran on a UUID match). Resolve that slug collision to the existing
+        # dashboard here so the same overwrite gate applies; align the UUID so
+        # the subsequent import updates that row deterministically.
+        existing = (
+            db.session.query(Dashboard)
+            .filter(
+                Dashboard.slug == incoming_slug,
+                Dashboard.deleted_at.is_(None),
+            )
+            .one_or_none()
+        )
+        if existing:
+            config["uuid"] = str(existing.uuid)
+    if existing:
         if existing.deleted_at is not None:
             # RESTORE path — re-importing a soft-deleted UUID is an implicit
             # restore-with-update, a distinct operation from overwriting an

--- a/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
@@ -703,3 +703,57 @@ def test_import_soft_deleted_dashboard_slug_collision_raises(
     # Postgres / MySQL 8.0.13+) and leave the row half-restored in the
     # session. A failed import must leave the row still soft-deleted.
     assert existing.deleted_at is not None
+
+
+def test_import_slug_collision_requires_overwrite_permission(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    A config carrying a fresh UUID but a slug that already belongs to an
+    active dashboard is matched by slug in ``import_from_dict``. That path must
+    go through the same overwrite permission gate as a UUID match, so a caller
+    who is neither an editor of the existing dashboard nor an admin cannot
+    update it by reusing its slug.
+    """
+    engine = session.get_bind()
+    Dashboard.metadata.create_all(engine)  # pylint: disable=no-member
+
+    existing = Dashboard(
+        id=300,
+        dashboard_title="Existing dash",
+        slug="shared-slug",
+        slices=[],
+        published=True,
+        uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    session.add(existing)
+    session.flush()
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+    mock_can_access_dashboard = mocker.patch.object(
+        security_manager, "can_access_dashboard", return_value=True
+    )
+
+    config = copy.deepcopy(dashboard_config)
+    config["uuid"] = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    config["slug"] = "shared-slug"
+
+    user = User(
+        first_name="Gina",
+        last_name="Amma",
+        email="gamma@example.org",
+        username="gamma",
+        roles=[Role(name="Gamma")],
+    )
+
+    with override_user(user):
+        with pytest.raises(ImportFailedError) as excinfo:
+            import_dashboard(config, overwrite=True)
+        assert (
+            str(excinfo.value)
+            == "A dashboard already exists and user doesn't have permissions to overwrite it"  # noqa: E501
+        )
+
+    mock_can_access_dashboard.assert_called_once_with(existing)
+    session.rollback()


### PR DESCRIPTION
### SUMMARY

`Dashboard.import_from_dict` matches an existing dashboard on any of the model's unique constraints, which include `slug` as well as `uuid`. `import_dashboard`, however, only looked up an existing dashboard by `uuid` before running the overwrite permission gate. A config carrying a fresh `uuid` but a `slug` that already belongs to an active dashboard therefore skipped that gate and was matched-and-updated by slug.

This change resolves a slug collision to the existing dashboard before the gate, so the same `can_write` + `can_access_dashboard` + editorship/admin check applies to it, and aligns the `uuid` so the subsequent import updates that row deterministically. This makes the import overwrite path consistent regardless of whether the incoming config matches an existing dashboard by `uuid` or by `slug`.

### TESTING INSTRUCTIONS

Added a unit regression test in `tests/unit_tests/dashboards/commands/importers/v1/import_test.py`: a fresh-`uuid` import whose `slug` collides with an existing active dashboard is rejected for a caller who is neither an editor of that dashboard nor an admin. Existing import tests continue to pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
