### PR TITLE
fix: localize alert/report execution toast messages

### DIFF
--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
@@ -29,6 +29,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
+import { addTranslation } from '@apache-superset/core/translation';
 import AlertListComponent from 'src/pages/AlertReportList';
 import { SubjectType } from 'src/types/Subject';
 import getBootstrapData from 'src/utils/getBootstrapData';
@@ -44,10 +45,21 @@ jest.mock('src/utils/getBootstrapData', () => ({
   })),
 }));
 
-// Mock withToasts HOC to be a passthrough so toast spies passed via props are preserved
+// Mock withToasts HOC to inject default toast functions while preserving explicit test spies passed via props
 jest.mock('src/components/MessageToasts/withToasts', () => ({
   __esModule: true,
-  default: <P extends object>(Component: React.ComponentType<P>) => Component,
+  default: <P extends object>(Component: React.ComponentType<P>) =>
+    function MockWithToasts(props: P) {
+      return (
+        <Component
+          addDangerToast={jest.fn()}
+          addSuccessToast={jest.fn()}
+          addInfoToast={jest.fn()}
+          addWarningToast={jest.fn()}
+          {...props}
+        />
+      );
+    },
 }));
 
 const mockGetBootstrapData = getBootstrapData as jest.MockedFunction<
@@ -265,6 +277,18 @@ beforeEach(() => {
   mockGetBootstrapData.mockReturnValue(mockBootstrapData([1]));
   fetchMock.removeRoutes().clearHistory();
   setupMocks();
+  addTranslation('Alert "%(alertName)s" triggered successfully', [
+    'Alert "%(alertName)s" triggered successfully [L10N]',
+  ]);
+  addTranslation('Report "%(alertName)s" triggered successfully', [
+    'Report "%(alertName)s" triggered successfully [L10N]',
+  ]);
+  addTranslation('Failed to trigger alert "%(alertName)s": %(error)s', [
+    'Failed to trigger alert "%(alertName)s": %(error)s [L10N]',
+  ]);
+  addTranslation('Failed to trigger report "%(alertName)s": %(error)s', [
+    'Failed to trigger report "%(alertName)s": %(error)s [L10N]',
+  ]);
 });
 
 afterEach(() => {
@@ -619,7 +643,7 @@ test('trigger-now action displays correct success toast for Alert', async () => 
 
   await waitFor(() => {
     expect(addSuccessToast).toHaveBeenCalledWith(
-      'Alert "Weekly Sales Alert" triggered successfully',
+      'Alert "Weekly Sales Alert" triggered successfully [L10N]',
     );
   });
 });
@@ -643,7 +667,7 @@ test('trigger-now action displays correct success toast for Report', async () =>
 
   await waitFor(() => {
     expect(addSuccessToast).toHaveBeenCalledWith(
-      'Report "Weekly Dashboard Report" triggered successfully',
+      'Report "Weekly Dashboard Report" triggered successfully [L10N]',
     );
   });
 });
@@ -667,7 +691,7 @@ test('trigger-now action displays correct failure toast for Alert', async () => 
 
   await waitFor(() => {
     expect(addDangerToast).toHaveBeenCalledWith(
-      'Failed to trigger alert "Weekly Sales Alert": Database failure',
+      'Failed to trigger alert "Weekly Sales Alert": Database failure [L10N]',
     );
   });
 });
@@ -691,7 +715,7 @@ test('trigger-now action displays correct failure toast for Report', async () =>
 
   await waitFor(() => {
     expect(addDangerToast).toHaveBeenCalledWith(
-      'Failed to trigger report "Weekly Dashboard Report": Renderer timeout',
+      'Failed to trigger report "Weekly Dashboard Report": Renderer timeout [L10N]',
     );
   });
 });

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
@@ -44,6 +44,12 @@ jest.mock('src/utils/getBootstrapData', () => ({
   })),
 }));
 
+// Mock withToasts HOC to be a passthrough so toast spies passed via props are preserved
+jest.mock('src/components/MessageToasts/withToasts', () => ({
+  __esModule: true,
+  default: <P extends object>(Component: React.ComponentType<P>) => Component,
+}));
+
 const mockGetBootstrapData = getBootstrapData as jest.MockedFunction<
   typeof getBootstrapData
 >;

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.tsx
@@ -593,3 +593,99 @@ test('trigger-now action does not duplicate in-flight requests', async () => {
     expect(fetchMock.callHistory.calls('execute-report-slow')).toHaveLength(1);
   });
 });
+
+test('trigger-now action displays correct success toast for Alert', async () => {
+  const addSuccessToast = jest.fn();
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    {
+      execution_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      message: 'Triggered',
+    },
+    { name: 'execute-alert-success' },
+  );
+
+  renderAlertList({ addSuccessToast });
+  await screen.findByText('Weekly Sales Alert');
+
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  fireEvent.click(triggerButtons[0]);
+
+  await waitFor(() => {
+    expect(addSuccessToast).toHaveBeenCalledWith(
+      'Alert "Weekly Sales Alert" triggered successfully',
+    );
+  });
+});
+
+test('trigger-now action displays correct success toast for Report', async () => {
+  const addSuccessToast = jest.fn();
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    {
+      execution_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      message: 'Triggered',
+    },
+    { name: 'execute-report-success' },
+  );
+
+  renderAlertList({ isReportEnabled: true, addSuccessToast });
+  await screen.findByText('Weekly Dashboard Report');
+
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  fireEvent.click(triggerButtons[0]);
+
+  await waitFor(() => {
+    expect(addSuccessToast).toHaveBeenCalledWith(
+      'Report "Weekly Dashboard Report" triggered successfully',
+    );
+  });
+});
+
+test('trigger-now action displays correct failure toast for Alert', async () => {
+  const addDangerToast = jest.fn();
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    {
+      status: 500,
+      body: { message: 'Database failure' },
+    },
+    { name: 'execute-alert-failure' },
+  );
+
+  renderAlertList({ addDangerToast });
+  await screen.findByText('Weekly Sales Alert');
+
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  fireEvent.click(triggerButtons[0]);
+
+  await waitFor(() => {
+    expect(addDangerToast).toHaveBeenCalledWith(
+      'Failed to trigger alert "Weekly Sales Alert": Database failure',
+    );
+  });
+});
+
+test('trigger-now action displays correct failure toast for Report', async () => {
+  const addDangerToast = jest.fn();
+  fetchMock.post(
+    'glob:*/api/v1/report/*/execute',
+    {
+      status: 500,
+      body: { message: 'Renderer timeout' },
+    },
+    { name: 'execute-report-failure' },
+  );
+
+  renderAlertList({ isReportEnabled: true, addDangerToast });
+  await screen.findByText('Weekly Dashboard Report');
+
+  const triggerButtons = screen.getAllByTestId('trigger-now-action');
+  fireEvent.click(triggerButtons[0]);
+
+  await waitFor(() => {
+    expect(addDangerToast).toHaveBeenCalledWith(
+      'Failed to trigger report "Weekly Dashboard Report": Renderer timeout',
+    );
+  });
+});

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -190,23 +190,31 @@ function AlertList({
       }
       executingIdsRef.current.add(alertId);
 
+      const isReport = alert.type === 'Report';
       executeReport(
         alertId,
         () => {
           addSuccessToast(
-            t('%(alertType)s "%(alertName)s" triggered successfully', {
-              alertType: alert.type,
-              alertName: alert.name,
-            }),
+            isReport
+              ? t('Report "%(alertName)s" triggered successfully', {
+                  alertName: alert.name,
+                })
+              : t('Alert "%(alertName)s" triggered successfully', {
+                  alertName: alert.name,
+                }),
           );
         },
         error => {
           addDangerToast(
-            t('Failed to trigger %(alertType)s "%(alertName)s": %(error)s', {
-              alertType: alert.type,
-              alertName: alert.name,
-              error,
-            }),
+            isReport
+              ? t('Failed to trigger report "%(alertName)s": %(error)s', {
+                  alertName: alert.name,
+                  error,
+                })
+              : t('Failed to trigger alert "%(alertName)s": %(error)s', {
+                  alertName: alert.name,
+                  error,
+                }),
           );
         },
       )


### PR DESCRIPTION
### SUMMARY

Fixes #42617.

The success and failure toast messages in `AlertReportList` currently interpolate the raw `alert.type` value (`Alert` or `Report`) into translated strings. This prevents proper localization and can produce grammatically incorrect translations in languages that require different sentence structures.

This PR replaces the interpolated resource type with separate translation strings for Alerts and Reports, following the existing i18n pattern already used in the codebase.

### TESTING

- Added unit tests covering:
  - Alert success toast
  - Report success toast
  - Alert failure toast
  - Report failure toast

### ADDITIONAL INFORMATION

- [x] Has associated issue: #42617
- [x] Changes UI
- [ ] Includes DB migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API