### PR TITLE
chore(deps): require manual deck.gl upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       # See https://github.com/apache/superset/pull/37384#issuecomment-3793991389
       # TODO: remove the plugin once Lodash usage has been migrated to a more readily tree-shakeable alternative
       - dependency-name: "@swc/plugin-transform-imports"
+      # deck.gl and luma.gl share strict peer constraints across the root and
+      # plugin workspaces, and root overrides pin their transitive versions.
+      # Upgrade both families together in a manually validated change.
+      - dependency-name: "@deck.gl/*"
+      - dependency-name: "@luma.gl/*"
       # `just-handlerbars-helpers` library in plugin-chart-handlebars requires `currencyformatter`` to be < 2
       - dependency-name: "currencyformatter.js"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,12 +64,6 @@ updates:
       babel:
         patterns:
           - "@babel/*"
-      deckgl:
-        patterns:
-          - "@deck.gl/*"
-      lumagl:
-        patterns:
-          - "@luma.gl/*"
       storybook:
         patterns:
           - "@storybook/*"


### PR DESCRIPTION
### SUMMARY

Exclude the coupled `@deck.gl/*` and `@luma.gl/*` package families from automated
npm updates. These dependencies span the frontend root and plugin workspaces and
are also pinned by root overrides, so they require a single manually validated
upgrade.

The master Dependabot run produced 13 `npm EOVERRIDE` errors while trying to
update direct dependencies whose versions are duplicated by literal overrides.
Using self-referencing overrides removes that immediate error but exposes
incompatible peer ranges across the workspaces, so it is not a safe automated
upgrade path. The ignore rules prevent these two failure families without
suppressing unrelated npm updates.

Observed failure: https://github.com/apache/superset/actions/runs/30611456387

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; Dependabot configuration only.

### TESTING INSTRUCTIONS

- `pre-commit run --files .github/dependabot.yml`
- `pre-commit run --all-files` was run. YAML and zizmor passed; unrelated master MyPy failures plus local frontend/docs dependency gaps prevented the repository-wide command from completing cleanly.
- Reproduced the original conflict with `npm install @deck.gl/core@9.3.7 --package-lock-only --dry-run=true --ignore-scripts` from `superset-frontend`.
- Confirm the next scheduled Dependabot run completes without deck.gl/luma.gl updater errors and still proposes unrelated dependency updates.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
