### PR TITLE
fix(security): grant SQL Lab query authors an explore access bypass (#39296)

### DIFF
--- a/superset/commands/explore/get.py
+++ b/superset/commands/explore/get.py
@@ -74,8 +74,19 @@ def _authorize_datasource(
         # superset/explore/utils.py::check_query_access), so the
         # Explore page for that transition actually opens for the
         # query's own author.
+        #
+        # The Query is still passed as ``datasource`` too: the
+        # ``EXTRA_RAISE_FOR_ACCESS_BYPASS`` hook only ever receives
+        # ``datasource`` (never ``query``), and before this reroute the
+        # Explore GET handed it the Query under that name. Dropping it
+        # would silently stop a deployment's custom bypass from seeing
+        # the query at all. The author bypass returns before the generic
+        # ``datasource`` perm check at the tail of ``raise_for_access``,
+        # so this does not weaken anything for anyone else.
         security_manager.raise_for_access(
-            query=datasource, allow_query_authorship_bypass=True
+            query=datasource,
+            datasource=datasource,
+            allow_query_authorship_bypass=True,
         )
     else:
         security_manager.raise_for_access(datasource=datasource)

--- a/superset/commands/explore/get.py
+++ b/superset/commands/explore/get.py
@@ -17,7 +17,7 @@
 import contextlib
 import logging
 from abc import ABC
-from typing import Any, cast, Optional
+from typing import Any, cast, Optional, TYPE_CHECKING
 
 from flask import request
 from flask_babel import lazy_gettext as _
@@ -38,6 +38,7 @@ from superset.exceptions import SupersetException
 from superset.explore.exceptions import WrongEndpointError
 from superset.explore.permalink.exceptions import ExplorePermalinkGetFailedError
 from superset.extensions import security_manager
+from superset.models.sql_lab import Query
 from superset.superset_typing import ExplorableData
 from superset.utils import core as utils, json
 from superset.views.utils import (
@@ -46,7 +47,38 @@ from superset.views.utils import (
     sanitize_datasource_data,
 )
 
+if TYPE_CHECKING:
+    from superset.models.slice import Slice
+
 logger = logging.getLogger(__name__)
+
+
+def _authorize_datasource(
+    datasource: "BaseDatasource | Query", slc: Optional["Slice"]
+) -> None:
+    """
+    Raise if the current user cannot access the resource being explored.
+
+    Split out of ``GetExploreCommand.run()`` so the authorship-bypass
+    routing below is testable without a request context.
+    """
+    if slc:
+        security_manager.raise_for_access(chart=slc)
+    elif isinstance(datasource, Query):
+        # A "query" datasource_type resolves to the actual SQL Lab
+        # Query row, not a registered dataset -- its .perm is a
+        # synthetic string no role is ever granted, so the generic
+        # datasource_access check below would always fail here.
+        # Route it through the same query-authorship bypass the
+        # explore/create-chart form-data step already applies (see
+        # superset/explore/utils.py::check_query_access), so the
+        # Explore page for that transition actually opens for the
+        # query's own author.
+        security_manager.raise_for_access(
+            query=datasource, allow_query_authorship_bypass=True
+        )
+    else:
+        security_manager.raise_for_access(datasource=datasource)
 
 
 class GetExploreCommand(BaseCommand, ABC):
@@ -124,10 +156,7 @@ class GetExploreCommand(BaseCommand, ABC):
 
         if datasource:
             datasource_name = datasource.name
-            if slc:
-                security_manager.raise_for_access(chart=slc)
-            else:
-                security_manager.raise_for_access(datasource=datasource)
+            _authorize_datasource(datasource, slc)
 
         viz_type = form_data.get("viz_type")
         if (

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -57,7 +57,12 @@ def check_query_access(query_id: int) -> Optional[bool]:
         query = QueryDAO.find_by_id(query_id, skip_base_filter=True)
         if query:
             try:
-                security_manager.raise_for_access(query=query)
+                # This is the one-time explore/create-chart transition the
+                # query-authorship bypass in raise_for_access is meant to
+                # cover; see allow_query_authorship_bypass's docstring there.
+                security_manager.raise_for_access(
+                    query=query, allow_query_authorship_bypass=True
+                )
             except TemplateError as ex:
                 # raise_for_access() Jinja-renders the query's SQL to resolve
                 # the tables it touches; a malformed template surfaces here as

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -53,7 +53,12 @@ def check_query_access(query_id: int) -> Optional[bool]:
         # Access checks below, no need to validate them twice as they can be expensive.
         query = QueryDAO.find_by_id(query_id, skip_base_filter=True)
         if query:
-            security_manager.raise_for_access(query=query)
+            # This is the one-time explore/create-chart transition the
+            # query-authorship bypass in raise_for_access is meant to
+            # cover; see allow_query_authorship_bypass's docstring there.
+            security_manager.raise_for_access(
+                query=query, allow_query_authorship_bypass=True
+            )
             return True
     raise QueryNotFoundValidationError()
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4316,6 +4316,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         schema: Optional[str] = None,
         template_params: Optional[dict[str, Any]] = None,
         force_dataset_match: bool = False,
+        allow_query_authorship_bypass: bool = False,
     ) -> None:
         """
         Raise an exception if the user cannot access the resource.
@@ -4338,6 +4339,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             The default (False) preserves the historical semantics for
             chart-data, dataset CRUD, ``/table_metadata/``, and
             ``/select_star/``.
+        :param allow_query_authorship_bypass: When True, a SQL Lab query's
+            own author is granted access to that exact, already-succeeded
+            query without an additional dataset-level ``datasource_access``
+            grant. Deliberately opt-in and scoped to the one-time
+            explore/create-chart transition: repeat, ongoing access to a
+            query-backed chart or dashboard (fetching its data, exporting
+            it) must keep going through the regular catalog/schema/
+            datasource_access checks below on every call, since authorship
+            alone does not track whether the author still holds that
+            access, and a query's SQL may be templated such that the
+            tables actually touched depend on parameters supplied at
+            request time.
         :raises SupersetSecurityException: If the user cannot access the resource
         """
         # pylint: disable=import-outside-toplevel
@@ -4425,14 +4438,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # this same method; the query path had no equivalent authorship
             # bypass.
             #
-            # Scoped to ``not force_dataset_match``: that flag is set by the
-            # call sites that execute a query or return its row data (SQL
-            # Lab execute, results/export, MetaDB), where every SQL Lab
-            # query's author trivially equals the current user and an
-            # unscoped bypass would erase the per-table
-            # catalog/schema/datasource_access checks below entirely. It is
-            # left unset only by the explore/form-data path this bypass is
-            # meant to cover.
+            # Gated on the explicit ``allow_query_authorship_bypass`` opt-in
+            # rather than firing for every ``not force_dataset_match`` call:
+            # that flag is also False for call sites unrelated to the
+            # one-time explore/create-chart transition this bypass is meant
+            # to cover, e.g. fetching or exporting a query-backed chart's
+            # data (``query_context_processor.raise_for_access``), which
+            # runs on every view of an already-created chart or dashboard.
+            # Those call sites must keep re-checking catalog/schema/
+            # datasource_access on every call: authorship alone does not
+            # track whether the author still holds that access, and the
+            # query's SQL may be templated such that the tables actually
+            # touched depend on parameters supplied at request time.
             #
             # Does not apply to the ephemeral query built above either:
             # that one's ``user_id`` is always the current user by
@@ -4451,6 +4468,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 query
                 and not is_ephemeral_query
                 and not force_dataset_match
+                and allow_query_authorship_bypass
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4416,21 +4416,31 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if self.can_access_database(database):
                 return
 
-            # A SQL Lab query's own author already has execution rights on
-            # the connection that produced it (SQL Lab wouldn't have run the
-            # query otherwise): exploring the exact query they just ran
-            # should not additionally require a dataset-level
-            # ``datasource_access`` grant on every table it happens to
-            # touch. This mirrors the ownership bypass already granted to
-            # dataset owners via ``is_editor`` further below in this same
-            # method; the query path had no equivalent authorship bypass.
-            # Does not apply to the ephemeral query built above: that one's
-            # ``user_id`` is always the current user by construction, which
-            # would trivially bypass the very check being performed on a
-            # brand new, never-before-run SQL string.
+            # A SQL Lab query's own author should be able to explore/chart
+            # the exact query they already ran without an additional
+            # dataset-level ``datasource_access`` grant on every table it
+            # happens to touch. This mirrors the ownership bypass already
+            # granted to dataset owners via ``is_editor`` further below in
+            # this same method; the query path had no equivalent authorship
+            # bypass.
+            #
+            # Scoped to ``not force_dataset_match``: that flag is set by the
+            # call sites that execute a query or return its row data (SQL
+            # Lab execute, results/export, MetaDB), where every SQL Lab
+            # query's author trivially equals the current user and an
+            # unscoped bypass would erase the per-table
+            # catalog/schema/datasource_access checks below entirely. It is
+            # left unset only by the explore/form-data path this bypass is
+            # meant to cover.
+            #
+            # Does not apply to the ephemeral query built above either:
+            # that one's ``user_id`` is always the current user by
+            # construction, which would trivially bypass the very check
+            # being performed on a brand new, never-before-run SQL string.
             if (
                 query
                 and not is_ephemeral_query
+                and not force_dataset_match
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4408,6 +4408,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if self.can_access_database(database):
                 return
 
+            # A SQL Lab query's own author already has execution rights on
+            # the connection that produced it (SQL Lab wouldn't have run the
+            # query otherwise): exploring the exact query they just ran
+            # should not additionally require a dataset-level
+            # ``datasource_access`` grant on every table it happens to
+            # touch. This mirrors the ownership bypass already granted to
+            # dataset owners via ``is_editor`` further below in this same
+            # method; the query path had no equivalent authorship bypass.
+            if (
+                query
+                and hasattr(query, "user_id")
+                and (user_id := get_user_id()) is not None
+                and query.user_id == user_id
+            ):
+                return
+
             # Type narrow: this path only applies to SQL Lab Query objects
             if query and hasattr(query, "sql") and hasattr(query, "catalog"):
                 # Getting the default schema for a query is hard. Users can select the

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4366,6 +4366,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 )
                 return
 
+        # An ephemeral Query built below from a raw `sql=` string always
+        # stamps the *current* user as its `user_id`, since there's no real
+        # query to attribute authorship to yet -- that must not be confused
+        # with a genuine, previously-persisted Query the caller fetched by
+        # id (e.g. from SQL Lab history), whose authorship bypass further
+        # down is meant to reward a query that was already run and stored.
+        is_ephemeral_query = bool(sql and database)
+
         if sql and database:
             query = Query(
                 database=database,
@@ -4416,8 +4424,13 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # touch. This mirrors the ownership bypass already granted to
             # dataset owners via ``is_editor`` further below in this same
             # method; the query path had no equivalent authorship bypass.
+            # Does not apply to the ephemeral query built above: that one's
+            # ``user_id`` is always the current user by construction, which
+            # would trivially bypass the very check being performed on a
+            # brand new, never-before-run SQL string.
             if (
                 query
+                and not is_ephemeral_query
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4344,6 +4344,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from flask import current_app
 
         from superset import is_feature_enabled
+        from superset.common.db_query_status import QueryStatus
         from superset.connectors.sqla.models import SqlaTable
         from superset.models.dashboard import Dashboard
         from superset.models.slice import Slice
@@ -4437,6 +4438,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # that one's ``user_id`` is always the current user by
             # construction, which would trivially bypass the very check
             # being performed on a brand new, never-before-run SQL string.
+            #
+            # Also requires ``status == SUCCESS``: SQL Lab persists a Query
+            # row (stamped with the current user's id) *before* running the
+            # strict ``force_dataset_match`` check at execute time, and
+            # marks it FAILED rather than deleting it when that check
+            # denies the statement. Without this guard, authorship alone
+            # would let that same user replay the denied SQL through this
+            # non-strict path merely by revisiting the failed query's id,
+            # defeating the very check that just rejected it.
             if (
                 query
                 and not is_ephemeral_query
@@ -4444,6 +4454,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id
+                and getattr(query, "status", None) == QueryStatus.SUCCESS
             ):
                 return
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3905,6 +3905,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if self.can_access_database(database):
                 return
 
+            # A SQL Lab query's own author already has execution rights on
+            # the connection that produced it (SQL Lab wouldn't have run the
+            # query otherwise): exploring the exact query they just ran
+            # should not additionally require a dataset-level
+            # ``datasource_access`` grant on every table it happens to
+            # touch. This mirrors the ownership bypass already granted to
+            # dataset owners via ``is_editor`` further below in this same
+            # method; the query path had no equivalent authorship bypass.
+            if (
+                query
+                and hasattr(query, "user_id")
+                and (user_id := get_user_id()) is not None
+                and query.user_id == user_id
+            ):
+                return
+
             # Type narrow: this path only applies to SQL Lab Query objects
             if query and hasattr(query, "sql") and hasattr(query, "catalog"):
                 # Getting the default schema for a query is hard. Users can select the

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3878,6 +3878,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 )
                 return
 
+        # An ephemeral Query built below from a raw `sql=` string always
+        # stamps the *current* user as its `user_id`, since there's no real
+        # query to attribute authorship to yet -- that must not be confused
+        # with a genuine, previously-persisted Query the caller fetched by
+        # id (e.g. from SQL Lab history), whose authorship bypass further
+        # down is meant to reward a query that was already run and stored.
+        is_ephemeral_query = bool(sql and database)
+
         if sql and database:
             query = Query(
                 database=database,
@@ -3913,8 +3921,13 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # touch. This mirrors the ownership bypass already granted to
             # dataset owners via ``is_editor`` further below in this same
             # method; the query path had no equivalent authorship bypass.
+            # Does not apply to the ephemeral query built above: that one's
+            # ``user_id`` is always the current user by construction, which
+            # would trivially bypass the very check being performed on a
+            # brand new, never-before-run SQL string.
             if (
                 query
+                and not is_ephemeral_query
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3913,21 +3913,31 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if self.can_access_database(database):
                 return
 
-            # A SQL Lab query's own author already has execution rights on
-            # the connection that produced it (SQL Lab wouldn't have run the
-            # query otherwise): exploring the exact query they just ran
-            # should not additionally require a dataset-level
-            # ``datasource_access`` grant on every table it happens to
-            # touch. This mirrors the ownership bypass already granted to
-            # dataset owners via ``is_editor`` further below in this same
-            # method; the query path had no equivalent authorship bypass.
-            # Does not apply to the ephemeral query built above: that one's
-            # ``user_id`` is always the current user by construction, which
-            # would trivially bypass the very check being performed on a
-            # brand new, never-before-run SQL string.
+            # A SQL Lab query's own author should be able to explore/chart
+            # the exact query they already ran without an additional
+            # dataset-level ``datasource_access`` grant on every table it
+            # happens to touch. This mirrors the ownership bypass already
+            # granted to dataset owners via ``is_editor`` further below in
+            # this same method; the query path had no equivalent authorship
+            # bypass.
+            #
+            # Scoped to ``not force_dataset_match``: that flag is set by the
+            # call sites that execute a query or return its row data (SQL
+            # Lab execute, results/export, MetaDB), where every SQL Lab
+            # query's author trivially equals the current user and an
+            # unscoped bypass would erase the per-table
+            # catalog/schema/datasource_access checks below entirely. It is
+            # left unset only by the explore/form-data path this bypass is
+            # meant to cover.
+            #
+            # Does not apply to the ephemeral query built above either:
+            # that one's ``user_id`` is always the current user by
+            # construction, which would trivially bypass the very check
+            # being performed on a brand new, never-before-run SQL string.
             if (
                 query
                 and not is_ephemeral_query
+                and not force_dataset_match
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3856,6 +3856,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from flask import current_app
 
         from superset import is_feature_enabled
+        from superset.common.db_query_status import QueryStatus
         from superset.connectors.sqla.models import SqlaTable
         from superset.models.dashboard import Dashboard
         from superset.models.slice import Slice
@@ -3934,6 +3935,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # that one's ``user_id`` is always the current user by
             # construction, which would trivially bypass the very check
             # being performed on a brand new, never-before-run SQL string.
+            #
+            # Also requires ``status == SUCCESS``: SQL Lab persists a Query
+            # row (stamped with the current user's id) *before* running the
+            # strict ``force_dataset_match`` check at execute time, and
+            # marks it FAILED rather than deleting it when that check
+            # denies the statement. Without this guard, authorship alone
+            # would let that same user replay the denied SQL through this
+            # non-strict path merely by revisiting the failed query's id,
+            # defeating the very check that just rejected it.
             if (
                 query
                 and not is_ephemeral_query
@@ -3941,6 +3951,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id
+                and getattr(query, "status", None) == QueryStatus.SUCCESS
             ):
                 return
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3827,6 +3827,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         schema: Optional[str] = None,
         template_params: Optional[dict[str, Any]] = None,
         force_dataset_match: bool = False,
+        allow_query_authorship_bypass: bool = False,
     ) -> None:
         """
         Raise an exception if the user cannot access the resource.
@@ -3850,6 +3851,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             The default (False) preserves the historical semantics for
             chart-data, dataset CRUD, ``/table_metadata/``, and
             ``/select_star/``.
+        :param allow_query_authorship_bypass: When True, a SQL Lab query's
+            own author is granted access to that exact, already-succeeded
+            query without an additional dataset-level ``datasource_access``
+            grant. Deliberately opt-in and scoped to the one-time
+            explore/create-chart transition: repeat, ongoing access to a
+            query-backed chart or dashboard (fetching its data, exporting
+            it) must keep going through the regular catalog/schema/
+            datasource_access checks below on every call, since authorship
+            alone does not track whether the author still holds that
+            access, and a query's SQL may be templated such that the
+            tables actually touched depend on parameters supplied at
+            request time.
         :raises SupersetSecurityException: If the user cannot access the resource
         """
         # pylint: disable=import-outside-toplevel
@@ -3922,14 +3935,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # this same method; the query path had no equivalent authorship
             # bypass.
             #
-            # Scoped to ``not force_dataset_match``: that flag is set by the
-            # call sites that execute a query or return its row data (SQL
-            # Lab execute, results/export, MetaDB), where every SQL Lab
-            # query's author trivially equals the current user and an
-            # unscoped bypass would erase the per-table
-            # catalog/schema/datasource_access checks below entirely. It is
-            # left unset only by the explore/form-data path this bypass is
-            # meant to cover.
+            # Gated on the explicit ``allow_query_authorship_bypass`` opt-in
+            # rather than firing for every ``not force_dataset_match`` call:
+            # that flag is also False for call sites unrelated to the
+            # one-time explore/create-chart transition this bypass is meant
+            # to cover, e.g. fetching or exporting a query-backed chart's
+            # data (``query_context_processor.raise_for_access``), which
+            # runs on every view of an already-created chart or dashboard.
+            # Those call sites must keep re-checking catalog/schema/
+            # datasource_access on every call: authorship alone does not
+            # track whether the author still holds that access, and the
+            # query's SQL may be templated such that the tables actually
+            # touched depend on parameters supplied at request time.
             #
             # Does not apply to the ephemeral query built above either:
             # that one's ``user_id`` is always the current user by
@@ -3948,6 +3965,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 query
                 and not is_ephemeral_query
                 and not force_dataset_match
+                and allow_query_authorship_bypass
                 and hasattr(query, "user_id")
                 and (user_id := get_user_id()) is not None
                 and query.user_id == user_id

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -405,7 +405,7 @@ class TestCreateFormDataCommand(SupersetTestCase):
 
         query = Query(
             sql="SELECT * FROM wb_health_population",
-            client_id="form_data_schema_access_test",
+            client_id="fd_sch_acc1",
             database=database,
             schema=schema,
             user_id=gamma_user.id,

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -31,9 +31,35 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
 from superset.utils import json
-from superset.utils.core import DatasourceType, get_example_default_schema
+from superset.utils.core import (
+    DatasourceType,
+    get_example_default_schema,
+    override_user,
+)
 from superset.utils.database import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
+
+# Mirrors the SCHEMA_ACCESS_ROLE pattern in tests/integration_tests/security_tests.py:
+# a role granting only schema_access on one schema, no all_datasource_access and no
+# per-table datasource_access.
+FORM_DATA_SCHEMA_ACCESS_ROLE = "form_data_schema_access_role"
+
+
+def _grant_schema_access(view_menu_name: str) -> None:
+    permission = "schema_access"
+    security_manager.add_permission_view_menu(permission, view_menu_name)
+    perm_view = security_manager.find_permission_view_menu(permission, view_menu_name)
+    security_manager.add_permission_role(
+        security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE), perm_view
+    )
+
+
+def _revoke_schema_access(view_menu_name: str) -> None:
+    pv = security_manager.find_permission_view_menu("schema_access", view_menu_name)
+    security_manager.del_permission_role(
+        security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE), pv
+    )
+    security_manager.del_permission_view_menu("schema_access", view_menu_name)
 
 
 class TestCreateFormDataCommand(SupersetTestCase):
@@ -345,3 +371,74 @@ class TestCreateFormDataCommand(SupersetTestCase):
         response = delete_command.run()
 
         assert response is False  # noqa: E712
+
+    def test_create_form_data_command_schema_access_no_all_datasource_access(self):
+        """
+        Regression for #39296: a user who has schema_access on the schema a
+        SQL Lab query ran in (but neither all_datasource_access nor
+        datasource_access on a specific registered dataset, since an ad-hoc
+        query result is never registered as one) should still be able to
+        jump straight from SQL Lab to "Create Chart" -- i.e.
+        CreateFormDataCommand.run() with datasource_type=QUERY should not be
+        blocked purely for lacking all_datasource_access, as long as the
+        query's schema is one they're granted schema_access on.
+
+        This exercises the same non-strict (force_dataset_match=False)
+        fallthrough in SupersetSecurityManager.raise_for_access that
+        test_raise_for_access_force_dataset_match_denies_schema_only (in
+        security_tests.py) exercises for the strict SQL Lab path -- here we
+        confirm the *non*-strict Explore/"Create Chart" path grants access on
+        schema_access alone, without needing a registered dataset at all.
+        """
+        schema = get_example_default_schema()
+        database = get_example_database()
+        view_menu_name = f"[{database.database_name}].[{schema}]"
+
+        security_manager.add_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
+        db.session.commit()
+        _grant_schema_access(view_menu_name)
+        gamma_user = security_manager.find_user(username="gamma")
+        gamma_user.roles.append(
+            security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
+        )
+        db.session.commit()
+
+        query = Query(
+            sql="SELECT * FROM wb_health_population",
+            client_id="form_data_schema_access_test",
+            database=database,
+            schema=schema,
+            user_id=gamma_user.id,
+        )
+        db.session.add(query)
+        db.session.commit()
+
+        try:
+            with override_user(gamma_user):
+                # Sanity check: gamma should NOT have all_datasource_access,
+                # or this test wouldn't be exercising the reported gap.
+                assert not security_manager.can_access_all_datasources()
+
+                args = CommandParameters(
+                    datasource_id=query.id,
+                    datasource_type=DatasourceType.QUERY,
+                    chart_id=None,
+                    tab_id=1,
+                    form_data=json.dumps(
+                        {"datasource": f"{query.id}__{DatasourceType.QUERY}"}
+                    ),
+                )
+                # Should NOT raise: schema_access on the query's schema is
+                # sufficient for the non-strict Explore access check, even
+                # without all_datasource_access or a registered dataset.
+                key = CreateFormDataCommand(args).run()
+                assert isinstance(key, str)
+        finally:
+            db.session.delete(query)
+            gamma_user.roles.remove(
+                security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
+            )
+            db.session.commit()
+            _revoke_schema_access(view_menu_name)
+            db.session.delete(security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE))
+            db.session.commit()

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -392,7 +392,15 @@ class TestCreateFormDataCommand(SupersetTestCase):
         """
         schema = get_example_default_schema()
         database = get_example_database()
-        view_menu_name = f"[{database.database_name}].[{schema}]"
+        # raise_for_access qualifies the query's tables against the
+        # database's default catalog (e.g. the Postgres database name),
+        # so the granted schema_access permission must be built the same
+        # way -- get_schema_perm() falls back to the plain [db].[schema]
+        # form when the backend (e.g. sqlite, mysql) doesn't support
+        # catalogs at all.
+        view_menu_name = security_manager.get_schema_perm(
+            database.database_name, database.get_default_catalog(), schema
+        )
 
         security_manager.add_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
         db.session.commit()

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -46,21 +46,37 @@ from tests.integration_tests.base_tests import SupersetTestCase
 FORM_DATA_SCHEMA_ACCESS_ROLE = "form_data_schema_access_role"
 
 
-def _grant_schema_access(view_menu_name: str) -> None:
+def _grant_schema_access(view_menu_name: str) -> bool:
+    """
+    Grants ``FORM_DATA_SCHEMA_ACCESS_ROLE`` schema_access on the given view
+    menu. Returns whether this call created the underlying permission-view
+    (as opposed to one that already existed, e.g. granted to some other
+    role by an earlier test), so the caller's teardown knows whether it's
+    safe to delete it without affecting other schema-access tests.
+    """
     permission = "schema_access"
+    created_permission_view = (
+        security_manager.find_permission_view_menu(permission, view_menu_name) is None
+    )
     security_manager.add_permission_view_menu(permission, view_menu_name)
     perm_view = security_manager.find_permission_view_menu(permission, view_menu_name)
     security_manager.add_permission_role(
         security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE), perm_view
     )
+    return created_permission_view
 
 
-def _revoke_schema_access(view_menu_name: str) -> None:
+def _revoke_schema_access(view_menu_name: str, delete_permission_view: bool) -> None:
     pv = security_manager.find_permission_view_menu("schema_access", view_menu_name)
     security_manager.del_permission_role(
         security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE), pv
     )
-    security_manager.del_permission_view_menu("schema_access", view_menu_name)
+    # Only remove the permission-view menu itself if this fixture created
+    # it; it may have pre-dated this test (e.g. granted to another role),
+    # and other schema-access tests shouldn't become order-dependent on
+    # this teardown.
+    if delete_permission_view:
+        security_manager.del_permission_view_menu("schema_access", view_menu_name)
 
 
 class TestCreateFormDataCommand(SupersetTestCase):
@@ -405,7 +421,7 @@ class TestCreateFormDataCommand(SupersetTestCase):
 
         security_manager.add_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
         db.session.commit()
-        _grant_schema_access(view_menu_name)
+        created_permission_view = _grant_schema_access(view_menu_name)
         gamma_user = security_manager.find_user(username="gamma")
         gamma_user.roles.append(
             security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
@@ -448,7 +464,7 @@ class TestCreateFormDataCommand(SupersetTestCase):
                 security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE)
             )
             db.session.commit()
-            _revoke_schema_access(view_menu_name)
+            _revoke_schema_access(view_menu_name, created_permission_view)
             db.session.delete(security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE))
             db.session.commit()
 

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -450,3 +450,61 @@ class TestCreateFormDataCommand(SupersetTestCase):
             _revoke_schema_access(view_menu_name)
             db.session.delete(security_manager.find_role(FORM_DATA_SCHEMA_ACCESS_ROLE))
             db.session.commit()
+
+    def test_create_form_data_command_query_author_no_all_datasource_access(self):
+        """
+        Regression for #39296 (the fix, not just the confirming test): a
+        user with no all_datasource_access and no catalog/schema/
+        datasource_access grant covering the table their SQL Lab query
+        touches should still be able to jump straight from SQL Lab to
+        "Create Chart" for that exact query, as long as they authored it.
+
+        SupersetSecurityManager.raise_for_access grants a bypass to a SQL
+        Lab query's own author, mirroring the ownership bypass already
+        granted to dataset owners via is_editor -- unlike
+        test_create_form_data_command_schema_access_no_all_datasource_access
+        above, this user has no schema_access grant of any kind; authorship
+        alone is what lets this through.
+        """
+        schema = get_example_default_schema()
+        database = get_example_database()
+        gamma_user = security_manager.find_user(username="gamma")
+
+        query = Query(
+            sql="SELECT * FROM wb_health_population",
+            client_id="fd_auth_acc1",
+            database=database,
+            schema=schema,
+            user_id=gamma_user.id,
+        )
+        db.session.add(query)
+        db.session.commit()
+
+        try:
+            with override_user(gamma_user):
+                # Sanity check: gamma should have neither all_datasource_access
+                # nor a schema_access grant covering this query's schema, or
+                # this test wouldn't be exercising the authorship bypass.
+                assert not security_manager.can_access_all_datasources()
+                view_menu_name = security_manager.get_schema_perm(
+                    database.database_name, database.get_default_catalog(), schema
+                )
+                assert not security_manager.can_access("schema_access", view_menu_name)
+
+                args = CommandParameters(
+                    datasource_id=query.id,
+                    datasource_type=DatasourceType.QUERY,
+                    chart_id=None,
+                    tab_id=1,
+                    form_data=json.dumps(
+                        {"datasource": f"{query.id}__{DatasourceType.QUERY}"}
+                    ),
+                )
+                # Should NOT raise: gamma authored this exact query, which
+                # is sufficient on its own, without any schema- or
+                # dataset-level grant.
+                key = CreateFormDataCommand(args).run()
+                assert isinstance(key, str)
+        finally:
+            db.session.delete(query)
+            db.session.commit()

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -472,7 +472,7 @@ class TestCreateFormDataCommand(SupersetTestCase):
 
         query = Query(
             sql="SELECT * FROM wb_health_population",
-            client_id="fd_auth_acc1",
+            client_id="fd_auth_ac1",
             database=database,
             schema=schema,
             user_id=gamma_user.id,

--- a/tests/integration_tests/explore/form_data/commands_tests.py
+++ b/tests/integration_tests/explore/form_data/commands_tests.py
@@ -27,6 +27,7 @@ from superset.commands.explore.form_data.delete import DeleteFormDataCommand
 from superset.commands.explore.form_data.get import GetFormDataCommand
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.commands.explore.form_data.update import UpdateFormDataCommand
+from superset.common.db_query_status import QueryStatus
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
@@ -476,6 +477,10 @@ class TestCreateFormDataCommand(SupersetTestCase):
             database=database,
             schema=schema,
             user_id=gamma_user.id,
+            # The authorship bypass only covers a query that actually
+            # succeeded -- see raise_for_access in
+            # superset/security/manager.py.
+            status=QueryStatus.SUCCESS,
         )
         db.session.add(query)
         db.session.commit()

--- a/tests/unit_tests/commands/explore/test_get_query_authorship_bypass.py
+++ b/tests/unit_tests/commands/explore/test_get_query_authorship_bypass.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from unittest.mock import Mock
+
+import pytest
 from pytest_mock import MockerFixture
 
 from superset.commands.explore.get import _authorize_datasource
@@ -41,8 +44,33 @@ def test_query_datasource_uses_authorship_bypass(mocker: MockerFixture) -> None:
     _authorize_datasource(query, None)
 
     mock_sm.raise_for_access.assert_called_once_with(
-        query=query, allow_query_authorship_bypass=True
+        query=query, datasource=query, allow_query_authorship_bypass=True
     )
+
+
+def test_query_datasource_still_reaches_extra_bypass_hook(
+    app_context: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    ``EXTRA_RAISE_FOR_ACCESS_BYPASS`` callbacks only ever receive the
+    resource under ``datasource`` (there is no ``query`` kwarg in that hook
+    call), and before the authorship reroute the Explore GET handed them the
+    SQL Lab ``Query`` that way. Rerouting through ``query=`` alone would
+    leave that argument ``None`` and silently bypass a deployment's custom
+    grant, so the Query must still arrive at the hook as ``datasource``.
+    """
+    from flask import current_app
+
+    query = Query(id=1)
+    bypass_mock = Mock(return_value=True)
+    monkeypatch.setitem(
+        current_app.config, "EXTRA_RAISE_FOR_ACCESS_BYPASS", bypass_mock
+    )
+
+    _authorize_datasource(query, None)
+
+    assert bypass_mock.call_count == 1
+    assert bypass_mock.call_args.kwargs["datasource"] is query
 
 
 def test_saved_chart_path_unaffected(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/commands/explore/test_get_query_authorship_bypass.py
+++ b/tests/unit_tests/commands/explore/test_get_query_authorship_bypass.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from pytest_mock import MockerFixture
+
+from superset.commands.explore.get import _authorize_datasource
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.slice import Slice
+from superset.models.sql_lab import Query
+
+
+def test_query_datasource_uses_authorship_bypass(mocker: MockerFixture) -> None:
+    """
+    Regression for #39296: ``superset.explore.utils.check_query_access``
+    already applies the query-authorship bypass to the form-data POST that
+    backs "Create Chart", but ``GetExploreCommand`` (the Explore page GET
+    that follows it) called ``raise_for_access(datasource=...)`` directly.
+    That routes a "query" datasource into ``raise_for_access``'s generic
+    ``datasource=`` branch, which never looks at authorship at all -- so
+    the same query author who just cleared the form-data check would still
+    get a 403 the moment the Explore page itself loaded. A ``Query``
+    datasource must instead be routed through
+    ``raise_for_access(query=..., allow_query_authorship_bypass=True)``.
+    """
+    query = Query(id=1)
+    mock_sm = mocker.patch("superset.commands.explore.get.security_manager")
+
+    _authorize_datasource(query, None)
+
+    mock_sm.raise_for_access.assert_called_once_with(
+        query=query, allow_query_authorship_bypass=True
+    )
+
+
+def test_saved_chart_path_unaffected(mocker: MockerFixture) -> None:
+    """A saved chart keeps going through the chart-based access check."""
+    slc = Slice()
+    mock_sm = mocker.patch("superset.commands.explore.get.security_manager")
+
+    _authorize_datasource(SqlaTable(), slc)
+
+    mock_sm.raise_for_access.assert_called_once_with(chart=slc)
+
+
+def test_table_datasource_path_unaffected(mocker: MockerFixture) -> None:
+    """A registered dataset keeps going through the generic datasource check."""
+    dataset = SqlaTable()
+    mock_sm = mocker.patch("superset.commands.explore.get.security_manager")
+
+    _authorize_datasource(dataset, None)
+
+    mock_sm.raise_for_access.assert_called_once_with(datasource=dataset)

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -362,3 +362,67 @@ def test_query_no_access(mocker: MockerFixture, client) -> None:
             datasource_id=1,
             datasource_type=DatasourceType.QUERY,
         )
+
+
+def test_unsaved_query_explore_allows_the_querys_own_author(
+    mocker: MockerFixture, client
+) -> None:
+    """
+    Regression for #39296: clicking "Create Chart" straight from a SQL Lab
+    query (no "Save dataset" step first) sends ``DatasourceType.QUERY`` into
+    ``CreateFormDataCommand``, which is the command backing that button (see
+    ``superset/commands/explore/form_data/create.py``). That command calls
+    this exact ``check_access`` function with ``chart_id=None``.
+
+    Unlike the TABLE path (``check_access`` -> ``can_access_datasource`` ->
+    ``raise_for_access(datasource=...)``), which grants access to a
+    dataset's *owners* via ``is_editor`` regardless of catalog/schema/table
+    permissions, the QUERY path has no equivalent "you authored this" bypass:
+    ``raise_for_access``'s ``query=`` branch (``superset/security/manager.py``)
+    only ever checks catalog/schema/table-level ``datasource_access``, and
+    never looks at ``Query.user_id`` at all. So a user who just ran this
+    exact query in SQL Lab themselves (and therefore has execution rights on
+    the connection) but lacks that dataset-level permission is denied here,
+    even though the identical underlying data becomes explorable to them the
+    moment it's saved as a dataset, since ``populate_owners()``
+    (``superset/commands/utils.py``) would make them an owner at that point.
+    That inconsistency, not a missing owner field, is the crux of #39296.
+
+    This test sets the query's ``user_id`` to match the current user (i.e.
+    the user IS the query's own author) and asserts access should be
+    granted, the behavior a fix should produce. It's expected to currently
+    FAIL: no code path today grants a bypass for query authorship, so
+    ``raise_for_access`` denies even the query's own author. A red result
+    here is the TDD signal that the reported gap is real; a future fix
+    adding that bypass should turn this green.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.explore.utils import check_access as check_chart_access
+    from superset.models.sql_lab import Query
+
+    current_user = User(id=1)
+
+    database = mocker.MagicMock()
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "public"
+    mocker.patch(
+        query_find_by_id,
+        return_value=Query(
+            database=database, sql="select * from foo", user_id=current_user.id
+        ),
+    )
+    mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])
+    mocker.patch(is_admin, return_value=False)
+    mocker.patch(is_editor, return_value=False)
+    # No catalog/schema/dataset-level datasource_access grant of any kind:
+    # the only thing that should let this through is query authorship.
+    mocker.patch(can_access, return_value=False)
+
+    with override_user(current_user):
+        # A user exploring a query they themselves just ran in SQL Lab
+        # should not be denied for lack of an unrelated dataset grant.
+        check_chart_access(
+            datasource_id=1,
+            chart_id=None,
+            datasource_type=DatasourceType.QUERY,
+        )

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -364,7 +364,7 @@ def test_query_no_access(mocker: MockerFixture, client) -> None:
         )
 
 
-def test_unsaved_query_explore_allows_the_querys_own_author(
+def test_unsaved_query_explore_allows_the_query_author(
     mocker: MockerFixture, client
 ) -> None:
     """

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -385,3 +385,67 @@ def test_query_no_access(mocker: MockerFixture, client) -> None:
             datasource_id=1,
             datasource_type=DatasourceType.QUERY,
         )
+
+
+def test_unsaved_query_explore_allows_the_querys_own_author(
+    mocker: MockerFixture, client
+) -> None:
+    """
+    Regression for #39296: clicking "Create Chart" straight from a SQL Lab
+    query (no "Save dataset" step first) sends ``DatasourceType.QUERY`` into
+    ``CreateFormDataCommand``, which is the command backing that button (see
+    ``superset/commands/explore/form_data/create.py``). That command calls
+    this exact ``check_access`` function with ``chart_id=None``.
+
+    Unlike the TABLE path (``check_access`` -> ``can_access_datasource`` ->
+    ``raise_for_access(datasource=...)``), which grants access to a
+    dataset's *owners* via ``is_editor`` regardless of catalog/schema/table
+    permissions, the QUERY path has no equivalent "you authored this" bypass:
+    ``raise_for_access``'s ``query=`` branch (``superset/security/manager.py``)
+    only ever checks catalog/schema/table-level ``datasource_access``, and
+    never looks at ``Query.user_id`` at all. So a user who just ran this
+    exact query in SQL Lab themselves (and therefore has execution rights on
+    the connection) but lacks that dataset-level permission is denied here,
+    even though the identical underlying data becomes explorable to them the
+    moment it's saved as a dataset, since ``populate_owners()``
+    (``superset/commands/utils.py``) would make them an owner at that point.
+    That inconsistency, not a missing owner field, is the crux of #39296.
+
+    This test sets the query's ``user_id`` to match the current user (i.e.
+    the user IS the query's own author) and asserts access should be
+    granted, the behavior a fix should produce. It's expected to currently
+    FAIL: no code path today grants a bypass for query authorship, so
+    ``raise_for_access`` denies even the query's own author. A red result
+    here is the TDD signal that the reported gap is real; a future fix
+    adding that bypass should turn this green.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.explore.utils import check_access as check_chart_access
+    from superset.models.sql_lab import Query
+
+    current_user = User(id=1)
+
+    database = mocker.MagicMock()
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "public"
+    mocker.patch(
+        query_find_by_id,
+        return_value=Query(
+            database=database, sql="select * from foo", user_id=current_user.id
+        ),
+    )
+    mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])
+    mocker.patch(is_admin, return_value=False)
+    mocker.patch(is_editor, return_value=False)
+    # No catalog/schema/dataset-level datasource_access grant of any kind:
+    # the only thing that should let this through is query authorship.
+    mocker.patch(can_access, return_value=False)
+
+    with override_user(current_user):
+        # A user exploring a query they themselves just ran in SQL Lab
+        # should not be denied for lack of an unrelated dataset grant.
+        check_chart_access(
+            datasource_id=1,
+            chart_id=None,
+            datasource_type=DatasourceType.QUERY,
+        )

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -31,6 +31,7 @@ from superset.commands.exceptions import (
     DatasourceNotFoundValidationError,
     QueryNotFoundValidationError,
 )
+from superset.common.db_query_status import QueryStatus
 from superset.exceptions import SupersetSecurityException, SupersetTemplateException
 from superset.utils.core import DatasourceType, override_user
 
@@ -429,7 +430,13 @@ def test_unsaved_query_explore_allows_the_query_author(
     mocker.patch(
         query_find_by_id,
         return_value=Query(
-            database=database, sql="select * from foo", user_id=current_user.id
+            database=database,
+            sql="select * from foo",
+            user_id=current_user.id,
+            # The authorship bypass only covers a query that actually
+            # succeeded -- see raise_for_access in
+            # superset/security/manager.py.
+            status=QueryStatus.SUCCESS,
         ),
     )
     mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -400,24 +400,22 @@ def test_unsaved_query_explore_allows_the_query_author(
     Unlike the TABLE path (``check_access`` -> ``can_access_datasource`` ->
     ``raise_for_access(datasource=...)``), which grants access to a
     dataset's *owners* via ``is_editor`` regardless of catalog/schema/table
-    permissions, the QUERY path has no equivalent "you authored this" bypass:
-    ``raise_for_access``'s ``query=`` branch (``superset/security/manager.py``)
-    only ever checks catalog/schema/table-level ``datasource_access``, and
-    never looks at ``Query.user_id`` at all. So a user who just ran this
-    exact query in SQL Lab themselves (and therefore has execution rights on
-    the connection) but lacks that dataset-level permission is denied here,
-    even though the identical underlying data becomes explorable to them the
-    moment it's saved as a dataset, since ``populate_owners()``
-    (``superset/commands/utils.py``) would make them an owner at that point.
-    That inconsistency, not a missing owner field, is the crux of #39296.
+    permissions, the QUERY path had no equivalent "you authored this"
+    bypass: ``raise_for_access``'s ``query=`` branch
+    (``superset/security/manager.py``) only ever checked catalog/schema/
+    table-level ``datasource_access``, and never looked at ``Query.user_id``
+    at all. So a user who just ran this exact query in SQL Lab themselves
+    (and therefore has execution rights on the connection) but lacks that
+    dataset-level permission was denied here, even though the identical
+    underlying data becomes explorable to them the moment it's saved as a
+    dataset, since ``populate_owners()`` (``superset/commands/utils.py``)
+    would make them an owner at that point. That inconsistency, not a
+    missing owner field, was the crux of #39296.
 
     This test sets the query's ``user_id`` to match the current user (i.e.
-    the user IS the query's own author) and asserts access should be
-    granted, the behavior a fix should produce. It's expected to currently
-    FAIL: no code path today grants a bypass for query authorship, so
-    ``raise_for_access`` denies even the query's own author. A red result
-    here is the TDD signal that the reported gap is real; a future fix
-    adding that bypass should turn this green.
+    the user IS the query's own author) and asserts access is granted.
+    ``raise_for_access`` now grants a bypass for query authorship,
+    mirroring the ``is_editor`` bypass the TABLE path already had.
     """
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -387,7 +387,7 @@ def test_query_no_access(mocker: MockerFixture, client) -> None:
         )
 
 
-def test_unsaved_query_explore_allows_the_querys_own_author(
+def test_unsaved_query_explore_allows_the_query_author(
     mocker: MockerFixture, client
 ) -> None:
     """

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -33,6 +33,7 @@ from superset.commands.exceptions import (
 )
 from superset.common.db_query_status import QueryStatus
 from superset.exceptions import SupersetSecurityException, SupersetTemplateException
+from superset.extensions import appbuilder
 from superset.utils.core import DatasourceType, override_user
 
 dataset_find_by_id = "superset.daos.dataset.DatasetDAO.find_by_id"
@@ -454,3 +455,50 @@ def test_unsaved_query_explore_allows_the_query_author(
             chart_id=None,
             datasource_type=DatasourceType.QUERY,
         )
+
+
+def test_query_authorship_bypass_does_not_cover_chart_data_fetch(
+    mocker: MockerFixture,
+) -> None:
+    """
+    The authorship bypass above is deliberately opt-in
+    (``allow_query_authorship_bypass``) and only set by the one-time
+    explore/create-chart transition (``check_query_access`` above). A
+    query-backed chart's *data*, fetched on every dashboard/chart view or
+    export via ``QueryContextProcessor.raise_for_access`` (see
+    ``superset/common/query_context_processor.py``), calls
+    ``raise_for_access(query=...)`` without that flag, and must keep going
+    through the regular catalog/schema/datasource_access checks on every
+    call -- authorship alone does not track whether the author still holds
+    that access.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.sql_lab import Query
+    from superset.security.manager import SupersetSecurityManager
+
+    sm = SupersetSecurityManager(appbuilder)
+    current_user = User(id=1)
+
+    database = mocker.MagicMock()
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "public"
+    query = Query(
+        database=database,
+        sql="select * from foo",
+        user_id=current_user.id,
+        status=QueryStatus.SUCCESS,
+    )
+
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "is_admin", return_value=False)
+    mocker.patch.object(sm, "is_editor", return_value=False)
+    mocker.patch.object(sm, "can_access", return_value=False)
+    mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])
+
+    with override_user(current_user):
+        # Same query, same author, same SUCCESS status as the explore-path
+        # bypass test above -- but with no allow_query_authorship_bypass
+        # (the chart-data/export call shape), so it must still be denied.
+        with raises(SupersetSecurityException):
+            sm.raise_for_access(query=query)

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -377,24 +377,22 @@ def test_unsaved_query_explore_allows_the_query_author(
     Unlike the TABLE path (``check_access`` -> ``can_access_datasource`` ->
     ``raise_for_access(datasource=...)``), which grants access to a
     dataset's *owners* via ``is_editor`` regardless of catalog/schema/table
-    permissions, the QUERY path has no equivalent "you authored this" bypass:
-    ``raise_for_access``'s ``query=`` branch (``superset/security/manager.py``)
-    only ever checks catalog/schema/table-level ``datasource_access``, and
-    never looks at ``Query.user_id`` at all. So a user who just ran this
-    exact query in SQL Lab themselves (and therefore has execution rights on
-    the connection) but lacks that dataset-level permission is denied here,
-    even though the identical underlying data becomes explorable to them the
-    moment it's saved as a dataset, since ``populate_owners()``
-    (``superset/commands/utils.py``) would make them an owner at that point.
-    That inconsistency, not a missing owner field, is the crux of #39296.
+    permissions, the QUERY path had no equivalent "you authored this"
+    bypass: ``raise_for_access``'s ``query=`` branch
+    (``superset/security/manager.py``) only ever checked catalog/schema/
+    table-level ``datasource_access``, and never looked at ``Query.user_id``
+    at all. So a user who just ran this exact query in SQL Lab themselves
+    (and therefore has execution rights on the connection) but lacks that
+    dataset-level permission was denied here, even though the identical
+    underlying data becomes explorable to them the moment it's saved as a
+    dataset, since ``populate_owners()`` (``superset/commands/utils.py``)
+    would make them an owner at that point. That inconsistency, not a
+    missing owner field, was the crux of #39296.
 
     This test sets the query's ``user_id`` to match the current user (i.e.
-    the user IS the query's own author) and asserts access should be
-    granted, the behavior a fix should produce. It's expected to currently
-    FAIL: no code path today grants a bypass for query authorship, so
-    ``raise_for_access`` denies even the query's own author. A red result
-    here is the TDD signal that the reported gap is real; a future fix
-    adding that bypass should turn this green.
+    the user IS the query's own author) and asserts access is granted.
+    ``raise_for_access`` now grants a bypass for query authorship,
+    mirroring the ``is_editor`` bypass the TABLE path already had.
     """
     from superset.connectors.sqla.models import SqlaTable
     from superset.explore.utils import check_access as check_chart_access

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -30,6 +30,7 @@ from superset.commands.exceptions import (
     DatasourceNotFoundValidationError,
     QueryNotFoundValidationError,
 )
+from superset.common.db_query_status import QueryStatus
 from superset.exceptions import SupersetSecurityException
 from superset.utils.core import DatasourceType, override_user
 
@@ -406,7 +407,13 @@ def test_unsaved_query_explore_allows_the_query_author(
     mocker.patch(
         query_find_by_id,
         return_value=Query(
-            database=database, sql="select * from foo", user_id=current_user.id
+            database=database,
+            sql="select * from foo",
+            user_id=current_user.id,
+            # The authorship bypass only covers a query that actually
+            # succeeded -- see raise_for_access in
+            # superset/security/manager.py.
+            status=QueryStatus.SUCCESS,
         ),
     )
     mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -32,6 +32,7 @@ from superset.commands.exceptions import (
 )
 from superset.common.db_query_status import QueryStatus
 from superset.exceptions import SupersetSecurityException
+from superset.extensions import appbuilder
 from superset.utils.core import DatasourceType, override_user
 
 dataset_find_by_id = "superset.daos.dataset.DatasetDAO.find_by_id"
@@ -431,3 +432,50 @@ def test_unsaved_query_explore_allows_the_query_author(
             chart_id=None,
             datasource_type=DatasourceType.QUERY,
         )
+
+
+def test_query_authorship_bypass_does_not_cover_chart_data_fetch(
+    mocker: MockerFixture,
+) -> None:
+    """
+    The authorship bypass above is deliberately opt-in
+    (``allow_query_authorship_bypass``) and only set by the one-time
+    explore/create-chart transition (``check_query_access`` above). A
+    query-backed chart's *data*, fetched on every dashboard/chart view or
+    export via ``QueryContextProcessor.raise_for_access`` (see
+    ``superset/common/query_context_processor.py``), calls
+    ``raise_for_access(query=...)`` without that flag, and must keep going
+    through the regular catalog/schema/datasource_access checks on every
+    call -- authorship alone does not track whether the author still holds
+    that access.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.sql_lab import Query
+    from superset.security.manager import SupersetSecurityManager
+
+    sm = SupersetSecurityManager(appbuilder)
+    current_user = User(id=1)
+
+    database = mocker.MagicMock()
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "public"
+    query = Query(
+        database=database,
+        sql="select * from foo",
+        user_id=current_user.id,
+        status=QueryStatus.SUCCESS,
+    )
+
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "is_admin", return_value=False)
+    mocker.patch.object(sm, "is_editor", return_value=False)
+    mocker.patch.object(sm, "can_access", return_value=False)
+    mocker.patch(query_datasources_by_name, return_value=[SqlaTable()])
+
+    with override_user(current_user):
+        # Same query, same author, same SUCCESS status as the explore-path
+        # bypass test above -- but with no allow_query_authorship_bypass
+        # (the chart-data/export call shape), so it must still be denied.
+        with raises(SupersetSecurityException):
+            sm.raise_for_access(query=query)


### PR DESCRIPTION
### SUMMARY

Fixes #39296. Clicking "Create Chart" straight from a SQL Lab query (no "Save dataset" step first) sends `DatasourceType.QUERY` into `CreateFormDataCommand`, which calls `superset.explore.utils.check_access` -> `security_manager.raise_for_access(query=...)`.

Unlike the TABLE path (`raise_for_access(datasource=...)`), which grants a dataset's *owners* access via `is_editor` regardless of catalog/schema/table permissions, the QUERY path had no equivalent "you authored this" bypass. `raise_for_access`'s `query=` branch only ever checked catalog/schema/table-level `datasource_access`, never `Query.user_id`. A user who just ran a query in SQL Lab themselves, and therefore obviously has execution rights on that connection, was still denied if they lacked a separate dataset-level grant, even though the identical data becomes explorable to them the instant it's saved as a dataset (`populate_owners()` makes the saving user an owner at that point). That inconsistency, not a missing owner field, was the actual bug dosubot's original theory missed.

This was originally opened as a **test-only TDD PR** pinning that gap down (see prior discussion below); this update adds the actual fix plus a stronger integration-level regression test.

### THE FIX

`SupersetSecurityManager.raise_for_access` (`superset/security/manager.py`), in the `query=` branch: after the existing `can_access_database` early-return, grant a bypass when the query's `user_id` matches the current user, before running the per-table catalog/schema/`datasource_access` checks. This mirrors the ownership bypass the TABLE path already gets via `is_editor`, keyed on query authorship instead of dataset ownership.

### BEFORE/AFTER

Before: a Gamma user (no `all_datasource_access`, no `schema_access`, no registered dataset) who runs `SELECT * FROM wb_health_population` in SQL Lab and clicks "Create Chart" gets a 403 `ChartAccessDeniedError`, despite having just successfully executed that exact query.

After: the same user succeeds, because `raise_for_access` recognizes they authored the query.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/explore/utils_test.py -k test_unsaved_query_explore_allows_the_query_author -v
pytest tests/integration_tests/explore/form_data/commands_tests.py -v
```

- `test_unsaved_query_explore_allows_the_query_author` (unit) — was expected/confirmed red before the fix; now green.
- `test_create_form_data_command_schema_access_no_all_datasource_access` (integration, pre-existing on this PR) — rules out an alternative "it's just schema_access" theory; unaffected by this fix, stays green.
- `test_create_form_data_command_query_author_no_all_datasource_access` (integration, **new**) — exercises the actual fix through the real `CreateFormDataCommand` path with a Gamma user who has neither `all_datasource_access` nor any `schema_access` grant, only query authorship. Confirmed red against the pre-fix code, green with the fix.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #39296
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)