### PR TITLE
docs: fix parameter name in Explorable.get_query_result docstring

### DIFF
--- a/superset/explorables/base.py
+++ b/superset/explorables/base.py
@@ -204,7 +204,7 @@ class Explorable(Protocol):
         object describing what data to fetch (columns, metrics, filters, time range,
         etc.) and returns a QueryResult containing a pandas DataFrame with the results.
 
-        :param query_obj: QueryObject describing the query
+        :param query_object: QueryObject describing the query
 
         :return: QueryResult containing:
             - df: pandas DataFrame with query results


### PR DESCRIPTION
### SUMMARY

`Explorable.get_query_result` documented `:param query_obj:`, but the parameter is named `query_object`:

```python
def get_query_result(self, query_object: QueryObject) -> QueryResult:
    """
    ...
    :param query_obj: QueryObject describing the query
```

So the docstring described a parameter that does not exist on the method, and the real one was left undocumented. Since this is the primary data-retrieval method on the `Explorable` protocol, the reference is worth having right.

One line. Documentation only — no behaviour change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — docstring change, no UI.

### TESTING INSTRUCTIONS

No behaviour to exercise; the change is a single word in a docstring. Verified mechanically that the documented parameter now matches the signature:

```python
import ast, re
src = open("superset/explorables/base.py").read()
fn = next(n for n in ast.walk(ast.parse(src))
          if isinstance(n, ast.FunctionDef) and n.name == "get_query_result")
print([a.arg for a in fn.args.args if a.arg != "self"])          # ['query_object']
print(re.findall(r":param (\w+):", ast.get_docstring(fn)))        # ['query_object']
```

`pre-commit run --files superset/explorables/base.py` passes in full, including `mypy`, `ruff`, `ruff-format` and `pylint`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Found by comparing documented `:param` entries against actual function signatures.
