### PR TITLE
fix(explore): pin and fix clipped segments in horizontal row-contribution stacked bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -854,23 +854,33 @@ export default function transformProps(
   if ((contributionMode === 'row' || isAreaExpand) && stack) {
     if (yAxisMin === undefined) yAxisMin = 0;
     if (yAxisMax === undefined) {
-      // Contribution percentages are normalized so each stacked row should
-      // sum to 1, but floating point rounding can push the actual stacked
-      // total fractionally above 1 (e.g. 1.0000000000000002). Hard-capping
-      // the axis max at exactly 1 in that case causes echarts to clip the
-      // topmost stacked segment entirely rather than just rounding the
-      // pixel width, which is most visible in horizontal orientation where
-      // this axis is swapped onto the x-axis. Pad the max up to the actual
-      // stacked total when it exceeds 1 so no segment gets clipped.
-      const stackedTotalMax = Math.max(
-        ...sortedTotalValues.filter(
-          (v): v is number => typeof v === 'number' && !Number.isNaN(v),
-        ),
-      );
-      yAxisMax =
-        Number.isFinite(stackedTotalMax) && stackedTotalMax > 1
-          ? stackedTotalMax
-          : 1;
+      if (contributionMode === 'row') {
+        // Contribution percentages are normalized so each stacked row should
+        // sum to 1, but floating point rounding can push the actual stacked
+        // total fractionally above 1 (e.g. 1.0000000000000002). Hard-capping
+        // the axis max at exactly 1 in that case causes echarts to clip the
+        // topmost stacked segment entirely rather than just rounding the
+        // pixel width, which is most visible in horizontal orientation where
+        // this axis is swapped onto the x-axis. Pad the max up to the actual
+        // stacked total when it exceeds 1 so no segment gets clipped.
+        //
+        // This padding only applies in row-contribution mode: for an Expand
+        // ("100% stacked") chart, `sortedTotalValues` holds the raw,
+        // pre-normalization row totals (e.g. 100), not values near 1, so
+        // padding against them here would stretch the axis out to the raw
+        // total instead of the intended 0-1 range.
+        const stackedTotalMax = sortedTotalValues.reduce<number>(
+          (max, v) =>
+            typeof v === 'number' && !Number.isNaN(v) ? Math.max(max, v) : max,
+          Number.NEGATIVE_INFINITY,
+        );
+        yAxisMax =
+          Number.isFinite(stackedTotalMax) && stackedTotalMax > 1
+            ? stackedTotalMax
+            : 1;
+      } else {
+        yAxisMax = 1;
+      }
     }
   } else if (
     logAxis &&

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -853,7 +853,25 @@ export default function transformProps(
   // default to 0-100% range when doing row-level contribution chart
   if ((contributionMode === 'row' || isAreaExpand) && stack) {
     if (yAxisMin === undefined) yAxisMin = 0;
-    if (yAxisMax === undefined) yAxisMax = 1;
+    if (yAxisMax === undefined) {
+      // Contribution percentages are normalized so each stacked row should
+      // sum to 1, but floating point rounding can push the actual stacked
+      // total fractionally above 1 (e.g. 1.0000000000000002). Hard-capping
+      // the axis max at exactly 1 in that case causes echarts to clip the
+      // topmost stacked segment entirely rather than just rounding the
+      // pixel width, which is most visible in horizontal orientation where
+      // this axis is swapped onto the x-axis. Pad the max up to the actual
+      // stacked total when it exceeds 1 so no segment gets clipped.
+      const stackedTotalMax = Math.max(
+        ...sortedTotalValues.filter(
+          (v): v is number => typeof v === 'number' && !Number.isNaN(v),
+        ),
+      );
+      yAxisMax =
+        Number.isFinite(stackedTotalMax) && stackedTotalMax > 1
+          ? stackedTotalMax
+          : 1;
+    }
   } else if (
     logAxis &&
     yAxisMin === undefined &&

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -180,6 +180,50 @@ function getSymbolMarker(symbol: string, color: string) {
   }
 }
 
+/**
+ * Given the fully-built ECharts series (each already carrying its resolved
+ * `stack` id, see `getTimeCompareStackId`), find the largest per-index total
+ * across all series sharing a stack, then return the largest such total
+ * across all stacks. Series without a `stack` id (e.g. annotation layers)
+ * are ignored since they aren't part of any stacked total.
+ */
+function getMaxStackedValueByStack(
+  series: SeriesOption[],
+  isHorizontal: boolean,
+): number {
+  const totalsByStack = new Map<string, number[]>();
+  series.forEach(entry => {
+    const rawStackId = (entry as { stack?: unknown }).stack;
+    const stackId = typeof rawStackId === 'string' ? rawStackId : undefined;
+    if (!stackId || !Array.isArray(entry.data)) return;
+    const totals = totalsByStack.get(stackId) ?? [];
+    (entry.data as unknown[]).forEach((datum, idx) => {
+      let value: unknown = datum;
+      if (Array.isArray(datum)) {
+        value = isHorizontal ? datum[0] : datum[1];
+      } else if (datum && typeof datum === 'object' && 'value' in datum) {
+        const rawValue = (datum as { value: unknown }).value;
+        if (Array.isArray(rawValue)) {
+          value = isHorizontal ? rawValue[0] : rawValue[1];
+        } else {
+          value = rawValue;
+        }
+      }
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        totals[idx] = (totals[idx] ?? 0) + value;
+      }
+    });
+    totalsByStack.set(stackId, totals);
+  });
+  let max = Number.NEGATIVE_INFINITY;
+  totalsByStack.forEach(totals => {
+    totals.forEach(value => {
+      if (value > max) max = value;
+    });
+  });
+  return max;
+}
+
 export default function transformProps(
   chartProps: EchartsTimeseriesChartProps,
 ): TimeseriesChartTransformedProps {
@@ -869,11 +913,14 @@ export default function transformProps(
         // pre-normalization row totals (e.g. 100), not values near 1, so
         // padding against them here would stretch the axis out to the raw
         // total instead of the intended 0-1 range.
-        const stackedTotalMax = sortedTotalValues.reduce<number>(
-          (max, v) =>
-            typeof v === 'number' && !Number.isNaN(v) ? Math.max(max, v) : max,
-          Number.NEGATIVE_INFINITY,
-        );
+        //
+        // `sortedTotalValues` sums every series value per row regardless of
+        // which ECharts stack it belongs to, but with time_compare each
+        // comparison period is its own independently-normalized stack (see
+        // getTimeCompareStackId), so a chart with N comparison periods would
+        // sum to ~N instead of ~1. Compute the max per stack instead, using
+        // the already-built series (which carry the resolved stack ids).
+        const stackedTotalMax = getMaxStackedValueByStack(series, isHorizontal);
         yAxisMax =
           Number.isFinite(stackedTotalMax) && stackedTotalMax > 1
             ? stackedTotalMax

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1396,11 +1396,17 @@ test('should not apply axis bounds calculation when seriesType is not Bar for ho
 
 test('should not clip small segments when row-contribution percentages float above 1 in horizontal stacked bar charts', () => {
   // These three shares are individually normalized (each column sums to 1),
-  // but due to floating point rounding their sum is 1.0000000000000002,
-  // fractionally over 1. See https://github.com/apache/superset/issues/30914
-  const shareA = 0.41960735305372;
-  const shareB = 0.37722784875089643;
-  const shareC = 0.20316479819538372;
+  // but due to floating point rounding their sum can land fractionally
+  // over 1. See https://github.com/apache/superset/issues/30914
+  //
+  // The margin above 1 is chosen large enough (~1e-7) that the sum stays
+  // above 1 no matter which order the underlying series get summed in
+  // (series are sorted by name for stacking, not in the order declared
+  // here), unlike a single-ULP overflow which can round differently
+  // depending on summation order and make this assertion order-dependent.
+  const shareA = 0.42;
+  const shareB = 0.38;
+  const shareC = 0.2000001;
   expect(shareA + shareB + shareC).toBeGreaterThan(1);
 
   const queriesData: ChartDataResponseResult[] = [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1459,6 +1459,47 @@ test('keeps the 0-1 axis range for Expand (100% stacked) charts instead of paddi
   expect(xAxisRaw.max).toBe(1);
 });
 
+test('computes row-contribution axis padding per stack when time_compare splits a row into multiple normalized stacks', () => {
+  // With time_compare, each comparison period is normalized and stacked
+  // independently (see getTimeCompareStackId), so the current-period
+  // columns sum to ~1 in their own stack and the comparison-period columns
+  // (suffixed with the offset) sum to ~1 in a separate stack. The combined
+  // row total across both stacks is therefore ~2, but the axis max must be
+  // computed per stack, not from that combined total, or a 100% bar would
+  // only occupy about half the plot.
+  const queriesData: ChartDataResponseResult[] = [
+    createTestQueryData(
+      createTestData(
+        [
+          {
+            'Series A': 0.6,
+            'Series B': 0.4,
+            'Series A__1 year ago': 0.55,
+            'Series B__1 year ago': 0.45,
+          },
+        ],
+        { intervalMs: 300000000 },
+      ),
+    ),
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      contributionMode: ContributionType.Row,
+      stack: StackControlsValue.Stack,
+      time_compare: ['1 year ago'],
+    },
+    queriesData,
+  });
+
+  const transformedProps = transformProps(chartProps);
+
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBeGreaterThanOrEqual(1);
+  expect(xAxisRaw.max).toBeLessThan(1.5);
+});
+
 test('legend is visible on tall charts when enabled by the user', () => {
   const chartProps = createTestChartProps({
     height: 400,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -22,6 +22,7 @@ import {
   AnnotationType,
   AxisType,
   ComparisonType,
+  ContributionType,
   DataRecord,
   EventAnnotationLayer,
   FormulaAnnotationLayer,
@@ -1391,6 +1392,43 @@ test('should not apply axis bounds calculation when seriesType is not Bar for ho
   const xAxisRaw = transformedProps.echartOptions.xAxis as any;
   // Should not have explicit max set when seriesType is not Bar
   expect(xAxisRaw.max).toBeUndefined();
+});
+
+test('should not clip small segments when row-contribution percentages float above 1 in horizontal stacked bar charts', () => {
+  // These three shares are individually normalized (each column sums to 1),
+  // but due to floating point rounding their sum is 1.0000000000000002,
+  // fractionally over 1. See https://github.com/apache/superset/issues/30914
+  const shareA = 0.41960735305372;
+  const shareB = 0.37722784875089643;
+  const shareC = 0.20316479819538372;
+  expect(shareA + shareB + shareC).toBeGreaterThan(1);
+
+  const queriesData: ChartDataResponseResult[] = [
+    createTestQueryData(
+      createTestData(
+        [{ 'Series A': shareA, 'Series B': shareB, 'Series C': shareC }],
+        { intervalMs: 300000000 },
+      ),
+    ),
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      contributionMode: ContributionType.Row,
+      stack: StackControlsValue.Stack,
+    },
+    queriesData,
+  });
+
+  const transformedProps = transformProps(chartProps);
+
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis.
+  // The axis max must not be hard-capped at exactly 1, otherwise echarts
+  // clips the topmost stacked segment entirely instead of just rendering
+  // a negligible sub-pixel overflow.
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBeGreaterThanOrEqual(shareA + shareB + shareC);
 });
 
 test('legend is visible on tall charts when enabled by the user', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1431,6 +1431,34 @@ test('should not clip small segments when row-contribution percentages float abo
   expect(xAxisRaw.max).toBeGreaterThanOrEqual(shareA + shareB + shareC);
 });
 
+test('keeps the 0-1 axis range for Expand (100% stacked) charts instead of padding to the raw row total', () => {
+  // Unlike row-contribution mode, an Expand stack is not pre-normalized in
+  // the query result -- these are raw values (summing to 100, not 1) that
+  // get divided down to a 0-1 range internally. The un-normalized row total
+  // must not be used to pad the axis max, or the chart would only occupy a
+  // sliver of the plot.
+  const queriesData: ChartDataResponseResult[] = [
+    createTestQueryData(
+      createTestData([{ 'Series A': 42, 'Series B': 38, 'Series C': 20 }], {
+        intervalMs: 300000000,
+      }),
+    ),
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      stack: StackControlsValue.Expand,
+    },
+    queriesData,
+  });
+
+  const transformedProps = transformProps(chartProps);
+
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBe(1);
+});
+
 test('legend is visible on tall charts when enabled by the user', () => {
   const chartProps = createTestChartProps({
     height: 400,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
In a horizontal, stacked, row-contribution (100%) bar chart, some segments could vanish from the render entirely even though the underlying percentages were correct and summed to 100%.

The row-contribution axis max was hard-coded to exactly `1`. Contribution shares are normalized so a stacked row is supposed to sum to `1`, but floating point rounding can push the actual stacked total fractionally above `1` (e.g. `1.0000000000000002`). When that happens, capping the axis max at exactly `1` causes echarts to clip the topmost stacked segment entirely on the swapped axis used for horizontal bars, instead of just rounding the pixel width. This lines up with the community's own workaround of nudging "Truncate Y Axis" max to `1.00001`, which happened to sidestep the same edge case.

This PR pads the axis max up to the actual stacked total when it exceeds `1`, so no segment gets clipped, while leaving the `0`-`1` default in place for the (much more common) case where the total is exactly `1` or below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this is a floating point edge case in axis-bounds calculation; see the reproduction and screenshots already on the issue.

### TESTING INSTRUCTIONS
1. Build a horizontal, stacked bar chart with contribution mode = Row over a dataset with several small groupby segments per category, using the SQL repro attached to #30914.
2. Reload the chart a few times; before this fix, the same segment goes missing on certain categories on every load. After the fix, all segments render.
3. `pytest`-equivalent for the frontend: `npm run test -- plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts` — new test `should not clip small segments when row-contribution percentages float above 1 in horizontal stacked bar charts` pins the regression.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30914
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
