### PR TITLE
docs: fix incorrect capitalization 'PiPY' to 'PyPI' in RELEASING/README.md

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -423,7 +423,7 @@ git push origin ${SUPERSET_VERSION}
 
 ### Publishing a Convenience Release to PyPI
 
-Extract the release to the `/tmp` folder to build the PiPY release. Files in the `/tmp` folder will be automatically deleted by the OS.
+Extract the release to the `/tmp` folder to build the PyPI release. Files in the `/tmp` folder will be automatically deleted by the OS.
 
 ```bash
 mkdir -p /tmp/superset && cd /tmp/superset


### PR DESCRIPTION
## Summary

This PR fixes an incorrect capitalization in `RELEASING/README.md` (line 426).

## Problem

'PiPY' is incorrectly capitalized. The correct spelling is 'PyPI' (Python Package Index).

## Fix

Changed `PiPY` to `PyPI`.

## Type of Change

- [x] Documentation fix (spelling/capitalization)
- [ ] Code change
- [ ] Breaking change