### PR TITLE
fix(migrations): actually drop _customer_location_uc (list == set no-op)

### DIFF
--- a/superset/migrations/versions/2026-07-31_10-00_16755d4ca4ae_drop__customer_location_uc_take_2.py
+++ b/superset/migrations/versions/2026-07-31_10-00_16755d4ca4ae_drop__customer_location_uc_take_2.py
@@ -18,7 +18,7 @@
 Drop _customer_location_uc (take 2)
 
 Revision ID: 16755d4ca4ae
-Revises: e7d93a524ff6
+Revises: f3a8c1d2e9b7
 Create Date: 2026-07-31 10:00:00.000000
 """
 

--- a/superset/migrations/versions/2026-07-31_10-00_16755d4ca4ae_drop__customer_location_uc_take_2.py
+++ b/superset/migrations/versions/2026-07-31_10-00_16755d4ca4ae_drop__customer_location_uc_take_2.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Drop _customer_location_uc (take 2)
+
+Revision ID: 16755d4ca4ae
+Revises: e7d93a524ff6
+Create Date: 2026-07-31 10:00:00.000000
+"""
+
+import logging
+
+from alembic import op
+from migration_utils import create_unique_constraint, drop_unique_constraint
+from sqlalchemy.engine.reflection import Inspector
+
+from superset.utils.core import generic_find_uq_constraint_name
+
+# revision identifiers, used by Alembic.
+revision = "16755d4ca4ae"
+down_revision = "f3a8c1d2e9b7"
+
+logger = logging.getLogger("alembic.env")
+
+
+def upgrade():
+    """Re-attempt the constraint drop that migration ``df3d7e2eb9a4``
+    intended but silently skipped.
+
+    That migration passed a **list** to ``generic_find_uq_constraint_name``,
+    whose body compared ``columns == set(uq["column_names"])`` — and
+    ``list == set`` is always ``False`` in Python, so the constraint was
+    never found and never dropped. Databases migrated through it still
+    carry the legacy 3-column constraint ``(database_id, schema,
+    table_name)``, which both leaks across catalogs (no ``catalog`` leg)
+    and diverges from schemas built from model metadata, where the model's
+    4-column constraint exists instead.
+
+    The lookup below passes a set (and the helper itself coerces, so the
+    foot-gun is gone either way). On databases where the legacy constraint
+    is already absent the lookup finds nothing and the migration is a
+    harmless no-op. The model's intended 4-column constraint can never
+    match a 3-column set comparison, so it is not at risk.
+    """
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if constraint_name := generic_find_uq_constraint_name(
+        "tables",
+        {"database_id", "schema", "table_name"},
+        inspector,
+    ):
+        drop_unique_constraint(op, constraint_name, "tables")
+
+
+def downgrade():
+    """Restore the legacy constraint, mirroring ``df3d7e2eb9a4``'s
+    downgrade. Best-effort: rows written after the drop may legitimately
+    collide on ``(database_id, schema, table_name)`` across catalogs, in
+    which case the constraint cannot be recreated and the downgrade
+    proceeds with a warning — matching the tolerant posture of the
+    constraint's original creator, which wrapped creation in try/except.
+    """
+    try:
+        create_unique_constraint(
+            op,
+            "_customer_location_uc",
+            "tables",
+            ["database_id", "schema", "table_name"],
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.warning(
+            "Could not recreate _customer_location_uc on 'tables'; existing "
+            "rows likely collide on (database_id, schema, table_name) across "
+            "catalogs. Continuing without the legacy constraint.",
+            exc_info=True,
+        )

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -36,7 +36,7 @@ import traceback
 import uuid
 import warnings
 import zlib
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
@@ -702,12 +702,19 @@ def generic_find_fk_constraint_names(  # pylint: disable=invalid-name
 
 
 def generic_find_uq_constraint_name(
-    table: str, columns: set[str], insp: Inspector
+    table: str, columns: Collection[str], insp: Inspector
 ) -> str | None:
-    """Utility to find a unique constraint name in alembic migrations"""
+    """Utility to find a unique constraint name in alembic migrations.
 
+    ``columns`` is coerced to a set before comparison. Historically the
+    parameter was annotated ``set[str]`` but compared with ``==`` against a
+    set — a caller passing a list (as migration ``df3d7e2eb9a4`` did)
+    silently never matched, because ``list == set`` is always ``False``.
+    Coercing removes that foot-gun for future callers.
+    """
+    target = set(columns)
     for uq in insp.get_unique_constraints(table):
-        if columns == set(uq["column_names"]):
+        if target == set(uq["column_names"]):
             return uq["name"]
 
     return None

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -36,6 +36,7 @@ from superset.utils.core import (
     FilterOperator,
     generic_find_constraint_name,
     generic_find_fk_constraint_name,
+    generic_find_uq_constraint_name,
     get_datasource_full_name,
     get_query_source_from_request,
     get_stacktrace,
@@ -695,6 +696,71 @@ def test_generic_find_fk_constraint_none_exist():
 
     result = generic_find_fk_constraint_name(
         table_name, columns, referenced_table_name, insp_mock
+    )
+
+    assert result is None
+
+
+def test_generic_find_uq_constraint_accepts_list():
+    """Regression pin for the ``list == set`` foot-gun (sc-112173).
+
+    Migration ``df3d7e2eb9a4`` passed a list and silently never matched,
+    because the helper compared it with ``==`` against a set. The helper
+    coerces its ``columns`` argument, so a list argument MUST find the
+    constraint."""
+    insp_mock = MagicMock()
+    insp_mock.get_unique_constraints.return_value = [
+        {
+            "name": "_customer_location_uc",
+            "column_names": ["database_id", "schema", "table_name"],
+        },
+    ]
+
+    result = generic_find_uq_constraint_name(
+        "tables",
+        ["database_id", "schema", "table_name"],  # deliberately a list
+        insp_mock,
+    )
+
+    assert result == "_customer_location_uc"
+
+
+def test_generic_find_uq_constraint_with_set():
+    """The documented set-shaped argument keeps working unchanged."""
+    insp_mock = MagicMock()
+    insp_mock.get_unique_constraints.return_value = [
+        {
+            "name": "_customer_location_uc",
+            "column_names": ["database_id", "schema", "table_name"],
+        },
+    ]
+
+    result = generic_find_uq_constraint_name(
+        "tables",
+        {"database_id", "schema", "table_name"},
+        insp_mock,
+    )
+
+    assert result == "_customer_location_uc"
+
+
+def test_generic_find_uq_constraint_no_partial_match():
+    """A 3-column lookup MUST NOT match a 4-column constraint: the
+    take-2 drop migration relies on exact set equality so the model's
+    intended ``(database_id, catalog, schema, table_name)`` constraint is
+    never at risk."""
+    insp_mock = MagicMock()
+    insp_mock.get_unique_constraints.return_value = [
+        {
+            "name": "uq_tables_database_id",
+            "column_names": ["database_id", "catalog", "schema", "table_name"],
+        },
+    ]
+
+    result = generic_find_uq_constraint_name(
+        "tables",
+        {"database_id", "schema", "table_name"},
+        insp_mock,
     )
 
     assert result is None


### PR DESCRIPTION
### SUMMARY

Migration `df3d7e2eb9a4` (2024) intended to drop the legacy 3-column unique constraint `_customer_location_uc` `(database_id, schema, table_name)` from `tables`, but passed a **list** to `generic_find_uq_constraint_name`, whose body compares `columns == set(uq["column_names"])`. `list == set` is always `False` in Python, so the constraint was never found and never dropped — a silent no-op.

Consequences on databases migrated through it:

- The NULL-leaky 3-column constraint (no `catalog` leg) is still present, while schemas built from model metadata (`create_all`, e.g. CI) carry the model's intended 4-column constraint `(database_id, catalog, schema, table_name)` instead — so CI cannot reproduce production failure shapes.
- A row keeps occupying `(database_id, schema, table_name)` **across catalogs**: creating the same table under a different catalog passes every catalog-aware app-level check and then hits an opaque `IntegrityError` only on migrated databases.

Two-part fix:

1. `generic_find_uq_constraint_name` now coerces its `columns` argument to a set (parameter widened to `Collection[str]`), removing the foot-gun for all callers. Existing set-passing callers are unaffected.
2. A take-2 migration (`16755d4ca4ae`) re-attempts the drop with exact set matching. It is a harmless no-op where the constraint is already absent, and the model's 4-column constraint can never match a 3-column set comparison, so it is not at risk. Downgrade restores the legacy constraint best-effort (rows written after the drop may legitimately collide across catalogs), mirroring the tolerant try/except posture of the constraint's original creator.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — schema-only change.

### TESTING INSTRUCTIONS

1. `pytest tests/unit_tests/utils/test_core.py -k generic_find_uq` — 3 tests: the list-argument regression pin (fails against the pre-fix helper), the set-argument happy path, and the exact-match guarantee (a 3-column lookup never matches the model's 4-column constraint).
2. Migration verified on **SQLite and PostgreSQL**: fresh full-chain `superset db upgrade` (clean), then `superset db downgrade` (constraint recreated: `_customer_location_uc (database_id, schema, table_name)`), then `superset db upgrade` (constraint dropped), with `uq_tables_uuid` untouched throughout. On a database that still carries the legacy constraint, the upgrade drops it; on one that never had it, the lookup finds nothing and the migration no-ops.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided: single `ALTER TABLE ... DROP CONSTRAINT` on `tables` (or a no-op lookup); sub-second on PostgreSQL/MySQL, table-rebuild via batch mode on SQLite. No data movement, no downtime expected.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)