### PR TITLE
test(deckgl): Polygon chart with a column literally named "polygon" (#33669)

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -538,39 +538,57 @@ describe('Polygon transformProps', () => {
   // other properties onto the feature, and the parsed `polygon` key is
   // assigned last in the returned object literal, so it should always win
   // over anything copied from the raw record, even when they share a name.
-  test('should correctly parse polygon geometry when the boundary column is itself named "polygon"', () => {
-    const collidingColumnNameProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        line_column: 'polygon',
-      },
-      queriesData: [
-        {
-          data: [
-            {
-              polygon: JSON.stringify([
-                [-122.4, 37.8],
-                [-122.3, 37.8],
-                [-122.3, 37.9],
-                [-122.4, 37.9],
-              ]),
-              population: 50000,
-            },
-          ],
+  //
+  // The fixture mirrors the GeoJSON `Feature` shape from the CSV attached to
+  // the issue (a `Feature` with nested `geometry.coordinates`), not a bare
+  // coordinate array, since those two shapes take different parsing paths
+  // in `getPolygonCoordinateParts`. Both reported column-name spellings,
+  // "polygon" and "Polygon", are covered.
+  test.each(['polygon', 'Polygon'])(
+    'should correctly parse polygon geometry when the boundary column is itself named "%s"',
+    columnName => {
+      const collidingColumnNameProps = {
+        ...mockChartProps,
+        rawFormData: {
+          ...mockChartProps.rawFormData,
+          line_column: columnName,
         },
-      ],
-    };
+        queriesData: [
+          {
+            data: [
+              {
+                [columnName]: JSON.stringify({
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                      [
+                        [-122.4, 37.8],
+                        [-122.3, 37.8],
+                        [-122.3, 37.9],
+                        [-122.4, 37.9],
+                      ],
+                    ],
+                  },
+                  properties: { NOM_COM: 'TEST' },
+                }),
+                population: 50000,
+              },
+            ],
+          },
+        ],
+      };
 
-    const result = transformProps(collidingColumnNameProps as ChartProps);
-    const features = result.payload.data.features as PolygonFeature[];
+      const result = transformProps(collidingColumnNameProps as ChartProps);
+      const features = result.payload.data.features as PolygonFeature[];
 
-    expect(features).toHaveLength(1);
-    expect(features[0]?.polygon).toEqual([
-      [-122.4, 37.8],
-      [-122.3, 37.8],
-      [-122.3, 37.9],
-      [-122.4, 37.9],
-    ]);
-  });
+      expect(features).toHaveLength(1);
+      expect(features[0]?.polygon).toEqual([
+        [-122.4, 37.8],
+        [-122.3, 37.8],
+        [-122.3, 37.9],
+        [-122.4, 37.9],
+      ]);
+    },
+  );
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -529,4 +529,48 @@ describe('Polygon transformProps', () => {
     expect(features[0]?.extraProps?.['SUM(population)']).toBe(50000);
     expect(features[0]?.metrics?.['SUM(population)']).toBe(50000);
   });
+
+  // Regression test for #33669: a boundary column literally named "polygon"
+  // (the same key this transform uses internally for the parsed geometry)
+  // reportedly broke rendering, because the raw column value could
+  // theoretically collide with the `polygon` key this function builds on
+  // each feature. `line_column` is excluded before spreading a record's
+  // other properties onto the feature, and the parsed `polygon` key is
+  // assigned last in the returned object literal, so it should always win
+  // over anything copied from the raw record, even when they share a name.
+  test('should correctly parse polygon geometry when the boundary column is itself named "polygon"', () => {
+    const collidingColumnNameProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        line_column: 'polygon',
+      },
+      queriesData: [
+        {
+          data: [
+            {
+              polygon: JSON.stringify([
+                [-122.4, 37.8],
+                [-122.3, 37.8],
+                [-122.3, 37.9],
+                [-122.4, 37.9],
+              ]),
+              population: 50000,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(collidingColumnNameProps as ChartProps);
+    const features = result.payload.data.features as PolygonFeature[];
+
+    expect(features).toHaveLength(1);
+    expect(features[0]?.polygon).toEqual([
+      [-122.4, 37.8],
+      [-122.3, 37.8],
+      [-122.3, 37.9],
+      [-122.4, 37.9],
+    ]);
+  });
 });


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #33669.

#33669 (filed 2025-06) reports that deck.gl **Polygon** charts break when the dataset column supplying the polygon geometry is itself named `polygon` (case-insensitive), presumably a naming collision with the internal `polygon` key the transform builds on each feature. The issue thread includes a prior maintainer test against the wrong chart type (deck.gl GeoJSON, not Polygon), which the reporter corrected.

This PR adds one regression test on `preset-chart-deckgl`'s Polygon `transformProps`:

1. **`should correctly parse polygon geometry when the boundary column is itself named "polygon"`** — sets `line_column: 'polygon'` (matching the exact reported column name) with a raw record `{ polygon: <JSON-encoded coordinates> }`, and asserts the resulting feature's `polygon` key resolves to the correctly parsed coordinate array rather than the raw string or being dropped.

### How to interpret CI

- **CI green** → the collision doesn't reproduce against current `master`. `processPolygonData` in `transformProps.ts` excludes `line_column` before spreading a record's other properties onto the feature object, and assigns the parsed `polygon` key last in the returned object literal, so it always wins regardless of the raw column's name. Merging this PR closes #33669 as already fixed (or the collision this specific mechanism guards against was never actually reachable in this exact form).
- **CI red** → the bug is real; likely fix location is `processPolygonData` in `superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts`.

Ran locally: 17/17 tests pass (16 pre-existing + this one), including full pre-commit (prettier, oxlint, custom-rules, stylelint, type-checking).

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #33669
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
