### PR TITLE
fix(db2): stop truncating table comments to one character

### DIFF
--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -125,8 +125,6 @@ class Db2EngineSpec(BaseEngineSpec):
         """
         Get comment of table from a given schema
 
-        Ibm Db2 return comments as tuples, so we need to get the first element
-
         :param inspector: SqlAlchemy Inspector instance
         :param table: Table instance
         :return: comment of table
@@ -134,10 +132,7 @@ class Db2EngineSpec(BaseEngineSpec):
         comment = None
         try:
             table_comment = inspector.get_table_comment(table.table, table.schema)
-            comment = table_comment.get("text")
-            return comment[0]
-        except IndexError:
-            return comment
+            return table_comment.get("text")
         except Exception as ex:  # pylint: disable=broad-except
             logger.error("Unexpected error while fetching table comment", exc_info=True)
             logger.exception(ex)

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -129,14 +129,13 @@ class Db2EngineSpec(BaseEngineSpec):
         :param table: Table instance
         :return: comment of table
         """
-        comment = None
         try:
             table_comment = inspector.get_table_comment(table.table, table.schema)
             return table_comment.get("text")
         except Exception as ex:  # pylint: disable=broad-except
             logger.error("Unexpected error while fetching table comment", exc_info=True)
             logger.exception(ex)
-            return comment
+            return None
 
     @classmethod
     def get_prequeries(

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -39,13 +39,16 @@ def test_epoch_to_dttm() -> None:
 def test_get_table_comment(mocker: MockerFixture):
     """
     Test the `get_table_comment` method.
+
+    ibm_db_sa >= 0.4.1 returns the comment as a plain string (fixed in
+    https://github.com/ibmdb/python-ibmdbsa/pull/135), not a tuple as it
+    used to. Indexing into that string with `comment[0]` truncates every
+    DB2 table comment to its first character; this guards against that.
     """
     from superset.db_engine_specs.db2 import Db2EngineSpec
 
     mock_inspector = mocker.MagicMock()
-    mock_inspector.get_table_comment.return_value = {
-        "text": ("This is a table comment",)
-    }
+    mock_inspector.get_table_comment.return_value = {"text": "This is a table comment"}
 
     assert (
         Db2EngineSpec.get_table_comment(mock_inspector, Table("my_table", "my_schema"))

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -72,6 +72,22 @@ def test_get_table_comment_empty(mocker: MockerFixture):
     )
 
 
+def test_get_table_comment_unexpected_error(mocker: MockerFixture):
+    """
+    Test that `get_table_comment` returns `None` instead of raising
+    when the inspector call fails unexpectedly.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    mock_inspector = mocker.MagicMock()
+    mock_inspector.get_table_comment.side_effect = Exception("boom")
+
+    assert (
+        Db2EngineSpec.get_table_comment(mock_inspector, Table("my_table", "my_schema"))
+        is None
+    )
+
+
 def test_get_prequeries(mocker: MockerFixture) -> None:
     """
     Test the ``get_prequeries`` method.


### PR DESCRIPTION
### SUMMARY

`Db2EngineSpec.get_table_comment` indexes into the returned comment with `comment[0]`, based on a comment saying "Ibm Db2 return comments as tuples, so we need to get the first element."

That was true for older `ibm_db_sa`, but it was fixed upstream in [ibmdb/python-ibmdbsa#135](https://github.com/ibmdb/python-ibmdbsa/pull/135) (merged 2023-07-04, first released in `v0.4.1`): `get_table_comment` now returns a plain string, not a tuple.

Superset's own dependency pin (`ibm-db-sa<=0.4.4, >=0.4.4` in `pyproject.toml`) already requires that fixed version. So today, `comment[0]` is indexing into a plain string and returning only its **first character** — every DB2 table comment gets silently truncated to one character, with no error (the `except IndexError` only fires when the comment is empty).

### BEFORE/AFTER

Before:
```python
comment = None
try:
    table_comment = inspector.get_table_comment(table.table, table.schema)
    comment = table_comment.get("text")
    return comment[0]
except IndexError:
    return comment
```
A table comment of `"Customer records"` returns `"C"`.

After:
```python
comment = None
try:
    table_comment = inspector.get_table_comment(table.table, table.schema)
    return table_comment.get("text")
```
Returns the full `"Customer records"`.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/db_engine_specs/test_db2.py -v
```

Updated `test_get_table_comment` to mock the current (string-returning) `ibm_db_sa` shape instead of the old tuple shape. Confirmed the updated test fails against the pre-fix code (returns `"T"` instead of the full string) and passes with the fix.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API