### PR TITLE
fix(reports): skip inactive owners in get_executor (#33584)

### DIFF
--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -52,6 +52,18 @@ logger = get_task_logger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def _is_active(user: User | None) -> bool:
+    """Return ``True`` only when ``user`` is a truthy, active FAB user.
+
+    ``User.active`` may be ``None`` on in-memory instances that were
+    never persisted (the SQLA column default only applies on INSERT),
+    so a plain ``user.active`` check would erroneously treat those as
+    inactive. Wrapping in ``bool`` keeps the intent explicit and guards
+    against ``None`` on both sides. See #33584.
+    """
+    return bool(user and user.active)
+
+
 def _get_indirect_editor_user(editors: list[Any]) -> User | None:
     """Return a deterministic user represented by role/group editor subjects."""
     from flask_appbuilder.security.sqla.models import (
@@ -154,26 +166,40 @@ def get_executor(  # noqa: C901
             raise InvalidExecutorError()
         if executor == ExecutorType.CURRENT_USER and current_user:
             return executor, current_user
+        # Direct-user paths below skip inactive users so the priority chain
+        # falls through to the next candidate. An inactive user's username
+        # would otherwise be handed to ``login_user()`` downstream, which
+        # silently returns ``False`` and leaves the schedule with no auth
+        # cookie. See #33584.
         if executor == ExecutorType.CREATOR_EDITOR:
-            if (user := model.created_by) and _is_editor(user.id):
+            if (user := model.created_by) and _is_active(user) and _is_editor(user.id):
                 return executor, user.username
         if executor == ExecutorType.CREATOR:
-            if user := model.created_by:
+            if (user := model.created_by) and _is_active(user):
                 return executor, user.username
         if executor == ExecutorType.MODIFIER_EDITOR:
-            if (user := model.changed_by) and _is_editor(user.id):
+            if (user := model.changed_by) and _is_active(user) and _is_editor(user.id):
                 return executor, user.username
         if executor == ExecutorType.MODIFIER:
-            if user := model.changed_by:
+            if (user := model.changed_by) and _is_active(user):
                 return executor, user.username
         if executor == ExecutorType.EDITOR:
             # Priority: modifier → creator → direct user editor → indirect editor.
-            if (modifier := model.changed_by) and _is_editor(modifier.id):
+            if (
+                (modifier := model.changed_by)
+                and _is_active(modifier)
+                and _is_editor(modifier.id)
+            ):
                 return executor, modifier.username
-            if (creator := model.created_by) and _is_editor(creator.id):
+            if (
+                (creator := model.created_by)
+                and _is_active(creator)
+                and _is_editor(creator.id)
+            ):
                 return executor, creator.username
-            if editor_users:
-                return executor, editor_users[0].username
+            active_editor = next((u for u in editor_users if _is_active(u)), None)
+            if active_editor:
+                return executor, active_editor.username
             if indirect_editor := _get_indirect_editor_user(
                 getattr(model, "editors", [])
             ):

--- a/tests/unit_tests/tasks/test_utils.py
+++ b/tests/unit_tests/tasks/test_utils.py
@@ -42,11 +42,15 @@ FIXED_USER_ID = 1234
 FIXED_USERNAME = "admin"
 
 
-def _make_user_subject(user_id: int) -> MagicMock:
-    """Create a mock user-type Subject with an underlying User."""
+def _make_user_subject(user_id: int, active: bool = True) -> MagicMock:
+    """Create a mock user-type Subject with an underlying User.
+
+    ``active`` propagates to the User instance so #33584 test cases can
+    build editor subjects backed by inactive users.
+    """
     from superset.subjects.types import SubjectType
 
-    user = User(id=user_id, username=str(user_id))
+    user = User(id=user_id, username=str(user_id), active=active)
     subject = MagicMock()
     subject.id = user_id  # deterministic subject ID
     subject.type = SubjectType.USER
@@ -83,12 +87,20 @@ def _make_group_subject(group_id: int) -> MagicMock:
 
 def _get_users(
     params: Optional[Union[int, list[int]]],
+    active: bool = True,
 ) -> Optional[Union[User, list[User]]]:
+    # ``User.active`` defaults to True at the SQLA column layer but that
+    # default only applies on INSERT — in-memory instances have
+    # ``active is None`` unless set explicitly. The ``get_executor``
+    # active-user filter added in #33584 treats ``None`` as inactive, so
+    # every helper-built User carries an explicit ``active`` flag. The
+    # default ``active=True`` preserves the historical "user is usable"
+    # test intent; #33584 cases pass ``active=False`` for inactive users.
     if params is None:
         return None
     if isinstance(params, int):
-        return User(id=params, username=str(params))
-    return [User(id=user, username=str(user)) for user in params]
+        return User(id=params, username=str(params), active=active)
+    return [User(id=user, username=str(user), active=active) for user in params]
 
 
 @dataclass
@@ -96,12 +108,18 @@ class EditorSpec:
     """Specification for building a list of mixed-type editor subjects."""
 
     user_ids: list[int]
+    # Optional inactive user-editor subjects — used by #33584 test cases
+    # that need to prove the active-user filter skips inactive editors.
+    inactive_user_ids: list[int] = field(default_factory=list)
     role_ids: list[int] | None = None
     group_ids: list[int] | None = None
 
     def build(self) -> list[MagicMock]:
         editors: list[MagicMock] = []
         editors.extend(_make_user_subject(uid) for uid in self.user_ids)
+        editors.extend(
+            _make_user_subject(uid, active=False) for uid in self.inactive_user_ids
+        )
         for rid in self.role_ids or []:
             editors.append(_make_role_subject(rid))
         for gid in self.group_ids or []:
@@ -114,6 +132,10 @@ class ModelConfig:
     editors: EditorSpec
     creator: Optional[int] = None
     modifier: Optional[int] = None
+    # #33584: build ``created_by`` / ``changed_by`` with ``active=False`` so
+    # ``get_executor`` skips them and falls through to the next candidate.
+    creator_active: bool = True
+    modifier_active: bool = True
     # Maps user_id → role_ids the user belongs to (for indirect editor resolution)
     user_roles: dict[int, list[int]] = field(default_factory=dict)
     # Maps user_id → group_ids the user belongs to (for indirect editor resolution)
@@ -530,6 +552,57 @@ class ModelType(int, Enum):
             None,
             ExecutorNotFoundError(),
         ),
+        # #33584 — CREATOR is inactive, MODIFIER is active → MODIFIER picked.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR, ExecutorType.MODIFIER],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[]),
+                creator=3,
+                creator_active=False,
+                modifier=4,
+            ),
+            None,
+            (ExecutorType.MODIFIER, 4),
+        ),
+        # #33584 — every direct-user candidate inactive → ExecutorNotFoundError.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR, ExecutorType.MODIFIER],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[]),
+                creator=3,
+                creator_active=False,
+                modifier=4,
+                modifier_active=False,
+            ),
+            None,
+            ExecutorNotFoundError(),
+        ),
+        # #33584 — EDITOR: inactive editor user comes first, active editor
+        # user comes second → the active one is picked.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[6], inactive_user_ids=[5]),
+            ),
+            None,
+            (ExecutorType.EDITOR, 6),
+        ),
+        # #33584 — CREATOR_EDITOR where creator IS an editor but inactive →
+        # falls through to next priority (none) → ExecutorNotFoundError.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR_EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[3]),
+                creator=3,
+                creator_active=False,
+            ),
+            None,
+            ExecutorNotFoundError(),
+        ),
     ],
 )
 def test_get_executor(
@@ -561,8 +634,10 @@ def test_get_executor(
 
     obj = model(
         id=1,
-        created_by=_get_users(model_config.creator),
-        changed_by=_get_users(model_config.modifier),
+        created_by=_get_users(model_config.creator, active=model_config.creator_active),
+        changed_by=_get_users(
+            model_config.modifier, active=model_config.modifier_active
+        ),
         **model_kwargs,
     )
     obj.editors = model_config.editors.build()


### PR DESCRIPTION
### SUMMARY

Fixes #33584.

`get_executor` in `superset/tasks/utils.py` walks the configured executor priority list (CREATOR → MODIFIER → EDITOR → …) and returns the first matching owner/creator/modifier without checking whether that user is active. When the picked user was later deactivated, their username lands in `login_user()` in `MachineAuthProviderUser.get_auth_cookies`, which silently returns `False` for inactive users. No session cookie is set; the downstream screenshot / CSV / dashboard-render request runs with no auth and surfaces as an opaque `ReportScheduleCsvFailedError`.

Per @rusackas on the [issue thread](https://github.com/apache/superset/issues/33584), the fix is to have `get_executor` skip inactive owners so the priority chain falls through to an active one (or raises the existing `ExecutorNotFoundError` if none exist).

### FIX

Adds a small `_is_active(user)` predicate and applies it at every direct-user return site in `get_executor`:
- `CREATOR`, `MODIFIER`, both `_EDITOR` variants
- `EDITOR`'s modifier/creator/editor-users fallback chain

Intentionally left unchanged:
- **`_get_indirect_editor_user`** — already filters on `User.active.is_(True)`
- **`FixedExecutor` / `CURRENT_USER`** — not `ab_user`-backed at this layer
- **`login_user(force=True)`** — considered and rejected: bypassing the FAB active-user check would let deactivated users execute schedules on their behalf, which is a regression, not a fix

### BEHAVIOR MATRIX

| Scenario | Before | After |
|---|---|---|
| Creator active | uses creator ✓ | uses creator ✓ (unchanged) |
| Creator inactive, modifier active | picks creator → auth fails → `ReportScheduleCsvFailedError` | uses modifier ✓ |
| All owners inactive | picks first inactive → auth fails → `ReportScheduleCsvFailedError` | `ExecutorNotFoundError` (actionable) |
| Indirect (role/group) editor | filtered by `is_active` ✓ | filtered by `is_active` ✓ (unchanged) |

### TESTING INSTRUCTIONS

Manual (requires a working Alerts & Reports setup):
1. Create a scheduled report as user A
2. Add user B as an owner
3. Deactivate user A (`UPDATE ab_user SET active=false WHERE username='A'`)
4. Trigger the schedule
5. **Before:** `ReportScheduleCsvFailedError` in logs, no email
6. **After:** report sends; the executor log line names user B

Automated:
```bash
pytest tests/unit_tests/tasks/test_utils.py::test_get_executor -v
```

Four new parametrized cases: inactive-creator-falls-through, all-inactive-raises, EDITOR-skips-inactive-editor-user, CREATOR_EDITOR-inactive-editor-falls-through. Existing cases stay green because the `_get_users` / `_make_user_subject` helpers now carry an explicit `active` flag defaulted to `True`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #33584
- [x] Required feature flags: none
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Includes CLI or Node.js commands: no
- [x] Breaking change: no