### PR TITLE
test(echarts): pin Bar chart X Axis Title flows through untouched (#42560)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -971,4 +971,56 @@ describe('Bar Chart X-axis Time Formatting', () => {
       );
     });
   });
+
+  describe('Regression test for Issue #42560', () => {
+    test('custom X Axis Title is preserved verbatim, not overwritten by the axis number/currency format ("unit")', () => {
+      const formData = {
+        ...baseFormData,
+        orientation: 'vertical',
+        xAxisTitle: 'My X Axis',
+        xAxisNumberFormat: 'SMART_NUMBER',
+        yAxisFormat: '$,.2f',
+      };
+
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        formData,
+      });
+
+      const transformedProps = transformProps(
+        chartProps as EchartsTimeseriesChartProps,
+      );
+      const xAxis = transformedProps.echartOptions.xAxis as any;
+
+      expect(xAxis.name).toBe('My X Axis');
+    });
+
+    test('X Axis Title control maps onto the rendered category (left) axis in horizontal orientation, not the bottom axis', () => {
+      // Documents the axis swap for horizontal bar charts: `xAxisTitle` ends
+      // up on `echartOptions.yAxis.name` (the vertical category axis) and
+      // `yAxisTitle` ends up on `echartOptions.xAxis.name` (the horizontal
+      // value axis). This is existing, intentional swap behavior, not the
+      // "unit" overwrite described in the issue.
+      const formData = {
+        ...baseFormData,
+        orientation: 'horizontal',
+        xAxisTitle: 'My X Axis',
+        yAxisTitle: 'My Y Axis',
+      };
+
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        formData,
+      });
+
+      const transformedProps = transformProps(
+        chartProps as EchartsTimeseriesChartProps,
+      );
+      const renderedXAxis = transformedProps.echartOptions.xAxis as any;
+      const renderedYAxis = transformedProps.echartOptions.yAxis as any;
+
+      expect(renderedYAxis.name).toBe('My X Axis');
+      expect(renderedXAxis.name).toBe('My Y Axis');
+    });
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -973,10 +973,40 @@ describe('Bar Chart X-axis Time Formatting', () => {
   });
 
   describe('Regression test for Issue #42560', () => {
+    const numericXAxisData = [
+      {
+        data: [
+          { x_value: 1000, metric: 10 },
+          { x_value: 2000, metric: 20 },
+          { x_value: 3000, metric: 30 },
+        ],
+        colnames: ['x_value', 'metric'],
+        coltypes: [GenericDataType.Numeric, GenericDataType.Numeric],
+      },
+    ];
+
+    const categoricalXAxisData = [
+      {
+        data: [
+          { category: 'A', metric: 10 },
+          { category: 'B', metric: 20 },
+          { category: 'C', metric: 30 },
+        ],
+        colnames: ['category', 'metric'],
+        coltypes: [GenericDataType.String, GenericDataType.Numeric],
+      },
+    ];
+
     test('custom X Axis Title is preserved verbatim, not overwritten by the axis number/currency format ("unit")', () => {
+      // Uses a numeric (non-temporal) x-axis column so `xAxisNumberFormat`
+      // actually drives `getNumberFormatter` in the axis-label formatter
+      // path, rather than being ignored in favor of the temporal formatter.
       const formData = {
         ...baseFormData,
         orientation: 'vertical',
+        groupby: [],
+        x_axis: 'x_value',
+        metric: 'metric',
         xAxisTitle: 'My X Axis',
         xAxisNumberFormat: 'SMART_NUMBER',
         yAxisFormat: '$,.2f',
@@ -984,11 +1014,12 @@ describe('Bar Chart X-axis Time Formatting', () => {
 
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
+        queriesData: numericXAxisData,
         formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
       const xAxis = transformedProps.echartOptions.xAxis as any;
 
@@ -1000,25 +1031,32 @@ describe('Bar Chart X-axis Time Formatting', () => {
       // up on `echartOptions.yAxis.name` (the vertical category axis) and
       // `yAxisTitle` ends up on `echartOptions.xAxis.name` (the horizontal
       // value axis). This is existing, intentional swap behavior, not the
-      // "unit" overwrite described in the issue.
+      // "unit" overwrite described in the issue. Uses categorical x-axis
+      // data so the rendered left axis is actually type `category`, matching
+      // what the test name claims.
       const formData = {
         ...baseFormData,
         orientation: 'horizontal',
+        groupby: [],
+        x_axis: 'category',
+        metric: 'metric',
         xAxisTitle: 'My X Axis',
         yAxisTitle: 'My Y Axis',
       };
 
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
+        queriesData: categoricalXAxisData,
         formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
       const renderedXAxis = transformedProps.echartOptions.xAxis as any;
       const renderedYAxis = transformedProps.echartOptions.yAxis as any;
 
+      expect(renderedYAxis.type).toBe('category');
       expect(renderedYAxis.name).toBe('My X Axis');
       expect(renderedXAxis.name).toBe('My Y Axis');
     });


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #42560.

#42560 reports that on an ECharts **Bar Chart**, a custom **X Axis Title** (Customize tab) is overwritten by "the unit" (e.g. a temporal grain/number-format label) instead of showing the user's custom text. @dosu investigated and found no code path in `Timeseries/transformProps.ts` that derives `xAxis.name` from any unit/format value — `xAxisTitle` is assigned directly with no fallback.

This PR independently re-verifies dosu's conclusion against the Bar chart's *actual* code path (Bar reuses the shared `Timeseries/transformProps.ts` and `Timeseries/buildQuery.ts` — its `Regular/Bar/` folder only contains `controlPanel.tsx` and `index.ts`, so there is no separate Bar-specific transform to check). No literal `unit` string logic exists anywhere in that transform path.

This PR adds 2 regression tests on `Timeseries/transformProps.ts` (Bar-specific suite):

1. **`custom X Axis Title is preserved verbatim, not overwritten by the axis number/currency format ("unit")`** — sets a custom `xAxisTitle` alongside a currency-like `yAxisFormat` and a `xAxisNumberFormat`, and asserts the rendered `xAxis.name` equals the custom title exactly.
2. **`X Axis Title control maps onto the rendered category (left) axis in horizontal orientation, not the bottom axis`** — documents the existing (and easy to misread) axis swap: in horizontal Bar charts, `xAxisTitle` ends up on `echartOptions.yAxis.name` (the vertical category axis) while `yAxisTitle` ends up on `echartOptions.xAxis.name` (the horizontal value axis). This swap is likely the real source of user confusion dosu flagged in point #2 of their investigation, separate from any "unit overwrite."

### How to interpret CI

- **CI green** (expected) — confirms `xAxisTitle` is never derived from a unit/number-format value in the code, ruling out that specific theory. **This does not close #42560** — if the bug is still reproducing for the reporter, the cause is elsewhere (stale/legacy stored form data, a rendering-layer issue outside this transform, or the horizontal-orientation control-mapping confusion documented in test 2).
- **CI red** — would mean the axis-name assignment has a hidden interaction with format/unit not visible from static reading of the code; would need re-investigation.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts -t "42560"
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: closes #42560
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Disclosure:** the local `type-checking-frontend` pre-commit hook was skipped (`SKIP=type-checking-frontend`) on this worktree — it requires a pre-built `lib/spec/index.d.ts` that a fresh worktree doesn't have. All other hooks (prettier, oxlint, custom-rules-frontend, stylelint) passed locally; CI is the real gate for type-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)