### PR TITLE
fix(reports): use zip extension for bundled CSV attachments

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -80,6 +80,11 @@ class EmailContent:
     images: Optional[dict[str, bytes]] = None
 
 
+def _get_csv_attachment_extension(content: bytes) -> str:
+    """Return ``zip`` for bundled CSV responses and ``csv`` otherwise."""
+    return "zip" if content.startswith(ZIP_LOCAL_FILE_HEADER) else "csv"
+
+
 def _get_xlsx_attachment_extension(content: bytes) -> str:
     """
     Return the attachment extension for bytes returned by the XLSX export endpoint.
@@ -243,7 +248,14 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         # so at most one tabular attachment is present in the data dict.
         attachment_data: dict[str, bytes | str] | None = None
         if self._content.csv:
-            attachment_data = {__("%(name)s.csv", name=self._name): self._content.csv}
+            extension = _get_csv_attachment_extension(self._content.csv)
+            attachment_data = {
+                __(
+                    "%(name)s.%(extension)s",
+                    name=self._name,
+                    extension=extension,
+                ): self._content.csv
+            }
         elif self._content.xlsx:
             extension = _get_xlsx_attachment_extension(self._content.xlsx)
             attachment_data = {

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -288,17 +288,17 @@ def test_get_xlsx_attachment_extension_reads_nested_zip_signatures_only(
 
 
 @pytest.mark.parametrize(
-    ("server_pagination", "expected_extension"),
+    ("is_multi_query_bundle", "expected_extension"),
     [
         (False, "xlsx"),
         (True, "zip"),
     ],
 )
 def test_xlsx_report_attachment_extension(
-    server_pagination: bool,
+    is_multi_query_bundle: bool,
     expected_extension: str,
 ) -> None:
-    """Server-paginated XLSX reports should be attached as ZIP archives."""
+    """Multi-query XLSX bundles should be attached as ZIP archives."""
     from superset.utils import excel
     from superset.utils.core import create_zip
 
@@ -310,7 +310,7 @@ def test_xlsx_report_attachment_extension(
                 "query_2.xlsx": xlsx,
             }
         ).getvalue()
-        if server_pagination
+        if is_multi_query_bundle
         else xlsx
     )
 
@@ -322,17 +322,17 @@ def test_xlsx_report_attachment_extension(
 
 
 @pytest.mark.parametrize(
-    ("server_pagination", "expected_extension"),
+    ("is_multi_query_bundle", "expected_extension"),
     [
         (False, "csv"),
         (True, "zip"),
     ],
 )
 def test_csv_report_attachment_extension(
-    server_pagination: bool,
+    is_multi_query_bundle: bool,
     expected_extension: str,
 ) -> None:
-    """Server-paginated CSV reports should be attached as ZIP archives."""
+    """Multi-query CSV bundles should be attached as ZIP archives."""
     from superset.utils.core import create_zip
 
     csv = b"value\n1\n2\n"
@@ -343,7 +343,7 @@ def test_csv_report_attachment_extension(
                 "query_2.csv": csv,
             }
         ).getvalue()
-        if server_pagination
+        if is_multi_query_bundle
         else csv
     )
 

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
+from io import BytesIO
 from typing import TYPE_CHECKING
-from zipfile import ZipExtFile
+from zipfile import is_zipfile, ZipExtFile
 
 import pandas as pd
 import pytest
@@ -152,7 +153,11 @@ def test_email_subject_with_datetime() -> None:
     assert frozen_now.strftime(datetime_pattern) in subject
 
 
-def _make_notification(xlsx: bytes) -> "EmailNotification":
+def _make_notification(
+    *,
+    csv: bytes | None = None,
+    xlsx: bytes | None = None,
+) -> "EmailNotification":
     """Build an email notification for attachment tests."""
     from superset.reports.models import ReportRecipients, ReportRecipientType
     from superset.reports.notifications.base import NotificationContent
@@ -162,9 +167,10 @@ def _make_notification(xlsx: bytes) -> "EmailNotification":
     content = NotificationContent(
         name="test report",
         text=None,
+        csv=csv,
         xlsx=xlsx,
         header_data={
-            "notification_format": "XLSX",
+            "notification_format": "CSV" if csv is not None else "XLSX",
             "notification_type": "Report",
             "editors": [1],
             "notification_source": None,
@@ -175,6 +181,51 @@ def _make_notification(xlsx: bytes) -> "EmailNotification":
         },
     )
     return EmailNotification(recipient=recipient, content=content)
+
+
+def test_get_csv_attachment_extension_for_csv_content() -> None:
+    """Plain CSV bytes keep the CSV extension."""
+    from superset.reports.notifications.email import (
+        _get_csv_attachment_extension,
+    )
+
+    assert _get_csv_attachment_extension(b"value\n1\n2\n") == "csv"
+
+
+def test_get_csv_attachment_extension_for_zip_content() -> None:
+    """A ZIP bundling one CSV per query is identified as an archive."""
+    from superset.reports.notifications.email import (
+        _get_csv_attachment_extension,
+    )
+    from superset.utils.core import create_zip
+
+    archive = create_zip({"query_1.csv": b"value\n1\n2\n"}).getvalue()
+
+    assert _get_csv_attachment_extension(archive) == "zip"
+
+
+def test_get_csv_attachment_extension_for_damaged_zip_content() -> None:
+    """Bytes carrying the archive signature stay an archive even if unreadable.
+
+    A truncated bundle no longer parses as a ZIP, but it is still what the
+    endpoint produced, so naming it ``.zip`` describes it correctly. Naming it
+    ``.csv`` would produce an attachment that opens as neither format.
+    """
+    from superset.reports.notifications.email import (
+        _get_csv_attachment_extension,
+    )
+    from superset.utils.core import create_zip
+
+    archive = create_zip(
+        {
+            "query_1.csv": b"value\n1\n2\n",
+            "query_2.csv": b"value\n3\n4\n",
+        }
+    ).getvalue()
+    truncated = archive[: len(archive) // 2]
+
+    assert not is_zipfile(BytesIO(truncated))
+    assert _get_csv_attachment_extension(truncated) == "zip"
 
 
 def test_get_xlsx_attachment_extension_for_non_zip_content() -> None:
@@ -264,6 +315,39 @@ def test_xlsx_report_attachment_extension(
     )
 
     email_content = _make_notification(xlsx=attachment)._get_content()
+
+    assert email_content.data == {
+        f"test report.{expected_extension}": attachment,
+    }
+
+
+@pytest.mark.parametrize(
+    ("server_pagination", "expected_extension"),
+    [
+        (False, "csv"),
+        (True, "zip"),
+    ],
+)
+def test_csv_report_attachment_extension(
+    server_pagination: bool,
+    expected_extension: str,
+) -> None:
+    """Server-paginated CSV reports should be attached as ZIP archives."""
+    from superset.utils.core import create_zip
+
+    csv = b"value\n1\n2\n"
+    attachment = (
+        create_zip(
+            {
+                "query_1.csv": csv,
+                "query_2.csv": csv,
+            }
+        ).getvalue()
+        if server_pagination
+        else csv
+    )
+
+    email_content = _make_notification(csv=attachment)._get_content()
 
     assert email_content.data == {
         f"test report.{expected_extension}": attachment,


### PR DESCRIPTION
### SUMMARY

Fixes #32858.

CSV email reports always used a `.csv` attachment name, even when the chart data endpoint returned a ZIP archive containing multiple query results. Charts that execute multiple data queries, such as Mixed Time-series with Query A and Query B, therefore produced attachments whose extension did not match their content.

The issue's server-paginated Table reproducer still applies to the 6.0 and 6.1 releases. On master, #41103 removes the pagination-only `is_rowcount` query from report exports, so the current-master reproduction below uses Mixed Time-series, which is multi-query by construction. The underlying attachment-extension defect is the same in both paths.

This selects the attachment extension from the returned payload signature, using `.zip` for bundled responses while preserving `.csv` for single-file and streamed responses. Regression coverage includes plain CSV content, multi-query CSV bundles, truncated bundles that retain the ZIP signature, and the existing XLSX attachment behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — this is a backend-only change to the generated attachment filename.

### TESTING INSTRUCTIONS

1. Enable `ALERT_REPORTS` and configure email reporting.
2. Create a Mixed Time-series chart with both Query A and Query B, then configure a CSV email report for it.
3. Trigger the report and verify that the attachment has a `.zip` extension and contains the CSV results for both queries.
4. Trigger a CSV report for a single-query chart and verify that its attachment retains the `.csv` extension.

Run:

`pytest tests/unit_tests/reports/notifications/email_tests.py`

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #32858
- [x] Required feature flags: `ALERT_REPORTS` (existing)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
