### PR TITLE
fix(sql): guard FORCE_LIMIT against SHOW statements (#36939)

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1408,10 +1408,12 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         """
         if method == LimitMethod.FORCE_LIMIT:
             # `SHOW` statements (`SHOW TABLES`, `SHOW DATABASES`, `SHOW CREATE
-            # TABLE`, etc.) have no real `LIMIT` slot in sqlglot's expression
-            # tree: setting `args["limit"]` doesn't get rejected, it renders a
-            # malformed statement with two `LIMIT` keywords, which engines
-            # like StarRocks reject outright. Leave them untouched.
+            # TABLE`, etc.) have no meaningful `LIMIT` slot to force. On
+            # MySQL/StarRocks, writing one renders a malformed statement with
+            # two `LIMIT` keywords that the engine rejects outright; on dialects
+            # like Snowflake it would render a valid `SHOW ... LIMIT`, but SHOW
+            # returns bounded metadata, so we skip it uniformly rather than
+            # special-case per dialect. Leave them untouched.
             if isinstance(self._parsed, exp.Show):
                 return
             self._parsed.args["limit"] = exp.Limit(

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1407,6 +1407,13 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         Modify the `LIMIT` or `TOP` value of the SQL statement inplace.
         """
         if method == LimitMethod.FORCE_LIMIT:
+            # `SHOW` statements (`SHOW TABLES`, `SHOW DATABASES`, `SHOW CREATE
+            # TABLE`, etc.) have no real `LIMIT` slot in sqlglot's expression
+            # tree: setting `args["limit"]` doesn't get rejected, it renders a
+            # malformed statement with two `LIMIT` keywords, which engines
+            # like StarRocks reject outright. Leave them untouched.
+            if isinstance(self._parsed, exp.Show):
+                return
             self._parsed.args["limit"] = exp.Limit(
                 expression=exp.Literal(this=str(limit), is_string=False)
             )

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2388,6 +2388,34 @@ def test_set_limit_value(
 
 
 @pytest.mark.parametrize(
+    "sql",
+    [
+        "SHOW TABLES",
+        "SHOW DATABASES",
+        "SHOW CREATE TABLE test.will_test1",
+    ],
+)
+def test_set_limit_value_leaves_show_statements_unchanged(sql: str) -> None:
+    """
+    Regression for #36939: FORCE_LIMIT must not touch ``SHOW`` statements.
+
+    ``SHOW`` statements have no `LIMIT` clause in sqlglot's expression tree,
+    so forcing one via ``args["limit"]`` doesn't reject cleanly, it produces
+    a malformed statement with two ``LIMIT`` keywords (one from a stray
+    rendering of the bare ``Limit`` expression, one from the forced value).
+    StarRocks (and presumably other engines) reject that outright: "Getting
+    syntax error ... Unexpected input 'LIMIT'". The statement should be
+    left untouched instead, matching how ``SELECT`` statements without a
+    scannable row source aren't force-limited either.
+    """
+    statement = SQLStatement(sql, "starrocks")
+    original = statement.format()
+    statement.set_limit_value(1000, LimitMethod.FORCE_LIMIT)
+    assert statement.format() == original
+    assert "LIMIT" not in statement.format()
+
+
+@pytest.mark.parametrize(
     "kql, limit, expected",
     [
         ("StormEvents | take 10", 100, "StormEvents | take 100"),

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2388,6 +2388,17 @@ def test_set_limit_value(
 
 
 @pytest.mark.parametrize(
+    "engine",
+    [
+        # Engines whose sqlglot dialect parses `SHOW` into a real `exp.Show`
+        # node (as opposed to falling back to an opaque `exp.Command`, which
+        # doesn't expose a `limit` arg and so was never affected by this bug).
+        "starrocks",
+        "mysql",
+        "snowflake",
+    ],
+)
+@pytest.mark.parametrize(
     "sql",
     [
         "SHOW TABLES",
@@ -2395,7 +2406,9 @@ def test_set_limit_value(
         "SHOW CREATE TABLE test.will_test1",
     ],
 )
-def test_set_limit_value_leaves_show_statements_unchanged(sql: str) -> None:
+def test_set_limit_value_leaves_show_statements_unchanged(
+    sql: str, engine: str
+) -> None:
     """
     Regression for #36939: FORCE_LIMIT must not touch ``SHOW`` statements.
 
@@ -2407,8 +2420,13 @@ def test_set_limit_value_leaves_show_statements_unchanged(sql: str) -> None:
     syntax error ... Unexpected input 'LIMIT'". The statement should be
     left untouched instead, matching how ``SELECT`` statements without a
     scannable row source aren't force-limited either.
+
+    Covers multiple engines, not just StarRocks: the fix guards on the AST
+    node type (``exp.Show``), not the dialect, so any engine whose sqlglot
+    dialect parses ``SHOW`` into a real ``Show`` node (e.g. MySQL, Snowflake)
+    is equally exposed and must be equally protected.
     """
-    statement = SQLStatement(sql, "starrocks")
+    statement = SQLStatement(sql, engine)
     original = statement.format()
     statement.set_limit_value(1000, LimitMethod.FORCE_LIMIT)
     assert statement.format() == original


### PR DESCRIPTION
### SUMMARY

Fixes #36939 (the `SHOW`-statement portion): `SHOW TABLES`, `SHOW DATABASES`, and `SHOW CREATE TABLE ...` failed with `Unexpected input 'LIMIT'` on StarRocks (and presumably other `FORCE_LIMIT` engines).

`SQLStatement.set_limit_value`'s `FORCE_LIMIT` path unconditionally set `_parsed.args["limit"]` regardless of statement type. sqlglot's `Show` expression has no real `LIMIT` slot, so instead of rejecting cleanly it rendered a malformed statement with the `LIMIT` keyword twice (`SHOW TABLES` → `'SHOW TABLES LIMIT \nLIMIT 1000'`). The fix guards the `FORCE_LIMIT` branch with `isinstance(self._parsed, exp.Show)` and leaves those statements untouched, matching how `SELECT` statements without a scannable row source aren't force-limited either.

This started as a test-only PR (`test_set_limit_value_leaves_show_statements_unchanged` in `tests/unit_tests/sql/parse_tests.py`) reproducing the bug; the guard above is the fix, and the test now passes.

Note: #36939 also reports `REFRESH EXTERNAL TABLE ...` and `DROP TABLE ... FORCE` failing with a sqlglot `ParseError`. That's a separate, upstream dialect gap (verified against pinned sqlglot 30.12.0, reproduces for every dialect, not just `starrocks`) — out of scope here.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/sql/parse_tests.py -k test_set_limit_value_leaves_show_statements_unchanged -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: fixes the `SHOW`-statement portion of #36939
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
