### PR TITLE
fix(caching): sort extra_cache_keys before hashing (#34543)

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -440,6 +440,18 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         cache_dict: dict[str, Any] = dict(self.to_dict())
         cache_dict.update(extra)
 
+        if "extra_cache_keys" in cache_dict:
+            # Order carries no meaning here (an unordered set of opaque
+            # Jinja url_param()-derived values), but hash_from_dict only
+            # sorts dict keys, not list values, so an unsorted list makes
+            # the cache key depend on Python's per-process hash-randomized
+            # set iteration order (see SqlaTable.get_extra_cache_keys).
+            # Normalize once here so every producer of extra_cache_keys is
+            # safe by construction.
+            cache_dict["extra_cache_keys"] = sorted(
+                cache_dict["extra_cache_keys"], key=str
+            )
+
         # TODO: the below KVs can all be cleaned up and moved to `to_dict()` at some
         #  predetermined point in time when orgs are aware that the previously
         #  cached results will be invalidated.

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -447,9 +447,13 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             # the cache key depend on Python's per-process hash-randomized
             # set iteration order (see SqlaTable.get_extra_cache_keys).
             # Normalize once here so every producer of extra_cache_keys is
-            # safe by construction.
+            # safe by construction. Sort on (type name, str value) rather
+            # than a bare str() so values that stringify identically but
+            # differ in type (e.g. 1 and "1") still sort deterministically
+            # instead of falling back to input order.
             cache_dict["extra_cache_keys"] = sorted(
-                cache_dict["extra_cache_keys"], key=str
+                cache_dict["extra_cache_keys"],
+                key=lambda value: (type(value).__name__, str(value)),
             )
 
         # TODO: the below KVs can all be cleaned up and moved to `to_dict()` at some

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -86,6 +86,34 @@ def test_cache_key_changes_for_new_query_object_different_params():
     assert query_object2.cache_key() != cache_key1
 
 
+def test_cache_key_stable_regardless_of_extra_cache_keys_order():
+    """
+    Regression for #34543: the cache key must not depend on the order of
+    ``extra_cache_keys``.
+
+    ``SqlaTable.get_extra_cache_keys`` (superset/connectors/sqla/models.py)
+    returns ``list(set(extra_cache_keys))``. Python's string hashing is
+    randomized per-process (``PYTHONHASHSEED``), so the same set of values
+    can iterate in a different order in the Celery worker process (which
+    writes the query results to cache) than in the web process (which
+    re-derives the cache key to read them back). Because ``hash_from_dict``
+    only sorts dict keys and not list values, two ``extra_cache_keys`` lists
+    with identical Jinja ``url_param()`` values but different order hash to
+    different cache keys, causing async chart-data lookups to 422 with
+    "Error loading data from cache" whenever more than one url_param is
+    referenced (a single-element list has only one possible order, which is
+    why the bug is only visible with multiple parameters).
+    """
+    query_object1 = QueryObject(row_limit=1)
+    query_object2 = QueryObject(row_limit=1)
+    same_values_different_order = ["CAR_IDS=1,2,3", "CHASSIS_IDS=100,200"]
+    cache_key1 = query_object1.cache_key(extra_cache_keys=same_values_different_order)
+    cache_key2 = query_object2.cache_key(
+        extra_cache_keys=list(reversed(same_values_different_order))
+    )
+    assert cache_key1 == cache_key2
+
+
 def test_cache_key_changes_for_new_query_object_same_params():
     """
     When a new query object is created with the same params,

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -21,6 +21,7 @@ from flask_appbuilder.security.sqla.models import User
 from superset.common.query_object import QueryObject
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
+from superset.superset_typing import Metric
 from superset.utils.core import override_user
 
 
@@ -112,6 +113,26 @@ def test_cache_key_stable_regardless_of_extra_cache_keys_order():
         extra_cache_keys=list(reversed(same_values_different_order))
     )
     assert cache_key1 == cache_key2
+
+
+def test_cache_key_sensitive_to_orderby_order():
+    """
+    Negative control for the ``extra_cache_keys`` fix above: unlike that
+    field, ``orderby`` is order-significant (it determines sort direction
+    of the executed SQL), so the cache key must still change when the
+    order of its entries changes. This guards against a fix that
+    canonicalizes list values generically instead of targeting
+    ``extra_cache_keys`` specifically.
+    """
+    metric_a: Metric = "count"
+    metric_b: Metric = "sum__value"
+    query_object1 = QueryObject(
+        row_limit=1, orderby=[(metric_a, True), (metric_b, False)]
+    )
+    query_object2 = QueryObject(
+        row_limit=1, orderby=[(metric_b, False), (metric_a, True)]
+    )
+    assert query_object1.cache_key() != query_object2.cache_key()
 
 
 def test_cache_key_changes_for_new_query_object_same_params():

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -115,6 +115,24 @@ def test_cache_key_stable_regardless_of_extra_cache_keys_order():
     assert cache_key1 == cache_key2
 
 
+def test_cache_key_stable_for_mixed_type_extra_cache_keys():
+    """
+    ``extra_cache_keys`` values are typed as ``Hashable``, so a mix of
+    strings and non-strings that stringify identically (e.g. ``1`` and
+    ``"1"``) can appear together. Sorting on a bare ``str()`` value treats
+    those as equal keys, so Python's stable sort would fall back to
+    whatever order they arrived in from ``list(set(...))`` -- which is not
+    deterministic across processes. The sort key must also account for
+    type so ordering doesn't silently regress to that non-determinism.
+    """
+    query_object1 = QueryObject(row_limit=1)
+    query_object2 = QueryObject(row_limit=1)
+    mixed_values = ["CAR_IDS=1,2,3", 1, "1", None]
+    cache_key1 = query_object1.cache_key(extra_cache_keys=mixed_values)
+    cache_key2 = query_object2.cache_key(extra_cache_keys=list(reversed(mixed_values)))
+    assert cache_key1 == cache_key2
+
+
 def test_cache_key_sensitive_to_orderby_order():
     """
     Negative control for the ``extra_cache_keys`` fix above: unlike that


### PR DESCRIPTION
### SUMMARY

Fixes #34543. Embedded dashboards with multiple Jinja `url_param()` filters failed async chart-data cache retrieval with a `422 Unprocessable Entity` / "Error loading data from cache", while a single `url_param` worked fine.

Root cause: `SqlaTable.get_extra_cache_keys()` (`superset/connectors/sqla/models.py`) returns `list(set(extra_cache_keys))`. Python randomizes string hashing per-process (`PYTHONHASHSEED`), so the same set of `url_param()` values can iterate in a different order in the Celery worker process (which writes the query results to cache) than in the web process (which later re-derives the cache key to read them back). `QueryObject.cache_key()` merges that list straight into the dict it hashes, in whatever order it arrives; `hash_from_dict()` only sorts **dict keys**, never list values. A single-element list has only one possible order, which is exactly why the bug is only visible with 2+ url_params, matching the reported single-vs-multi-parameter split precisely.

This was originally opened as a **test-only TDD PR** pinning the gap down; this update adds the actual fix.

### THE FIX

`QueryObject.cache_key()` (`superset/common/query_object.py`): sort `extra_cache_keys` (by `str`, since entries are just `Hashable`, not guaranteed mutually orderable) right where it enters the dict that gets hashed, before calling `hash_from_dict()`. Order carries no meaning for this field, it's an unordered set of opaque Jinja-derived values, so normalizing it here makes any current or future producer of `extra_cache_keys` safe by construction, rather than patching each producer individually.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/queries/query_object_test.py -v
```

`test_cache_key_stable_regardless_of_extra_cache_keys_order` was expected/confirmed red before the fix (asserts two otherwise-identical query objects with `extra_cache_keys` differing only in order produce the same cache key); now green. Confirmed the rest of `tests/unit_tests/queries/`, `tests/unit_tests/common/`, and `tests/unit_tests/charts/` (344 tests) are unaffected.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #34543
- [ ] Required feature flags: `GLOBAL_ASYNC_QUERIES` (only needed to reproduce the end-to-end symptom; the fix and test operate on the cache-key logic directly)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)