### PR TITLE
fix(docs): sync live component demos to the docs site's dark mode toggle

### DIFF
--- a/docs/src/components/StorybookWrapper.jsx
+++ b/docs/src/components/StorybookWrapper.jsx
@@ -87,9 +87,16 @@ function getProviders() {
     // Docusaurus tracks the toggle in React context (useColorMode), so
     // mirror it onto the singleton via the toggleDarkMode() method Theme
     // already exposes for exactly this purpose.
+    //
+    // Use useLayoutEffect (not useEffect) so the sync runs before the
+    // browser paints. This component only ever mounts client-side (it's
+    // built inside a BrowserOnly callback), so there's no SSR mismatch
+    // concern -- and running synchronously before paint avoids a brief
+    // flash of the singleton's previous palette when a page loads directly
+    // in dark mode or the toggle fires during route navigation.
     function ThemeSync({ children }) {
       const { colorMode } = useColorMode();
-      React.useEffect(() => {
+      React.useLayoutEffect(() => {
         themeObject.toggleDarkMode(colorMode === 'dark');
       }, [colorMode]);
       return children;

--- a/docs/src/components/StorybookWrapper.jsx
+++ b/docs/src/components/StorybookWrapper.jsx
@@ -68,6 +68,8 @@ function getProviders() {
     const { themeObject } = require('@apache-superset/core/theme');
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { App, ConfigProvider } = require('antd');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useColorMode } = require('@docusaurus/theme-common');
 
     // Configure Ant Design to render portals (tooltips, dropdowns, etc.)
     // inside the closest .storybook-example container instead of document.body
@@ -78,15 +80,32 @@ function getProviders() {
       return container || document.body;
     };
 
+    // `themeObject` is a module-level singleton (superset-core/src/theme
+    // index.tsx: `Theme.fromConfig()`), created once with no dark/light
+    // config, so SupersetThemeProvider always rendered whatever that default
+    // algorithm was -- it had no way to know about Docusaurus's theme toggle.
+    // Docusaurus tracks the toggle in React context (useColorMode), so
+    // mirror it onto the singleton via the toggleDarkMode() method Theme
+    // already exposes for exactly this purpose.
+    function ThemeSync({ children }) {
+      const { colorMode } = useColorMode();
+      React.useEffect(() => {
+        themeObject.toggleDarkMode(colorMode === 'dark');
+      }, [colorMode]);
+      return children;
+    }
+
     SupersetProviders = ({ children }) => (
-      <themeObject.SupersetThemeProvider>
-        <ConfigProvider
-          getPopupContainer={getPopupContainer}
-          getTargetContainer={() => document.body}
-        >
-          <App>{children}</App>
-        </ConfigProvider>
-      </themeObject.SupersetThemeProvider>
+      <ThemeSync>
+        <themeObject.SupersetThemeProvider>
+          <ConfigProvider
+            getPopupContainer={getPopupContainer}
+            getTargetContainer={() => document.body}
+          >
+            <App>{children}</App>
+          </ConfigProvider>
+        </themeObject.SupersetThemeProvider>
+      </ThemeSync>
     );
     return SupersetProviders;
   } catch (error) {
@@ -133,7 +152,7 @@ function LoadingPlaceholder() {
   return (
     <div
       style={{
-        border: '1px solid #e8e8e8',
+        border: '1px solid var(--ifm-color-emphasis-300)',
         borderRadius: '4px',
         padding: '20px',
         marginBottom: '20px',
@@ -141,7 +160,7 @@ function LoadingPlaceholder() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        color: '#999',
+        color: 'var(--ifm-color-emphasis-600)',
       }}
     >
       Loading component...
@@ -162,7 +181,7 @@ export function StoryExample({ component, props = {} }) {
             <div
               className="storybook-example"
               style={{
-                border: '1px solid #e8e8e8',
+                border: '1px solid var(--ifm-color-emphasis-300)',
                 borderRadius: '4px',
                 padding: '20px',
                 marginBottom: '20px',
@@ -172,7 +191,7 @@ export function StoryExample({ component, props = {} }) {
               {Component ? (
                 <Component {...restProps}>{children}</Component>
               ) : (
-                <div style={{ color: '#999' }}>
+                <div style={{ color: 'var(--ifm-color-emphasis-600)' }}>
                   Component &quot;{String(component)}&quot; not found
                 </div>
               )}
@@ -373,7 +392,7 @@ function StoryWithControlsInner({
         <div
           className="storybook-example"
           style={{
-            border: '1px solid #e8e8e8',
+            border: '1px solid var(--ifm-color-emphasis-300)',
             borderRadius: '4px',
             padding: '20px',
             marginBottom: '20px',
@@ -393,7 +412,7 @@ function StoryWithControlsInner({
               </Component>
             </>
           ) : (
-            <div style={{ color: '#999' }}>
+            <div style={{ color: 'var(--ifm-color-emphasis-600)' }}>
               Component &quot;{String(componentToRender)}&quot; not found
             </div>
           )}
@@ -403,7 +422,7 @@ function StoryWithControlsInner({
           <div
             className="storybook-controls"
             style={{
-              border: '1px solid #e8e8e8',
+              border: '1px solid var(--ifm-color-emphasis-300)',
               borderRadius: '4px',
               padding: '20px',
               marginBottom: '20px',
@@ -545,7 +564,7 @@ function ComponentGalleryInner({
 
   if (!Component) {
     return (
-      <div style={{ color: '#999' }}>
+      <div style={{ color: 'var(--ifm-color-emphasis-600)' }}>
         Component &quot;{String(component)}&quot; not found
       </div>
     );
@@ -556,7 +575,14 @@ function ComponentGalleryInner({
       <div className="component-gallery">
         {sizes.map(size => (
           <div key={size} style={{ marginBottom: 40 }}>
-            <h4 style={{ marginBottom: 16, color: '#666' }}>{size}</h4>
+            <h4
+              style={{
+                marginBottom: 16,
+                color: 'var(--ifm-color-emphasis-700)',
+              }}
+            >
+              {size}
+            </h4>
             <div
               style={{
                 display: 'flex',

--- a/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, act } from '@testing-library/react';
+import { theme as antdThemeImport } from 'antd';
+import { Theme } from './Theme';
+
+// SupersetThemeProvider stores theme state via React.useState, then
+// overrides Theme#updateProviders (a no-op by default) to call setThemeState
+// whenever a *later* call to setConfig/toggleDarkMode runs on the same
+// instance. Consumers (docs/src/components/StorybookWrapper.jsx in
+// particular) rely on this: they call toggleDarkMode() from outside, on an
+// already-mounted provider, expecting it to propagate.
+//
+// The probe below reads the theme via antd's theme.useToken() -- the same
+// context-consumption path every real antd component (Button, Input, ...)
+// uses internally -- rather than reading themeObject.theme directly off the
+// singleton. That distinction matters: React bails out of re-rendering a
+// child whose element reference didn't change (the common "static children
+// prop" case, true here since <Probe /> is passed once and never
+// recreated), UNLESS that child consumes a React Context whose value
+// changed, which bypasses the bail-out. A probe reading the plain object
+// directly would misleadingly appear "not updated" even though every real
+// themed component downstream re-renders correctly.
+test('an already-mounted SupersetThemeProvider re-renders context-consuming children when toggleDarkMode is called on the same instance', () => {
+  const themeObject = Theme.fromConfig();
+  let renderCount = 0;
+  let lastColorBgBase: string | undefined;
+
+  function Probe() {
+    const { token } = antdThemeImport.useToken();
+    renderCount += 1;
+    lastColorBgBase = token.colorBgBase;
+    return <div data-test="probe" />;
+  }
+
+  render(
+    <themeObject.SupersetThemeProvider>
+      <Probe />
+    </themeObject.SupersetThemeProvider>,
+  );
+
+  expect(screen.getByTestId('probe')).toBeTruthy();
+  const rendersBefore = renderCount;
+  const tokenBefore = lastColorBgBase;
+
+  act(() => {
+    themeObject.toggleDarkMode(true);
+  });
+
+  expect(renderCount).toBeGreaterThan(rendersBefore);
+  expect(lastColorBgBase).not.toBe(tokenBefore);
+});
+
+test('a toggleDarkMode call on an unmounted (or different) theme instance does not affect a mounted provider', () => {
+  const mounted = Theme.fromConfig();
+  const other = Theme.fromConfig();
+  let renderCount = 0;
+  let lastColorBgBase: string | undefined;
+
+  function Probe() {
+    const { token } = antdThemeImport.useToken();
+    renderCount += 1;
+    lastColorBgBase = token.colorBgBase;
+    return <div data-test="probe" />;
+  }
+
+  render(
+    <mounted.SupersetThemeProvider>
+      <Probe />
+    </mounted.SupersetThemeProvider>,
+  );
+
+  const rendersBefore = renderCount;
+  const tokenBefore = lastColorBgBase;
+
+  act(() => {
+    other.toggleDarkMode(true);
+  });
+
+  // Each Theme instance owns its own updateProviders override; toggling a
+  // *different* instance must not re-render a provider mounted from another.
+  expect(renderCount).toBe(rendersBefore);
+  expect(lastColorBgBase).toBe(tokenBefore);
+});

--- a/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
@@ -21,11 +21,15 @@ import { theme as antdThemeImport } from 'antd';
 import { Theme } from './Theme';
 
 // SupersetThemeProvider stores theme state via React.useState, then
-// overrides Theme#updateProviders (a no-op by default) to call setThemeState
+// registers a listener (in a useEffect, on mount) that calls setThemeState
 // whenever a *later* call to setConfig/toggleDarkMode runs on the same
-// instance. Consumers (docs/src/components/StorybookWrapper.jsx in
-// particular) rely on this: they call toggleDarkMode() from outside, on an
-// already-mounted provider, expecting it to propagate.
+// Theme instance. Every provider currently mounted from that instance
+// listens independently, so toggling the instance updates all of them, not
+// just the most recently rendered one. Consumers
+// (docs/src/components/StorybookWrapper.jsx in particular) rely on this:
+// they call toggleDarkMode() from outside, on one or more already-mounted
+// providers sharing a single Theme instance, expecting it to propagate to
+// all of them.
 //
 // The probe below reads the theme via antd's theme.useToken() -- the same
 // context-consumption path every real antd component (Button, Input, ...)
@@ -37,17 +41,25 @@ import { Theme } from './Theme';
 // changed, which bypasses the bail-out. A probe reading the plain object
 // directly would misleadingly appear "not updated" even though every real
 // themed component downstream re-renders correctly.
-test('an already-mounted SupersetThemeProvider re-renders context-consuming children when toggleDarkMode is called on the same instance', () => {
-  const themeObject = Theme.fromConfig();
+function makeProbe() {
   let renderCount = 0;
   let lastColorBgBase: string | undefined;
-
   function Probe() {
     const { token } = antdThemeImport.useToken();
     renderCount += 1;
     lastColorBgBase = token.colorBgBase;
     return <div data-test="probe" />;
   }
+  return {
+    Probe,
+    getRenderCount: () => renderCount,
+    getLastColorBgBase: () => lastColorBgBase,
+  };
+}
+
+test('an already-mounted SupersetThemeProvider re-renders context-consuming children when toggleDarkMode is called on the same instance', () => {
+  const themeObject = Theme.fromConfig();
+  const { Probe, getRenderCount, getLastColorBgBase } = makeProbe();
 
   render(
     <themeObject.SupersetThemeProvider>
@@ -56,29 +68,50 @@ test('an already-mounted SupersetThemeProvider re-renders context-consuming chil
   );
 
   expect(screen.getByTestId('probe')).toBeTruthy();
-  const rendersBefore = renderCount;
-  const tokenBefore = lastColorBgBase;
+  const rendersBefore = getRenderCount();
+  const tokenBefore = getLastColorBgBase();
 
   act(() => {
     themeObject.toggleDarkMode(true);
   });
 
-  expect(renderCount).toBeGreaterThan(rendersBefore);
-  expect(lastColorBgBase).not.toBe(tokenBefore);
+  expect(getRenderCount()).toBeGreaterThan(rendersBefore);
+  expect(getLastColorBgBase()).not.toBe(tokenBefore);
 });
 
-test('a toggleDarkMode call on an unmounted (or different) theme instance does not affect a mounted provider', () => {
+test('toggleDarkMode updates every concurrently mounted provider for the same theme instance', () => {
+  const themeObject = Theme.fromConfig();
+  const first = makeProbe();
+  const second = makeProbe();
+
+  render(
+    <>
+      <themeObject.SupersetThemeProvider>
+        <first.Probe />
+      </themeObject.SupersetThemeProvider>
+      <themeObject.SupersetThemeProvider>
+        <second.Probe />
+      </themeObject.SupersetThemeProvider>
+    </>,
+  );
+
+  const firstTokenBefore = first.getLastColorBgBase();
+  const secondTokenBefore = second.getLastColorBgBase();
+
+  act(() => {
+    themeObject.toggleDarkMode(true);
+  });
+
+  // Both providers share the same Theme instance, so both must pick up the
+  // toggle -- not just whichever one rendered last.
+  expect(first.getLastColorBgBase()).not.toBe(firstTokenBefore);
+  expect(second.getLastColorBgBase()).not.toBe(secondTokenBefore);
+});
+
+test('a toggleDarkMode call on a different theme instance does not affect a mounted provider', () => {
   const mounted = Theme.fromConfig();
   const other = Theme.fromConfig();
-  let renderCount = 0;
-  let lastColorBgBase: string | undefined;
-
-  function Probe() {
-    const { token } = antdThemeImport.useToken();
-    renderCount += 1;
-    lastColorBgBase = token.colorBgBase;
-    return <div data-test="probe" />;
-  }
+  const { Probe, getRenderCount, getLastColorBgBase } = makeProbe();
 
   render(
     <mounted.SupersetThemeProvider>
@@ -86,15 +119,42 @@ test('a toggleDarkMode call on an unmounted (or different) theme instance does n
     </mounted.SupersetThemeProvider>,
   );
 
-  const rendersBefore = renderCount;
-  const tokenBefore = lastColorBgBase;
+  const rendersBefore = getRenderCount();
+  const tokenBefore = getLastColorBgBase();
 
   act(() => {
     other.toggleDarkMode(true);
   });
 
-  // Each Theme instance owns its own updateProviders override; toggling a
+  // Each Theme instance owns its own set of provider listeners; toggling a
   // *different* instance must not re-render a provider mounted from another.
-  expect(renderCount).toBe(rendersBefore);
-  expect(lastColorBgBase).toBe(tokenBefore);
+  expect(getRenderCount()).toBe(rendersBefore);
+  expect(getLastColorBgBase()).toBe(tokenBefore);
+});
+
+test('a toggleDarkMode call after a provider unmounts does not throw and no longer updates it', () => {
+  const themeObject = Theme.fromConfig();
+  const { Probe, getRenderCount, getLastColorBgBase } = makeProbe();
+
+  const { unmount } = render(
+    <themeObject.SupersetThemeProvider>
+      <Probe />
+    </themeObject.SupersetThemeProvider>,
+  );
+
+  const rendersBefore = getRenderCount();
+  const tokenBefore = getLastColorBgBase();
+
+  unmount();
+
+  expect(() => {
+    act(() => {
+      themeObject.toggleDarkMode(true);
+    });
+  }).not.toThrow();
+
+  // The unmounted provider's listener was deregistered, so it shouldn't
+  // have re-rendered (or updated) in response to the toggle.
+  expect(getRenderCount()).toBe(rendersBefore);
+  expect(getLastColorBgBase()).toBe(tokenBefore);
 });

--- a/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useLayoutEffect, type ReactNode } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { theme as antdThemeImport } from 'antd';
 import { Theme } from './Theme';
@@ -157,4 +158,48 @@ test('a toggleDarkMode call after a provider unmounts does not throw and no long
   // have re-rendered (or updated) in response to the toggle.
   expect(getRenderCount()).toBe(rendersBefore);
   expect(getLastColorBgBase()).toBe(tokenBefore);
+});
+
+test('a toggleDarkMode call from an ancestor layout effect during the initial commit is not dropped', () => {
+  // Regression harness for the initial-mount race: StorybookWrapper.jsx
+  // toggles the singleton from its own layout effect (ThemeSync) as soon
+  // as a demo mounts. SupersetThemeProvider must have its listener
+  // registered *before* that ancestor effect fires, which only holds if
+  // registration itself runs in a layout effect -- layout effects fire
+  // bottom-up, so this component (nested inside the toggling ancestor)
+  // registers first. If that registration ever regresses to a plain
+  // useEffect, it runs after the ancestor's toggle (passive effects are
+  // deferred until after all layout effects), the notification is
+  // dropped, and this probe would still show the pre-toggle palette.
+  const lightBaseline = Theme.fromConfig();
+  const baseline = makeProbe();
+
+  render(
+    <lightBaseline.SupersetThemeProvider>
+      <baseline.Probe />
+    </lightBaseline.SupersetThemeProvider>,
+  );
+
+  const lightColorBgBase = baseline.getLastColorBgBase();
+
+  const themeObject = Theme.fromConfig();
+  const { Probe, getLastColorBgBase } = makeProbe();
+
+  function AncestorToggler({ children }: { children: ReactNode }) {
+    useLayoutEffect(() => {
+      themeObject.toggleDarkMode(true);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return children;
+  }
+
+  render(
+    <AncestorToggler>
+      <themeObject.SupersetThemeProvider>
+        <Probe />
+      </themeObject.SupersetThemeProvider>
+    </AncestorToggler>,
+  );
+
+  expect(getLastColorBgBase()).not.toBe(lightColorBgBase);
 });

--- a/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
@@ -22,11 +22,11 @@ import { theme as antdThemeImport } from 'antd';
 import { Theme } from './Theme';
 
 // SupersetThemeProvider stores theme state via React.useState, then
-// registers a listener (in a useEffect, on mount) that calls setThemeState
-// whenever a *later* call to setConfig/toggleDarkMode runs on the same
-// Theme instance. Every provider currently mounted from that instance
-// listens independently, so toggling the instance updates all of them, not
-// just the most recently rendered one. Consumers
+// registers a listener (in a useLayoutEffect, on mount) that calls
+// setThemeState whenever a *later* call to setConfig/toggleDarkMode runs
+// on the same Theme instance. Every provider currently mounted from that
+// instance listens independently, so toggling the instance updates all of
+// them, not just the most recently rendered one. Consumers
 // (docs/src/components/StorybookWrapper.jsx in particular) rely on this:
 // they call toggleDarkMode() from outside, on one or more already-mounted
 // providers sharing a single Theme instance, expecting it to propagate to

--- a/superset-frontend/packages/superset-core/src/theme/Theme.test.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.test.tsx
@@ -243,6 +243,47 @@ test('Theme.toggleDarkMode preserves other algorithms when toggling dark mode', 
   expect(serialized.algorithm).not.toContain(ThemeAlgorithm.DARK);
 });
 
+test('Theme.toggleDarkMode is a no-op when the requested mode is already active', () => {
+  // Pages with many live component demos (see docs/src/components/
+  // StorybookWrapper.jsx's ThemeSync) mount one dark-mode-sync bridge per
+  // demo, so a single toggle event can call toggleDarkMode once per demo
+  // with the same isDark value. Only the first of those calls should
+  // actually recompute the theme and fan out to providers.
+  const theme = Theme.fromConfig();
+  const setConfigSpy = jest.spyOn(theme, 'setConfig');
+
+  theme.toggleDarkMode(true);
+  expect(setConfigSpy).toHaveBeenCalledTimes(1);
+
+  // Repeating the same toggle should not recompute the theme again.
+  theme.toggleDarkMode(true);
+  theme.toggleDarkMode(true);
+  expect(setConfigSpy).toHaveBeenCalledTimes(1);
+
+  // Toggling to the other mode should still go through.
+  theme.toggleDarkMode(false);
+  expect(setConfigSpy).toHaveBeenCalledTimes(2);
+
+  setConfigSpy.mockRestore();
+});
+
+test('Theme.toggleDarkMode no-op check accounts for other algorithms in the array', () => {
+  // Start already in dark mode alongside a non-mode algorithm (compact).
+  const theme = Theme.fromConfig({
+    algorithm: [
+      antdThemeImport.compactAlgorithm,
+      antdThemeImport.darkAlgorithm,
+    ],
+  });
+  const setConfigSpy = jest.spyOn(theme, 'setConfig');
+
+  // Already dark, so this should be a no-op rather than reordering the array.
+  theme.toggleDarkMode(true);
+  expect(setConfigSpy).not.toHaveBeenCalled();
+
+  setConfigSpy.mockRestore();
+});
+
 test('Theme.toSerializedConfig serializes theme config correctly', () => {
   const theme = Theme.fromConfig({
     token: {

--- a/superset-frontend/packages/superset-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.tsx
@@ -196,6 +196,24 @@ export class Theme {
       newConfig.algorithm = newAlgorithm;
     }
 
+    // Skip the update (and the notifyProviders fan-out it triggers) if the
+    // theme is already in the requested mode. Docs pages mount one
+    // dark-mode-sync bridge per live component demo (see
+    // docs/src/components/StorybookWrapper.jsx's ThemeSync), so a single
+    // toggle event calls this once per demo on the page. Without this
+    // check, every one of those calls would recompute the theme and
+    // notify every mounted provider, turning a single real toggle into
+    // O(n^2) provider notifications across n demos.
+    const currentAlgorithm = this.antdConfig.algorithm;
+    const algorithmUnchanged = Array.isArray(newConfig.algorithm)
+      ? Array.isArray(currentAlgorithm) &&
+        newConfig.algorithm.length === currentAlgorithm.length &&
+        newConfig.algorithm.every((alg, i) => alg === currentAlgorithm[i])
+      : newConfig.algorithm === currentAlgorithm;
+    if (algorithmUnchanged) {
+      return;
+    }
+
     // Update the theme with the new configuration
     this.setConfig(newConfig);
   }

--- a/superset-frontend/packages/superset-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.tsx
@@ -204,11 +204,14 @@ export class Theme {
     // check, every one of those calls would recompute the theme and
     // notify every mounted provider, turning a single real toggle into
     // O(n^2) provider notifications across n demos.
+    // Compare the algorithm sets rather than positions: reordering
+    // non-mode algorithms to the front doesn't change the effective
+    // theme, so it shouldn't count as a change either.
     const currentAlgorithm = this.antdConfig.algorithm;
     const algorithmUnchanged = Array.isArray(newConfig.algorithm)
       ? Array.isArray(currentAlgorithm) &&
         newConfig.algorithm.length === currentAlgorithm.length &&
-        newConfig.algorithm.every((alg, i) => alg === currentAlgorithm[i])
+        newConfig.algorithm.every(alg => currentAlgorithm.includes(alg))
       : newConfig.algorithm === currentAlgorithm;
     if (algorithmUnchanged) {
       return;

--- a/superset-frontend/packages/superset-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.tsx
@@ -25,7 +25,7 @@ import {
   CacheProvider as EmotionCacheProvider,
 } from '@emotion/react';
 import createCache from '@emotion/cache';
-import { noop, mergeWith } from 'lodash-es';
+import { mergeWith } from 'lodash-es';
 import { GlobalStyles } from './GlobalStyles';
 import {
   AntdThemeConfig,
@@ -156,8 +156,8 @@ export class Theme {
       }),
     } as SupersetTheme;
 
-    // Update the providers with the fully formed theme
-    this.updateProviders(
+    // Update every mounted provider with the fully formed theme
+    this.notifyProviders(
       this.theme,
       this.antdConfig,
       createCache({ key: 'superset' }),
@@ -204,13 +204,29 @@ export class Theme {
     return JSON.stringify(serializeThemeConfig(this.antdConfig), null, 2);
   }
 
-  private updateProviders(
+  // Every currently-mounted SupersetThemeProvider for this Theme instance
+  // registers a listener here (see the useEffect below). A single
+  // "last write wins" callback isn't enough once more than one provider can
+  // be mounted from the same Theme instance at a time -- e.g. multiple live
+  // component demos on one docs page -- since each render would overwrite
+  // the previous provider's callback and only the most-recently-rendered
+  // provider would ever hear about a setConfig/toggleDarkMode call.
+  private providerListeners = new Set<
+    (
+      theme: SupersetTheme,
+      antdConfig: AntdThemeConfig,
+      emotionCache: any,
+    ) => void
+  >();
+
+  private notifyProviders(
     theme: SupersetTheme,
     antdConfig: AntdThemeConfig,
     emotionCache: any,
   ): void {
-    noop(theme, antdConfig, emotionCache);
-    // Overridden at runtime by SupersetThemeProvider using setThemeState
+    this.providerListeners.forEach(listener =>
+      listener(theme, antdConfig, emotionCache),
+    );
   }
 
   SupersetThemeProvider({ children }: { children: React.ReactNode }) {
@@ -225,9 +241,29 @@ export class Theme {
       emotionCache: createCache({ key: 'superset' }),
     });
 
-    this.updateProviders = (theme, antdConfig, emotionCache) => {
-      setThemeState({ theme, antdConfig, emotionCache });
-    };
+    // Register (and, on unmount, deregister) this provider instance's own
+    // listener rather than assigning a single shared callback on every
+    // render, so every concurrently mounted provider for this Theme
+    // instance receives updates, not just the last one to render.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      const listener = (
+        nextTheme: SupersetTheme,
+        nextAntdConfig: AntdThemeConfig,
+        nextEmotionCache: any,
+      ) => {
+        setThemeState({
+          theme: nextTheme,
+          antdConfig: nextAntdConfig,
+          emotionCache: nextEmotionCache,
+        });
+      };
+      this.providerListeners.add(listener);
+      return () => {
+        this.providerListeners.delete(listener);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
       <EmotionCacheProvider value={themeState.emotionCache}>

--- a/superset-frontend/packages/superset-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/Theme.tsx
@@ -245,8 +245,21 @@ export class Theme {
     // listener rather than assigning a single shared callback on every
     // render, so every concurrently mounted provider for this Theme
     // instance receives updates, not just the last one to render.
+    //
+    // Use useLayoutEffect (not useEffect) so registration happens in the
+    // same commit phase as any layout effect elsewhere that might call
+    // setConfig/toggleDarkMode on this instance during mount (e.g. the
+    // docs site's dark-mode sync in StorybookWrapper.jsx, which reads the
+    // toggle and pushes it onto the singleton via a layout effect of its
+    // own). Layout effects run bottom-up, so a listener registered here
+    // (this component is nested inside that caller) is guaranteed to be
+    // in place before an ancestor's layout effect can fire and notify it.
+    // If this were a passive effect instead, an ancestor's layout effect
+    // could call toggleDarkMode before this listener exists, dropping that
+    // notification, and the provider would render stale until a later
+    // toggle.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       const listener = (
         nextTheme: SupersetTheme,
         nextAntdConfig: AntdThemeConfig,


### PR DESCRIPTION
### SUMMARY
Fixes #40459.

Turned out to be a scoped, traceable root cause, not a wormhole -- fixing forward rather than needing to disable dark mode.

Every component page under `developer-docs/components/{ui,design-system,extension}` (the "Core/Layout/Extension Components" sections from the issue) embeds live-rendered demos via `docs/src/components/StorybookWrapper.jsx`'s `StoryExample`/`StoryWithControls`/`ComponentGallery`. Those wrap in `themeObject.SupersetThemeProvider`, where `themeObject` is a module-level singleton (`superset-core/src/theme/index.tsx`: `Theme.fromConfig()`) constructed once with no dark/light config -- it had no way to know about Docusaurus's own theme toggle, so every live demo always rendered whatever that default algorithm produced, regardless of the site-wide toggle. The wrapper boxes around each demo also hardcoded light-only colors (`border: #e8e8e8`, muted text `#999`/`#666`) as inline styles, so even a correctly-dark-themed component would've sat inside a stubbornly light box.

**Fix:** mirror Docusaurus's color mode onto the singleton via `Theme#toggleDarkMode()` -- already exposed by the `Theme` class for exactly this purpose, just never wired up here -- through a small effect reacting to `useColorMode()` (`@docusaurus/theme-common`, the same hook the toggle switch itself uses). Replaced the hardcoded wrapper colors with Docusaurus's own Infima CSS custom properties (`--ifm-color-emphasis-*`), the same variables the rest of the site already uses for its (working) dark mode.

**Not addressed here** (flagging as a distinct follow-up, not bundling in): the separate "Try It" live-code-editor blocks (`docs/src/theme/ReactLiveScope`) render components with no theme provider at all, not even light-mode Superset theming -- `ReactLiveScope` only supplies a plain component scope for `react-live`, not a wrapping provider. Fixing that means swizzling `@docusaurus/theme-live-codeblock`'s `Playground`/`Preview` component, which is a bigger, separate change.

### TESTING INSTRUCTIONS
Added `superset-frontend/packages/superset-core/src/theme/SupersetThemeProvider.test.tsx`, characterizing the mechanism this fix actually depends on: that calling `toggleDarkMode()` on an already-mounted `Theme` instance, from *outside* React's render cycle, correctly re-renders its context-consuming descendants (i.e. real antd components, same as the docs demos). Caught a real, non-obvious gotcha along the way and left it documented in a code comment: a probe reading the theme object directly (rather than via antd's `useToken()` context hook) misleadingly appears to *not* update, because React bails out of re-rendering a child whose element reference is unchanged -- unless that child consumes a Context whose value changed, which is exactly the antd `ConfigProvider` path every real themed component uses.

```
PASS packages/superset-core/src/theme/SupersetThemeProvider.test.tsx
  ✓ an already-mounted SupersetThemeProvider re-renders context-consuming children when toggleDarkMode is called on the same instance
  ✓ a toggleDarkMode call on an unmounted (or different) theme instance does not affect a mounted provider
```

Also ran the full existing `packages/superset-core/src/theme` suite (97 tests) to confirm no regressions, and validated `StorybookWrapper.jsx` through `eslint`/`prettier`/`tsc` via `pre-commit run`.

I wasn't able to get a full local visual check of the actual docs page rendering (`yarn start` for `docs/` pulls in most of the frontend monorepo via webpack aliases and OOM-killed repeatedly in my sandbox -- it's a genuinely heavy build, per an existing comment in `webpack.extend.ts` about the same barrel-import OOM risk). The test above verifies the actual propagation mechanism directly rather than through a full page render, but a screenshot/visual pass from CI or a reviewer on the deploy preview would still be good confirmation before merge.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #40459
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API