### PR TITLE
fix(sqllab): stop OAuth2 banner from ballooning the database selector popover

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -135,6 +135,7 @@ const SqlEditorLeftBar = ({
       data-test="DatabaseSelector"
       css={css`
         min-width: 500px;
+        max-width: 500px;
       `}
     >
       <Typography.Title level={5} style={{ margin: 0 }}>

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -146,6 +146,17 @@ describe('OAuth2RedirectMessage Component', () => {
     expect(getByText(/provide authorization/i)).toBeInTheDocument();
   });
 
+  test('renders the prose body without preformatted/monospace styling so it wraps within the popover', () => {
+    const { container } = render(setup());
+
+    // The OAuth2 body is prose, not a stack trace, so it must not be styled as
+    // preformatted (monospace + pre-wrap). Otherwise it renders as a single
+    // unwrapped line that balloons the SQL Lab popover width.
+    const description = container.querySelector('[data-testid="description"]');
+    expect(description).not.toBeNull();
+    expect(description).not.toHaveStyle({ whiteSpace: 'pre-wrap' });
+  });
+
   test('renders the authorization link pointing at the OAuth2 URL', () => {
     const { getByText } = render(setup());
 

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -181,6 +181,7 @@ export function OAuth2RedirectMessage({
       message={subtitle}
       type={level}
       description={body}
+      descriptionPre={false}
       closable={closable}
     />
   );


### PR DESCRIPTION
### SUMMARY

In SQL Lab, the "Select Database and Schema" popover shows an "Authorization needed" banner (`OAuth2RedirectMessage`) when the selected database uses OAuth2 and the user has not yet authorized. The banner's body text rendered as a single unwrapped monospace line, which forced the entire popover — and the Database/Schema selects inside it — to balloon to roughly 3x its normal width.

Two things combined to cause this:

1. **`SqlEditorLeftBar`** — the popover content container had `min-width: 500px` but no `max-width`, so the antd Popover sized to `max-content` and grew to fit the widest child.
2. **`ErrorAlert`** applies `descriptionPre = true` by default, styling the `description` as preformatted code (monospace `fontFamilyCode` + `white-space: pre-wrap`). The OAuth2 message body is prose, not a stack trace, so `pre-wrap` only wrapped against a constrained width the ballooning popover never provided.

### Changes

- `OAuth2RedirectMessage` now passes `descriptionPre={false}` so its prose body wraps normally instead of rendering as monospace preformatted text.
- The `SqlEditorLeftBar` popover content is capped with `max-width: 500px` so its width stays constant whether or not the banner is shown.

Net effect: the popover keeps a stable width, and the authorization message wraps and uses vertical space.

### BEFORE

The "Authorization needed" banner appears on one long unwrapped monospace line, stretching the popover ~3x wider and pushing the Database/Schema selects out with it.
<img width="1693" height="482" alt="Screenshot 2026-07-30 at 11 14 05 AM" src="https://github.com/user-attachments/assets/492b548f-e7a9-4c06-9ad6-509c43b31b44" />

### AFTER

The popover width is unchanged from the no-banner state; the banner text wraps within the popover and flows downward.
<img width="585" height="601" alt="image" src="https://github.com/user-attachments/assets/aa90dc15-8975-467c-83a2-81fe24a0799c" />


### TESTING INSTRUCTIONS

1. In SQL Lab, open the database/schema selector for a database configured with OAuth2 (e.g. Snowflake OAuth) while unauthorized.
2. Confirm the "Authorization needed" banner appears, its text wraps within the popover, and the popover width matches the no-banner state.

Unit tests: `OAuth2RedirectMessage.test.tsx` adds a case asserting the prose body is not rendered with preformatted/monospace (`pre-wrap`) styling.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

This addresses a customer-reported layout regression.