### PR TITLE
fix(alerts-reports): skip inactive users when resolving report executor

### DIFF
--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -155,25 +155,39 @@ def get_executor(  # noqa: C901
         if executor == ExecutorType.CURRENT_USER and current_user:
             return executor, current_user
         if executor == ExecutorType.CREATOR_EDITOR:
-            if (user := model.created_by) and _is_editor(user.id):
+            if (user := model.created_by) and user.is_active and _is_editor(user.id):
                 return executor, user.username
         if executor == ExecutorType.CREATOR:
-            if user := model.created_by:
+            if (user := model.created_by) and user.is_active:
                 return executor, user.username
         if executor == ExecutorType.MODIFIER_EDITOR:
-            if (user := model.changed_by) and _is_editor(user.id):
+            if (user := model.changed_by) and user.is_active and _is_editor(user.id):
                 return executor, user.username
         if executor == ExecutorType.MODIFIER:
-            if user := model.changed_by:
+            if (user := model.changed_by) and user.is_active:
                 return executor, user.username
         if executor == ExecutorType.EDITOR:
             # Priority: modifier → creator → direct user editor → indirect editor.
-            if (modifier := model.changed_by) and _is_editor(modifier.id):
+            # Inactive users are skipped at every step so that scheduling can
+            # fall through to another active owner/editor instead of failing
+            # outright (see: ExecutorNotFoundError only once no active
+            # candidate remains).
+            if (
+                (modifier := model.changed_by)
+                and modifier.is_active
+                and _is_editor(modifier.id)
+            ):
                 return executor, modifier.username
-            if (creator := model.created_by) and _is_editor(creator.id):
+            if (
+                (creator := model.created_by)
+                and creator.is_active
+                and _is_editor(creator.id)
+            ):
                 return executor, creator.username
-            if editor_users:
-                return executor, editor_users[0].username
+            if active_editor_user := next(
+                (user for user in editor_users if user.is_active), None
+            ):
+                return executor, active_editor_user.username
             if indirect_editor := _get_indirect_editor_user(
                 getattr(model, "editors", [])
             ):

--- a/tests/unit_tests/tasks/test_utils.py
+++ b/tests/unit_tests/tasks/test_utils.py
@@ -42,11 +42,11 @@ FIXED_USER_ID = 1234
 FIXED_USERNAME = "admin"
 
 
-def _make_user_subject(user_id: int) -> MagicMock:
+def _make_user_subject(user_id: int, active: bool = True) -> MagicMock:
     """Create a mock user-type Subject with an underlying User."""
     from superset.subjects.types import SubjectType
 
-    user = User(id=user_id, username=str(user_id))
+    user = User(id=user_id, username=str(user_id), active=active)
     subject = MagicMock()
     subject.id = user_id  # deterministic subject ID
     subject.type = SubjectType.USER
@@ -83,12 +83,13 @@ def _make_group_subject(group_id: int) -> MagicMock:
 
 def _get_users(
     params: Optional[Union[int, list[int]]],
+    active: bool = True,
 ) -> Optional[Union[User, list[User]]]:
     if params is None:
         return None
     if isinstance(params, int):
-        return User(id=params, username=str(params))
-    return [User(id=user, username=str(user)) for user in params]
+        return User(id=params, username=str(params), active=active)
+    return [User(id=user, username=str(user), active=active) for user in params]
 
 
 @dataclass
@@ -98,10 +99,14 @@ class EditorSpec:
     user_ids: list[int]
     role_ids: list[int] | None = None
     group_ids: list[int] | None = None
+    # Direct user-type editors that should be built as inactive users
+    inactive_user_ids: list[int] | None = None
 
     def build(self) -> list[MagicMock]:
         editors: list[MagicMock] = []
         editors.extend(_make_user_subject(uid) for uid in self.user_ids)
+        for uid in self.inactive_user_ids or []:
+            editors.append(_make_user_subject(uid, active=False))
         for rid in self.role_ids or []:
             editors.append(_make_role_subject(rid))
         for gid in self.group_ids or []:
@@ -114,6 +119,8 @@ class ModelConfig:
     editors: EditorSpec
     creator: Optional[int] = None
     modifier: Optional[int] = None
+    creator_active: bool = True
+    modifier_active: bool = True
     # Maps user_id → role_ids the user belongs to (for indirect editor resolution)
     user_roles: dict[int, list[int]] = field(default_factory=dict)
     # Maps user_id → group_ids the user belongs to (for indirect editor resolution)
@@ -530,6 +537,105 @@ class ModelType(int, Enum):
             None,
             ExecutorNotFoundError(),
         ),
+        # CREATOR: an inactive creator is skipped (no other executor configured)
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[]),
+                creator=3,
+                creator_active=False,
+            ),
+            None,
+            ExecutorNotFoundError(),
+        ),
+        # CREATOR: an inactive creator is skipped, falling through to an active
+        # MODIFIER later in the executor chain.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR, ExecutorType.MODIFIER],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[]),
+                creator=3,
+                creator_active=False,
+                modifier=4,
+            ),
+            None,
+            (ExecutorType.MODIFIER, 4),
+        ),
+        # CREATOR_EDITOR: creator is an editor but inactive → not resolved
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.CREATOR_EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[4]),
+                creator=4,
+                creator_active=False,
+            ),
+            None,
+            ExecutorNotFoundError(),
+        ),
+        # MODIFIER_EDITOR: modifier is an editor but inactive → not resolved
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.MODIFIER_EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[4]),
+                modifier=4,
+                modifier_active=False,
+            ),
+            None,
+            ExecutorNotFoundError(),
+        ),
+        # EDITOR: creator (the only editor) is inactive, so scheduling falls
+        # through to the still-active direct-user editor instead of failing.
+        # This is the scenario from #33584: the original report creator has
+        # gone inactive but a currently-active owner/editor should still be
+        # usable as the executor.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[2], inactive_user_ids=[3]),
+                creator=3,
+                creator_active=False,
+            ),
+            None,
+            (ExecutorType.EDITOR, 2),
+        ),
+        # EDITOR: both modifier and creator are inactive editors, and the only
+        # direct-user editor is also inactive → falls through to the indirect
+        # (role/group) editor resolution.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.EDITOR],
+            ModelConfig(
+                editors=EditorSpec(
+                    user_ids=[], inactive_user_ids=[3, 4], role_ids=[10]
+                ),
+                creator=3,
+                creator_active=False,
+                modifier=4,
+                modifier_active=False,
+                user_roles={6: [10]},
+            ),
+            None,
+            (ExecutorType.EDITOR, 6),
+        ),
+        # EDITOR: modifier is an inactive editor, creator is an active editor →
+        # resolves to the creator instead of failing outright.
+        (
+            ModelType.REPORT_SCHEDULE,
+            [ExecutorType.EDITOR],
+            ModelConfig(
+                editors=EditorSpec(user_ids=[3], inactive_user_ids=[4]),
+                creator=3,
+                modifier=4,
+                modifier_active=False,
+            ),
+            None,
+            (ExecutorType.EDITOR, 3),
+        ),
     ],
 )
 def test_get_executor(
@@ -561,8 +667,10 @@ def test_get_executor(
 
     obj = model(
         id=1,
-        created_by=_get_users(model_config.creator),
-        changed_by=_get_users(model_config.modifier),
+        created_by=_get_users(model_config.creator, active=model_config.creator_active),
+        changed_by=_get_users(
+            model_config.modifier, active=model_config.modifier_active
+        ),
         **model_kwargs,
     )
     obj.editors = model_config.editors.build()


### PR DESCRIPTION
### SUMMARY
`get_executor()` (used to pick who Alerts & Reports / thumbnails run as) resolved the creator, modifier, and editors of a report/dashboard without ever checking `User.is_active`. If the report's creator became inactive, execution would try to authenticate as that inactive user, and instead of raising a clear error it surfaced downstream as an opaque `ReportScheduleScreenshotFailedError` — even when the report had other, currently-active owners/editors.

This fixes `get_executor` to skip inactive users at each resolution step (`CREATOR`, `MODIFIER`, `CREATOR_EDITOR`, `MODIFIER_EDITOR`, and within the `EDITOR` fallback chain: modifier → creator → direct user editor → indirect role/group editor), falling through to another active candidate instead of picking a dead-end user. `ExecutorNotFoundError` is now only raised once no active candidate remains.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (backend logic fix)

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/tasks/test_utils.py -q`

Added parametrized cases to `test_get_executor` that pin the bug: an inactive creator/modifier is skipped in favor of a fallback executor type or an active editor, and `ExecutorNotFoundError` is only raised when no active candidate exists at all. These new cases fail against the pre-fix code and pass after.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #33584
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
