### PR TITLE
docs(installation): document how to add translations to a custom Docker image

### DIFF
--- a/docs/admin_docs/installation/docker-builds.mdx
+++ b/docs/admin_docs/installation/docker-builds.mdx
@@ -164,7 +164,9 @@ came out of, credit to the community for working it out.
   steps are skipped and only `en` ships. This only takes effect when building the image from source
   (`docker build` against this repo's own `Dockerfile`); it has no effect on a downstream
   Dockerfile that just extends an already-published tag, see
-  "Adding translations to a custom image" above.
+  "Adding translations to a custom image" above. Note that the backend `pybabel compile`
+  step ignores its exit code, so a `.po` file with a compile error won't fail the build;
+  check the build logs for `pybabel` warnings if a locale's backend strings aren't showing up.
 - `DEV_MODE`: whether to skip the frontend build, this is used by our `docker-compose` dev setup
   where we mount the local volume and build using `webpack` in `--watch` mode, meaning as you
   alter the code in the local file system, webpack, from within a docker image used for this

--- a/docs/admin_docs/installation/docker-builds.mdx
+++ b/docs/admin_docs/installation/docker-builds.mdx
@@ -132,12 +132,14 @@ Docker can reuse the cached upstream layers and only rebuild what your stage add
 FROM apache/superset:5.0.0 AS my-custom-image
 USER root
 
-# Pull the compiled translation files out of the earlier build stages. These
-# only exist mid-build (frontend .json in `superset-node`, backend .mo in
-# `python-translation-compiler`) and get stripped from the final `lean`/`dev`
-# stages unless BUILD_TRANSLATIONS=true.
+# Pull the translation files out of the earlier build stages (frontend
+# .json in `superset-node`, backend .mo in `python-translation-compiler`).
+# Those stages' own cleanup only matches single-character extensions, so
+# the source `.po` files can still be present here; strip them explicitly
+# so this stage only keeps the compiled translations.
 COPY --from=superset-node /app/superset/translations superset/translations
 COPY --from=python-translation-compiler /app/translations_mo superset/translations
+RUN find superset/translations -name '*.po' -delete
 
 USER superset
 ```

--- a/docs/admin_docs/installation/docker-builds.mdx
+++ b/docs/admin_docs/installation/docker-builds.mdx
@@ -112,12 +112,54 @@ USER superset
 CMD ["/app/docker/entrypoints/run-server.sh"]
 ```
 
+### Adding translations to a custom image
+
+The pattern above, a small Dockerfile that just extends `FROM apache/superset:...`, can't add
+translations after the fact. By the time an official tag is published, its frontend and backend
+layers have already had non-English translation files stripped out unless `BUILD_TRANSLATIONS`
+was set at build time (see below), and there's no `superset/translations` source tree left in the
+final image to compile from.
+
+To get translations into your own image, you need to build from the full Superset source (a
+clone or fork of this repo) rather than extend a published tag. The most efficient way to do this
+is to append your customizations as one more stage at the end of the repo's own `Dockerfile`, so
+Docker can reuse the cached upstream layers and only rebuild what your stage adds:
+
+```Dockerfile
+# Append this to the end of the repo's Dockerfile
+FROM apache/superset:5.0.0 AS my-custom-image
+USER root
+
+# Pull the compiled translation files out of the earlier build stages. These
+# only exist mid-build (frontend .json in `superset-node`, backend .mo in
+# `python-translation-compiler`) and get stripped from the final `lean`/`dev`
+# stages unless BUILD_TRANSLATIONS=true.
+COPY --from=superset-node /app/superset/translations superset/translations
+COPY --from=python-translation-compiler /app/translations_mo superset/translations
+
+USER superset
+```
+
+Then build with:
+
+```bash
+docker build --target=my-custom-image --build-arg=BUILD_TRANSLATIONS=true -t mysuperset:5.0.0 .
+```
+
+You can combine this with the database-driver/dependency pattern above by adding your own
+`RUN uv pip install ...` step before switching back to `USER superset`. See
+[issue #35959](https://github.com/apache/superset/issues/35959) for the discussion this pattern
+came out of, credit to the community for working it out.
+
 ## Key ARGs in Dockerfile
 
 - `BUILD_TRANSLATIONS`: whether to build the translations into the image. For the
   frontend build this tells webpack to strip out all locales other than `en` from
-  the `moment-timezone` library. For the backendthis skips compiling the
-  `*.po` translation files
+  the `moment-timezone` library. For the backend this skips compiling the
+  `*.po` translation files. This only takes effect when building the image from source
+  (`docker build` against this repo's own `Dockerfile`); it has no effect on a downstream
+  Dockerfile that just extends an already-published tag, see
+  "Adding translations to a custom image" above.
 - `DEV_MODE`: whether to skip the frontend build, this is used by our `docker-compose` dev setup
   where we mount the local volume and build using `webpack` in `--watch` mode, meaning as you
   alter the code in the local file system, webpack, from within a docker image used for this

--- a/docs/admin_docs/installation/docker-builds.mdx
+++ b/docs/admin_docs/installation/docker-builds.mdx
@@ -127,6 +127,8 @@ Docker can reuse the cached upstream layers and only rebuild what your stage add
 
 ```Dockerfile
 # Append this to the end of the repo's Dockerfile
+# Keep this tag in sync with the branch/tag of the repo you cloned, so the
+# translation files built from source match the keys the runtime expects:
 FROM apache/superset:5.0.0 AS my-custom-image
 USER root
 
@@ -153,10 +155,11 @@ came out of, credit to the community for working it out.
 
 ## Key ARGs in Dockerfile
 
-- `BUILD_TRANSLATIONS`: whether to build the translations into the image. For the
-  frontend build this tells webpack to strip out all locales other than `en` from
-  the `moment-timezone` library. For the backend this skips compiling the
-  `*.po` translation files. This only takes effect when building the image from source
+- `BUILD_TRANSLATIONS`: whether to compile non-English translations into the image.
+  When `true`, the frontend build converts the `*.po` files to locale JSON and the
+  backend runs `pybabel compile` to produce `*.mo` files; both source `*.po` files
+  are stripped afterward either way. When `false` (the default), those compile
+  steps are skipped and only `en` ships. This only takes effect when building the image from source
   (`docker build` against this repo's own `Dockerfile`); it has no effect on a downstream
   Dockerfile that just extends an already-published tag, see
   "Adding translations to a custom image" above.


### PR DESCRIPTION
### SUMMARY
Follow-up to #35959. `BUILD_TRANSLATIONS` was documented as "whether to build the translations into the image," but not that it only does anything when building from source, extending an already-published tag (the pattern this same page already documents) can't add translations after the fact, since non-English files are already stripped out of the published layers by the time a tag ships. That gap caused real confusion in #35959: a user tried exactly the "small downstream Dockerfile" pattern with `ARG BUILD_TRANSLATIONS=true` and it silently did nothing.

Adds a new "Adding translations to a custom image" section documenting the multi-stage `COPY --from=superset-node` / `COPY --from=python-translation-compiler` pattern @dawagner worked out in that thread (verified the stage names and output paths still match the current `Dockerfile`), and updates the `BUILD_TRANSLATIONS` ARG description to point at it. Also fixed a stray missing space ("backendthis" → "backend this") while in there.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs only.

### TESTING INSTRUCTIONS
Read-through; `pre-commit run` passes on the changed file. The documented Dockerfile snippet's stage names (`superset-node`, `python-translation-compiler`) and paths (`/app/superset/translations`, `/app/translations_mo`) were checked against the current `Dockerfile` on `master`, not just copied from the issue comment.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #35959
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
