### PR TITLE
fix(sqllab): key overwrite-dataset options by id, not table name

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -30,6 +30,7 @@ import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { createDatasource } from 'src/SqlLab/actions/sqlLab';
 import { user, testQuery, mockdatasets } from 'src/SqlLab/fixtures';
 import { FeatureFlag, SupersetClient } from '@superset-ui/core';
+import rison from 'rison';
 
 const mockedProps = {
   visible: true,
@@ -264,9 +265,39 @@ describe('SaveDatasetModal', () => {
         table_name: 'task_instance',
       },
     ];
-    const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
-      json: { result: sameNameDatasets, count: sameNameDatasets.length },
-    } as any);
+    // Pad past a single API page so searching cannot be served from options
+    // already in memory — the search term has to reach the API and come back
+    // with the right rows.
+    const PAGE_SIZE = 100;
+    const allDatasets = [
+      ...sameNameDatasets,
+      ...Array.from({ length: PAGE_SIZE * 2 }, (_, i) => ({
+        ...mockdatasets[0],
+        id: 1000 + i,
+        schema: `schema_${i}`,
+        table_name: `table_${i}`,
+      })),
+    ];
+    // Apply the requested filters and paginate the way the API does, rather
+    // than returning everything regardless of the search string. A mock that
+    // ignores the filters hides searches that match nothing server-side.
+    const getSpy = jest
+      .spyOn(SupersetClient, 'get')
+      .mockImplementation(({ endpoint }: any) => {
+        const { filters } = rison.decode(
+          endpoint.slice(endpoint.indexOf('q=') + 2),
+        ) as { filters: { col: string; opr: string; value: any }[] };
+        const matches = allDatasets.filter(dataset =>
+          filters.every(({ col, value }) => {
+            if (col === 'table_name') return dataset.table_name.includes(value);
+            if (col === 'schema') return (dataset.schema ?? '').includes(value);
+            return true;
+          }),
+        );
+        return Promise.resolve({
+          json: { result: matches.slice(0, PAGE_SIZE), count: matches.length },
+        }) as any;
+      });
     const putSpy = jest
       .spyOn(SupersetClient, 'put')
       .mockResolvedValue({ json: { result: { id: 22 } } } as any);
@@ -287,16 +318,28 @@ describe('SaveDatasetModal', () => {
       expect(loading === null || !loading.checkVisibility()).toBe(true);
     });
 
+    const combobox = screen.getByRole('combobox', {
+      name: /existing dataset/i,
+    });
+
     // Each dataset appears exactly once, under its own schema-qualified label
+    await userEvent.type(combobox, 'task_instance');
+    await act(async () => {
+      jest.runAllTimers();
+    });
     expect(await screen.findAllByText('staging.task_instance')).toHaveLength(1);
     expect(await screen.findAllByText('prod.task_instance')).toHaveLength(1);
 
-    // The autocomplete filter matches on the label, so the schema prefix
-    // narrows the list down to a single row
-    await userEvent.type(
-      screen.getByRole('combobox', { name: /existing dataset/i }),
-      'prod.',
-    );
+    // Typing a schema prefix narrows the list to a single row. The prefix has
+    // to reach the API as a `schema` filter — sending `prod.task_instance` as
+    // a table_name filter matches nothing, and with the list spanning several
+    // pages the wanted row is not in memory for a client-side filter to save.
+    await userEvent.clear(combobox);
+    await userEvent.click(combobox);
+    await userEvent.type(combobox, 'prod.task_instance');
+    await act(async () => {
+      jest.runAllTimers();
+    });
     await act(async () => {
       jest.runAllTimers();
     });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -193,7 +193,7 @@ describe('SaveDatasetModal', () => {
     });
 
     // Select the first "existing dataset" from the listbox
-    const option = screen.getAllByText('coolest table 0')[1];
+    const option = screen.getAllByText('schema 0.coolest table 0')[0];
     await userEvent.click(option);
 
     // Overwrite button should now be enabled
@@ -224,7 +224,7 @@ describe('SaveDatasetModal', () => {
     });
 
     // Select the first "existing dataset" from the listbox
-    const option = screen.getAllByText('coolest table 0')[1];
+    const option = screen.getAllByText('schema 0.coolest table 0')[0];
     await userEvent.click(option);
 
     // Click the overwrite button to access the confirmation screen
@@ -244,6 +244,69 @@ describe('SaveDatasetModal', () => {
     expect(
       screen.getByRole('button', { name: /overwrite/i }),
     ).toBeInTheDocument();
+  });
+
+  test('distinguishes datasets that share a table name and overwrites the selected one', async () => {
+    // Two editable datasets in different schemas sharing one table name. Keying
+    // the options by table_name collapsed them onto a single Select key, which
+    // rendered duplicated rows and made the overwrite target ambiguous.
+    const sameNameDatasets = [
+      {
+        ...mockdatasets[0],
+        id: 11,
+        schema: 'staging',
+        table_name: 'task_instance',
+      },
+      {
+        ...mockdatasets[0],
+        id: 22,
+        schema: 'prod',
+        table_name: 'task_instance',
+      },
+    ];
+    const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+      json: { result: sameNameDatasets, count: sameNameDatasets.length },
+    } as any);
+    const putSpy = jest
+      .spyOn(SupersetClient, 'put')
+      .mockResolvedValue({ json: { result: { id: 22 } } } as any);
+
+    renderModal();
+
+    await userEvent.click(
+      screen.getByRole('radio', { name: /overwrite existing/i }),
+    );
+    await userEvent.click(
+      screen.getByRole('combobox', { name: /existing dataset/i }),
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => {
+      const loading = screen.queryByText('Loading...');
+      expect(loading === null || !loading.checkVisibility()).toBe(true);
+    });
+
+    // Each dataset appears exactly once, under its own schema-qualified label
+    expect(await screen.findAllByText('staging.task_instance')).toHaveLength(1);
+    expect(await screen.findAllByText('prod.task_instance')).toHaveLength(1);
+
+    // Picking the prod row must target dataset 22, not the staging one
+    await userEvent.click(screen.getByText('prod.task_instance'));
+    await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+    await screen.findByText(/are you sure you want to overwrite this dataset/i);
+    await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+
+    await waitFor(() => {
+      expect(
+        putSpy.mock.calls.some(([req]) =>
+          req.endpoint?.includes('api/v1/dataset/22'),
+        ),
+      ).toBe(true);
+    });
+
+    getSpy.mockRestore();
+    putSpy.mockRestore();
   });
 
   test('sends the schema when creating the dataset', async () => {
@@ -401,8 +464,8 @@ describe('SaveDatasetModal', () => {
       expect(loading === null || !loading.checkVisibility()).toBe(true);
     });
     // Pick an existing dataset (use the listbox item, not the input mirror)
-    const options = await screen.findAllByText('coolest table 0');
-    await userEvent.click(options[1]);
+    const options = await screen.findAllByText('schema 0.coolest table 0');
+    await userEvent.click(options[0]);
     // First overwrite click → confirmation screen
     await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
     // Wait for the confirmation screen to render

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -248,19 +248,31 @@ describe('SaveDatasetModal', () => {
   });
 
   test('distinguishes datasets that share a table name and overwrites the selected one', async () => {
-    // Two editable datasets in different schemas sharing one table name. Keying
-    // the options by table_name collapsed them onto a single Select key, which
+    // Datasets are unique by database, catalog, schema and table name, so the
+    // same table name can legitimately appear several times. Keying the
+    // options by table_name collapsed them onto a single Select key, which
     // rendered duplicated rows and made the overwrite target ambiguous.
     const sameNameDatasets = [
       {
         ...mockdatasets[0],
         id: 11,
+        database: { database_name: 'warehouse' },
         schema: 'staging',
         table_name: 'task_instance',
       },
       {
         ...mockdatasets[0],
         id: 22,
+        database: { database_name: 'warehouse' },
+        schema: 'prod',
+        table_name: 'task_instance',
+      },
+      // Same schema and table as the one above — only the database differs
+      {
+        ...mockdatasets[0],
+        id: 33,
+        database: { database_name: 'analytics' },
+        catalog: 'reporting',
         schema: 'prod',
         table_name: 'task_instance',
       },
@@ -274,6 +286,7 @@ describe('SaveDatasetModal', () => {
       ...Array.from({ length: PAGE_SIZE * 2 }, (_, i) => ({
         ...mockdatasets[0],
         id: 1000 + i,
+        database: { database_name: 'warehouse' },
         schema: `schema_${i}`,
         table_name: `table_${i}`,
       })),
@@ -288,11 +301,9 @@ describe('SaveDatasetModal', () => {
           endpoint.slice(endpoint.indexOf('q=') + 2),
         ) as { filters: { col: string; opr: string; value: any }[] };
         const matches = allDatasets.filter(dataset =>
-          filters.every(({ col, value }) => {
-            if (col === 'table_name') return dataset.table_name.includes(value);
-            if (col === 'schema') return (dataset.schema ?? '').includes(value);
-            return true;
-          }),
+          filters.every(({ col, value }) =>
+            col === 'table_name' ? dataset.table_name.includes(value) : true,
+          ),
         );
         return Promise.resolve({
           json: { result: matches.slice(0, PAGE_SIZE), count: matches.length },
@@ -300,16 +311,17 @@ describe('SaveDatasetModal', () => {
       });
     const putSpy = jest
       .spyOn(SupersetClient, 'put')
-      .mockResolvedValue({ json: { result: { id: 22 } } } as any);
+      .mockResolvedValue({ json: { result: { id: 33 } } } as any);
 
     renderModal();
 
     await userEvent.click(
       screen.getByRole('radio', { name: /overwrite existing/i }),
     );
-    await userEvent.click(
-      screen.getByRole('combobox', { name: /existing dataset/i }),
-    );
+    const combobox = screen.getByRole('combobox', {
+      name: /existing dataset/i,
+    });
+    await userEvent.click(combobox);
     await act(async () => {
       jest.runAllTimers();
     });
@@ -318,25 +330,29 @@ describe('SaveDatasetModal', () => {
       expect(loading === null || !loading.checkVisibility()).toBe(true);
     });
 
-    const combobox = screen.getByRole('combobox', {
-      name: /existing dataset/i,
-    });
-
-    // Each dataset appears exactly once, under its own schema-qualified label
+    // Each dataset appears exactly once, under its own fully qualified label
     await userEvent.type(combobox, 'task_instance');
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(await screen.findAllByText('staging.task_instance')).toHaveLength(1);
-    expect(await screen.findAllByText('prod.task_instance')).toHaveLength(1);
+    expect(
+      await screen.findAllByText('warehouse.staging.task_instance'),
+    ).toHaveLength(1);
+    expect(
+      await screen.findAllByText('warehouse.prod.task_instance'),
+    ).toHaveLength(1);
+    expect(
+      await screen.findAllByText('analytics.reporting.prod.task_instance'),
+    ).toHaveLength(1);
 
-    // Typing a schema prefix narrows the list to a single row. The prefix has
-    // to reach the API as a `schema` filter — sending `prod.task_instance` as
-    // a table_name filter matches nothing, and with the list spanning several
-    // pages the wanted row is not in memory for a client-side filter to save.
+    // Qualifying the search narrows the list down — skipping the catalog is
+    // fine, the parts just have to be present. The table part still has to
+    // reach the API: sending the whole string as a table_name filter would
+    // match nothing, and with the list spanning several pages the wanted row
+    // is not in memory for the local filter to fall back on.
     await userEvent.clear(combobox);
     await userEvent.click(combobox);
-    await userEvent.type(combobox, 'prod.task_instance');
+    await userEvent.type(combobox, 'analytics.prod.task_instance');
     await act(async () => {
       jest.runAllTimers();
     });
@@ -345,12 +361,17 @@ describe('SaveDatasetModal', () => {
     });
     await waitFor(() =>
       expect(
-        screen.queryByText('staging.task_instance'),
+        screen.queryByText('warehouse.prod.task_instance'),
       ).not.toBeInTheDocument(),
     );
+    expect(
+      screen.queryByText('warehouse.staging.task_instance'),
+    ).not.toBeInTheDocument();
 
-    // Picking the prod row must target dataset 22, not the staging one
-    await userEvent.click(screen.getByText('prod.task_instance'));
+    // Picking that row must target dataset 33, not either warehouse dataset
+    await userEvent.click(
+      screen.getByText('analytics.reporting.prod.task_instance'),
+    );
     await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
     await screen.findByText(/are you sure you want to overwrite this dataset/i);
     await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
@@ -358,7 +379,7 @@ describe('SaveDatasetModal', () => {
     await waitFor(() => {
       expect(
         putSpy.mock.calls.some(([req]) =>
-          req.endpoint?.includes('api/v1/dataset/22'),
+          req.endpoint?.includes('api/v1/dataset/33'),
         ),
       ).toBe(true);
     });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -291,6 +291,21 @@ describe('SaveDatasetModal', () => {
     expect(await screen.findAllByText('staging.task_instance')).toHaveLength(1);
     expect(await screen.findAllByText('prod.task_instance')).toHaveLength(1);
 
+    // The autocomplete filter matches on the label, so the schema prefix
+    // narrows the list down to a single row
+    await userEvent.type(
+      screen.getByRole('combobox', { name: /existing dataset/i }),
+      'prod.',
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByText('staging.task_instance'),
+      ).not.toBeInTheDocument(),
+    );
+
     // Picking the prod row must target dataset 22, not the staging one
     await userEvent.click(screen.getByText('prod.task_instance'));
     await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -249,9 +249,7 @@ describe('SaveDatasetModal', () => {
 
   test('distinguishes datasets that share a table name and overwrites the selected one', async () => {
     // Datasets are unique by database, catalog, schema and table name, so the
-    // same table name can legitimately appear several times. Keying the
-    // options by table_name collapsed them onto a single Select key, which
-    // rendered duplicated rows and made the overwrite target ambiguous.
+    // same table name can legitimately appear several times.
     const sameNameDatasets = [
       {
         ...mockdatasets[0],
@@ -277,9 +275,8 @@ describe('SaveDatasetModal', () => {
         table_name: 'task_instance',
       },
     ];
-    // Pad past a single API page so searching cannot be served from options
-    // already in memory — the search term has to reach the API and come back
-    // with the right rows.
+    // Pad past a single API page so the search cannot be served from options
+    // already in memory — it has to reach the API.
     const PAGE_SIZE = 100;
     const allDatasets = [
       ...sameNameDatasets,
@@ -291,9 +288,8 @@ describe('SaveDatasetModal', () => {
         table_name: `table_${i}`,
       })),
     ];
-    // Apply the requested filters and paginate the way the API does, rather
-    // than returning everything regardless of the search string. A mock that
-    // ignores the filters hides searches that match nothing server-side.
+    // Filter and paginate the way the API does — a mock that returns
+    // everything regardless of the search hides server-side mismatches.
     const getSpy = jest
       .spyOn(SupersetClient, 'get')
       .mockImplementation(({ endpoint }: any) => {
@@ -330,7 +326,6 @@ describe('SaveDatasetModal', () => {
       expect(loading === null || !loading.checkVisibility()).toBe(true);
     });
 
-    // Each dataset appears exactly once, under its own fully qualified label
     await userEvent.type(combobox, 'task_instance');
     await act(async () => {
       jest.runAllTimers();
@@ -345,11 +340,7 @@ describe('SaveDatasetModal', () => {
       await screen.findAllByText('analytics.reporting.prod.task_instance'),
     ).toHaveLength(1);
 
-    // Qualifying the search narrows the list down — skipping the catalog is
-    // fine, the parts just have to be present. The table part still has to
-    // reach the API: sending the whole string as a table_name filter would
-    // match nothing, and with the list spanning several pages the wanted row
-    // is not in memory for the local filter to fall back on.
+    // Qualifying the search narrows the list, skipping the catalog included.
     await userEvent.clear(combobox);
     await userEvent.click(combobox);
     await userEvent.type(combobox, 'analytics.prod.task_instance');
@@ -368,7 +359,6 @@ describe('SaveDatasetModal', () => {
       screen.queryByText('warehouse.staging.task_instance'),
     ).not.toBeInTheDocument();
 
-    // Picking that row must target dataset 33, not either warehouse dataset
     await userEvent.click(
       screen.getByText('analytics.reporting.prod.task_instance'),
     );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -196,15 +196,38 @@ const updateDataset = async ({
 const UNTITLED = t('Untitled Dataset');
 
 /**
- * Split a search string typed against a `schema.table_name` label into its
- * schema and table parts. Everything before the first dot is treated as the
- * schema; a search with no dot is a plain table-name search.
+ * Datasets are unique by database, catalog, schema and table name, so the
+ * overwrite options are labelled with every part that is set — e.g.
+ * `examples.public.cleaned_sales_data`. Two datasets can otherwise render the
+ * same label and leave the user unable to tell which one they are about to
+ * overwrite.
  */
-const splitQualifiedSearch = (input: string): [string, string] => {
-  const separatorIndex = input.indexOf('.');
-  return separatorIndex === -1
-    ? ['', input]
-    : [input.slice(0, separatorIndex), input.slice(separatorIndex + 1)];
+const qualifiedLabel = (dataset: {
+  database?: { database_name?: string };
+  catalog?: string | null;
+  schema?: string | null;
+  table_name: string;
+}) =>
+  [
+    dataset.database?.database_name,
+    dataset.catalog,
+    dataset.schema,
+    dataset.table_name,
+  ]
+    .filter(Boolean)
+    .join('.');
+
+/**
+ * Break a search typed against those labels into its dot-separated parts. The
+ * trailing part is the table name the user is after — unless they have just
+ * typed a separator, in which case everything so far is qualification.
+ */
+const parseQualifiedSearch = (input: string) => {
+  const parts = input.split('.').filter(Boolean);
+  return {
+    parts,
+    tableSearch: input.endsWith('.') ? '' : (parts[parts.length - 1] ?? ''),
+  };
 };
 
 // The filters param is only used to test jinja templates.
@@ -333,13 +356,13 @@ export const SaveDatasetModal = ({
   };
 
   const loadDatasetOverwriteOptions = useCallback(async (input = '') => {
-    // Options are labelled `schema.table_name`, so the search string can carry
-    // a schema prefix. Split it and filter on both columns server-side: sending
-    // the whole string as a table_name filter matches nothing as soon as the
-    // user types the dot, and on a list that spans several pages the rows that
-    // should have matched may never be fetched for a client-side filter to
-    // recover.
-    const [schemaSearch, tableSearch] = splitQualifiedSearch(input);
+    // Only the table-name part of the search can be pushed to the API: the
+    // qualifiers in a label are spread over three columns, one of which
+    // (`database`) is a relationship the list endpoint cannot match on by
+    // name. Sending the whole string as a `table_name` filter would match
+    // nothing the moment the user types a separator, so send the table part
+    // and let filterAutocompleteOption narrow the qualifiers.
+    const { tableSearch } = parseQualifiedSearch(input);
 
     const queryParams = rison.encode({
       filters: [
@@ -348,15 +371,6 @@ export const SaveDatasetModal = ({
           opr: 'ct',
           value: tableSearch,
         },
-        ...(schemaSearch
-          ? [
-              {
-                col: 'schema',
-                opr: 'ct',
-                value: schemaSearch,
-              },
-            ]
-          : []),
         {
           col: 'id',
           opr: 'is_editable',
@@ -375,13 +389,15 @@ export const SaveDatasetModal = ({
           table_name: string;
           id: number;
           editors: Subject[];
-          schema?: string;
+          database?: { database_name?: string };
+          catalog?: string | null;
+          schema?: string | null;
         }) => ({
           // `id` is unique; `table_name` is not. Keying options by the table
           // name collapses same-named datasets onto a single Select key, which
           // renders duplicate rows and makes the overwrite target ambiguous.
           value: r.id,
-          label: r.schema ? `${r.schema}.${r.table_name}` : r.table_name,
+          label: qualifiedLabel(r),
           datasetId: r.id,
           editors: r.editors,
         }),
@@ -462,18 +478,12 @@ export const SaveDatasetModal = ({
     inputValue: string,
     option: DatasetOverwriteOption,
   ) => {
-    const search = inputValue.toLowerCase();
     const label = option.label.toLowerCase();
-    if (!search.includes('.')) {
-      return label.includes(search);
-    }
-    // Mirror the server-side split, so this local pass (which only exists to
-    // hide options left over from an earlier search) can never hide a row the
-    // API deliberately returned — e.g. `prod.` matching schema `production`.
-    const [schemaSearch, tableSearch] = splitQualifiedSearch(search);
-    const [optionSchema, optionTable] = splitQualifiedSearch(label);
-    return (
-      optionSchema.includes(schemaSearch) && optionTable.includes(tableSearch)
+    // Every part the user typed has to appear somewhere in the label, but not
+    // in any particular position: a dataset may or may not have a catalog, and
+    // a search like `examples.sales` skipping the schema should still match.
+    return parseQualifiedSearch(inputValue.toLowerCase()).parts.every(part =>
+      label.includes(part),
     );
   };
 

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -342,9 +342,17 @@ export const SaveDatasetModal = ({
       endpoint: `/api/v1/dataset/?q=${queryParams}`,
     }).then(response => ({
       data: response.json.result.map(
-        (r: { table_name: string; id: number; editors: Subject[] }) => ({
-          value: r.table_name,
-          label: r.table_name,
+        (r: {
+          table_name: string;
+          id: number;
+          editors: Subject[];
+          schema?: string;
+        }) => ({
+          // `id` is unique; `table_name` is not. Keying options by the table
+          // name collapses same-named datasets onto a single Select key, which
+          // renders duplicate rows and makes the overwrite target ambiguous.
+          value: r.id,
+          label: r.schema ? `${r.schema}.${r.table_name}` : r.table_name,
           datasetId: r.id,
           editors: r.editors,
         }),
@@ -424,7 +432,7 @@ export const SaveDatasetModal = ({
   const filterAutocompleteOption = (
     inputValue: string,
     option: DatasetOverwriteOption,
-  ) => option.value.toLowerCase().includes(inputValue.toLowerCase());
+  ) => option.label.toLowerCase().includes(inputValue.toLowerCase());
 
   return (
     <Modal

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -196,11 +196,8 @@ const updateDataset = async ({
 const UNTITLED = t('Untitled Dataset');
 
 /**
- * Datasets are unique by database, catalog, schema and table name, so the
- * overwrite options are labelled with every part that is set — e.g.
- * `examples.public.cleaned_sales_data`. Two datasets can otherwise render the
- * same label and leave the user unable to tell which one they are about to
- * overwrite.
+ * Datasets are unique by database, catalog, schema and table name, so a label
+ * built from anything less can be ambiguous — e.g. `examples.public.sales`.
  */
 const qualifiedLabel = (dataset: {
   database?: { database_name?: string };
@@ -218,9 +215,8 @@ const qualifiedLabel = (dataset: {
     .join('.');
 
 /**
- * Break a search typed against those labels into its dot-separated parts. The
- * trailing part is the table name the user is after — unless they have just
- * typed a separator, in which case everything so far is qualification.
+ * Break a search typed against those labels into its parts. The trailing part
+ * is the table name, unless the user has just typed a separator.
  */
 const parseQualifiedSearch = (input: string) => {
   const parts = input.split('.').filter(Boolean);
@@ -356,12 +352,10 @@ export const SaveDatasetModal = ({
   };
 
   const loadDatasetOverwriteOptions = useCallback(async (input = '') => {
-    // Only the table-name part of the search can be pushed to the API: the
-    // qualifiers in a label are spread over three columns, one of which
-    // (`database`) is a relationship the list endpoint cannot match on by
-    // name. Sending the whole string as a `table_name` filter would match
-    // nothing the moment the user types a separator, so send the table part
-    // and let filterAutocompleteOption narrow the qualifiers.
+    // Only the table part can be filtered server-side — `database` is a
+    // relationship the list endpoint cannot match on by name. Sending the
+    // whole search as a `table_name` filter matches nothing once the user
+    // types a separator; filterAutocompleteOption narrows the qualifiers.
     const { tableSearch } = parseQualifiedSearch(input);
 
     const queryParams = rison.encode({
@@ -393,9 +387,8 @@ export const SaveDatasetModal = ({
           catalog?: string | null;
           schema?: string | null;
         }) => ({
-          // `id` is unique; `table_name` is not. Keying options by the table
-          // name collapses same-named datasets onto a single Select key, which
-          // renders duplicate rows and makes the overwrite target ambiguous.
+          // `id` is unique; `table_name` is not. Keying by the table name
+          // collapses same-named datasets onto a single Select key.
           value: r.id,
           label: qualifiedLabel(r),
           datasetId: r.id,
@@ -479,9 +472,8 @@ export const SaveDatasetModal = ({
     option: DatasetOverwriteOption,
   ) => {
     const label = option.label.toLowerCase();
-    // Every part the user typed has to appear somewhere in the label, but not
-    // in any particular position: a dataset may or may not have a catalog, and
-    // a search like `examples.sales` skipping the schema should still match.
+    // Position-independent: a dataset may or may not have a catalog, and a
+    // search skipping a part (`examples.sales`) should still match.
     return parseQualifiedSearch(inputValue.toLowerCase()).parts.every(part =>
       label.includes(part),
     );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -195,6 +195,18 @@ const updateDataset = async ({
 
 const UNTITLED = t('Untitled Dataset');
 
+/**
+ * Split a search string typed against a `schema.table_name` label into its
+ * schema and table parts. Everything before the first dot is treated as the
+ * schema; a search with no dot is a plain table-name search.
+ */
+const splitQualifiedSearch = (input: string): [string, string] => {
+  const separatorIndex = input.indexOf('.');
+  return separatorIndex === -1
+    ? ['', input]
+    : [input.slice(0, separatorIndex), input.slice(separatorIndex + 1)];
+};
+
 // The filters param is only used to test jinja templates.
 // Remove the special filters entry from the templateParams
 // before saving the dataset.
@@ -321,13 +333,30 @@ export const SaveDatasetModal = ({
   };
 
   const loadDatasetOverwriteOptions = useCallback(async (input = '') => {
+    // Options are labelled `schema.table_name`, so the search string can carry
+    // a schema prefix. Split it and filter on both columns server-side: sending
+    // the whole string as a table_name filter matches nothing as soon as the
+    // user types the dot, and on a list that spans several pages the rows that
+    // should have matched may never be fetched for a client-side filter to
+    // recover.
+    const [schemaSearch, tableSearch] = splitQualifiedSearch(input);
+
     const queryParams = rison.encode({
       filters: [
         {
           col: 'table_name',
           opr: 'ct',
-          value: input,
+          value: tableSearch,
         },
+        ...(schemaSearch
+          ? [
+              {
+                col: 'schema',
+                opr: 'ct',
+                value: schemaSearch,
+              },
+            ]
+          : []),
         {
           col: 'id',
           opr: 'is_editable',
@@ -432,7 +461,21 @@ export const SaveDatasetModal = ({
   const filterAutocompleteOption = (
     inputValue: string,
     option: DatasetOverwriteOption,
-  ) => option.label.toLowerCase().includes(inputValue.toLowerCase());
+  ) => {
+    const search = inputValue.toLowerCase();
+    const label = option.label.toLowerCase();
+    if (!search.includes('.')) {
+      return label.includes(search);
+    }
+    // Mirror the server-side split, so this local pass (which only exists to
+    // hide options left over from an earlier search) can never hide a row the
+    // API deliberately returned — e.g. `prod.` matching schema `production`.
+    const [schemaSearch, tableSearch] = splitQualifiedSearch(search);
+    const [optionSchema, optionTable] = splitQualifiedSearch(label);
+    return (
+      optionSchema.includes(schemaSearch) && optionTable.includes(tableSearch)
+    );
+  };
 
   return (
     <Modal

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -137,7 +137,7 @@ export const EXPLORE_CHART_DEFAULT = {
 };
 
 export interface DatasetOptionAutocomplete {
-  value: string;
+  value: number;
   datasetId: number;
   editors: Subject[];
 }


### PR DESCRIPTION
### SUMMARY

The "Overwrite existing" dropdown in SQL Lab's **Save or Overwrite Dataset** modal builds its options with `value: r.table_name`:

```ts
data: response.json.result.map(
  (r: { table_name: string; id: number; editors: Subject[] }) => ({
    value: r.table_name,
    label: r.table_name,
    datasetId: r.id,
    editors: r.editors,
  }),
),
```

Table names are not unique — the same table name can exist in several schemas, and a user can be an editor on datasets for all of them (Airflow metadata tables such as `task_instance` saved from a staging and a prod schema are a common case). When that happens:

- duplicate `value`s collide on one Select key, so the listbox intermittently renders the same row several times (reported as "sometimes I get 8 identical rows")
- the labels are identical, so the datasets are indistinguishable to the user
- the resulting selection is ambiguous, so **Overwrite can target the wrong dataset**

This PR keys the options by the dataset `id`, which is unique, and renders a schema-qualified label so same-named datasets can be told apart:

```ts
value: r.id,
label: r.schema ? `${r.schema}.${r.table_name}` : r.table_name,
```

`schema` is already part of the dataset API's `list_columns`, so no backend change is needed. `filterAutocompleteOption` now matches on the label rather than the value, since the value is no longer a string, and `DatasetOptionAutocomplete.value` is typed `number`. The overwrite path itself is unaffected — it already used `datasetToOverwrite.datasetId`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: with three editable datasets named `task_instance` in different schemas, the dropdown shows repeated, identical `task_instance` rows and there is no way to tell which one Overwrite will hit.

After: one row per dataset, each labelled `staging.task_instance`, `prod.task_instance`, etc., and Overwrite targets the row that was clicked.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
```

20/20 pass. Added a regression test — `distinguishes datasets that share a table name and overwrites the selected one` — that stubs two editable datasets sharing the table name `task_instance` across a `staging` and a `prod` schema, asserts each renders exactly once under its schema-qualified label, that typing the `prod.` prefix filters the staging row out (the autocomplete filter now matches on the label), and that selecting the `prod` row issues the PUT against that dataset's id. The test fails on `master` (both labels resolve to two rendered nodes) and passes with this change.

The three existing test call sites that looked up `'coolest table 0'` were updated to the new qualified label. `prettier --check` and `oxlint` are clean on the touched files; `tsc --noEmit` reports no new errors.

Manual check: open SQL Lab → run a query → **Save** → **Save or Overwrite Dataset** → **Overwrite existing**, with an account that can edit two datasets sharing a table name in different schemas.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

