### PR TITLE
fix(alerts-reports): catch CroniterBadDateError in report frequency validation

### DIFF
--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Any, Optional
 
-from croniter import croniter
+from croniter import croniter, CroniterBadDateError
 from flask import current_app as app
 from flask_babel import gettext as _
 from marshmallow import ValidationError
@@ -29,6 +29,7 @@ from superset.commands.report.exceptions import (
     ChartNotSavedValidationError,
     DashboardNotFoundValidationError,
     DashboardNotSavedValidationError,
+    ReportScheduleCrontabNotValidError,
     ReportScheduleEitherChartOrDashboardError,
     ReportScheduleForbiddenError,
     ReportScheduleFrequencyNotAllowed,
@@ -288,13 +289,18 @@ class BaseReportScheduleCommand(BaseCommand):
             return
 
         iterations = 60 if minimum_interval <= 3660 else 24
-        schedule = croniter(cron_schedule)
-        current_exec = next(schedule)
+        try:
+            schedule = croniter(cron_schedule)
+            current_exec = next(schedule)
 
-        for _i in range(iterations):
-            next_exec = next(schedule)
-            diff, current_exec = next_exec - current_exec, next_exec
-            if int(diff) < minimum_interval:
-                raise ReportScheduleFrequencyNotAllowed(
-                    report_type=report_type, minimum_interval=minimum_interval
-                )
+            for _i in range(iterations):
+                next_exec = next(schedule)
+                diff, current_exec = next_exec - current_exec, next_exec
+                if int(diff) < minimum_interval:
+                    raise ReportScheduleFrequencyNotAllowed(
+                        report_type=report_type, minimum_interval=minimum_interval
+                    )
+        except CroniterBadDateError as ex:
+            raise ReportScheduleCrontabNotValidError(
+                cron_schedule=cron_schedule
+            ) from ex

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -133,6 +133,23 @@ class ReportScheduleFrequencyNotAllowed(ValidationError):  # noqa: N818
         )
 
 
+class ReportScheduleCrontabNotValidError(ValidationError):  # noqa: N818
+    """
+    Marshmallow validation error for a crontab that is syntactically valid
+    but never matches a real calendar date (e.g. February 30th)
+    """
+
+    def __init__(self, cron_schedule: str = "") -> None:
+        super().__init__(
+            _(
+                "Invalid crontab schedule: %(cron_schedule)s never matches"
+                " a valid date",
+                cron_schedule=cron_schedule,
+            ),
+            field_name="crontab",
+        )
+
+
 class ChartNotSavedValidationError(ValidationError):
     """
     Marshmallow validation error for charts that haven't been saved yet

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -26,7 +26,10 @@ from unittest.mock import patch
 import pytest
 
 from superset.commands.report.base import BaseReportScheduleCommand
-from superset.commands.report.exceptions import ReportScheduleFrequencyNotAllowed
+from superset.commands.report.exceptions import (
+    ReportScheduleCrontabNotValidError,
+    ReportScheduleFrequencyNotAllowed,
+)
 from superset.reports.models import ReportScheduleType
 
 REPORT_TYPES = {
@@ -172,6 +175,28 @@ def test_validate_report_frequency_report_only(schedule: str) -> None:
         schedule,
         ReportScheduleType.ALERT,
     )
+
+
+@pytest.mark.parametrize("report_type", REPORT_TYPES)
+@app_custom_config(
+    alert_minimum_interval=int(timedelta(minutes=5).total_seconds()),
+    report_minimum_interval=int(timedelta(minutes=5).total_seconds()),
+)
+def test_validate_report_frequency_never_matching_crontab(report_type: str) -> None:
+    """
+    Test the ``validate_report_frequency`` method with a crontab that is
+    syntactically valid but never matches a real calendar date (Feb 30th).
+
+    Such schedules pass ``croniter.is_valid()`` (purely syntactic) and thus
+    marshmallow schema validation, but raise ``CroniterBadDateError`` when
+    iterated. This should surface as a ``ValidationError`` rather than
+    propagating the raw croniter exception.
+    """
+    with pytest.raises(ReportScheduleCrontabNotValidError):
+        BaseReportScheduleCommand().validate_report_frequency(
+            "0 0 30 2 *",
+            report_type,
+        )
 
 
 @pytest.mark.parametrize("report_type", REPORT_TYPES)


### PR DESCRIPTION
### SUMMARY
`superset/reports/schemas.py::validate_crontab()` only checks `croniter.is_valid(str(value))`, which is purely syntactic — it returns `True` for cron expressions that can never produce a real calendar date (e.g. `0 0 30 2 *` for February 30th, or `0 0 31 4 *` for April 31st).

When `ALERT_MINIMUM_INTERVAL`/`REPORT_MINIMUM_INTERVAL` is configured >= 120 seconds (a common operator setting to enforce a minimum report/alert interval), `BaseReportScheduleCommand.validate_report_frequency()` calls `croniter(cron_schedule)` and iterates it with `next(schedule)`. For a never-matching crontab this raises `croniter.croniter.CroniterBadDateError` — whose MRO is `(CroniterBadDateError, CroniterError, ValueError, Exception, BaseException, object)`, i.e. **not** a marshmallow `ValidationError`. Both `CreateReportScheduleCommand.run()` and `UpdateReportScheduleCommand.run()` wrap the call in `except ValidationError`, so the raw croniter exception propagates past that handler, uncaught, up to the API layer, producing an opaque 500 instead of a 422.

This is the same underlying croniter behavior fixed once already in #42486 (`superset/tasks/cron_util.py::cron_schedule_window()`, the celery-beat scheduler path — catch + log + skip), but this is a different site: synchronous API-layer validation during report/alert create/update, where the correct fix is to surface a proper validation error rather than silently skip.

Related prior fixes in this bug-class pipeline (raw system/library exceptions propagating instead of proper Superset/marshmallow validation errors): #42366, #42401, #42426, #42442, #42486.

### FIX
- Added `ReportScheduleCrontabNotValidError` (`superset/commands/report/exceptions.py`), a marshmallow `ValidationError` subclass on the `crontab` field, following the existing `ReportScheduleFrequencyNotAllowed` pattern.
- Wrapped the `croniter` iteration in `validate_report_frequency()` (`superset/commands/report/base.py`) in `try/except CroniterBadDateError`, raising `ReportScheduleCrontabNotValidError` from the caught exception.
- Added a regression test in `tests/unit_tests/commands/report/base_test.py` covering both `ReportScheduleType.ALERT` and `ReportScheduleType.REPORT` with the `0 0 30 2 *` crontab.

### TESTING INSTRUCTIONS
- Confirmed empirically (before applying the fix) that `croniter.is_valid("0 0 30 2 *")` returns `True` in this environment's pinned croniter version, and that calling `validate_report_frequency("0 0 30 2 *", ReportScheduleType.ALERT)` with a minimum interval configured (e.g. 5 minutes) raised an uncaught `CroniterBadDateError`, not a `ValidationError`.
- Applied the fix and confirmed the same call now raises `ReportScheduleCrontabNotValidError` (a `ValidationError`) instead.
- Ran the full `tests/unit_tests/commands/report/base_test.py` file: 95 passed (93 pre-existing + 2 new, one per report type), no regressions.
- Ran `ruff check` and `ruff format --check` on all changed files: all checks passed / already formatted.
- Ran `mypy` on the changed files: no new errors introduced (one pre-existing, unrelated `call-arg` error on `not_found_exc()` at line 73 of `base.py` was confirmed present on unmodified `HEAD` as well).

To manually verify: configure `ALERT_MINIMUM_INTERVAL = 300` (or any value >= 120), then attempt to create an alert with crontab `0 0 30 2 *` via the API — before this fix, the request returns a 500; after, it returns a 422 with a clear "Invalid crontab schedule" message.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Tradeoffs:** This is a new, additive validation error on a previously-uncaught crash path — no existing behavior changes for any crontab that currently passes. This code path only triggers for genuinely never-firing crontabs that admins would have needed to fix anyway; before this fix they got an opaque 500, after this fix they get a clear 422 telling them the crontab is invalid.