### PR TITLE
test(jinja): pin filter_values() drill-to-detail native-filter fallback for virtual datasets (#35263)

### DIFF
--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2457,6 +2457,22 @@ def test_get_sqla_query_virtual_dataset_filter_values_drill_to_detail(
         f"filters inside a virtual dataset's own SQL. Generated SQL: {sql}"
     )
 
+    # The assertion above can pass even when filter_values() itself is
+    # broken, because get_sqla_query() independently applies the native
+    # filter as an outer WHERE predicate on top of whatever the virtual
+    # dataset's own SQL renders to. Render the virtual dataset's SQL in
+    # isolation to confirm filter_values() actually resolved the native
+    # filter *inside* the templated subquery.
+    template_processor = table.get_template_processor(
+        filter=[{"col": "b", "op": "IN", "val": ["Alice"]}]
+    )
+    rendered_inner_sql = table.get_rendered_sql(template_processor)
+    assert "'Alice'" in rendered_inner_sql, (
+        "filter_values() should render the native drill-to-detail-style "
+        "filter directly into the virtual dataset's own templated SQL, "
+        f"not just the outer query. Rendered SQL: {rendered_inner_sql}"
+    )
+
 
 def test_extras_where_is_parenthesized(
     database: Database,

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2460,13 +2460,14 @@ def test_get_sqla_query_virtual_dataset_filter_values_drill_to_detail(
     # The assertion above can pass even when filter_values() itself is
     # broken, because get_sqla_query() independently applies the native
     # filter as an outer WHERE predicate on top of whatever the virtual
-    # dataset's own SQL renders to. Render the virtual dataset's SQL in
-    # isolation to confirm filter_values() actually resolved the native
-    # filter *inside* the templated subquery.
-    template_processor = table.get_template_processor(
-        filter=[{"col": "b", "op": "IN", "val": ["Alice"]}]
-    )
-    rendered_inner_sql = table.get_rendered_sql(template_processor)
+    # dataset's own SQL renders to. Pull the virtual dataset's own rendered
+    # SQL directly out of the compiled query (rather than re-rendering it
+    # via a separately constructed template processor, which would not
+    # catch get_sqla_query() failing to forward the filter to the template
+    # processor it builds internally) to confirm filter_values() actually
+    # resolved the native filter *inside* the templated subquery.
+    virtual_table_from = result.sqla_query.get_final_froms()[0]
+    rendered_inner_sql = virtual_table_from.element.element.text
     assert "'Alice'" in rendered_inner_sql, (
         "filter_values() should render the native drill-to-detail-style "
         "filter directly into the virtual dataset's own templated SQL, "

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2405,6 +2405,59 @@ def test_get_sqla_query_allows_jinja_templated_custom_sql_metric_with_columns(
     assert "{{" not in sql
 
 
+def test_get_sqla_query_virtual_dataset_filter_values_drill_to_detail(
+    database: Database,
+) -> None:
+    """
+    Regression for #35263: a Jinja-templated virtual dataset that calls
+    ``filter_values()`` in its own SQL must see filters sent in the native
+    ``{col, op, val}`` format that Drill to Detail/Drill by use, not just
+    the ``adhoc_filters`` format used by ordinary chart/explore requests.
+    Without this, Jinja-based datasets return zero rows when drilled into,
+    even though the parent chart shows data for the selected value.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        sql=(
+            "SELECT a, b FROM t WHERE 1=1 "
+            "{% if filter_values('b') %} "
+            "AND b IN {{ filter_values('b') | where_in }} "
+            "{% endif %}"
+        ),
+        columns=[
+            TableColumn(column_name="a", type="INTEGER"),
+            TableColumn(column_name="b", type="TEXT"),
+        ],
+    )
+
+    result = table.get_sqla_query(
+        columns=["a", "b"],
+        metrics=[],
+        extras={},
+        filter=[{"col": "b", "op": "IN", "val": ["Alice"]}],
+        granularity=None,
+        is_timeseries=False,
+    )
+    assert result is not None
+
+    with database.get_sqla_engine() as engine:
+        sql = str(
+            result.sqla_query.compile(
+                dialect=engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    assert "'Alice'" in sql, (
+        "filter_values() should resolve native drill-to-detail-style "
+        f"filters inside a virtual dataset's own SQL. Generated SQL: {sql}"
+    )
+
+
 def test_extras_where_is_parenthesized(
     database: Database,
 ) -> None:


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #35263.

#35263 (filed 2026, reproduced on 5.0.0) reports that Drill to Detail / Drill by on charts backed by Jinja-templated (virtual SQL) datasets returns zero rows, even though the parent chart clearly shows data for the selected value. dosubot's diagnosis pointed at an architectural gap: drill queries send filters in the native `{col, op, val}` format used by `QueryContext`/`query_obj["filter"]`, not the `adhoc_filters` format that `filter_values()`/`get_filters()` originally only read from the Flask request's form data — so a Jinja dataset's `filter_values()` call would see nothing during a drill request.

Investigating on master, that specific gap is **already closed**: `ExtraCache.get_filters()` in `superset/jinja_context.py` falls back to `_get_filters_from_query_context()`, which reads `query_obj["filter"]` (the native format) when the adhoc-filters lookup finds nothing. That fallback already has thorough isolated unit coverage in `tests/unit_tests/jinja_context_test.py` (e.g. `test_filter_values_query_context_filters`), but nothing exercised it through a real **virtual dataset** end-to-end via `SqlaTable.get_sqla_query` — the exact code path the reporter's Jinja-templated dataset goes through.

This PR adds that missing end-to-end regression test:

1. **`test_get_sqla_query_virtual_dataset_filter_values_drill_to_detail`** — builds a virtual `SqlaTable` whose own SQL calls `filter_values('b')` in a `WHERE` clause (mirroring the reporter's `{% if filter_values(...) %} AND col IN {{ filter_values(...) | where_in }} {% endif %}` pattern), calls `get_sqla_query(..., filter=[{"col": "b", "op": "IN", "val": ["Alice"]}])` — the native format Drill to Detail/Drill by send — and asserts the compiled SQL contains the drilled-into value.

### How to interpret CI

- **CI green** (expected, confirmed locally) → the native-filter fallback already covers virtual/Jinja datasets end-to-end; the specific mechanism reported in #35263 is fixed on master. This PR can be merged as a regression guard; #35263 can likely be closed once a reporter or maintainer confirms current behavior on 5.x/master, since the originally diagnosed root cause no longer reproduces.
- **CI red** → the fallback doesn't actually reach virtual dataset SQL templating the way isolated `ExtraCache` unit tests suggest; look at `SqlaTable.get_sqla_query` → `template_kwargs["filter"]` → `get_template_processor(**template_kwargs)` wiring in `superset/models/helpers.py`.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/models/helpers_test.py::test_get_sqla_query_virtual_dataset_filter_values_drill_to_detail -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #35263
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)