### PR TITLE
docs: fix missing apostrophe in 'doesn't' in superset/mcp_service/README.md

### DIFF
--- a/superset/mcp_service/README.md
+++ b/superset/mcp_service/README.md
@@ -157,7 +157,7 @@ Add this to your Claude Desktop config file:
 
 **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-Since claude desktop doesnt like non https mcp servers you can use this proxy:
+Since claude desktop doesn't like non https mcp servers you can use this proxy:
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

This PR fixes a grammar error in `superset/mcp_service/README.md` (line 160).

## Problem

The word 'doesnt' is missing an apostrophe and should be 'doesn't'.

## Fix

Changed `doesnt` to `doesn't`.

## Type of Change

- [x] Documentation fix (grammar)
- [ ] Code change
- [ ] Breaking change