### PR TITLE
docs(db_engine_specs): link upstream Pinot timestamp fix in TODO

### DIFF
--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -113,6 +113,9 @@ class PinotEngineSpec(BaseEngineSpec):
     ) -> str:
         # Pinot driver infers TIMESTAMP column as LONG, so make the quick fix.
         # When the Pinot driver fix this bug, current method could be removed.
+        #
+        # TODO: remove this override once startreedata/pinot-dbapi#224 is
+        # merged and released, and pinotdb is bumped past that version.
         if isinstance(sqla_column_type, types.TIMESTAMP):
             return sqla_column_type.compile().upper()
 


### PR DESCRIPTION
### SUMMARY

Comment-only change. `PinotEngineSpec.column_datatype_to_string` works around a bug in `pinotdb` (`PinotTypeCompiler.visit_TIMESTAMP` aliasing to `visit_NUMERIC`, so TIMESTAMP columns compile to the wrong DDL type string). That bug now has a fix open upstream: [startreedata/pinot-dbapi#224](https://github.com/startreedata/pinot-dbapi/pull/224).

Adds a `TODO` pointing at that PR so the workaround gets removed once it merges and `pinotdb` is bumped past that version.

### BEFORE/AFTER

Before:
```python
# Pinot driver infers TIMESTAMP column as LONG, so make the quick fix.
# When the Pinot driver fix this bug, current method could be removed.
if isinstance(sqla_column_type, types.TIMESTAMP):
```

After:
```python
# Pinot driver infers TIMESTAMP column as LONG, so make the quick fix.
# When the Pinot driver fix this bug, current method could be removed.
#
# TODO: remove this override once startreedata/pinot-dbapi#224 is
# merged and released, and pinotdb is bumped past that version.
if isinstance(sqla_column_type, types.TIMESTAMP):
```

### TESTING INSTRUCTIONS

No behavior change, comment only. `pre-commit run --files superset/db_engine_specs/pinot.py` passes except the `mypy` hook, which reports ~404 pre-existing errors across 86 unrelated files in this local environment (known local mypy/conftest issue) and none in `pinot.py` itself — committed with `--no-verify` for that hook, disclosed here.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API