### PR TITLE
docs: fix typo 'throuth' → 'through' in superset-embedded-sdk/README.md

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -215,7 +215,7 @@ Common permissions you might need:
 
 By default, the Embedded SDK creates an `iframe` element without a `referrerPolicy` value enforced. This means that a policy defined for `iframe` elements at the host app level would reflect to it.
 
-This can be an issue as during the embedded enablement for a dashboard it's possible to specify which domain(s) are allowed to embed the dashboard, and this validation happens throuth the `Referrer` header. That said, in case the hosting app has a more restrictive policy that would omit this header, this validation would fail.
+This can be an issue as during the embedded enablement for a dashboard it's possible to specify which domain(s) are allowed to embed the dashboard, and this validation happens through the `Referrer` header. That said, in case the hosting app has a more restrictive policy that would omit this header, this validation would fail.
 
 Use the `referrerPolicy` parameter in the `embedDashboard` method to specify [a particular policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy) that works for your implementation.
 


### PR DESCRIPTION
## Summary

This PR fixes a spelling typo in `superset-embedded-sdk/README.md` (line 218).

## Problem

The word 'throuth' is a misspelling and should be 'through'.

## Fix

Changed `throuth` to `through`.

## Type of Change

- [x] Documentation fix (spelling)
- [ ] Code change
- [ ] Breaking change