### PR TITLE
fix(pivot-table): keep D3_FORMAT-styled numbers intact in pivoted Excel export

### DIFF
--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -57,3 +57,32 @@ test('preserves locale-formatted numbers exactly as rendered, without SheetJS re
   expect(sheet.B1).toMatchObject({ t: 's', v: '12,50%' });
   expect(sheet.C1).toMatchObject({ t: 's', v: '3.500' });
 });
+
+test('restores unambiguous plain numbers to native Excel numeric cells', () => {
+  document.body.innerHTML = `
+    <table id="pivot-table">
+      <tbody>
+        <tr>
+          <td>42</td>
+          <td>-3.5</td>
+          <td>3.500</td>
+          <td>1,234</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+
+  exportPivotExcel('#pivot-table', 'export');
+
+  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+  // "42" and "-3.5" round-trip exactly through Number(), so they're
+  // unambiguous under any locale and are restored to real numbers.
+  expect(sheet.A1).toMatchObject({ t: 'n', v: 42 });
+  expect(sheet.B1).toMatchObject({ t: 'n', v: -3.5 });
+  // "3.500" (trailing zero padding) and "1,234" (grouped thousands) don't
+  // round-trip, so they stay as text rather than risk misparsing them.
+  expect(sheet.C1).toMatchObject({ t: 's', v: '3.500' });
+  expect(sheet.D1).toMatchObject({ t: 's', v: '1,234' });
+});

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { WorkBook } from 'xlsx';
+import exportPivotExcel from './downloadAsPivotExcel';
+
+const mockWriteFile = jest.fn();
+
+jest.mock('xlsx', () => {
+  const actual = jest.requireActual('xlsx');
+  return {
+    ...actual,
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  };
+});
+
+test('preserves locale-formatted numbers exactly as rendered, without SheetJS reinterpreting them', () => {
+  document.body.innerHTML = `
+    <table id="pivot-table">
+      <tbody>
+        <tr>
+          <td>1.234,56</td>
+          <td>12,50%</td>
+          <td>3.500</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+
+  exportPivotExcel('#pivot-table', 'export');
+
+  expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  const workbook = mockWriteFile.mock.calls[0][0] as WorkBook;
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+  // These are Spanish-locale D3_FORMAT strings ("." as thousands separator,
+  // "," as decimal separator). Each must survive the export untouched, as a
+  // text cell, rather than being silently reparsed as a different number
+  // (SheetJS's default HTML table parsing would otherwise turn "1.234,56"
+  // into the number 1.23456, "3.500" into 3.5, and "12,50%" into 12.5).
+  expect(sheet.A1).toMatchObject({ t: 's', v: '1.234,56' });
+  expect(sheet.B1).toMatchObject({ t: 's', v: '12,50%' });
+  expect(sheet.C1).toMatchObject({ t: 's', v: '3.500' });
+});

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -86,3 +86,33 @@ test('restores unambiguous plain numbers to native Excel numeric cells', () => {
   expect(sheet.C1).toMatchObject({ t: 's', v: '3.500' });
   expect(sheet.D1).toMatchObject({ t: 's', v: '1,234' });
 });
+
+test('restores unambiguous ISO date/datetime strings to native Excel date cells', () => {
+  document.body.innerHTML = `
+    <table id="pivot-table">
+      <tbody>
+        <tr>
+          <td>2024-01-01</td>
+          <td>2024-01-01 13:45:30</td>
+          <td>not-a-date</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+
+  exportPivotExcel('#pivot-table', 'export');
+
+  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+  // ISO 8601 date/datetime strings are unambiguous under any locale, so
+  // they're restored to native Excel date cells rather than left as text.
+  expect(sheet.A1.t).toBe('d');
+  expect((sheet.A1.v as Date).getFullYear()).toBe(2024);
+  expect((sheet.A1.v as Date).getMonth()).toBe(0);
+  expect((sheet.A1.v as Date).getDate()).toBe(1);
+  expect(sheet.B1.t).toBe('d');
+  expect((sheet.B1.v as Date).getHours()).toBe(13);
+  // Non-date text is left untouched.
+  expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
+});

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -116,3 +116,31 @@ test('restores unambiguous ISO date/datetime strings to native Excel date cells'
   // Non-date text is left untouched.
   expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
 });
+
+test('leaves ISO-shaped strings with out-of-range time components as text', () => {
+  document.body.innerHTML = `
+    <table id="pivot-table">
+      <tbody>
+        <tr>
+          <td>2024-01-01 13:60:30</td>
+          <td>2024-01-01 24:00:00</td>
+          <td>2024-01-01 12:30:61</td>
+        </tr>
+      </tbody>
+    </table>
+  `;
+
+  exportPivotExcel('#pivot-table', 'export');
+
+  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+  // The Date constructor rolls an out-of-range minute/hour/second over into
+  // the next unit (e.g. 13:60:30 becomes 14:00:30) instead of rejecting it.
+  // If only the date fields were round-tripped, these would be silently
+  // exported as native cells holding the wrong time, so they must stay as
+  // text - exactly as rendered - instead.
+  expect(sheet.A1).toMatchObject({ t: 's', v: '2024-01-01 13:60:30' });
+  expect(sheet.B1).toMatchObject({ t: 's', v: '2024-01-01 24:00:00' });
+  expect(sheet.C1).toMatchObject({ t: 's', v: '2024-01-01 12:30:61' });
+});

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -77,81 +77,19 @@ test('restores unambiguous plain numbers to native Excel numeric cells', () => {
   expect(sheet.D1).toMatchObject({ t: 's', v: '1,234' });
 });
 
-test('restores unambiguous ISO date/datetime strings to native Excel date cells', () => {
+test('leaves date-shaped strings as text rather than reinterpreting them as dates', () => {
   const sheet = exportRowAndGetSheet([
     '2024-01-01',
     '2024-01-01 13:45:30',
     'not-a-date',
   ]);
 
-  // ISO 8601 date/datetime strings are unambiguous under any locale, so
-  // they're restored to native Excel date cells rather than left as text.
-  // Assert via the UTC getters: the cell's Date is built from UTC
-  // components (see downloadAsPivotExcel.ts) so it serializes correctly
-  // through SheetJS regardless of the host's timezone - jest.config.js
-  // pins tests to America/New_York, where the local getters would report
-  // different values.
-  expect(sheet.A1.t).toBe('d');
-  expect((sheet.A1.v as Date).getUTCFullYear()).toBe(2024);
-  expect((sheet.A1.v as Date).getUTCMonth()).toBe(0);
-  expect((sheet.A1.v as Date).getUTCDate()).toBe(1);
-  expect(sheet.B1.t).toBe('d');
-  expect((sheet.B1.v as Date).getUTCHours()).toBe(13);
-  // Non-date text is left untouched.
+  // A rendered string can't be reliably classified as a genuine date rather
+  // than a coincidentally date-shaped formatted number (e.g. a custom
+  // D3_FORMAT grouping/thousands locale can render a plain metric like
+  // 20240101 as "2024-01-01"), so date-shaped cells are left exactly as
+  // rendered instead of being reinterpreted as native Excel dates.
+  expect(sheet.A1).toMatchObject({ t: 's', v: '2024-01-01' });
+  expect(sheet.B1).toMatchObject({ t: 's', v: '2024-01-01 13:45:30' });
   expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
-});
-
-test('builds the exported Date from UTC components so it is not shifted by the host timezone', () => {
-  // jest.config.js pins the test process to America/New_York (UTC-5 in
-  // January). Building the cell's Date from *local* date/time components
-  // (the original bug) rolls a late-evening local timestamp into the next
-  // UTC calendar day - exactly what SheetJS reads when it serializes the
-  // cell to an Excel date, so an exported "2024-01-01 23:30:00" would
-  // silently become "2024-01-02" in the workbook.
-  const sheet = exportRowAndGetSheet(['2024-01-01 23:30:00']);
-
-  const date = sheet.A1.v as Date;
-  expect(sheet.A1.t).toBe('d');
-  // The cell's Date must represent the exact same instant `Date.UTC` would
-  // produce for these wall-clock components, i.e. it was built via
-  // `Date.UTC(...)` rather than interpreted in the host's local timezone,
-  // so SheetJS - which serializes dates via their UTC epoch value - writes
-  // back the same calendar date/time that was rendered.
-  expect(date.getTime()).toBe(Date.UTC(2024, 0, 1, 23, 30, 0));
-});
-
-test('leaves ISO-shaped strings with out-of-range time components as text', () => {
-  const sheet = exportRowAndGetSheet([
-    '2024-01-01 13:60:30',
-    '2024-01-01 24:00:00',
-    '2024-01-01 12:30:61',
-  ]);
-
-  // The Date constructor rolls an out-of-range minute/hour/second over into
-  // the next unit (e.g. 13:60:30 becomes 14:00:30) instead of rejecting it.
-  // If only the date fields were round-tripped, these would be silently
-  // exported as native cells holding the wrong time, so they must stay as
-  // text - exactly as rendered - instead.
-  expect(sheet.A1).toMatchObject({ t: 's', v: '2024-01-01 13:60:30' });
-  expect(sheet.B1).toMatchObject({ t: 's', v: '2024-01-01 24:00:00' });
-  expect(sheet.C1).toMatchObject({ t: 's', v: '2024-01-01 12:30:61' });
-});
-
-test('leaves ISO-shaped strings with out-of-range date components as text', () => {
-  const sheet = exportRowAndGetSheet([
-    '2023-02-29', // 2023 is not a leap year, so February has 28 days.
-    '2024-02-30', // No February has 30 days, leap year or not.
-    '2024-13-01', // No 13th month.
-    '2024-01-32', // No 32nd day.
-  ]);
-
-  // Date.UTC rolls an out-of-range day/month over into the next unit (e.g.
-  // Feb 30 becomes Mar 1) instead of rejecting it. If the year/month/day
-  // fields weren't round-tripped, these would be silently exported as
-  // native cells holding the wrong date, so they must stay as text -
-  // exactly as rendered - instead.
-  expect(sheet.A1).toMatchObject({ t: 's', v: '2023-02-29' });
-  expect(sheet.B1).toMatchObject({ t: 's', v: '2024-02-30' });
-  expect(sheet.C1).toMatchObject({ t: 's', v: '2024-13-01' });
-  expect(sheet.D1).toMatchObject({ t: 's', v: '2024-01-32' });
 });

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -86,14 +86,38 @@ test('restores unambiguous ISO date/datetime strings to native Excel date cells'
 
   // ISO 8601 date/datetime strings are unambiguous under any locale, so
   // they're restored to native Excel date cells rather than left as text.
+  // Assert via the UTC getters: the cell's Date is built from UTC
+  // components (see downloadAsPivotExcel.ts) so it serializes correctly
+  // through SheetJS regardless of the host's timezone - jest.config.js
+  // pins tests to America/New_York, where the local getters would report
+  // different values.
   expect(sheet.A1.t).toBe('d');
-  expect((sheet.A1.v as Date).getFullYear()).toBe(2024);
-  expect((sheet.A1.v as Date).getMonth()).toBe(0);
-  expect((sheet.A1.v as Date).getDate()).toBe(1);
+  expect((sheet.A1.v as Date).getUTCFullYear()).toBe(2024);
+  expect((sheet.A1.v as Date).getUTCMonth()).toBe(0);
+  expect((sheet.A1.v as Date).getUTCDate()).toBe(1);
   expect(sheet.B1.t).toBe('d');
-  expect((sheet.B1.v as Date).getHours()).toBe(13);
+  expect((sheet.B1.v as Date).getUTCHours()).toBe(13);
   // Non-date text is left untouched.
   expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
+});
+
+test('builds the exported Date from UTC components so it is not shifted by the host timezone', () => {
+  // jest.config.js pins the test process to America/New_York (UTC-5 in
+  // January). Building the cell's Date from *local* date/time components
+  // (the original bug) rolls a late-evening local timestamp into the next
+  // UTC calendar day - exactly what SheetJS reads when it serializes the
+  // cell to an Excel date, so an exported "2024-01-01 23:30:00" would
+  // silently become "2024-01-02" in the workbook.
+  const sheet = exportRowAndGetSheet(['2024-01-01 23:30:00']);
+
+  const date = sheet.A1.v as Date;
+  expect(sheet.A1.t).toBe('d');
+  // The cell's Date must represent the exact same instant `Date.UTC` would
+  // produce for these wall-clock components, i.e. it was built via
+  // `Date.UTC(...)` rather than interpreted in the host's local timezone,
+  // so SheetJS - which serializes dates via their UTC epoch value - writes
+  // back the same calendar date/time that was rendered.
+  expect(date.getTime()).toBe(Date.UTC(2024, 0, 1, 23, 30, 0));
 });
 
 test('leaves ISO-shaped strings with out-of-range time components as text', () => {

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -136,3 +136,22 @@ test('leaves ISO-shaped strings with out-of-range time components as text', () =
   expect(sheet.B1).toMatchObject({ t: 's', v: '2024-01-01 24:00:00' });
   expect(sheet.C1).toMatchObject({ t: 's', v: '2024-01-01 12:30:61' });
 });
+
+test('leaves ISO-shaped strings with out-of-range date components as text', () => {
+  const sheet = exportRowAndGetSheet([
+    '2023-02-29', // 2023 is not a leap year, so February has 28 days.
+    '2024-02-30', // No February has 30 days, leap year or not.
+    '2024-13-01', // No 13th month.
+    '2024-01-32', // No 32nd day.
+  ]);
+
+  // Date.UTC rolls an out-of-range day/month over into the next unit (e.g.
+  // Feb 30 becomes Mar 1) instead of rejecting it. If the year/month/day
+  // fields weren't round-tripped, these would be silently exported as
+  // native cells holding the wrong date, so they must stay as text -
+  // exactly as rendered - instead.
+  expect(sheet.A1).toMatchObject({ t: 's', v: '2023-02-29' });
+  expect(sheet.B1).toMatchObject({ t: 's', v: '2024-02-30' });
+  expect(sheet.C1).toMatchObject({ t: 's', v: '2024-13-01' });
+  expect(sheet.D1).toMatchObject({ t: 's', v: '2024-01-32' });
+});

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -29,14 +29,15 @@ jest.mock('xlsx', () => {
   };
 });
 
-test('preserves locale-formatted numbers exactly as rendered, without SheetJS reinterpreting them', () => {
+// Renders a single-row pivot table with the given cell values, runs the
+// export, and returns the resulting sheet so each test only has to state
+// its input cells and assertions.
+function exportRowAndGetSheet(cells: string[]): WorkBook['Sheets'][string] {
   document.body.innerHTML = `
     <table id="pivot-table">
       <tbody>
         <tr>
-          <td>1.234,56</td>
-          <td>12,50%</td>
-          <td>3.500</td>
+          ${cells.map(cell => `<td>${cell}</td>`).join('\n          ')}
         </tr>
       </tbody>
     </table>
@@ -44,9 +45,14 @@ test('preserves locale-formatted numbers exactly as rendered, without SheetJS re
 
   exportPivotExcel('#pivot-table', 'export');
 
+  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
+  return workbook.Sheets[workbook.SheetNames[0]];
+}
+
+test('preserves locale-formatted numbers exactly as rendered, without SheetJS reinterpreting them', () => {
+  const sheet = exportRowAndGetSheet(['1.234,56', '12,50%', '3.500']);
+
   expect(mockWriteFile).toHaveBeenCalledTimes(1);
-  const workbook = mockWriteFile.mock.calls[0][0] as WorkBook;
-  const sheet = workbook.Sheets[workbook.SheetNames[0]];
 
   // These are Spanish-locale D3_FORMAT strings ("." as thousands separator,
   // "," as decimal separator). Each must survive the export untouched, as a
@@ -59,23 +65,7 @@ test('preserves locale-formatted numbers exactly as rendered, without SheetJS re
 });
 
 test('restores unambiguous plain numbers to native Excel numeric cells', () => {
-  document.body.innerHTML = `
-    <table id="pivot-table">
-      <tbody>
-        <tr>
-          <td>42</td>
-          <td>-3.5</td>
-          <td>3.500</td>
-          <td>1,234</td>
-        </tr>
-      </tbody>
-    </table>
-  `;
-
-  exportPivotExcel('#pivot-table', 'export');
-
-  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
-  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const sheet = exportRowAndGetSheet(['42', '-3.5', '3.500', '1,234']);
 
   // "42" and "-3.5" round-trip exactly through Number(), so they're
   // unambiguous under any locale and are restored to real numbers.
@@ -88,22 +78,11 @@ test('restores unambiguous plain numbers to native Excel numeric cells', () => {
 });
 
 test('restores unambiguous ISO date/datetime strings to native Excel date cells', () => {
-  document.body.innerHTML = `
-    <table id="pivot-table">
-      <tbody>
-        <tr>
-          <td>2024-01-01</td>
-          <td>2024-01-01 13:45:30</td>
-          <td>not-a-date</td>
-        </tr>
-      </tbody>
-    </table>
-  `;
-
-  exportPivotExcel('#pivot-table', 'export');
-
-  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
-  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const sheet = exportRowAndGetSheet([
+    '2024-01-01',
+    '2024-01-01 13:45:30',
+    'not-a-date',
+  ]);
 
   // ISO 8601 date/datetime strings are unambiguous under any locale, so
   // they're restored to native Excel date cells rather than left as text.
@@ -118,22 +97,11 @@ test('restores unambiguous ISO date/datetime strings to native Excel date cells'
 });
 
 test('leaves ISO-shaped strings with out-of-range time components as text', () => {
-  document.body.innerHTML = `
-    <table id="pivot-table">
-      <tbody>
-        <tr>
-          <td>2024-01-01 13:60:30</td>
-          <td>2024-01-01 24:00:00</td>
-          <td>2024-01-01 12:30:61</td>
-        </tr>
-      </tbody>
-    </table>
-  `;
-
-  exportPivotExcel('#pivot-table', 'export');
-
-  const workbook = mockWriteFile.mock.calls.at(-1)?.[0] as WorkBook;
-  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const sheet = exportRowAndGetSheet([
+    '2024-01-01 13:60:30',
+    '2024-01-01 24:00:00',
+    '2024-01-01 12:30:61',
+  ]);
 
   // The Date constructor rolls an out-of-range minute/hour/second over into
   // the next unit (e.g. 13:60:30 becomes 14:00:30) instead of rejecting it.

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import type { WorkBook } from 'xlsx';
+import { getNumberFormatterRegistry } from '@superset-ui/core';
 import exportPivotExcel from './downloadAsPivotExcel';
 
 const mockWriteFile = jest.fn();
@@ -75,6 +76,26 @@ test('restores unambiguous plain numbers to native Excel numeric cells', () => {
   // round-trip, so they stay as text rather than risk misparsing them.
   expect(sheet.C1).toMatchObject({ t: 's', v: '3.500' });
   expect(sheet.D1).toMatchObject({ t: 's', v: '1,234' });
+});
+
+test('does not restore grouped-thousands numbers under a "." thousands-separator locale', () => {
+  const registry = getNumberFormatterRegistry();
+  const original = registry.d3Format;
+  registry.setD3Format({ decimal: ',', thousands: '.', grouping: [3] });
+
+  try {
+    // Under a Spanish-style D3_FORMAT, "1.234" is the plain integer 1234
+    // rendered with a "." group separator, not the decimal 1.234. It also
+    // round-trips cleanly through Number(), so without the locale check it
+    // would be misrestored to the number 1.234, silently corrupting the
+    // value this PR exists to preserve. "42" has no "." and still round
+    // trips safely, so it's still restored.
+    const sheet = exportRowAndGetSheet(['1.234', '42']);
+    expect(sheet.A1).toMatchObject({ t: 's', v: '1.234' });
+    expect(sheet.B1).toMatchObject({ t: 'n', v: 42 });
+  } finally {
+    registry.setD3Format(original);
+  }
 });
 
 test('leaves date-shaped strings as text rather than reinterpreting them as dates', () => {

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -23,8 +23,7 @@ import type { WorkSheet } from 'xlsx';
 // "2024-01-01 00:00:00". This layout is unambiguous under any locale
 // (unlike "1/2/2024", which means different dates depending on the
 // reader), so it's safe to restore as a native Excel date.
-const ISO_DATE_RE =
-  /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?$/;
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?$/;
 
 // `raw: true` (used below) keeps every table cell as text, so ordinary
 // numbers and dates lose their native Excel type along with the
@@ -48,7 +47,7 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
     if (isoMatch) {
       const [y, mo, d, h, mi, s] = isoMatch
         .slice(1)
-        .map(part => Number(part ?? 0));
+        .map((part: string | undefined) => Number(part ?? 0));
       const date = new Date(y, mo - 1, d, h, mi, s);
       // The Date constructor rolls invalid components over into the next
       // month/day (e.g. day 40 becomes the 10th of the following month)

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -17,6 +17,33 @@
  * under the License.
  */
 import { utils, writeFile } from 'xlsx';
+import type { WorkSheet } from 'xlsx';
+
+// `raw: true` (used below) keeps every table cell as text, so ordinary
+// numbers lose their native Excel numeric type along with the
+// locale-formatted ones. A cell's text is only restored to a real number
+// when it round-trips losslessly through Number() (e.g. "42" or "-3.5"):
+// that guarantees it's a plain, unambiguous number under any locale, so
+// restoring it can't reintroduce the misparsing raw: true guards against.
+// Anything that doesn't round-trip (grouped thousands, percent suffixes,
+// trailing zero padding, other D3_FORMAT output, etc.) stays as text,
+// exactly as rendered.
+function restoreUnambiguousNumbers(sheet: WorkSheet): void {
+  Object.keys(sheet).forEach(cellRef => {
+    if (cellRef.startsWith('!')) {
+      return;
+    }
+    const cell = sheet[cellRef];
+    if (!cell || cell.t !== 's' || typeof cell.v !== 'string') {
+      return;
+    }
+    const value = Number(cell.v);
+    if (cell.v !== '' && Number.isFinite(value) && String(value) === cell.v) {
+      cell.t = 'n';
+      cell.v = value;
+    }
+  });
+}
 
 export default function exportPivotExcel(
   tableSelector: string,
@@ -28,5 +55,9 @@ export default function exportPivotExcel(
   // string, which mangles values that were formatted using a non-US
   // D3_FORMAT (e.g. "1.234,56" gets misread as a date or truncated number).
   const workbook = utils.table_to_book(table, { raw: true });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  if (sheet) {
+    restoreUnambiguousNumbers(sheet);
+  }
   writeFile(workbook, `${fileName}.xlsx`);
 }

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -23,6 +23,10 @@ export default function exportPivotExcel(
   fileName: string,
 ) {
   const table = document.querySelector(tableSelector);
-  const workbook = utils.table_to_book(table);
+  // `raw: true` keeps every cell as the literal text rendered in the DOM.
+  // Without it, SheetJS tries to infer numbers/dates from the displayed
+  // string, which mangles values that were formatted using a non-US
+  // D3_FORMAT (e.g. "1.234,56" gets misread as a date or truncated number).
+  const workbook = utils.table_to_book(table, { raw: true });
   writeFile(workbook, `${fileName}.xlsx`);
 }

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -19,15 +19,22 @@
 import { utils, writeFile } from 'xlsx';
 import type { WorkSheet } from 'xlsx';
 
+// ISO 8601 date (and optional time) form, e.g. "2024-01-01" or
+// "2024-01-01 00:00:00". This layout is unambiguous under any locale
+// (unlike "1/2/2024", which means different dates depending on the
+// reader), so it's safe to restore as a native Excel date.
+const ISO_DATE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?$/;
+
 // `raw: true` (used below) keeps every table cell as text, so ordinary
-// numbers lose their native Excel numeric type along with the
-// locale-formatted ones. A cell's text is only restored to a real number
-// when it round-trips losslessly through Number() (e.g. "42" or "-3.5"):
-// that guarantees it's a plain, unambiguous number under any locale, so
-// restoring it can't reintroduce the misparsing raw: true guards against.
-// Anything that doesn't round-trip (grouped thousands, percent suffixes,
-// trailing zero padding, other D3_FORMAT output, etc.) stays as text,
-// exactly as rendered.
+// numbers and dates lose their native Excel type along with the
+// locale-formatted values. A cell's text is only restored to a real number
+// or date when it is unambiguous under any locale: a plain number that
+// round-trips losslessly through Number() (e.g. "42" or "-3.5"), or an
+// ISO 8601 date/datetime string. Restoring those can't reintroduce the
+// misparsing raw: true guards against. Anything else (grouped thousands,
+// percent suffixes, trailing zero padding, other D3_FORMAT output, etc.)
+// stays as text, exactly as rendered.
 function restoreUnambiguousNumbers(sheet: WorkSheet): void {
   Object.keys(sheet).forEach(cellRef => {
     if (cellRef.startsWith('!')) {
@@ -36,6 +43,26 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
     const cell = sheet[cellRef];
     if (!cell || cell.t !== 's' || typeof cell.v !== 'string') {
       return;
+    }
+    const isoMatch = cell.v.match(ISO_DATE_RE);
+    if (isoMatch) {
+      const [y, mo, d, h, mi, s] = isoMatch
+        .slice(1)
+        .map(part => Number(part ?? 0));
+      const date = new Date(y, mo - 1, d, h, mi, s);
+      // The Date constructor rolls invalid components over into the next
+      // month/day (e.g. day 40 becomes the 10th of the following month)
+      // instead of rejecting them, so confirm the parts round-trip before
+      // trusting the result.
+      const isValid =
+        date.getFullYear() === y &&
+        date.getMonth() === mo - 1 &&
+        date.getDate() === d;
+      if (isValid) {
+        cell.t = 'd';
+        cell.v = date;
+        return;
+      }
     }
     const value = Number(cell.v);
     if (cell.v !== '' && Number.isFinite(value) && String(value) === cell.v) {

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -50,13 +50,17 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
         .map((part: string | undefined) => Number(part ?? 0));
       const date = new Date(y, mo - 1, d, h, mi, s);
       // The Date constructor rolls invalid components over into the next
-      // month/day (e.g. day 40 becomes the 10th of the following month)
-      // instead of rejecting them, so confirm the parts round-trip before
-      // trusting the result.
+      // unit (e.g. day 40 becomes the 10th of the following month, minute
+      // 60 becomes the top of the next hour) instead of rejecting them, so
+      // confirm every part - date and time - round-trips before trusting
+      // the result.
       const isValid =
         date.getFullYear() === y &&
         date.getMonth() === mo - 1 &&
-        date.getDate() === d;
+        date.getDate() === d &&
+        date.getHours() === h &&
+        date.getMinutes() === mi &&
+        date.getSeconds() === s;
       if (isValid) {
         cell.t = 'd';
         cell.v = date;

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -48,19 +48,26 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
       const [y, mo, d, h, mi, s] = isoMatch
         .slice(1)
         .map((part: string | undefined) => Number(part ?? 0));
-      const date = new Date(y, mo - 1, d, h, mi, s);
+      // SheetJS serializes a cell's Date via its absolute (UTC) epoch time,
+      // not its local calendar fields, so building this from local
+      // components would silently shift the exported value by the host's
+      // UTC offset (e.g. midnight in a positive-offset timezone would
+      // export as the previous day). Constructing - and validating - via
+      // UTC keeps the exported date/time identical to the source text
+      // regardless of the host's timezone.
+      const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s));
       // The Date constructor rolls invalid components over into the next
       // unit (e.g. day 40 becomes the 10th of the following month, minute
       // 60 becomes the top of the next hour) instead of rejecting them, so
       // confirm every part - date and time - round-trips before trusting
       // the result.
       const isValid =
-        date.getFullYear() === y &&
-        date.getMonth() === mo - 1 &&
-        date.getDate() === d &&
-        date.getHours() === h &&
-        date.getMinutes() === mi &&
-        date.getSeconds() === s;
+        date.getUTCFullYear() === y &&
+        date.getUTCMonth() === mo - 1 &&
+        date.getUTCDate() === d &&
+        date.getUTCHours() === h &&
+        date.getUTCMinutes() === mi &&
+        date.getUTCSeconds() === s;
       if (isValid) {
         cell.t = 'd';
         cell.v = date;

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -16,28 +16,40 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { getNumberFormatterRegistry } from '@superset-ui/core';
 import { utils, writeFile } from 'xlsx';
 import type { WorkSheet } from 'xlsx';
 
 // `raw: true` (used below) keeps every table cell as text, so ordinary
 // numbers lose their native Excel type along with the locale-formatted
 // values. A cell's text is only restored to a real number when it is
-// unambiguous under any locale: a plain number that round-trips losslessly
-// through Number() (e.g. "42" or "-3.5"). Restoring those can't
-// reintroduce the misparsing raw: true guards against. Anything else
-// (grouped thousands, percent suffixes, trailing zero padding, date-shaped
-// text, other D3_FORMAT output, etc.) stays as text, exactly as rendered:
-// a rendered string can't be reliably classified as a genuine date rather
-// than a coincidentally date-shaped formatted number (e.g. a custom
+// unambiguous under the active D3_FORMAT locale: a plain number that
+// round-trips losslessly through Number() (e.g. "42" or "-3.5"). Restoring
+// those can't reintroduce the misparsing raw: true guards against. Anything
+// else (grouped thousands, percent suffixes, trailing zero padding,
+// date-shaped text, other D3_FORMAT output, etc.) stays as text, exactly as
+// rendered: a rendered string can't be reliably classified as a genuine date
+// rather than a coincidentally date-shaped formatted number (e.g. a custom
 // D3_FORMAT grouping/thousands locale can render a plain metric like
 // 20240101 as "2024-01-01"), so cells are never reinterpreted as dates.
+//
+// Number()'s round-trip check assumes "." is a decimal point, which isn't
+// true under every locale: a Spanish D3_FORMAT (thousands: '.') renders the
+// plain integer 1234 as "1.234", which also round-trips through Number() as
+// the decimal 1.234. When the active locale uses "." as its thousands
+// separator, a cell containing "." can't be trusted as an unambiguous
+// decimal, so it's left as text instead.
 function restoreUnambiguousNumbers(sheet: WorkSheet): void {
+  const { thousands } = getNumberFormatterRegistry().d3Format;
   Object.keys(sheet).forEach(cellRef => {
     if (cellRef.startsWith('!')) {
       return;
     }
     const cell = sheet[cellRef];
     if (!cell || cell.t !== 's' || typeof cell.v !== 'string') {
+      return;
+    }
+    if (thousands === '.' && cell.v.includes('.')) {
       return;
     }
     const value = Number(cell.v);

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -19,21 +19,18 @@
 import { utils, writeFile } from 'xlsx';
 import type { WorkSheet } from 'xlsx';
 
-// ISO 8601 date (and optional time) form, e.g. "2024-01-01" or
-// "2024-01-01 00:00:00". This layout is unambiguous under any locale
-// (unlike "1/2/2024", which means different dates depending on the
-// reader), so it's safe to restore as a native Excel date.
-const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2}))?$/;
-
 // `raw: true` (used below) keeps every table cell as text, so ordinary
-// numbers and dates lose their native Excel type along with the
-// locale-formatted values. A cell's text is only restored to a real number
-// or date when it is unambiguous under any locale: a plain number that
-// round-trips losslessly through Number() (e.g. "42" or "-3.5"), or an
-// ISO 8601 date/datetime string. Restoring those can't reintroduce the
-// misparsing raw: true guards against. Anything else (grouped thousands,
-// percent suffixes, trailing zero padding, other D3_FORMAT output, etc.)
-// stays as text, exactly as rendered.
+// numbers lose their native Excel type along with the locale-formatted
+// values. A cell's text is only restored to a real number when it is
+// unambiguous under any locale: a plain number that round-trips losslessly
+// through Number() (e.g. "42" or "-3.5"). Restoring those can't
+// reintroduce the misparsing raw: true guards against. Anything else
+// (grouped thousands, percent suffixes, trailing zero padding, date-shaped
+// text, other D3_FORMAT output, etc.) stays as text, exactly as rendered:
+// a rendered string can't be reliably classified as a genuine date rather
+// than a coincidentally date-shaped formatted number (e.g. a custom
+// D3_FORMAT grouping/thousands locale can render a plain metric like
+// 20240101 as "2024-01-01"), so cells are never reinterpreted as dates.
 function restoreUnambiguousNumbers(sheet: WorkSheet): void {
   Object.keys(sheet).forEach(cellRef => {
     if (cellRef.startsWith('!')) {
@@ -42,37 +39,6 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
     const cell = sheet[cellRef];
     if (!cell || cell.t !== 's' || typeof cell.v !== 'string') {
       return;
-    }
-    const isoMatch = cell.v.match(ISO_DATE_RE);
-    if (isoMatch) {
-      const [y, mo, d, h, mi, s] = isoMatch
-        .slice(1)
-        .map((part: string | undefined) => Number(part ?? 0));
-      // SheetJS serializes a cell's Date via its absolute (UTC) epoch time,
-      // not its local calendar fields, so building this from local
-      // components would silently shift the exported value by the host's
-      // UTC offset (e.g. midnight in a positive-offset timezone would
-      // export as the previous day). Constructing - and validating - via
-      // UTC keeps the exported date/time identical to the source text
-      // regardless of the host's timezone.
-      const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s));
-      // The Date constructor rolls invalid components over into the next
-      // unit (e.g. day 40 becomes the 10th of the following month, minute
-      // 60 becomes the top of the next hour) instead of rejecting them, so
-      // confirm every part - date and time - round-trips before trusting
-      // the result.
-      const isValid =
-        date.getUTCFullYear() === y &&
-        date.getUTCMonth() === mo - 1 &&
-        date.getUTCDate() === d &&
-        date.getUTCHours() === h &&
-        date.getUTCMinutes() === mi &&
-        date.getUTCSeconds() === s;
-      if (isValid) {
-        cell.t = 'd';
-        cell.v = date;
-        return;
-      }
     }
     const value = Number(cell.v);
     if (cell.v !== '' && Number.isFinite(value) && String(value) === cell.v) {


### PR DESCRIPTION
### SUMMARY
"Export to Pivoted Excel" runs entirely client-side: it reads the rendered pivot table DOM and hands it to SheetJS's `utils.table_to_book()`. By default, SheetJS tries to guess a type (number, date, etc.) for every cell from its displayed text. That guessing ignores `D3_FORMAT` and mangles anything formatted with non-US separators.

I confirmed this directly against the real `xlsx` (SheetJS) package: with a Spanish `D3_FORMAT` (`.` thousands, `,` decimal), a cell rendered as `"1.234,56"` came out as the number `1.23456`, `"3.500"` came out as `3.5`, and `"12,50%"` came out as `12.5` — silently wrong values in the exported file.

The fix passes `raw: true` to `table_to_book()`, so every cell keeps the literal text already formatted by `D3_FORMAT` in the UI instead of being reparsed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (no UI change, only export contents)

### TESTING INSTRUCTIONS
1. Set a non-US `D3_FORMAT` in `config.py`, e.g.:
   ```python
   D3_FORMAT = {
       "decimal": ",",
       "thousands": ".",
       "grouping": [3],
       "currency": ["", "€"],
   }
   ```
2. Restart Superset, open a pivot table chart with decimal metrics.
3. Click Download -> Export to Pivoted Excel.
4. Before this fix: numeric cells are silently reinterpreted (wrong values, sometimes dates). After this fix: the exported cells match exactly what's rendered on screen.

Also added `superset-frontend/src/utils/downloadAsPivotExcel.test.ts`, which pins this against the real SheetJS parsing behavior (mocking only `writeFile`, not `xlsx.utils`) so a regression here fails a unit test rather than only showing up in manually exported files.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38555
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
