### PR TITLE
fix: upgrade brace-expansion to patched versions (CVE-2026-14257)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -5233,9 +5233,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12974,16 +12974,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -15575,9 +15575,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20740,9 +20740,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25318,9 +25318,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26255,9 +26255,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -40646,15 +40646,15 @@
       }
     },
     "node_modules/typescript-json-schema/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/typescript-json-schema/node_modules/glob": {


### PR DESCRIPTION
## Summary

Fixes CVE-2026-14257 (brace-expansion regex denial-of-service, GHSA-mh99-v99m-4gvg) for `superset-frontend` with a lockfile-only change: no `package.json` edits.

Every dependent in `superset-frontend/package-lock.json` that pulls in `brace-expansion` already declares a caret range (`^1.1.7`, `^2.0.1`/`^2.0.2`, `^5.0.2`/`^5.0.5`) that permits the patched same-major releases. The lockfile was simply pinned to older, vulnerable patch versions. Regenerating the lock (`npm update brace-expansion`) moves every resolution to a patched version with **zero `package.json` diff**:

| Location | Before | After |
|---|---|---|
| `node_modules/brace-expansion` (root) | 1.1.16 | 1.1.17 |
| `@jest/reporters` | 2.1.2 | 2.1.3 |
| `filelist` | 2.1.2 | 2.1.3 |
| `jest-config` | 2.1.2 | 2.1.3 |
| `jest-runtime` | 2.1.2 | 2.1.3 |
| `@typescript-eslint/typescript-estree` | 5.0.7 | 5.0.8 |
| `typescript-json-schema` | 5.0.7 | 5.0.8 |

That's 7 of the 19 total `brace-expansion` lock entries; the other 12 were already resolved to a patched version (1.1.17 / 2.1.3 / 5.0.8) before this change.

## Why not `overrides` (superseding #42435)

#42435 attempted to fix this with a `package.json` `overrides` block forcing `brace-expansion` to `1.1.17`/`2.1.3`/`5.0.8` globally. That approach broke `lint-frontend`/`validate-frontend` (see [#42435 comment](https://github.com/apache/superset/pull/42435#issuecomment-5113498865)): the root `minimatch@3.1.4` dependency — pinned by `lerna` and resolved transitively by `eslint-plugin-import` (part of the lint chain) — depends on `brace-expansion@^1.1.7` (the 1.x API). Forcing that resolution to `5.0.8` is a 4-major-version jump whose API no longer matches what `Minimatch.braceExpand` expects, producing `TypeError: expand is not a function`.

This PR instead bumps only the resolutions that are actually vulnerable, each staying within its own dependent's existing semver range, so the `minimatch@3.x`/`brace-expansion@1.x` chain used by lint is untouched (it moves from `1.1.16` to `1.1.17`, both within the same API generation).

## Test plan

- [x] `npm update brace-expansion` regenerates the lock with the 7 resolutions above; confirmed zero `package.json` diff (`git diff --stat` shows only `package-lock.json`).
- [x] `npx eslint --version` resolves cleanly (`v10.7.0`) after the lockfile change.
- [x] Sanity check that the `minimatch`/`brace-expansion` chain still loads and works: `require('minimatch')('src/foo.tsx', 'src/**/*.{ts,tsx}')` returns `true`, and `minimatch.braceExpand('{a,b,c}.js')` returns `['a.js','b.js','c.js']`.
- Full `lint-frontend` / `validate-frontend` / test suite left to CI.

Advisory: GHSA-mh99-v99m-4gvg
CVE: CVE-2026-14257
